### PR TITLE
improve(pr-bot): add alternative checkout commands for existing repo (not extension pr)

### DIFF
--- a/scripts/bots/pr-bot.ts
+++ b/scripts/bots/pr-bot.ts
@@ -533,6 +533,8 @@ function getCheckoutInstructions(
 <details>
 <summary>📋 Quick checkout commands</summary>
 
+**Don't have the repository yet?**
+
 \`\`\`bash
 BRANCH="${branch}"
 FORK_URL="${forkUrl}"
@@ -543,6 +545,22 @@ git clone -n --depth=1 --filter=tree:0 -b $BRANCH $FORK_URL
 cd $REPO_NAME
 git sparse-checkout set --no-cone "extensions/$EXTENSION_NAME"
 git checkout
+cd "extensions/$EXTENSION_NAME"
+npm install && npm run dev
+\`\`\`
+
+**Already have the repository cloned?**
+
+\`\`\`bash
+BRANCH="${branch}"
+FORK_URL="${forkUrl}"
+EXTENSION_NAME="${extensionFolder}"
+REPO_NAME="${repoName}"
+
+git remote add $REPO_NAME $FORK_URL 2>/dev/null || git remote set-url $REPO_NAME $FORK_URL
+git fetch --filter=tree:0 --no-tags $REPO_NAME $BRANCH
+git sparse-checkout add "extensions/$EXTENSION_NAME"
+git checkout $REPO_NAME/$BRANCH -- "extensions/$EXTENSION_NAME"
 cd "extensions/$EXTENSION_NAME"
 npm install && npm run dev
 \`\`\`

--- a/scripts/bots/pr-bot.ts
+++ b/scripts/bots/pr-bot.ts
@@ -559,7 +559,6 @@ REPO_NAME="${repoName}"
 
 git remote add $REPO_NAME $FORK_URL 2>/dev/null || git remote set-url $REPO_NAME $FORK_URL
 git fetch --filter=tree:0 --no-tags $REPO_NAME $BRANCH
-git sparse-checkout add "extensions/$EXTENSION_NAME"
 git checkout $REPO_NAME/$BRANCH -- "extensions/$EXTENSION_NAME"
 cd "extensions/$EXTENSION_NAME"
 npm install && npm run dev


### PR DESCRIPTION
## Description

> [!NOTE]
> This PR modifies a bot script (`scripts/bots/pr-bot.ts`), not an extension. 

This PR improves the checkout instructions posted by the PR bot to make it easier for reviewers who already have the `raycast-extensions` repository cloned locally.

Previously, the bot only provided a fresh clone command. For reviewers who maintain extensions and already have the repo, this required either cloning into a separate directory or manually adapting the commands. This change adds a second set of commands for the existing-repo case.

## Screencast

<table>
<tr>
 <td>

  ###  ASIS

 <td>

###  TOBE

<tr>
 <td>
<img width="792" height="531" alt="image" src="https://github.com/user-attachments/assets/544ca5de-9854-4be1-906c-ae5864f8cdbd" />

 <td>
<img width="792" height="803" alt="image" src="https://github.com/user-attachments/assets/e145480d-2796-4747-8df2-826e8de98380" />

<tr>
 <td>

 https://github.com/raycast/extensions/pull/25491#issuecomment-3906840612

 <td>
this is preview
</table>

## Demo Command

(in raycast-extension directory)

```sh
BRANCH="feat/ccusage-enhancements"
FORK_URL="https://github.com/SandeepBaskaran/raycast-extensions.git"
EXTENSION_NAME="ccusage"
REPO_NAME="raycast-extensions"

git remote add $REPO_NAME $FORK_URL 2>/dev/null || git remote set-url $REPO_NAME $FORK_URL
git fetch --filter=tree:0 --no-tags $REPO_NAME $BRANCH
git sparse-checkout add "extensions/$EXTENSION_NAME"
git checkout $REPO_NAME/$BRANCH -- "extensions/$EXTENSION_NAME"
cd "extensions/$EXTENSION_NAME"
npm install && npm run dev
```

## Checklist

> This PR modifies a bot script (`scripts/bots/pr-bot.ts`), not an extension. The following checklist items are not applicable.

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
