### PR TITLE
Update font-awesome extension

### DIFF
--- a/extensions/fontawesome/.gitignore
+++ b/extensions/fontawesome/.gitignore
@@ -27,3 +27,4 @@ raycast-env.d.ts
 .raycast-swift-build
 .swiftpm
 compiled_raycast_swift
+*.code-workspace

--- a/extensions/fontawesome/CHANGELOG.md
+++ b/extensions/fontawesome/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Font Awesome Changelog
 
-## [Added Custom Kits Support for Pro accounts] - {PR_MERGE_DATE}
+## [Added Custom Kits Support for Pro accounts] - 2025-11-25
 
 - Added support for browsing and searching custom kit icons
 - Added "Remember Last Used Kit" preference to restore your previous selection on launch

--- a/extensions/fontawesome/CHANGELOG.md
+++ b/extensions/fontawesome/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Font Awesome Changelog
 
+## [Added Custom Kits Support for Pro accounts] - {PR_MERGE_DATE}
+
+- Added support for browsing and searching custom kit icons
+- Added "Remember Last Used Kit" preference to restore your previous selection on launch
+- Added "Filter Custom Kits" preference to limit which kits appear in the dropdown
+
 ## [Improvements] - 2025-10-13
 
 - Fixed issue where the search would sometimes fail and the cached state gets corrupted (ref: [Issue #22051](https://github.com/raycast/extensions/issues/22051))

--- a/extensions/fontawesome/font-awesome.code-workspace
+++ b/extensions/fontawesome/font-awesome.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/extensions/fontawesome/package.json
+++ b/extensions/fontawesome/package.json
@@ -11,7 +11,8 @@
     "ridemountainpig",
     "yusifaliyevpro",
     "xmok",
-    "j3lte"
+    "j3lte",
+    "hellonicolas"
   ],
   "categories": [
     "Design Tools",
@@ -32,7 +33,7 @@
       "type": "password",
       "required": false,
       "title": "API Token (For Font Awesome Pro Accounts)",
-      "description": "Optionally Use Font Awesome Pro icons by providing an API Token, not necessary to access free icons."
+      "description": "Optionally use Font Awesome Pro icons and custom kits by providing an API Token. Not necessary to access free icons."
     },
     {
       "name": "STYLE_PREFERENCE",
@@ -113,6 +114,21 @@
       ],
       "title": "Icon primary action",
       "description": "Choose which action to perform when selecting an icon."
+    },
+    {
+      "name": "REMEMBER_LAST_KIT",
+      "type": "checkbox",
+      "required": false,
+      "default": false,
+      "label": "Remember Last Used Kit",
+      "description": "When enabled, the extension will open with your previously selected icon style or custom kit."
+    },
+    {
+      "name": "KIT_FILTER",
+      "type": "textfield",
+      "required": false,
+      "title": "Filter Custom Kits",
+      "description": "Limit which custom kits appear in the dropdown. Enter kit names or IDs separated by commas (e.g., \"My Icons, abc123\"). Leave empty to show all kits."
     }
   ],
   "dependencies": {

--- a/extensions/fontawesome/src/components/StyleSelector.tsx
+++ b/extensions/fontawesome/src/components/StyleSelector.tsx
@@ -1,13 +1,16 @@
 import { Color, Grid } from "@raycast/api";
+import type { Kit } from "@/types";
 import { familyStylesByPrefix, iconForStyle } from "@/utils/data";
 
 type StyleSelectorProps = {
   setType: (newValue: string) => void;
   STYLE_PREFERENCE: string;
   account: string;
+  kits?: Kit[];
+  isKitsLoading?: boolean;
 };
 
-export const StyleSelector = ({ setType, STYLE_PREFERENCE, account }: StyleSelectorProps) => {
+export const StyleSelector = ({ setType, STYLE_PREFERENCE, account, kits }: StyleSelectorProps) => {
   return (
     <Grid.Dropdown
       tooltip="Select Family & Style"
@@ -64,6 +67,18 @@ export const StyleSelector = ({ setType, STYLE_PREFERENCE, account }: StyleSelec
                 />
               ))}
           </Grid.Dropdown.Section>
+          {kits && kits.length > 0 && (
+            <Grid.Dropdown.Section title="Custom Kits">
+              {kits.map((kit) => (
+                <Grid.Dropdown.Item
+                  key={`kit:${kit.id ?? kit.token}`}
+                  title={kit.name}
+                  value={`kit:${kit.id ?? kit.token}`}
+                  icon={{ source: iconForStyle("fas"), tintColor: Color.SecondaryText }}
+                />
+              ))}
+            </Grid.Dropdown.Section>
+          )}
         </>
       ) : (
         <>

--- a/extensions/fontawesome/src/hooks/useData.ts
+++ b/extensions/fontawesome/src/hooks/useData.ts
@@ -1,19 +1,26 @@
 import { useCachedState, useFetch } from "@raycast/utils";
-import { SearchResult } from "@/types";
+import type { KitIconsResult, SearchItem, SearchResult } from "@/types";
 import { familyStylesByPrefix } from "@/utils/data";
-import { iconQuery } from "@/utils/query";
+import { iconQuery, kitIconsQuery } from "@/utils/query";
+
+type ApiResult = SearchResult | KitIconsResult | undefined;
 
 export const useData = (accessToken: string, execute: boolean, query: string, type: string) => {
-  const [iconData, setIconData] = useCachedState<SearchResult>("iconData");
+  const [iconData, setIconData] = useCachedState<ApiResult>("iconData");
 
-  // Fetch icons for a specific family and style based on query
-  const { isLoading, data, revalidate } = useFetch<SearchResult>("https://api.fontawesome.com", {
+  const isKitSelection = type.startsWith("kit:");
+  const kitToken = isKitSelection ? type.replace("kit:", "") : "";
+
+  const body = isKitSelection ? kitIconsQuery() : iconQuery(query, familyStylesByPrefix[type]);
+
+  // Fetch icons for a specific family/style or kit based on query
+  const { isLoading, data, revalidate } = useFetch<ApiResult>("https://api.fontawesome.com", {
     execute: !!(accessToken && execute),
     keepPreviousData: true,
     method: "POST",
-    body: iconQuery(query, familyStylesByPrefix[type]),
-    onData: (data) => {
-      setIconData(data);
+    body,
+    onData: (result) => {
+      setIconData(result);
     },
     headers: {
       Accept: "application/json",
@@ -21,7 +28,62 @@ export const useData = (accessToken: string, execute: boolean, query: string, ty
     },
   });
 
-  const filteredData = ((iconData || data)?.data?.search || []).filter((searchItem) => searchItem.svgs.length != 0);
+  const raw = iconData || data;
+
+  let normalized: SearchItem[] = [];
+
+  if (raw) {
+    if (isKitSelection) {
+      const kitResult = raw as KitIconsResult;
+      const kits = kitResult?.data?.me?.kits ?? [];
+      const kit = kits.find((k: { token: string; id: string }) => k.token === kitToken || k.id === kitToken) ?? kits[0];
+      const uploads = kit?.iconUploads ?? [];
+
+      const trimmedQuery = query.trim().toLowerCase();
+
+      normalized = uploads
+        .filter((upload) => {
+          if (!trimmedQuery) {
+            return true;
+          }
+
+          const nameMatch = upload.name.toLowerCase().includes(trimmedQuery);
+
+          const unicodeValue = upload.unicode;
+          const unicodeString =
+            typeof unicodeValue === "string" || typeof unicodeValue === "number" ? String(unicodeValue) : "";
+          const unicodeMatch = unicodeString.toLowerCase().includes(trimmedQuery);
+
+          return nameMatch || unicodeMatch;
+        })
+        .map((upload) => {
+          const rawPathData = upload.pathData;
+          const paths = Array.isArray(rawPathData) ? rawPathData : [rawPathData];
+
+          const svgHtml = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${upload.width} ${upload.height}">${paths
+            .map((d) => `<path d="${d}"/>`)
+            .join("")}</svg>`;
+
+          return {
+            id: upload.name,
+            unicode: upload.unicode ?? "",
+            svgs: [
+              {
+                html: svgHtml,
+                familyStyle: {
+                  prefix: "kit",
+                },
+              },
+            ],
+          };
+        });
+    } else {
+      const searchResult = raw as SearchResult;
+      normalized = (searchResult?.data?.search ?? []) as SearchItem[];
+    }
+  }
+
+  const filteredData = normalized.filter((searchItem) => searchItem.svgs.length != 0);
 
   return { isLoading, data: filteredData, revalidate };
 };

--- a/extensions/fontawesome/src/hooks/useKits.ts
+++ b/extensions/fontawesome/src/hooks/useKits.ts
@@ -34,8 +34,10 @@ export const useKits = (accessToken: string, execute: boolean, kitFilter?: strin
 
     if (tokensOrNames.length > 0) {
       filteredKits = allKits.filter((kit) => {
-        const nameLower = kit.name.toLowerCase();
-        return tokensOrNames.some((value) => value === kit.token || value === kit.id || value === nameLower);
+        const nameLower = kit.name?.toLowerCase() ?? "";
+        const tokenLower = kit.token?.toLowerCase() ?? "";
+        const idLower = kit.id?.toLowerCase() ?? "";
+        return tokensOrNames.some((value) => value === tokenLower || value === idLower || value === nameLower);
       });
     }
   }

--- a/extensions/fontawesome/src/hooks/useKits.ts
+++ b/extensions/fontawesome/src/hooks/useKits.ts
@@ -1,0 +1,44 @@
+import { useCachedState, useFetch } from "@raycast/utils";
+import type { Kit, KitsResult } from "@/types";
+import { kitsQuery } from "@/utils/query";
+
+export const useKits = (accessToken: string, execute: boolean, kitFilter?: string) => {
+  const [cachedKits, setCachedKits] = useCachedState<Kit[]>("kits", []);
+
+  const { isLoading, data, revalidate } = useFetch<KitsResult>("https://api.fontawesome.com", {
+    execute: !!(accessToken && execute),
+    keepPreviousData: true,
+    method: "POST",
+    body: kitsQuery(),
+    onData: (result) => {
+      const kits = result?.data?.me?.kits ?? [];
+      setCachedKits(kits);
+    },
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const allKits = (cachedKits && cachedKits.length > 0 ? cachedKits : data?.data?.me?.kits) ?? [];
+
+  const trimmedFilter = kitFilter?.trim();
+  let filteredKits: Kit[] = allKits;
+
+  if (trimmedFilter && allKits.length > 0) {
+    const tokensOrNames = trimmedFilter
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => s.toLowerCase());
+
+    if (tokensOrNames.length > 0) {
+      filteredKits = allKits.filter((kit) => {
+        const nameLower = kit.name.toLowerCase();
+        return tokensOrNames.some((value) => value === kit.token || value === kit.id || value === nameLower);
+      });
+    }
+  }
+
+  return { kits: filteredKits, isLoading, revalidate };
+};

--- a/extensions/fontawesome/src/hooks/usePreferences.ts
+++ b/extensions/fontawesome/src/hooks/usePreferences.ts
@@ -1,7 +1,9 @@
 import { getPreferenceValues } from "@raycast/api";
 
 export const usePreferences = () => {
-  let { API_TOKEN, STYLE_PREFERENCE } = getPreferenceValues<Preferences>();
+  const preferences = getPreferenceValues<Preferences>();
+  let { API_TOKEN, STYLE_PREFERENCE } = preferences;
+  const { KIT_FILTER, REMEMBER_LAST_KIT } = preferences;
   let account = "pro";
 
   //if pro API Token not provided, use free API Token
@@ -11,5 +13,5 @@ export const usePreferences = () => {
     STYLE_PREFERENCE = "fas";
   }
 
-  return { API_TOKEN, STYLE_PREFERENCE, account };
+  return { API_TOKEN, STYLE_PREFERENCE, account, kitFilter: KIT_FILTER, rememberLastKit: REMEMBER_LAST_KIT };
 };

--- a/extensions/fontawesome/src/types/index.ts
+++ b/extensions/fontawesome/src/types/index.ts
@@ -1,14 +1,17 @@
 export interface SearchResult {
-  data: Data;
+  data: SearchData;
 }
-interface Data {
+
+interface SearchData {
   search: SearchItem[];
 }
+
 export interface SearchItem {
   id: string;
   svgs: SvgsItem[];
   unicode: string;
 }
+
 interface SvgsItem {
   html: string;
   familyStyle: {
@@ -21,4 +24,44 @@ export interface TokenData {
   expires_in: number;
   scopes: string[];
   token_type: string;
+}
+
+// Kits metadata returned from the Font Awesome GraphQL API
+export interface Kit {
+  id: string;
+  name: string;
+  token: string;
+}
+
+export interface KitsResult {
+  data: {
+    me: {
+      kits: Kit[];
+    };
+  };
+}
+
+// Icon uploads that belong to a specific kit
+export interface KitIconUpload {
+  name: string;
+  id?: string;
+  unicode?: string;
+  width: number;
+  height: number;
+  version?: number;
+  // The API may return either a single path string or an array of path strings
+  pathData: string | string[];
+}
+
+export interface KitIconsResult {
+  data: {
+    me: {
+      kits: {
+        id: string;
+        name: string;
+        token: string;
+        iconUploads: KitIconUpload[];
+      }[];
+    };
+  };
 }

--- a/extensions/fontawesome/src/utils/actions.ts
+++ b/extensions/fontawesome/src/utils/actions.ts
@@ -22,10 +22,18 @@ export const copyFAUnicodeClipboard = async (icon: SearchItem) => {
 };
 
 export const copyFAClassesToClipboard = async (icon: SearchItem) => {
+  const prefix = icon.svgs[0].familyStyle.prefix;
+
+  // Handle custom kit icons differently
+  if (prefix === "kit") {
+    const faClass = `fa-kit fa-${icon.id}`;
+    await Clipboard.copy(faClass);
+    await showHUD("Copied classes to clipboard!");
+    return;
+  }
+
   // Get first style of icon, or use the default iconStyle
-  const faClass = `fa-${familyStylesByPrefix[icon.svgs[0].familyStyle.prefix].split(", ")[1].toLowerCase()} fa-${
-    icon.id
-  }`;
+  const faClass = `fa-${familyStylesByPrefix[prefix].split(", ")[1].toLowerCase()} fa-${icon.id}`;
   await Clipboard.copy(faClass);
   await showHUD("Copied classes to clipboard!");
 };

--- a/extensions/fontawesome/src/utils/query.ts
+++ b/extensions/fontawesome/src/utils/query.ts
@@ -1,21 +1,50 @@
-//GraphQL Query to fetch icons for a specific style
+// GraphQL query to fetch icons for a specific style
 export const iconQuery = (squery: string, stype: string) => `query Search {
-    search(query:"${squery}", version: "6.7.2", first: 48) {
-        id
-        unicode
-        svgs(filter: { familyStyles: [
-          { family: ${
-            stype.split(" ").length === 3
-              ? stype.split(", ")[0].replace(" ", "_").toUpperCase()
-              : stype.split(", ")[0].toUpperCase()
-          }, style: ${stype.split(", ")[1].toUpperCase()} }
-          { family: CLASSIC, style: BRANDS }
-        ] }) {
-            html
-            familyStyle{
-              prefix
-            }
-        }
+  search(query:"${squery}", version: "6.7.2", first: 48) {
+    id
+    unicode
+    svgs(filter: { familyStyles: [
+      { family: ${
+        stype.split(" ").length === 3
+          ? stype.split(", ")[0].replace(" ", "_").toUpperCase()
+          : stype.split(", ")[0].toUpperCase()
+      }, style: ${stype.split(", ")[1].toUpperCase()} }
+      { family: CLASSIC, style: BRANDS }
+    ] }) {
+      html
+      familyStyle{
+        prefix
+      }
     }
   }
+}
+`;
+
+// GraphQL query to fetch the current user's kits
+export const kitsQuery = () => `query Kits {
+  me {
+    kits {
+      name
+      token
+    }
+  }
+}
+`;
+
+// GraphQL query to fetch icon uploads for all kits (we'll filter client-side by token)
+export const kitIconsQuery = () => `query KitIcons {
+  me {
+    kits {
+      name
+      token
+      iconUploads {
+        name
+        unicode
+        width
+        height
+        pathData
+      }
+    }
+  }
+}
 `;


### PR DESCRIPTION
## Description

We use custom kits on our team and I always forget the names of our icons 😂 Raycast feels like the fastest way to get  information at my fingertips, so I updated this extension to support for custom kits if you've entered an API token, as well as filter the returned custom kits. Bonus: added a preference to remember your last used kit because I got tired of switching kits every time.

## Screencast

https://github.com/user-attachments/assets/ad9c9dce-4e8b-4722-943c-349d4017c9f5

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
