### PR TITLE
Update quick-jump extension

### DIFF
--- a/extensions/quick-jump/CHANGELOG.md
+++ b/extensions/quick-jump/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Quick Jump Changelog
 
+## [Enhancement] - {PR_MERGE_DATE}
+
+### Added
+- Nested placeholder expansion: placeholders can now reference other placeholders (e.g., `teamDir: "${baseDir}/team"`)
+- Circular dependency detection with detailed error UI showing cycle path and fix instructions
+
 ## [Enhancement] - 2026-01-15
 
 ### Added

--- a/extensions/quick-jump/CHANGELOG.md
+++ b/extensions/quick-jump/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quick Jump Changelog
 
-## [Enhancement] - {PR_MERGE_DATE}
+## [Enhancement] - 2026-01-24
 
 ### Added
 - Nested placeholder expansion: placeholders can now reference other placeholders (e.g., `teamDir: "${baseDir}/team"`)

--- a/extensions/quick-jump/src/components/group-detail-view.tsx
+++ b/extensions/quick-jump/src/components/group-detail-view.tsx
@@ -2,6 +2,7 @@ import { Action, ActionPanel, Detail, Icon } from "@raycast/api";
 import { Group, Root } from "../types";
 import { OpenConfigFileAction } from "./open-config-action";
 import { extractPlaceholders, getEnhancedKeywords, combineKeywords } from "../utils";
