### PR TITLE
Update zed-recent-projects extension

### DIFF
--- a/extensions/zed-recent-projects/CHANGELOG.md
+++ b/extensions/zed-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zed Recent Projects Changelog
 
-## [Fix Environment Inheritance] - {PR_MERGE_DATE}
+## [Fix Environment Inheritance] - 2026-02-23
 
 - Fix Zed inheriting Raycast environment variables when launched via extension
 

--- a/extensions/zed-recent-projects/CHANGELOG.md
+++ b/extensions/zed-recent-projects/CHANGELOG.md
@@ -1,4 +1,8 @@
-#  Zed Recent Projects Changelog
+# Zed Recent Projects Changelog
+
+## [Fix Environment Inheritance] - {PR_MERGE_DATE}
+
+- Fix Zed inheriting Raycast environment variables when launched via extension
 
 ## [Multi-folder Workspace Support] - 2026-01-21
 

--- a/extensions/zed-recent-projects/package-lock.json
+++ b/extensions/zed-recent-projects/package-lock.json
@@ -2944,9 +2944,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/extensions/zed-recent-projects/src/lib/utils.test.ts
+++ b/extensions/zed-recent-projects/src/lib/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { shellEscape } from "./utils";
+
+describe("shellEscape", () => {
+  it("should wrap simple strings in single quotes", () => {
+    expect(shellEscape("hello")).toBe("'hello'");
+    expect(shellEscape("world")).toBe("'world'");
+  });
+
+  it("should handle strings with spaces", () => {
+    expect(shellEscape("hello world")).toBe("'hello world'");
+    expect(shellEscape("path/to/my file.txt")).toBe("'path/to/my file.txt'");
+  });
+
+  it("should escape single quotes within strings", () => {
+    expect(shellEscape("it's")).toBe("'it'\\''s'");
+    expect(shellEscape("don't stop")).toBe("'don'\\''t stop'");
+  });
+
+  it("should handle multiple single quotes", () => {
+    expect(shellEscape("it's a 'test'")).toBe("'it'\\''s a '\\''test'\\'''");
+  });
+
+  it("should handle empty strings", () => {
+    expect(shellEscape("")).toBe("''");
+  });
+
+  it("should not escape double quotes (they're safe in single quotes)", () => {
+    expect(shellEscape('"quoted"')).toBe("'\"quoted\"'");
+  });
+
+  it("should handle paths with special characters", () => {
+    expect(shellEscape("/Users/test/My Documents")).toBe("'/Users/test/My Documents'");
+    expect(shellEscape("/path/with$dollar")).toBe("'/path/with$dollar'");
+    expect(shellEscape("/path/with`backtick`")).toBe("'/path/with`backtick`'");
+  });
+
+  it("should handle unicode characters", () => {
+    expect(shellEscape("/Users/test/日本語")).toBe("'/Users/test/日本語'");
+    expect(shellEscape("emoji-folder-🚀")).toBe("'emoji-folder-🚀'");
+  });
+});

--- a/extensions/zed-recent-projects/src/lib/utils.ts
+++ b/extensions/zed-recent-projects/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import util from "util";
 import { existsSync } from "fs";
 import { execFile, execFileSync } from "child_process";
-import { homedir } from "os";
+import { homedir, userInfo } from "os";
 
 export const execFilePromise = util.promisify(execFile);
 
