### PR TITLE
Update `TerminalFinder` extension - better error message when no Finder windows or accessing non-filesystem folder

### DIFF
--- a/extensions/terminalfinder/CHANGELOG.md
+++ b/extensions/terminalfinder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Terminal Finder Changelog
 
-## [Better "Finder" Errors] - {PR_MERGE_DATE}
+## [Better "Finder" Errors] - 2026-01-12
 
 - Show a better error message when no **Finder** window open or when trying to pass non-filesystem folder (e.g. **Recents**) (ref: [Issue #24386](https://github.com/raycast/extensions/issues/24386))
 

--- a/extensions/terminalfinder/CHANGELOG.md
+++ b/extensions/terminalfinder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Terminal Finder Changelog
 
+## [Better "Finder Not Open" Error] - {PR_MERGE_DATE}
+
+- Show a better error message when no **Finder** window open (ref: [Issue #24386](https://github.com/raycast/extensions/issues/24386))
+
 ## [Fix Kitty Casing] - 2026-01-12
 
 - Fix "Kitty" terminal not working due to different casing (ref: [Issue #24377](https://github.com/raycast/extensions/issues/24377))

--- a/extensions/terminalfinder/CHANGELOG.md
+++ b/extensions/terminalfinder/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Terminal Finder Changelog
 
-## [Better "Finder Not Open" Error] - {PR_MERGE_DATE}
+## [Better "Finder" Errors] - {PR_MERGE_DATE}
 
-- Show a better error message when no **Finder** window open (ref: [Issue #24386](https://github.com/raycast/extensions/issues/24386))
+- Show a better error message when no **Finder** window open or when trying to pass non-filesystem folder (e.g. **Recents**) (ref: [Issue #24386](https://github.com/raycast/extensions/issues/24386))
 
 ## [Fix Kitty Casing] - 2026-01-12
 

--- a/extensions/terminalfinder/src/utils.ts
+++ b/extensions/terminalfinder/src/utils.ts
@@ -61,12 +61,11 @@ export async function finderToApplication(name: Terminal) {
 
     tell application "Finder"
       if (count of Finder windows) = 0 then error "No Finder window open"
-      
       try
         set pathList to POSIX path of (folder of the front window as alias)
         return pathList
       on error
-        error "Front window is not a real filesystem folder"
+        error "Could not access Finder window path"
       end try
     end tell
   `;

--- a/extensions/terminalfinder/src/utils.ts
+++ b/extensions/terminalfinder/src/utils.ts
@@ -60,8 +60,12 @@ export async function finderToApplication(name: Terminal) {
     end if
 
     tell application "Finder"
-        set pathList to POSIX path of (folder of the front window as alias)
-        return pathList
+        try
+          set pathList to POSIX path of (folder of the front window as alias)
+          return pathList
+        on error
+          error "No Finder window open"
+        end try
     end tell
   `;
   try {

--- a/extensions/terminalfinder/src/utils.ts
+++ b/extensions/terminalfinder/src/utils.ts
@@ -60,12 +60,14 @@ export async function finderToApplication(name: Terminal) {
     end if
 
     tell application "Finder"
-        try
-          set pathList to POSIX path of (folder of the front window as alias)
-          return pathList
-        on error
-          error "No Finder window open"
-        end try
+      if (count of Finder windows) = 0 then error "No Finder window open"
+      
+      try
+        set pathList to POSIX path of (folder of the front window as alias)
+        return pathList
+      on error
+        error "Front window is not a real filesystem folder"
+      end try
     end tell
   `;
   try {


### PR DESCRIPTION
## Description

- Show a better error message when no **Finder** window open or when trying to pass non-filesystem folder (e.g. **Recents**) (close #24386)

## Screenshots

### BEFORE

<img width="2000" height="1250" alt="terminalfinder-before" src="https://github.com/user-attachments/assets/4c4ae38c-0b27-410d-b0b4-5d8104ec0d60" />

### AFTER

<img width="2000" height="1250" alt="terminalfinder-after" src="https://github.com/user-attachments/assets/18730b98-5069-4245-afae-d85fdc6f0d91" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
