### PR TITLE
Update bitwarden extension

### DIFF
--- a/extensions/bitwarden/CHANGELOG.md
+++ b/extensions/bitwarden/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Bitwarden Changelog
 
-## [Added PasteUsernameAction] - {PR_MERGE_DATE}
+## [Added PasteUsernameAction] - 2026-01-01
 
 ## [Added support for Windows] - 2025-10-15
 

--- a/extensions/bitwarden/CHANGELOG.md
+++ b/extensions/bitwarden/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Bitwarden Changelog
 
+## [Added PasteUsernameAction] - {PR_MERGE_DATE}
+
 ## [Added support for Windows] - 2025-10-15
 
 ## [New Command] - 2025-10-07

--- a/extensions/bitwarden/package.json
+++ b/extensions/bitwarden/package.json
@@ -17,7 +17,8 @@
     "gaspihabif",
     "marinsokol",
     "jose-elias-alvarez",
-    "krambono"
+    "krambono",
+    "clins1994"
   ],
   "pastContributors": [
     "pomdtr"

--- a/extensions/bitwarden/src/components/searchVault/ItemActionPanel.tsx
+++ b/extensions/bitwarden/src/components/searchVault/ItemActionPanel.tsx
@@ -7,6 +7,7 @@ import {
   CopyUsernameAction,
   OpenUrlInBrowserAction,
   PastePasswordAction,
+  PasteUsernameAction,
   ShowCardDetailsAction,
   ShowNotesAction,
   ShowIdentityDetailsAction,
@@ -39,7 +40,10 @@ const VaultItemActionPanel = () => {
           </ComponentReverser>
           <CopyTotpAction />
           <PasteTotpAction />
-          <CopyUsernameAction />
+          <ComponentReverser reverse={primaryAction === "paste"}>
+            <CopyUsernameAction />
+            <PasteUsernameAction />
+          </ComponentReverser>
           <OpenUrlInBrowserAction />
           <CopyLoginUrisActions />
           <ShowNotesAction />

--- a/extensions/bitwarden/src/components/searchVault/ItemActionPanel.tsx
+++ b/extensions/bitwarden/src/components/searchVault/ItemActionPanel.tsx
@@ -40,10 +40,8 @@ const VaultItemActionPanel = () => {
           </ComponentReverser>
           <CopyTotpAction />
           <PasteTotpAction />
-          <ComponentReverser reverse={primaryAction === "paste"}>
-            <CopyUsernameAction />
-            <PasteUsernameAction />
-          </ComponentReverser>
+          <CopyUsernameAction />
+          <PasteUsernameAction />
           <OpenUrlInBrowserAction />
           <CopyLoginUrisActions />
           <ShowNotesAction />

--- a/extensions/bitwarden/src/components/searchVault/actions/PasteUsernameAction.tsx
+++ b/extensions/bitwarden/src/components/searchVault/actions/PasteUsernameAction.tsx
@@ -28,6 +28,10 @@ function PasteUsernameAction() {
       icon={Icon.Window}
       onAction={pasteUsername}
       repromptDescription={`Pasting the username of <${selectedItem.name}>`}
+      shortcut={{
+        macOS: { key: "u", modifiers: ["cmd", "opt"] },
+        windows: { key: "u", modifiers: ["ctrl", "alt"] },
+      }}
     />
   );
 }

--- a/extensions/bitwarden/src/components/searchVault/actions/PasteUsernameAction.tsx
+++ b/extensions/bitwarden/src/components/searchVault/actions/PasteUsernameAction.tsx
@@ -8,7 +8,7 @@ import useFrontmostApplicationName from "~/utils/hooks/useFrontmostApplicationNa
 function PasteUsernameAction() {
   const selectedItem = useSelectedVaultItem();
   const getUpdatedVaultItem = useGetUpdatedVaultItem();
-  const actionTitle = useActionTitle();
+  const currentApplication = useFrontmostApplicationName();
 
   if (!selectedItem.login?.username) return null;
 
@@ -24,7 +24,7 @@ function PasteUsernameAction() {
 
   return (
     <ActionWithReprompt
-      title={actionTitle}
+      title={currentApplication ? `Paste Username into ${currentApplication}` : "Paste Username"}
       icon={Icon.Window}
       onAction={pasteUsername}
       repromptDescription={`Pasting the username of <${selectedItem.name}>`}
@@ -34,11 +34,6 @@ function PasteUsernameAction() {
       }}
     />
   );
-}
-
-function useActionTitle() {
-  const currentApplication = useFrontmostApplicationName();
-  return currentApplication ? `Paste Username into ${currentApplication}` : "Paste Username";
 }
 
 export default PasteUsernameAction;

--- a/extensions/bitwarden/src/components/searchVault/actions/PasteUsernameAction.tsx
+++ b/extensions/bitwarden/src/components/searchVault/actions/PasteUsernameAction.tsx
@@ -1,0 +1,40 @@
+import { Clipboard, Icon, Toast, showToast } from "@raycast/api";
+import ActionWithReprompt from "~/components/actions/ActionWithReprompt";
+import { useSelectedVaultItem } from "~/components/searchVault/context/vaultItem";
+import useGetUpdatedVaultItem from "~/components/searchVault/utils/useGetUpdatedVaultItem";
+import { captureException } from "~/utils/development";
+import useFrontmostApplicationName from "~/utils/hooks/useFrontmostApplicationName";
+
+function PasteUsernameAction() {
+  const selectedItem = useSelectedVaultItem();
+  const getUpdatedVaultItem = useGetUpdatedVaultItem();
+  const actionTitle = useActionTitle();
+
+  if (!selectedItem.login?.username) return null;
+
+  const pasteUsername = async () => {
+    try {
+      const username = await getUpdatedVaultItem(selectedItem, (item) => item.login?.username, "Getting username...");
+      if (username) await Clipboard.paste(username);
+    } catch (error) {
+      await showToast(Toast.Style.Failure, "Failed to get username");
+      captureException("Failed to paste username", error);
+    }
+  };
+
+  return (
+    <ActionWithReprompt
+      title={actionTitle}
+      icon={Icon.Window}
+      onAction={pasteUsername}
+      repromptDescription={`Pasting the username of <${selectedItem.name}>`}
+    />
+  );
+}
+
+function useActionTitle() {
+  const currentApplication = useFrontmostApplicationName();
+  return currentApplication ? `Paste Username into ${currentApplication}` : "Paste Username";
+}
+
+export default PasteUsernameAction;

--- a/extensions/bitwarden/src/components/searchVault/actions/index.ts
+++ b/extensions/bitwarden/src/components/searchVault/actions/index.ts
@@ -3,6 +3,7 @@ export { default as PastePasswordAction } from "./PastePasswordAction";
 export { default as CopyTotpAction } from "./CopyTotpAction";
 export { default as PasteTotpAction } from "./PasteTotpAction";
 export { default as CopyUsernameAction } from "./CopyUsernameAction";
+export { default as PasteUsernameAction } from "./PasteUsernameAction";
 export { default as OpenUrlInBrowserAction } from "./OpenUrlInBrowserAction";
 export { default as ShowCardDetailsAction } from "./ShowCardDetailsAction";
 export { default as ShowIdentityDetailsAction } from "./ShowIdentityDetailsAction";


### PR DESCRIPTION
## Description

Adds "PasteUsername" Action for conveniently pasting username to frontmost app 😄 

Since copy username is ALT + U I made the shortcut on Mac/Windows to be CMD + ALT + U / CTRL + ALT + U

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
