### PR TITLE
Update fathom extension

### DIFF
--- a/extensions/fathom/CHANGELOG.md
+++ b/extensions/fathom/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fathom for Raycast Changelog
 
-## [Instant Display, Stop Fetching & Cache Performance] - {PR_MERGE_DATE}
+## [Instant Display, Stop Fetching & Cache Performance] - 2026-02-25
 
 ### Added
 

--- a/extensions/fathom/CHANGELOG.md
+++ b/extensions/fathom/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Fathom for Raycast Changelog
 
+## [Instant Display, Stop Fetching & Cache Performance] - {PR_MERGE_DATE}
+
+### Added
+
+- **Instant meeting display**: First page of meetings appears immediately on launch; remaining pages load in the background without blocking the UI
+- **Stop Fetching**: Background fetch toasts now include a "Stop Fetching Meetings" button to abort mid-pagination
+- **HUD on copy**: Copying a meeting's share link now shows a native HUD notification confirming the copy
+
+### Changed
+
+- **Batch cache writes**: Meetings are now written to LocalStorage in parallel instead of sequentially, significantly reducing cache write time
+- **Bulk cache reads**: `getAllCachedMeetings` now uses `LocalStorage.allItems()` for a single bulk read on launch instead of N individual reads
+- **Separate abort tokens**: `fetchRemainingPages` and `loadMoreMeetings` each have their own abort token, preventing them from accidentally cancelling each other
+- **Cleaner error display**: Refactored `search-meetings` error view into `getErrorDisplay()` helper and `ErrorEmptyView` component
+
+### Fixed
+
+- **Spurious "Stopped" toast**: Fixed a token collision where triggering "Load More" would falsely abort the initial background fetch and show a green "Stopped" toast
+
 ## [Lazy Pagination & Smart Cache] - 2026-02-19
 
 ### Added

