### PR TITLE
Add cmux external terminal support to Shell extension, improve external terminal execution consistency

### DIFF
--- a/extensions/shell/CHANGELOG.md
+++ b/extensions/shell/CHANGELOG.md
@@ -1,12 +1,12 @@
 # shell Changelog
 
-## [Add cmux support] - {PR_MERGE_DATE}
-
 ## [Fix external terminal execution consistency] - 2026-03-05
 
 - Fix Ghostty command injection so commands are entered and executed reliably.
 - Update external terminal runners to return explicit success/failure signals and only show success HUD on true execution.
 - Improve Warp/Ghostty focus + submit flow to auto-run commands instead of leaving them prefilled.
+
+## [Add cmux support] - {PR_MERGE_DATE}
 
 Adds support for running shell commands in `cmux`, including:
 

--- a/extensions/shell/CHANGELOG.md
+++ b/extensions/shell/CHANGELOG.md
@@ -1,5 +1,15 @@
 # shell Changelog
 
+## [Add cmux support] - 2026-03-03
+
+Adds support for running shell commands in `cmux`, including:
+
+- External terminal selection for `cmux`
+- Optional run mode preference (`Active Workspace` or `New Workspace`)
+- Socket path override preference
+- Keychain-first password mode support with optional extension password fallback
+- Improved failure toasts for socket/auth/workspace errors
+
 ## [Fix edit executed command] - 2026-02-16
 
 Fix edit command that was not in recent section, but on shell history.

--- a/extensions/shell/CHANGELOG.md
+++ b/extensions/shell/CHANGELOG.md
@@ -1,11 +1,5 @@
 # shell Changelog
 
-## [Fix external terminal execution consistency] - 2026-03-05
-
-- Fix Ghostty command injection so commands are entered and executed reliably.
-- Update external terminal runners to return explicit success/failure signals and only show success HUD on true execution.
-- Improve Warp/Ghostty focus + submit flow to auto-run commands instead of leaving them prefilled.
-
 ## [Add cmux support] - {PR_MERGE_DATE}
 
 Adds support for running shell commands in `cmux`, including:
@@ -15,6 +9,12 @@ Adds support for running shell commands in `cmux`, including:
 - Socket path override preference
 - Keychain-first password mode support with optional extension password fallback
 - Improved failure toasts for socket/auth/workspace errors
+
+## [Fix external terminal execution consistency] - 2026-03-05
+
+- Fix Ghostty command injection so commands are entered and executed reliably.
+- Update external terminal runners to return explicit success/failure signals and only show success HUD on true execution.
+- Improve Warp/Ghostty focus + submit flow to auto-run commands instead of leaving them prefilled.
 
 ## [Fix edit executed command] - 2026-02-16
 

--- a/extensions/shell/CHANGELOG.md
+++ b/extensions/shell/CHANGELOG.md
@@ -1,6 +1,6 @@
 # shell Changelog
 
-## [Add cmux support] - 2026-03-03
+## [Add cmux support] - {PR_MERGE_DATE}
 
 Adds support for running shell commands in `cmux`, including:
 

--- a/extensions/shell/CHANGELOG.md
+++ b/extensions/shell/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Add cmux support] - {PR_MERGE_DATE}
 
+## [Fix external terminal execution consistency] - 2026-03-05
+
+- Fix Ghostty command injection so commands are entered and executed reliably.
+- Update external terminal runners to return explicit success/failure signals and only show success HUD on true execution.
+- Improve Warp/Ghostty focus + submit flow to auto-run commands instead of leaving them prefilled.
+
 Adds support for running shell commands in `cmux`, including:
 
 - External terminal selection for `cmux`

--- a/extensions/shell/package-lock.json
+++ b/extensions/shell/package-lock.json
@@ -8,6 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.89.1",
+        "ray": "^0.0.1",
         "raycast-toolkit": "^1.0.6",
         "run-applescript": "^6.0.0",
         "shell-env": "^4.0.1",
@@ -1066,17 +1067,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@oclif/plugin-not-found/node_modules/@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@oclif/plugin-not-found/node_modules/fast-levenshtein": {
@@ -2788,6 +2778,11 @@
         }
       ]
     },
+    "node_modules/ray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/ray/-/ray-0.0.1.tgz",
+      "integrity": "sha512-yyKtRfrxOL39pjJArN6cw7ZnMnPsFeZsDKWO3aoJ8uK1wulWzbVJ5PbUC62pRPKjdSym0f+HwiWyellASrcXxQ=="
+    },
     "node_modules/raycast-toolkit": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/raycast-toolkit/-/raycast-toolkit-1.0.6.tgz",
@@ -3197,14 +3192,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3843,16 +3830,6 @@
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.9.tgz",
           "integrity": "sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==",
           "requires": {}
