### PR TITLE
Update `Placeholder` extension - cross-platform `Keyboard` shortcuts

### DIFF
--- a/extensions/placeholder/CHANGELOG.md
+++ b/extensions/placeholder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Placeholder Changelog
 
+## [Cross-Platform Keyboard Shortcuts] - {PR_MERGE_DATE}
+
+- Make `Keyboard` shortcuts cross-platform
+
 ## [Updates] - 2025-12-16
 
 - Add Windows support

--- a/extensions/placeholder/CHANGELOG.md
+++ b/extensions/placeholder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Placeholder Changelog
 
-## [Cross-Platform Keyboard Shortcuts] - {PR_MERGE_DATE}
+## [Cross-Platform Keyboard Shortcuts] - 2026-02-23
 
 - Make `Keyboard` shortcuts cross-platform
 

--- a/extensions/placeholder/package-lock.json
+++ b/extensions/placeholder/package-lock.json
@@ -7,8 +7,8 @@
       "name": "placeholder",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.103.3",
-        "@raycast/utils": "^2.2.0",
+        "@raycast/api": "^1.104.6",
+        "@raycast/utils": "^2.2.2",
         "fs-extra": "^11.2.0",
         "picsum-photos": "^3.0.10"
       },
@@ -1501,9 +1501,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.103.10",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.103.10.tgz",
-      "integrity": "sha512-FOxqq47+YVCo4+Eq8eU8+esoLNwcxHHBVhw/JmZwsViTqMB3DF8WorXL+ZwrXW/8srruuzyyx9+ACyRdZ+zbSg==",
+      "version": "1.104.6",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.6.tgz",
+      "integrity": "sha512-W3UnZrfh1EH9mteQQOibeUvniDnVsbRgcfSUgVWFTGuI6mzKLFzoM8mD6n5amYQM51JVvbuJbaqtfMqsTmnQCQ==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.5.4",
@@ -1690,7 +1690,6 @@
       "integrity": "sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1750,7 +1749,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -1955,7 +1953,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2308,7 +2305,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3237,7 +3233,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3270,7 +3265,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3495,7 +3489,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/placeholder/package.json
+++ b/extensions/placeholder/package.json
@@ -6,7 +6,8 @@
   "icon": "placeholder-icon.png",
   "author": "koinzhang",
   "contributors": [
-    "j3lte"
+    "j3lte",
+    "xmok"
   ],
   "platforms": [
     "macOS",
@@ -227,8 +228,8 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.103.3",
-    "@raycast/utils": "^2.2.0",
+    "@raycast/api": "^1.104.6",
+    "@raycast/utils": "^2.2.2",
     "fs-extra": "^11.2.0",
     "picsum-photos": "^3.0.10"
   },
@@ -243,11 +244,11 @@
     "typescript": "^5.9.3"
   },
   "scripts": {
-    "build": "ray build -e dist",
+    "build": "ray build",
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
-    "publish": "npx -y @raycast/api@latest publish"
+    "publish": "npx @raycast/api@latest publish"
   }
 }