--- a/extensions/fathom/package-lock.json
+++ b/extensions/fathom/package-lock.json
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -588,9 +588,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1521,9 +1521,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1979,9 +1979,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2123,9 +2123,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
+      "integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -2455,18 +2455,39 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/ms": {

--- a/extensions/fathom/src/actions/RefreshCacheAction.tsx
+++ b/extensions/fathom/src/actions/RefreshCacheAction.tsx
@@ -2,9 +2,22 @@ import { Action, Icon, Keyboard } from "@raycast/api";
 
 interface RefreshCacheActionProps {
   onRefresh: () => Promise<void>;
+  onStop?: () => void;
+  isFetchingBackground?: boolean;
 }
 
-export function RefreshCacheAction({ onRefresh }: RefreshCacheActionProps) {
+export function RefreshCacheAction({ onRefresh, onStop, isFetchingBackground }: RefreshCacheActionProps) {
+  if (isFetchingBackground && onStop) {
+    return (
+      <Action
+        title="Stop Fetching"
+        icon={Icon.XMarkCircle}
+        onAction={onStop}
+        shortcut={Keyboard.Shortcut.Common.Refresh}
+      />
+    );
+  }
+
   return (
     <Action
       title="Refresh Cache"

--- a/extensions/fathom/src/search-meetings.tsx
+++ b/extensions/fathom/src/search-meetings.tsx
@@ -57,9 +57,7 @@ function ErrorEmptyView(props: { error: Error; onRefresh: () => Promise<void> })
       description={description}
       actions={
         <ActionPanel>
-          {isAuth && (
-            <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={openExtensionPreferences} />
-          )}
+          {isAuth && <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={openExtensionPreferences} />}
           <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={props.onRefresh} />
         </ActionPanel>
       }

--- a/extensions/fathom/src/search-meetings.tsx
+++ b/extensions/fathom/src/search-meetings.tsx
@@ -12,6 +12,61 @@ import { MeetingListItem } from "./components/MeetingListItem";
 import { RefreshCacheAction } from "./actions/RefreshCacheAction";
 import { getDateRanges } from "./utils/dates";
 
+function getErrorDisplay(error: Error): { icon: Icon; title: string; description: string; isAuth: boolean } {
+  const errorType = classifyError(error);
+
+  switch (errorType) {
+    case ErrorType.API_KEY_MISSING:
+      return {
+        icon: Icon.Key,
+        title: "API Key Required",
+        description: "Please check your Fathom API Key in Extension Preferences.",
+        isAuth: true,
+      };
+    case ErrorType.API_KEY_INVALID:
+      return {
+        icon: Icon.Key,
+        title: "Invalid API Key",
+        description: "Please check your Fathom API Key in Extension Preferences.",
+        isAuth: true,
+      };
+    case ErrorType.RATE_LIMIT:
+      return {
+        icon: Icon.ExclamationMark,
+        title: "Rate Limit Exceeded",
+        description: "You've made too many requests. Please wait a moment and try again.",
+        isAuth: false,
+      };
+    default:
+      return {
+        icon: Icon.ExclamationMark,
+        title: "Failed to Load Meetings",
+        description: getUserFriendlyError(error).message,
+        isAuth: false,
+      };
+  }
+}
+
+function ErrorEmptyView(props: { error: Error; onRefresh: () => Promise<void> }) {
+  const { icon, title, description, isAuth } = getErrorDisplay(props.error);
+
+  return (
+    <List.EmptyView
+      icon={icon}
+      title={title}
+      description={description}
+      actions={
+        <ActionPanel>
+          {isAuth && (
+            <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={openExtensionPreferences} />
+          )}
+          <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={props.onRefresh} />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
 function Command() {
   const [filterType, setFilterType] = useState<string>("all");
   const [searchText, setSearchText] = useState<string>("");
@@ -53,9 +108,11 @@ function Command() {
   const {
     meetings: cachedMeetings,
     isLoading,
+    isFetchingBackground,
     error: meetingsError,
     searchMeetings,
     refreshCache,
+    stopFetch,
     loadMore,
     hasMore,
   } = useCachedMeetings({
@@ -167,7 +224,7 @@ function Command() {
       navigationTitle={filterDisplayName ? `Meetings: ${filterDisplayName}` : "Search Meetings"}
       actions={
         <ActionPanel>
-          <RefreshCacheAction onRefresh={refreshCache} />
+          <RefreshCacheAction onRefresh={refreshCache} onStop={stopFetch} isFetchingBackground={isFetchingBackground} />
         </ActionPanel>
       }
       pagination={apiKeyPresent && !error ? { pageSize: 20, hasMore, onLoadMore: loadMoreMeetings } : undefined}
@@ -190,41 +247,7 @@ function Command() {
       }
     >
       {error ? (
-        (() => {
-          const errorType = classifyError(error);
-          const isAuthError = errorType === ErrorType.API_KEY_MISSING || errorType === ErrorType.API_KEY_INVALID;
-          const isRateLimitError = errorType === ErrorType.RATE_LIMIT;
-
-          return (
-            <List.EmptyView
-              icon={isAuthError ? Icon.Key : Icon.ExclamationMark}
-              title={
-                errorType === ErrorType.API_KEY_MISSING
-                  ? "API Key Required"
-                  : errorType === ErrorType.API_KEY_INVALID
-                    ? "Invalid API Key"
-                    : isRateLimitError
-                      ? "Rate Limit Exceeded"
-                      : "Failed to Load Meetings"
-              }
-              description={
-                isAuthError
-                  ? "Please check your Fathom API Key in Extension Preferences."
-                  : isRateLimitError
-                    ? "You've made too many requests. Please wait a moment and try again."
-                    : getUserFriendlyError(error).message
-              }
-              actions={
-                <ActionPanel>
-                  {isAuthError && (
-                    <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={openExtensionPreferences} />
-                  )}
-                  <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={refreshCache} />
-                </ActionPanel>
-              }
-            />
-          );
-        })()
+        <ErrorEmptyView error={error} onRefresh={refreshCache} />
       ) : totalMeetings === 0 ? (
         <List.EmptyView
           icon={Icon.Calendar}
@@ -304,7 +327,7 @@ export function MeetingSummaryDetail({ meeting, recordingId }: { meeting: Meetin
       showToast({
         style: Toast.Style.Failure,
         title: "Failed to Load Summary",
-        message: message,
+        message,
       });
     },
   });
@@ -372,7 +395,7 @@ export function MeetingTranscriptDetail({ meeting, recordingId }: { meeting: Mee
       showToast({
         style: Toast.Style.Failure,
         title: "Failed to Load Transcript",
-        message: message,
+        message,
       });
     },
   });

--- a/extensions/fathom/src/utils/cache.ts
+++ b/extensions/fathom/src/utils/cache.ts
@@ -185,7 +185,6 @@ export async function getAllCachedMeetings(): Promise<CachedMeetingData[]> {
   try {
     const all = await LocalStorage.allItems();
     const prefix = CACHE_CONFIG.MEETINGS.KEY_PREFIX;
-    const now = Date.now();
     const ttl = CACHE_CONFIG.MEETINGS.TTL;
     const actionItemsTtl = CACHE_CONFIG.ACTION_ITEMS.TTL;
 
@@ -357,7 +356,12 @@ export function searchCachedMeetings(cachedMeetings: CachedMeetingData[], query:
 
   const results = cachedMeetings.filter((cached) => {
     const meeting = cached.meeting as { title?: string; meetingTitle?: string };
-    const searchableText = [meeting.title || "", meeting.meetingTitle || "", cached.summary || "", cached.transcript || ""]
+    const searchableText = [
+      meeting.title || "",
+      meeting.meetingTitle || "",
+      cached.summary || "",
+      cached.transcript || "",
+    ]
       .join(" ")
       .toLowerCase();
 

--- a/extensions/fathom/src/utils/cache.ts
+++ b/extensions/fathom/src/utils/cache.ts
@@ -59,6 +59,42 @@ function isCacheValid(cachedAt: number, ttl: number): boolean {
 }
 
 /**
+ * Store a batch of meetings in the cache in one pass.
+ * Writes all meeting items in parallel, then updates the index once.
+ */
+export async function cacheMeetingsBatch(
+  meetings: Array<{
+    meetingId: string;
+    meeting: unknown;
+    summary?: string;
+    transcript?: string;
+    actionItems?: unknown[];
+  }>,
+): Promise<void> {
+  const now = Date.now();
+
+  // Write all meeting entries in parallel
+  await Promise.all(
+    meetings.map(({ meetingId, meeting, summary, transcript, actionItems }) => {
+      const cacheKey = `${CACHE_CONFIG.MEETINGS.KEY_PREFIX}${meetingId}`;
+      const cached: CachedMeetingData = {
+        meeting,
+        summary,
+        transcript,
+        actionItems,
+        cachedAt: now,
+        hash: generateHash(meetingId),
+      };
+      return LocalStorage.setItem(cacheKey, JSON.stringify(cached));
+    }),
+  );
+
+  // Update index once for the whole batch
+  const meetingIds = meetings.map((m) => m.meetingId);
+  await updateMeetingIndexBatch(meetingIds);
+}
+
+/**
  * Store a meeting with its summary and transcript in the cache
  */
 export async function cacheMeeting(
@@ -68,22 +104,7 @@ export async function cacheMeeting(
   transcript?: string,
   actionItems?: unknown[],
 ): Promise<void> {
-  const hash = generateHash(meetingId);
-  const cacheKey = `${CACHE_CONFIG.MEETINGS.KEY_PREFIX}${meetingId}`;
-
-  const cached: CachedMeetingData = {
-    meeting,
-    summary,
-    transcript,
-    actionItems,
-    cachedAt: Date.now(),
-    hash,
-  };
-
-  await LocalStorage.setItem(cacheKey, JSON.stringify(cached));
-
-  // Update index
-  await updateMeetingIndex(meetingId);
+  await cacheMeetingsBatch([{ meetingId, meeting, summary, transcript, actionItems }]);
 }
 
 /**
@@ -117,15 +138,22 @@ export async function getCachedMeeting(meetingId: string): Promise<CachedMeeting
 }
 
 /**
- * Update the index of cached meeting IDs
+ * Update the index for a batch of meeting IDs (single read + single write)
  */
-async function updateMeetingIndex(meetingId: string): Promise<void> {
+async function updateMeetingIndexBatch(meetingIds: string[]): Promise<void> {
   try {
     const indexData = await LocalStorage.getItem<string>(CACHE_CONFIG.MEETINGS.INDEX_KEY);
     const index: CachedMeetingIndex = indexData ? JSON.parse(indexData) : { meetingIds: [], lastUpdated: Date.now() };
 
-    if (!index.meetingIds.includes(meetingId)) {
-      index.meetingIds.push(meetingId);
+    let changed = false;
+    for (const meetingId of meetingIds) {
+      if (!index.meetingIds.includes(meetingId)) {
+        index.meetingIds.push(meetingId);
+        changed = true;
+      }
+    }
+
+    if (changed) {
       index.lastUpdated = Date.now();
       await LocalStorage.setItem(CACHE_CONFIG.MEETINGS.INDEX_KEY, JSON.stringify(index));
     }
@@ -151,20 +179,70 @@ export async function getCachedMeetingIds(): Promise<string[]> {
 }
 
 /**
- * Get all cached meetings
+ * Get all cached meetings — uses allItems() for a single bulk read instead of N individual reads.
  */
 export async function getAllCachedMeetings(): Promise<CachedMeetingData[]> {
-  const meetingIds = await getCachedMeetingIds();
-  const meetings: CachedMeetingData[] = [];
+  try {
+    const all = await LocalStorage.allItems();
+    const prefix = CACHE_CONFIG.MEETINGS.KEY_PREFIX;
+    const now = Date.now();
+    const ttl = CACHE_CONFIG.MEETINGS.TTL;
+    const actionItemsTtl = CACHE_CONFIG.ACTION_ITEMS.TTL;
 
-  for (const id of meetingIds) {
-    const cached = await getCachedMeeting(id);
-    if (cached) {
-      meetings.push(cached);
+    const meetings: CachedMeetingData[] = [];
+    const expiredIds: string[] = [];
+
+    for (const [key, value] of Object.entries(all)) {
+      if (!key.startsWith(prefix)) continue;
+      // Skip the index key itself
+      if (key === CACHE_CONFIG.MEETINGS.INDEX_KEY) continue;
+
+      try {
+        const data = JSON.parse(value as string) as CachedMeetingData;
+
+        if (!isCacheValid(data.cachedAt, ttl)) {
+          expiredIds.push(key.slice(prefix.length));
+          continue;
+        }
+
+        if (data.actionItems && !isCacheValid(data.cachedAt, actionItemsTtl)) {
+          data.actionItems = undefined;
+        }
+
+        meetings.push(data);
+      } catch {
+        // Skip malformed entries
+      }
     }
-  }
 
-  return meetings;
+    // Prune expired entries from the index asynchronously (don't block return)
+    if (expiredIds.length > 0) {
+      pruneExpiredFromIndex(expiredIds).catch(() => {});
+    }
+
+    return meetings;
+  } catch (error) {
+    logger.error("Error reading all cached meetings:", error);
+    return [];
+  }
+}
+
+/**
+ * Remove expired IDs from the index (background cleanup)
+ */
+async function pruneExpiredFromIndex(expiredIds: string[]): Promise<void> {
+  try {
+    const indexData = await LocalStorage.getItem<string>(CACHE_CONFIG.MEETINGS.INDEX_KEY);
+    if (!indexData) return;
+    const index: CachedMeetingIndex = JSON.parse(indexData);
+    const expiredSet = new Set(expiredIds);
+    index.meetingIds = index.meetingIds.filter((id) => !expiredSet.has(id));
+    index.lastUpdated = Date.now();
+    await LocalStorage.setItem(CACHE_CONFIG.MEETINGS.INDEX_KEY, JSON.stringify(index));
+    await Promise.all(expiredIds.map((id) => LocalStorage.removeItem(`${CACHE_CONFIG.MEETINGS.KEY_PREFIX}${id}`)));
+  } catch (error) {
+    logger.error("Error pruning expired meetings from index:", error);
+  }
 }
 
 /**
@@ -173,36 +251,29 @@ export async function getAllCachedMeetings(): Promise<CachedMeetingData[]> {
  */
 export async function pruneCache(keepCount: number = 50): Promise<void> {
   try {
-    const indexData = await LocalStorage.getItem<string>(CACHE_CONFIG.MEETINGS.INDEX_KEY);
-    if (!indexData) return;
+    const meetings = await getAllCachedMeetings();
+    if (meetings.length <= keepCount) return;
 
-    const index: CachedMeetingIndex = JSON.parse(indexData);
+    // Sort by cachedAt descending, keep newest N
+    meetings.sort((a, b) => b.cachedAt - a.cachedAt);
+    const toRemove = meetings.slice(keepCount);
+    const toKeep = meetings.slice(0, keepCount);
 
-    if (index.meetingIds.length <= keepCount) return;
+    const getMeetingId = (m: CachedMeetingData): string => {
+      const meeting = m.meeting as { recordingId?: string; id?: string };
+      return meeting.recordingId || meeting.id || "";
+    };
 
-    // Get all cached meetings with their dates
-    const meetingsWithDates: Array<{ id: string; cachedAt: number }> = [];
+    await Promise.all(
+      toRemove.map((m) => {
+        const id = getMeetingId(m);
+        return id ? LocalStorage.removeItem(`${CACHE_CONFIG.MEETINGS.KEY_PREFIX}${id}`) : Promise.resolve();
+      }),
+    );
 
-    for (const id of index.meetingIds) {
-      const cached = await getCachedMeeting(id);
-      if (cached) {
-        meetingsWithDates.push({ id, cachedAt: cached.cachedAt });
-      }
-    }
-
-    // Sort by cachedAt (newest first) and keep only top N
-    meetingsWithDates.sort((a, b) => b.cachedAt - a.cachedAt);
-    const toKeep = meetingsWithDates.slice(0, keepCount).map((m) => m.id);
-    const toRemove = index.meetingIds.filter((id) => !toKeep.includes(id));
-
-    // Remove old entries
-    for (const id of toRemove) {
-      await LocalStorage.removeItem(`${CACHE_CONFIG.MEETINGS.KEY_PREFIX}${id}`);
-    }
-
-    // Update index
-    index.meetingIds = toKeep;
-    index.lastUpdated = Date.now();
+    // Rewrite index with only kept IDs
+    const keptIds = toKeep.map(getMeetingId).filter(Boolean);
+    const index: CachedMeetingIndex = { meetingIds: keptIds, lastUpdated: Date.now() };
     await LocalStorage.setItem(CACHE_CONFIG.MEETINGS.INDEX_KEY, JSON.stringify(index));
   } catch (error) {
     logger.error("Error pruning cache:", error);
@@ -210,12 +281,10 @@ export async function pruneCache(keepCount: number = 50): Promise<void> {
 }
 
 /**
- * Update cache metadata
+ * Update cache metadata from in-memory meetings (avoids re-reading from storage)
  */
-export async function updateCacheMetadata(): Promise<void> {
+export async function updateCacheMetadataFromMeetings(meetings: CachedMeetingData[]): Promise<void> {
   try {
-    const meetings = await getAllCachedMeetings();
-
     if (meetings.length === 0) {
       await LocalStorage.removeItem(CACHE_CONFIG.METADATA.KEY);
       return;
@@ -233,6 +302,14 @@ export async function updateCacheMetadata(): Promise<void> {
   } catch (error) {
     logger.error("Error updating cache metadata:", error);
   }
+}
+
+/**
+ * Update cache metadata
+ */
+export async function updateCacheMetadata(): Promise<void> {
+  const meetings = await getAllCachedMeetings();
+  await updateCacheMetadataFromMeetings(meetings);
 }
 
 /**
@@ -271,43 +348,22 @@ export async function clearAllCache(): Promise<void> {
  * Searches titles, summaries, and transcripts
  */
 export function searchCachedMeetings(cachedMeetings: CachedMeetingData[], query: string): CachedMeetingData[] {
-  if (!query || query.trim() === "") {
-    logger.log("[searchCachedMeetings] Empty query, returning all meetings");
+  if (!query.trim()) {
     return cachedMeetings;
   }
 
   const searchTerms = query.toLowerCase().split(/\s+/);
-  logger.log(`[searchCachedMeetings] Searching for: "${query}" (terms: ${searchTerms.join(", ")})`);
-  logger.log(`[searchCachedMeetings] Total meetings to search: ${cachedMeetings.length}`);
-
-  // Log cache content stats
-  const withSummary = cachedMeetings.filter((c) => c.summary && c.summary.length > 0).length;
-  const withTranscript = cachedMeetings.filter((c) => c.transcript && c.transcript.length > 0).length;
-  logger.log(`[searchCachedMeetings] Cache stats: ${withSummary} with summaries, ${withTranscript} with transcripts`);
+  logger.log(`[searchCachedMeetings] Searching ${cachedMeetings.length} meetings for: "${query}"`);
 
   const results = cachedMeetings.filter((cached) => {
-    const meeting = cached.meeting as { title?: string; meetingTitle?: string; recordingId?: string };
-    const title = meeting.title || "";
-    const meetingTitle = meeting.meetingTitle || "";
-    const summary = cached.summary || "";
-    const transcript = cached.transcript || "";
+    const meeting = cached.meeting as { title?: string; meetingTitle?: string };
+    const searchableText = [meeting.title || "", meeting.meetingTitle || "", cached.summary || "", cached.transcript || ""]
+      .join(" ")
+      .toLowerCase();
 
-    const searchableText = [title, meetingTitle, summary, transcript].join(" ").toLowerCase();
-
-    const matches = searchTerms.every((term) => searchableText.includes(term));
-
-    // Log detailed match info for first few meetings
-    if (cachedMeetings.indexOf(cached) < 3) {
-      logger.log(
-        `[searchCachedMeetings] Meeting "${title}" (${meeting.recordingId}): ` +
-          `title=${title.length}ch, summary=${summary.length}ch, transcript=${transcript.length}ch, matches=${matches}`,
-      );
-    }
-
-    return matches;
+    return searchTerms.every((term) => searchableText.includes(term));
   });
 
-  logger.log(`[searchCachedMeetings] Found ${results.length} matching meetings`);
-
+  logger.log(`[searchCachedMeetings] Found ${results.length} matches`);
   return results;
 }

--- a/extensions/fathom/src/utils/cacheManager.ts
+++ b/extensions/fathom/src/utils/cacheManager.ts
@@ -6,16 +6,17 @@
  * - Shares cached data across all components
  * - Provides event-based updates when cache changes
  * - Handles cache invalidation and refresh
+ * - Supports aborting background fetches
  */
 
 import { showToast, Toast } from "@raycast/api";
-import { listAllMeetings } from "../fathom/api";
+import { listMeetings } from "../fathom/api";
 import type { MeetingFilter, Meeting } from "../types/Types";
 import {
-  cacheMeeting,
+  cacheMeetingsBatch,
   getAllCachedMeetings,
   pruneCache,
-  updateCacheMetadata,
+  updateCacheMetadataFromMeetings,
   getCacheMetadata,
   type CachedMeetingData,
 } from "./cache";
@@ -26,6 +27,7 @@ import { logger } from "@chrismessina/raycast-logger";
 const CACHE_SIZE = 500; // Keep all meetings (auto-paginated from API)
 
 type CacheListener = (meetings: CachedMeetingData[]) => void;
+type FetchingListener = (isFetching: boolean) => void;
 
 class CacheManager {
   private cachedMeetings: CachedMeetingData[] = [];
@@ -33,28 +35,29 @@ class CacheManager {
   private isLoading = false;
   private isCaching = false;
   private listeners = new Set<CacheListener>();
+  private fetchingListeners = new Set<FetchingListener>();
   private lastApiDataHash: string | null = null;
   private lastFetchTime = 0;
   private lastCacheUpdateTime = 0;
-  private CACHE_STALE_THRESHOLD = 5 * 60 * 1000; // 5 minutes - fetch fresh data if cache is older
+  private CACHE_STALE_THRESHOLD = 5 * 60 * 1000; // 5 minutes
   private FETCH_COOLDOWN = 5000; // 5 seconds minimum between fetches
-  private nextCursor: string | undefined = undefined; // Pagination cursor for loading more
-  private hasMoreMeetings = true; // Whether more meetings are available
+  private nextCursor: string | undefined = undefined;
+  private hasMoreMeetings = true;
   private isLoadingMore = false;
 
-  /**
-   * Subscribe to cache updates
-   */
+  // Separate abort tokens for each fetch path so they don't cancel each other
+  private remainingPagesToken = 0;
+  private loadMoreToken = 0;
+  private _isFetchingBackground = false;
+
+  // ─── Subscriptions ────────────────────────────────────────────────────────
+
   subscribe(listener: CacheListener): () => void {
     this.listeners.add(listener);
     logger.log(`[CacheManager] Subscriber added (total: ${this.listeners.size})`);
-
-    // Immediately notify with current data if loaded
     if (this.isLoaded) {
       listener(this.cachedMeetings);
     }
-
-    // Return unsubscribe function
     return () => {
       this.listeners.delete(listener);
       logger.log(`[CacheManager] Subscriber removed (total: ${this.listeners.size})`);
@@ -62,40 +65,69 @@ class CacheManager {
   }
 
   /**
-   * Notify all listeners of cache updates
+   * Subscribe to background-fetch state changes (true = fetching, false = idle).
+   * Lets the UI show/hide a Stop action.
    */
+  subscribeFetching(listener: FetchingListener): () => void {
+    this.fetchingListeners.add(listener);
+    // Immediately notify with current state
+    listener(this._isFetchingBackground);
+    return () => {
+      this.fetchingListeners.delete(listener);
+    };
+  }
+
   private notifyListeners(): void {
     logger.log(`[CacheManager] Notifying ${this.listeners.size} listeners`);
     this.listeners.forEach((listener) => listener(this.cachedMeetings));
   }
 
-  /**
-   * Check if the cache is stale (needs fresh data from API)
-   */
-  isCacheStale(): boolean {
-    if (!this.lastCacheUpdateTime) return true;
-    const age = Date.now() - this.lastCacheUpdateTime;
-    return age > this.CACHE_STALE_THRESHOLD;
+  private setFetchingBackground(value: boolean): void {
+    if (this._isFetchingBackground === value) return;
+    this._isFetchingBackground = value;
+    this.fetchingListeners.forEach((l) => l(value));
+  }
+
+  isFetchingBackground(): boolean {
+    return this._isFetchingBackground;
   }
 
   /**
-   * Get cache age in minutes for display
+   * Abort any in-progress background fetch.
+   * The current page request will finish (HTTP can't be cancelled),
+   * but no further pages will be fetched and the cache won't be updated.
    */
+  stopBackgroundFetch(): void {
+    if (!this._isFetchingBackground) return;
+    this.remainingPagesToken++;
+    this.loadMoreToken++;
+    logger.log(`[CacheManager] Background fetch aborted (remainingPages token: ${this.remainingPagesToken}, loadMore token: ${this.loadMoreToken})`);
+    this.setFetchingBackground(false);
+  }
+
+  // ─── Staleness ────────────────────────────────────────────────────────────
+
+  isCacheStale(): boolean {
+    if (!this.lastCacheUpdateTime) return true;
+    return Date.now() - this.lastCacheUpdateTime > this.CACHE_STALE_THRESHOLD;
+  }
+
   getCacheAgeMinutes(): number {
     if (!this.lastCacheUpdateTime) return 0;
     return Math.round((Date.now() - this.lastCacheUpdateTime) / 60000);
   }
+
+  // ─── Load from storage ────────────────────────────────────────────────────
+
   async loadCache(): Promise<CachedMeetingData[]> {
     if (this.isLoaded) {
       logger.log(`[CacheManager] Cache already loaded (${this.cachedMeetings.length} meetings)`);
       return this.cachedMeetings;
     }
 
-    // Prevent concurrent loads
     if (this.isLoading) {
       logger.log("[CacheManager] Cache load already in progress, waiting...");
-      // Wait for the current load to complete with timeout
-      const maxWaitTime = 30000; // 30 seconds max wait
+      const maxWaitTime = 30000;
       const startTime = Date.now();
       while (this.isLoading) {
         if (Date.now() - startTime > maxWaitTime) {
@@ -117,7 +149,6 @@ class CacheManager {
       this.isLoaded = true;
       logger.log(`[CacheManager] Loaded ${cached.length} cached meetings`);
 
-      // Restore last cache update time from metadata (persists across process restarts)
       const metadata = await getCacheMetadata();
       if (metadata) {
         this.lastCacheUpdateTime = metadata.lastUpdated;
@@ -135,16 +166,11 @@ class CacheManager {
     }
   }
 
-  /**
-   * Fetch meetings from API and cache them (deduplicated)
-   * @param filter - Meeting filter options
-   * @param options - Additional options
-   * @param options.force - If true, bypasses cooldown and data hash checks to ensure fresh data
-   */
+  // ─── Fetch & Cache ────────────────────────────────────────────────────────
+
   async fetchAndCache(filter: MeetingFilter = {}, options: { force?: boolean } = {}): Promise<Meeting[]> {
     const { force = false } = options;
 
-    // Check cooldown to prevent rapid re-fetches (unless forced)
     const now = Date.now();
     const timeSinceLastFetch = now - this.lastFetchTime;
 
@@ -155,90 +181,133 @@ class CacheManager {
       return this.cachedMeetings.map((cached) => cached.meeting as Meeting);
     }
 
-    // When forced, clear the data hash so new results always get cached
     if (force) {
       logger.log("[CacheManager] Forced fetch - clearing data hash for fresh results");
       this.lastApiDataHash = null;
     }
 
-    // Create a unique key for this filter
     const filterKey = JSON.stringify(filter);
     const requestKey = `fetch-meetings:${filterKey}`;
 
     logger.log(`[CacheManager] Fetch request for filter: ${filterKey}`);
-
-    // Update last fetch time
     this.lastFetchTime = now;
 
-    // Use the global queue to deduplicate requests
     const result = await globalQueue.enqueue(
       requestKey,
       async () => {
-        let progressToast: Toast | undefined;
+        logger.log(`[CacheManager] Fetching first page for: ${filterKey}`);
 
-        try {
-          logger.log(`[CacheManager] Fetching all meetings for: ${filterKey}`);
+        const firstPage = await listMeetings(filter);
+        const firstPageMeetings = firstPage.items;
+        const firstPageCursor = firstPage.nextCursor;
 
-          // Show progress toast during pagination
-          progressToast = await showToast({
-            style: Toast.Style.Animated,
-            title: "Fetching meetings from Fathom API...",
+        logger.log(`[CacheManager] First page: ${firstPageMeetings.length} meetings`);
+
+        // Cache and display first page immediately
+        await this.cacheApiResults(firstPageMeetings);
+
+        // Background-fetch remaining pages without blocking the UI
+        if (firstPageCursor) {
+          this.nextCursor = firstPageCursor;
+          this.hasMoreMeetings = true;
+          this.fetchRemainingPages(filter, firstPageCursor, firstPageMeetings).catch((err) => {
+            logger.error("[CacheManager] Background fetch error:", err);
           });
-
-          const result = await listAllMeetings(
-            filter,
-            (fetched) => {
-              if (progressToast) {
-                progressToast.title = `Fetching from Fathom API... (${fetched} downloaded)`;
-              }
-            },
-            5, // Fetch first 5 pages (~50 meetings)
-          );
-
-          // Store cursor for incremental loading
-          this.nextCursor = result.nextCursor;
-          this.hasMoreMeetings = !!result.nextCursor;
-
-          if (progressToast) {
-            progressToast.title = `Saving ${result.meetings.length} meetings to local cache...`;
-          }
-
-          // Cache the results
-          await this.cacheApiResults(result.meetings);
+        } else {
+          this.nextCursor = undefined;
+          this.hasMoreMeetings = false;
           this.lastCacheUpdateTime = Date.now();
-
-          // Persist cache update time to survive process restarts
-          await updateCacheMetadata();
-
-          if (progressToast) {
-            progressToast.style = Toast.Style.Success;
-            progressToast.title = `${result.meetings.length} meetings ready — cached locally`;
-            if (this.hasMoreMeetings) {
-              progressToast.message = "Scroll to the bottom to load older meetings";
-            }
-          }
-
-          return result.meetings;
-        } catch (error) {
-          // Hide or update toast on error
-          if (progressToast) {
-            progressToast.hide();
-          }
-          throw error;
+          await updateCacheMetadataFromMeetings(this.cachedMeetings);
         }
+
+        return firstPageMeetings;
       },
-      1, // Priority: 1 (normal)
+      1,
     );
 
     return result;
   }
 
   /**
-   * Cache API results (deduplicated by data hash)
+   * Background-fetch pages 2–5 and merge them into the cache progressively.
+   * Respects abort tokens — stops immediately if stopBackgroundFetch() is called.
    */
+  private async fetchRemainingPages(
+    filter: MeetingFilter,
+    startCursor: string,
+    alreadyCached: Meeting[],
+  ): Promise<void> {
+    const token = this.remainingPagesToken;
+    this.setFetchingBackground(true);
+
+    const progressToast = await showToast({
+      style: Toast.Style.Animated,
+      title: `Fetching more meetings... (${alreadyCached.length} loaded)`,
+      primaryAction: {
+        title: "Stop Fetching Meetings",
+        onAction: () => this.stopBackgroundFetch(),
+      },
+    });
+
+    try {
+      // Page-by-page so we can check the abort token between pages
+      let cursor: string | undefined = startCursor;
+      const additionalMeetings: Meeting[] = [];
+      let pageNum = 0;
+      const MAX_BACKGROUND_PAGES = 4;
+
+      while (cursor && pageNum < MAX_BACKGROUND_PAGES) {
+        // Check abort token before each page request
+        if (this.remainingPagesToken !== token) {
+          logger.log("[CacheManager] Background fetch aborted — stopping");
+          progressToast.hide();
+          return;
+        }
+
+        pageNum++;
+        const page = await listMeetings({ ...filter, cursor });
+        additionalMeetings.push(...page.items);
+        cursor = page.nextCursor;
+
+        const totalSoFar = alreadyCached.length + additionalMeetings.length;
+        progressToast.title = `Fetching more meetings... (${totalSoFar} loaded)`;
+        logger.log(`[CacheManager] Background page ${pageNum}: ${page.items.length} meetings (total: ${totalSoFar})`);
+      }
+
+      // Final abort check before writing
+      if (this.remainingPagesToken !== token) {
+        logger.log("[CacheManager] Background fetch aborted before write — discarding results");
+        progressToast.hide();
+        return;
+      }
+
+      this.nextCursor = cursor;
+      this.hasMoreMeetings = !!cursor;
+
+      const allMeetings = [...alreadyCached, ...additionalMeetings];
+      await this.cacheApiResults(allMeetings);
+      this.lastCacheUpdateTime = Date.now();
+      await updateCacheMetadataFromMeetings(this.cachedMeetings);
+
+      progressToast.style = Toast.Style.Success;
+      progressToast.title = `${allMeetings.length} meetings ready`;
+      progressToast.primaryAction = undefined;
+      if (this.hasMoreMeetings) {
+        progressToast.message = "Scroll to the bottom to load older meetings";
+      }
+    } catch (error) {
+      progressToast.hide();
+      throw error;
+    } finally {
+      if (this.remainingPagesToken === token) {
+        this.setFetchingBackground(false);
+      }
+    }
+  }
+
+  // ─── Cache writes ─────────────────────────────────────────────────────────
+
   private async cacheApiResults(meetings: Meeting[]): Promise<void> {
-    // Create a hash of meeting IDs to detect if the set of meetings has changed
-    // Only use recordingId (immutable) to avoid invalidation from timestamp updates
     const dataHash = meetings
       .map((m) => m.recordingId)
       .sort()
@@ -258,29 +327,26 @@ class CacheManager {
     this.lastApiDataHash = dataHash;
 
     try {
-      const totalMeetings = meetings.length;
-      logger.log(`[CacheManager] Caching ${totalMeetings} meetings`);
+      logger.log(`[CacheManager] Caching ${meetings.length} meetings`);
 
-      // Cache each meeting sequentially
-      for (const meeting of meetings) {
-        await cacheMeeting(
-          meeting.recordingId,
-          meeting,
-          meeting.summaryText,
-          meeting.transcriptText,
-          meeting.actionItems,
-        );
-      }
+      // Batch write — all meetings in parallel, index updated once
+      await cacheMeetingsBatch(
+        meetings.map((m) => ({
+          meetingId: m.recordingId,
+          meeting: m,
+          summary: m.summaryText,
+          transcript: m.transcriptText,
+          actionItems: m.actionItems,
+        })),
+      );
 
-      // Prune old entries to maintain cache size
       await pruneCache(CACHE_SIZE);
 
-      // Reload cached meetings
+      // Reload from storage to get the authoritative merged set
       const cached = await getAllCachedMeetings();
       this.cachedMeetings = cached;
       logger.log(`[CacheManager] Cache updated, now have ${cached.length} meetings`);
 
-      // Notify all subscribers
       this.notifyListeners();
     } catch (error) {
       logger.error("[CacheManager] Error caching meetings:", error);
@@ -290,9 +356,8 @@ class CacheManager {
     }
   }
 
-  /**
-   * Load more meetings from the next page (incremental pagination)
-   */
+  // ─── Load More ────────────────────────────────────────────────────────────
+
   async loadMoreMeetings(filter: MeetingFilter = {}): Promise<void> {
     if (this.isLoadingMore) {
       logger.log("[CacheManager] loadMoreMeetings already in progress");
@@ -301,51 +366,68 @@ class CacheManager {
 
     if (!this.hasMoreMeetings || !this.nextCursor) {
       logger.log("[CacheManager] No more meetings to load");
-      await showToast({
-        style: Toast.Style.Success,
-        title: "All meetings loaded",
-      });
+      await showToast({ style: Toast.Style.Success, title: "All meetings loaded" });
       return;
     }
 
     const cursor = this.nextCursor;
+    const token = ++this.loadMoreToken;
     const requestKey = `load-more-meetings:${cursor}:${JSON.stringify(filter)}`;
 
     await globalQueue.enqueue(
       requestKey,
       async () => {
         this.isLoadingMore = true;
-        try {
-          const progressToast = await showToast({
-            style: Toast.Style.Animated,
-            title: "Fetching older meetings from Fathom...",
-          });
+        this.setFetchingBackground(true);
 
+        const progressToast = await showToast({
+          style: Toast.Style.Animated,
+          title: "Fetching older meetings...",
+          primaryAction: {
+            title: "Stop Fetching Meetings",
+            onAction: () => this.stopBackgroundFetch(),
+          },
+        });
+
+        try {
           logger.log(`[CacheManager] Loading more meetings from cursor: ${cursor}`);
 
-          const result = await listAllMeetings(
-            { ...filter, cursor },
-            (fetched) => {
-              progressToast.title = `Fetching older meetings from Fathom... (${fetched} downloaded)`;
-            },
-            5, // Fetch next 5 pages (~50 more meetings)
-          );
+          let pageCursor: string | undefined = cursor;
+          const fetched: Meeting[] = [];
+          let pageNum = 0;
+          const MAX_PAGES = 5;
 
-          // Update cursor for next load
-          this.nextCursor = result.nextCursor;
-          this.hasMoreMeetings = !!result.nextCursor;
+          while (pageCursor && pageNum < MAX_PAGES) {
+            if (this.loadMoreToken !== token) {
+              logger.log("[CacheManager] loadMore aborted — stopping");
+              progressToast.hide();
+              return;
+            }
 
-          progressToast.title = `Saving ${result.meetings.length} meetings to local cache...`;
+            pageNum++;
+            const page = await listMeetings({ ...filter, cursor: pageCursor });
+            fetched.push(...page.items);
+            pageCursor = page.nextCursor;
+            progressToast.title = `Fetching older meetings... (${fetched.length} downloaded)`;
+            logger.log(`[CacheManager] loadMore page ${pageNum}: ${page.items.length} meetings`);
+          }
 
-          // Cache the new results (will merge with existing)
-          await this.cacheApiResults(result.meetings);
+          if (this.loadMoreToken !== token) {
+            logger.log("[CacheManager] loadMore aborted before write — discarding");
+            progressToast.hide();
+            return;
+          }
+
+          this.nextCursor = pageCursor;
+          this.hasMoreMeetings = !!pageCursor;
+
+          await this.cacheApiResults(fetched);
           this.lastCacheUpdateTime = Date.now();
-
-          // Persist cache update time to survive process restarts
-          await updateCacheMetadata();
+          await updateCacheMetadataFromMeetings(this.cachedMeetings);
 
           progressToast.style = Toast.Style.Success;
-          progressToast.title = `${result.meetings.length} older meetings cached locally`;
+          progressToast.title = `${fetched.length} older meetings loaded`;
+          progressToast.primaryAction = undefined;
           progressToast.message = this.hasMoreMeetings ? "Scroll to the bottom to load more" : "All meetings loaded";
         } catch (error) {
           await showContextualError(error, {
@@ -355,47 +437,34 @@ class CacheManager {
           throw error;
         } finally {
           this.isLoadingMore = false;
+          if (this.loadMoreToken === token) {
+            this.setFetchingBackground(false);
+          }
         }
       },
       1,
     );
   }
 
-  /**
-   * Check if more meetings are available to load
-   */
-  hasMore(): boolean {
-    return this.hasMoreMeetings;
-  }
+  // ─── Refresh ──────────────────────────────────────────────────────────────
 
-  /**
-   * Refresh cache by fetching from API
-   */
   async refreshCache(filter: MeetingFilter = {}): Promise<void> {
-    let progressToast: Toast | undefined;
+    const progressToast = await showToast({
+      style: Toast.Style.Animated,
+      title: "Refreshing meetings...",
+    });
 
     try {
-      progressToast = await showToast({
-        style: Toast.Style.Animated,
-        title: "Refreshing meetings...",
-      });
-
-      // Clear the last data hash and cursor to force fresh fetch
       this.lastApiDataHash = null;
       this.nextCursor = undefined;
       this.hasMoreMeetings = true;
 
       await this.fetchAndCache(filter, { force: true });
 
-      if (progressToast) {
-        progressToast.style = Toast.Style.Success;
-        progressToast.title = "Meetings refreshed";
-      }
+      progressToast.style = Toast.Style.Success;
+      progressToast.title = "Meetings refreshed";
     } catch (error) {
-      // Hide the animated toast on error (error toast will be shown separately)
-      if (progressToast) {
-        progressToast.hide();
-      }
+      progressToast.hide();
       await showContextualError(error, {
         action: "refresh meetings",
         fallbackTitle: "Failed to Refresh Meetings",
@@ -404,29 +473,21 @@ class CacheManager {
     }
   }
 
-  /**
-   * Get current cached meetings
-   */
+  // ─── Accessors ────────────────────────────────────────────────────────────
+
+  hasMore(): boolean {
+    return this.hasMoreMeetings;
+  }
+
   getCachedMeetings(): CachedMeetingData[] {
     return this.cachedMeetings;
   }
 
-  /**
-   * Check if cache is loaded
-   */
   isCacheLoaded(): boolean {
     return this.isLoaded;
   }
 
-  /**
-   * Get cache stats for debugging
-   */
-  getStats(): {
-    loaded: boolean;
-    caching: boolean;
-    count: number;
-    listeners: number;
-  } {
+  getStats(): { loaded: boolean; caching: boolean; count: number; listeners: number } {
     return {
       loaded: this.isLoaded,
       caching: this.isCaching,
@@ -440,4 +501,4 @@ class CacheManager {
 const cacheManager = new CacheManager();
 
 export { cacheManager };
-export type { CacheListener };
+export type { CacheListener, FetchingListener };

--- a/extensions/fathom/src/utils/cacheManager.ts
+++ b/extensions/fathom/src/utils/cacheManager.ts
@@ -101,7 +101,9 @@ class CacheManager {
     if (!this._isFetchingBackground) return;
     this.remainingPagesToken++;
     this.loadMoreToken++;
-    logger.log(`[CacheManager] Background fetch aborted (remainingPages token: ${this.remainingPagesToken}, loadMore token: ${this.loadMoreToken})`);
+    logger.log(
+      `[CacheManager] Background fetch aborted (remainingPages token: ${this.remainingPagesToken}, loadMore token: ${this.loadMoreToken})`,
+    );
     this.setFetchingBackground(false);
   }
 


### PR DESCRIPTION
## Summary

- **Instant meeting display**: First page of meetings appears immediately on launch; remaining pages load in the background without blocking the UI
- **Stop Fetching**: Background fetch toasts now include a "Stop Fetching" button to abort mid-pagination
- **HUD on copy**: Copying a meeting's share link now shows a native HUD notification confirming the copy
- **Batch cache writes**: Meetings are now written to LocalStorage in parallel instead of sequentially, significantly reducing cache write time
- **Bulk cache reads**: `getAllCachedMeetings` now uses `LocalStorage.allItems()` for a single bulk read on launch instead of N individual reads
- **Separate abort tokens**: `fetchRemainingPages` and `loadMoreMeetings` each have their own abort token, preventing them from accidentally cancelling each other
- **Fix spurious "Stopped" toast**: Fixed a token collision where triggering "Load More" would falsely abort the initial background fetch
- **Cleaner error display**: Refactored `search-meetings` error view into `getErrorDisplay()` helper and `ErrorEmptyView` component

## Test plan

- [ ] Launch Search Meetings — first page of meetings should appear immediately without waiting for full pagination
- [ ] While meetings are loading in background, verify a "Stop Fetching" button appears in the toast
- [ ] Click Stop Fetching — background fetch should abort cleanly with no spurious toasts
- [ ] Copy a meeting's share link — verify HUD shows "Share Link Copied"
- [ ] Trigger Load More (scroll to bottom) — verify it does not cancel the background fetch or show a "Stopped" toast
- [ ] Verify cache loads instantly on subsequent launches (bulk read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)