### PR TITLE
Update ghostty extension

### DIFF
--- a/extensions/ghostty/CHANGELOG.md
+++ b/extensions/ghostty/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ghostty Changelog
 
-## [Command] 2026-02-19
+## [Command] {PR_MERGE_DATE}
 
 - Add new command to run launch configuration using arguments.
 

--- a/extensions/ghostty/CHANGELOG.md
+++ b/extensions/ghostty/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Ghostty Changelog
 
+## [Command] 2026-02-19
+
+- Add new command to run launch configuration using arguments.
+
 ## [Command] 2025-03-13
 
 - Add new command to open currently selected Finder directory in new Ghostty Window

--- a/extensions/ghostty/package.json
+++ b/extensions/ghostty/package.json
@@ -8,7 +8,8 @@
   "contributors": [
     "friendlyusername",
     "alexs",
-    "mathisfoxius"
+    "mathisfoxius",
+    "kelvin_jaison"
   ],
   "categories": [
     "Productivity",
@@ -41,11 +42,24 @@
       "description": "Open Ghostty with a specific configuration",
       "mode": "view"
     },
-    {
-      "name": "open-with-ghostty",
+    { "name": "open-with-ghostty",
       "title": "Open with Ghostty",
       "description": "Open the currently selected Finder item with Ghostty",
       "mode": "no-view"
+    },
+    {
+      "name": "run-ghostty-launch-configuration",
+      "title": "Run Ghostty Launch Configuration",
+      "description": "Run a launch configuration in Ghostty using an argument",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "config",
+          "placeholder": "config name",
+          "type": "text",
+          "required": true
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/extensions/ghostty/package.json
+++ b/extensions/ghostty/package.json
@@ -56,7 +56,7 @@
       "arguments": [
         {
           "name": "config",
-          "placeholder": "config name",
+          "placeholder": "Config Name",
           "type": "text",
           "required": true
         }

--- a/extensions/ghostty/package.json
+++ b/extensions/ghostty/package.json
@@ -42,7 +42,8 @@
       "description": "Open Ghostty with a specific configuration",
       "mode": "view"
     },
-    { "name": "open-with-ghostty",
+    {
+      "name": "open-with-ghostty",
       "title": "Open with Ghostty",
       "description": "Open the currently selected Finder item with Ghostty",
       "mode": "no-view"

--- a/extensions/ghostty/src/open-ghostty-launch-configuration.tsx
+++ b/extensions/ghostty/src/open-ghostty-launch-configuration.tsx
@@ -93,7 +93,7 @@ export default function Command() {
   );
 }
 
-async function RunLaunchConfiguration({ name }: { name: string }) {
+export async function RunLaunchConfiguration({ name }: { name: string }) {
   const yamlContent = await LocalStorage.getItem<string>(name);
   if (!yamlContent) {
     return;

--- a/extensions/ghostty/src/run-ghostty-launch-configuration.tsx
+++ b/extensions/ghostty/src/run-ghostty-launch-configuration.tsx
@@ -1,0 +1,9 @@
+import { LaunchProps } from "@raycast/api";
+import { RunLaunchConfiguration } from "./open-ghostty-launch-configuration";
+
+export default async function Command(props: LaunchProps<{ arguments: Arguments.RunGhosttyLaunchConfiguration }>) {
+  let { config } = props.arguments;
+  config = config.toLowerCase().replace(/\s+/g, "-");
+  await RunLaunchConfiguration({ name: config });
+}
+// Doesn't work consistently

--- a/extensions/ghostty/src/run-ghostty-launch-configuration.tsx
+++ b/extensions/ghostty/src/run-ghostty-launch-configuration.tsx
@@ -6,4 +6,3 @@ export default async function Command(props: LaunchProps<{ arguments: Arguments.
   config = config.toLowerCase().replace(/\s+/g, "-");
   await RunLaunchConfiguration({ name: config });
 }
-// Doesn't work consistently


### PR DESCRIPTION
## Description

Added a new command to run launch configurations directly using arguments. Allows user to skip looking through the list of launch configuration to open the one they want. Also additional benefit of using deeplinks to directly launch the configuration they want


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
