### PR TITLE
feat(kitty): support kitty terminal

### DIFF
--- a/extensions/terminalfinder/CHANGELOG.md
+++ b/extensions/terminalfinder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Terminal Finder Changelog
 
+## [Update] - 2023-09-09
+
+- [nicoandmee](https://github.com/nicoandmee) added support for [Kitty](https://sw.kovidgoyal.net/kitty/) terminal.
+
 ## [Update] - 2023-03-02
 
 - Updated `@raycast/api`

--- a/extensions/terminalfinder/package-lock.json
+++ b/extensions/terminalfinder/package-lock.json
@@ -7,7 +7,8 @@
       "name": "terminalfinder",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.48.5"
+        "@raycast/api": "^1.48.5",
+        "@raycast/utils": "^1.9.1"
       },
       "devDependencies": {
         "@types/node": "~16.10.0",
@@ -239,9 +240,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.48.5",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.48.5.tgz",
-      "integrity": "sha512-/4ojqBg4xyIfab9ce8YvwG31VILavgj1gffe6W2/FibkyN/xd8vrklMVvltJOzBLiLGw53FZqpRvdc1ZVtKplQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.58.0.tgz",
+      "integrity": "sha512-nWOL4UIn3KlEwDKvZDCWlX+oeNN77zC5V95AFp14Z2C23uc5FABC2ZIBfirQ2j5C10X4PHRg+S39rwDHQAeuLA==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/node": "18.8.3",
@@ -278,6 +279,33 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@raycast/utils": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-1.9.1.tgz",
+      "integrity": "sha512-/lkxze0WP32pOrpQiAyOGNi8ylbF4Igneo7KBTG1QOZZmwUePXTZC7jCeyKEDyEpOIG0dapGFs9Jynw14tVyZg==",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "cross-fetch": "^3.1.6",
+        "dequal": "^2.0.3",
+        "media-typer": "^1.1.0",
+        "object-hash": "^3.0.0",
+        "signal-exit": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@raycast/api": ">=1.52.0"
+      }
+    },
+    "node_modules/@raycast/utils/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -998,6 +1026,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -1014,6 +1050,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -1105,6 +1149,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-node": {
@@ -2202,6 +2254,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2275,6 +2335,25 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/normalize-url": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
@@ -2296,6 +2375,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-keys": {
@@ -3296,6 +3383,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -3524,6 +3616,20 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -3847,9 +3953,9 @@
       }
     },
     "@raycast/api": {
-      "version": "1.48.5",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.48.5.tgz",
-      "integrity": "sha512-/4ojqBg4xyIfab9ce8YvwG31VILavgj1gffe6W2/FibkyN/xd8vrklMVvltJOzBLiLGw53FZqpRvdc1ZVtKplQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.58.0.tgz",
+      "integrity": "sha512-nWOL4UIn3KlEwDKvZDCWlX+oeNN77zC5V95AFp14Z2C23uc5FABC2ZIBfirQ2j5C10X4PHRg+S39rwDHQAeuLA==",
       "requires": {
         "@types/node": "18.8.3",
         "@types/react": "18.0.9",
@@ -3871,6 +3977,26 @@
             "@types/scheduler": "*",
             "csstype": "^3.0.2"
           }
+        }
+      }
+    },
+    "@raycast/utils": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-1.9.1.tgz",
+      "integrity": "sha512-/lkxze0WP32pOrpQiAyOGNi8ylbF4Igneo7KBTG1QOZZmwUePXTZC7jCeyKEDyEpOIG0dapGFs9Jynw14tVyZg==",
+      "requires": {
+        "content-type": "^1.0.5",
+        "cross-fetch": "^3.1.6",
+        "dequal": "^2.0.3",
+        "media-typer": "^1.1.0",
+        "object-hash": "^3.0.0",
+        "signal-exit": "^4.0.2"
+      },
+      "dependencies": {
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
         }
       }
     },
@@ -4401,6 +4527,11 @@
         "xdg-basedir": "^3.0.0"
       }
     },
+    "content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -4414,6 +4545,14 @@
       "dev": true,
       "requires": {
         "capture-stack-trace": "^1.0.0"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "requires": {
+        "node-fetch": "^2.6.12"
       }
     },
     "cross-spawn": {
@@ -4483,6 +4622,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "detect-node": {
       "version": "2.1.0",
@@ -5348,6 +5492,11 @@
         "escape-string-regexp": "^4.0.0"
       }
     },