--- a/extensions/placeholder/src/components/action-on-placeholder-image.tsx
+++ b/extensions/placeholder/src/components/action-on-placeholder-image.tsx
@@ -28,7 +28,7 @@ export function ActionOnPlaceholderImage(props: {
         <Action
           icon={Icon.ChevronUp}
           title={"Previous Page"}
-          shortcut={{ modifiers: ["cmd"], key: "[" }}
+          shortcut={{ macOS: { modifiers: ["cmd"], key: "[" }, Windows: { modifiers: ["ctrl"], key: "[" } }}
           onAction={() => {
             if (page > 1) {
               setPage(page - 1);
@@ -38,7 +38,7 @@ export function ActionOnPlaceholderImage(props: {
         <Action
           icon={Icon.ChevronDown}
           title={"Next Page"}
-          shortcut={{ modifiers: ["cmd"], key: "]" }}
+          shortcut={{ macOS: { modifiers: ["cmd"], key: "]" }, Windows: { modifiers: ["ctrl"], key: "]" } }}
           onAction={() => setPage(page + 1)}
         />
       </ActionPanel.Section>
@@ -49,11 +49,14 @@ export function ActionOnPlaceholderImage(props: {
         <RevealImageAction imageURL={picsumImage.download_url} size={picsumImage.width + "x" + picsumImage.height} />
         <Action.OpenInBrowser
           title={"Open in Unsplash"}
-          shortcut={{ modifiers: ["cmd"], key: "u" }}
+          shortcut={{ macOS: { modifiers: ["cmd"], key: "u" }, Windows: { modifiers: ["ctrl"], key: "u" } }}
           url={picsumImage.url}
         />
         <Action.CopyToClipboard
-          shortcut={{ modifiers: ["opt", "cmd"], key: "." }}
+          shortcut={{
+            macOS: { modifiers: ["opt", "cmd"], key: "." },
+            Windows: { modifiers: ["alt", "ctrl"], key: "." },
+          }}
           title={"Copy Unsplash URL"}
           content={picsumImage.url}
         />

--- a/extensions/placeholder/src/components/action-open-preferences.tsx
+++ b/extensions/placeholder/src/components/action-open-preferences.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Icon, openCommandPreferences, openExtensionPreferences } from "@raycast/api";
+import { Action, ActionPanel, Icon, Keyboard, openCommandPreferences, openExtensionPreferences } from "@raycast/api";
 
 export function ActionOpenPreferences() {
   return (
@@ -6,13 +6,13 @@ export function ActionOpenPreferences() {
       <Action
         icon={Icon.Gear}
         title="Configure Command"
-        shortcut={{ modifiers: ["shift", "cmd"], key: "," }}
+        shortcut={Keyboard.Shortcut.Common.CopyPath}
         onAction={openCommandPreferences}
       />
       <Action
         icon={Icon.Gear}
         title="Configure Extension"
-        shortcut={{ modifiers: ["opt", "cmd"], key: "," }}
+        shortcut={{ macOS: { modifiers: ["opt", "cmd"], key: "," }, Windows: { modifiers: ["opt", "ctrl"], key: "," } }}
         onAction={openExtensionPreferences}
       />
     </ActionPanel.Section>

--- a/extensions/placeholder/src/components/action-open-preferences.tsx
+++ b/extensions/placeholder/src/components/action-open-preferences.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Icon, Keyboard, openCommandPreferences, openExtensionPreferences } from "@raycast/api";
+import { Action, ActionPanel, Icon, openCommandPreferences, openExtensionPreferences } from "@raycast/api";
 
 export function ActionOpenPreferences() {
   return (
@@ -6,7 +6,10 @@ export function ActionOpenPreferences() {
       <Action
         icon={Icon.Gear}
         title="Configure Command"
-        shortcut={Keyboard.Shortcut.Common.CopyPath}
+        shortcut={{
+          macOS: { modifiers: ["shift", "cmd"], key: "," },
+          Windows: { modifiers: ["shift", "ctrl"], key: "," },
+        }}
         onAction={openCommandPreferences}
       />
       <Action

--- a/extensions/placeholder/src/components/image-detail.tsx
+++ b/extensions/placeholder/src/components/image-detail.tsx
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
-import { Action, ActionPanel, Detail, Icon, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, Detail, Icon, Keyboard, useNavigation } from "@raycast/api";
 import { ActionOpenPreferences } from "@/components/action-open-preferences";
 import { PicsumImageAction } from "@/components/picsum-image-action";
 
@@ -21,7 +21,7 @@ export function ImageDetail(props: {
             <Action
               icon={Icon.Minimize}
               title={"Quit Preview"}
-              shortcut={{ modifiers: ["cmd"], key: "y" }}
+              shortcut={Keyboard.Shortcut.Common.ToggleQuickLook}
               onAction={useNavigation().pop}
             />
           </ActionPanel.Section>

--- a/extensions/placeholder/src/components/picsum-image-action.tsx
+++ b/extensions/placeholder/src/components/picsum-image-action.tsx
@@ -24,8 +24,14 @@ export function PicsumImageAction(props: {
         icon={Icon.Clipboard}
         title={primaryAction === "Copy Image URL" ? "Copy Image URL" : "Copy Image File"}
         shortcut={{
-          modifiers: primaryAction === "Copy Image URL" ? ["shift", "cmd"] : ["cmd"],
-          key: primaryAction === "Copy Image URL" ? "." : ".",
+          macOS: {
+            modifiers: primaryAction === "Copy Image URL" ? ["shift", "cmd"] : ["cmd"],
+            key: primaryAction === "Copy Image URL" ? "." : ".",
+          },
+          Windows: {
+            modifiers: primaryAction === "Copy Image URL" ? ["shift", "ctrl"] : ["ctrl"],
+            key: primaryAction === "Copy Image URL" ? "." : ".",
+          },
         }}
         onAction={() => {
           if (primaryAction === "Copy Image URL") {
@@ -44,8 +50,14 @@ export function PicsumImageAction(props: {
         icon={Icon.Clipboard}
         title={primaryAction === "Copy Image URL" ? "Copy Image File" : "Copy Image URL"}
         shortcut={{
-          modifiers: primaryAction === "Copy Image URL" ? ["cmd"] : ["shift", "cmd"],
-          key: primaryAction === "Copy Image URL" ? "." : ",",
+          macOS: {
+            modifiers: primaryAction === "Copy Image URL" ? ["cmd"] : ["shift", "cmd"],
+            key: primaryAction === "Copy Image URL" ? "." : ",",
+          },
+          Windows: {
+            modifiers: primaryAction === "Copy Image URL" ? ["ctrl"] : ["shift", "ctrl"],
+            key: primaryAction === "Copy Image URL" ? "." : ",",
+          },
         }}
         onAction={() => {
           if (primaryAction === "Copy Image URL") {
@@ -62,7 +74,7 @@ export function PicsumImageAction(props: {
       />
       <Action
         icon={Icon.Download}
-        shortcut={{ modifiers: ["cmd"], key: "d" }}
+        shortcut={{ macOS: { modifiers: ["cmd"], key: "d" }, Windows: { modifiers: ["ctrl"], key: "d" } }}
         title={"Download Image"}
         onAction={() => {
           downloadImage(imageURL, size).then();

--- a/extensions/placeholder/src/components/reveal-image-action.tsx
+++ b/extensions/placeholder/src/components/reveal-image-action.tsx
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
-import { Action, Icon } from "@raycast/api";
+import { Action, Icon, Keyboard } from "@raycast/api";
 import { ImageDetail } from "@/components/image-detail";
 
 export function RevealImageAction(props: {
@@ -21,11 +21,11 @@ export function RevealImageAction(props: {
     <>
       <Action.Push
         icon={Icon.Maximize}
-        shortcut={{ modifiers: ["cmd"], key: "y" }}
+        shortcut={Keyboard.Shortcut.Common.ToggleQuickLook}
         title={"Preview Image"}
         target={<ImageDetail imageURL={imageURL} size={size} autoRefresh={autoRefresh} setRefresh={setRefresh} />}
       />
-      <Action.OpenInBrowser shortcut={{ modifiers: ["cmd"], key: "o" }} url={imageURL} />
+      <Action.OpenInBrowser shortcut={Keyboard.Shortcut.Common.Open} url={imageURL} />
     </>
   );
 }

--- a/extensions/placeholder/src/utils/preferences.ts
+++ b/extensions/placeholder/src/utils/preferences.ts
@@ -1,18 +1,6 @@
 import { getPreferenceValues } from "@raycast/api";
 
-interface Preferences {
-  layout: string;
-  columns: string;
-  primaryAction: string;
-  perPage: string;
-  defaultWidth: string;
-  defaultHeight: string;
-  staticRandom: boolean;
-  blur: string;
-  jpg: boolean;
-  grayscale: boolean;
-  noCache: boolean;
-}
+type Preferences = Preferences.RandomPlaceholderImage & Preferences.SearchPlaceholderImages;
 export const {
   layout,
   columns,


### PR DESCRIPTION
## Description

- Make `Keyboard` shortcuts cross-platform

## Screencast

N/A

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
