### PR TITLE
markmarks extension: add support for Dia browser

### DIFF
--- a/extensions/markmarks/CHANGELOG.md
+++ b/extensions/markmarks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # MarkMarks Changelog
 
-## [1.1.0] - 2026-01-19
+## [1.1.0] - {PR_MERGE_DATE}
 
 - Add Dia browser support
 

--- a/extensions/markmarks/CHANGELOG.md
+++ b/extensions/markmarks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MarkMarks Changelog
 
+## [1.1.0] - 2026-01-19
+
+- Add Dia browser support
+
 ## [Initial Release] - 2026-01-08
 
 - Add bookmark from Safari, Chrome, or Arc browser tabs

--- a/extensions/markmarks/CHANGELOG.md
+++ b/extensions/markmarks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # MarkMarks Changelog
 
-## [1.1.0] - {PR_MERGE_DATE}
+## [1.1.0] - 2026-01-20
 
 - Add Dia browser support
 

--- a/extensions/markmarks/README.md
+++ b/extensions/markmarks/README.md
@@ -5,7 +5,7 @@ A Raycast extension that uses a markdown file as the persistence layer for your 
 ## Features
 
 - **Bookmarks** - Browse all your bookmarks organized by groups with website favicons
-- **New Bookmark** - Save the active tab from Safari, Chrome, or Arc
+- **New Bookmark** - Save the active tab from Safari, Chrome, Arc, or Dia
 - **Edit & Delete** - Modify or remove bookmarks directly from Raycast
 - **Move Between Groups** - Reorganize bookmarks by moving them to different groups
 - **Search** - Quick search across all bookmarks by title, URL, or description
@@ -65,6 +65,7 @@ The "New Bookmark" command can capture the active tab from:
 - Safari
 - Google Chrome
 - Arc
+- Dia
 
 The extension automatically detects which supported browser is frontmost.
 

--- a/extensions/markmarks/src/lib/browser.ts
+++ b/extensions/markmarks/src/lib/browser.ts
@@ -1,7 +1,7 @@
 import { runAppleScript } from "@raycast/utils";
 import { ActiveTab, SupportedBrowser } from "./types";
 
-const SUPPORTED_BROWSERS: SupportedBrowser[] = ["Safari", "Google Chrome", "Arc"];
+const SUPPORTED_BROWSERS: SupportedBrowser[] = ["Safari", "Google Chrome", "Arc", "Dia"];
 
 /**
  * Get the frontmost application name
@@ -65,6 +65,31 @@ async function getArcTab(): Promise<ActiveTab> {
 }
 
 /**
+ * Get the active tab from Dia
+ */
+async function getDiaTab(): Promise<ActiveTab> {
+  const script = `
+    tell application "Dia"
+      tell front window
+        set tabTitle to ""
+        set tabURL to ""
+        repeat with t in tabs
+          if isFocused of t is true then
+            set tabTitle to title of t
+            set tabURL to URL of t
+            exit repeat
+          end if
+        end repeat
+      end tell
+    end tell
+    return tabTitle & "|||" & tabURL
+  `;
+  const result = await runAppleScript(script);
+  const [title, url] = result.split("|||");
+  return { title: title.trim(), url: url.trim() };
+}
+
+/**
  * Check if the given app name is a supported browser
  */
 function isSupportedBrowser(appName: string): appName is SupportedBrowser {
@@ -95,6 +120,9 @@ export async function getActiveTabFromFrontmostBrowser(): Promise<{
       break;
     case "Arc":
       tab = await getArcTab();
+      break;
+    case "Dia":
+      tab = await getDiaTab();
       break;
   }
 

--- a/extensions/markmarks/src/lib/types.ts
+++ b/extensions/markmarks/src/lib/types.ts
@@ -24,4 +24,4 @@ export interface ActiveTab {
   url: string;
 }
 
-export type SupportedBrowser = "Safari" | "Google Chrome" | "Arc";
+export type SupportedBrowser = "Safari" | "Google Chrome" | "Arc" | "Dia";


### PR DESCRIPTION
## Description

Adds support for Dia browser. You can now capture the current tab's title and URL from Dia using the "New Bookmark" command.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

n/a

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
