### PR TITLE
Update csfd extension

### DIFF
--- a/extensions/csfd/CHANGELOG.md
+++ b/extensions/csfd/CHANGELOG.md
@@ -1,3 +1,7 @@
 # ČSFD Changelog
 
+## [1.0.1] - 2025-01-07
+
+- Fixed crash when viewing movie details by updating `node-csfd-api` to v4.1.2
+
 ## [Initial Version] - 2025-07-04

--- a/extensions/csfd/CHANGELOG.md
+++ b/extensions/csfd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ČSFD Changelog
 
-## [1.0.1] - {PR_MERGE_DATE}
+## [1.0.1] - 2026-01-08
 
 - Fixed crash when viewing movie details by updating `node-csfd-api` to v4.1.2
 

--- a/extensions/csfd/CHANGELOG.md
+++ b/extensions/csfd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ČSFD Changelog
 
-## [1.0.1] - 2025-01-07
+## [1.0.1] - {PR_MERGE_DATE}
 
 - Fixed crash when viewing movie details by updating `node-csfd-api` to v4.1.2
 

--- a/extensions/csfd/package-lock.json
+++ b/extensions/csfd/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@raycast/api": "^1.94.3",
         "@raycast/utils": "^1.17.0",
-        "node-csfd-api": "^2.11.0"
+        "node-csfd-api": "^4.1.2"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.0.4",
@@ -396,11 +396,10 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
+      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -424,13 +423,12 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
+      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -439,11 +437,10 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -454,7 +451,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -463,37 +459,19 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.0.tgz",
+      "integrity": "sha512-yJLLmLexii32mGrhW29qvU3QBVTu0GUmEf/J4XsBtVhp4JkIUFN/BjWqTF63yRvGApIDpZm5fa97LtYtINmfeQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.17.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -525,11 +503,10 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -560,50 +537,31 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
-      "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
+      "version": "9.23.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
+      "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -670,15 +628,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@inquirer/ansi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.1.tgz",
-      "integrity": "sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@inquirer/checkbox": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.4.tgz",
@@ -723,14 +672,13 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.0.tgz",
-      "integrity": "sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==",
-      "license": "MIT",
+      "version": "10.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.9.tgz",
+      "integrity": "sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.1",
-        "@inquirer/figures": "^1.0.14",
-        "@inquirer/type": "^3.0.9",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
+        "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
@@ -763,14 +711,13 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.21.tgz",
-      "integrity": "sha512-MjtjOGjr0Kh4BciaFShYpZ1s9400idOdvQ5D7u7lE6VztPFoyLcVNE5dXBmEEIQq5zi4B9h2kU+q7AVBxJMAkQ==",
-      "license": "MIT",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.9.tgz",
+      "integrity": "sha512-8HjOppAxO7O4wV1ETUlJFg6NDjp/W2NP5FB9ZPAcinAlNT4ZIWOLe2pUVwmmPRSV0NMdI5r/+lflN55AwZOKSw==",
       "dependencies": {
-        "@inquirer/core": "^10.3.0",
-        "@inquirer/external-editor": "^1.0.2",
-        "@inquirer/type": "^3.0.9"
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
+        "external-editor": "^3.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -805,32 +752,10 @@
         }
       }
     },
-    "node_modules/@inquirer/external-editor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
-      "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^2.1.0",
-        "iconv-lite": "^0.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.14.tgz",
-      "integrity": "sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==",
-      "license": "MIT",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
       "engines": {
         "node": ">=18"
       }
@@ -991,10 +916,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.9.tgz",
-      "integrity": "sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==",
-      "license": "MIT",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.5.tgz",
+      "integrity": "sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==",
       "engines": {
         "node": ">=18"
       },
@@ -1110,6 +1034,7 @@
       "version": "1.94.3",
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.94.3.tgz",
       "integrity": "sha512-f1d8Tafpc5ZbG9GALzPOmlr3wArjHl6AuylwPys5iFtoRGVWhNr0DWoFjvw3iFd/Or92vqCydH7py9JELKdlJg==",
+      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.0.33",
         "@oclif/plugin-autocomplete": "^3.2.10",
@@ -1199,13 +1124,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "22.13.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1252,6 +1177,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.29.0.tgz",
       "integrity": "sha512-8C0+jlNJOwQso2GapCVWWfW/rzaq7Lbme+vGUFKE31djwNncIpgXD7Cd4weEsDdkoZDjH0lwwr3QDQFuyrMg9g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.29.0",
         "@typescript-eslint/types": "8.29.0",
@@ -1403,11 +1329,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
-      "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1514,10 +1440,9 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1569,10 +1494,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
-      "license": "MIT"
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "node_modules/clean-stack": {
       "version": "3.0.1",
@@ -1854,32 +1778,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
-      "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
+      "version": "9.23.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
+      "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
       "dev": true,
-      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
-        "@eslint/config-helpers": "^0.4.1",
-        "@eslint/core": "^0.16.0",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/config-helpers": "^0.2.0",
+        "@eslint/core": "^0.12.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.38.0",
-        "@eslint/plugin-kit": "^0.4.0",
+        "@eslint/js": "9.23.0",
+        "@eslint/plugin-kit": "^0.2.7",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1926,11 +1851,10 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -1955,22 +1879,20 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1991,15 +1913,14 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.14.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2009,11 +1930,10 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2038,7 +1958,6 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -2062,6 +1981,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2277,19 +2209,14 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-      "license": "MIT",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "safer-buffer": ">= 2.1.2 < 3"
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -2417,10 +2344,9 @@
       }
     },
     "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2575,9 +2501,10 @@
       "dev": true
     },
     "node_modules/node-csfd-api": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/node-csfd-api/-/node-csfd-api-2.11.4.tgz",
-      "integrity": "sha512-HyP1Udz0yDqtgKjah2UviA9kj1wciFt/3RkBF+wdUeH4wig+uAyeRfRvkqMXNo4+HM0Y1BqgOhF7WbiXWImbOQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/node-csfd-api/-/node-csfd-api-4.1.2.tgz",
+      "integrity": "sha512-VtS44yaPVk2rU0DRQahAW+moRJSakFsUE3bENn3CfpSWbGC3JU+ZOZbVurfOZ6KvzMbN2KhA32mzU8h6HOWuoQ==",
+      "license": "MIT",
       "dependencies": {
         "cross-fetch": "^4.1.0",
         "node-html-parser": "^7.0.1"
@@ -2663,6 +2590,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -2757,6 +2692,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2846,8 +2782,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -2963,6 +2898,17 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3019,6 +2965,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3309,9 +3256,9 @@
       "optional": true
     },
     "@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
+      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^3.4.3"
@@ -3324,20 +3271,20 @@
       "dev": true
     },
     "@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
+      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
       "dev": true,
       "requires": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -3356,29 +3303,15 @@
       }
     },
     "@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-      "dev": true,
-      "requires": {
-        "@eslint/core": "^0.17.0"
-      },
-      "dependencies": {
-        "@eslint/core": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-          "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.15"
-          }
-        }
-      }
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.0.tgz",
+      "integrity": "sha512-yJLLmLexii32mGrhW29qvU3QBVTu0GUmEf/J4XsBtVhp4JkIUFN/BjWqTF63yRvGApIDpZm5fa97LtYtINmfeQ==",
+      "dev": true
     },
     "@eslint/core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.15"
@@ -3402,9 +3335,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -3429,36 +3362,25 @@
       }
     },
     "@eslint/js": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
-      "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
+      "version": "9.23.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
+      "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
       "dev": true
     },
     "@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true
     },
     "@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
       "dev": true,
       "requires": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
-      },
-      "dependencies": {
-        "@eslint/core": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-          "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.15"
-          }
-        }
       }
     },
     "@humanfs/core": {
@@ -3497,11 +3419,6 @@
       "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
       "dev": true
     },
-    "@inquirer/ansi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.1.tgz",
-      "integrity": "sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw=="
-    },
     "@inquirer/checkbox": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.4.tgz",
@@ -3524,13 +3441,13 @@
       }
     },
     "@inquirer/core": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.0.tgz",
