### PR TITLE
Add Telegram 2-step verification auth flow

### DIFF
--- a/extensions/telegram/CHANGELOG.md
+++ b/extensions/telegram/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Telegram Changelog
 
+## [Add 2-Step Verification Login Support] - {PR_MERGE_DATE}
+
+- Handle Telegram 2FA (`SESSION_PASSWORD_NEEDED`) with a password step
+- Add resend verification code action and inline hint on code entry screen
+- Improve auth error handling for invalid/expired codes, wrong password, and flood wait
+
 ## [Initial Version] - 2026-02-04

--- a/extensions/telegram/CHANGELOG.md
+++ b/extensions/telegram/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Telegram Changelog
 
-## [Add 2-Step Verification Login Support] - {PR_MERGE_DATE}
+## [Add 2-Step Verification Login Support] - 2026-03-26
 
 - Handle Telegram 2FA (`SESSION_PASSWORD_NEEDED`) with a password step
 - Add resend verification code action and inline hint on code entry screen

--- a/extensions/telegram/src/authenticate.tsx
+++ b/extensions/telegram/src/authenticate.tsx
@@ -3,7 +3,6 @@ import { Form, ActionPanel, Action, showToast, Toast, popToRoot, Icon } from "@r
 import { useForm, FormValidation } from "@raycast/utils";
 import dedent from "dedent";
 import { handleAuthFlow } from "./utils/auth";
