### PR TITLE
[Spotify Player] show error view in queue + keyboard shortcut for add + mark as `premium`

### DIFF
--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Spotify Player Changelog
 
+## [Show Error View in Queue] - {PR_MERGE_DATE}
+
+- When an error occurs in queue, show the error view
+- Add "queue" to README and mark as premium-only
+
 ## [Generate Playlist Improvements] - 2025-12-05
 
 - Updated AI model from **GPT-4o mini** to **GPT-5 Mini** for higher-quality playlist generation  

--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Spotify Player Changelog
 
-## [Show Error View in Queue] - {PR_MERGE_DATE}
+## [Show Error View in Queue] - 2026-01-01
 
 - Add "queue" to README and mark as premium-only
 - When an error occurs in queue, show the error view

--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [Show Error View in Queue] - {PR_MERGE_DATE}
 
-- When an error occurs in queue, show the error view
 - Add "queue" to README and mark as premium-only
+- When an error occurs in queue, show the error view
+- When an error occurs in devices, show the error view
 
 ## [Generate Playlist Improvements] - 2025-12-05
 

--- a/extensions/spotify-player/README.md
+++ b/extensions/spotify-player/README.md
@@ -6,6 +6,8 @@ Spotify's most common features, now at your fingertips. Search for music and pod
 
 ## Commands
 
+> Commands with "💸" require Spotify Premium
+
 ### Search
 
 A single unified search command. Use this to search for artists, albums, songs, playlists, podcasts, and episodes. Use the dropdown menu to filter your search to a specific category. Each category offers contextual actions, so you can dive deeper into the search.
@@ -121,6 +123,10 @@ Use this to skip ahead 15 seconds.
 ### Back 15 Seconds
 
 Use this to go back 15 seconds.
+
+### Queue (💸)
+
+Use this to see your queue.
 
 ---
 

--- a/extensions/spotify-player/package-lock.json
+++ b/extensions/spotify-player/package-lock.json
@@ -7,8 +7,8 @@
       "name": "spotify-player",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.103.0",
-        "@raycast/utils": "^2.2.1",
+        "@raycast/api": "^1.104.1",
+        "@raycast/utils": "^2.2.2",
         "@types/async-retry": "^1.4.9",
         "@types/node-fetch": "^2.6.13",
         "async-retry": "^1.3.3",
@@ -1262,9 +1262,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.103.6",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.103.6.tgz",
-      "integrity": "sha512-x34deBLt8BNCIztMjsYPU8eGz4xFp444PJzxybIvDt86ZCk6phlTLD11qtkyZKOURFIoncebNDVTJn5KdO09nA==",
+      "version": "1.104.1",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.1.tgz",
+      "integrity": "sha512-5v52JDzAAoCA6/JOoBfsgCXK4fzIY02lvMH0IA3ghuxZuk8i2ID2rtPkTuIAbebpkILADB7gP4yaBphkMLiCJA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.5.4",
@@ -1356,9 +1356,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.1.tgz",
-      "integrity": "sha512-MBOD3eccHTu1HVQstoqoJJsA5PubWv18EUq8Dxwg1PEJE+xVjEuslXpsNgR/2RtpTGeKgGiXePxUiVp5mILN5w==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.2.tgz",
+      "integrity": "sha512-tZcyWCHZvz4L/i1CGEnSZkBoK6wwX1pzlTKjcWWugbrQyG0QCMOxjKJfRC/iNkD+hHaqhMWUj4Y0LNo/NknvFw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"

--- a/extensions/spotify-player/package.json
+++ b/extensions/spotify-player/package.json
@@ -592,10 +592,11 @@
     "typescript": "^5.9.2"
   },
   "scripts": {
-    "build": "ray build -e dist",
+    "build": "ray build",
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
+    "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish",
     "generate-spotify-client": "oazapfts --optimistic ./fixed-spotify-open-api.yml ./src/helpers/spotify.api.ts"
   },

--- a/extensions/spotify-player/package.json
+++ b/extensions/spotify-player/package.json
@@ -41,7 +41,8 @@
     "kartheesan05",
     "joshkat",
     "CaffeineCat",
