### PR TITLE
[cURL] fix valid POST fail + update more keyboard shortcuts

### DIFF
--- a/extensions/curl/CHANGELOG.md
+++ b/extensions/curl/CHANGELOG.md
@@ -1,5 +1,10 @@
 # cURL Changelog
 
+## [Fix: Valid POST Failing] - {PR_MERGE_DATE}
+
+- Fixed an issue where valid POST requests were failing (ref: [Issue #24065](https://github.com/raycast/extensions/issues/24065))
+- Updated more shortcuts
+
 ## [Fix: Windows Shortcuts] - 2025-09-18
 
 - Updated `@raycast/api` to the latest version

--- a/extensions/curl/CHANGELOG.md
+++ b/extensions/curl/CHANGELOG.md
@@ -1,6 +1,6 @@
 # cURL Changelog
 
-## [Fix: Valid POST Failing] - {PR_MERGE_DATE}
+## [Fix: Valid POST Failing] - 2026-01-05
 
 - Fixed an issue where valid POST requests were failing (ref: [Issue #24065](https://github.com/raycast/extensions/issues/24065))
 - Updated more shortcuts

--- a/extensions/curl/package-lock.json
+++ b/extensions/curl/package-lock.json
@@ -7,8 +7,8 @@
       "name": "curl",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.103.1",
-        "@raycast/utils": "^2.2.1",
+        "@raycast/api": "^1.104.1",
+        "@raycast/utils": "^2.2.2",
         "axios": "^0.27.2",
         "curl-string": "^1.1.1",
         "jsonpath-plus": "^10.3.0"
@@ -1196,9 +1196,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.103.5",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.103.5.tgz",
-      "integrity": "sha512-LPI9bIr+Q6NSy+vhhn8uqy73+oKEZsiUMkW5FDNBw0ngV32atAZH7df4ZGSNba2+HTZKquYdmoEycWeRFnDWRA==",
+      "version": "1.104.1",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.1.tgz",
+      "integrity": "sha512-5v52JDzAAoCA6/JOoBfsgCXK4fzIY02lvMH0IA3ghuxZuk8i2ID2rtPkTuIAbebpkILADB7gP4yaBphkMLiCJA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.5.4",

--- a/extensions/curl/package.json
+++ b/extensions/curl/package.json
@@ -9,7 +9,8 @@
     "pernielsentikaer",
     "bkeys818",
     "ridemountainpig",
-    "yusifaliyevpro"
+    "yusifaliyevpro",
+    "xmok"
   ],
   "categories": [
     "Productivity",
@@ -121,8 +122,8 @@
     ]
   },
   "dependencies": {
-    "@raycast/api": "^1.103.1",
-    "@raycast/utils": "^2.2.1",
+    "@raycast/api": "^1.104.1",
+    "@raycast/utils": "^2.2.2",
     "axios": "^0.27.2",
     "curl-string": "^1.1.1",
     "jsonpath-plus": "^10.3.0"
@@ -139,11 +140,12 @@
     "typescript": "^5.9.2"
   },
   "scripts": {
-    "build": "ray build -e dist",
+    "build": "ray build",
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "publish": "ray publish"
+    "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
+    "publish": "npx @raycast/api@latest publish"
   },
   "platforms": [
     "macOS",

--- a/extensions/curl/src/requests.tsx
+++ b/extensions/curl/src/requests.tsx
@@ -154,7 +154,8 @@ export default function Requests() {
               <ActionPanel>
                 <ActionPanel.Section title="Actions">
                   <Action.CopyToClipboard
-                    title="Copy Curl"
+                    // eslint-disable-next-line @raycast/prefer-title-case
+                    title="Copy cURL"
                     content={generateCurl({ url: req.key, payload: req.value })}
                   />
                   <Action
@@ -168,7 +169,7 @@ export default function Requests() {
                     icon={Icon.AppWindowList}
                     shortcut={{
                       macOS: { modifiers: ["cmd"], key: "m" },
-                      windows: { modifiers: ["ctrl"], key: "m" },
+                      Windows: { modifiers: ["ctrl"], key: "m" },
                     }}
                   />
                 </ActionPanel.Section>
@@ -179,7 +180,7 @@ export default function Requests() {
                     onAction={() => handleDeleteItem(req.key)}
                     shortcut={{
                       macOS: { modifiers: ["cmd", "shift"], key: "delete" },
-                      windows: { modifiers: ["ctrl", "shift"], key: "delete" },
+                      Windows: { modifiers: ["ctrl", "shift"], key: "delete" },
                     }}
                     style={Action.Style.Destructive}
                   />
@@ -189,7 +190,7 @@ export default function Requests() {
                     onAction={handleDeleteAll}
                     shortcut={{
                       macOS: { modifiers: ["cmd", "opt"], key: "delete" },
-                      windows: { modifiers: ["ctrl", "alt"], key: "delete" },
+                      Windows: { modifiers: ["ctrl", "alt"], key: "delete" },
                     }}
                     style={Action.Style.Destructive}
                   />

--- a/extensions/curl/src/views/Form.tsx
+++ b/extensions/curl/src/views/Form.tsx
@@ -35,6 +35,10 @@ export default function FormView({ push }: { push: Navigation["push"] }) {
   const [body, setBody] = useState<string>("");
 
   async function handleSubmit() {
+    if (!url) {
+      await showFailureToast("URL is required", { title: "Request Failed" });
+      return;
+    }
     setIsLoading(true);
     let response;
 
@@ -47,7 +51,7 @@ export default function FormView({ push }: { push: Navigation["push"] }) {
       ...(method !== "GET" &&
         method !== "DELETE" && {
           data: {
-            ...JSON.parse(body.replace("```\n\b\b", "")),
+            ...JSON.parse(body.replace("```\n\b\b", "") || "{}"),
           },
         }),
     };
@@ -57,16 +61,7 @@ export default function FormView({ push }: { push: Navigation["push"] }) {
         response = res;
         const result = { method, response };
 
-        const curlOptions = {
-          method,
-          headers: makeObject(headers),
-          ...(method !== "GET" &&
-            method !== "DELETE" && {
-              data: {
-                ...JSON.parse(body.replace("```\n\b\b", "")),
-              },
-            }),
-        };
+        const curlOptions = payload;
 
         const curl = curlString(finalUrl, curlOptions);
 
@@ -164,7 +159,7 @@ export default function FormView({ push }: { push: Navigation["push"] }) {
             icon={Icon.Plus}
             shortcut={{
               macOS: { modifiers: ["opt"], key: "p" },
-              windows: { modifiers: ["alt"], key: "p" },
+              Windows: { modifiers: ["alt"], key: "p" },
             }}
             onAction={handleAddParameter}
           />
@@ -173,7 +168,7 @@ export default function FormView({ push }: { push: Navigation["push"] }) {
             icon={Icon.Minus}
             shortcut={{
               macOS: { modifiers: ["opt", "shift"], key: "p" },
-              windows: { modifiers: ["alt", "shift"], key: "p" },
+              Windows: { modifiers: ["alt", "shift"], key: "p" },
             }}
             onAction={handleRemoveParameter}
           />
@@ -182,7 +177,7 @@ export default function FormView({ push }: { push: Navigation["push"] }) {
             icon={Icon.Plus}
             shortcut={{
               macOS: { modifiers: ["cmd"], key: "h" },
-              windows: { modifiers: ["ctrl"], key: "h" },
+              Windows: { modifiers: ["ctrl"], key: "h" },
             }}
             onAction={handleAddHeader}
           />
@@ -191,7 +186,7 @@ export default function FormView({ push }: { push: Navigation["push"] }) {
             icon={Icon.Minus}
             shortcut={{
               macOS: { modifiers: ["cmd", "shift"], key: "h" },
-              windows: { modifiers: ["ctrl", "shift"], key: "h" },
+              Windows: { modifiers: ["ctrl", "shift"], key: "h" },
             }}
             onAction={handleRemoveHeader}
           />

--- a/extensions/curl/src/views/Result.tsx
+++ b/extensions/curl/src/views/Result.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @raycast/prefer-title-case */
-import { Action, ActionPanel, Color, Detail } from "@raycast/api";
+import { Action, ActionPanel, Color, Detail, Keyboard } from "@raycast/api";
 import { AxiosRequestConfig } from "axios";
 import { methodColors } from "../../utils";
 
@@ -61,13 +61,17 @@ export default function ResultView({
           <Action.CopyToClipboard
             title="Copy JSONPath Result"
             content={jsonPathResultToClipboard}
-            shortcut={{ modifiers: ["cmd"], key: "c" }}
+            shortcut={{ macOS: { modifiers: ["cmd"], key: "c" }, Windows: { modifiers: ["ctrl"], key: "c" } }}
           />
-          <Action.CopyToClipboard title="Copy Response" content={JSON.stringify(result.response.data, null, 2)} />
+          <Action.CopyToClipboard
+            title="Copy Response"
+            content={JSON.stringify(result.response.data, null, 2)}
+            shortcut={Keyboard.Shortcut.Common.Copy}
+          />
           <Action.CopyToClipboard
             title="Copy Headers"
             content={JSON.stringify(result.response.headers, null, 2)}
-            shortcut={{ modifiers: ["cmd"], key: "h" }}
+            shortcut={{ macOS: { modifiers: ["cmd"], key: "h" }, Windows: { modifiers: ["ctrl"], key: "h" } }}
           />
         </ActionPanel>
       }

--- a/extensions/curl/utils/index.ts
+++ b/extensions/curl/utils/index.ts
@@ -133,7 +133,7 @@ export function buildUrlFromParameters(baseUrl: string, params: Parameter[]) {
     });
 
     return queryParts.length > 0 ? `${baseUrlOnly}?${queryParts.join("&")}` : baseUrlOnly;
-  } catch (e) {
+  } catch {
     return baseUrl;
   }
 };


### PR DESCRIPTION
## Description

- Fixed an issue where valid POST requests were failing (close #24065)
- Updated more shortcuts

## Screencast

https://github.com/user-attachments/assets/9fe1c474-68d7-4811-b931-47a97a2ac7a2

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
