### PR TITLE
feat(imessage-2fa): add support for the 2FA from Epos Card Japan

### DIFF
--- a/extensions/imessage-2fa/CHANGELOG.md
+++ b/extensions/imessage-2fa/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Messages 2FA Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2025-11-08
 - Add support for Epos Card 2FA (Japanese Credit Card)
 
 ## [Update] - 2025-04-29

--- a/extensions/imessage-2fa/CHANGELOG.md
+++ b/extensions/imessage-2fa/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Messages 2FA Changelog
 
+## [Update] - {PR_MERGE_DATE}
+- Add support for Epos Card 2FA (Japanese Credit Card)
+
 ## [Update] - 2025-04-29
 - Resolves issue with code extraction for iMessage
 

--- a/extensions/imessage-2fa/package.json
+++ b/extensions/imessage-2fa/package.json
@@ -11,7 +11,8 @@
     "ronaldheft",
     "hitolaus",
     "taschaub",
-    "omaerkhan"
+    "omaerkhan",
+    "clins1994"
   ],
   "pastContributors": [
     "navtoj"

--- a/extensions/imessage-2fa/src/utils.test.ts
+++ b/extensions/imessage-2fa/src/utils.test.ts
@@ -53,6 +53,10 @@ describe("Testing matching logic", () => {
     expect(extractCode("123-456")).toBe("123456");
     expect(extractCode("Your Stripe verification code is: 719-839.")).toBe("719839");
   });
+
+  test("Japanese 2FA message with full-width colon", () => {
+    expect(extractCode("ご利用金額をご確認ください 金額：20JPY パスワード：11223344 フィッシング詐欺にご注意！ エポスカード")).toBe("11223344");
+  });
 });
 
 describe("Testing verification link extraction", () => {

--- a/extensions/imessage-2fa/src/utils.test.ts
+++ b/extensions/imessage-2fa/src/utils.test.ts
@@ -55,7 +55,9 @@ describe("Testing matching logic", () => {
   });
 
   test("Japanese 2FA message with full-width colon", () => {
-    expect(extractCode("ご利用金額をご確認ください 金額：20JPY パスワード：11223344 フィッシング詐欺にご注意！ エポスカード")).toBe("11223344");
+    expect(
+      extractCode("ご利用金額をご確認ください 金額：20JPY パスワード：11223344 フィッシング詐欺にご注意！ エポスカード")
+    ).toBe("11223344");
   });
 });
 