+    "media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5406,6 +5555,14 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "normalize-url": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
@@ -5422,6 +5579,11 @@
         "config-chain": "^1.1.11",
         "pify": "^3.0.0"
       }
+    },
+    "object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -6191,6 +6353,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -6366,6 +6533,20 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/extensions/terminalfinder/package.json
+++ b/extensions/terminalfinder/package.json
@@ -87,6 +87,10 @@
       "title": "Kitty → Finder"
     }
   ],
+  "contributors": [
+    "nicoandmee",
+    "yedongze"
+  ],
   "dependencies": {
     "@raycast/api": "^1.48.5",
     "@raycast/utils": "^1.9.1"

--- a/extensions/terminalfinder/package.json
+++ b/extensions/terminalfinder/package.json
@@ -1,79 +1,97 @@
 {
   "$schema": "https://www.raycast.com/schemas/extension.json",
-  "name": "terminalfinder",
-  "title": "Terminal Finder",
-  "description": "Open currently selected Finder (or Path Finder) window in Terminal (or iTerm2, Warp) and vice versa",
-  "icon": "command-icon.png",
   "author": "yedongze",
-  "license": "MIT",
   "commands": [
     {
+      "description": "Open current Finder directory in Terminal",
+      "mode": "no-view",
+      "name": "clipboardToKitty",
+      "subtitle": "Open Path",
+      "title": "Clipboard → Kitty"
+    },
+    {
+      "description": "Open current Finder directory in Terminal",
+      "mode": "no-view",
       "name": "clipboardToITerm",
-      "title": "Clipboard → iTerm",
       "subtitle": "Open Path",
-      "description": "Open current Finder directory in Terminal",
-      "mode": "no-view"
+      "title": "Clipboard → iTerm"
     },
     {
+      "description": "Open current Finder directory in Terminal",
+      "mode": "no-view",
       "name": "clipboardToTerminal",
-      "title": "Clipboard → Terminal",
       "subtitle": "Open Path",
-      "description": "Open current Finder directory in Terminal",
-      "mode": "no-view"
+      "title": "Clipboard → Terminal"
     },
     {
+      "description": "Open current Finder directory in Terminal",
+      "mode": "no-view",
       "name": "clipboardToWarp",
-      "title": "Clipboard → Warp",
       "subtitle": "Open Path",
-      "description": "Open current Finder directory in Terminal",
-      "mode": "no-view"
+      "title": "Clipboard → Warp"
     },
     {
+      "description": "Open current Finder directory in Terminal",
+      "mode": "no-view",
       "name": "finderToITerm",
-      "title": "Finder → iTerm",
       "subtitle": "Open Path",
-      "description": "Open current Finder directory in Terminal",
-      "mode": "no-view"
+      "title": "Finder → iTerm"
     },
     {
+      "description": "Open current Finder directory in Terminal",
+      "mode": "no-view",
       "name": "finderToTerminal",
-      "title": "Finder → Terminal",
       "subtitle": "Open Path",
-      "description": "Open current Finder directory in Terminal",
-      "mode": "no-view"
+      "title": "Finder → Terminal"
     },
     {
+      "description": "Open current Finder directory in Terminal",
+      "mode": "no-view",
       "name": "finderToWarp",
-      "title": "Finder → Warp",
       "subtitle": "Open Path",
-      "description": "Open current Finder directory in Terminal",
-      "mode": "no-view"
+      "title": "Finder → Warp"
     },
     {
+      "description": "Open current Finder directory in Terminal",
+      "mode": "no-view",
+      "name": "finderToKitty",
+      "subtitle": "Open Path",
+      "title": "Finder → Kitty"
+    },
+    {
+      "description": "Open current Finder directory in Terminal",
+      "mode": "no-view",
       "name": "iTermToFinder",
-      "title": "iTerm → Finder",
       "subtitle": "Open Path",
-      "description": "Open current Finder directory in Terminal",
-      "mode": "no-view"
+      "title": "iTerm → Finder"
     },
     {
+      "description": "Open current Finder directory in Terminal",
+      "mode": "no-view",
       "name": "terminalToFinder",
-      "title": "Terminal → Finder",
       "subtitle": "Open Path",
-      "description": "Open current Finder directory in Terminal",
-      "mode": "no-view"
+      "title": "Terminal → Finder"
     },
     {
-      "name": "warpToFinder",
-      "title": "Warp → Finder",
-      "subtitle": "Open Path",
       "description": "Open current Finder directory in Terminal",
-      "mode": "no-view"
+      "mode": "no-view",
+      "name": "warpToFinder",
+      "subtitle": "Open Path",
+      "title": "Warp → Finder"
+    },
+    {
+      "description": "Open current Finder directory in Terminal",
+      "mode": "no-view",
+      "name": "kittyToFinder",
+      "subtitle": "Open Path",
+      "title": "Kitty → Finder"
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.48.5"
+    "@raycast/api": "^1.48.5",
+    "@raycast/utils": "^1.9.1"
   },
+  "description": "Open currently selected Finder (or Path Finder) window in Terminal (or iTerm2, Warp, Kitty) and vice versa",
   "devDependencies": {
     "@types/node": "~16.10.0",
     "@types/react": "^17.0.28",
@@ -84,8 +102,12 @@
     "react-devtools": "^4.19.2",
     "typescript": "^4.4.3"
   },
+  "icon": "command-icon.png",
+  "license": "MIT",
+  "name": "terminalfinder",
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop"
-  }
+  },
+  "title": "Terminal Finder"
 }

--- a/extensions/terminalfinder/src/KittyToFinder.tsx
+++ b/extensions/terminalfinder/src/KittyToFinder.tsx
@@ -1,0 +1,23 @@
+import { Toast, showToast } from "@raycast/api";
+import { runAppleScript } from "./utils";
+
+export default async () => {
+  const script = `
+      if application "kitty" is not running then
+          return "Not running"
+      end if
+
+      set command to "open -a Finder ./"
+      set CR to " \\x0d"
+
+      tell application "kitty" to activate
+      do shell script "/Applications/Kitty.app/Contents/MacOS/kitty @ --to unix:/tmp/mykitty send-text " & command & quoted form of CR
+  `;
+
+  try {
+    const result = await runAppleScript(script);
+    await showToast(Toast.Style.Success, "Done", result);
+  } catch (err) {
+    await showToast(Toast.Style.Failure, "Something went wrong");
+  }
+};

--- a/extensions/terminalfinder/src/KittyToFinder.tsx
+++ b/extensions/terminalfinder/src/KittyToFinder.tsx
@@ -1,15 +1,32 @@
 import { Toast, showToast } from "@raycast/api";
-import { runAppleScript } from "./utils";
+import { runAppleScript } from "@raycast/utils";
 
 export default async () => {
   const script = `
+      use framework "Foundation"
+      use scripting additions
       if application "kitty" is not running then
           return "Not running"
       end if
 
+      on readJSON(strJSON)
+        set ca to current application
+        set {x, e} to ca's NSJSONSerialization's JSONObjectWithData:((ca's NSString's stringWithString:strJSON)'s dataUsingEncoding:(ca's NSUTF8StringEncoding)) options:0 |error|:(reference)
+        if x is missing value then
+          error e's localizedDescription() as text
+        else
+          item 1 of ((ca's NSArray's arrayWithObject:x) as list)
+        end if
+      end readJSON
+
+      set kittyWindows to do shell script "/Applications/Kitty.app/Contents/MacOS/kitty @ --to unix:/tmp/mykitty ls"
+      set kittyWindows to readJSON(kittyWindows)
+      log kittyWindows
+
       set command to "open -a Finder ./"
       set CR to " \\x0d"
 
+      do shell script "open -a kitty"
       tell application "kitty" to activate
       do shell script "/Applications/Kitty.app/Contents/MacOS/kitty @ --to unix:/tmp/mykitty send-text " & command & quoted form of CR
   `;

--- a/extensions/terminalfinder/src/clipboardToKitty.tsx
+++ b/extensions/terminalfinder/src/clipboardToKitty.tsx
@@ -1,0 +1,40 @@
+import { Clipboard, Toast, showToast } from "@raycast/api";
+import { runAppleScript } from "./utils";
+
+export default async () => {
+  const directory = await Clipboard.readText();
+
+      const script = `
+      on readJSON(strJSON)
+        set ca to current application
+        set {x, e} to ca's NSJSONSerialization's JSONObjectWithData:((ca's NSString's stringWithString:strJSON)'s dataUsingEncoding:(ca's NSUTF8StringEncoding)) options:0 |error|:(reference)
+        if x is missing value then
+          error e's localizedDescription() as text
+        else
+          item 1 of ((ca's NSArray's arrayWithObject:x) as list)
+        end if
+      end readJSON
+
+      -- start kitty if not already running
+      try
+        set kittyWindows to do shell script "/Applications/Kitty.app/Contents/MacOS/kitty @ --to unix:/tmp/mykitty ls"
+        set kittyWindows to readJSON(kittyWindows)
+      on error
+        set kittyWindows to {}
+      end try
+
+      tell application "kitty" to activate
+
+      if (count of kittyWindows) > 0 then
+        do shell script "/Applications/Kitty.app/Contents/MacOS/kitty @ --to unix:/tmp/mykitty new-window --location=neighbor --new-tab --cwd=${directory}"
+      else
+        do shell script "/Applications/Kitty.app/Contents/MacOS/kitty --to unix:/tmp/mykitty new-window --cwd=${directory}"
+      end if
+`;
+  try {
+    const result = await runAppleScript(script);
+    await showToast(Toast.Style.Success, "Done", result);
+  } catch (err) {
+    await showToast(Toast.Style.Failure, "Something went wrong");
+  }
+};

--- a/extensions/terminalfinder/src/clipboardToKitty.tsx
+++ b/extensions/terminalfinder/src/clipboardToKitty.tsx
@@ -3,11 +3,9 @@ import { runAppleScript } from "@raycast/utils";
 
 export default async () => {
   const directory = await Clipboard.readText();
-  console.log("clipboard: ", directory);
-
   const script = `
-      set pathList to "${directory}"
-      set command to "clear; cd " & pathList
+    set pathList to "${directory}"
+    set command to "clear; cd " & pathList
     tell application "System Events"
       if not (exists (processes where name is "kitty")) then
           set open_cmd to "/Applications/Kitty.app/Contents/MacOS/kitty -o allow_remote_control=yes --listen-on unix:/tmp/mykitty"

--- a/extensions/terminalfinder/src/finderToKitty.tsx
+++ b/extensions/terminalfinder/src/finderToKitty.tsx
@@ -1,0 +1,45 @@
+import { Toast, showToast } from "@raycast/api";
+import { runAppleScript } from "@raycast/utils";
+
+export default async () => {
+  let script = `
+        if application "Finder" is not running then
+            return "Not running"
+        end if
+
+        tell application "Finder"
+            set pathList to (quoted form of POSIX path of (folder of the front window as alias))
+            set textToType to "clear; cd " & pathList
+        end tell
+    `;
+
+  script += `
+    tell application "System Events"
+    if not (exists (processes where name is "kitty")) then
+        set open_cmd to "open -a kitty" & "-o allow_remote_control=yes --listen-on unix:/tmp/mykitty"
+        do shell script open_cmd
+    else
+        set activeApp to ""
+        repeat while activeApp is not "kitty"
+          tell application "System Events"
+            set activeApp to name of first application process whose frontmost is true
+          end tell
+        end repeat
+        tell application "kitty" to activate
+        tell application "System Events" to keystroke textToType
+        tell application "System Events"
+            key code 36 -- enter key
+        end tell
+      end if
+    end tell
+    `;
+
+  try {
+    const result = await runAppleScript(script);
+    console.dir(result);
+
+    await showToast(Toast.Style.Success, "Done", result);
+  } catch (err) {
+    await showToast(Toast.Style.Failure, "Something went wrong");
+  }
+};

--- a/extensions/terminalfinder/src/finderToKitty.tsx
+++ b/extensions/terminalfinder/src/finderToKitty.tsx
@@ -36,8 +36,6 @@ export default async () => {
 
   try {
     const result = await runAppleScript(script);
-    console.dir(result);
-
     await showToast(Toast.Style.Success, "Done", result);
   } catch (err) {
     await showToast(Toast.Style.Failure, "Something went wrong");


### PR DESCRIPTION
![kitty](https://sw.kovidgoyal.net/kitty/_static/kitty.svg)

This PR adds support for the [kitty](https://sw.kovidgoyal.net/kitty) terminal emulator to the `terminalfinder` extension. Consequently, resolves [7494](https://github.com/raycast/extensions/issues/7494#issuecomment-1703253494) as well 😄 Three commands in particular were added:
* kittyToFinder: opens current directory that is open in kitty in finder
* clipboardToKitty: opens the directory present on clipboard stack in kitty terminal
* finderToKitty: opens the directory open in finder in kitty

Small caveat: to take advantage of existing kitty processes, the user is advised to:

```
echo '--listen-on unix:/tmp/mykitty' >> ~/.config/kitty/macos-launch-services-cmdline
```

That will ensure all kitty processes launched can be communicated with over the `/tmp/mykitty` socket.