-    "AdrianKokot"
+    "AdrianKokot",
+    "xmok"
   ],
   "pastContributors": [
     "bkeys818",
@@ -573,8 +574,8 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.103.0",
-    "@raycast/utils": "^2.2.1",
+    "@raycast/api": "^1.104.1",
+    "@raycast/utils": "^2.2.2",
     "@types/async-retry": "^1.4.9",
     "@types/node-fetch": "^2.6.13",
     "async-retry": "^1.3.3",

--- a/extensions/spotify-player/src/components/AddtoQueueAction.tsx
+++ b/extensions/spotify-player/src/components/AddtoQueueAction.tsx
@@ -14,7 +14,10 @@ export function AddToQueueAction({ uri, title }: AddToQueueActionProps) {
     <Action
       icon={Icon.Plus}
       title="Add to Queue"
-      shortcut={{ modifiers: ["opt"], key: "q" }}
+      shortcut={{
+        macOS: { modifiers: ["opt"], key: "q" },
+        Windows: { modifiers: ["alt"], key: "q" },
+      }}
       onAction={async () => {
         try {
           await addToQueue({ uri });

--- a/extensions/spotify-player/src/components/PlayAction.tsx
+++ b/extensions/spotify-player/src/components/PlayAction.tsx
@@ -14,7 +14,7 @@ type PlayActionProps = {
 };
 
 export function PlayAction({ id, type, playingContext, onPlay, tracksToQueue }: PlayActionProps) {
-  const { closeWindowOnAction } = getPreferenceValues<{ closeWindowOnAction?: boolean }>();
+  const { closeWindowOnAction } = getPreferenceValues<ExtensionPreferences>();
 
   const handlePlayAction = async () => {
     try {

--- a/extensions/spotify-player/src/devices.tsx
+++ b/extensions/spotify-player/src/devices.tsx
@@ -21,24 +21,26 @@ function Devices() {
   const { closeWindowOnAction } = getPreferenceValues<{ closeWindowOnAction?: boolean }>();
 
   if (myDevicesError) {
-    <List isLoading={myDevicesIsLoading}>
-      <List.EmptyView
-        title="Unable to load devices"
-        description={getErrorMessage(myDevicesError)}
-        actions={
-          <ActionPanel>
-            <Action
-              icon={Icon.Repeat}
-              title="Refresh"
-              onAction={async () => {
-                myDevicesRevalidate();
-              }}
-              shortcut={Keyboard.Shortcut.Common.Refresh}
-            />
-          </ActionPanel>
-        }
-      />
-    </List>;
+    return (
+      <List isLoading={myDevicesIsLoading}>
+        <List.EmptyView
+          title="Unable to load devices"
+          description={getErrorMessage(myDevicesError)}
+          actions={
+            <ActionPanel>
+              <Action
+                icon={Icon.Repeat}
+                title="Refresh"
+                onAction={async () => {
+                  myDevicesRevalidate();
+                }}
+                shortcut={Keyboard.Shortcut.Common.Refresh}
+              />
+            </ActionPanel>
+          }
+        />
+      </List>
+    );
   }
 
   if (!Array.isArray(myDevicesData?.devices)) {

--- a/extensions/spotify-player/src/queue.tsx
+++ b/extensions/spotify-player/src/queue.tsx
@@ -9,22 +9,24 @@ function Queue() {
   const { queueData, queueError, queueIsLoading, queueRevalidate } = useQueue();
 
   if (queueError) {
-    <List isLoading={queueIsLoading}>
-      <List.EmptyView
-        title="Unable to load devices"
-        description={getErrorMessage(queueError)}
-        actions={
-          <ActionPanel>
-            <Action
-              icon={Icon.Repeat}
-              title="Refresh"
-              onAction={async () => queueRevalidate()}
-              shortcut={Keyboard.Shortcut.Common.Refresh}
-            />
-          </ActionPanel>
-        }
-      />
-    </List>;
+    return (
+      <List isLoading={queueIsLoading}>
+        <List.EmptyView
+          title="Unable to load devices"
+          description={getErrorMessage(queueError)}
+          actions={
+            <ActionPanel>
+              <Action
+                icon={Icon.Repeat}
+                title="Refresh"
+                onAction={async () => queueRevalidate()}
+                shortcut={Keyboard.Shortcut.Common.Refresh}
+              />
+            </ActionPanel>
+          }
+        />
+      </List>
+    );
   }
 
   if (!queueData || queueData.length == 0) {

--- a/extensions/spotify-player/src/queue.tsx
+++ b/extensions/spotify-player/src/queue.tsx
@@ -12,7 +12,7 @@ function Queue() {
     return (
       <List isLoading={queueIsLoading}>
         <List.EmptyView
-          title="Unable to load devices"
+          title="Unable to load queue"
           description={getErrorMessage(queueError)}
           actions={
             <ActionPanel>

--- a/extensions/spotify-player/tsconfig.json
+++ b/extensions/spotify-player/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "lib": ["ES2023"],
     "module": "commonjs",
-    "target": "ES2022",
+    "target": "ES2023",
     "strict": true,
     "isolatedModules": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Description

- When an error occurs in queue, show the error view
- Add "queue" to README and mark as premium-only

## Screencast

https://github.com/user-attachments/assets/50f58589-0bcc-4645-81e4-179c7fb81bd5

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