+import { SHORTCUTS } from "../constants";
 
 interface GroupDetailViewProps {
   groupKey: string;
@@ -202,7 +203,7 @@ export function GroupDetailView({ groupKey, group, rootData, onBrowseGroup }: Gr
         <ActionPanel>
           {onBrowseGroup && <Action title="Browse Group" icon={Icon.Folder} onAction={onBrowseGroup} />}
           <ActionPanel.Section>
-            <OpenConfigFileAction shortcut={{ modifiers: ["cmd", "shift"], key: "c" }} />
+            <OpenConfigFileAction shortcut={SHORTCUTS.OPEN_CONFIG} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/quick-jump/src/components/help-view.tsx
+++ b/extensions/quick-jump/src/components/help-view.tsx
@@ -65,13 +65,67 @@ ${error.suggestion ? `**Suggestion:** ${error.suggestion}` : ""}
 2. Navigate to the location mentioned above
 3. ${error.suggestion || "Review and correct the configuration"}
 
-### Example
+${
+  error.type === "missing_placeholder"
+    ? `### Example Fixes
+
+${
+  error.message.includes('requires placeholder "')
+    ? `You have **3 options** to fix this:
+
+#### Option 1: Add to Local Placeholders (Recommended)
+Add the placeholder to the same location where it's used:
+
+\`\`\`json
+{
+  "templatePlaceholders": {
+    "existingPlaceholder": "value",
+    "${error.message.match(/"([^"]+)"/)?.[1] || "placeholder"}": "your-value-here"
+  }
+}
+\`\`\`
+
+#### Option 2: Add to Global Placeholders
+If this placeholder is used in multiple places, add it globally:
+
+\`\`\`json
+{
+  "globalPlaceholders": {
+    "${error.message.match(/"([^"]+)"/)?.[1] || "placeholder"}": "your-value-here"
+  }
+}
+\`\`\`
+
+#### Option 3: Remove the Reference
+If you don't need this placeholder, remove it from the template:
+
+\`\`\`json
+{
+  "projectDirectory": "/path/without/placeholder"
+}
+\`\`\`
+`
+    : `### Example
+
+\`\`\`json
+{
+  "templatePlaceholders": {
+    "placeholder": "value"
+  }
+}
+\`\`\`
+`
+}
+`
+    : `### Example
 
 \`\`\`json
 {
   "${error.location.split(".").pop()}": "correct-value"
 }
 \`\`\`
+`
+}
 `}
                       />
                     }

--- a/extensions/quick-jump/src/components/url-list-item.tsx
+++ b/extensions/quick-jump/src/components/url-list-item.tsx
@@ -2,6 +2,7 @@ import { Action, ActionPanel, Application, List, Detail, Icon } from "@raycast/a
 import { DisplayUrl } from "../types";
 import { OpenConfigFileAction } from "./open-config-action";
 import { getTagAccessories, getFallbackIcon, getAppIcon } from "../utils";
+import { SHORTCUTS } from "../constants";
 
 interface URLListItemProps {
   item: DisplayUrl;
@@ -58,7 +59,7 @@ function URLDetailView({ item, applications }: { item: DisplayUrl; applications:
           )}
           <Action.CopyToClipboard content={item.url} title="Copy URL" />
           <ActionPanel.Section>
-            <OpenConfigFileAction shortcut={{ modifiers: ["cmd", "shift"], key: "c" }} />
+            <OpenConfigFileAction shortcut={SHORTCUTS.OPEN_CONFIG} />
           </ActionPanel.Section>
         </ActionPanel>
       }
@@ -92,7 +93,7 @@ export function URLListItem({ item, applications }: URLListItemProps) {
           ) : (
             <Action.OpenInBrowser url={item.url} />
           )}
-          <Action.CopyToClipboard content={item.url} />
+          <Action.CopyToClipboard content={item.url} title="Copy URL" />
           <Action.Push
             title="Show Details"
             icon={Icon.Eye}
@@ -100,7 +101,7 @@ export function URLListItem({ item, applications }: URLListItemProps) {
             target={<URLDetailView item={item} applications={applications} />}
           />
           <ActionPanel.Section>
-            <OpenConfigFileAction shortcut={{ modifiers: ["cmd", "shift"], key: "c" }} />
+            <OpenConfigFileAction shortcut={SHORTCUTS.OPEN_CONFIG} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/quick-jump/src/constants.ts
+++ b/extensions/quick-jump/src/constants.ts
@@ -1,9 +1,11 @@
+import { Keyboard } from "@raycast/api";
+
 export const APP_NAME = "Quick Jump";
 
-export const DEFAULT_ICON = "icon.png";
 export const DEFAULT_TITLE = "Untitled";
 export const FALLBACK_ICON = "icon.png";
-export const COMMON_TLDS = new Set(["com", "net", "org", "io", "co", "edu", "gov", "mil", "biz", "info"]);
+
+export const PLACEHOLDER_PATTERN = /\$\{([^{}]+)\}/g;
 
 export const SECTION_TITLES = {
   GROUPS: "Groups",
@@ -18,6 +20,10 @@ export const ACTION_TITLES = {
   OPEN_CONFIG_FILE: "Open Config File",
   COPY_URL: "Copy URL",
 } as const;
+
+export const SHORTCUTS: { OPEN_CONFIG: Keyboard.Shortcut } = {
+  OPEN_CONFIG: { modifiers: ["cmd", "shift"], key: "c" },
+};
 
 export const ERROR_MESSAGES = {
   FILE_NOT_FOUND: "Configuration file not found. Please check your extension preferences.",

--- a/extensions/quick-jump/src/template-utils.ts
+++ b/extensions/quick-jump/src/template-utils.ts
@@ -37,13 +37,18 @@ export function createTemplateDisplayUrls(
   const templateUrls: DisplayUrl[] = [];
   const allAppliedTemplates = getAllAppliedTemplates(entity, rootData);
 
+  const placeholdersResult = mergePlaceholders(rootData.globalPlaceholders, entity.templatePlaceholders);
+
+  if (!placeholdersResult.success) {
+    console.error(`Placeholder error for ${keyPrefix}: ${placeholdersResult.error}`);
+    return templateUrls;
+  }
+
+  const placeholders = placeholdersResult.placeholders;
+
   for (const templateKey of allAppliedTemplates) {
     const template = rootData.templates?.[templateKey];
     if (!template || !template.templateUrl) continue;
-
-    const placeholders = mergePlaceholders(rootData.globalPlaceholders, entity.templatePlaceholders);
-
-    if (!placeholders) continue;
 
     const finalUrl = applyTemplate(template.templateUrl, placeholders);
     const tags = template.tags || [];

--- a/extensions/quick-jump/src/url-list.tsx
+++ b/extensions/quick-jump/src/url-list.tsx
@@ -1,6 +1,13 @@
 import { List } from "@raycast/api";
 import { Group, Root, DisplayUrl } from "./types";
-import { getDomainKeywords, getEnhancedKeywords, combineKeywords, getFallbackIcon } from "./utils";
+import {
+  getDomainKeywords,
+  getEnhancedKeywords,
+  combineKeywords,
+  getFallbackIcon,
+  applyTemplate,
+  mergePlaceholders,
+} from "./utils";
 import { createTemplateDisplayUrls } from "./template-utils";
 import { useApplications } from "./hooks/use-applications";
 import { URLListItem } from "./components/url-list-item";
@@ -17,18 +24,31 @@ export function URLList({ group, rootData, isLoading = false }: URLListProps) {
 
   const combinedLoading = isLoading || applicationsLoading;
 
+  const placeholdersResult = mergePlaceholders(rootData.globalPlaceholders, group.templatePlaceholders);
+
+  if (!placeholdersResult.success) {
+    return (
+      <List isLoading={combinedLoading}>
+        <List.EmptyView title="Configuration Error" description={placeholdersResult.error} />
+      </List>
+    );
+  }
+
+  const placeholders = placeholdersResult.placeholders;
+
   const otherUrls: DisplayUrl[] = Object.entries(group.otherUrls || {}).map(([key, otherUrl]) => {
     const title = otherUrl.title || key;
     const tags = otherUrl.tags || [];
+    const resolvedUrl = applyTemplate(otherUrl.url, placeholders);
     return {
       key: `other-${key}`,
       title: title,
-      url: otherUrl.url,
+      url: resolvedUrl,
       keywords: combineKeywords(
         getEnhancedKeywords(key),
         getEnhancedKeywords(title),
         tags,
-        getDomainKeywords(otherUrl.url),
+        getDomainKeywords(resolvedUrl),
       ),
       icon: getFallbackIcon(otherUrl.icon, !!otherUrl.openIn),
       tags: tags,

--- a/extensions/quick-jump/src/url-list.tsx
+++ b/extensions/quick-jump/src/url-list.tsx
@@ -65,15 +65,16 @@ export function URLList({ group, rootData, isLoading = false }: URLListProps) {
 
       const tags = linkedUrl.tags || [];
       const title = linkedUrl.title || linkedUrlKey;
+      const resolvedUrl = applyTemplate(linkedUrl.url, placeholders);
       linkedUrls.push({
         key: `linked-${linkedUrlKey}`,
         title: title,
-        url: linkedUrl.url,
+        url: resolvedUrl,
         keywords: combineKeywords(
           getEnhancedKeywords(linkedUrlKey),
           getEnhancedKeywords(title),
           tags,
-          getDomainKeywords(linkedUrl.url),
+          getDomainKeywords(resolvedUrl),
         ),
         icon: getFallbackIcon(linkedUrl.icon, !!linkedUrl.openIn),
         tags: tags,

--- a/extensions/quick-jump/src/use-data.ts
+++ b/extensions/quick-jump/src/use-data.ts
@@ -2,7 +2,7 @@ import { getPreferenceValues } from "@raycast/api";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { useEffect, useState, useRef, useCallback } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Root } from "./types";
 import { ERROR_MESSAGES } from "./constants";
 import { validateConfiguration, ValidationResult } from "./validation";
@@ -13,8 +13,6 @@ export function useData() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
-
-  const lastFileStats = useRef<{ mtime: number; size: number } | null>(null);
 
   const loadData = useCallback(async () => {
     try {
@@ -36,9 +34,6 @@ export function useData() {
         throw new Error(`${ERROR_MESSAGES.FILE_NOT_FOUND} Path: ${filePath}`);
       }
 
-      const fileStats = fs.statSync(filePath);
-      const currentFileStats = { mtime: fileStats.mtime.getTime(), size: fileStats.size };
-
       const fileContent = fs.readFileSync(filePath, "utf-8");
       if (!fileContent.trim()) {
         throw new Error(ERROR_MESSAGES.EMPTY_FILE);
@@ -52,7 +47,6 @@ export function useData() {
 
       const validation = validateConfiguration(jsonData);
       setValidationResult(validation);
-      lastFileStats.current = currentFileStats;
 
       // Clear caches when config reloads to avoid stale data
       clearKeywordCache();

--- a/extensions/quick-jump/src/utils.ts
+++ b/extensions/quick-jump/src/utils.ts
@@ -1,18 +1,138 @@
-import { DEFAULT_TITLE, FALLBACK_ICON } from "./constants";
+import { DEFAULT_TITLE, FALLBACK_ICON, PLACEHOLDER_PATTERN } from "./constants";
 import { Application, Image } from "@raycast/api";
+
+export type MergePlaceholdersResult =
+  | { success: true; placeholders: Record<string, string> }
+  | { success: false; error: string };
 
 export function mergePlaceholders(
   globalPlaceholders: Record<string, string> | undefined,
   localPlaceholders: Record<string, string> | undefined,
-): Record<string, string> | undefined {
+): MergePlaceholdersResult {
   if (!globalPlaceholders && !localPlaceholders) {
-    return undefined;
+    return { success: true, placeholders: {} };
   }
 
-  return {
+  const merged = {
     ...globalPlaceholders,
     ...localPlaceholders,
   };
+
+  const circularError = detectCircularPlaceholderDependencies(merged);
+  if (circularError) {
+    return { success: false, error: circularError };
+  }
+
+  return { success: true, placeholders: resolvePlaceholderValues(merged) };
+}
+
+/**
+ * Extracts placeholder keys referenced in a value string.
+ * e.g., "${foo}/bar/${baz}" -> ["foo", "baz"]
+ */
+function extractReferencedPlaceholders(value: string): string[] {
+  const matches = value.match(PLACEHOLDER_PATTERN);
+  if (!matches) return [];
+  return matches.map((match) => match.slice(2, -1));
+}
+
+/**
+ * Detects circular dependencies in placeholder references using DFS.
+ * Returns an error message if a cycle is found, or null if no cycles exist.
+ * Exported for use in validation.
+ */
+export function detectCircularPlaceholderDependencies(placeholders: Record<string, string>): string | null {
+  const dependencies = new Map<string, string[]>();
+
+  for (const [key, value] of Object.entries(placeholders)) {
+    const refs = extractReferencedPlaceholders(value);
+    const validRefs = refs.filter((ref) => ref in placeholders);
+    if (validRefs.length > 0) {
+      dependencies.set(key, validRefs);
+    }
+  }
+
+  const visited = new Set<string>();
+  const inStack = new Set<string>();
+  const path: string[] = [];
+
+  function dfs(node: string): string | null {
+    if (inStack.has(node)) {
+      const cycleStart = path.indexOf(node);
+      const cycle = [...path.slice(cycleStart), node];
+      return `Circular dependency detected: ${cycle.join(" -> ")}`;
+    }
+
+    if (visited.has(node)) {
+      return null;
+    }
+
+    visited.add(node);
+    inStack.add(node);
+    path.push(node);
+
+    const deps = dependencies.get(node) || [];
+    for (const dep of deps) {
+      const error = dfs(dep);
+      if (error) return error;
+    }
+
+    path.pop();
+    inStack.delete(node);
+    return null;
+  }
+
+  for (const key of dependencies.keys()) {
+    const error = dfs(key);
+    if (error) return error;
+  }
+
+  return null;
+}
+
+/**
+ * Resolves placeholder references within placeholder values.
+ * Handles cases like: projectDirectory: "${teamProjectDirectory}/api/ab-decider"
+ * where teamProjectDirectory is another placeholder that needs to be resolved first.
+ *
+ * Note: This function assumes no circular dependencies exist (checked beforehand).
+ */
+function resolvePlaceholderValues(placeholders: Record<string, string>): Record<string, string> {
+  const resolved: Record<string, string> = { ...placeholders };
+  const maxIterations = Object.keys(placeholders).length + 1;
+
+  for (let iteration = 0; iteration < maxIterations; iteration++) {
+    let hasUnresolvedPlaceholders = false;
+
+    for (const [key, value] of Object.entries(resolved)) {
+      // Check if value contains placeholder references
+      let newValue = value;
+      let match;
+      // Reset lastIndex for global regex
+      PLACEHOLDER_PATTERN.lastIndex = 0;
+
+      while ((match = PLACEHOLDER_PATTERN.exec(value)) !== null) {
+        const placeholderKey = match[1];
+        const placeholderValue = resolved[placeholderKey];
+
+        if (placeholderValue !== undefined && !placeholderValue.includes("${")) {
+          // Only replace if the referenced placeholder is fully resolved
+          newValue = newValue.replace(`\${${placeholderKey}}`, placeholderValue);
+        } else if (placeholderValue !== undefined) {
+          // There's still an unresolved placeholder
+          hasUnresolvedPlaceholders = true;
+        }
+      }
+
+      resolved[key] = newValue;
+    }
+
+    if (!hasUnresolvedPlaceholders) {
+      break;
+    }
+  }
+
+  return resolved;
 }
 
 export function applyTemplate(templateUrl: string, placeholders: Record<string, string>): string {
@@ -91,13 +211,9 @@ export function getTagAccessories(tags: string[] = []): import("@raycast/api").L
   return accessories;
 }
 
-export function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 export function extractPlaceholders(templateUrl: string): string[] {
   if (!templateUrl) return [];
-  const matches = templateUrl.match(/\$\{([^{}]+)\}/g);
+  const matches = templateUrl.match(PLACEHOLDER_PATTERN);
   if (!matches) return [];
   return matches.map((match) => match.slice(2, -1));
 }

--- a/extensions/quick-jump/src/validation.ts
+++ b/extensions/quick-jump/src/validation.ts
@@ -220,6 +220,16 @@ function validateTemplateable(
     referencedPlaceholders.forEach((placeholder) => allRequiredPlaceholders.add(placeholder));
   }
 
+  // Check placeholders used in otherUrls (for groups)
+  if ("otherUrls" in entity && entity.otherUrls) {
+    for (const url of Object.values(entity.otherUrls)) {
+      if (url?.url) {
+        const referencedPlaceholders = extractPlaceholders(url.url);
+        referencedPlaceholders.forEach((placeholder) => allRequiredPlaceholders.add(placeholder));
+      }
+    }
+  }
+
   for (const placeholder of allRequiredPlaceholders) {
     if (!allProvidedPlaceholders.includes(placeholder)) {
       errors.push({

--- a/extensions/quick-jump/src/validation.ts
+++ b/extensions/quick-jump/src/validation.ts
@@ -1,7 +1,8 @@
 import { Root, Templateable } from "./types";
+import { detectCircularPlaceholderDependencies, extractPlaceholders } from "./utils";
 
 export interface ValidationError {
-  type: "missing_placeholder" | "invalid_template" | "invalid_url" | "missing_template";
+  type: "missing_placeholder" | "invalid_template" | "invalid_url" | "missing_template" | "circular_dependency";
   message: string;
   location: string;
   severity: "error" | "warning";
@@ -29,6 +30,8 @@ export function validateConfiguration(data: Root): ValidationResult {
     return { isValid: false, errors, warnings };
   }
 
+  validatePlaceholderCircularDependencies(data.globalPlaceholders, errors, "globalPlaceholders");
+
   if (data.templates) {
     validateTemplates(data, errors, warnings);
   }
@@ -41,6 +44,8 @@ export function validateConfiguration(data: Root): ValidationResult {
   if (data.templateGroups) {
     validateTemplateGroups(data, errors);
   }
+
+  validateUnusedGlobalPlaceholders(data, warnings);
 
   return {
     isValid: errors.length === 0,
@@ -204,6 +209,17 @@ function validateTemplateable(
     requiredPlaceholders.forEach((placeholder) => allRequiredPlaceholders.add(placeholder));
   }
 
+  // Also check placeholders used within other placeholder values (nested placeholders)
+  // e.g., projectDirectory: "${teamProjectDirectory}/api/${foo}" uses both teamProjectDirectory and foo
+  const allPlaceholderValues = {
+    ...data.globalPlaceholders,
+    ...entity.templatePlaceholders,
+  };
+  for (const value of Object.values(allPlaceholderValues)) {
+    const referencedPlaceholders = extractPlaceholders(value);
+    referencedPlaceholders.forEach((placeholder) => allRequiredPlaceholders.add(placeholder));
+  }
+
   for (const placeholder of allRequiredPlaceholders) {
     if (!allProvidedPlaceholders.includes(placeholder)) {
       errors.push({
@@ -264,10 +280,125 @@ function validateAppliedTemplates(
   }
 }
 
-function extractPlaceholders(templateUrl: string): string[] {
-  if (!templateUrl) return [];
+function validatePlaceholderCircularDependencies(
+  placeholders: Record<string, string> | undefined,
+  errors: ValidationError[],
+  location: string,
+) {
+  if (!placeholders) return;
 
-  const matches = templateUrl.match(/\$\{([^{}]+)\}/g);
-  if (!matches) return [];
-  return matches.map((match) => match.slice(2, -1));
+  const circularError = detectCircularPlaceholderDependencies(placeholders);
+  if (circularError) {
+    errors.push({
+      type: "circular_dependency",
+      message: circularError,
+      location,
+      severity: "error",
+      suggestion: "Remove the circular reference by ensuring placeholders don't reference each other in a cycle",
+    });
+  }
+}
+
+function validateUnusedGlobalPlaceholders(data: Root, warnings: ValidationError[]) {
+  if (!data.globalPlaceholders) return;
+
+  const globalPlaceholderKeys = Object.keys(data.globalPlaceholders);
+  if (globalPlaceholderKeys.length === 0) return;
+
+  const usedPlaceholders = new Set<string>();
+
+  // Collect all placeholders used in templates
+  if (data.templates) {
+    for (const template of Object.values(data.templates)) {
+      if (!template?.templateUrl) continue;
+      const placeholders = extractPlaceholders(template.templateUrl);
+      placeholders.forEach((p) => usedPlaceholders.add(p));
+    }
+  }
+
+  // Collect all placeholders used in groups
+  if (data.groups) {
+    for (const group of Object.values(data.groups)) {
+      if (!group) continue;
+
+      // Check applied templates
+      const allAppliedTemplates = [
+        ...(group.appliedTemplates || []),
+        ...(group.appliedTemplateGroups?.flatMap((tgKey) => data.templateGroups?.[tgKey]?.appliedTemplates || []) ||
+          []),
+      ];
+
+      for (const templateKey of allAppliedTemplates) {
+        const template = data.templates?.[templateKey];
+        if (!template?.templateUrl) continue;
+        const placeholders = extractPlaceholders(template.templateUrl);
+        placeholders.forEach((p) => usedPlaceholders.add(p));
+      }
+
+      // Check local placeholder values (they might reference global placeholders)
+      if (group.templatePlaceholders) {
+        for (const value of Object.values(group.templatePlaceholders)) {
+          const placeholders = extractPlaceholders(value);
+          placeholders.forEach((p) => usedPlaceholders.add(p));
+        }
+      }
+
+      // Check other URLs
+      if (group.otherUrls) {
+        for (const url of Object.values(group.otherUrls)) {
+          if (url.url) {
+            const placeholders = extractPlaceholders(url.url);
+            placeholders.forEach((p) => usedPlaceholders.add(p));
+          }
+        }
+      }
+    }
+  }
+
+  // Collect all placeholders used in standalone URLs
+  if (data.urls) {
+    for (const url of Object.values(data.urls)) {
+      if (!url) continue;
+
+      // Check applied templates
+      const allAppliedTemplates = [
+        ...(url.appliedTemplates || []),
+        ...(url.appliedTemplateGroups?.flatMap((tgKey) => data.templateGroups?.[tgKey]?.appliedTemplates || []) || []),
+      ];
+
+      for (const templateKey of allAppliedTemplates) {
+        const template = data.templates?.[templateKey];
+        if (!template?.templateUrl) continue;
+        const placeholders = extractPlaceholders(template.templateUrl);
+        placeholders.forEach((p) => usedPlaceholders.add(p));
+      }
+
+      // Check local placeholder values
+      if (url.templatePlaceholders) {
+        for (const value of Object.values(url.templatePlaceholders)) {
+          const placeholders = extractPlaceholders(value);
+          placeholders.forEach((p) => usedPlaceholders.add(p));
+        }
+      }
+    }
+  }
+
+  // Check if global placeholders reference each other
+  for (const value of Object.values(data.globalPlaceholders)) {
+    const placeholders = extractPlaceholders(value);
+    placeholders.forEach((p) => usedPlaceholders.add(p));
+  }
+
+  // Find unused global placeholders
+  const unusedGlobalPlaceholders = globalPlaceholderKeys.filter((key) => !usedPlaceholders.has(key));
+
+  if (unusedGlobalPlaceholders.length > 0) {
+    warnings.push({
+      type: "missing_placeholder",
+      message: `Unused global placeholders: ${unusedGlobalPlaceholders.join(", ")}`,
+      location: "globalPlaceholders",
+      severity: "warning",
+      suggestion: "Consider removing unused global placeholders to keep configuration clean",
+    });
+  }
 }


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Enable placeholders to reference other placeholders for more flexible and DRY configuration. Add circular dependency detection to prevent infinite resolution loops.

- **Nested placeholder resolution**: Placeholders can now reference other placeholders (e.g., `teamDir: "${baseDir}/team"`)
- **Circular dependency detection**: Automatically detects and blocks circular placeholder references with detailed error UI showing the cycle path and fix instructions
- **Improved validation**: Validates nested placeholder references across global, group, and URL levels


## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
