### PR TITLE
Update git-repos extension

### DIFF
--- a/extensions/git-repos/CHANGELOG.md
+++ b/extensions/git-repos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Git Repos Changelog
 
-## [Enhancement] - {PR_MERGE_DATE}
+## [Enhancement] - 2026-01-19
 
 - Added "Create Quicklink" action to GitRepoListItem component
 - Added "shkreios" to contributors list

--- a/extensions/git-repos/CHANGELOG.md
+++ b/extensions/git-repos/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Git Repos Changelog
 
+## [Enhancement] - {PR_MERGE_DATE}
+
+- Added "Create Quicklink" action to GitRepoListItem component
+- Added "shkreios" to contributors list
+
 ## [Bug Fix] - 2025-09-10
 
 - Fixes determination of remote URLs for worktrees.

--- a/extensions/git-repos/package.json
+++ b/extensions/git-repos/package.json
@@ -158,5 +158,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/git-repos/package.json
+++ b/extensions/git-repos/package.json
@@ -10,7 +10,8 @@
     "go_dima",
     "cameronsstone",
     "hacdias",
-    "AaronMoat"
+    "AaronMoat",
+    "shkreios"
   ],
   "categories": [
     "Developer Tools",

--- a/extensions/git-repos/src/list.tsx
+++ b/extensions/git-repos/src/list.tsx
@@ -171,6 +171,15 @@ function GitRepoListItem(props: {
               }}
               shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
             />
+            <Action.CreateQuicklink
+              title="Create Quicklink"
+              quicklink={{
+                link: repo.fullPath,
+                name: repo.name,
+                application: preferences.openWith1.bundleId,
+              }}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
+            />
           </ActionPanel.Section>
           <ActionPanel.Section>
             {repo.remotes.map((remote) => {


### PR DESCRIPTION
## Description

Add a "Create Quicklink" action to git repository items. This allows users to quickly create a Raycast quicklink that opens a specific repository with their preferred application.

## Screencast

This is a straightforward enhancement adding a single action. The new "Create Quicklink" option appears in the action panel with the shortcut ⌘⇧L.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder