### PR TITLE
Update leetcode extension

### DIFF
--- a/extensions/leetcode/CHANGELOG.md
+++ b/extensions/leetcode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # LeetCode Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Unescape square brackets in markdown conversion to avoid matching Latex delimiters (see [this](https://leetcode.com/problems/minimum-cost-walk-in-weighted-graph/description/) LeetCode problem to see what goes wrong if we do not unescape square brackets)
+
 ## [Code Template Features] - 2025-01-23
 
 - Add Copy Code Template submenu action to copy problem's code template to clipboard

--- a/extensions/leetcode/CHANGELOG.md
+++ b/extensions/leetcode/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LeetCode Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2025-03-20
 
 - Unescape square brackets in markdown conversion to avoid matching Latex delimiters (see [this](https://leetcode.com/problems/minimum-cost-walk-in-weighted-graph/description/) LeetCode problem to see what goes wrong if we do not unescape square brackets)
 

--- a/extensions/leetcode/package-lock.json
+++ b/extensions/leetcode/package-lock.json
@@ -805,10 +805,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2684,9 +2685,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",

--- a/extensions/leetcode/package.json
+++ b/extensions/leetcode/package.json
@@ -7,7 +7,8 @@
   "author": "justin0u0",
   "contributors": [
     "xmok",
-    "doxxx93"
+    "doxxx93",
+    "svenhofman"
   ],
   "categories": [
     "Web"

--- a/extensions/leetcode/src/utils.ts
+++ b/extensions/leetcode/src/utils.ts
@@ -3,7 +3,12 @@ import { NodeHtmlMarkdown } from 'node-html-markdown';
 import { Problem, ProblemStats } from './types';
 
 const html2markdown = new NodeHtmlMarkdown(
-  {},
+  {
+    textReplace: [
+      [/\\\[/g, '['],
+      [/\\\]/g, ']'],
+    ],
+  },
   {
     pre: {
       spaceIfRepeatingChar: true,


### PR DESCRIPTION
## Description

Unescape square brackets in markdown conversion to avoid matching Latex delimiters (see [this](https://leetcode.com/problems/minimum-cost-walk-in-weighted-graph/description/) LeetCode problem to see what goes wrong if we do not unescape square brackets)

## Screencast

Old version:
![Raycast 2025-03-20 at 08 14 20](https://github.com/user-attachments/assets/e1e7d5ce-4fc4-4073-abd1-473d2742501a)

Updated version:
![leetcode 2025-03-20 at 08 14 41](https://github.com/user-attachments/assets/7dc32b5c-9e4c-44ed-a4c8-5b02c27ed921)



## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
