### PR TITLE
Update vercast extension

### DIFF
--- a/extensions/vercast/CHANGELOG.md
+++ b/extensions/vercast/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Vercast Changelog
 
+## [2.11] - {PR_MERGE_DATE}
+
+- Avoid broken links by removeing personal account from team switcher following Vercel's [personal team change](https://vercel.com/changelog/2024-01-account-changes).
+
 ## [2.10] - 2025-04-09
 
 - Added `Check Domain Availability` command and AI tool to check if a domain is available

--- a/extensions/vercast/CHANGELOG.md
+++ b/extensions/vercast/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.11] - {PR_MERGE_DATE}
 
-- Avoid broken links by removeing personal account from team switcher following Vercel's [personal team change](https://vercel.com/changelog/2024-01-account-changes).
+- Avoid broken links by removing personal account from the team switcher following Vercel's [personal team change](https://vercel.com/changelog/2024-01-account-changes).
 
 ## [2.10] - 2025-04-09
 

--- a/extensions/vercast/CHANGELOG.md
+++ b/extensions/vercast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Vercast Changelog
 
-## [2.11] - {PR_MERGE_DATE}
+## [2.11] - 2025-08-14
 
 - Avoid broken links by removing personal account from the team switcher following Vercel's [personal team change](https://vercel.com/changelog/2024-01-account-changes).
 

--- a/extensions/vercast/README.md
+++ b/extensions/vercast/README.md
@@ -1,28 +1,33 @@
 # Vercast
+
 Vercel for Raycast.
 
 Not affiliated with Vercel.
 
 ## Setup:
+
 - You need to add your Vercel token in the extension settings. You can get it from https://vercel.com/account/tokens.
 
 ## Current features:
-- View and search projects (by team or user)
+
+- View and search projects
 - View and search deployments
 - Edit, add, and delete environment variables
 - Inspect deployment files
 - View and search domains
 
 ## Roadmap (in no particular order):
+
 - Recents list
-- Ability to ping and see logs for serverless functions 
+- Ability to ping and see logs for serverless functions
 - Manage DNS Records
 
 ## Contributing
+
 The [Vercel REST API docs](https://vercel.com/docs/rest-api) and [Raycast developer docs](https://developers.raycast.com/) are good places to start. Feel free to open an issue or [ping me on Twitter](https://twitter.com/max_leiter) if you want to help out.
 
-
 ## Screenshots:
+
 <img src="media/vercast-1.png" width="600">
 <img src="media/vercast-2.png" width="600">
 <img src="media/vercast-3.png" width="600">

--- a/extensions/vercast/src/pages/search-projects/team-switch-search-accessory.tsx
+++ b/extensions/vercast/src/pages/search-projects/team-switch-search-accessory.tsx
@@ -20,7 +20,6 @@ const searchBarAccessory = ({ onTeamChange }: { onTeamChange: () => void }) => {
       onChange={async (newValue) => await onChange(newValue)}
     >
       {team && <List.Dropdown.Item title={team.name} value={team.id} icon={Icon.TwoPeople} />}
-      {user && <List.Dropdown.Item title={user.username} value={user.username} icon={Icon.Person} />}
       {teams?.length &&
         teams
           .filter((team) => team.id !== selectedTeam)

--- a/extensions/vercast/src/pages/search-projects/team-switch-search-accessory.tsx
+++ b/extensions/vercast/src/pages/search-projects/team-switch-search-accessory.tsx
@@ -3,7 +3,7 @@ import { Icon } from "@raycast/api";
 import useVercel from "../../hooks/use-vercel-info";
 
 const searchBarAccessory = ({ onTeamChange }: { onTeamChange: () => void }) => {
-  const { user, selectedTeam, teams, updateSelectedTeam } = useVercel();
+  const { selectedTeam, teams, updateSelectedTeam } = useVercel();
 
   const onChange = async (teamIdOrUsername: string) => {
     if (!teamIdOrUsername) {
@@ -14,11 +14,7 @@ const searchBarAccessory = ({ onTeamChange }: { onTeamChange: () => void }) => {
   };
   const team = teams?.find((x) => x.id === selectedTeam);
   return (
-    <List.Dropdown
-      value={selectedTeam}
-      tooltip="Switch Team"
-      onChange={async (newValue) => await onChange(newValue)}
-    >
+    <List.Dropdown value={selectedTeam} tooltip="Switch Team" onChange={async (newValue) => await onChange(newValue)}>
       {team && <List.Dropdown.Item title={team.name} value={team.id} icon={Icon.TwoPeople} />}
       {teams?.length &&
         teams

--- a/extensions/vercast/src/pages/search-projects/team-switch-search-accessory.tsx
+++ b/extensions/vercast/src/pages/search-projects/team-switch-search-accessory.tsx
@@ -15,7 +15,7 @@ const searchBarAccessory = ({ onTeamChange }: { onTeamChange: () => void }) => {
   const team = teams?.find((x) => x.id === selectedTeam);
   return (
     <List.Dropdown
-      value={selectedTeam || user?.username}
+      value={selectedTeam}
       tooltip="Switch Team"
       onChange={async (newValue) => await onChange(newValue)}
     >


### PR DESCRIPTION
## Description

When selecting your personal account from the team picker all links to deployments leads to incorrect urls since Vercel moved from personal accounts to personal teams. This PR removes the personal account from the team picker leaving only actual teams.

Closes #18044

## Screencast
Before:
<img width="550" height="424" alt="Sam 2025-08-07 at 12 23 32@2x" src="https://github.com/user-attachments/assets/f6c837d7-20c0-4048-bb30-d7794b222fd1" />


After:
<img width="570" height="384" alt="Sam 2025-08-07 at 12 23 12@2x" src="https://github.com/user-attachments/assets/c3007e6f-7eab-44bf-85ba-b797af59ace6" />

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