--- a/extensions/imessage-2fa/src/utils.ts
+++ b/extensions/imessage-2fa/src/utils.ts
@@ -30,10 +30,11 @@ export function extractCode(original: string): string | null {
   if ((m = /^(\d{4,8})(\sis your.*code)/.exec(message)) !== null) {
     code = m[1];
   } else if (
-    // Look for the last occurrence of "code: DIGITS" pattern
+    // Look for the last occurrence of "code: DIGITS" pattern (including Japanese and full-width colons)
     // This helps with cases like "test code: test code: 883848" where we want the last match
+    // Supports: code:, is:, 码 (with or without colon), use code, passcode:, autorização:, código:, パスワード： (Japanese password)
     (m =
-      /(code\s*:|is\s*:|码|use code|passcode\s*:|autoriza(?:ca|çã)o\s*:|c(?:o|ó)digo\s*:)\s*(\d{4,8})($|\s|\\R|\t|\b|\.|,)/i.exec(
+      /(code\s*[：:]|is\s*[：:]|码[：:]?|use code|passcode\s*[：:]|autoriza(?:ca|çã)o\s*[：:]|c(?:o|ó)digo\s*[：:]|パスワード[：:])\s*(\d{4,8})($|\s|\\R|\t|\b|\.|,)/i.exec(
         message
       )) !== null
   ) {
@@ -41,12 +42,12 @@ export function extractCode(original: string): string | null {
     code = findLastMatchingCode(
       message,
       m,
-      /(code\s*:|is\s*:|码|use code|passcode\s*:|autoriza(?:ca|çã)o\s*:|c(?:o|ó)digo\s*:)\s*(\d{4,8})($|\s|\\R|\t|\b|\.|,)/i
+      /(code\s*[：:]|is\s*[：:]|码[：:]?|use code|passcode\s*[：:]|autoriza(?:ca|çã)o\s*[：:]|c(?:o|ó)digo\s*[：:]|パスワード[：:])\s*(\d{4,8})($|\s|\\R|\t|\b|\.|,)/i
     );
   } else if (
-    // Modified to match alphanumeric codes
+    // Modified to match alphanumeric codes (including Japanese and full-width colons)
     (m =
-      /(code\s*:|is\s*:|码|use code|passcode\s*:|autoriza(?:ca|çã)o\s*:|c(?:o|ó)digo\s*:)\s*([A-Z0-9]{4,8})($|\s|\\R|\t|\b|\.|,)/i.exec(
+      /(code\s*[：:]|is\s*[：:]|码[：:]?|use code|passcode\s*[：:]|autoriza(?:ca|çã)o\s*[：:]|c(?:o|ó)digo\s*[：:]|パスワード[：:])\s*([A-Z0-9]{4,8})($|\s|\\R|\t|\b|\.|,)/i.exec(
         message
       )) !== null
   ) {
@@ -54,7 +55,7 @@ export function extractCode(original: string): string | null {
     code = findLastMatchingCode(
       message,
       m,
-      /(code\s*:|is\s*:|码|use code|passcode\s*:|autoriza(?:ca|çã)o\s*:|c(?:o|ó)digo\s*:)\s*([A-Z0-9]{4,8})($|\s|\\R|\t|\b|\.|,)/i
+      /(code\s*[：:]|is\s*[：:]|码[：:]?|use code|passcode\s*[：:]|autoriza(?:ca|çã)o\s*[：:]|c(?:o|ó)digo\s*[：:]|パスワード[：:])\s*([A-Z0-9]{4,8})($|\s|\\R|\t|\b|\.|,)/i
     );
   } else {
     // more generic, brute force patterns
@@ -65,15 +66,15 @@ export function extractCode(original: string): string | null {
 
     message = message.replaceAll(phoneRegex, "");
 
-    if ((m = /(^|\s|\\R|\t|\b|G-|:)(\d{5,8})($|\s|\\R|\t|\b|\.|,)/.exec(message)) !== null) {
+    if ((m = /(^|\s|\\R|\t|\b|G-|[：:])(\d{5,8})($|\s|\\R|\t|\b|\.|,)/.exec(message)) !== null) {
       code = m[2];
     } else if ((m = /\b(?=[A-Z]*[0-9])(?=[0-9]*[A-Z])[0-9A-Z]{3,8}\b/.exec(message)) !== null) {
       code = m[0];
-    } else if ((m = /(^|code:|is:|\b)\s*(\d{3})-(\d{3})($|\s|\\R|\t|\b|\.|,)/i.exec(message)) !== null) {
+    } else if ((m = /(^|code[：:]|is[：:]|\b)\s*(\d{3})-(\d{3})($|\s|\\R|\t|\b|\.|,)/i.exec(message)) !== null) {
       const first = m[2];
       const second = m[3];
       code = `${first}${second}`;
-    } else if ((m = /(code|is):?\s*(\d{3,8})($|\s|\\R|\t|\b|\.|,)/i.exec(message)) !== null) {
+    } else if ((m = /(code|is)[：:]?\s*(\d{3,8})($|\s|\\R|\t|\b|\.|,)/i.exec(message)) !== null) {
       code = m[2];
     }
   }


### PR DESCRIPTION
## Description

✅ Add support for the 2FA from Epos Card Japan  👍 

## Tests

✅ Add a unit test for it
✅ Ran locally (see screenshot)

<img width="1000" height="625" alt="imessage-2fa 2025-11-03 at 00 50 18" src="https://github.com/user-attachments/assets/e53b45c9-89e3-4238-b7c2-9f48130e6881" />

## Considerations

We could try to ask AI to extract these codes as a fallback 💡 

If I run into the same issue again I'll try to do it ...