### PR TITLE
Update apple-reminders extension

### DIFF
--- a/extensions/apple-reminders/CHANGELOG.md
+++ b/extensions/apple-reminders/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Apple Reminders Changelog
 
+## [Fix Quick Add Reminder AI model selection] - {PR_MERGE_DATE}
+
+- Fix Quick Add Reminder to use user's selected AI model instead of hardcoded OpenAI GPT-4o
+- Fix date formatting bug in non-AI path when displaying success messages
+- Resolves: https://github.com/raycast/extensions/issues/23932
+
 ## [Improve search results ordering] - 2026-02-06
 
 - Keep incomplete reminders above completed ones when filtering in My Reminders

--- a/extensions/apple-reminders/CHANGELOG.md
+++ b/extensions/apple-reminders/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Apple Reminders Changelog
 
-## [Fix Quick Add Reminder AI model selection] - {PR_MERGE_DATE}
+## [Fix Quick Add Reminder AI model selection] - 2026-02-10
 
 - Fix Quick Add Reminder to use user's selected AI model instead of hardcoded OpenAI GPT-4o
 - Fix date formatting bug in non-AI path when displaying success messages


### PR DESCRIPTION
## Description

Fixes issue where Quick Add Reminder fails when AI is enabled with non-OpenAI models (Gemini, Qwen, etc.). The code was hardcoded to use `AI.Model.OpenAI_GPT4o`, which ignored the user's selected AI model preference.

**Changes:**
- Remove hardcoded AI model parameter to respect user's selected model (or Raycast's default)
- Fix date formatting bug in non-AI path where string dates were incorrectly passed to `format()` function
- Improve error handling in `askAI()` function with better logging and error propagation

This ensures the extension works correctly whether AI is enabled or disabled, and supports all AI models available in Raycast.

Fixes #23932

## Screencast

N/A - Bug fix with no UI changes

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder