### PR TITLE
Update duckduckgo-image-search extension

### DIFF
--- a/extensions/duckduckgo-image-search/CHANGELOG.md
+++ b/extensions/duckduckgo-image-search/CHANGELOG.md
@@ -1,5 +1,12 @@
 # DuckDuckGo Image Search Changelog
 
+## [Windows Support] - {PR_MERGE_DATE}
+
+- Added platform-specific shortcuts for macOS and Windows.
+- Extended supported platforms to include Windows.
+- Introduced a fallback for the download directory and added validation.
+- Standardized naming to "DuckDuckGo" in metadata and documentation.
+
 ## [Save image] - 2025-10-09
 
 - Added functionality to save images.

--- a/extensions/duckduckgo-image-search/CHANGELOG.md
+++ b/extensions/duckduckgo-image-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # DuckDuckGo Image Search Changelog
 
-## [Windows Support] - {PR_MERGE_DATE}
+## [Windows Support] - 2025-10-13
 
 - Added platform-specific shortcuts for macOS and Windows.
 - Extended supported platforms to include Windows.

--- a/extensions/duckduckgo-image-search/README.md
+++ b/extensions/duckduckgo-image-search/README.md
@@ -1,15 +1,15 @@
-# Duckduckgo Image Search
+# DuckDuckGo Image Search
 
 Search Images inside [Raycast](https://raycast.com) by [DuckDuckGo](https://duckduckgo.com/) Image!
 
 ## Installation
 
-[![Install Duckduckgo Image Search Raycast Extension](https://www.raycast.com/jag-k/duckduckgo-image-search/install_button@2x.png?v=1.1)](https://www.raycast.com/jag-k/duckduckgo-image-search)
+[![Install DuckDuckGo Image Search Raycast Extension](https://www.raycast.com/jag-k/duckduckgo-image-search/install_button@2x.png?v=1.1)](https://www.raycast.com/jag-k/duckduckgo-image-search)
 
 ## Screenshots
 
-![Duckduckgo Image Search Raycast Extension in Raycast menu](https://github.com/jag-k/ddg-image-raycast-extension/raw/main/metadata/duckduckgo-image-search-1.png)
-![Duckduckgo Image Search Raycast Extension in Raycast menu (but with Linus meme)](https://github.com/jag-k/ddg-image-raycast-extension/raw/main/metadata/duckduckgo-image-search-2.png)
+![DuckDuckGo Image Search Raycast Extension in Raycast menu](https://github.com/jag-k/ddg-image-raycast-extension/raw/main/metadata/duckduckgo-image-search-1.png)
+![DuckDuckGo Image Search Raycast Extension in Raycast menu (but with Linus meme)](https://github.com/jag-k/ddg-image-raycast-extension/raw/main/metadata/duckduckgo-image-search-2.png)
 
 ## Links
 

--- a/extensions/duckduckgo-image-search/package.json
+++ b/extensions/duckduckgo-image-search/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "duckduckgo-image-search",
-  "title": "Duckduckgo Image Search",
+  "title": "DuckDuckGo Image Search",
   "description": "Search Images inside Raycast by DuckDuckGo Image!",
   "icon": "extension-icon.png",
   "author": "jag-k",
@@ -114,7 +114,7 @@
   "dependencies": {
     "@raycast/api": "^1.94.0",
     "@raycast/utils": "^1.18.0",
-    "axios": "^1.7.7",
+    "axios": "^1.11.0",
     "html-entities": "^2.5.2",
     "mime-types": "^2.1.35"
   },
@@ -137,9 +137,11 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
+    "pull-contributions": "npx @raycast/api@latest pull-contributions",
     "publish": "npx @raycast/api@latest publish"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ]
 }

--- a/extensions/duckduckgo-image-search/src/search-image.tsx
+++ b/extensions/duckduckgo-image-search/src/search-image.tsx
@@ -36,8 +36,14 @@ function ActionsPanel({ item }: { item: DuckDuckGoImage }) {
       <Action
         title="Paste Image"
         shortcut={{
-          modifiers: ["cmd", "shift"],
-          key: "enter",
+          macOS: {
+            modifiers: ["cmd", "shift"],
+            key: "enter",
+          },
+          windows: {
+            modifiers: ["ctrl", "shift"],
+            key: "enter",
+          },
         }}
         icon={Icon.Clipboard}
         onAction={() =>
@@ -59,8 +65,14 @@ function ActionsPanel({ item }: { item: DuckDuckGoImage }) {
       <Action
         title="Copy Image"
         shortcut={{
-          modifiers: ["cmd", "shift"],
-          key: "c",
+          macOS: {
+            modifiers: ["cmd", "shift"],
+            key: "c",
+          },
+          windows: {
+            modifiers: ["ctrl", "shift"],
+            key: "c",
+          },
         }}
         icon={Icon.Clipboard}
         onAction={() =>
@@ -75,8 +87,14 @@ function ActionsPanel({ item }: { item: DuckDuckGoImage }) {
       <Action
         title="Save Image"
         shortcut={{
-          modifiers: ["cmd"],
-          key: "s",
+          macOS: {
+            modifiers: ["cmd"],
+            key: "s",
+          },
+          windows: {
+            modifiers: ["ctrl"],
+            key: "s",
+          },
         }}
         icon={Icon.Download}
         onAction={() => saveImage(item)}
@@ -85,16 +103,28 @@ function ActionsPanel({ item }: { item: DuckDuckGoImage }) {
         title="Copy Image URL"
         content={item.image}
         shortcut={{
-          modifiers: ["cmd", "opt"],
-          key: "c",
+          macOS: {
+            modifiers: ["cmd", "opt"],
+            key: "c",
+          },
+          windows: {
+            modifiers: ["ctrl", "alt"],
+            key: "c",
+          },
         }}
       />
       <Action.CopyToClipboard
         title="Copy Site URL"
         content={item.url}
         shortcut={{
-          modifiers: ["cmd", "shift", "opt"],
-          key: "c",
+          macOS: {
+            modifiers: ["cmd", "shift", "opt"],
+            key: "c",
+          },
+          windows: {
+            modifiers: ["ctrl", "shift", "alt"],
+            key: "c",
+          },
         }}
       />
     </ActionPanel>

--- a/extensions/duckduckgo-image-search/utils/helpers.ts
+++ b/extensions/duckduckgo-image-search/utils/helpers.ts
@@ -103,7 +103,7 @@ export async function downloadImage(
   await fs.promises.writeFile(filePath, response.data);
   setCachedImagePath(image_token, filePath);
 
-  if (showToast) {
+  if (showToastMessage) {
     await showToast({
       title: "Image Downloaded!",
       style: Toast.Style.Success,
@@ -155,7 +155,7 @@ export async function saveImage(image: DuckDuckGoImage) {
   });
 
   try {
-    // Download the image to temp folder first
+    // Download the image to the temp folder first
     const tempFile = await downloadImage(image, false);
 
     // Create a clean filename from the image title
@@ -164,13 +164,17 @@ export async function saveImage(image: DuckDuckGoImage) {
       .replace(/\s+/g, "_") // Replace spaces with underscores
       .substring(0, 100); // Limit filename length
 
-    // Get file extension from temp file
+    // Get file extension from a temp file
     const extension = path.extname(tempFile);
     const filename = `${cleanTitle || "duckduckgo_image"}_${image.image_token}${extension}`;
 
     // Get save directory from preferences (with fallback to ~/Downloads)
-    const allPreferences = getPreferenceValues<Preferences & { saveDirectory?: string }>();
+    const allPreferences = getPreferenceValues<Preferences>();
     const saveDirectory = expandTildePath(allPreferences.saveDirectory || "~/Downloads");
+    if (!saveDirectory) {
+      // noinspection ExceptionCaughtLocallyJS
+      throw new Error("Save directory is not set");
+    }
 
     // Ensure the save directory exists
     await fs.promises.mkdir(saveDirectory, { recursive: true });


### PR DESCRIPTION
## Description

- Added platform-specific shortcuts for macOS and Windows.
- Extended supported platforms to include Windows.
- Introduced a fallback for the download directory and added validation.
- Standardized naming to "DuckDuckGo" in metadata and documentation.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
