### PR TITLE
[Bing Search]fixed: Chinese garbled characters in the search list

### DIFF
--- a/extensions/bing-search/src/search.tsx
+++ b/extensions/bing-search/src/search.tsx
@@ -11,8 +11,8 @@ export default function Command() {
         {results.map((item) => (
           <List.Item
             key={item.id}
-            title={item.query}
-            subtitle={item.description}
+            title={Buffer.from(item.query, 'binary').toString()}
+            subtitle={Buffer.from(item.description, 'binary').toString()}
             icon={getIcon(item)}
             actions={
               <ActionPanel>


### PR DESCRIPTION
## Description

[Bing Search]fixed: Chinese garbled characters in the search list

There's still something wrong with the first default item in the list, but I'm not sure how to fix it


## Screencast

<img width="751" alt="WechatIMG521" src="https://github.com/raycast/extensions/assets/25897113/e8661eb3-4afd-4e92-b544-11d268fe0bac">



