### PR TITLE
things: optimize JXA performance with `properties()` batching

### DIFF
--- a/extensions/things/CHANGELOG.md
+++ b/extensions/things/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Things Changelog
 
+## [JXA Performance Optimization] - {PR_MERGE_DATE}
+
+- Reduced JXA fetch times by ~75% using `properties()` batching to minimize Apple Event overhead
+- Removed nested area tags from todo data (tags on containing areas are no longer fetched)
+
 ## [Improved Query String Creation] - 2026-01-08
 
 - Replaced the `⁠qs` package with `⁠query-string` to automatically exclude empty strings and null values when generating Things URLs

--- a/extensions/things/CHANGELOG.md
+++ b/extensions/things/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Things Changelog
 
-## [JXA Performance Optimization] - {PR_MERGE_DATE}
+## [JXA Performance Optimization] - 2026-01-12
 
 - Reduced JXA fetch times by ~75% using `properties()` batching to minimize Apple Event overhead
 - Removed nested area tags from todo data (tags on containing areas are no longer fetched)

--- a/extensions/things/src/types.ts
+++ b/extensions/things/src/types.ts
@@ -28,7 +28,7 @@ export type Project = {
 export type Area = {
   id: string;
   name: string;
-  tags: string;
+  tags?: string;
   todos?: Todo[];
 };
 


### PR DESCRIPTION
## Description

Optimizes JXA performance in the Things extension by using `properties()` batching instead of individual property calls. This reduces Apple Event overhead from ~15+ round-trips per todo to ~3-4, resulting in **~75% faster list loading times**.

This is particularly impactful on macOS Tahoe, where Apple Event latency appears to have increased significantly. Before this change, loading 28 todos took ~5+ seconds. After, it takes ~1-1.5 seconds.

### Changes

- **`api.ts`**: Rewrote `getListTodos` to use `properties()` batching for todos, projects, and areas
- **`api.ts`**: Applied same optimization to `getProjects`, `getAreas`, and `getTagsProjectsAndAreas` mapping templates
- Made `tags` optional in `Area` type since nested areas no longer include them

### Benchmark Results

| List | Items | Baseline | Optimized | Improvement |
|------|-------|----------|-----------|-------------|
| Inbox | 5 | 782ms | 149ms | 81% faster |
| Today | 28 | 5,295ms | 1,141ms | 78% faster |
| Upcoming | 42 | 7,050ms | 1,629ms | 77% faster |
| Anytime | 49 | 8,911ms | 1,993ms | 78% faster |

### Breaking Change: Nested Area Tags Removed

Tags on containing areas (`todo.area.tags`, `todo.project.area.tags`) are no longer fetched. Todo and project data now only includes:

- `todo.tags` — the todo's own tags
- `todo.project.tags` — the project's tags
- `todo.area.name` / `todo.project.area.name` — area names (still available)

Nested area tags required additional Apple Event calls per todo and provided marginal value—users are unlikely to need a tag assigned to a todo's grandparent area. Removing them contributes ~14% additional performance improvement.

## Screencast

N/A - performance optimization with no visual changes.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
