### PR TITLE
Linear: Add multi-workspace support

### DIFF
--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Linear Changelog
 
-## [Multi-Workspace Support] - 2026-02-20
+## [Multi-Workspace Support] - {PR_MERGE_DATE}
 
 - Added "Add Workspace" command to connect additional Linear workspaces using Personal API Keys
 - Added "Switch Workspace" command to switch between connected workspaces

--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Linear Changelog
 
+## [Multi-Workspace Support] - 2026-02-20
+
+- Added "Add Workspace" command to connect additional Linear workspaces using Personal API Keys
+- Added "Switch Workspace" command to switch between connected workspaces
+- OAuth workspace remains the primary; additional workspaces use PATs
+- All existing commands now respect the active workspace
+
 ## [Update Shortcuts] - 2026-01-06
 
 - Updated shortcuts to make them cross-platform

--- a/extensions/linear/README.md
+++ b/extensions/linear/README.md
@@ -16,4 +16,4 @@ The Linear extension brings the speed, quality and joy of the app to every corne
 
 **Q2. How do I switch workspaces?**
 
-**Ans.** You can't switch workspaces on the fly; however, you can go to `Preferences`, `click` "Logout" then run any `command` now selecting the appropriate workspace.
+**Ans.** Use the **Add Workspace** command to connect additional Linear workspaces via Personal API Keys (PATs). Then use the **Switch Workspace** command to switch between them. Your primary OAuth workspace is always available alongside any PAT workspaces you add.

--- a/extensions/linear/package.json
+++ b/extensions/linear/package.json
@@ -169,6 +169,14 @@
           "required": false
         },
         {
+          "name": "preferredStatusName",
+          "type": "textfield",
+          "title": "Preferred Status",
+          "placeholder": "Todo",
+          "description": "Specify the name of the preferred status for new issues (e.g. Todo, Backlog). If not specified, uses Linear's default.",
+          "required": false
+        },
+        {
           "name": "shouldCloseMainWindow",
           "type": "checkbox",
           "title": "Advanced",

--- a/extensions/linear/package.json
+++ b/extensions/linear/package.json
@@ -169,14 +169,6 @@
           "required": false
         },
         {
-          "name": "preferredStatusName",
-          "type": "textfield",
-          "title": "Preferred Status",
-          "placeholder": "Todo",
-          "description": "Specify the name of the preferred status for new issues (e.g. Todo, Backlog). If not specified, uses Linear's default.",
-          "required": false
-        },
-        {
           "name": "shouldCloseMainWindow",
           "type": "checkbox",
           "title": "Advanced",

--- a/extensions/linear/package.json
+++ b/extensions/linear/package.json
@@ -16,7 +16,8 @@
     "fil",
     "joeb",
     "itsmingjie",
-    "xmok"
+    "xmok",
+    "eduwass"
   ],
   "pastContributors": [
     "mathieudutour",
@@ -234,6 +235,18 @@
       "name": "favorites",
       "title": "Favorites",
       "description": "Browse through your Linear favorites.",
+      "mode": "view"
+    },
+    {
+      "name": "add-workspace",
+      "title": "Add Workspace",
+      "description": "Add an additional Linear workspace using a Personal API Key.",
+      "mode": "view"
+    },
+    {
+      "name": "switch-workspace",
+      "title": "Switch Workspace",
+      "description": "Switch between your connected Linear workspaces.",
       "mode": "view"
     }
   ],

--- a/extensions/linear/src/add-workspace.tsx
+++ b/extensions/linear/src/add-workspace.tsx
@@ -1,0 +1,61 @@
+import { Action, ActionPanel, Form, launchCommand, LaunchType, showToast, Toast } from "@raycast/api";
+import { withAccessToken } from "@raycast/utils";
+
+import { createLinearClient, linear } from "./api/linearClient";
+import { addWorkspace } from "./api/workspaces";
+
+function AddWorkspaceForm() {
+  async function handleSubmit(values: { pat: string }) {
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Validating token..." });
+
+    try {
+      const client = createLinearClient(values.pat, "pat");
+      const org = await client.organization;
+
+      await addWorkspace({
+        id: org.id,
+        name: org.name,
+        urlKey: org.urlKey,
+        logoUrl: org.logoUrl ?? undefined,
+        type: "pat",
+        pat: values.pat,
+      });
+
+      toast.style = Toast.Style.Success;
+      toast.title = `Added workspace: ${org.name}`;
+      await launchCommand({ name: "switch-workspace", type: LaunchType.UserInitiated });
+    } catch (error) {
+      console.error("Add workspace error:", error);
+      toast.style = Toast.Style.Failure;
+      toast.title = "Invalid token";
+      toast.message =
+        error instanceof Error
+          ? error.message
+          : "Could not authenticate with this token. Make sure it's a valid Personal Access Token.";
+    }
+  }
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Add Workspace" onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.Description
+        title="Step 1"
+        text="In the Linear app, switch to the workspace you want to add using the top-left dropdown."
+      />
+      <Form.Description title="Step 2" text="Go to Settings → Security & Access → Personal API Keys." />
+      <Form.Description
+        title="Step 3"
+        text="Create a new key (e.g. 'raycast-workspace'), copy it, and paste it below."
+      />
+      <Form.PasswordField id="pat" title="Personal Access Token" placeholder="lin_api_..." />
+      <Form.Description title="Then" text="Use the 'Switch Workspace' command to switch between your workspaces." />
+    </Form>
+  );
+}
+
+export default withAccessToken(linear)(AddWorkspaceForm);

--- a/extensions/linear/src/api/linearClient.ts
+++ b/extensions/linear/src/api/linearClient.ts
@@ -2,25 +2,62 @@ import { LinearClient, LinearGraphQLClient } from "@linear/sdk";
 import { environment } from "@raycast/api";
 import { OAuthService } from "@raycast/utils";
 
-let linearClient: LinearClient | null = null;
+let oauthLinearClient: LinearClient | null = null;
+let oauthWorkspaceId: string | null = null;
+let activeClient: LinearClient | null = null;
+
+export function createLinearClient(token: string, type: "oauth" | "pat" = "oauth"): LinearClient {
+  return new LinearClient({
+    ...(type === "pat" ? { apiKey: token } : { accessToken: token }),
+    headers: {
+      "public-file-urls-expire-in": "60",
+      "linear-raycast-extension-name": environment.extensionName,
+    },
+  });
+}
 
 export const linear = OAuthService.linear({
   scope: "read write",
   onAuthorize({ token }) {
-    linearClient = new LinearClient({
-      accessToken: token,
-      headers: {
-        "public-file-urls-expire-in": "60",
-        "linear-raycast-extension-name": environment.extensionName,
-      },
-    });
+    oauthLinearClient = createLinearClient(token);
   },
 });
 