-        },
-        "@types/node": {
-          "version": "22.13.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-          "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "undici-types": "~6.20.0"
-          }
         },
         "fast-levenshtein": {
           "version": "3.0.0",
@@ -5017,6 +4994,11 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
+    "ray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/ray/-/ray-0.0.1.tgz",
+      "integrity": "sha512-yyKtRfrxOL39pjJArN6cw7ZnMnPsFeZsDKWO3aoJ8uK1wulWzbVJ5PbUC62pRPKjdSym0f+HwiWyellASrcXxQ=="
+    },
     "raycast-toolkit": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/raycast-toolkit/-/raycast-toolkit-1.0.6.tgz",
@@ -5280,13 +5262,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true
-    },
-    "undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "optional": true,
-      "peer": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/extensions/shell/package.json
+++ b/extensions/shell/package.json
@@ -192,8 +192,11 @@
     {
       "name": "cmux_run_mode",
       "type": "dropdown",
+    {
+      "name": "cmux_run_mode",
+      "type": "dropdown",
       "required": false,
-      "title": "cmux Run Mode",
+      "title": "Cmux Run Mode",
       "description": "Choose whether commands run in the active cmux workspace or in a newly created workspace.",
       "data": [
         {
@@ -211,14 +214,14 @@
       "name": "cmux_socket_path",
       "type": "textfield",
       "required": false,
-      "title": "cmux Socket Path",
+      "title": "Cmux Socket Path",
       "description": "Optional override for the cmux control socket path. If empty, uses CMUX_SOCKET_PATH or /tmp/cmux.sock."
     },
     {
       "name": "cmux_socket_password",
       "type": "password",
       "required": false,
-      "title": "cmux Socket Password",
+      "title": "Cmux Socket Password",
       "description": "Optional override. If unset, cmux keychain password is used in password mode."
     }
   ],

--- a/extensions/shell/package.json
+++ b/extensions/shell/package.json
@@ -192,9 +192,6 @@
     {
       "name": "cmux_run_mode",
       "type": "dropdown",
-    {
-      "name": "cmux_run_mode",
-      "type": "dropdown",
       "required": false,
       "title": "Cmux Run Mode",
       "description": "Choose whether commands run in the active cmux workspace or in a newly created workspace.",
@@ -227,6 +224,7 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.89.1",
+    "ray": "^0.0.1",
     "raycast-toolkit": "^1.0.6",
     "run-applescript": "^6.0.0",
     "shell-env": "^4.0.1",

--- a/extensions/shell/package.json
+++ b/extensions/shell/package.json
@@ -148,7 +148,7 @@
       "type": "dropdown",
       "required": false,
       "title": "Decide which Terminal Application you want to use",
-      "description": "Pick the external terminal to run commands in (iTerm/Warp/kitty/Ghostty on macOS, PowerShell/PowerShell 7/Command Prompt on Windows).",
+      "description": "Pick the external terminal to run commands in (iTerm/Warp/kitty/Ghostty/cmux on macOS, PowerShell/PowerShell 7/Command Prompt on Windows).",
       "data": [
         {
           "title": "Terminal",
@@ -171,6 +171,10 @@
           "value": "ghostty"
         },
         {
+          "title": "cmux",
+          "value": "cmux"
+        },
+        {
           "title": "PowerShell",
           "value": "powershell"
         },
@@ -184,6 +188,38 @@
         }
       ],
       "default": "Terminal"
+    },
+    {
+      "name": "cmux_run_mode",
+      "type": "dropdown",
+      "required": false,
+      "title": "cmux Run Mode",
+      "description": "Choose whether commands run in the active cmux workspace or in a newly created workspace.",
+      "data": [
+        {
+          "title": "Active Workspace",
+          "value": "activeWorkspace"
+        },
+        {
+          "title": "New Workspace",
+          "value": "newWorkspace"
+        }
+      ],
+      "default": "activeWorkspace"
+    },
+    {
+      "name": "cmux_socket_path",
+      "type": "textfield",
+      "required": false,
+      "title": "cmux Socket Path",
+      "description": "Optional override for the cmux control socket path. If empty, uses CMUX_SOCKET_PATH or /tmp/cmux.sock."
+    },
+    {
+      "name": "cmux_socket_password",
+      "type": "password",
+      "required": false,
+      "title": "cmux Socket Password",
+      "description": "Optional override. If unset, cmux keychain password is used in password mode."
     }
   ],
   "dependencies": {

--- a/extensions/shell/src/index.tsx
+++ b/extensions/shell/src/index.tsx
@@ -34,6 +34,14 @@ interface ShellArguments {
   command: string;
 }
 
+interface Preferences {
+  arguments_terminal: boolean;
+  arguments_terminal_type: string;
+  cmux_run_mode: string;
+  cmux_socket_path: string;
+  cmux_socket_password: string;
+}
+
 let cachedEnv: null | EnvType = null;
 
 const escapePosixCommand = (command: string) => command.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
@@ -424,97 +432,32 @@ const runInWarp = async (command: string) => {
 };
 
 const runInGhostty = async (command: string) => {
-  const escapedCommand = escapeAppleScriptString(command);
-  const script = `
-      -- Set this property to true to always open in a new window
-      property open_in_new_window : true
+  // 1. Open/activate Ghostty
+  spawnSync("/usr/bin/open", ["-a", "Ghostty"], { encoding: "utf8" });
 
-      -- Set this property to true to always open in a new tab
-      property open_in_new_tab : false
+  // 2. Write osascript to a temp file to safely handle special characters in command
+  //    (avoids shell/AppleScript string escaping issues on the command line)
+  const asEscaped = command.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const typeScript = `tell application "System Events" to tell process "Ghostty" to keystroke "${asEscaped}"`;
+  spawnSync("bash", ["-c", "cat > /tmp/ghostty-type.scpt"], { input: typeScript, encoding: "utf8" });
 
-      -- Reset this property to false
-      property opened_new_window : false
+  // 3. Short synchronous wait — must stay within Raycast's ~2.3s process window.
+  //    Running inside the Raycast process ensures Accessibility is inherited.
+  spawnSync("sleep", ["0.8"]);
 
-      -- Handlers
-      on new_window()
-          tell application "System Events" to tell process "Ghostty"
-              click menu item "New Window" of menu "File" of menu bar 1
-              set frontmost to true
-          end tell
-      end new_window
+  // 4. Type the command into Ghostty
+  spawnSync("/usr/bin/osascript", ["/tmp/ghostty-type.scpt"], { encoding: "utf8" });
 
-      on new_tab()
-          tell application "System Events" to tell process "Ghostty"
-              click menu item "New Tab" of menu "File" of menu bar 1
-              set frontmost to true
-          end tell
-      end new_tab
+  // 5. Press enter
+  spawnSync("sleep", ["0.1"]);
+  spawnSync("/usr/bin/osascript", [
+    "-e",
+    'tell application "System Events" to tell process "Ghostty" to key code 36',
+  ], { encoding: "utf8" });
 
-      on call_forward()
-          tell application "Ghostty" to activate
-      end call_forward
-
-      on is_running()
-          application "Ghostty" is running
-      end is_running
-
-      on has_windows()
-          if not is_running() then return false
-          tell application "System Events"
-              if windows of process "Ghostty" is {} then return false
-          end tell
-          true
-      end has_windows
-
-      on send_text(custom_text)
-          tell application "System Events"
-              keystroke custom_text
-          end tell
-      end send_text
-
-      on press_enter()
-          tell application "System Events"
-              key code 36
-          end tell
-      end press_enter
-
-
-      -- Main
-      if not is_running() then
-          call_forward()
-          set opened_new_window to true
-      else
-          call_forward()
-          set opened_new_window to false
-      end if
-
-      if has_windows() then
-          if open_in_new_window and not opened_new_window then
-              new_window()
-          else if open_in_new_tab and not opened_new_window then
-              new_tab()
-          end if
-      else
-          new_window()
-      end if
-
-
-      -- Make sure a window exists before we continue, or the write may fail
-      repeat until has_windows()
-          delay 0.5
-      end repeat
-      delay 0.5
-
-      call_forward()
-      delay 0.1
-      send_text("${escapedCommand}")
-      delay 0.05
-      press_enter()
-      call_forward()
-  `;
-
-  return runAppleScriptSafe(script, "Ghostty");
+  return true;
 };
+
 
 const runInTerminal = async (command: string) => {
   const escapedCommand = escapeAppleScriptString(command);

--- a/extensions/shell/src/index.tsx
+++ b/extensions/shell/src/index.tsx
@@ -33,13 +33,6 @@ export interface EnvType {
 interface ShellArguments {
   command: string;
 }
-interface Preferences {
-  arguments_terminal: boolean;
-  arguments_terminal_type: string;
-  cmux_run_mode?: "activeWorkspace" | "newWorkspace";
-  cmux_socket_path?: string;
-  cmux_socket_password?: string;
-}
 
 let cachedEnv: null | EnvType = null;
 

--- a/extensions/shell/src/index.tsx
+++ b/extensions/shell/src/index.tsx
@@ -14,7 +14,7 @@ import {
 } from "@raycast/api";
 import { shellHistory } from "shell-history";
 import { shellEnv } from "shell-env";
-import { ChildProcess, exec } from "child_process";
+import { ChildProcess, exec, spawnSync } from "child_process";
 import { usePersistentState } from "raycast-toolkit";
 import fs from "fs";
 import { runAppleScript } from "run-applescript";
@@ -36,6 +36,9 @@ interface ShellArguments {
 interface Preferences {
   arguments_terminal: boolean;
   arguments_terminal_type: string;
+  cmux_run_mode?: "activeWorkspace" | "newWorkspace";
+  cmux_socket_path?: string;
+  cmux_socket_password?: string;
 }
 
 let cachedEnv: null | EnvType = null;
@@ -476,6 +479,296 @@ const runInTerminal = (command: string) => {
   runAppleScript(script);
 };
 
+const CMUX_APP_PATH = "/Applications/cmux.app";
+const CMUX_CLI_PATH = "/Applications/cmux.app/Contents/Resources/bin/cmux";
+const CMUX_DEFAULT_SOCKET_PATH = "/tmp/cmux.sock";
+const CMUX_BUNDLE_ID = "com.cmuxterm.app";
+const CMUX_SOCKET_MODES = {
+  cmuxOnly: "cmuxonly",
+  password: "password",
+  external: "external",
+} as const;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isSocketPath = (path: string) => {
+  try {
+    return fs.statSync(path).isSocket();
+  } catch {
+    return false;
+  }
+};
+
+const redactSecrets = (text: string, secrets: Array<string | undefined>) => {
+  let sanitized = text;
+  for (const secret of secrets) {
+    if (!secret) {
+      continue;
+    }
+    sanitized = sanitized.split(secret).join("[REDACTED]");
+  }
+  return sanitized;
+};
+
+const getCommandError = (result: { stderr?: string; stdout?: string; status: number | null }, secrets: string[] = []) => {
+  const stderr = result?.stderr?.toString().trim() || "";
+  if (stderr) {
+    return redactSecrets(stderr, secrets);
+  }
+
+  const stdout = result?.stdout?.toString().trim() || "";
+  if (stdout) {
+    return redactSecrets(stdout, secrets);
+  }
+
+  return `Process exited with code ${result?.status ?? "unknown"}`;
+};
+
+const showCmuxFailure = (title: string, message: string) => {
+  showToast({
+    style: Toast.Style.Failure,
+    title,
+    message,
+  });
+};
+
+const resolveCmuxSocketPath = (configuredSocketPath?: string) => {
+  const preferredSocketPath = configuredSocketPath?.trim();
+  if (preferredSocketPath) {
+    return preferredSocketPath;
+  }
+  if (process.env.CMUX_SOCKET_PATH?.trim()) {
+    return process.env.CMUX_SOCKET_PATH.trim();
+  }
+  return CMUX_DEFAULT_SOCKET_PATH;
+};
+
+const readCmuxSocketMode = () => {
+  const result = spawnSync("/usr/bin/defaults", ["read", CMUX_BUNDLE_ID, "socketControlMode"], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    return "";
+  }
+  return result.stdout.trim().toLowerCase();
+};
+
+const runCmuxCli = (
+  args: string[],
+  options?: {
+    socketPath?: string;
+    password?: string;
+    json?: boolean;
+  },
+) => {
+  const fullArgs: string[] = [];
+  if (options?.socketPath) {
+    fullArgs.push("--socket", options.socketPath);
+  }
+  if (options?.json) {
+    fullArgs.push("--json");
+  }
+  fullArgs.push(...args);
+
+  const env = { ...process.env };
+  if (options?.password) {
+    env.CMUX_SOCKET_PASSWORD = options.password;
+  }
+  return spawnSync(CMUX_CLI_PATH, fullArgs, { encoding: "utf8", env });
+};
+
+const getCmuxAuthAttempts = (socketMode: string, extensionPassword?: string) => {
+  const password = extensionPassword?.trim() || "";
+  if (socketMode === CMUX_SOCKET_MODES.password) {
+    return [{ password: undefined as string | undefined }, ...password ? [{ password }] : []];
+  }
+  return [{ password: undefined as string | undefined }];
+};
+
+const waitForCmuxConnection = async (socketPath: string, authAttempts: Array<{ password?: string }>) => {
+  let lastError = "";
+  for (let i = 0; i < 20; i++) {
+    if (isSocketPath(socketPath)) {
+      for (const authAttempt of authAttempts) {
+        const pingResult = runCmuxCli(["ping"], { socketPath, password: authAttempt.password });
+        if (pingResult.status === 0) {
+          return { ok: true as const, authPassword: authAttempt.password };
+        }
+        lastError = getCommandError(pingResult, [authAttempt.password ?? ""]);
+      }
+    }
+    await sleep(200);
+  }
+
+  return {
+    ok: false as const,
+    error: lastError || `Unable to connect to cmux socket at ${socketPath}`,
+  };
+};
+
+const readWorkspaceFromOutput = (rawOutput: string) => {
+  const text = rawOutput.trim();
+  if (!text) {
+    return "";
+  }
+
+  const refMatch = text.match(/workspace:\d+/);
+  if (refMatch?.[0]) {
+    return refMatch[0];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return "";
+  }
+
+  const candidates: string[] = [];
+  const collectValues = (value: unknown) => {
+    if (value === null || value === undefined) {
+      return;
+    }
+    if (typeof value === "string") {
+      candidates.push(value.trim());
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        collectValues(entry);
+      }
+      return;
+    }
+    if (typeof value === "object") {
+      for (const [key, entry] of Object.entries(value)) {
+        if (typeof entry === "string" && ["workspace", "workspaceRef", "workspaceId", "id", "ref"].includes(key)) {
+          candidates.push(entry.trim());
+        }
+        collectValues(entry);
+      }
+    }
+  };
+  collectValues(parsed);
+
+  const workspaceRef = candidates.find((value) => value.startsWith("workspace:"));
+  if (workspaceRef) {
+    return workspaceRef;
+  }
+
+  const uuidValue = candidates.find((value) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value),
+  );
+  return uuidValue || "";
+};
+
+const getCurrentWorkspace = (socketPath: string, authPassword?: string) => {
+  const workspaceResult = runCmuxCli(["current-workspace"], { socketPath, password: authPassword, json: true });
+  if (workspaceResult.status !== 0) {
+    return {
+      ok: false as const,
+      error: getCommandError(workspaceResult, [authPassword ?? ""]),
+    };
+  }
+  const workspace = readWorkspaceFromOutput(workspaceResult.stdout || "");
+  if (!workspace) {
+    return {
+      ok: false as const,
+      error: "Could not resolve active workspace from cmux output.",
+    };
+  }
+  return { ok: true as const, workspace };
+};
+
+const runInCmux = async (
+  command: string,
+  options?: {
+    runMode?: "activeWorkspace" | "newWorkspace";
+    socketPathPreference?: string;
+    socketPassword?: string;
+  },
+) => {
+  if (!fs.existsSync(CMUX_APP_PATH) || !fs.existsSync(CMUX_CLI_PATH)) {
+    showCmuxFailure("cmux is not installed", `Install cmux at ${CMUX_APP_PATH} before using this terminal target.`);
+    return false;
+  }
+
+  const socketMode = readCmuxSocketMode();
+  const socketPath = resolveCmuxSocketPath(options?.socketPathPreference);
+  if (socketMode === CMUX_SOCKET_MODES.cmuxOnly) {
+    showCmuxFailure(
+      "cmux socket mode blocks external clients",
+      "Set cmux socket mode to external or password in cmux settings.",
+    );
+    return false;
+  }
+
+  const launchResult = spawnSync("/usr/bin/open", ["-a", "cmux"], { encoding: "utf8" });
+  if (launchResult.status !== 0) {
+    showCmuxFailure("Could not launch cmux", getCommandError(launchResult));
+    return false;
+  }
+
+  const authAttempts = getCmuxAuthAttempts(socketMode, options?.socketPassword);
+  const connectionResult = await waitForCmuxConnection(socketPath, authAttempts);
+  if (!connectionResult.ok) {
+    showCmuxFailure(
+      "cmux is not ready",
+      connectionResult.error ||
+        "Could not authenticate to cmux. If password mode is enabled, verify keychain access or set extension password override.",
+    );
+    return false;
+  }
+
+  if ((options?.runMode ?? "activeWorkspace") === "newWorkspace") {
+    const newWorkspaceResult = runCmuxCli(["new-workspace", "--command", command], {
+      socketPath,
+      password: connectionResult.authPassword,
+    });
+    if (newWorkspaceResult.status !== 0) {
+      showCmuxFailure(
+        "Failed to run command in new cmux workspace",
+        getCommandError(newWorkspaceResult, [connectionResult.authPassword ?? ""]),
+      );
+      return false;
+    }
+    return true;
+  }
+
+  const workspaceResult = getCurrentWorkspace(socketPath, connectionResult.authPassword);
+  if (!workspaceResult.ok) {
+    showCmuxFailure(
+      "Failed to resolve active cmux workspace",
+      `${workspaceResult.error} Try switching run mode to 'New Workspace'.`,
+    );
+    return false;
+  }
+
+  const sendResult = runCmuxCli(["send", "--workspace", workspaceResult.workspace, command], {
+    socketPath,
+    password: connectionResult.authPassword,
+  });
+  if (sendResult.status !== 0) {
+    showCmuxFailure(
+      "Failed to send command to active cmux workspace",
+      `${getCommandError(sendResult, [connectionResult.authPassword ?? ""])}. Try switching run mode to 'New Workspace' or adjust cmux socket mode.`,
+    );
+    return false;
+  }
+
+  const enterResult = runCmuxCli(["send-key", "--workspace", workspaceResult.workspace, "enter"], {
+    socketPath,
+    password: connectionResult.authPassword,
+  });
+  if (enterResult.status !== 0) {
+    showCmuxFailure(
+      "Failed to submit command in cmux",
+      getCommandError(enterResult, [connectionResult.authPassword ?? ""]),
+    );
+    return false;
+  }
+  return true;
+};
+
 export default function Command(props: { arguments?: ShellArguments }) {
   const [cmd, setCmd] = useState<string>("");
   const [history, setHistory] = useState<string[]>();
@@ -485,6 +778,7 @@ export default function Command(props: { arguments?: ShellArguments }) {
   const kittyInstalled = fs.existsSync("/Applications/kitty.app");
   const WarpInstalled = fs.existsSync("/Applications/Warp.app");
   const GhosttyInstalled = fs.existsSync("/Applications/Ghostty.app");
+  const cmuxInstalled = fs.existsSync(CMUX_APP_PATH);
 
   const addToRecentlyUsed = (command: string) => {
     setRecentlyUsed((list) => (list.find((x) => x === command) ? list : [command, ...list].slice(0, 10)));
@@ -501,8 +795,14 @@ export default function Command(props: { arguments?: ShellArguments }) {
     }
   }, []);
 
-  const { arguments_terminal_type: terminalType, arguments_terminal: openInTerminal } =
-    getPreferenceValues<Preferences>();
+  const {
+    arguments_terminal_type: terminalType,
+    arguments_terminal: openInTerminal,
+    cmux_run_mode: cmuxRunModePreference,
+    cmux_socket_path: cmuxSocketPathPreference,
+    cmux_socket_password: cmuxSocketPassword,
+  } = getPreferenceValues<Preferences>();
+  const cmuxRunMode = cmuxRunModePreference === "newWorkspace" ? "newWorkspace" : "activeWorkspace";
   const normalizedTerminalType = (terminalType?.toLowerCase?.() ?? (isWindows ? "powershell" : "terminal")) as string;
 
   const getTerminalDisplayName = () => {
@@ -519,42 +819,50 @@ export default function Command(props: { arguments?: ShellArguments }) {
         return "Warp";
       case "ghostty":
         return "Ghostty";
+      case "cmux":
+        return "cmux";
       default:
         return "Terminal";
     }
   };
 
-  const openCommandInPreferredTerminal = (command: string) => {
+  const openCommandInPreferredTerminal = async (command: string) => {
     if (isWindows) {
       const runner = getWindowsRunner(normalizedTerminalType);
       runner(command);
-      return;
+      return true;
     }
 
     switch (normalizedTerminalType) {
       case "kitty":
         runInKitty(command);
-        break;
+        return true;
       case "iterm":
         runInIterm(command);
-        break;
+        return true;
       case "warp":
         runInWarp(command);
-        break;
+        return true;
       case "ghostty":
         runInGhostty(command);
-        break;
+        return true;
+      case "cmux":
+        return await runInCmux(command, {
+          runMode: cmuxRunMode,
+          socketPathPreference: cmuxSocketPathPreference,
+          socketPassword: cmuxSocketPassword,
+        });
       default:
         runInTerminal(command);
-        break;
+        return true;
     }
   };
 
-  const handleExternalRun = (command: string, runner: (value: string) => void) => {
+  const handleExternalRun = async (command: string, runner: (value: string) => void | Promise<boolean>) => {
     closeMainWindow();
     popToRoot();
     addToRecentlyUsed(command);
-    runner(command);
+    await Promise.resolve(runner(command));
   };
 
   useEffect(() => {
@@ -570,11 +878,22 @@ export default function Command(props: { arguments?: ShellArguments }) {
     executedArgumentRef.current = executionKey;
 
     addToRecentlyUsed(commandArgument);
-    showHUD(`Ran command in ${getTerminalDisplayName()}`);
-    openCommandInPreferredTerminal(commandArgument);
-    closeMainWindow();
-    popToRoot();
-  }, [props.arguments?.command, openInTerminal, normalizedTerminalType]);
+    (async () => {
+      const didRun = await openCommandInPreferredTerminal(commandArgument);
+      if (didRun) {
+        showHUD(`Ran command in ${getTerminalDisplayName()}`);
+      }
+      closeMainWindow();
+      popToRoot();
+    })();
+  }, [
+    props.arguments?.command,
+    openInTerminal,
+    normalizedTerminalType,
+    cmuxRunMode,
+    cmuxSocketPathPreference,
+    cmuxSocketPassword,
+  ]);
 
   if (props.arguments?.command) {
     if (openInTerminal) {
@@ -666,6 +985,21 @@ export default function Command(props: { arguments?: ShellArguments }) {
                           title="Execute in Warp.app"
                           icon={{ fileIcon: "/Applications/Warp.app" }}
                           onAction={() => handleExternalRun(command, runInWarp)}
+                        />
+                      ) : null}
+                      {cmuxInstalled ? (
+                        <Action
+                          title="Execute in cmux.app"
+                          icon={{ fileIcon: CMUX_APP_PATH }}
+                          onAction={() =>
+                            handleExternalRun(command, (cmd) =>
+                              runInCmux(cmd, {
+                                runMode: cmuxRunMode,
+                                socketPathPreference: cmuxSocketPathPreference,
+                                socketPassword: cmuxSocketPassword,
+                              }),
+                            )
+                          }
                         />
                       ) : null}
                       <Action

--- a/extensions/shell/src/index.tsx
+++ b/extensions/shell/src/index.tsx
@@ -37,6 +37,23 @@ interface ShellArguments {
 let cachedEnv: null | EnvType = null;
 
 const escapePosixCommand = (command: string) => command.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+const escapeAppleScriptString = (value: string) => value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+
+const runAppleScriptSafe = async (script: string, terminalName: string) => {
+  try {
+    await runAppleScript(script);
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to execute command in ${terminalName}`, error);
+    await showToast({
+      style: Toast.Style.Failure,
+      title: `Failed to run command in ${terminalName}`,
+      message,
+    });
+    return false;
+  }
+};
 
 const encodePowerShellString = (command: string) => Buffer.from(command, "utf16le").toString("base64");
 
@@ -45,27 +62,42 @@ const escapeForPowerShellSingleQuotes = (command: string) => command.replaceAll(
 const getPowerShellArgumentList = (escapedCommand: string) =>
   `'-NoLogo','-NoProfile','-NoExit','-Command','${escapedCommand}'`;
 
-const runDetachedPowerShellScript = (script: string) => {
+const runDetachedPowerShellScript = async (script: string, terminalName: string) => {
   if (!isWindows) {
-    return;
+    return false;
   }
 
-  exec(`powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodePowerShellString(script)}`);
+  try {
+    exec(`powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodePowerShellString(script)}`);
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to execute command in ${terminalName}`, error);
+    await showToast({
+      style: Toast.Style.Failure,
+      title: `Failed to run command in ${terminalName}`,
+      message,
+    });
+    return false;
+  }
 };
 
 const runInPowerShellConsole = (command: string) => {
   const escaped = escapeForPowerShellSingleQuotes(command);
-  runDetachedPowerShellScript(`Start-Process PowerShell -ArgumentList ${getPowerShellArgumentList(escaped)}`);
+  return runDetachedPowerShellScript(
+    `Start-Process PowerShell -ArgumentList ${getPowerShellArgumentList(escaped)}`,
+    "PowerShell",
+  );
 };
 
 const runInCommandPrompt = (command: string) => {
   const escaped = escapeForPowerShellSingleQuotes(command);
-  runDetachedPowerShellScript(`Start-Process cmd -ArgumentList '/d','/k','${escaped}'`);
+  return runDetachedPowerShellScript(`Start-Process cmd -ArgumentList '/d','/k','${escaped}'`, "Command Prompt");
 };
 
 const runInPowerShell7Console = (command: string) => {
   const escaped = escapeForPowerShellSingleQuotes(command);
-  runDetachedPowerShellScript(`
+  return runDetachedPowerShellScript(`
     $candidatePaths = @(
       "${envProgramFiles}\\PowerShell\\7\\pwsh.exe",
       "${envProgramFiles}\\PowerShell\\7-preview\\pwsh.exe",
@@ -84,7 +116,7 @@ const runInPowerShell7Console = (command: string) => {
     } else {
       Start-Process PowerShell -ArgumentList ${getPowerShellArgumentList(escaped)}
     }
-  `);
+  `, "PowerShell 7");
 };
 
 const WINDOWS_RUNNERS = {
@@ -218,18 +250,19 @@ const Result = ({ cmd }: { cmd: string }) => {
   );
 };
 
-const runInKitty = (command: string) => {
-  const escaped_command = command.replaceAll('"', '\\"');
+const runInKitty = async (command: string) => {
+  const escapedCommand = escapeAppleScriptString(command);
   const script = `
     tell application "System Events"
-      do shell script "/Applications/kitty.app/Contents/MacOS/kitty -1 kitten @ launch --hold ${escaped_command}"
+      do shell script "/Applications/kitty.app/Contents/MacOS/kitty -1 kitten @ launch --hold ${escapedCommand}"
     end tell
   `;
 
-  runAppleScript(script);
+  return runAppleScriptSafe(script, "kitty");
 };
 
-const runInIterm = (command: string) => {
+const runInIterm = async (command: string) => {
+  const escapedCommand = escapeAppleScriptString(command);
   const script = `
     -- Set this property to true to open in a new window instead of a new tab
     property open_in_new_window : false
@@ -287,14 +320,15 @@ const runInIterm = (command: string) => {
     	delay 0.01
     end repeat
 
-    send_text("${command.replaceAll('"', '\\"')}")
+    send_text("${escapedCommand}")
     call_forward()
   `;
 
-  runAppleScript(script);
+  return runAppleScriptSafe(script, "iTerm");
 };
 
-const runInWarp = (command: string) => {
+const runInWarp = async (command: string) => {
+  const escapedCommand = escapeAppleScriptString(command);
   const script = `
       -- For the latest version:
       -- https://github.com/DavidMChan/custom-alfred-warp-scripts
@@ -345,6 +379,12 @@ const runInWarp = (command: string) => {
           end tell
       end send_text
 
+      on press_enter()
+          tell application "System Events"
+              key code 36
+          end tell
+      end press_enter
+
 
       -- Main
       if not is_running() then
@@ -372,14 +412,19 @@ const runInWarp = (command: string) => {
       end repeat
       delay 0.5
 
-      send_text("${command}")
+      call_forward()
+      delay 0.1
+      send_text("${escapedCommand}")
+      delay 0.05
+      press_enter()
       call_forward()
   `;
 
-  runAppleScript(script);
+  return runAppleScriptSafe(script, "Warp");
 };
 
-const runInGhostty = (command: string) => {
+const runInGhostty = async (command: string) => {
+  const escapedCommand = escapeAppleScriptString(command);
   const script = `
       -- Set this property to true to always open in a new window
       property open_in_new_window : true
@@ -427,6 +472,12 @@ const runInGhostty = (command: string) => {
           end tell
       end send_text
 
+      on press_enter()
+          tell application "System Events"
+              key code 36
+          end tell
+      end press_enter
+
 
       -- Main
       if not is_running() then
@@ -454,22 +505,27 @@ const runInGhostty = (command: string) => {
       end repeat
       delay 0.5
 
-      send_text("${command}")
+      call_forward()
+      delay 0.1
+      send_text("${escapedCommand}")
+      delay 0.05
+      press_enter()
       call_forward()
   `;
 
-  runAppleScript(script);
+  return runAppleScriptSafe(script, "Ghostty");
 };
 
-const runInTerminal = (command: string) => {
+const runInTerminal = async (command: string) => {
+  const escapedCommand = escapeAppleScriptString(command);
   const script = `
   tell application "Terminal"
-    do script "${command.replaceAll('"', '\\"')}"
+    do script "${escapedCommand}"
     activate
   end tell
   `;
 
-  runAppleScript(script);
+  return runAppleScriptSafe(script, "Terminal");
 };
 
 const CMUX_APP_PATH = "/Applications/cmux.app";
@@ -822,23 +878,18 @@ export default function Command(props: { arguments?: ShellArguments }) {
   const openCommandInPreferredTerminal = async (command: string) => {
     if (isWindows) {
       const runner = getWindowsRunner(normalizedTerminalType);
-      runner(command);
-      return true;
+      return await runner(command);
     }
 
     switch (normalizedTerminalType) {
       case "kitty":
-        runInKitty(command);
-        return true;
+        return await runInKitty(command);
       case "iterm":
-        runInIterm(command);
-        return true;
+        return await runInIterm(command);
       case "warp":
-        runInWarp(command);
-        return true;
+        return await runInWarp(command);
       case "ghostty":
-        runInGhostty(command);
-        return true;
+        return await runInGhostty(command);
       case "cmux":
         return await runInCmux(command, {
           runMode: cmuxRunMode,
@@ -846,16 +897,15 @@ export default function Command(props: { arguments?: ShellArguments }) {
           socketPassword: cmuxSocketPassword,
         });
       default:
-        runInTerminal(command);
-        return true;
+        return await runInTerminal(command);
     }
   };
 
-  const handleExternalRun = async (command: string, runner: (value: string) => void | Promise<boolean>) => {
+  const handleExternalRun = async (command: string, runner: (value: string) => Promise<boolean>) => {
     closeMainWindow();
     popToRoot();
     addToRecentlyUsed(command);
-    await Promise.resolve(runner(command));
+    await runner(command);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add cmux as an external terminal option in the Shell extension
- add cmux preferences for run mode, socket path, and optional password override
- replace fragile cmux execution with preflighted CLI dispatch and explicit error surfacing

## cmux behavior
- auto-launch cmux before dispatch
- resolve socket path from preference/env/default
- detect socket control mode (external, password, cmuxOnly)
- use keychain-first auth in password mode, then optional extension password fallback
- support both active workspace send and new workspace execution
- show actionable failure toasts on connection/auth/mode errors

## Notes
- existing non-cmux terminal integrations are unchanged