-import { getTelegramErrorMessage } from "./utils/errors";
 
 interface AuthCodeFormValues {
   code: string;
@@ -11,6 +10,10 @@ interface AuthCodeFormValues {
 
 interface AuthPasswordFormValues {
   password: string;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown error occurred";
 }
 
 export default function Authenticate() {
@@ -38,7 +41,7 @@ export default function Authenticate() {
         await showToast({
           style: Toast.Style.Failure,
           title: "Authentication Failed",
-          message: getTelegramErrorMessage(error),
+          message: getErrorMessage(error),
         });
       } finally {
         setIsSubmitting(false);
@@ -65,7 +68,7 @@ export default function Authenticate() {
         await showToast({
           style: Toast.Style.Failure,
           title: "Authentication Failed",
-          message: getTelegramErrorMessage(error),
+          message: getErrorMessage(error),
         });
       } finally {
         setIsSubmitting(false);
@@ -94,7 +97,7 @@ export default function Authenticate() {
       await showToast({
         style: Toast.Style.Failure,
         title: "Authentication Failed",
-        message: getTelegramErrorMessage(error),
+        message: getErrorMessage(error),
       });
     }
   };
@@ -118,7 +121,7 @@ export default function Authenticate() {
       await showToast({
         style: Toast.Style.Failure,
         title: "Authentication Failed",
-        message: getTelegramErrorMessage(error),
+        message: getErrorMessage(error),
       });
     } finally {
       setIsSubmitting(false);

--- a/extensions/telegram/src/authenticate.tsx
+++ b/extensions/telegram/src/authenticate.tsx
@@ -3,20 +3,57 @@ import { Form, ActionPanel, Action, showToast, Toast, popToRoot, Icon } from "@r
 import { useForm, FormValidation } from "@raycast/utils";
 import dedent from "dedent";
 import { handleAuthFlow } from "./utils/auth";
+import { getTelegramErrorMessage } from "./utils/errors";
 
 interface AuthCodeFormValues {
   code: string;
 }
 
+interface AuthPasswordFormValues {
+  password: string;
+}
+
 export default function Authenticate() {
-  const [needsCode, setNeedsCode] = useState(false);
+  const [authStep, setAuthStep] = useState<"setup" | "code" | "password">("setup");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { handleSubmit, itemProps } = useForm<AuthCodeFormValues>({
+  const codeForm = useForm<AuthCodeFormValues>({
     onSubmit: async (values) => {
       setIsSubmitting(true);
       try {
-        const result = await handleAuthFlow(values.code);
+        const result = await handleAuthFlow({ code: values.code });
+        if (result.success) {
+          await showToast({
+            style: Toast.Style.Success,
+            title: "Successfully authenticated with Telegram",
+          });
+          await popToRoot();
+          return;
+        }
+
+        if (result.needsPassword) {
+          setAuthStep("password");
+        }
+      } catch (error) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Authentication Failed",
+          message: getTelegramErrorMessage(error),
+        });
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    validation: {
+      code: FormValidation.Required,
+    },
+  });
+
+  const passwordForm = useForm<AuthPasswordFormValues>({
+    onSubmit: async (values) => {
+      setIsSubmitting(true);
+      try {
+        const result = await handleAuthFlow({ password: values.password });
         if (result.success) {
           await showToast({
             style: Toast.Style.Success,
@@ -28,14 +65,14 @@ export default function Authenticate() {
         await showToast({
           style: Toast.Style.Failure,
           title: "Authentication Failed",
-          message: error instanceof Error ? error.message : "Unknown error occurred",
+          message: getTelegramErrorMessage(error),
         });
       } finally {
         setIsSubmitting(false);
       }
     },
     validation: {
-      code: FormValidation.Required,
+      password: FormValidation.Required,
     },
   });
 
@@ -43,7 +80,9 @@ export default function Authenticate() {
     try {
       const result = await handleAuthFlow();
       if (result.needsCode) {
-        setNeedsCode(true);
+        setAuthStep("code");
+      } else if (result.needsPassword) {
+        setAuthStep("password");
       } else if (result.success) {
         await showToast({
           style: Toast.Style.Success,
@@ -55,12 +94,38 @@ export default function Authenticate() {
       await showToast({
         style: Toast.Style.Failure,
         title: "Authentication Failed",
-        message: error instanceof Error ? error.message : "Unknown error occurred",
+        message: getTelegramErrorMessage(error),
       });
     }
   };
 
-  if (!needsCode) {
+  const handleResendCode = async () => {
+    setIsSubmitting(true);
+    try {
+      const result = await handleAuthFlow({ forceResendCode: true });
+      if (result.needsCode) {
+        setAuthStep("code");
+      } else if (result.needsPassword) {
+        setAuthStep("password");
+      } else if (result.success) {
+        await showToast({
+          style: Toast.Style.Success,
+          title: "Successfully authenticated with Telegram",
+        });
+        await popToRoot();
+      }
+    } catch (error) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Authentication Failed",
+        message: getTelegramErrorMessage(error),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (authStep === "setup") {
     return (
       <Form
         actions={
@@ -94,12 +159,38 @@ export default function Authenticate() {
     );
   }
 
+  if (authStep === "password") {
+    return (
+      <Form
+        isLoading={isSubmitting}
+        actions={
+          <ActionPanel>
+            <Action.SubmitForm icon={Icon.ArrowRight} title="Verify Password" onSubmit={passwordForm.handleSubmit} />
+          </ActionPanel>
+        }
+      >
+        <Form.PasswordField
+          title="2-Step Verification Password"
+          info="Enter your Telegram 2-Step Verification password"
+          placeholder="Password"
+          {...passwordForm.itemProps.password}
+        />
+      </Form>
+    );
+  }
+
   return (
     <Form
       isLoading={isSubmitting}
       actions={
         <ActionPanel>
-          <Action.SubmitForm icon={Icon.ArrowRight} title="Verify Code" onSubmit={handleSubmit} />
+          <Action.SubmitForm icon={Icon.ArrowRight} title="Verify Code" onSubmit={codeForm.handleSubmit} />
+          <Action
+            icon={Icon.Repeat}
+            title="Resend Verification Code"
+            onAction={handleResendCode}
+            shortcut={{ modifiers: ["cmd"], key: "r" }}
+          />
         </ActionPanel>
       }
     >
@@ -107,8 +198,9 @@ export default function Authenticate() {
         title="Verification Code"
         info="Enter the verification code sent to your Telegram app"
         placeholder="12345"
-        {...itemProps.code}
+        {...codeForm.itemProps.code}
       />
+      <Form.Description title="Need a New Code?" text="Didn't get a code? Press ⌘R to resend." />
     </Form>
   );
 }

--- a/extensions/telegram/src/services/telegram-client.ts
+++ b/extensions/telegram/src/services/telegram-client.ts
@@ -2,6 +2,7 @@ import { TelegramClient } from "telegram";
 import { StringSession } from "telegram/sessions";
 import { LocalStorage, environment } from "@raycast/api";
 import { Api } from "telegram/tl";
+import { computeCheck } from "telegram/Password";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -100,6 +101,11 @@ export interface SendMessageOptions {
   filePaths?: string | string[];
 }
 
+export interface AuthenticationResult {
+  needsCode: boolean;
+  needsPassword: boolean;
+}
+
 let clientInstance: TelegramClient | null = null;
 
 export async function getClient(config: TelegramConfig): Promise<TelegramClient> {
@@ -123,18 +129,40 @@ export async function isAuthenticated(): Promise<boolean> {
   return !!sessionString;
 }
 
-export async function authenticate(config: TelegramConfig, code?: string): Promise<{ needsCode: boolean }> {
+async function completeAuthentication(client: TelegramClient): Promise<AuthenticationResult> {
+  const session = client.session.save() as unknown as string;
+  await LocalStorage.setItem(SESSION_KEY, session);
+
+  const me = await client.getMe();
+  await LocalStorage.setItem(USER_ID_KEY, me.id.toString());
+
+  await LocalStorage.removeItem(PHONE_CODE_HASH_KEY);
+
+  return { needsCode: false, needsPassword: false };
+}
+
+export async function authenticate(
+  config: TelegramConfig,
+  options?: { code?: string; password?: string; forceResendCode?: boolean },
+): Promise<AuthenticationResult> {
   const client = await getClient(config);
+  const code = options?.code;
+  const password = options?.password;
+  const forceResendCode = options?.forceResendCode ?? false;
 
   if (!client.connected) {
     await client.connect();
   }
 
   if (await client.isUserAuthorized()) {
-    return { needsCode: false };
+    return { needsCode: false, needsPassword: false };
   }
 
-  if (!code) {
+  if (!code && !password) {
+    if (forceResendCode) {
+      await LocalStorage.removeItem(PHONE_CODE_HASH_KEY);
+    }
+
     const phoneCodeHash = await LocalStorage.getItem<string>(PHONE_CODE_HASH_KEY);
     if (!phoneCodeHash) {
       const result = await client.sendCode(
@@ -145,9 +173,20 @@ export async function authenticate(config: TelegramConfig, code?: string): Promi
         config.phoneNumber,
       );
       await LocalStorage.setItem(PHONE_CODE_HASH_KEY, result.phoneCodeHash);
-      return { needsCode: true };
+      return { needsCode: true, needsPassword: false };
     }
-    return { needsCode: true };
+    return { needsCode: true, needsPassword: false };
+  }
+
+  if (password) {
+    const accountPassword = await client.invoke(new Api.account.GetPassword());
+    await client.invoke(
+      new Api.auth.CheckPassword({
+        password: await computeCheck(accountPassword, password),
+      }),
+    );
+
+    return completeAuthentication(client);
   }
 
   const phoneCodeHash = await LocalStorage.getItem<string>(PHONE_CODE_HASH_KEY);
@@ -155,23 +194,33 @@ export async function authenticate(config: TelegramConfig, code?: string): Promi
     throw new Error("Phone code hash not found. Please restart authentication.");
   }
 
-  await client.invoke(
-    new Api.auth.SignIn({
-      phoneNumber: config.phoneNumber,
-      phoneCodeHash: phoneCodeHash,
-      phoneCode: code,
-    }),
-  );
+  try {
+    await client.invoke(
+      new Api.auth.SignIn({
+        phoneNumber: config.phoneNumber,
+        phoneCodeHash: phoneCodeHash,
+        phoneCode: code!,
+      }),
+    );
+  } catch (error) {
+    const errorText =
+      error instanceof Error
+        ? error.message
+        : String((error as { errorMessage?: string } | undefined)?.errorMessage || "");
+    const normalizedErrorText = errorText.toUpperCase();
 
-  const session = client.session.save() as unknown as string;
-  await LocalStorage.setItem(SESSION_KEY, session);
+    if (normalizedErrorText.includes("SESSION_PASSWORD_NEEDED")) {
+      return { needsCode: false, needsPassword: true };
+    }
 
-  const me = await client.getMe();
-  await LocalStorage.setItem(USER_ID_KEY, me.id.toString());
+    if (normalizedErrorText.includes("PHONE_CODE_EXPIRED")) {
+      await LocalStorage.removeItem(PHONE_CODE_HASH_KEY);
+    }
 
-  await LocalStorage.removeItem(PHONE_CODE_HASH_KEY);
+    throw error;
+  }
 
-  return { needsCode: false };
+  return completeAuthentication(client);
 }
 
 function ensureMediaCacheDir(): void {

--- a/extensions/telegram/src/utils/auth.ts
+++ b/extensions/telegram/src/utils/auth.ts
@@ -1,5 +1,6 @@
 import { getPreferenceValues, showToast, Toast } from "@raycast/api";
 import { isAuthenticated, authenticate, TelegramConfig } from "../services/telegram-client";
+import { getTelegramErrorMessage } from "./errors";
 
 export interface Preferences {
   apiId: string;
@@ -37,36 +38,36 @@ export async function ensureAuthenticated(): Promise<boolean> {
   return true;
 }
 
-export async function handleAuthFlow(code?: string): Promise<{ success: boolean; needsCode: boolean }> {
+export async function handleAuthFlow(options?: {
+  code?: string;
+  password?: string;
+  forceResendCode?: boolean;
+}): Promise<{ success: boolean; needsCode: boolean; needsPassword: boolean }> {
+  const config = getConfig();
+
   try {
-    const config = getConfig();
-    const result = await authenticate(config, code);
+    const result = await authenticate(config, options);
 
-    if (result.needsCode && !code) {
+    if (result.needsCode && !options?.code && !options?.password) {
       await showToast({
         style: Toast.Style.Success,
-        title: "Code Sent",
-        message: "Please enter the code sent to your Telegram app.",
+        title: options?.forceResendCode ? "Code Resent" : "Code Sent",
+        message: "Check your Telegram app (official Telegram chat) for the latest login code.",
       });
-      return { success: false, needsCode: true };
+      return { success: false, needsCode: true, needsPassword: false };
     }
 
-    if (!result.needsCode) {
+    if (result.needsPassword) {
       await showToast({
         style: Toast.Style.Success,
-        title: "Authenticated",
-        message: "Successfully authenticated with Telegram!",
+        title: "Password Required",
+        message: "Enter your Telegram 2-Step Verification password.",
       });
-      return { success: true, needsCode: false };
+      return { success: false, needsCode: false, needsPassword: true };
     }
 
-    return { success: false, needsCode: result.needsCode };
+    return { success: true, needsCode: false, needsPassword: false };
   } catch (error) {
-    await showToast({
-      style: Toast.Style.Failure,
-      title: "Authentication Failed",
-      message: error instanceof Error ? error.message : "Unknown error occurred",
-    });
-    return { success: false, needsCode: false };
+    throw new Error(getTelegramErrorMessage(error));
   }
 }

--- a/extensions/telegram/src/utils/errors.ts
+++ b/extensions/telegram/src/utils/errors.ts
@@ -1,9 +1,65 @@
-export function handleTelegramError(error: unknown): never {
-  if (error instanceof Error && error.message.includes("FloodWaitError")) {
-    const match = error.message.match(/(\d+) seconds/);
-    const seconds = match ? match[1] : "unknown";
-    throw new Error(`Rate limited by Telegram. Please wait ${seconds} seconds before trying again.`);
+function getErrorText(error: unknown): string {
+  if (!error) return "";
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+
+  const details = error as { message?: string; errorMessage?: string };
+  return `${details.errorMessage || ""} ${details.message || ""}`.trim();
+}
+
+function formatFloodWaitMessage(errorText: string): string | null {
+  const floodWaitMatch = errorText.match(/FLOOD_WAIT_(\d+)/);
+  if (floodWaitMatch?.[1]) {
+    const totalSeconds = parseInt(floodWaitMatch[1], 10);
+    if (Number.isNaN(totalSeconds)) return null;
+
+    if (totalSeconds < 60) {
+      return `Rate limited by Telegram. Try again in ${totalSeconds} second${totalSeconds === 1 ? "" : "s"}.`;
+    }
+
+    const minutes = Math.ceil(totalSeconds / 60);
+    return `Rate limited by Telegram. Try again in ${minutes} minute${minutes === 1 ? "" : "s"}.`;
   }
 
-  throw error instanceof Error ? error : new Error("Unknown error occurred");
+  const secondsMatch = errorText.match(/(\d+)\s+seconds?/i);
+  if (secondsMatch?.[1]) {
+    return `Rate limited by Telegram. Try again in ${secondsMatch[1]} seconds.`;
+  }
+
+  return null;
+}
+
+export function getTelegramErrorMessage(error: unknown): string {
+  const errorText = getErrorText(error).toUpperCase();
+
+  if (errorText.includes("SESSION_PASSWORD_NEEDED")) {
+    return "This account has 2-Step Verification enabled. Please enter your password to continue.";
+  }
+
+  if (errorText.includes("PASSWORD_HASH_INVALID")) {
+    return "Incorrect 2-Step Verification password. Please try again.";
+  }
+
+  if (errorText.includes("PHONE_CODE_INVALID")) {
+    return "The verification code is invalid. Please check the code and try again.";
+  }
+
+  if (errorText.includes("PHONE_CODE_EXPIRED")) {
+    return "The verification code has expired. Request a new code and try again.";
+  }
+
+  const floodWaitMessage = formatFloodWaitMessage(errorText);
+  if (floodWaitMessage) {
+    return floodWaitMessage;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Unknown error occurred";
+}
+
+export function handleTelegramError(error: unknown): never {
+  throw new Error(getTelegramErrorMessage(error));
 }


### PR DESCRIPTION
## Description

Adds Telegram 2-Step Verification support to the authentication flow.

### What changed

- Added auth flow branching for `SESSION_PASSWORD_NEEDED` after code verification.
- Added a secure password step (`Form.PasswordField`) to complete 2FA login.
- Implemented password verification via Telegram API (`auth.checkPassword` flow).
- Persist session only after full authentication succeeds.
- Added resend flow improvements:
  - Resend action on code screen (`⌘R`)
  - Inline hint: “Didn't get a code? Press ⌘R to resend.”
  - Proper handling of expired code state (`PHONE_CODE_EXPIRED`) by resetting stale code hash.
- Improved user-facing error mapping for:
  - `SESSION_PASSWORD_NEEDED`
  - `PASSWORD_HASH_INVALID`
  - `PHONE_CODE_INVALID`
  - `PHONE_CODE_EXPIRED`
  - `FLOOD_WAIT_X` (human-readable wait message)

Fixes https://github.com/raycast/extensions/issues/25850

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