+export function setActiveClient(client: LinearClient | null): void {
+  activeClient = client;
+}
+
 export function getLinearClient(): { linearClient: LinearClient; graphQLClient: LinearGraphQLClient } {
-  if (!linearClient) {
+  const client = activeClient ?? oauthLinearClient;
+  if (!client) {
     throw new Error("No linear client initialized");
   }
 
-  return { linearClient, graphQLClient: linearClient.client };
+  return { linearClient: client, graphQLClient: client.client };
+}
+
+/**
+ * Fetches and caches the OAuth workspace ID. Called lazily when needed
+ * (e.g., by resolveActiveClient or the Switch Workspace command).
+ */
+export async function fetchOAuthWorkspaceId(): Promise<string | null> {
+  if (oauthWorkspaceId) return oauthWorkspaceId;
+  if (!oauthLinearClient) return null;
+
+  try {
+    const org = await oauthLinearClient.organization;
+    oauthWorkspaceId = org.id;
+  } catch {
+    // Non-fatal
+  }
+
+  return oauthWorkspaceId;
+}
+
+export function getOAuthWorkspaceId(): string | null {
+  return oauthWorkspaceId;
+}
+
+export function getOAuthLinearClient(): LinearClient | null {
+  return oauthLinearClient;
 }

--- a/extensions/linear/src/api/resolveActiveClient.ts
+++ b/extensions/linear/src/api/resolveActiveClient.ts
@@ -1,0 +1,23 @@
+import { setActiveClient, fetchOAuthWorkspaceId, createLinearClient } from "./linearClient";
+import { getActiveWorkspaceId, getStoredWorkspaces } from "./workspaces";
+
+/**
+ * Resolves the active workspace and sets the appropriate LinearClient.
+ * Called by View.tsx for view commands, and directly in no-view commands.
+ */
+export async function resolveActiveClient(): Promise<void> {
+  const activeWorkspaceId = await getActiveWorkspaceId();
+  const oauthWorkspaceId = await fetchOAuthWorkspaceId();
+
+  if (activeWorkspaceId && activeWorkspaceId !== oauthWorkspaceId) {
+    const workspaces = await getStoredWorkspaces();
+    const workspace = workspaces.find((w) => w.id === activeWorkspaceId);
+    if (workspace?.type === "pat" && workspace.pat) {
+      setActiveClient(createLinearClient(workspace.pat, "pat"));
+      return;
+    }
+  }
+
+  // Default to OAuth client
+  setActiveClient(null);
+}

--- a/extensions/linear/src/api/workspaces.ts
+++ b/extensions/linear/src/api/workspaces.ts
@@ -1,0 +1,55 @@
+import { LocalStorage } from "@raycast/api";
+
+export interface WorkspaceConfig {
+  id: string;
+  name: string;
+  urlKey: string;
+  logoUrl?: string;
+  type: "oauth" | "pat";
+  pat?: string;
+}
+
+const WORKSPACES_KEY = "linear-workspaces";
+const ACTIVE_WORKSPACE_KEY = "linear-active-workspace";
+
+export async function getStoredWorkspaces(): Promise<WorkspaceConfig[]> {
+  const json = await LocalStorage.getItem<string>(WORKSPACES_KEY);
+  return json ? JSON.parse(json) : [];
+}
+
+async function setStoredWorkspaces(workspaces: WorkspaceConfig[]): Promise<void> {
+  await LocalStorage.setItem(WORKSPACES_KEY, JSON.stringify(workspaces));
+}
+
+export async function addWorkspace(workspace: WorkspaceConfig): Promise<void> {
+  const workspaces = await getStoredWorkspaces();
+  const existing = workspaces.findIndex((w) => w.id === workspace.id);
+  if (existing >= 0) {
+    workspaces[existing] = workspace;
+  } else {
+    workspaces.push(workspace);
+  }
+  await setStoredWorkspaces(workspaces);
+}
+
+export async function removeWorkspace(workspaceId: string): Promise<void> {
+  const workspaces = await getStoredWorkspaces();
+  await setStoredWorkspaces(workspaces.filter((w) => w.id !== workspaceId));
+
+  const active = await getActiveWorkspaceId();
+  if (active === workspaceId) {
+    await clearActiveWorkspace();
+  }
+}
+
+export async function getActiveWorkspaceId(): Promise<string | null> {
+  return (await LocalStorage.getItem<string>(ACTIVE_WORKSPACE_KEY)) ?? null;
+}
+
+export async function setActiveWorkspaceId(workspaceId: string): Promise<void> {
+  await LocalStorage.setItem(ACTIVE_WORKSPACE_KEY, workspaceId);
+}
+
+export async function clearActiveWorkspace(): Promise<void> {
+  await LocalStorage.removeItem(ACTIVE_WORKSPACE_KEY);
+}

--- a/extensions/linear/src/components/View.tsx
+++ b/extensions/linear/src/components/View.tsx
@@ -1,17 +1,23 @@
 import { withAccessToken } from "@raycast/utils";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { linear } from "../api/linearClient";
+import { resolveActiveClient } from "../api/resolveActiveClient";
 import { checkLinearApp } from "../helpers/isLinearInstalled";
 
 /**
- * Makes sure that we have a authenticated linear client available in the children
+ * Makes sure that we have an authenticated linear client available in the children.
+ * Resolves the active workspace (OAuth or PAT) before rendering.
  */
 function View({ children }: { children: React.ReactNode }) {
+  const [ready, setReady] = useState(false);
+
   useEffect(() => {
     checkLinearApp();
+    resolveActiveClient().then(() => setReady(true));
   }, []);
 
+  if (!ready) return null;
   return children;
 }
 

--- a/extensions/linear/src/create-issue-for-myself.ts
+++ b/extensions/linear/src/create-issue-for-myself.ts
@@ -26,11 +26,31 @@ const command = async (props: { arguments: Arguments.CreateIssueForMyself }) => 
       throw Error("No team found");
     }
 
