### PR TITLE
Brew: Improve handling of abort signal

### DIFF
--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Brew Changelog
 
+## [Improvements] - {PR_MERGE_DATE}
+
+- Improve handling of abort signal when loading search command
+
 ## [Improved Memory Usage] - 2026-02-16
 
 - Use chunking to significantly reduce working memory

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Brew Changelog
 
-## [Improvements] - {PR_MERGE_DATE}
+## [Improvements] - 2026-02-19
 
 - Improve handling of abort signal when loading search command
 

--- a/extensions/brew/src/search.tsx
+++ b/extensions/brew/src/search.tsx
@@ -60,7 +60,8 @@ export default function SearchView() {
   // Show initializing toast on cold start (no cache files)
   useEffect(() => {
     // Only show on cold start when we're still loading
-    if (hasCacheFiles !== false || phase === "complete") {
+    // Once completion toast has been shown, never show init toast again
+    if (hasCacheFiles !== false || phase === "complete" || hasShownCompletionToast.current) {
       // Hide toast if it exists and we're done
       if (initToastRef.current) {
         initToastRef.current.hide();

--- a/extensions/brew/src/utils/brew/search.ts
+++ b/extensions/brew/src/utils/brew/search.ts
@@ -58,7 +58,7 @@ export async function brewSearch(
         casksProgress: progress,
         formulaeProgress,
       });
-    }),
+    }, signal),
     fetchFormulaIndex((progress) => {
       formulaeProgress = progress;
       onProgress?.({
@@ -66,7 +66,7 @@ export async function brewSearch(
         casksProgress,
         formulaeProgress: progress,
       });
-    }),
+    }, signal),
   ]);
 
   if (signal?.aborted) {


### PR DESCRIPTION
## Description

Improves handling of abort signal when initializing the search command.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
