### PR TITLE
Update gitlab extension

### DIFF
--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitLab Changelog
 
+## [Bugfix merge requests] - {PR_MERGE_DATE}
+
+- Update merge request list to show approvals properly
+
 ## [Optimize Windows Experience] - 2025-12-05
 
 - Better milestones view

--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitLab Changelog
 
-## [Bugfix merge requests] - {PR_MERGE_DATE}
+## [Bugfix merge requests] - 2026-02-18
 
 - Update merge request list to show approvals properly
 

--- a/extensions/gitlab/package.json
+++ b/extensions/gitlab/package.json
@@ -426,7 +426,8 @@
     "tane_van_wifferen",
     "1weiho",
     "pnowy",
-    "ridemountainpig"
+    "ridemountainpig",
+    "j3lte"
   ],
   "dependencies": {
     "@apollo/client": "^3.4.8",

--- a/extensions/gitlab/src/components/mr.tsx
+++ b/extensions/gitlab/src/components/mr.tsx
@@ -7,6 +7,7 @@ import {
   capitalizeFirstLetter,
   daysInSeconds,
   getErrorMessage,
+  isNumber,
   now,
   optimizeMarkdownText,
   Query,
@@ -428,13 +429,23 @@ export function MRListItem(props: {
 
   const accessories: List.Item.Accessory[] = [];
   if (!getListDetailsPreference()) {
+    if (approval) {
+      if (isNumber(approval.approvals_left) && isNumber(approval.approvals_required)) {
+        accessories.push({
+          icon: Icon.Eye,
+          text: `${approval.approvals_required - approval.approvals_left}/${approval.approvals_required}`,
+        });
+      } else if (approval.approved) {
+        accessories.push({
+          icon: {
+            source: Icon.Checkmark,
+            tintColor: Color.Green,
+          },
+        });
+      }
+    }
+
     accessories.push(
-      {
-        icon: approval ? Icon.Eye : undefined,
-        text: approval
-          ? `${approval.approvals_required - approval.approvals_left}/${approval.approvals_required}`
-          : undefined,
-      },
       {
         icon: mr.merge_when_pipeline_succeeds && mr.state === "opened" ? Icon.Rewind : undefined,
         tooltip: mr.merge_when_pipeline_succeeds && mr.state === "opened" ? "Auto Merge" : undefined,

--- a/extensions/gitlab/src/gitlabapi.ts
+++ b/extensions/gitlab/src/gitlabapi.ts
@@ -369,8 +369,9 @@ export interface Status {
 
 export interface MergeRequestApprovals {
   approved: boolean;
-  approvals_required: number;
-  approvals_left: number;
+  approvals_required?: number;
+  approvals_left?: number;
+  approved_by?: { user: User; approved_at: string }[];
 }
 
 export function isValidStatus(status: Status): boolean {

--- a/extensions/gitlab/src/utils.ts
+++ b/extensions/gitlab/src/utils.ts
@@ -320,3 +320,7 @@ export function shortify(text: string, maxLength: number): string {
   }
   return text.slice(0, maxLength - 3) + "...";
 }
+
+export function isNumber(value?: unknown): value is number {
+  return typeof value === "number" && !isNaN(value);
+}


### PR DESCRIPTION
## Description

While running this on my own Gitlab server that does not enforce approvals on merge requests, it shows `NaN/undefined` for the approvals. Updated the the MR list to only selectively show an accessory if it is returned

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