-      "integrity": "sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==",
+      "version": "10.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.9.tgz",
+      "integrity": "sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==",
       "requires": {
-        "@inquirer/ansi": "^1.0.1",
-        "@inquirer/figures": "^1.0.14",
-        "@inquirer/type": "^3.0.9",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
+        "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
@@ -3551,13 +3468,13 @@
       }
     },
     "@inquirer/editor": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.21.tgz",
-      "integrity": "sha512-MjtjOGjr0Kh4BciaFShYpZ1s9400idOdvQ5D7u7lE6VztPFoyLcVNE5dXBmEEIQq5zi4B9h2kU+q7AVBxJMAkQ==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.9.tgz",
+      "integrity": "sha512-8HjOppAxO7O4wV1ETUlJFg6NDjp/W2NP5FB9ZPAcinAlNT4ZIWOLe2pUVwmmPRSV0NMdI5r/+lflN55AwZOKSw==",
       "requires": {
-        "@inquirer/core": "^10.3.0",
-        "@inquirer/external-editor": "^1.0.2",
-        "@inquirer/type": "^3.0.9"
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
+        "external-editor": "^3.1.0"
       }
     },
     "@inquirer/expand": {
@@ -3570,19 +3487,10 @@
         "yoctocolors-cjs": "^2.1.2"
       }
     },
-    "@inquirer/external-editor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
-      "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
-      "requires": {
-        "chardet": "^2.1.0",
-        "iconv-lite": "^0.7.0"
-      }
-    },
     "@inquirer/figures": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.14.tgz",
-      "integrity": "sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw=="
     },
     "@inquirer/input": {
       "version": "4.1.8",
@@ -3663,9 +3571,9 @@
       }
     },
     "@inquirer/type": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.9.tgz",
-      "integrity": "sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.5.tgz",
+      "integrity": "sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {
@@ -3750,6 +3658,7 @@
       "version": "1.94.3",
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.94.3.tgz",
       "integrity": "sha512-f1d8Tafpc5ZbG9GALzPOmlr3wArjHl6AuylwPys5iFtoRGVWhNr0DWoFjvw3iFd/Or92vqCydH7py9JELKdlJg==",
+      "peer": true,
       "requires": {
         "@oclif/core": "^4.0.33",
         "@oclif/plugin-autocomplete": "^3.2.10",
@@ -3812,6 +3721,7 @@
       "version": "22.13.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "peer": true,
       "requires": {
         "undici-types": "~6.20.0"
       }
@@ -3846,6 +3756,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.29.0.tgz",
       "integrity": "sha512-8C0+jlNJOwQso2GapCVWWfW/rzaq7Lbme+vGUFKE31djwNncIpgXD7Cd4weEsDdkoZDjH0lwwr3QDQFuyrMg9g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.29.0",
         "@typescript-eslint/types": "8.29.0",
@@ -3929,10 +3840,11 @@
       }
     },
     "acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -4006,9 +3918,9 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "requires": {
         "balanced-match": "^1.0.0"
       }
@@ -4047,9 +3959,9 @@
       }
     },
     "chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "clean-stack": {
       "version": "3.0.1",
@@ -4244,31 +4156,33 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
     },
     "eslint": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
-      "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
+      "version": "9.23.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
+      "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
-        "@eslint/config-helpers": "^0.4.1",
-        "@eslint/core": "^0.16.0",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/config-helpers": "^0.2.0",
+        "@eslint/core": "^0.12.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.38.0",
-        "@eslint/plugin-kit": "^0.4.0",
+        "@eslint/js": "9.23.0",
+        "@eslint/plugin-kit": "^0.2.7",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -4286,9 +4200,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -4296,9 +4210,9 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-          "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+          "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
           "dev": true
         },
         "minimatch": {
@@ -4320,9 +4234,9 @@
       "requires": {}
     },
     "eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
@@ -4336,20 +4250,20 @@
       "dev": true
     },
     "espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
       "requires": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.14.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^4.2.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-          "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+          "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
           "dev": true
         }
       }
@@ -4383,6 +4297,16 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -4550,11 +4474,11 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
@@ -4637,9 +4561,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4760,9 +4684,9 @@
       "dev": true
     },
     "node-csfd-api": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/node-csfd-api/-/node-csfd-api-2.11.4.tgz",
-      "integrity": "sha512-HyP1Udz0yDqtgKjah2UviA9kj1wciFt/3RkBF+wdUeH4wig+uAyeRfRvkqMXNo4+HM0Y1BqgOhF7WbiXWImbOQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/node-csfd-api/-/node-csfd-api-4.1.2.tgz",
+      "integrity": "sha512-VtS44yaPVk2rU0DRQahAW+moRJSakFsUE3bENn3CfpSWbGC3JU+ZOZbVurfOZ6KvzMbN2KhA32mzU8h6HOWuoQ==",
       "requires": {
         "cross-fetch": "^4.1.0",
         "node-html-parser": "^7.0.1"
@@ -4830,6 +4754,11 @@
         }
       }
     },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
+    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4889,7 +4818,8 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "punycode": {
       "version": "2.3.1",
@@ -5006,6 +4936,14 @@
         "has-flag": "^4.0.0"
       }
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5044,7 +4982,8 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "typescript-eslint": {
       "version": "8.29.0",

--- a/extensions/csfd/package.json
+++ b/extensions/csfd/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@raycast/api": "^1.94.3",
     "@raycast/utils": "^1.17.0",
-    "node-csfd-api": "^2.11.0"
+    "node-csfd-api": "^4.1.2"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.0.4",

--- a/extensions/csfd/package.json
+++ b/extensions/csfd/package.json
@@ -83,7 +83,10 @@
                     }
                   ]
                 },
-                "origins": ["USA", "Velká Británie"],
+                "origins": [
+                  "USA",
+                  "Velká Británie"
+                ],
                 "url": "https://www.csfd.cz/film/64768-inception/"
               }
             ],
@@ -96,8 +99,15 @@
             "rating": 88,
             "colorRating": "good",
             "duration": 148,
-            "genres": ["Sci-Fi", "Action", "Thriller"],
-            "origins": ["USA", "Velká Británie"],
+            "genres": [
+              "Sci-Fi",
+              "Action",
+              "Thriller"
+            ],
+            "origins": [
+              "USA",
+              "Velká Británie"
+            ],
             "poster": "https://image.pmgstatic.com/cache/resized/w1080/files/images/film/posters/158/180/158180052_2e67c1.jpg",
             "description": "Dom Cobb je zručný zloděj, největší na světě v nebezpečném umění extrakce: krade cenné tajemství z hlubin nevědomí během snového stavu, kdy je mysl nejvíce zranitelná.",
             "cast": {
@@ -164,7 +174,10 @@
                     }
                   ]
                 },
-                "origins": ["USA", "Velká Británie"],
+                "origins": [
+                  "USA",
+                  "Velká Británie"
+                ],
                 "url": "https://www.csfd.cz/film/278133-interstellar/"
               }
             ],
@@ -177,8 +190,15 @@
             "rating": 90,
             "colorRating": "good",
             "duration": 169,