@@ -19,7 +19,8 @@ export function shellEscape(arg: string): string {
  */
 function getUserShell(): string {
   try {
-    const result = execFileSync("dscl", [".", "-read", `/Users/${process.env.USER}`, "UserShell"], {
+    const username = process.env.USER || userInfo().username;
+    const result = execFileSync("dscl", [".", "-read", `/Users/${username}`, "UserShell"], {
       encoding: "utf8",
     });
     // Output format: "UserShell: /path/to/shell"
@@ -40,20 +41,28 @@ function getUserShell(): string {
  * The approach:
  * 1. `env -i` starts with an empty environment
  * 2. Only HOME is passed (required for login shell to find profile files)
- * 3. User's default shell runs as login shell, sourcing their profile
+ * 3. A POSIX-compatible login shell (zsh or bash) sources the user's profile,
+ *    then execs the target command directly — avoiding shell-escaping issues
+ *    with non-POSIX shells like fish.
  *
  * This gives the command the same environment as a fresh terminal window.
  */
 export async function execWithCleanEnv(command: string, args: string[]): Promise<void> {
+  const userShell = getUserShell();
+
+  // If the user's shell is fish (or any other non-POSIX shell), fall back to
+  // /bin/zsh for the -lc invocation. Fish does not support POSIX-style quoting
+  // or the `-c` flag in the same way, so we must use a POSIX shell to source
+  // the profile and then exec the real command.
+  const isFish = userShell.endsWith("fish");
+  const posixShell = isFish ? "/bin/zsh" : userShell;
+
   const escapedArgs = args.map(shellEscape).join(" ");
   const shellCommand = `${shellEscape(command)} ${escapedArgs}`;
 
-  const userShell = getUserShell();
-
   // Use env -i to start with empty environment, then login shell for user's profile
   // -l = login shell (sources profile), -c = execute command
-  // This works for bash, zsh, fish, and most POSIX shells
-  await execFilePromise("env", ["-i", `HOME=${process.env.HOME || homedir()}`, userShell, "-lc", shellCommand]);
+  await execFilePromise("env", ["-i", `HOME=${process.env.HOME || homedir()}`, posixShell, "-lc", shellCommand]);
 }
 
 export function exists(p: string) {

--- a/extensions/zed-recent-projects/src/lib/utils.ts
+++ b/extensions/zed-recent-projects/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import util from "util";
 import { existsSync } from "fs";
 import { execFile, execFileSync } from "child_process";
+import { homedir } from "os";
 
 export const execFilePromise = util.promisify(execFile);
 
@@ -52,7 +53,7 @@ export async function execWithCleanEnv(command: string, args: string[]): Promise
   // Use env -i to start with empty environment, then login shell for user's profile
   // -l = login shell (sources profile), -c = execute command
   // This works for bash, zsh, fish, and most POSIX shells
-  await execFilePromise("env", ["-i", `HOME=${process.env.HOME || require('os').homedir()}`, userShell, "-lc", shellCommand]);
+  await execFilePromise("env", ["-i", `HOME=${process.env.HOME || homedir()}`, userShell, "-lc", shellCommand]);
 }
 
 export function exists(p: string) {

--- a/extensions/zed-recent-projects/src/lib/utils.ts
+++ b/extensions/zed-recent-projects/src/lib/utils.ts
@@ -7,6 +7,54 @@ export const execFilePromise = util.promisify(execFile);
 export const isWindows = process.platform === "win32";
 export const isMac = process.platform === "darwin";
 
+export function shellEscape(arg: string): string {
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Gets the user's default shell from the system.
+ * Uses dscl (Directory Service) on macOS to read the UserShell attribute.
+ * Falls back to /bin/zsh if unable to determine.
+ */
+function getUserShell(): string {
+  try {
+    const result = execFileSync("dscl", [".", "-read", `/Users/${process.env.USER}`, "UserShell"], {
+      encoding: "utf8",
+    });
+    // Output format: "UserShell: /path/to/shell"
+    const match = result.match(/UserShell:\s*(.+)/);
+    if (match && match[1]) {
+      return match[1].trim();
+    }
+  } catch {
+    // Fall through to default
+  }
+  return "/bin/zsh";
+}
+
+/**
+ * Executes a command with a clean environment using `env -i` and a login shell.
+ * This ensures child processes don't inherit Raycast's environment variables.
+ *
+ * The approach:
+ * 1. `env -i` starts with an empty environment
+ * 2. Only HOME is passed (required for login shell to find profile files)
+ * 3. User's default shell runs as login shell, sourcing their profile
+ *
+ * This gives the command the same environment as a fresh terminal window.
+ */
+export async function execWithCleanEnv(command: string, args: string[]): Promise<void> {
+  const escapedArgs = args.map(shellEscape).join(" ");
+  const shellCommand = `${shellEscape(command)} ${escapedArgs}`;
+
+  const userShell = getUserShell();
+
+  // Use env -i to start with empty environment, then login shell for user's profile
+  // -l = login shell (sources profile), -c = execute command
+  // This works for bash, zsh, fish, and most POSIX shells
+  await execFilePromise("env", ["-i", `HOME=${process.env.HOME}`, userShell, "-lc", shellCommand]);
+}
+
 export function exists(p: string) {
   try {
     return existsSync(new URL(p));

--- a/extensions/zed-recent-projects/src/lib/utils.ts
+++ b/extensions/zed-recent-projects/src/lib/utils.ts
@@ -52,7 +52,7 @@ export async function execWithCleanEnv(command: string, args: string[]): Promise
   // Use env -i to start with empty environment, then login shell for user's profile
   // -l = login shell (sources profile), -c = execute command
   // This works for bash, zsh, fish, and most POSIX shells
-  await execFilePromise("env", ["-i", `HOME=${process.env.HOME}`, userShell, "-lc", shellCommand]);
+  await execFilePromise("env", ["-i", `HOME=${process.env.HOME || require('os').homedir()}`, userShell, "-lc", shellCommand]);
 }
 
 export function exists(p: string) {

--- a/extensions/zed-recent-projects/src/lib/zed.ts
+++ b/extensions/zed-recent-projects/src/lib/zed.ts
@@ -1,13 +1,9 @@
 import fs from "fs";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { getApplications, getPreferenceValues } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
 import { homedir } from "os";
-import { isMac, isWindows } from "./utils";
+import { execWithCleanEnv, isMac, isWindows } from "./utils";
 import { zedBuild } from "./preferences";
-
-const execFileAsync = promisify(execFile);
 
 export type ZedBuild = Preferences["build"];
 export type ZedBundleId = "dev.zed.Zed" | "dev.zed.Zed-Preview" | "dev.zed.Zed-Dev";
@@ -144,6 +140,9 @@ end tell
  * Open a workspace with multiple paths using the Zed CLI.
  * This is required for multi-folder workspaces since the URI scheme only supports a single path.
  *
+ * Uses a clean environment to prevent Raycast's environment variables from
+ * being inherited by Zed terminals.
+ *
  * @param cliPath - Path to the Zed CLI executable
  * @param paths - Array of paths to open (supports multiple folders)
  * @param newWindow - Whether to open in a new window (default: false)
@@ -153,7 +152,7 @@ export async function openWithZedCli(cliPath: string, paths: string[], newWindow
   const args = newWindow ? ["-n", ...paths] : paths;
 
   try {
-    await execFileAsync(cliPath, args);
+    await execWithCleanEnv(cliPath, args);
   } catch (error) {
     console.error("Failed to open with Zed CLI:", error);
     throw error;


### PR DESCRIPTION
## Description

Launch Zed with a clean environment using `env -i` and the user's login shell

closes #24758
closes #24807

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