+    let stateId: string | undefined;
+
+    if (preferences.preferredStatusName) {
+      const states = await linearClient.workflowStates({
+        filter: {
+          team: { id: { eq: team.id } },
+          name: { eq: preferences.preferredStatusName },
+        },
+      });
+
+      const state = states.nodes[0];
+
+      if (!state) {
+        throw Error(`Status "${preferences.preferredStatusName}" not found`);
+      }
+
+      stateId = state.id;
+    }
+
     const payload = await linearClient.createIssue({
       teamId: team.id,
       title: props.arguments.title,
       description: props.arguments.description,
       assigneeId: viewer.id,
+      stateId: stateId,
     });
 
     const issue = await payload.issue;

--- a/extensions/linear/src/create-issue-for-myself.ts
+++ b/extensions/linear/src/create-issue-for-myself.ts
@@ -1,16 +1,14 @@
-import { LinearClient } from "@linear/sdk";
-import { Clipboard, closeMainWindow, getPreferenceValues, open, Toast, showToast, Keyboard } from "@raycast/api";
-import { getAccessToken, withAccessToken } from "@raycast/utils";
+import { Clipboard, closeMainWindow, getPreferenceValues, open, Toast, showToast } from "@raycast/api";
 
-import { getTeams } from "./api/getTeams";
-import { linear } from "./api/linearClient";
+import { getLinearClient } from "./api/linearClient";
+import { resolveActiveClient } from "./api/resolveActiveClient";
 
 const command = async (props: { arguments: Arguments.CreateIssueForMyself }) => {
   const toast = await showToast({ style: Toast.Style.Animated, title: "Creating issue" });
 
   try {
-    const { token } = getAccessToken();
-    const linearClient = new LinearClient({ accessToken: token });
+    await resolveActiveClient();
+    const { linearClient } = getLinearClient();
 
     const preferences = getPreferenceValues<Preferences.CreateIssueForMyself>();
 
@@ -19,50 +17,20 @@ const command = async (props: { arguments: Arguments.CreateIssueForMyself }) => 
     }
 
     const viewer = await linearClient.viewer;
-    const { teams } = await getTeams();
+    const teams = await viewer.teams();
 
-    let teamId: string | undefined;
-
-    if (preferences.preferredTeamKey) {
-      const team = teams.find((t) => t.key === preferences.preferredTeamKey);
-      if (team) {
-        teamId = team.id;
-      }
-    }
-
-    if (!teamId) {
-      teamId = teams[0].id;
-    }
-
-    if (!teamId) {
+    const team = preferences.preferredTeamKey
+      ? teams.nodes.find((t) => t.key === preferences.preferredTeamKey)
+      : teams.nodes[0];
+    if (!team) {
       throw Error("No team found");
     }
 
-    let stateId: string | undefined;
-
-    if (preferences.preferredStatusName) {
-      const states = await linearClient.workflowStates({
-        filter: {
-          team: { id: { eq: teamId } },
-          name: { eq: preferences.preferredStatusName },
-        },
-      });
-
-      const state = states.nodes[0];
-
-      if (!state) {
-        throw Error(`Status "${preferences.preferredStatusName}" not found`);
-      }
-
-      stateId = state.id;
-    }
-
     const payload = await linearClient.createIssue({
-      teamId: teamId,
+      teamId: team.id,
       title: props.arguments.title,
       description: props.arguments.description,
       assigneeId: viewer.id,
-      stateId: stateId,
     });
 
     const issue = await payload.issue;
@@ -74,7 +42,7 @@ const command = async (props: { arguments: Arguments.CreateIssueForMyself }) => 
     toast.title = `Created issue • ${issue.identifier}`;
     toast.primaryAction = {
       title: "Open Issue",
-      shortcut: Keyboard.Shortcut.Common.OpenWith,
+      shortcut: { modifiers: ["cmd", "shift"], key: "o" },
       onAction: async () => {
         await open(issue.url);
         await toast.hide();
@@ -83,7 +51,7 @@ const command = async (props: { arguments: Arguments.CreateIssueForMyself }) => 
 
     toast.secondaryAction = {
       title: "Copy Issue ID",
-      shortcut: Keyboard.Shortcut.Common.Copy,
+      shortcut: { modifiers: ["cmd", "shift"], key: "c" },
       onAction: () => Clipboard.copy(issue.identifier),
     };
   } catch (e) {
@@ -92,10 +60,10 @@ const command = async (props: { arguments: Arguments.CreateIssueForMyself }) => 
     toast.message = e instanceof Error ? e.message : String(e);
     toast.primaryAction = {
       title: "Copy Error Log",
-      shortcut: Keyboard.Shortcut.Common.Copy,
+      shortcut: { modifiers: ["cmd", "shift"], key: "c" },
       onAction: () => Clipboard.copy(e instanceof Error ? (e.stack ?? e.message) : String(e)),
     };
   }
 };
 
-export default withAccessToken(linear)(command);
+export default command;

--- a/extensions/linear/src/quick-add-comment-to-issue.ts
+++ b/extensions/linear/src/quick-add-comment-to-issue.ts
@@ -1,17 +1,7 @@
-import { LinearClient } from "@linear/sdk";
-import {
-  Clipboard,
-  closeMainWindow,
-  getPreferenceValues,
-  open,
-  Toast,
-  showToast,
-  showHUD,
-  Keyboard,
-} from "@raycast/api";
-import { getAccessToken, withAccessToken } from "@raycast/utils";
+import { Clipboard, closeMainWindow, getPreferenceValues, open, Toast, showToast, showHUD } from "@raycast/api";
 
-import { linear } from "./api/linearClient";
+import { getLinearClient } from "./api/linearClient";
+import { resolveActiveClient } from "./api/resolveActiveClient";
 
 const command = async (props: { arguments: Arguments.QuickAddCommentToIssue }) => {
   const { issueId, comment } = props.arguments;
@@ -24,8 +14,8 @@ const command = async (props: { arguments: Arguments.QuickAddCommentToIssue }) =
   const preferences = getPreferenceValues<Preferences.QuickAddCommentToIssue>();
 
   try {
-    const { token } = getAccessToken();
-    const linearClient = new LinearClient({ accessToken: token });
+    await resolveActiveClient();
+    const { linearClient } = getLinearClient();
 
     if (preferences.shouldCloseMainWindow) {
       await closeMainWindow();
@@ -52,7 +42,7 @@ const command = async (props: { arguments: Arguments.QuickAddCommentToIssue }) =
       if (newComment) {
         toast.primaryAction = {
           title: "Open Comment",
-          shortcut: Keyboard.Shortcut.Common.OpenWith,
+          shortcut: { modifiers: ["cmd", "shift"], key: "o" },
           onAction: async () => {
             await open(newComment.url);
             await toast.hide();
@@ -70,11 +60,11 @@ const command = async (props: { arguments: Arguments.QuickAddCommentToIssue }) =
       toast.title = failureTitle;
       toast.primaryAction = {
         title: "Copy Error Log",
-        shortcut: Keyboard.Shortcut.Common.Copy,
+        shortcut: { modifiers: ["cmd", "shift"], key: "c" },
         onAction: () => Clipboard.copy(e instanceof Error ? (e.stack ?? e.message) : String(e)),
       };
     }
   }
 };
 
-export default withAccessToken(linear)(command);
+export default command;

--- a/extensions/linear/src/switch-workspace.tsx
+++ b/extensions/linear/src/switch-workspace.tsx
@@ -1,0 +1,139 @@
+import {
+  Action,
+  ActionPanel,
+  Color,
+  Icon,
+  Image,
+  launchCommand,
+  LaunchType,
+  List,
+  popToRoot,
+  showToast,
+  Toast,
+} from "@raycast/api";
+import { useCachedPromise, withAccessToken } from "@raycast/utils";
+
+import { fetchOAuthWorkspaceId, getOAuthLinearClient, linear } from "./api/linearClient";
+import { getActiveWorkspaceId, getStoredWorkspaces, removeWorkspace, setActiveWorkspaceId } from "./api/workspaces";
+
+interface WorkspaceListItem {
+  id: string;
+  name: string;
+  urlKey: string;
+  logoUrl?: string;
+  type: "oauth" | "pat";
+}
+
+function SwitchWorkspace() {
+  const { data, isLoading, revalidate } = useCachedPromise(async () => {
+    const storedWorkspaces = await getStoredWorkspaces();
+    const activeWorkspaceId = await getActiveWorkspaceId();
+    const oauthWorkspaceId = await fetchOAuthWorkspaceId();
+
+    let oauthWorkspace: WorkspaceListItem | null = null;
+    const oauthClient = getOAuthLinearClient();
+    if (oauthClient) {
+      try {
+        const org = await oauthClient.organization;
+        oauthWorkspace = {
+          id: org.id,
+          name: org.name,
+          urlKey: org.urlKey,
+          logoUrl: org.logoUrl ?? undefined,
+          type: "oauth",
+        };
+      } catch {
+        // OAuth client may not be fully initialized yet
+      }
+    }
+
+    const allWorkspaces: WorkspaceListItem[] = [
+      ...(oauthWorkspace ? [oauthWorkspace] : []),
+      ...storedWorkspaces
+        .filter((w) => w.type === "pat")
+        .map((w) => ({
+          id: w.id,
+          name: w.name,
+          urlKey: w.urlKey,
+          logoUrl: w.logoUrl,
+          type: w.type,
+        })),
+    ];
+
+    const effectiveActiveId = activeWorkspaceId ?? oauthWorkspaceId;
+
+    return { allWorkspaces, effectiveActiveId };
+  });
+
+  const allWorkspaces = data?.allWorkspaces ?? [];
+  const effectiveActiveId = data?.effectiveActiveId;
+
+  return (
+    <List isLoading={isLoading}>
+      {allWorkspaces.map((workspace) => {
+        const isActive = workspace.id === effectiveActiveId;
+        return (
+          <List.Item
+            key={workspace.id}
+            icon={workspace.logoUrl ? { source: workspace.logoUrl, mask: Image.Mask.RoundedRectangle } : Icon.Building}
+            title={workspace.name}
+            subtitle={workspace.urlKey}
+            accessories={[
+              ...(workspace.type === "pat" ? [{ tag: "PAT" }] : [{ tag: "OAuth" }]),
+              ...(isActive ? [{ icon: { source: Icon.Checkmark, tintColor: Color.Green }, tooltip: "Active" }] : []),
+            ]}
+            actions={
+              <ActionPanel>
+                <ActionPanel.Section>
+                  {!isActive && (
+                    <Action
+                      title="Switch to This Workspace"
+                      icon={Icon.Switch}
+                      onAction={async () => {
+                        await setActiveWorkspaceId(workspace.id);
+                        await showToast({ style: Toast.Style.Success, title: `Switched to ${workspace.name}` });
+                        await popToRoot();
+                      }}
+                    />
+                  )}
+                </ActionPanel.Section>
+                {workspace.type === "pat" && (
+                  <ActionPanel.Section>
+                    <Action
+                      title="Remove Workspace"
+                      icon={Icon.Trash}
+                      style={Action.Style.Destructive}
+                      shortcut={{ modifiers: ["ctrl"], key: "x" }}
+                      onAction={async () => {
+                        await removeWorkspace(workspace.id);
+                        await showToast({ style: Toast.Style.Success, title: `Removed ${workspace.name}` });
+                        revalidate();
+                      }}
+                    />
+                  </ActionPanel.Section>
+                )}
+              </ActionPanel>
+            }
+          />
+        );
+      })}
+      <List.Item
+        key="add-workspace"
+        icon={Icon.Plus}
+        title="Add Workspace"
+        subtitle="Connect another workspace via Personal Access Token"
+        actions={
+          <ActionPanel>
+            <Action
+              title="Add Workspace"
+              icon={Icon.Plus}
+              onAction={() => launchCommand({ name: "add-workspace", type: LaunchType.UserInitiated })}
+            />
+          </ActionPanel>
+        }
+      />
+    </List>
+  );
+}
+
+export default withAccessToken(linear)(SwitchWorkspace);


### PR DESCRIPTION
## Description

Resolves: https://github.com/raycast/extensions/issues/24297

- Add "Add Workspace" command to connect additional workspaces using PATs
- Add "Switch Workspace" command to switch between connected workspaces (also allows to remove PAT workspaces)
- OAuth workspace remains the primary; additional workspaces use PATs
- All existing commands respect the active workspace selection

## Screencast

<img width="1724" height="1172" alt="2026 02 20 07 42 54@2x" src="https://github.com/user-attachments/assets/d776ef97-333f-4a88-9898-75abf9d710d0" />


https://github.com/user-attachments/assets/8142a6d1-202d-42d3-975b-050ef1821885


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
