### PR TITLE
[Skills] Use explicit npx path resolution on macOS

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Improve macOS `npx` Path Resolution] - {PR_MERGE_DATE}
+
+- Run the Skills CLI without spawning a login shell by building an explicit PATH for Homebrew and common Node.js version-manager installs
+- Add a custom `npx` path preference for non-standard setups
+- Show clearer recovery guidance for `npx` and Skills CLI failures, including a shortcut to open Extension Preference
+
 ## [Fix Incomplete Agent List] - 2026-03-17
 
 - Use `skills list --json` for structured output instead of parsing ANSI text

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Improve macOS `npx` Path Resolution] - {PR_MERGE_DATE}
+## [Improve macOS `npx` Path Resolution] - 2026-03-20
 
 - Run the Skills CLI without spawning a login shell by building an explicit PATH for Homebrew and common Node.js version-manager installs
 - Add a custom `npx` path preference for non-standard setups

--- a/extensions/skills/eslint.config.js
+++ b/extensions/skills/eslint.config.js
@@ -1,5 +1,15 @@
 const { defineConfig } = require("eslint/config");
 const raycastConfig = require("@raycast/eslint-config");
+const nodePlugin = require("eslint-plugin-n");
 
-module.exports = defineConfig([...raycastConfig]);
-
+module.exports = defineConfig([
+  ...raycastConfig,
+  {
+    plugins: {
+      n: nodePlugin,
+    },
+    rules: {
+      "n/prefer-node-protocol": ["error", { version: ">=16.0.0" }],
+    },
+  },
+]);

--- a/extensions/skills/package-lock.json
+++ b/extensions/skills/package-lock.json
@@ -10,13 +10,16 @@
         "@raycast/api": "1.104.5",
         "@raycast/utils": "2.2.3",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "semver": "^7.7.3"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
         "@types/node": "^25.2.3",
         "@types/react": "^19.2.13",
+        "@types/semver": "^7.7.1",
         "eslint": "^10.0.0",
+        "eslint-plugin-n": "^17.24.0",
         "prettier": "^3.8.1",
         "typescript": "^5.9.3"
       }
@@ -456,6 +459,19 @@
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
@@ -467,37 +483,76 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.1.tgz",
+      "integrity": "sha512-uVSdg/V4dfQmTjJzR0szNczjOH/J+FyUMMjYtr07xFRXR7EDf9i1qdxrD0VusZH9knj1/ecxzCQQxyic5NzAiA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.3",
+        "@eslint/object-schema": "^3.0.1",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^10.1.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
+      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1"
+        "@eslint/core": "^1.1.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -508,9 +563,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -521,9 +576,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.1.tgz",
+      "integrity": "sha512-P9cq2dpr+LU8j3qbLygLcSZrl2/ds/pUpfnHNNuk5HW7mnngHs+6WSq5C9mO3rqRX8A1poxqLTC9cu0KOyJlBg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -531,13 +586,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
+      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1",
+        "@eslint/core": "^1.1.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -945,9 +1000,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.9.0.tgz",
-      "integrity": "sha512-k/ntRgDcUprTT+aaNoF+whk3cY3f9fRD2lkF6ul7JeCUg2MaMXVXZXfbRhJCfsiX51X8/5Pqo0LGdO9SLYXNHg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.0.tgz",
+      "integrity": "sha512-jteNUQKgJHLHFbbz806aGZqf+RJJ7t4gwF4MYa8fCwCxQ8/klJNWc0MvaJiBebk7Mc+J39mdlsB4XraaCKznFw==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -960,7 +1015,7 @@
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
-        "minimatch": "^10.2.4",
+        "minimatch": "^9.0.5",
         "semver": "^7.7.3",
         "string-width": "^4.2.3",
         "supports-color": "^8",
@@ -974,9 +1029,9 @@
       }
     },
     "node_modules/@oclif/plugin-autocomplete": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.41.tgz",
-      "integrity": "sha512-s8IcxohWtnbYCOA1nC6cUGWFGLBG3MjNWfCBTTa5pUyh4tGsjC5ihLeLCs8WJgGnFkPhVVQ+CfmKOIVmVGYMvA==",
+      "version": "3.2.40",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.40.tgz",
+      "integrity": "sha512-HCfDuUV3l5F5Wz7SKkaoFb+OMQ5vKul8zvsPNgI0QbZcQuGHmn3svk+392wSfXboyA1gq8kzEmKPAoQK6r6UNw==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
@@ -989,9 +1044,9 @@
       }
     },
     "node_modules/@oclif/plugin-help": {
-      "version": "6.2.38",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.38.tgz",
-      "integrity": "sha512-aTVQ8qPy5kD/Neq2B4OEo2joukHWdEabTMHfQyXtsagW1O2MvhM58+JUWADvieX67OSjSXseD6f6O/e5SA2N/Q==",
+      "version": "6.2.37",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.37.tgz",
+      "integrity": "sha512-5N/X/FzlJaYfpaHwDC0YHzOzKDWa41s9t+4FpCDu4f9OMReds4JeNBaaWk9rlIzdKjh2M6AC5Q18ORfECRkHGA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4"
@@ -1001,13 +1056,13 @@
       }
     },
     "node_modules/@oclif/plugin-not-found": {
-      "version": "3.2.75",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.75.tgz",
-      "integrity": "sha512-xBEf7fJoS/fIqzGBUe0i6yc7ozo23KTyusy50DHqh+oqay5gtMLPUfr1RbvJBGGwozzFAMMFXN9o+AvUDt/zTA==",
+      "version": "3.2.74",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.74.tgz",
+      "integrity": "sha512-6RD/EuIUGxAYR45nMQg+nw+PqwCXUxkR6Eyn+1fvbVjtb9d+60OPwB77LCRUI4zKNI+n0LOFaMniEdSpb+A7kQ==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",
-        "@oclif/core": "^4.9.0",
+        "@oclif/core": "^4.8.0",
         "ansis": "^3.17.0",
         "fast-levenshtein": "^3.0.0"
       },
@@ -1105,6 +1160,143 @@
         "typescript": ">=4"
       }
     },
+    "node_modules/@raycast/eslint-config/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@raycast/eslint-config/node_modules/typescript-eslint": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.55.0.tgz",
+      "integrity": "sha512-HE4wj+r5lmDVS9gdaN0/+iqNvPZwGfnJ5lZuz7s5vLlg9ODw0bIiiETaios9LvFI1U94/VBXGm3CB2Y5cNFMpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.55.0",
+        "@typescript-eslint/parser": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0",
+        "@typescript-eslint/utils": "8.55.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@raycast/eslint-config/node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.55.0.tgz",
+      "integrity": "sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.55.0",
+        "@typescript-eslint/type-utils": "8.55.0",
+        "@typescript-eslint/utils": "8.55.0",
+        "@typescript-eslint/visitor-keys": "8.55.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.55.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@raycast/eslint-config/node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.55.0.tgz",
+      "integrity": "sha512-x1iH2unH4qAt6I37I2CGlsNs+B9WGxurP2uyZLRz6UJoZWDBx9cJL1xVN/FiOmHEONEg6RIufdvyT0TEYIgC5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0",
+        "@typescript-eslint/utils": "8.55.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@raycast/eslint-config/node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.55.0.tgz",
+      "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.55.0",
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0",
+        "@typescript-eslint/visitor-keys": "8.55.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@raycast/eslint-config/node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.55.0.tgz",
+      "integrity": "sha512-BqZEsnPGdYpgyEIkDC1BadNY8oMwckftxBT+C8W0g1iKPdeqKZBtTfnvcq0nf60u7MkjFO8RBvpRGZBPw4L2ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.55.0",
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
     "node_modules/@raycast/eslint-plugin": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-2.1.1.tgz",
@@ -1116,6 +1308,30 @@
       },
       "peerDependencies": {
         "eslint": ">=8.23.0"
+      }
+    },
+    "node_modules/@raycast/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.55.0.tgz",
+      "integrity": "sha512-BqZEsnPGdYpgyEIkDC1BadNY8oMwckftxBT+C8W0g1iKPdeqKZBtTfnvcq0nf60u7MkjFO8RBvpRGZBPw4L2ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.55.0",
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@raycast/utils": {
@@ -1158,98 +1374,41 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
+      "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.0.tgz",
-      "integrity": "sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==",
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.57.0",
-        "@typescript-eslint/type-utils": "8.57.0",
-        "@typescript-eslint/utils": "8.57.0",
-        "@typescript-eslint/visitor-keys": "8.57.0",
-        "ignore": "^7.0.5",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.57.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
-      "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.57.0",
-        "@typescript-eslint/types": "8.57.0",
-        "@typescript-eslint/typescript-estree": "8.57.0",
-        "@typescript-eslint/visitor-keys": "8.57.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
-      "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.55.0.tgz",
+      "integrity": "sha512-zRcVVPFUYWa3kNnjaZGXSu3xkKV1zXy8M4nO/pElzQhFweb7PPtluDLQtKArEOGmjXoRjnUZ29NjOiF0eCDkcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.57.0",
-        "@typescript-eslint/types": "^8.57.0",
+        "@typescript-eslint/tsconfig-utils": "^8.55.0",
+        "@typescript-eslint/types": "^8.55.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1264,14 +1423,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
-      "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.55.0.tgz",
+      "integrity": "sha512-fVu5Omrd3jeqeQLiB9f1YsuK/iHFOwb04bCtY4BSCLgjNbOD33ZdV6KyEqplHr+IlpgT0QTZ/iJ+wT7hvTx49Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.0",
-        "@typescript-eslint/visitor-keys": "8.57.0"
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/visitor-keys": "8.55.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1282,9 +1441,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
-      "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.55.0.tgz",
+      "integrity": "sha512-1R9cXqY7RQd7WuqSN47PK9EDpgFUK3VqdmbYrvWJZYDd0cavROGn+74ktWBlmJ13NXUQKlZ/iAEQHI/V0kKe0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1295,38 +1454,13 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.0.tgz",
-      "integrity": "sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.57.0",
-        "@typescript-eslint/typescript-estree": "8.57.0",
-        "@typescript-eslint/utils": "8.57.0",
-        "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
-      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.55.0.tgz",
+      "integrity": "sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1338,18 +1472,18 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
-      "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.55.0.tgz",
+      "integrity": "sha512-EwrH67bSWdx/3aRQhCoxDaHM+CrZjotc2UCCpEDVqfCE+7OjKAGWNY2HsCSTEVvWH2clYQK8pdeLp42EVs+xQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.57.0",
-        "@typescript-eslint/tsconfig-utils": "8.57.0",
-        "@typescript-eslint/types": "8.57.0",
-        "@typescript-eslint/visitor-keys": "8.57.0",
+        "@typescript-eslint/project-service": "8.55.0",
+        "@typescript-eslint/tsconfig-utils": "8.55.0",
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/visitor-keys": "8.55.0",
         "debug": "^4.4.3",
-        "minimatch": "^10.2.2",
+        "minimatch": "^9.0.5",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
         "ts-api-utils": "^2.4.0"
@@ -1365,39 +1499,15 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.0.tgz",
-      "integrity": "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.57.0",
-        "@typescript-eslint/types": "8.57.0",
-        "@typescript-eslint/typescript-estree": "8.57.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
-      "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.55.0.tgz",
+      "integrity": "sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.0",
-        "eslint-visitor-keys": "^5.0.0"
+        "@typescript-eslint/types": "8.55.0",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1408,22 +1518,22 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1515,24 +1625,18 @@
       "license": "MIT"
     },
     "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/chardet": {
@@ -1670,6 +1774,20 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -1724,29 +1842,29 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
-      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.0.tgz",
+      "integrity": "sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-array": "^0.23.0",
         "@eslint/config-helpers": "^0.5.2",
-        "@eslint/core": "^1.1.1",
-        "@eslint/plugin-kit": "^0.6.1",
+        "@eslint/core": "^1.1.0",
+        "@eslint/plugin-kit": "^0.6.0",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
+        "ajv": "^6.12.4",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.1.1",
+        "eslint-scope": "^9.1.0",
+        "eslint-visitor-keys": "^5.0.0",
+        "espree": "^11.1.0",
         "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1757,7 +1875,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.1.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -1779,6 +1897,22 @@
         }
       }
     },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-config-prettier": {
       "version": "10.1.8",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
@@ -1795,10 +1929,72 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+      "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/ota-meshi",
+        "https://opencollective.com/eslint"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.11.0",
+        "eslint-compat-utils": "^0.5.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "17.24.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.24.0.tgz",
+      "integrity": "sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.5.0",
+        "enhanced-resolve": "^5.17.1",
+        "eslint-plugin-es-x": "^7.8.0",
+        "get-tsconfig": "^4.8.1",
+        "globals": "^15.11.0",
+        "globrex": "^0.1.2",
+        "ignore": "^5.3.2",
+        "semver": "^7.6.3",
+        "ts-declaration-location": "^1.0.6"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.23.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.0.tgz",
+      "integrity": "sha512-CkWE42hOJsNj9FJRaoMX9waUFYhqY4jmyLFdAdzZr6VaCg3ynLYx4WnOdkaIifGfH4gsUcBTn4OZbHXkpLD0FQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1815,22 +2011,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
+      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1838,32 +2021,58 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.0.tgz",
+      "integrity": "sha512-WFWYhO1fV4iYkqOOvq8FbqIhr2pYfoDY0kCotMkDeNtGpiGGkZ1iov2u8ydjtgM8yF8rzK7oaTbw2NAzbAbehw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.16.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "eslint-visitor-keys": "^5.0.0"
       },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -1980,27 +2189,12 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
-      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -2047,9 +2241,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
     },
@@ -2060,6 +2254,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob-parent": {
@@ -2087,6 +2294,20 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2299,15 +2520,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "license": "BlueOak-1.0.0",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2487,6 +2708,16 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2587,6 +2818,20 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2614,6 +2859,29 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-declaration-location": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
+      "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "picomatch": "^4.0.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.0.0"
       }
     },
     "node_modules/type-check": {
@@ -2655,34 +2923,10 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/typescript-eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.0.tgz",
-      "integrity": "sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.57.0",
-        "@typescript-eslint/parser": "8.57.0",
-        "@typescript-eslint/typescript-estree": "8.57.0",
-        "@typescript-eslint/utils": "8.57.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/extensions/skills/package.json
+++ b/extensions/skills/package.json
@@ -45,6 +45,14 @@
   ],
   "preferences": [
     {
+      "name": "customNpxPath",
+      "title": "Custom npx Path",
+      "description": "Optional custom `npx` path override for cases when the extension cannot detect it automatically.",
+      "placeholder": "e.g., /opt/homebrew/bin/npx or ~/.local/bin/npx",
+      "type": "textfield",
+      "required": false
+    },
+    {
       "name": "githubToken",
       "title": "GitHub Personal Access Token",
       "description": "Optional token to increase the GitHub API rate limit from 60 to 5,000 requests/hour.",
@@ -56,13 +64,16 @@
     "@raycast/api": "1.104.5",
     "@raycast/utils": "2.2.3",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "semver": "^7.7.3"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",
     "@types/node": "^25.2.3",
     "@types/react": "^19.2.13",
+    "@types/semver": "^7.7.1",
     "eslint": "^10.0.0",
+    "eslint-plugin-n": "^17.24.0",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3"
   },

--- a/extensions/skills/src/components/InstalledSkillListItem.tsx
+++ b/extensions/skills/src/components/InstalledSkillListItem.tsx
@@ -1,6 +1,6 @@
 import { ActionPanel, Action, Icon, Keyboard, List, Color } from "@raycast/api";
-import { readFile } from "fs/promises";
-import { join } from "path";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { useCachedPromise } from "@raycast/utils";
 import { type InstalledSkill, parseFrontmatter } from "../shared";
 import { RemoveSkillAction } from "./actions/RemoveSkillAction";

--- a/extensions/skills/src/manage-skills.tsx
+++ b/extensions/skills/src/manage-skills.tsx
@@ -1,6 +1,7 @@
-import { List, Icon, Detail, ActionPanel, Action, Color } from "@raycast/api";
+import { List, Icon, Detail, ActionPanel, Action, Color, openExtensionPreferences } from "@raycast/api";
 import { useState } from "react";
 import { useInstalledSkills } from "./hooks/useInstalledSkills";
+import { isNpxResolutionError } from "./utils/skills-cli";
 import { InstalledSkillListItem } from "./components/InstalledSkillListItem";
 import { UpdateSkillAction } from "./components/actions/UpdateSkillAction";
 
@@ -10,14 +11,46 @@ export default function Command() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [isShowingDetail, setIsShowingDetail] = useState(true);
   const toggleDetail = () => setIsShowingDetail((prev) => !prev);
+  const hasNpxResolutionError = error ? isNpxResolutionError(error) : false;
+
+  let errorMarkdown = `# Error Loading Installed Skills
+
+**Error:** ${error?.message}
+
+---
+
+This is a local skills CLI execution failure.
+
+If this persists:
+
+1. Retry the command.
+2. Open Extension Preferences and verify **Custom npx Path** if you use a non-standard Node.js setup.
+3. Run \`npx -y skills@latest list -g\` in Terminal to inspect the underlying CLI error.
+`;
+
+  if (hasNpxResolutionError) {
+    errorMarkdown = `# Error Loading Installed Skills
+
+**Error:** ${error?.message}
+
+---
+
+This is an npx resolution issue in the local CLI runtime.
+
+1. Run \`which npx\` in Terminal.
+2. Open Extension Preferences (\`Cmd+Shift+,\`).
+3. Set **Custom npx Path** to the path from step 1, then retry.
+`;
+  }
 
   if (error && skills.length === 0) {
     return (
       <Detail
-        markdown={`# Error Loading Installed Skills\n\n**Error:** ${error.message}\n\n---\n\nMake sure you have the skills CLI available: \`npx skills list -g\``}
+        markdown={errorMarkdown}
         actions={
           <ActionPanel>
             <Action title="Retry" onAction={revalidate} icon={Icon.RotateClockwise} />
+            <Action title="Open Preferences" onAction={openExtensionPreferences} icon={Icon.Gear} />
           </ActionPanel>
         }
       />

--- a/extensions/skills/src/manage-skills.tsx
+++ b/extensions/skills/src/manage-skills.tsx
@@ -13,7 +13,8 @@ export default function Command() {
   const toggleDetail = () => setIsShowingDetail((prev) => !prev);
   const hasNpxResolutionError = error ? isNpxResolutionError(error) : false;
 
-  let errorMarkdown = `# Error Loading Installed Skills
+  if (error && skills.length === 0) {
+    let errorMarkdown = `# Error Loading Installed Skills
 
 **Error:** ${error?.message}
 
@@ -28,8 +29,8 @@ If this persists:
 3. Run \`npx -y skills@latest list -g\` in Terminal to inspect the underlying CLI error.
 `;
 
-  if (hasNpxResolutionError) {
-    errorMarkdown = `# Error Loading Installed Skills
+    if (hasNpxResolutionError) {
+      errorMarkdown = `# Error Loading Installed Skills
 
 **Error:** ${error?.message}
 
@@ -41,9 +42,8 @@ This is an npx resolution issue in the local CLI runtime.
 2. Open Extension Preferences (\`Cmd+Shift+,\`).
 3. Set **Custom npx Path** to the path from step 1, then retry.
 `;
-  }
+    }
 
-  if (error && skills.length === 0) {
     return (
       <Detail
         markdown={errorMarkdown}

--- a/extensions/skills/src/preferences.ts
+++ b/extensions/skills/src/preferences.ts
@@ -1,0 +1,20 @@
+import { getPreferenceValues } from "@raycast/api";
+import { homedir } from "node:os";
+import { sep } from "node:path";
+
+export const preferences = getPreferenceValues<Preferences>();
+
+export const getCustomNpxPath = (): string | undefined => {
+  const customPath = preferences.customNpxPath?.trim();
+  if (!customPath) return undefined;
+
+  if (customPath === "~") {
+    return homedir();
+  }
+
+  if (customPath.startsWith("~/") || customPath.startsWith(`~${sep}`)) {
+    return homedir() + customPath.slice(1);
+  }
+
+  return customPath;
+};

--- a/extensions/skills/src/utils/exec-async.ts
+++ b/extensions/skills/src/utils/exec-async.ts
@@ -1,0 +1,4 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+export const execAsync = promisify(exec);

--- a/extensions/skills/src/utils/exec-options.ts
+++ b/extensions/skills/src/utils/exec-options.ts
@@ -1,0 +1,45 @@
+import { dirname } from "node:path";
+import { getCustomNpxPath } from "../preferences";
+import { getEnhancedNodePaths, resolveFnmBaseDir } from "./node-path-resolver";
+
+const isWindows = process.platform === "win32";
+
+export const getExecOptions = () => {
+  const env: Record<string, string> = {
+    ...process.env,
+    PATH: getEnhancedNodePaths(),
+  };
+
+  const customNpxPath = getCustomNpxPath();
+  if (customNpxPath) {
+    const customDir = dirname(customNpxPath);
+    env.PATH = isWindows ? `${customDir};${env.PATH}` : `${customDir}:${env.PATH}`;
+  }
+
+  if (!isWindows && process.env.HOME) {
+    const home = process.env.HOME;
+
+    if (!process.env.NVM_DIR) {
+      env.NVM_DIR = `${home}/.nvm`;
+    }
+
+    if (!process.env.FNM_DIR) {
+      const fnmBaseDir = resolveFnmBaseDir(home);
+      if (fnmBaseDir) {
+        env.FNM_DIR = fnmBaseDir;
+      }
+    }
+
+    if (!process.env.npm_config_prefix) {
+      env.npm_config_prefix = `${home}/.npm-global`;
+    }
+  }
+
+  const cwd = isWindows ? process.env.USERPROFILE || process.cwd() : process.env.HOME || process.cwd();
+
+  return {
+    env,
+    timeout: 30000,
+    cwd,
+  };
+};

--- a/extensions/skills/src/utils/exec-options.ts
+++ b/extensions/skills/src/utils/exec-options.ts
@@ -1,13 +1,13 @@
 import { dirname } from "node:path";
 import { getCustomNpxPath } from "../preferences";
-import { getEnhancedNodePaths, resolveFnmBaseDir } from "./node-path-resolver";
+import { getEnhancedNodePaths, pathExists, resolveFnmBaseDir } from "./node-path-resolver";
 
 const isWindows = process.platform === "win32";
 
-export const getExecOptions = () => {
+export const getExecOptions = async () => {
   const env: Record<string, string> = {
     ...process.env,
-    PATH: getEnhancedNodePaths(),
+    PATH: await getEnhancedNodePaths(),
   };
 
   const customNpxPath = getCustomNpxPath();
@@ -19,19 +19,21 @@ export const getExecOptions = () => {
   if (!isWindows && process.env.HOME) {
     const home = process.env.HOME;
 
-    if (!process.env.NVM_DIR) {
-      env.NVM_DIR = `${home}/.nvm`;
+    const nvmDir = `${home}/.nvm`;
+    if (!process.env.NVM_DIR && (await pathExists(nvmDir))) {
+      env.NVM_DIR = nvmDir;
     }
 
     if (!process.env.FNM_DIR) {
-      const fnmBaseDir = resolveFnmBaseDir(home);
-      if (fnmBaseDir) {
+      const fnmBaseDir = await resolveFnmBaseDir(home);
+      if (fnmBaseDir && (await pathExists(fnmBaseDir))) {
         env.FNM_DIR = fnmBaseDir;
       }
     }
 
-    if (!process.env.npm_config_prefix) {
-      env.npm_config_prefix = `${home}/.npm-global`;
+    const npmGlobalDir = `${home}/.npm-global`;
+    if (!process.env.npm_config_prefix && (await pathExists(npmGlobalDir))) {
+      env.npm_config_prefix = npmGlobalDir;
     }
   }
 

--- a/extensions/skills/src/utils/node-path-resolver.ts
+++ b/extensions/skills/src/utils/node-path-resolver.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from "node:fs";
+import { access, readdir } from "node:fs/promises";
 import { cpus } from "node:os";
 import { join } from "node:path";
 import semver from "semver";
@@ -6,6 +6,7 @@ import semver from "semver";
 const isWindows = process.platform === "win32";
 
 let cachedPaths: string | null = null;
+let cachedPathsPromise: Promise<string> | null = null;
 let cachedIsAppleSilicon: boolean | null = null;
 
 const getAppleSiliconStatus = (): boolean => {
@@ -26,11 +27,46 @@ const sortPathsByVersion = (paths: Array<{ path: string; version: string }>): st
   return paths.sort((a, b) => parseVersion(b.version) - parseVersion(a.version)).map((item) => item.path);
 };
 
-export const resolveFnmBaseDir = (home = process.env.HOME): string | null => {
+export const pathExists = async (path: string): Promise<boolean> => {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const resolveExistingVersionedPaths = async (
+  versionedPaths: Array<{ path: string; version: string }>,
+): Promise<Array<{ path: string; version: string }>> => {
+  const results = await Promise.all(
+    versionedPaths.map(async (versionedPath) => ((await pathExists(versionedPath.path)) ? versionedPath : null)),
+  );
+  return results.filter((item): item is { path: string; version: string } => item !== null);
+};
+
+const resolveExistingPaths = async (paths: string[]): Promise<string[]> => {
+  const results = await Promise.all(paths.map(async (path) => ((await pathExists(path)) ? path : null)));
+  return results.filter((path): path is string => path !== null);
+};
+
+const scanVersionedNodePaths = async (
+  versionsDir: string,
+  getBinPath: (version: string) => string,
+): Promise<Array<{ path: string; version: string }>> => {
+  try {
+    const nodeVersions = await readdir(versionsDir);
+    return resolveExistingVersionedPaths(nodeVersions.map((version) => ({ path: getBinPath(version), version })));
+  } catch {
+    return [];
+  }
+};
+
+export const resolveFnmBaseDir = async (home = process.env.HOME): Promise<string | null> => {
   if (!home) return null;
 
   const legacyFnmPath = join(home, ".fnm");
-  if (existsSync(legacyFnmPath)) {
+  if (await pathExists(legacyFnmPath)) {
     // Older fnm installs keep everything under ~/.fnm instead of XDG data directories
     return legacyFnmPath;
   }
@@ -39,70 +75,37 @@ export const resolveFnmBaseDir = (home = process.env.HOME): string | null => {
   return join(xdgDataHome, "fnm");
 };
 
-export const resolveVersionManagerPaths = (): string[] => {
-  const versionedPaths: Array<{ path: string; version: string }> = [];
-  const staticPaths: string[] = [];
+export const resolveVersionManagerPaths = async (): Promise<string[]> => {
   const home = process.env.HOME;
 
   if (!home) return [];
 
   const nvmVersionsDir = join(home, ".nvm", "versions", "node");
-  try {
-    const nodeVersions = readdirSync(nvmVersionsDir);
-    for (const version of nodeVersions) {
-      const binPath = join(nvmVersionsDir, version, "bin");
-      if (existsSync(binPath)) {
-        versionedPaths.push({ path: binPath, version });
-      }
-    }
-  } catch {
-    // Ignore missing or unreadable directories.
-  }
-
-  const fnmBaseDir = resolveFnmBaseDir(home);
-  if (fnmBaseDir) {
-    const fnmVersionsDir = join(fnmBaseDir, "node-versions");
-
-    try {
-      const nodeVersions = readdirSync(fnmVersionsDir);
-      for (const version of nodeVersions) {
-        const binPath = join(fnmVersionsDir, version, "installation", "bin");
-        if (existsSync(binPath)) {
-          versionedPaths.push({ path: binPath, version });
-        }
-      }
-    } catch {
-      // Ignore missing or unreadable directories.
-    }
-  }
-
   const staticPathCandidates = [join(home, ".n", "bin"), join(home, ".volta", "bin")];
+  const [nvmPaths, fnmPaths, staticPaths] = await Promise.all([
+    scanVersionedNodePaths(nvmVersionsDir, (version) => join(nvmVersionsDir, version, "bin")),
+    (async () => {
+      const fnmBaseDir = await resolveFnmBaseDir(home);
+      if (!fnmBaseDir) return [];
 
-  for (const path of staticPathCandidates) {
-    if (existsSync(path)) {
-      staticPaths.push(path);
-    }
-  }
+      const fnmVersionsDir = join(fnmBaseDir, "node-versions");
+      return scanVersionedNodePaths(fnmVersionsDir, (version) => join(fnmVersionsDir, version, "installation", "bin"));
+    })(),
+    resolveExistingPaths(staticPathCandidates),
+  ]);
 
-  const sortedVersionedPaths = sortPathsByVersion(versionedPaths);
+  const sortedVersionedPaths = sortPathsByVersion([...nvmPaths, ...fnmPaths]);
   return [...sortedVersionedPaths, ...staticPaths];
 };
 
-export const getEnhancedNodePaths = (): string => {
-  if (cachedPaths !== null) return cachedPaths;
-
-  if (isWindows) {
-    cachedPaths = process.env.PATH || "";
-    return cachedPaths;
-  }
-
+const buildEnhancedNodePaths = async (): Promise<string> => {
   const isAppleSilicon = getAppleSiliconStatus();
 
   const platformPaths = isAppleSilicon
     ? ["/opt/homebrew/bin", "/opt/homebrew/lib/node_modules/.bin"]
     : ["/usr/local/bin", "/usr/local/lib/node_modules/.bin"];
 
-  const versionManagerPaths = resolveVersionManagerPaths();
+  const versionManagerPaths = await resolveVersionManagerPaths();
 
   const systemPaths = ["/usr/bin", "/bin"];
 
@@ -110,14 +113,32 @@ export const getEnhancedNodePaths = (): string => {
     systemPaths.push(`${process.env.HOME}/.npm/bin`, `${process.env.HOME}/.yarn/bin`);
   }
 
-  // Preserve the current PATH first, then prepend common package-manager and version-manager locations
-  const allPaths = [process.env.PATH || "", ...platformPaths, ...versionManagerPaths, ...systemPaths];
+  const allPaths = [...platformPaths, ...versionManagerPaths, ...systemPaths, process.env.PATH || ""];
 
   cachedPaths = allPaths.filter((path) => path).join(":");
   return cachedPaths;
 };
 
+export const getEnhancedNodePaths = async (): Promise<string> => {
+  if (cachedPaths !== null) return cachedPaths;
+  if (cachedPathsPromise !== null) return cachedPathsPromise;
+
+  if (isWindows) {
+    cachedPaths = process.env.PATH || "";
+    return cachedPaths;
+  }
+
+  cachedPathsPromise = buildEnhancedNodePaths();
+
+  try {
+    return await cachedPathsPromise;
+  } finally {
+    cachedPathsPromise = null;
+  }
+};
+
 export const clearPathCache = (): void => {
   cachedPaths = null;
+  cachedPathsPromise = null;
   cachedIsAppleSilicon = null;
 };

--- a/extensions/skills/src/utils/node-path-resolver.ts
+++ b/extensions/skills/src/utils/node-path-resolver.ts
@@ -1,0 +1,123 @@
+import { existsSync, readdirSync } from "node:fs";
+import { cpus } from "node:os";
+import { join } from "node:path";
+import semver from "semver";
+
+const isWindows = process.platform === "win32";
+
+let cachedPaths: string | null = null;
+let cachedIsAppleSilicon: boolean | null = null;
+
+const getAppleSiliconStatus = (): boolean => {
+  if (cachedIsAppleSilicon !== null) return cachedIsAppleSilicon;
+  cachedIsAppleSilicon = cpus()[0]?.model?.includes("Apple") ?? false;
+  return cachedIsAppleSilicon;
+};
+
+const parseVersion = (version: string): number => {
+  const coerced = semver.coerce(version);
+  if (!coerced) return 0;
+
+  // Convert semver to a sortable number so directory names can be ordered newest-first
+  return coerced.major * 1000000 + coerced.minor * 1000 + coerced.patch;
+};
+
+const sortPathsByVersion = (paths: Array<{ path: string; version: string }>): string[] => {
+  return paths.sort((a, b) => parseVersion(b.version) - parseVersion(a.version)).map((item) => item.path);
+};
+
+export const resolveFnmBaseDir = (home = process.env.HOME): string | null => {
+  if (!home) return null;
+
+  const legacyFnmPath = join(home, ".fnm");
+  if (existsSync(legacyFnmPath)) {
+    // Older fnm installs keep everything under ~/.fnm instead of XDG data directories
+    return legacyFnmPath;
+  }
+
+  const xdgDataHome = process.env.XDG_DATA_HOME || join(home, ".local", "share");
+  return join(xdgDataHome, "fnm");
+};
+
+export const resolveVersionManagerPaths = (): string[] => {
+  const versionedPaths: Array<{ path: string; version: string }> = [];
+  const staticPaths: string[] = [];
+  const home = process.env.HOME;
+
+  if (!home) return [];
+
+  const nvmVersionsDir = join(home, ".nvm", "versions", "node");
+  try {
+    const nodeVersions = readdirSync(nvmVersionsDir);
+    for (const version of nodeVersions) {
+      const binPath = join(nvmVersionsDir, version, "bin");
+      if (existsSync(binPath)) {
+        versionedPaths.push({ path: binPath, version });
+      }
+    }
+  } catch {
+    // Ignore missing or unreadable directories.
+  }
+
+  const fnmBaseDir = resolveFnmBaseDir(home);
+  if (fnmBaseDir) {
+    const fnmVersionsDir = join(fnmBaseDir, "node-versions");
+
+    try {
+      const nodeVersions = readdirSync(fnmVersionsDir);
+      for (const version of nodeVersions) {
+        const binPath = join(fnmVersionsDir, version, "installation", "bin");
+        if (existsSync(binPath)) {
+          versionedPaths.push({ path: binPath, version });
+        }
+      }
+    } catch {
+      // Ignore missing or unreadable directories.
+    }
+  }
+
+  const staticPathCandidates = [join(home, ".n", "bin"), join(home, ".volta", "bin")];
+
+  for (const path of staticPathCandidates) {
+    if (existsSync(path)) {
+      staticPaths.push(path);
+    }
+  }
+
+  const sortedVersionedPaths = sortPathsByVersion(versionedPaths);
+  return [...sortedVersionedPaths, ...staticPaths];
+};
+
+export const getEnhancedNodePaths = (): string => {
+  if (cachedPaths !== null) return cachedPaths;
+
+  if (isWindows) {
+    cachedPaths = process.env.PATH || "";
+    return cachedPaths;
+  }
+
+  const isAppleSilicon = getAppleSiliconStatus();
+
+  const platformPaths = isAppleSilicon
+    ? ["/opt/homebrew/bin", "/opt/homebrew/lib/node_modules/.bin"]
+    : ["/usr/local/bin", "/usr/local/lib/node_modules/.bin"];
+
+  const versionManagerPaths = resolveVersionManagerPaths();
+
+  const systemPaths = ["/usr/bin", "/bin"];
+
+  if (process.env.HOME) {
+    systemPaths.push(`${process.env.HOME}/.npm/bin`, `${process.env.HOME}/.yarn/bin`);
+  }
+
+  // Preserve the current PATH first, then prepend common package-manager and version-manager locations
+  const allPaths = [process.env.PATH || "", ...platformPaths, ...versionManagerPaths, ...systemPaths];
+
+  cachedPaths = allPaths.filter((path) => path).join(":");
+  return cachedPaths;
+};
+
+export const clearPathCache = (): void => {
+  cachedPaths = null;
+  cachedIsAppleSilicon = null;
+};

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -31,8 +31,8 @@ function buildSkillsCliCommand(npxCommand: string, args: string[]): string {
 async function runSkillsCli(args: string[]): Promise<string> {
   const npxCommand = getCustomNpxPath() ?? "npx";
   try {
-    const { stdout } = await execAsync(buildSkillsCliCommand(npxCommand, args), getExecOptions());
-    return stdout.toString();
+    const { stdout } = await execAsync(buildSkillsCliCommand(npxCommand, args), await getExecOptions());
+    return stdout;
   } catch (error) {
     throw normalizeCliError(error, npxCommand);
   }

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -1,23 +1,41 @@
-import { exec } from "child_process";
-import { promisify } from "util";
-import { homedir } from "os";
+import { homedir } from "node:os";
+import { basename } from "node:path";
+import { getCustomNpxPath } from "../preferences";
 import type { InstalledSkill, Skill } from "../shared";
+import { execAsync } from "./exec-async";
+import { getExecOptions } from "./exec-options";
 
-const execAsync = promisify(exec);
 const home = homedir();
 const isWindows = process.platform === "win32";
-const SKILLS_CLI = "npx -y skills@latest";
 
-/**
- * Run a CLI command with the user's full PATH.
- * - macOS/Linux: wraps in `zsh -l -c` so PATH includes mise, nvm, homebrew, etc.
- * - Windows: runs directly via cmd since PATH is inherited.
- */
-function execWithPath(command: string) {
-  if (isWindows) {
-    return execAsync(command);
+type ExecFailure = Error & {
+  code?: string | number;
+  stderr?: string;
+};
+
+export class NpxResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NpxResolutionError";
   }
-  return execAsync(`zsh -l -c ${shellEscape(command)}`);
+}
+
+export function isNpxResolutionError(error: unknown): boolean {
+  return error instanceof NpxResolutionError;
+}
+
+function buildSkillsCliCommand(npxCommand: string, args: string[]): string {
+  return [npxCommand, "-y", "skills@latest", ...args].map(shellEscape).join(" ");
+}
+
+async function runSkillsCli(args: string[]): Promise<string> {
+  const npxCommand = getCustomNpxPath() ?? "npx";
+  try {
+    const { stdout } = await execAsync(buildSkillsCliCommand(npxCommand, args), getExecOptions());
+    return stdout.toString();
+  } catch (error) {
+    throw normalizeCliError(error, npxCommand);
+  }
 }
 
 // eslint-disable-next-line no-control-regex
@@ -37,6 +55,48 @@ function shellEscape(arg: string): string {
     return `"${arg.replace(/"/g, '\\"')}"`;
   }
   return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+function normalizeCliError(error: unknown, npxCommand: string): Error {
+  if (isNpxCommandResolutionFailure(error, npxCommand)) {
+    return new NpxResolutionError(
+      "Unable to find a working npx command. Run `which npx` in Terminal, then set that path in Extension Preferences under 'Custom npx Path'.",
+    );
+  }
+
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error("Failed to execute the skills CLI command.");
+}
+
+function isNpxCommandResolutionFailure(error: unknown, npxCommand: string): boolean {
+  const failure = error as ExecFailure | undefined;
+  const code = typeof failure?.code === "string" || typeof failure?.code === "number" ? String(failure.code) : "";
+  const details = [failure?.message, failure?.stderr]
+    .filter((value): value is string => typeof value === "string")
+    .join("\n")
+    .toLowerCase();
+  const normalizedNpxCommand = npxCommand.toLowerCase();
+  const commandBase = basename(normalizedNpxCommand).replace(/\.exe$/, "");
+  const windowsCommandNotFound = `'${commandBase}' is not recognized as an internal or external command`;
+
+  const mentionsCommand =
+    details.includes(`spawn ${normalizedNpxCommand} `) ||
+    details.includes(`spawn ${commandBase} `) ||
+    details.includes(`command not found: ${commandBase}`) ||
+    details.includes(`${commandBase}: command not found`) ||
+    details.includes(windowsCommandNotFound);
+
+  return (
+    (code === "ENOENT" && mentionsCommand) ||
+    details.includes(`spawn ${normalizedNpxCommand} enoent`) ||
+    details.includes(`spawn ${commandBase} enoent`) ||
+    details.includes(`command not found: ${commandBase}`) ||
+    details.includes(`${commandBase}: command not found`) ||
+    details.includes(windowsCommandNotFound)
+  );
 }
 
 /** Shape of each entry from `skills list --json` */
@@ -61,7 +121,7 @@ function parseSkillsListJson(stdout: string): InstalledSkill[] {
 }
 
 export async function listInstalledSkills(): Promise<InstalledSkill[]> {
-  const { stdout } = await execWithPath(`${SKILLS_CLI} list -g --json`);
+  const stdout = await runSkillsCli(["list", "-g", "--json"]);
   try {
     return parseSkillsListJson(stdout);
   } catch {
@@ -70,11 +130,11 @@ export async function listInstalledSkills(): Promise<InstalledSkill[]> {
 }
 
 export async function installSkill(skill: Skill): Promise<void> {
-  await execWithPath(`${SKILLS_CLI} add ${shellEscape(`${skill.source}@${skill.skillId}`)} -g -y`);
+  await runSkillsCli(["add", `${skill.source}@${skill.skillId}`, "-g", "-y"]);
 }
 
 export async function removeSkill(skillName: string): Promise<void> {
-  await execWithPath(`${SKILLS_CLI} remove ${shellEscape(skillName)} -g -y`);
+  await runSkillsCli(["remove", skillName, "-g", "-y"]);
 }
 
 /**
@@ -82,7 +142,7 @@ export async function removeSkill(skillName: string): Promise<void> {
  * Parses `npx -y skills@latest check` output for "↑ skillName" lines.
  */
 export async function checkForUpdates(): Promise<string[]> {
-  const { stdout } = await execWithPath(`${SKILLS_CLI} check`);
+  const stdout = await runSkillsCli(["check"]);
   return stripAnsi(stdout)
     .split("\n")
     .map((line) => line.match(/↑\s+(\S+)/))
@@ -94,5 +154,5 @@ export async function checkForUpdates(): Promise<string[]> {
  * Update all installed skills.
  */
 export async function updateAllSkills(): Promise<void> {
-  await execWithPath(`${SKILLS_CLI} update -y`);
+  await runSkillsCli(["update", "-y"]);
 }


### PR DESCRIPTION
## Description

This change updates the CLI execution path to function more reliably on macOS setups where `npx` is not available in the default shell environment. In my case, the extension was not working because it couldn't resolve `npx` properly.

The previous implementation relied on zsh login-shell execution. To make this more robust, this change follows the same general approach used by other Raycast extensions, and specifically I followed the approach in [ccusage](https://github.com/raycast/extensions/tree/main/extensions/ccusage): resolve `npx` from known Node installation locations and version-manager paths instead of depending on shell startup behavior.

Additionally, the changes allow users with uncommon setups to specify a custom path for `npx`, enabling them to direct the extension to the exact `npx` path they wish to use.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
