### PR TITLE
feat(clipboard-type): add soft newlines preference to use Shift+Enter

### DIFF
--- a/extensions/clipboard-type/CHANGELOG.md
+++ b/extensions/clipboard-type/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clipboard Type Changelog
 
-## [Added soft newlines preference] {PR_MERGE_DATE}
+## [Added soft newlines preference] 2026-03-23
 
 - Added a new preference to use Shift+Enter for newlines instead of Enter. Useful for apps and websites that treat Enter as submit.
 

--- a/extensions/clipboard-type/CHANGELOG.md
+++ b/extensions/clipboard-type/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clipboard Type Changelog
 
-## [Added soft newlines preference] 2026-02-23
+## [Added soft newlines preference] {PR_MERGE_DATE}
 
 - Added a new preference to use Shift+Enter for newlines instead of Enter. Useful for apps and websites that treat Enter as submit.
 

--- a/extensions/clipboard-type/CHANGELOG.md
+++ b/extensions/clipboard-type/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Clipboard Type Changelog
 
+## [Added soft newlines preference] 2026-02-23
+
+- Added a new preference to use Shift+Enter for newlines instead of Enter. Useful for apps and websites that treat Enter as submit.
+
 ## [Added human cadence typing] 2026-02-10
 
 - Added a new preference to enable human cadence typing, which simulates more natural typing by introducing random delays between keystrokes.

--- a/extensions/clipboard-type/package.json
+++ b/extensions/clipboard-type/package.json
@@ -35,6 +35,14 @@
       "default": true
     },
     {
+      "name": "softNewlines",
+      "type": "checkbox",
+      "label": "Soft Newlines (Shift+Enter)",
+      "required": false,
+      "description": "Use Shift+Enter for newlines instead of Enter. Useful for apps and websites that treat Enter as submit.",
+      "default": false
+    },
+    {
       "name": "humanCadenceSpeed",
       "type": "dropdown",
       "title": "Human Cadence Speed",

--- a/extensions/clipboard-type/src/type-clipboard.ts
+++ b/extensions/clipboard-type/src/type-clipboard.ts
@@ -10,7 +10,7 @@ export default async function Command() {
     return;
   }
   await closeMainWindow();
-  const { humanCadence, humanCadenceSpeed } = getPreferenceValues<Preferences>();
+  const { humanCadence, humanCadenceSpeed, softNewlines } = getPreferenceValues<Preferences>();
 
   const humanCadenceSpeeds = {
     "very-slow": { min: 0.1, max: 0.3 },
@@ -32,7 +32,7 @@ tell application "System Events"
   repeat with ch in characters of theText
     set c to contents of ch
     if c is return or c is linefeed then
-      key code 36
+      key code 36${softNewlines ? " using shift down" : ""}
     else if c is tab then
       key code 48
     else


### PR DESCRIPTION
## Summary

- Adds a new **Soft Newlines** preference (checkbox, disabled by default) to the Clipboard Type extension
- When enabled, newlines are typed as **Shift+Enter** instead of Enter
- Existing behavior is completely unchanged unless the user opts in

## Why?

Many websites and apps (Slack, Discord, ChatGPT, etc.) treat Enter as "submit/send" rather than "insert a newline". When pasting multiline clipboard content via keystroke simulation, each newline triggers a form submission, splitting your text into multiple messages.

With this option enabled, newlines are sent as Shift+Enter, which inserts an actual line break in most apps without submitting.

## Changes

- `package.json`: Added `softNewlines` checkbox preference (default: `false`)
- `src/type-clipboard.ts`: When enabled, uses `key code 36 using shift down` (Shift+Enter) instead of `key code 36` (Enter) for newline characters
