### PR TITLE
Update nixpkgs-search extension

### DIFF
--- a/extensions/nixpkgs-search/CHANGELOG.md
+++ b/extensions/nixpkgs-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NixPkgs Search Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-01-27
 
 - Add "Open Package Details" action to open the package on search.nixos.org
 - **Updated available branches**: Removed unsupported branch (25.05) and kept only working versions (unstable, 25.11)

--- a/extensions/nixpkgs-search/CHANGELOG.md
+++ b/extensions/nixpkgs-search/CHANGELOG.md
@@ -1,5 +1,10 @@
 # NixPkgs Search Changelog
 
+## [Update] - {PR_MERGE_DATE}
+
+- Add "Open Package Details" action to open the package on search.nixos.org
+- **Updated available branches**: Removed unsupported branch (25.05) and kept only working versions (unstable, 25.11)
+
 ## [Update] - 2025-12-07
 
 - Update shortcuts to use Raycast's common keyboard shortcuts

--- a/extensions/nixpkgs-search/README.md
+++ b/extensions/nixpkgs-search/README.md
@@ -6,6 +6,7 @@ Raycast version of <https://search.nixos.org>
 
 - Search NixOS packages directly from Raycast
 - View package details including description, version, homepage, and licenses
+- Open package details on search.nixos.org, homepage, and source code
 - Copy package attribute names, URLs, and source code links
 - **Support for multiple NixOS branches** - switch between different NixOS versions
 - In-app branch switcher with validation
@@ -32,7 +33,7 @@ The extension features a **branch selector** directly in the search interface. A
 The dropdown includes:
 
 - **Unstable** (rolling release) - Latest bleeding edge packages
-- **NixOS 25.05** - Current stable release
+- **NixOS 25.11** - Current stable release
 
 Simply select your preferred branch from the dropdown in the search bar to switch between different NixOS versions.
 

--- a/extensions/nixpkgs-search/package.json
+++ b/extensions/nixpkgs-search/package.json
@@ -7,7 +7,8 @@
   "author": "aiotter",
   "contributors": [
     "xmok",
-    "0xdhrv"
+    "0xdhrv",
+    "SConaway"
   ],
   "categories": [
     "Developer Tools"

--- a/extensions/nixpkgs-search/src/components/SearchListItem.tsx
+++ b/extensions/nixpkgs-search/src/components/SearchListItem.tsx
@@ -15,16 +15,16 @@ export function SearchListItem({ searchResult, channel }: SearchListItemProps) {
         <ActionPanel>
           <ActionPanel.Section>
             <ActionPanel.Submenu icon={Icon.Globe} title="Open…" shortcut={Keyboard.Shortcut.Common.Open}>
-              <Action.OpenInBrowser
-                title="Open Package Details"
-                url={`https://search.nixos.org/packages?channel=${channel}&show=${encodeURIComponent(searchResult.attrName)}&query=${encodeURIComponent(searchResult.attrName)}`}
-              />
               {searchResult.source && (
                 <Action.OpenInBrowser title="Open Package Source Code" url={searchResult.source} />
               )}
               {searchResult.homepage[0] && (
                 <Action.OpenInBrowser title="Open Package Homepage" url={searchResult.homepage[0]} />
               )}
+              <Action.OpenInBrowser
+                title="Open Package Details"
+                url={`https://search.nixos.org/packages?channel=${channel}&show=${encodeURIComponent(searchResult.attrName)}&query=${encodeURIComponent(searchResult.attrName)}`}
+              />
             </ActionPanel.Submenu>
 
             <ActionPanel.Submenu icon={Icon.Clipboard} title="Copy…" shortcut={Keyboard.Shortcut.Common.Copy}>

--- a/extensions/nixpkgs-search/src/components/SearchListItem.tsx
+++ b/extensions/nixpkgs-search/src/components/SearchListItem.tsx
@@ -4,9 +4,10 @@ import type { SearchResult } from "../types";
 
 interface SearchListItemProps {
   searchResult: SearchResult;
+  channel: string;
 }
 
-export function SearchListItem({ searchResult }: SearchListItemProps) {
+export function SearchListItem({ searchResult, channel }: SearchListItemProps) {
   return (
     <List.Item
       title={searchResult.attrName}
@@ -14,6 +15,10 @@ export function SearchListItem({ searchResult }: SearchListItemProps) {
         <ActionPanel>
           <ActionPanel.Section>
             <ActionPanel.Submenu icon={Icon.Globe} title="Open…" shortcut={Keyboard.Shortcut.Common.Open}>
+              <Action.OpenInBrowser
+                title="Open Package Details"
+                url={`https://search.nixos.org/packages?channel=${channel}&show=${encodeURIComponent(searchResult.attrName)}&query=${encodeURIComponent(searchResult.attrName)}`}
+              />
               {searchResult.source && (
                 <Action.OpenInBrowser title="Open Package Source Code" url={searchResult.source} />
               )}

--- a/extensions/nixpkgs-search/src/constants.ts
+++ b/extensions/nixpkgs-search/src/constants.ts
@@ -1,7 +1,7 @@
 // Available NixOS branches/versions
 export const AVAILABLE_BRANCHES = [
   { value: "unstable", title: "Unstable (rolling release)" },
-  { value: "25.05", title: "NixOS 25.05" },
+  { value: "25.11", title: "NixOS 25.11" },
 ] as const;
 
 // Elasticsearch query fields with their boost values

--- a/extensions/nixpkgs-search/src/index.tsx
+++ b/extensions/nixpkgs-search/src/index.tsx
@@ -78,7 +78,7 @@ export default function Command() {
       ) : (
         <List.Section title="Results" subtitle={state.results.length + ""}>
           {state.results.map((searchResult) => (
-            <SearchListItem key={searchResult.id} searchResult={searchResult} />
+            <SearchListItem key={searchResult.id} searchResult={searchResult} channel={selectedBranch} />
           ))}
         </List.Section>
       )}


### PR DESCRIPTION
## Description

- Add "Open Package Details" action to open the package on search.nixos.org
- **Updated available branches**: Removed unsupported branch (25.05) and kept only working versions (unstable, 25.11)

## Screencast
<img width="550" height="246" alt="CleanShot 2026-01-25 at 21 15 04@2x" src="https://github.com/user-attachments/assets/6470d74b-4371-4609-8b15-dcb108eed0ae" />

<img width="1872" height="1320" alt="CleanShot 2026-01-25 at 21 14 48@2x" src="https://github.com/user-attachments/assets/a2f7afe6-863d-42d4-bf43-9231e7f7d46c" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
