### PR TITLE
Update freeagent extension

### DIFF
--- a/extensions/freeagent/CHANGELOG.md
+++ b/extensions/freeagent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # FreeAgent Changelog
 
-## [Fix time parsing in Create Timeslip] - {PR_MERGE_DATE}
+## [Fix time parsing in Create Timeslip] - 2026-01-08
 
 - Fixed bug where entering time in HH:MM format (e.g., `4:30`) would only record the hours portion
 - Now supports both HH:MM format (`4:30` = 4.5 hours) and decimal format (`4.5`)

--- a/extensions/freeagent/CHANGELOG.md
+++ b/extensions/freeagent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # FreeAgent Changelog
 
+## [Fix time parsing in Create Timeslip] - {PR_MERGE_DATE}
+
+- Fixed bug where entering time in HH:MM format (e.g., `4:30`) would only record the hours portion
+- Now supports both HH:MM format (`4:30` = 4.5 hours) and decimal format (`4.5`)
+- Added validation for invalid time inputs with helpful error messages
+
 ## [Added new command to create tasks in projects] - 2025-11-12
 
 - New `Create a new task in FreeAgent` command

--- a/extensions/freeagent/src/create-timeslip.tsx
+++ b/extensions/freeagent/src/create-timeslip.tsx
@@ -7,6 +7,36 @@ import { useFreeAgent } from "./hooks/useFreeAgent";
 import { showFailureToast } from "@raycast/utils";
 import { formatDateForAPI } from "./utils/formatting";
 
+/**
+ * Parses a time string into decimal hours.
+ * Supports formats: "4:30" (4h 30m = 4.5), "4.5", "4"
+ * Returns null if the input is invalid.
+ */
+function parseHours(input: string): number | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // Check for HH:MM format
+  if (trimmed.includes(":")) {
+    const parts = trimmed.split(":");
+    if (parts.length !== 2) return null;
+
+    const hours = parseInt(parts[0], 10);
+    const minutes = parseInt(parts[1], 10);
+
+    if (isNaN(hours) || isNaN(minutes)) return null;
+    if (hours < 0 || minutes < 0 || minutes >= 60) return null;
+
+    return hours + minutes / 60;
+  }
+
+  // Otherwise treat as decimal
+  const value = parseFloat(trimmed);
+  if (isNaN(value) || value < 0) return null;
+
+  return value;
+}
+
 const CreateTimeslip = function Command() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -71,13 +101,22 @@ const CreateTimeslip = function Command() {
       return;
     }
 
+    const hours = parseHours(values.hours);
+    if (hours === null) {
+      handleError(
+        new Error("Invalid hours format. Use decimal (e.g., 2.5) or HH:MM (e.g., 2:30)"),
+        "Failed to create timeslip",
+      );
+      return;
+    }
+
     try {
       const timeslipData = {
         task: values.task,
         user: currentUser.url,
         project: values.project,
         dated_on: values.dated_on ? formatDateForAPI(values.dated_on) : formatDateForAPI(new Date()),
-        hours: parseFloat(values.hours) || 0,
+        hours: hours,
         comment: values.comment,
       };
 
@@ -143,7 +182,12 @@ const CreateTimeslip = function Command() {
 
       <Form.TextField id="comment" title="Comment" placeholder="Enter additional comments (optional)" />
       <Form.DatePicker id="dated_on" title="Date" />
-      <Form.TextField id="hours" title="Hours" placeholder="Enter number of hours (e.g., 2.5)" />
+      <Form.TextField
+        id="hours"
+        title="Hours"
+        placeholder="e.g., 2.5 or 2:30"
+        info="Supports decimal (2.5) or HH:MM (2:30) format"
+      />
     </Form>
   );
 };


### PR DESCRIPTION
## Description

### Problem

When entering time in HH:MM format (e.g., 4:30 for 4 hours 30 minutes), the form was incorrectly sending only 4 hours to FreeAgent. This was because parseFloat("4:30") stops parsing at the colon and returns 4.

### Solution

Added a parseHours function that properly handles both time formats:
  - HH:MM format: 4:30 → 4.5 hours (converts minutes to decimal)
  - Decimal format: 4.5 → 4.5 hours

Invalid inputs (negative values, minutes ≥ 60, non-numeric strings) now show a validation error instead of silently failing.

### Changes

  - Added parseHours() function with proper validation
  - Updated form submission to validate hours before sending
  - Added info tooltip to the hours field explaining supported formats
  - Updated placeholder text to show example formats

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