-            "genres": ["Sci-Fi", "Drama", "Thriller"],
-            "origins": ["USA", "Velká Británie"],
+            "genres": [
+              "Sci-Fi",
+              "Drama",
+              "Thriller"
+            ],
+            "origins": [
+              "USA",
+              "Velká Británie"
+            ],
             "poster": "https://image.pmgstatic.com/cache/resized/w1080/files/images/film/posters/162/784/162784693_1653c1.jpg",
             "description": "Skupina výzkumníků a průzkumníků, vedená Cooperem, se vydává na nejdůležitější misi v lidské historii; cestují za hranice této galaxie, aby objevili, zda má lidstvo budoucnost mezi hvězdami.",
             "cast": {
@@ -220,672 +240,669 @@
         ]
       },
       {
-        "input" : "Where can I watch Simpsons TV Show? @csfd ",
-        "mocks" : {
-          "get-movie-details" : {
-            "cast" : {
-              "actors" : "Dan Castellaneta, Julie Kavner, Nancy Cartwright, Yeardley Smith, Harry Shearer",
-              "directors" : "Mike B. Anderson, Mark Kirkland, Steven Dean Moore, Bob Anderson, Matthew Nastuk, Jim Reardon, David Silverman, Mike Frank Polcino, Wesley Archer, Nancy Kruse, Lance Kramer, Chris Clements, Chuck Sheetz, Rob Oliver, Rich Moore, Matthew Faughnan, Jeffrey Lynch, Timothy Bailey, Susie Dietter, Pete Michels, Raymond S. Persi, Carlos Baeza, Swinton O. Scott III, Dominic Polcino, Neil Affleck, Michael Marcantel, Lauren MacMullan, Matthew Schofield, Ralph Sosa, Mark Ervin, Jen Kamerman, Milton Gray, Brad Bird, Kent Butterworth, Gregg Vanzo, Alan Smart, David Mirkin, Klay Hall, Shaun Cashman, John Harvatine IV, Jennifer Moeller, Debbie Mahan, Gabriel DeFrancesco, Gabor Csupo, Eric Koenig"
+        "input": "Where can I watch Simpsons TV Show? @csfd ",
+        "mocks": {
+          "get-movie-details": {
+            "cast": {
+              "actors": "Dan Castellaneta, Julie Kavner, Nancy Cartwright, Yeardley Smith, Harry Shearer",
+              "directors": "Mike B. Anderson, Mark Kirkland, Steven Dean Moore, Bob Anderson, Matthew Nastuk, Jim Reardon, David Silverman, Mike Frank Polcino, Wesley Archer, Nancy Kruse, Lance Kramer, Chris Clements, Chuck Sheetz, Rob Oliver, Rich Moore, Matthew Faughnan, Jeffrey Lynch, Timothy Bailey, Susie Dietter, Pete Michels, Raymond S. Persi, Carlos Baeza, Swinton O. Scott III, Dominic Polcino, Neil Affleck, Michael Marcantel, Lauren MacMullan, Matthew Schofield, Ralph Sosa, Mark Ervin, Jen Kamerman, Milton Gray, Brad Bird, Kent Butterworth, Gregg Vanzo, Alan Smart, David Mirkin, Klay Hall, Shaun Cashman, John Harvatine IV, Jennifer Moeller, Debbie Mahan, Gabriel DeFrancesco, Gabor Csupo, Eric Koenig"
             },
-            "colorRating" : "good",
-            "description" : "Natvrdlý lenoch Homer, pedantská puťka Marge, drzounský Bart, přechytralá Líza a roztomilá Maggie – to jsou členové rodiny nejslavnějšího a nejpopulárnějšího animovaného seriálu Simpsonovi.Už dvacet let se jich miliony fanoušků na celém světě nemohou nabažit a v pravidelných intervalech nakukují do zákulisí legendárního Springfieldu, aby byli svědky neuvěřitelných dobrodružství bláznivé, ale přesto vlastně normální americké rodinky. Simpsonovi si získali své obecenstvo především neotřelým a trochu drsným humorem, s nímž vykreslují typickou americkou rodinu z městečka Springfield. Ta se skládá z pěti naprosto odlišných lidí, pro které je občas pořádně těžké se sebou vyjít. Nemluvě o ostatních obyvatelích města, v němž to opravdu neustále žije – je tu vlastní upadlá kultura, zkorumpovaná politika, drsná mafie a lenivá policie, ale také prostí občané, kteří se každý týden chodí kát do místního kostela. V neposlední řadě si mohou diváci všimnout jednoho všudypřítomného detailu – Simpsonovi totiž téměř v každé scénce něco nebo někoho parodují – ať už jde o svět filmový, hudební, politický, ale i náboženský. Tvůrci seriálu se zkrátka s velkou odvahou pouštějí do neustálých provokací osob a institucí z reálného života.(TV Prima)",
-            "duration" : 17154,
-            "genres" : [
+            "colorRating": "good",
+            "description": "Natvrdlý lenoch Homer, pedantská puťka Marge, drzounský Bart, přechytralá Líza a roztomilá Maggie – to jsou členové rodiny nejslavnějšího a nejpopulárnějšího animovaného seriálu Simpsonovi.Už dvacet let se jich miliony fanoušků na celém světě nemohou nabažit a v pravidelných intervalech nakukují do zákulisí legendárního Springfieldu, aby byli svědky neuvěřitelných dobrodružství bláznivé, ale přesto vlastně normální americké rodinky. Simpsonovi si získali své obecenstvo především neotřelým a trochu drsným humorem, s nímž vykreslují typickou americkou rodinu z městečka Springfield. Ta se skládá z pěti naprosto odlišných lidí, pro které je občas pořádně těžké se sebou vyjít. Nemluvě o ostatních obyvatelích města, v němž to opravdu neustále žije – je tu vlastní upadlá kultura, zkorumpovaná politika, drsná mafie a lenivá policie, ale také prostí občané, kteří se každý týden chodí kát do místního kostela. V neposlední řadě si mohou diváci všimnout jednoho všudypřítomného detailu – Simpsonovi totiž téměř v každé scénce něco nebo někoho parodují – ať už jde o svět filmový, hudební, politický, ale i náboženský. Tvůrci seriálu se zkrátka s velkou odvahou pouštějí do neustálých provokací osob a institucí z reálného života.(TV Prima)",
+            "duration": 17154,
+            "genres": [
               "Animovaný",
               "Komedie"
             ],
-            "id" : 72489,
-            "origins" : [
+            "id": 72489,
+            "origins": [
               "USA"
             ],
-            "poster" : "https://image.pmgstatic.com/cache/resized/w1080/files/images/film/posters/166/402/166402931_d24f3c.jpg",
-            "rating" : 92,
-            "title" : "Simpsonovi",
-            "url" : "https://www.csfd.cz/film/72489",
-            "watchOn" : [
+            "poster": "https://image.pmgstatic.com/cache/resized/w1080/files/images/film/posters/166/402/166402931_d24f3c.jpg",
+            "rating": 92,
+            "title": "Simpsonovi",
+            "url": "https://www.csfd.cz/film/72489",
+            "watchOn": [
               {
-                "title" : "Disney+",
-                "url" : "https://www.disneyplus.com/cs-cz/series/the-simpsons/3ZoBZ52QHb4x"
+                "title": "Disney+",
+                "url": "https://www.disneyplus.com/cs-cz/series/the-simpsons/3ZoBZ52QHb4x"
               },
               {
-                "title" : "Lepší.TV",
-                "url" : "https://www.lepsi.tv/top_tv/serial/simpsonovi-online?utm_source=csfd&utm_content=csfd"
+                "title": "Lepší.TV",
+                "url": "https://www.lepsi.tv/top_tv/serial/simpsonovi-online?utm_source=csfd&utm_content=csfd"
               },
               {
-                "title" : "SledovaniTV",
-                "url" : "https://sledovanitv.cz/epg/event/primacool:20250324615348a9cf91bfe7e29d3ddff2809e4d"
+                "title": "SledovaniTV",
+                "url": "https://sledovanitv.cz/epg/event/primacool:20250324615348a9cf91bfe7e29d3ddff2809e4d"
               },
               {
-                "title" : "DVD",
-                "url" : "https://www.martinus.cz/?uItem=846821"
+                "title": "DVD",
+                "url": "https://www.martinus.cz/?uItem=846821"
               }
             ],
-            "year" : 1989
+            "year": 1989
           },
-          "search-movies" : {
-            "message" : "Found 7 results for \"Simpsons\"",
-            "results" : [
+          "search-movies": {
+            "message": "Found 7 results for \"Simpsons\"",
+            "results": [
               {
-                "colorRating" : "good",
-                "creators" : {
-                  "actors" : [
+                "colorRating": "good",
+                "creators": {
+                  "actors": [
                     {
-                      "id" : 11255,
-                      "name" : "Dan Castellaneta",
-                      "url" : "https://www.csfd.cz/tvurce/11255-dan-castellaneta/"
+                      "id": 11255,
+                      "name": "Dan Castellaneta",
+                      "url": "https://www.csfd.cz/tvurce/11255-dan-castellaneta/"
                     },
                     {
-                      "id" : 11585,
-                      "name" : "Julie Kavner",
-                      "url" : "https://www.csfd.cz/tvurce/11585-julie-kavner/"
+                      "id": 11585,
+                      "name": "Julie Kavner",
+                      "url": "https://www.csfd.cz/tvurce/11585-julie-kavner/"
                     }
                   ],
-                  "directors" : [
+                  "directors": [
                     {
-                      "id" : 296039,
-                      "name" : "Mike B. Anderson",
-                      "url" : "https://www.csfd.cz/tvurce/296039-mike-b-anderson/"
+                      "id": 296039,
+                      "name": "Mike B. Anderson",
+                      "url": "https://www.csfd.cz/tvurce/296039-mike-b-anderson/"
                     },
                     {
-                      "id" : 284739,
-                      "name" : "Mark Kirkland",
-                      "url" : "https://www.csfd.cz/tvurce/284739-mark-kirkland/"
+                      "id": 284739,
+                      "name": "Mark Kirkland",
+                      "url": "https://www.csfd.cz/tvurce/284739-mark-kirkland/"
                     }
                   ]
                 },
-                "id" : 72489,
-                "origins" : [
+                "id": 72489,
+                "origins": [
                   "USA"
                 ],
-                "poster" : "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/166/402/166402931_d24f3c.jpg",
-                "title" : "Simpsonovi",
-                "type" : "tvshow",
-                "url" : "https://www.csfd.cz/film/72489-simpsonovi/",
-                "year" : 1989
+                "poster": "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/166/402/166402931_d24f3c.jpg",
+                "title": "Simpsonovi",
+                "type": "tvshow",
+                "url": "https://www.csfd.cz/film/72489-simpsonovi/",
+                "year": 1989
               },
               {
-                "colorRating" : "average",
-                "creators" : {
-                  "actors" : [
+                "colorRating": "average",
+                "creators": {
+                  "actors": [
                     {
-                      "id" : 11255,
-                      "name" : "Dan Castellaneta",
-                      "url" : "https://www.csfd.cz/tvurce/11255-dan-castellaneta/"
+                      "id": 11255,
+                      "name": "Dan Castellaneta",
+                      "url": "https://www.csfd.cz/tvurce/11255-dan-castellaneta/"
                     },
                     {
-                      "id" : 11585,
-                      "name" : "Julie Kavner",
-                      "url" : "https://www.csfd.cz/tvurce/11585-julie-kavner/"
+                      "id": 11585,
+                      "name": "Julie Kavner",
+                      "url": "https://www.csfd.cz/tvurce/11585-julie-kavner/"
                     }
                   ],
-                  "directors" : [
+                  "directors": [
                     {
-                      "id" : 296039,
-                      "name" : "Mike B. Anderson",
-                      "url" : "https://www.csfd.cz/tvurce/296039-mike-b-anderson/"
+                      "id": 296039,
+                      "name": "Mike B. Anderson",
+                      "url": "https://www.csfd.cz/tvurce/296039-mike-b-anderson/"
                     },
                     {
-                      "id" : 64823,
-                      "name" : "Steven Dean Moore",
-                      "url" : "https://www.csfd.cz/tvurce/64823-steven-dean-moore/"
+                      "id": 64823,
+                      "name": "Steven Dean Moore",
+                      "url": "https://www.csfd.cz/tvurce/64823-steven-dean-moore/"
                     }
                   ]
                 },
-                "id" : 72489,
-                "origins" : [
+                "id": 72489,
+                "origins": [
                   "USA"
                 ],
-                "poster" : "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/168/639/168639242_uin5ni.png",
-                "title" : "Simpsonovi - Série 35",
-                "type" : "tvshow",
-                "url" : "https://www.csfd.cz/film/72489-simpsonovi/1364303-serie-35/",
-                "year" : 2023
+                "poster": "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/168/639/168639242_uin5ni.png",
+                "title": "Simpsonovi - Série 35",
+                "type": "tvshow",
+                "url": "https://www.csfd.cz/film/72489-simpsonovi/1364303-serie-35/",
+                "year": 2023
               },
               {
-                "colorRating" : "average",
-                "creators" : {
-                  "actors" : [
+                "colorRating": "average",
+                "creators": {
+                  "actors": [
                     {
-                      "id" : 11255,
-                      "name" : "Dan Castellaneta",
-                      "url" : "https://www.csfd.cz/tvurce/11255-dan-castellaneta/"
+                      "id": 11255,
+                      "name": "Dan Castellaneta",
+                      "url": "https://www.csfd.cz/tvurce/11255-dan-castellaneta/"
                     },
                     {
-                      "id" : 11585,
-                      "name" : "Julie Kavner",
-                      "url" : "https://www.csfd.cz/tvurce/11585-julie-kavner/"
+                      "id": 11585,
+                      "name": "Julie Kavner",
+                      "url": "https://www.csfd.cz/tvurce/11585-julie-kavner/"
                     }
                   ],
-                  "directors" : [
+                  "directors": [
                     {
-                      "id" : 291288,
-                      "name" : "Rob Oliver",
-                      "url" : "https://www.csfd.cz/tvurce/291288-rob-oliver/"
+                      "id": 291288,
+                      "name": "Rob Oliver",
+                      "url": "https://www.csfd.cz/tvurce/291288-rob-oliver/"
                     },
                     {
-                      "id" : 291383,
-                      "name" : "Timothy Bailey",
-                      "url" : "https://www.csfd.cz/tvurce/291383-timothy-bailey/"
+                      "id": 291383,
+                      "name": "Timothy Bailey",
+                      "url": "https://www.csfd.cz/tvurce/291383-timothy-bailey/"
                     }
                   ]
                 },
-                "id" : 72489,
-                "origins" : [
+                "id": 72489,
+                "origins": [
                   "USA"
                 ],
-                "poster" : "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/169/613/169613112_k6m9i8.jpg",
-                "title" : "Simpsonovi - Série 36",
-                "type" : "tvshow",
-                "url" : "https://www.csfd.cz/film/72489-simpsonovi/1521444-serie-36/",
-                "year" : 2024
+                "poster": "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/169/613/169613112_k6m9i8.jpg",
+                "title": "Simpsonovi - Série 36",
+                "type": "tvshow",
+                "url": "https://www.csfd.cz/film/72489-simpsonovi/1521444-serie-36/",
+                "year": 2024
               },
               {
-                "colorRating" : "good",
-                "creators" : {
-                  "actors" : [
+                "colorRating": "good",
+                "creators": {
+                  "actors": [
                     {
-                      "id" : 11255,
-                      "name" : "Dan Castellaneta",
-                      "url" : "https://www.csfd.cz/tvurce/11255-dan-castellaneta/"
+                      "id": 11255,
+                      "name": "Dan Castellaneta",
+                      "url": "https://www.csfd.cz/tvurce/11255-dan-castellaneta/"
                     },
                     {
-                      "id" : 11585,
-                      "name" : "Julie Kavner",
-                      "url" : "https://www.csfd.cz/tvurce/11585-julie-kavner/"
+                      "id": 11585,
+                      "name": "Julie Kavner",
+                      "url": "https://www.csfd.cz/tvurce/11585-julie-kavner/"
                     }
                   ],
-                  "directors" : [
+                  "directors": [
                     {
-                      "id" : 284739,
-                      "name" : "Mark Kirkland",
-                      "url" : "https://www.csfd.cz/tvurce/284739-mark-kirkland/"
+                      "id": 284739,
+                      "name": "Mark Kirkland",
+                      "url": "https://www.csfd.cz/tvurce/284739-mark-kirkland/"
                     },
                     {
-                      "id" : 35041,
-                      "name" : "Rich Moore",
-                      "url" : "https://www.csfd.cz/tvurce/35041-rich-moore/"
+                      "id": 35041,
+                      "name": "Rich Moore",
+                      "url": "https://www.csfd.cz/tvurce/35041-rich-moore/"
                     }
                   ]
                 },
-                "id" : 72489,
-                "origins" : [
+                "id": 72489,
+                "origins": [
                   "USA"
                 ],
-                "poster" : "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/158/294/158294127_cc47ad.jpg",
-                "title" : "Simpsonovi - Série 5",
-                "type" : "tvshow",
-                "url" : "https://www.csfd.cz/film/72489-simpsonovi/474508-serie-5/",
-                "year" : 1993
+                "poster": "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/158/294/158294127_cc47ad.jpg",
+                "title": "Simpsonovi - Série 5",
+                "type": "tvshow",
+                "url": "https://www.csfd.cz/film/72489-simpsonovi/474508-serie-5/",
+                "year": 1993
               },
               {
-                "colorRating" : "good",
-                "creators" : {
-                  "actors" : [
+                "colorRating": "good",
+                "creators": {
+                  "actors": [
                     {
-                      "id" : 11255,
-                      "name" : "Dan Castellaneta",
-                      "url" : "https://www.csfd.cz/tvurce/11255-dan-castellaneta/"
+                      "id": 11255,
+                      "name": "Dan Castellaneta",
+                      "url": "https://www.csfd.cz/tvurce/11255-dan-castellaneta/"
                     },
                     {
-                      "id" : 11585,
-                      "name" : "Julie Kavner",
-                      "url" : "https://www.csfd.cz/tvurce/11585-julie-kavner/"
+                      "id": 11585,
+                      "name": "Julie Kavner",
+                      "url": "https://www.csfd.cz/tvurce/11585-julie-kavner/"
                     }
                   ],
-                  "directors" : [
+                  "directors": [
                     {
-                      "id" : 64823,
-                      "name" : "Steven Dean Moore",
-                      "url" : "https://www.csfd.cz/tvurce/64823-steven-dean-moore/"
+                      "id": 64823,
+                      "name": "Steven Dean Moore",
+                      "url": "https://www.csfd.cz/tvurce/64823-steven-dean-moore/"
                     },
                     {
-                      "id" : 64825,
-                      "name" : "Jim Reardon",
-                      "url" : "https://www.csfd.cz/tvurce/64825-jim-reardon/"
+                      "id": 64825,
+                      "name": "Jim Reardon",
+                      "url": "https://www.csfd.cz/tvurce/64825-jim-reardon/"
                     }
                   ]
                 },
-                "id" : 72489,
-                "origins" : [
+                "id": 72489,
+                "origins": [
                   "USA"
                 ],
-                "poster" : "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/000/359/359041_b8b8e1.jpg",
-                "title" : "Simpsonovi - Série 9",
-                "type" : "tvshow",
-                "url" : "https://www.csfd.cz/film/72489-simpsonovi/475881-serie-9/",
-                "year" : 1997
+                "poster": "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/000/359/359041_b8b8e1.jpg",
+                "title": "Simpsonovi - Série 9",
+                "type": "tvshow",
+                "url": "https://www.csfd.cz/film/72489-simpsonovi/475881-serie-9/",
+                "year": 1997
               }
             ],
-            "totalCount" : 7
+            "totalCount": 7
           }
         },
-        "expected" : [
+        "expected": [
           {
-            "callsTool" : {
-              "arguments" : {
-                "contentType" : "tvshows",
-                "limit" : 5,
-                "query" : "Simpsons"
+            "callsTool": {
+              "arguments": {
+                "contentType": "tvshows",
+                "limit": 5,
+                "query": "Simpsons"
               },
-              "name" : "search-movies"
+              "name": "search-movies"
             }
           },
           {
-            "callsTool" : {
-              "arguments" : {
-                "movieId" : 72489
+            "callsTool": {
+              "arguments": {
+                "movieId": 72489
               },
-              "name" : "get-movie-details"
+              "name": "get-movie-details"
             }
           }
         ]
       },
       {
-        "input" : "What is rating for Forrest Gump? @csfd ",
-        "mocks" : {
-          "get-movie-details" : {
-            "cast" : {
-              "actors" : "Tom Hanks, Robin Wright, Gary Sinise, Mykelti Williamson, Sally Field",
-              "directors" : "Robert Zemeckis"
+        "input": "What is rating for Forrest Gump? @csfd ",
+        "mocks": {
+          "get-movie-details": {
+            "cast": {
+              "actors": "Tom Hanks, Robin Wright, Gary Sinise, Mykelti Williamson, Sally Field",
+              "directors": "Robert Zemeckis"
             },
-            "colorRating" : "good",
-            "description" : "Zemeckisův film je brilantním shrnutím dosavadních režisérových poznatků o možnostech \"comicsového\" vyprávění. Formálně i obsahově nejméně konvenční z jeho snímků přesvědčuje komediálními gagy i naléhavě patetickým tónem. Jeho hrdinou je prosťáček Forrest Gump, typický obyčejný muž, který od dětství dělal, co se mu řeklo. Do života si tak odnesl několik ponaučení své pečlivé maminky a osvědčené pravidlo, jež se mu hodí mnohokrát v nejrůznějších situacích: Když se dostaneš do problémů, utíkej. Forrest proutíká školou, jako hráč amerického fotbalu i univerzitou, potom peklem vietnamské války a zoufalstvím nad matčinou smrtí. Vždycky je totiž někdo nebo něco, co po něm skutečně či obrazně \"hází kameny\". Nakonec však Forrest poznává, že jsou i jiná řešení situací než útěk. Svůj život spojuje s kamarádkou ze školy Jenny, která pro něj zůstane provždycky jedinou láskou, s přítelem z vojny, černochem Bubbou, který dá směr jeho úvahám o lovu krevet a s poručíkem Taylorem, jemuž ve Vietnamu zachrání život. Forrestova životní pouť od 50. do 80. let je koncipovaná jako totálně \"bezelstné\" vyprávění hrdiny, neschopného obecnějšího hodnocení situace. Forrest jako sportovec i jako válečný hrdina se setkává se slavnými lidmi, které nakonec vždycky někdo zastřelí (J. F. Kennedy, J. Lennon). Také jeho bližní umírají, ale on sám zůstává. Empiricky se dopracovává od impulsivního útěku před životem k úvahám o lidském osudu a o Bohu. Soukromý hrdinův osud zároveň postihuje třicet let poválečných amerických dějin.(oficiální text distributora)",
-            "duration" : 142,
-            "genres" : [
+            "colorRating": "good",
+            "description": "Zemeckisův film je brilantním shrnutím dosavadních režisérových poznatků o možnostech \"comicsového\" vyprávění. Formálně i obsahově nejméně konvenční z jeho snímků přesvědčuje komediálními gagy i naléhavě patetickým tónem. Jeho hrdinou je prosťáček Forrest Gump, typický obyčejný muž, který od dětství dělal, co se mu řeklo. Do života si tak odnesl několik ponaučení své pečlivé maminky a osvědčené pravidlo, jež se mu hodí mnohokrát v nejrůznějších situacích: Když se dostaneš do problémů, utíkej. Forrest proutíká školou, jako hráč amerického fotbalu i univerzitou, potom peklem vietnamské války a zoufalstvím nad matčinou smrtí. Vždycky je totiž někdo nebo něco, co po něm skutečně či obrazně \"hází kameny\". Nakonec však Forrest poznává, že jsou i jiná řešení situací než útěk. Svůj život spojuje s kamarádkou ze školy Jenny, která pro něj zůstane provždycky jedinou láskou, s přítelem z vojny, černochem Bubbou, který dá směr jeho úvahám o lovu krevet a s poručíkem Taylorem, jemuž ve Vietnamu zachrání život. Forrestova životní pouť od 50. do 80. let je koncipovaná jako totálně \"bezelstné\" vyprávění hrdiny, neschopného obecnějšího hodnocení situace. Forrest jako sportovec i jako válečný hrdina se setkává se slavnými lidmi, které nakonec vždycky někdo zastřelí (J. F. Kennedy, J. Lennon). Také jeho bližní umírají, ale on sám zůstává. Empiricky se dopracovává od impulsivního útěku před životem k úvahám o lidském osudu a o Bohu. Soukromý hrdinův osud zároveň postihuje třicet let poválečných amerických dějin.(oficiální text distributora)",
+            "duration": 142,
+            "genres": [
               "Drama",
               "Komedie",
               "Romantický"
             ],
-            "id" : 10135,
-            "origins" : [
+            "id": 10135,
+            "origins": [
               "USA"
             ],
-            "poster" : "https://image.pmgstatic.com/cache/resized/w1080/files/images/film/posters/158/988/158988468_acc7b5.jpg",
-            "rating" : 94,
-            "title" : "Forrest Gump",
-            "url" : "https://www.csfd.cz/film/10135",
-            "watchOn" : [
+            "poster": "https://image.pmgstatic.com/cache/resized/w1080/files/images/film/posters/158/988/158988468_acc7b5.jpg",
+            "rating": 94,
+            "title": "Forrest Gump",
+            "url": "https://www.csfd.cz/film/10135",
+            "watchOn": [
               {
-                "title" : "SkyShowtime",
-                "url" : "https://www.skyshowtime.com/cz/stream/movies/forrest-gump/6a2c3789-01da-3bc6-b805-38857f6df934"
+                "title": "SkyShowtime",
+                "url": "https://www.skyshowtime.com/cz/stream/movies/forrest-gump/6a2c3789-01da-3bc6-b805-38857f6df934"
               },
               {
-                "title" : "Apple TV+",
-                "url" : "https://srv.clickfuse.com/ads/adclkr.php?id=100006636&url=https%3A//tv.apple.com/cz/movie/forrest-gump/umc.cmc.5ov9f55aw8qvmd5pumhgnwu3e"
+                "title": "Apple TV+",
+                "url": "https://srv.clickfuse.com/ads/adclkr.php?id=100006636&url=https%3A//tv.apple.com/cz/movie/forrest-gump/umc.cmc.5ov9f55aw8qvmd5pumhgnwu3e"
               },
               {
-                "title" : "Rakuten.tv",
-                "url" : "https://rakuten.tv/cz/movies/forrest-gump"
+                "title": "Rakuten.tv",
+                "url": "https://rakuten.tv/cz/movies/forrest-gump"
               },
               {
-                "title" : "YouTube Movies",
-                "url" : "https://www.youtube.com/watch?v=77ij5gCTjYU"
+                "title": "YouTube Movies",
+                "url": "https://www.youtube.com/watch?v=77ij5gCTjYU"
               },
               {
-                "title" : "DVD",
-                "url" : "https://www.martinus.cz/?uItem=93150"
+                "title": "DVD",
+                "url": "https://www.martinus.cz/?uItem=93150"
               },
               {
-                "title" : "Blu-ray",
-                "url" : "https://www.martinus.cz/?uItem=242368"
+                "title": "Blu-ray",
+                "url": "https://www.martinus.cz/?uItem=242368"
               },
               {
-                "title" : "Kniha",
-                "url" : "https://www.martinus.cz/?uItem=45196"
+                "title": "Kniha",
+                "url": "https://www.martinus.cz/?uItem=45196"
               }
             ],
-            "year" : 1994
+            "year": 1994
           },
-          "search-movies" : {
-            "message" : "Found 7 results for \"Forrest Gump\"",
-            "results" : [
+          "search-movies": {
+            "message": "Found 7 results for \"Forrest Gump\"",
+            "results": [
               {
-                "colorRating" : "good",
-                "creators" : {
-                  "actors" : [
+                "colorRating": "good",
+                "creators": {
+                  "actors": [
                     {
-                      "id" : 330,
-                      "name" : "Tom Hanks",
-                      "url" : "https://www.csfd.cz/tvurce/330-tom-hanks/"
+                      "id": 330,
+                      "name": "Tom Hanks",
+                      "url": "https://www.csfd.cz/tvurce/330-tom-hanks/"
                     },
                     {
-                      "id" : 604,
-                      "name" : "Robin Wright",
-                      "url" : "https://www.csfd.cz/tvurce/604-robin-wright/"
+                      "id": 604,
+                      "name": "Robin Wright",
+                      "url": "https://www.csfd.cz/tvurce/604-robin-wright/"
                     }
                   ],
-                  "directors" : [
+                  "directors": [
                     {
-                      "id" : 3137,
-                      "name" : "Robert Zemeckis",
-                      "url" : "https://www.csfd.cz/tvurce/3137-robert-zemeckis/"
+                      "id": 3137,
+                      "name": "Robert Zemeckis",
+                      "url": "https://www.csfd.cz/tvurce/3137-robert-zemeckis/"
                     }
                   ]
                 },
-                "id" : 10135,
-                "origins" : [
+                "id": 10135,
+                "origins": [
                   "USA"
                 ],
-                "poster" : "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/158/988/158988468_acc7b5.jpg",
-                "title" : "Forrest Gump",
-                "type" : "movie",
-                "url" : "https://www.csfd.cz/film/10135-forrest-gump/",
-                "year" : 1994
+                "poster": "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/158/988/158988468_acc7b5.jpg",
+                "title": "Forrest Gump",
+                "type": "movie",
+                "url": "https://www.csfd.cz/film/10135-forrest-gump/",
+                "year": 1994
               }
             ],
-            "totalCount" : 7
+            "totalCount": 7
           }
         },
-        "expected" : [
+        "expected": [
           {
-            "callsTool" : {
-              "arguments" : {
-                "contentType" : "movies",
-                "limit" : 1,
-                "query" : "Forrest Gump"
+            "callsTool": {
+              "arguments": {
+                "contentType": "movies",
+                "limit": 1,
+                "query": "Forrest Gump"
               },
-              "name" : "search-movies"
+              "name": "search-movies"
             }
           },
           {
-            "callsTool" : {
-              "arguments" : {
-                "movieId" : 10135
+            "callsTool": {
+              "arguments": {
+                "movieId": 10135
               },
-              "name" : "get-movie-details"
+              "name": "get-movie-details"
             }
           }
         ]
       },
       {
-        "input" : "How long is Green Mile? @csfd ",
-        "mocks" : {
-          "get-movie-details" : {
-            "cast" : {
-              "actors" : "Tom Hanks, David Morse, Bonnie Hunt, Michael Clarke Duncan, James Cromwell",
-              "directors" : "Frank Darabont"
+        "input": "How long is Green Mile? @csfd ",
+        "mocks": {
+          "get-movie-details": {
+            "cast": {
+              "actors": "Tom Hanks, David Morse, Bonnie Hunt, Michael Clarke Duncan, James Cromwell",
+              "directors": "Frank Darabont"
             },
-            "colorRating" : "good",
-            "description" : "Na začátku příběhu se potkáme se starým mužem Paulem Edgecombem (Dabbs Greer). Žije v domově s pečovatelskou službou a právě se dojatě dívá na starý film s Fredem Astairem. Snad až příliš dojatě, protože jedna ze sester ho musí zkontrolovat, když slyší všechny ty vzlyky. Paul je tak naměkko, že jí začne vypravovat svůj příběh starý 60 let, který ještě nikomu nevypravoval. Kolem roku 1935 v Louisianě, mladý Paul (teď už Tom Hanks) pracuje jako dozorce ve vězení pro těžké zločince, kteří jsou odsud posíláni na smrt. Paul není jen \"zaměstnancem\", ale bystrým pozorovatelem, který citlivě vnímá rázovité postavy těžkých zločinců i jejich osudy. Setkává se například s s černým obrem Johnem, který má ruce jako lopaty a je obviněn z vraždy dvou dětí. Nemůže uvěřit, že člověk, který se bojí spát potmě by byl schopen tak hrůzného činu. Je tu také hluboce věřící Arlen, a bláznivý psychopat zvaný Divoký Bill, ale je tu také ta hrůzostrašná chodba, natřená na zeleno, které všichni říkají \"Zelená míle\", je to cesta, na konci které čeká smrt, pokud se nestane zázrak.(oficiální text distributora)",
-            "duration" : 188,
-            "genres" : [
+            "colorRating": "good",
+            "description": "Na začátku příběhu se potkáme se starým mužem Paulem Edgecombem (Dabbs Greer). Žije v domově s pečovatelskou službou a právě se dojatě dívá na starý film s Fredem Astairem. Snad až příliš dojatě, protože jedna ze sester ho musí zkontrolovat, když slyší všechny ty vzlyky. Paul je tak naměkko, že jí začne vypravovat svůj příběh starý 60 let, který ještě nikomu nevypravoval. Kolem roku 1935 v Louisianě, mladý Paul (teď už Tom Hanks) pracuje jako dozorce ve vězení pro těžké zločince, kteří jsou odsud posíláni na smrt. Paul není jen \"zaměstnancem\", ale bystrým pozorovatelem, který citlivě vnímá rázovité postavy těžkých zločinců i jejich osudy. Setkává se například s s černým obrem Johnem, který má ruce jako lopaty a je obviněn z vraždy dvou dětí. Nemůže uvěřit, že člověk, který se bojí spát potmě by byl schopen tak hrůzného činu. Je tu také hluboce věřící Arlen, a bláznivý psychopat zvaný Divoký Bill, ale je tu také ta hrůzostrašná chodba, natřená na zeleno, které všichni říkají \"Zelená míle\", je to cesta, na konci které čeká smrt, pokud se nestane zázrak.(oficiální text distributora)",
+            "duration": 188,
+            "genres": [
               "Drama",
               "Mysteriózní",
               "Krimi"
             ],
-            "id" : 2292,
-            "origins" : [
+            "id": 2292,
+            "origins": [
               "USA"
             ],
-            "poster" : "https://image.pmgstatic.com/cache/resized/w1080/files/images/film/posters/000/079/79050_b712c4.jpg",
-            "rating" : 93,
-            "title" : "Zelená míle",
-            "url" : "https://www.csfd.cz/film/2292",
-            "watchOn" : [
+            "poster": "https://image.pmgstatic.com/cache/resized/w1080/files/images/film/posters/000/079/79050_b712c4.jpg",
+            "rating": 93,
+            "title": "Zelená míle",
+            "url": "https://www.csfd.cz/film/2292",
+            "watchOn": [
               {
-                "title" : "SkyShowtime",
-                "url" : "https://www.skyshowtime.com/cz/stream/movies/zelena-mile/5bc8599d-bcf9-3c62-8b16-d9389ab32ea7"
+                "title": "SkyShowtime",
+                "url": "https://www.skyshowtime.com/cz/stream/movies/zelena-mile/5bc8599d-bcf9-3c62-8b16-d9389ab32ea7"
               },
               {
-                "title" : "Apple TV+",
-                "url" : "https://srv.clickfuse.com/ads/adclkr.php?id=100006636&url=https%3A//tv.apple.com/cz/movie/the-green-mile/umc.cmc.7hcm0jk7o0ko95ghs171h7v41"
+                "title": "Apple TV+",
+                "url": "https://srv.clickfuse.com/ads/adclkr.php?id=100006636&url=https%3A//tv.apple.com/cz/movie/the-green-mile/umc.cmc.7hcm0jk7o0ko95ghs171h7v41"
               },
               {
-                "title" : "Rakuten.tv",
-                "url" : "https://rakuten.tv/cz/movies/the-green-mile"
+                "title": "Rakuten.tv",
+                "url": "https://rakuten.tv/cz/movies/the-green-mile"
               },
               {
-                "title" : "YouTube Movies",
-                "url" : "https://www.youtube.com/watch?v=WKKiIRbwLQY"
+                "title": "YouTube Movies",
+                "url": "https://www.youtube.com/watch?v=WKKiIRbwLQY"
               },
               {
-                "title" : "DVD",
-                "url" : "https://www.martinus.cz/?uItem=2136153"
+                "title": "DVD",
+                "url": "https://www.martinus.cz/?uItem=2136153"
               },
               {
-                "title" : "Kniha",
-                "url" : "https://www.martinus.cz/?uItem=166923"
+                "title": "Kniha",
+                "url": "https://www.martinus.cz/?uItem=166923"
               }
             ],
-            "year" : 1999
+            "year": 1999
           },
-          "search-movies" : {
-            "message" : "Found 7 results for \"Green Mile\"",
-            "results" : [
+          "search-movies": {
+            "message": "Found 7 results for \"Green Mile\"",
+            "results": [
               {
-                "colorRating" : "good",
-                "creators" : {
-                  "actors" : [
+                "colorRating": "good",
+                "creators": {
+                  "actors": [
                     {
-                      "id" : 330,
-                      "name" : "Tom Hanks",
-                      "url" : "https://www.csfd.cz/tvurce/330-tom-hanks/"
+                      "id": 330,
+                      "name": "Tom Hanks",
+                      "url": "https://www.csfd.cz/tvurce/330-tom-hanks/"
                     },
                     {
-                      "id" : 324,
-                      "name" : "David Morse",
-                      "url" : "https://www.csfd.cz/tvurce/324-david-morse/"
+                      "id": 324,
+                      "name": "David Morse",
+                      "url": "https://www.csfd.cz/tvurce/324-david-morse/"
                     }
                   ],
-                  "directors" : [
+                  "directors": [
                     {
-                      "id" : 2869,
-                      "name" : "Frank Darabont",
-                      "url" : "https://www.csfd.cz/tvurce/2869-frank-darabont/"
+                      "id": 2869,
+                      "name": "Frank Darabont",
+                      "url": "https://www.csfd.cz/tvurce/2869-frank-darabont/"
                     }
                   ]
                 },
-                "id" : 2292,
-                "origins" : [
+                "id": 2292,
+                "origins": [
                   "USA"
                 ],
-                "poster" : "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/000/079/79050_b712c4.jpg",
-                "title" : "Zelená míle",
-                "type" : "movie",
-                "url" : "https://www.csfd.cz/film/2292-zelena-mile/",
-                "year" : 1999
+                "poster": "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/000/079/79050_b712c4.jpg",
+                "title": "Zelená míle",
+                "type": "movie",
+                "url": "https://www.csfd.cz/film/2292-zelena-mile/",
+                "year": 1999
               },
               {
-                "colorRating" : "unknown",
-                "creators" : {
-                  "actors" : [
+                "colorRating": "unknown",
+                "creators": {
+                  "actors": [
                     {
-                      "id" : 9441,
-                      "name" : "Brent Briscoe",
-                      "url" : "https://www.csfd.cz/tvurce/9441-brent-briscoe/"
+                      "id": 9441,
+                      "name": "Brent Briscoe",
+                      "url": "https://www.csfd.cz/tvurce/9441-brent-briscoe/"
                     },
                     {
-                      "id" : 4852,
-                      "name" : "Patricia Clarkson",
-                      "url" : "https://www.csfd.cz/tvurce/4852-patricia-clarkson/"
+                      "id": 4852,
+                      "name": "Patricia Clarkson",
+                      "url": "https://www.csfd.cz/tvurce/4852-patricia-clarkson/"
                     }
                   ],
-                  "directors" : [
+                  "directors": [
                     {
-                      "id" : 733662,
-                      "name" : "Constantine Nasr",
-                      "url" : "https://www.csfd.cz/tvurce/733662-constantine-nasr/"
+                      "id": 733662,
+                      "name": "Constantine Nasr",
+                      "url": "https://www.csfd.cz/tvurce/733662-constantine-nasr/"
                     }
                   ]
                 },
-                "id" : 311842,
-                "origins" : [
+                "id": 311842,
+                "origins": [
                   "USA"
                 ],
-                "poster" : "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
-                "title" : "Miracles and Mystery: Creating 'The Green Mile'",
-                "type" : "movie",
-                "url" : "https://www.csfd.cz/film/311842-miracles-and-mystery-creating-the-green-mile/",
-                "year" : 2006
+                "poster": "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+                "title": "Miracles and Mystery: Creating 'The Green Mile'",
+                "type": "movie",
+                "url": "https://www.csfd.cz/film/311842-miracles-and-mystery-creating-the-green-mile/",
+                "year": 2006
               },
               {
-                "colorRating" : "good",
-                "creators" : {
-                  "actors" : [
+                "colorRating": "good",
+                "creators": {
+                  "actors": [
                     {
-                      "id" : 203,
-                      "name" : "William Sadler",
-                      "url" : "https://www.csfd.cz/tvurce/203-william-sadler/"
+                      "id": 203,
+                      "name": "William Sadler",
+                      "url": "https://www.csfd.cz/tvurce/203-william-sadler/"
                     },
                     {
-                      "id" : 324,
-                      "name" : "David Morse",
-                      "url" : "https://www.csfd.cz/tvurce/324-david-morse/"
+                      "id": 324,
+                      "name": "David Morse",
+                      "url": "https://www.csfd.cz/tvurce/324-david-morse/"
                     }
                   ],
-                  "directors" : [
+                  "directors": [
                     {
-                      "id" : 733662,
-                      "name" : "Constantine Nasr",
-                      "url" : "https://www.csfd.cz/tvurce/733662-constantine-nasr/"
+                      "id": 733662,
+                      "name": "Constantine Nasr",
+                      "url": "https://www.csfd.cz/tvurce/733662-constantine-nasr/"
                     }
                   ]
                 },
-                "id" : 89554,
-                "origins" : [
+                "id": 89554,
+                "origins": [
                   "USA"
                 ],
-                "poster" : "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
-                "title" : "Walking the Mile",
-                "type" : "movie",
-                "url" : "https://www.csfd.cz/film/89554-walking-the-mile/",
-                "year" : 2000
+                "poster": "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+                "title": "Walking the Mile",
+                "type": "movie",
+                "url": "https://www.csfd.cz/film/89554-walking-the-mile/",
+                "year": 2000
               },
               {
-                "colorRating" : "good",
-                "creators" : {
-                  "actors" : [
+                "colorRating": "good",
+                "creators": {
+                  "actors": [
                     {
-                      "id" : 552,
-                      "name" : "Bonnie Hunt",
-                      "url" : "https://www.csfd.cz/tvurce/552-bonnie-hunt/"
+                      "id": 552,
+                      "name": "Bonnie Hunt",
+                      "url": "https://www.csfd.cz/tvurce/552-bonnie-hunt/"
                     },
                     {
-                      "id" : 491,
-                      "name" : "Gary Sinise",
-                      "url" : "https://www.csfd.cz/tvurce/491-gary-sinise/"
+                      "id": 491,
+                      "name": "Gary Sinise",
+                      "url": "https://www.csfd.cz/tvurce/491-gary-sinise/"
                     }
                   ],
-                  "directors" : [
+                  "directors": [
                     {
-                      "id" : 15137,
-                      "name" : "Doug Hutchison",
-                      "url" : "https://www.csfd.cz/tvurce/15137-doug-hutchison/"
+                      "id": 15137,
+                      "name": "Doug Hutchison",
+                      "url": "https://www.csfd.cz/tvurce/15137-doug-hutchison/"
                     }
                   ]
                 },
-                "id" : 73363,
-                "origins" : [
+                "id": 73363,
+                "origins": [
                   "USA"
                 ],
-                "poster" : "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
-                "title" : "The Miracle of the Green Mile",
-                "type" : "movie",
-                "url" : "https://www.csfd.cz/film/73363-the-miracle-of-the-green-mile/",
-                "year" : 1999
+                "poster": "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+                "title": "The Miracle of the Green Mile",
+                "type": "movie",
+                "url": "https://www.csfd.cz/film/73363-the-miracle-of-the-green-mile/",
+                "year": 1999
               },
               {
-                "colorRating" : "good",
-                "creators" : {
-                  "actors" : [
-      
-                  ],
-                  "directors" : [
+                "colorRating": "good",
+                "creators": {
+                  "actors": [],
+                  "directors": [
                     {
-                      "id" : 9039,
-                      "name" : "Zdeněk Miler",
-                      "url" : "https://www.csfd.cz/tvurce/9039-zdenek-miler/"
+                      "id": 9039,
+                      "name": "Zdeněk Miler",
+                      "url": "https://www.csfd.cz/tvurce/9039-zdenek-miler/"
                     }
                   ]
                 },
-                "id" : 130721,
-                "origins" : [
+                "id": 130721,
+                "origins": [
                   "Československo"
                 ],
-                "poster" : "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/000/036/36591_5ddbc5.jpg",
-                "title" : "Krtek a zelená hvězda",
-                "type" : "movie",
-                "url" : "https://www.csfd.cz/film/130721-krtek-a-zelena-hvezda/",
-                "year" : 1969
+                "poster": "https://image.pmgstatic.com/cache/resized/w60h85/files/images/film/posters/000/036/36591_5ddbc5.jpg",
+                "title": "Krtek a zelená hvězda",
+                "type": "movie",
+                "url": "https://www.csfd.cz/film/130721-krtek-a-zelena-hvezda/",
+                "year": 1969
               },
               {
-                "colorRating" : "unknown",
-                "creators" : {
-                  "actors" : [
+                "colorRating": "unknown",
+                "creators": {
+                  "actors": [
                     {
-                      "id" : 53832,
-                      "name" : "Michelle Bauer",
-                      "url" : "https://www.csfd.cz/tvurce/53832-michelle-bauer/"
+                      "id": 53832,
+                      "name": "Michelle Bauer",
+                      "url": "https://www.csfd.cz/tvurce/53832-michelle-bauer/"
                     },
                     {
-                      "id" : 303597,
-                      "name" : "Jason Whitman",
-                      "url" : "https://www.csfd.cz/tvurce/303597-jason-whitman/"
+                      "id": 303597,
+                      "name": "Jason Whitman",
+                      "url": "https://www.csfd.cz/tvurce/303597-jason-whitman/"
                     }
                   ],
-                  "directors" : [
-      
-                  ]
+                  "directors": []
                 },
-                "id" : 492165,
-                "origins" : [
+                "id": 492165,
+                "origins": [
                   "USA"
                 ],
-                "poster" : "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
-                "title" : "Greek File",
-                "type" : "movie",
-                "url" : "https://www.csfd.cz/film/492165-greek-file/",
-                "year" : 1987
+                "poster": "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+                "title": "Greek File",
+                "type": "movie",
+                "url": "https://www.csfd.cz/film/492165-greek-file/",
+                "year": 1987
               },
               {
-                "colorRating" : "unknown",
-                "creators" : {
-                  "actors" : [
-      
-                  ],
-                  "directors" : [
+                "colorRating": "unknown",
+                "creators": {
+                  "actors": [],
+                  "directors": [
                     {
-                      "id" : 512279,
-                      "name" : "Roderick Angle",
-                      "url" : "https://www.csfd.cz/tvurce/512279-roderick-angle/"
+                      "id": 512279,
+                      "name": "Roderick Angle",
+                      "url": "https://www.csfd.cz/tvurce/512279-roderick-angle/"
                     }
                   ]
                 },
-                "id" : 776747,
-                "origins" : [
+                "id": 776747,
+                "origins": [
                   "USA"
                 ],
-                "poster" : "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
-                "title" : "Mike Osterhout & the Church of the Little Green Man",
-                "type" : "movie",
-                "url" : "https://www.csfd.cz/film/776747-mike-osterhout-the-church-of-the-little-green-man/",
-                "year" : 2019
+                "poster": "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+                "title": "Mike Osterhout & the Church of the Little Green Man",
+                "type": "movie",
+                "url": "https://www.csfd.cz/film/776747-mike-osterhout-the-church-of-the-little-green-man/",
+                "year": 2019
               }
             ],
-            "totalCount" : 7
+            "totalCount": 7
           }
         },
-        "expected" : [
+        "expected": [
           {
-            "callsTool" : {
-              "arguments" : {
-                "contentType" : "movies",
-                "query" : "Green Mile",
-                "limit" : 1
+            "callsTool": {
+              "arguments": {
+                "contentType": "movies",
+                "query": "Green Mile",
+                "limit": 1
               },
-              "name" : "search-movies"
+              "name": "search-movies"
             }
           },
           {
-            "callsTool" : {
-              "arguments" : {
-                "movieId" : 2292
+            "callsTool": {
+              "arguments": {
+                "movieId": 2292
               },
-              "name" : "get-movie-details"
+              "name": "get-movie-details"
             }
           }
         ]
       }
     ]
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }


### PR DESCRIPTION
## Description

Updates `node-csfd-api` dependency from v2.11.0 to v4.1.2

Fixes #24228

The previous version of the `node-csfd-api` library had a bug causing `TypeError: Cannot read properties of null (reading 'textContent')` when viewing movie details. This update resolves the issue.

## Screencast

No UI changes - this is a dependency update fix.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder