### PR TITLE
[MXroute] set mail hosting status + open webmail link

### DIFF
--- a/extensions/mxroute/CHANGELOG.md
+++ b/extensions/mxroute/CHANGELOG.md
@@ -1,6 +1,6 @@
 # MXroute Changelog
 
-## [Toggle Domain Mail Hosting Status] - {PR_MERGE_DATE}
+## [Toggle Domain Mail Hosting Status] - 2026-02-27
 
 - Enable or Disable mail hosting in "Domains"
 - Open Webmail

--- a/extensions/mxroute/CHANGELOG.md
+++ b/extensions/mxroute/CHANGELOG.md
@@ -1,5 +1,10 @@
 # MXroute Changelog
 
+## [Toggle Domain Mail Hosting Status] - {PR_MERGE_DATE}
+
+- Enable or Disable mail hosting in "Domains"
+- Open Webmail
+
 ## [Show Email Account Usage] - 2026-02-16
 
 - Show MB Usage in "Email Accounts"

--- a/extensions/mxroute/package-lock.json
+++ b/extensions/mxroute/package-lock.json
@@ -7,7 +7,7 @@
       "name": "mxroute",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.6",
+        "@raycast/api": "^1.104.7",
         "@raycast/utils": "^2.2.2"
       },
       "devDependencies": {
@@ -1099,9 +1099,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.6",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.6.tgz",
-      "integrity": "sha512-W3UnZrfh1EH9mteQQOibeUvniDnVsbRgcfSUgVWFTGuI6mzKLFzoM8mD6n5amYQM51JVvbuJbaqtfMqsTmnQCQ==",
+      "version": "1.104.7",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.7.tgz",
+      "integrity": "sha512-EeBg7zU1OjJlfoPlb88T1G1K4rZuD46gvLr6bWqPALGPfNDvkkBFz7G+9cq+Zayq8Ex7k4vjp/ZibC24j7xnzA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.5.4",

--- a/extensions/mxroute/package.json
+++ b/extensions/mxroute/package.json
@@ -138,7 +138,7 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.104.6",
+    "@raycast/api": "^1.104.7",
     "@raycast/utils": "^2.2.2"
   },
   "devDependencies": {

--- a/extensions/mxroute/src/mxroute.ts
+++ b/extensions/mxroute/src/mxroute.ts
@@ -37,6 +37,11 @@ export const mxroute = {
     create: (domain: string) => makeRequest("domains", { method: "POST", body: JSON.stringify({ domain }) }),
     get: (domain: string) => makeRequest<Domain>(`domains/${domain}`),
     list: () => makeRequest<string[]>("domains"),
+    setMailHostingStatus: (domain: string, values: { enabled: boolean }) =>
+      makeRequest<{ domain: string; mail_hosting: boolean }>(`domains/${domain}/mail-status`, {
+        method: "PATCH",
+        body: JSON.stringify(values),
+      }),
     accounts: {
       create: (domain: string, values: CreateEmailAccountRequest) =>
         makeRequest(`domains/${domain}/email-accounts`, { method: "POST", body: JSON.stringify(values) }),


### PR DESCRIPTION
## Description

- Enable or Disable mail hosting in "Domains"
- Open Webmail

## Screencast

N/A

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
