### PR TITLE
Update `Plane` extension - show icon state color in project work items

### DIFF
--- a/extensions/plane/CHANGELOG.md
+++ b/extensions/plane/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Plane Changelog
 
+## [Show State Color in Search Projects > Work Items] - {PR_MERGE_DATE}
+
+- In "Search Projects" > "Work Items", the `Icon` is colored and has `tooltip` of the _state_ name
+
 ## [Add Start Date and Due Date to Work Item Creation and Editing] - 2026-01-17
 
 ## [Update README with correct API Base Path format] - 2025-11-04

--- a/extensions/plane/CHANGELOG.md
+++ b/extensions/plane/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plane Changelog
 
-## [Show State Color in Search Projects > Work Items] - {PR_MERGE_DATE}
+## [Show State Color in Search Projects > Work Items] - 2026-01-23
 
 - In "Search Projects" > "Work Items", the `Icon` is colored and has `tooltip` of the _state_ name
 

--- a/extensions/plane/package-lock.json
+++ b/extensions/plane/package-lock.json
@@ -8,8 +8,8 @@
       "license": "MIT",
       "dependencies": {
         "@makeplane/plane-node-sdk": "0.1.3",
-        "@raycast/api": "^1.103.3",
-        "@raycast/utils": "^2.2.1",
+        "@raycast/api": "^1.104.3",
+        "@raycast/utils": "^2.2.2",
         "date-fns": "^4.1.0",
         "marked": "^16.1.0",
         "turndown": "^7.2.0"
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.103.3",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.103.3.tgz",
-      "integrity": "sha512-+lS8yOrqSP7++ZyomZnMkN0pzEZto/XOqag8MXt9SmTuJBZvfMV74f9wzXmJkRmynYxQHnpLqvs9otWrDd3Bvw==",
+      "version": "1.104.3",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.3.tgz",
+      "integrity": "sha512-ud3c2csFd3VywjqDuY33U184ZmbAJmY+Z7qYpiMOOAzDZye49ZE7Qjw4s/2Vob+LCLX/XduzWpVFv5omdfNThQ==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.5.4",
@@ -1222,9 +1222,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.1.tgz",
-      "integrity": "sha512-MBOD3eccHTu1HVQstoqoJJsA5PubWv18EUq8Dxwg1PEJE+xVjEuslXpsNgR/2RtpTGeKgGiXePxUiVp5mILN5w==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.2.tgz",
+      "integrity": "sha512-tZcyWCHZvz4L/i1CGEnSZkBoK6wwX1pzlTKjcWWugbrQyG0QCMOxjKJfRC/iNkD+hHaqhMWUj4Y0LNo/NknvFw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"

--- a/extensions/plane/package.json
+++ b/extensions/plane/package.json
@@ -40,8 +40,8 @@
   ],
   "dependencies": {
     "@makeplane/plane-node-sdk": "0.1.3",
-    "@raycast/api": "^1.103.3",
-    "@raycast/utils": "^2.2.1",
+    "@raycast/api": "^1.104.3",
+    "@raycast/utils": "^2.2.2",
     "date-fns": "^4.1.0",
     "marked": "^16.1.0",
     "turndown": "^7.2.0"

--- a/extensions/plane/src/api/work-items.ts
+++ b/extensions/plane/src/api/work-items.ts
@@ -1,4 +1,4 @@
-import { IssueSearchItem, IssueRequest, PatchedIssueRequest } from "@makeplane/plane-node-sdk";
+import { IssueSearchItem, IssueRequest, PatchedIssueRequest, StateLite } from "@makeplane/plane-node-sdk";
 import { planeClient } from "./auth";
 
 export async function createWorkItem(projectId: string, workItemRequest: IssueRequest) {
@@ -33,10 +33,16 @@ export async function getProjectWorkItems({
     slug: planeClient?.workspaceSlug,
     perPage,
     cursor,
+    expand: "state",
   });
 
+  const results = (response?.results || []).map((workItem) => ({
+    ...workItem,
+    state: workItem.state as StateLite,
+  }));
+
   return {
-    data: response?.results || [],
+    data: results,
     hasMore: !!response?.nextPageResults,
     cursor: response?.nextCursor,
   };

--- a/extensions/plane/src/components/ProjectWorkItemsList.tsx
+++ b/extensions/plane/src/components/ProjectWorkItemsList.tsx
@@ -12,7 +12,7 @@ export default function ProjectWorkItemsList({ projectItem }: { projectItem: Pro
       {workItems.map((workItem, i) => (
         <List.Item
           key={i}
-          icon={Icon.BullsEye}
+          icon={{ source: Icon.BullsEye, tintColor: workItem.state.color, tooltip: workItem.state.name }}
           title={workItem.name}
           subtitle={`${projectItem.identifier} ${workItem.sequenceId}`}
           detail={
@@ -23,7 +23,10 @@ export default function ProjectWorkItemsList({ projectItem }: { projectItem: Pro
           actions={
             <ActionPanel>
               <Action.OpenInBrowser
-                url={getWorkItemBrowseUrl(planeClient?.workspaceSlug ?? "", projectItem, workItem)}
+                url={getWorkItemBrowseUrl(planeClient?.workspaceSlug ?? "", projectItem, {
+                  ...workItem,
+                  state: workItem.state.id,
+                })}
               />
             </ActionPanel>
           }


### PR DESCRIPTION
## Description

- In "Search Projects" > "Work Items", the `Icon` is colored and has `tooltip` of the _state_ name

## Screenshot

<img width="2000" height="1250" alt="plane-2026-01-23" src="https://github.com/user-attachments/assets/847ab24f-ff7f-4749-ac7f-574b9cdb8415" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
