### PR TITLE
[Bitwarden] Fix invalid generate password options

### DIFF
--- a/extensions/bitwarden/CHANGELOG.md
+++ b/extensions/bitwarden/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bitwarden Changelog
 
+## [Fix Password Generation] - {PR_MERGE_DATE}
+
+- Fix password generation failing due to false boolean options
+
 ## [Fix & Improvements] - 2026-02-17
 
 - Fix potential stale session token issue

--- a/extensions/bitwarden/CHANGELOG.md
+++ b/extensions/bitwarden/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Bitwarden Changelog
 
-## [Fix Password Generation] - {PR_MERGE_DATE}
+## [Fix Password Generation] - 2026-02-18
 
 - Fix password generation failing due to false boolean options
 

--- a/extensions/bitwarden/package.json
+++ b/extensions/bitwarden/package.json
@@ -454,10 +454,11 @@
     "build": "ray build -e dist",
     "dev": "ray develop",
     "publish": "npm run test && npx @raycast/api@latest publish",
+    "pull-contributions": "npx @raycast/api@latest pull-contributions",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "test": "jest --verbose",
-    "test:watch": "jest --watch",
+    "test": "jest --verbose --detectOpenHandles",
+    "test:watch": "jest --watch --detectOpenHandles",
     "tsc:watch": "tsc --noEmit --watch"
   }
 }

--- a/extensions/bitwarden/src/utils/passwords.test.ts
+++ b/extensions/bitwarden/src/utils/passwords.test.ts
@@ -1,0 +1,56 @@
+import { getPasswordGeneratingArgs } from "~/utils/passwords";
+import type { PasswordGeneratorOptions } from "~/types/passwords";
+
+describe("getPasswordGeneratingArgs", () => {
+  it("includes only boolean flags that are true", () => {
+    const options: PasswordGeneratorOptions = {
+      lowercase: true,
+      uppercase: false,
+      number: true,
+      special: false,
+      passphrase: true,
+    };
+
+    expect(getPasswordGeneratingArgs(options)).toEqual(["--lowercase", "--number", "--passphrase"]);
+  });
+
+  it("adds string-based arguments in insertion order", () => {
+    const options: PasswordGeneratorOptions = {
+      length: "18",
+      minNumber: "2",
+      minSpecial: "1",
+      words: "4",
+      separator: "_",
+      capitalize: true,
+      includeNumber: true,
+    };
+
+    expect(getPasswordGeneratingArgs(options)).toEqual([
+      "--length",
+      "18",
+      "--minNumber",
+      "2",
+      "--minSpecial",
+      "1",
+      "--words",
+      "4",
+      "--separator",
+      "_",
+      "--capitalize",
+      "--includeNumber",
+    ]);
+  });
+
+  it("merges boolean and string options consistently", () => {
+    const options: PasswordGeneratorOptions = {
+      lowercase: true,
+      uppercase: true,
+      number: false,
+      special: true,
+      passphrase: false,
+      length: "12",
+    };
+
+    expect(getPasswordGeneratingArgs(options)).toEqual(["--lowercase", "--uppercase", "--special", "--length", "12"]);
+  });
+});

--- a/extensions/bitwarden/src/utils/passwords.ts
+++ b/extensions/bitwarden/src/utils/passwords.ts
@@ -5,11 +5,19 @@ import { DEFAULT_PASSWORD_OPTIONS, REPROMPT_HASH_SALT } from "~/constants/passwo
 import { PasswordGeneratorOptions } from "~/types/passwords";
 
 export function getPasswordGeneratingArgs(options: PasswordGeneratorOptions): string[] {
-  return Object.entries(options).flatMap(([arg, value]) => {
-    if (value == null || value === "") return [];
-    if (value === true) return [`--${arg}`];
-    return [`--${arg}`, value];
-  });
+  return Object.entries(options).flatMap(
+    ([arg, value]: [string, PasswordGeneratorOptions[keyof PasswordGeneratorOptions]]) => {
+      switch (typeof value) {
+        case "boolean":
+          if (value) return [`--${arg}`];
+          return [];
+        case "string":
+          return [`--${arg}`, value];
+        default:
+          return [];
+      }
+    }
+  );
 }
 
 export function hashMasterPasswordForReprompting(password: string): Promise<string> {


### PR DESCRIPTION
## Description

#25549

Invalid password options are still being passed to the generate command.

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [X] I checked that files in the `assets` folder are used by the extension itself
- [X] I checked that assets used by the `README` are placed outside of the `metadata` folder
