### PR TITLE
Update one-time-password extension

### DIFF
--- a/extensions/one-time-password/.gitignore
+++ b/extensions/one-time-password/.gitignore
@@ -6,3 +6,6 @@
 # misc
 .DS_Store
 raycast-env.d.ts
+
+# pnpm
+pnpm-lock.yaml

--- a/extensions/one-time-password/CHANGELOG.md
+++ b/extensions/one-time-password/CHANGELOG.md
@@ -1,5 +1,9 @@
 # One Time Password Changelog
 
+## 2024-12-04
+
+- Icons will now be displayed black or white depending on the system appearance.
+
 ## 2024-11-07
 
 ### Added

--- a/extensions/one-time-password/package.json
+++ b/extensions/one-time-password/package.json
@@ -6,7 +6,8 @@
   "icon": "icon.png",
   "author": "lachero",
   "contributors": [
-    "soulevans07"
+    "soulevans07",
+    "BalliAsghar"
   ],
   "categories": [
     "Security",

--- a/extensions/one-time-password/src/one-time-password.tsx
+++ b/extensions/one-time-password/src/one-time-password.tsx
@@ -13,6 +13,7 @@ import {
   popToRoot,
   confirmAlert,
   Color,
+  environment,
 } from '@raycast/api';
 import { useEffect, useState } from 'react';
 import { getProgressIcon } from '@raycast/utils';
@@ -34,6 +35,8 @@ export default () => {
   const [timer, setTimer] = useState(0);
   const [accounts, setAccounts] = useState<store.Account[]>([]);
   const [qrCodeScanType, setQRCodeScanType] = useState<ScanType>(null);
+
+  const { theme } = environment;
 
   async function loadAccounts() {
     if (accounts.length === 0) setLoading(true);
@@ -189,7 +192,9 @@ export default () => {
           <List.Item
             key={account.id}
             icon={{
-              source: `https://cdn.simpleicons.org/${account.issuer?.toLowerCase() || account.name?.toLowerCase()}`,
+              source: `https://cdn.simpleicons.org/${account.issuer?.toLowerCase() || account.name?.toLowerCase()}/${
+                theme === 'dark' ? 'white' : 'black'
+              }`,
               fallback: Icon.Key,
             }}
             title={account.name}


### PR DESCRIPTION
## Description

Icons will now be displayed black or white depending on the system appearance.

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

![391680218-ef1d7956-eca5-4b3c-a29e-3e056238dc0f](https://github.com/user-attachments/assets/82c77b89-a20b-4710-88a1-083d4c700bdf)
![391680212-f80a1aa1-aec0-4bab-828a-c7149360d381](https://github.com/user-attachments/assets/1d99f25d-f244-4709-ab14-aec7c2040977)


## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
