### PR TITLE
[OVH] display domain dns records cache properly

### DIFF
--- a/extensions/ovh/CHANGELOG.md
+++ b/extensions/ovh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OVHcloud Changelog
 
+## [Improve DNS Records Display] - {PR_MERGE_DATE}
+
+- Improved DNS Records loading so it loads the relevant cached records (previously, dns records for the last domain were shown until updated)
+
 ## [Update Domain & DNS Service Information] - 2026-01-28
 
 - Update Domain Service Information (renewal)

--- a/extensions/ovh/CHANGELOG.md
+++ b/extensions/ovh/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OVHcloud Changelog
 
-## [Improve DNS Records Display] - {PR_MERGE_DATE}
+## [Improve DNS Records Display] - 2026-02-08
 
 - Improved DNS Records loading so it loads the relevant cached records (previously, dns records for the last domain were shown until updated)
 

--- a/extensions/ovh/package-lock.json
+++ b/extensions/ovh/package-lock.json
@@ -7,7 +7,7 @@
       "name": "ovhcloud",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.3",
+        "@raycast/api": "^1.104.5",
         "@raycast/utils": "^2.2.2"
       },
       "devDependencies": {
@@ -1134,9 +1134,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.3",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.3.tgz",
-      "integrity": "sha512-ud3c2csFd3VywjqDuY33U184ZmbAJmY+Z7qYpiMOOAzDZye49ZE7Qjw4s/2Vob+LCLX/XduzWpVFv5omdfNThQ==",
+      "version": "1.104.5",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.5.tgz",
+      "integrity": "sha512-H2eyeTU5BPd2ZiP5p4bO3krh70xpdglgDRJBHSIg7Dnx4ICOOfvQDo39JMcuDlV7cI8Dca3Ht5kybLXg3G6Ibw==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.5.4",

--- a/extensions/ovh/package.json
+++ b/extensions/ovh/package.json
@@ -86,7 +86,7 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.104.3",
+    "@raycast/api": "^1.104.5",
     "@raycast/utils": "^2.2.2"
   },
   "devDependencies": {

--- a/extensions/ovh/src/manage-domains.tsx
+++ b/extensions/ovh/src/manage-domains.tsx
@@ -159,14 +159,14 @@ function DNSRecords({ domain }: { domain: Domain }) {
     data: records,
     mutate,
   } = useCachedPromise(
-    async () => {
-      const list = await callOvh<string[]>(`v1/domain/zone/${domain.domain}/record`);
+    async (domain: string) => {
+      const list = await callOvh<string[]>(`v1/domain/zone/${domain}/record`);
       const records = await Promise.all(
-        list.map((record) => callOvh<DNSRecord>(`v1/domain/zone/${domain.domain}/record/${record}`)),
+        list.map((record) => callOvh<DNSRecord>(`v1/domain/zone/${domain}/record/${record}`)),
       );
       return records;
     },
-    [],
+    [domain.domain],
     {
       initialData: [],
     },


### PR DESCRIPTION
## Description

- Improved DNS Records loading so it loads the relevant cached records (previously, dns records for the last domain were shown until updated)

## Screencast

N/A

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
