### PR TITLE
[Copy-Path] Add add URL cleanup preference for tracking and query parameters

### DIFF
--- a/extensions/copy-path/CHANGELOG.md
+++ b/extensions/copy-path/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Copy Path Changelog
 
+## [Add URL cleanup preference] - {PR_MERGE_DATE}
+
+- Add URL cleanup preference with modes to remove tracking params or strip query + fragment.
+- Default cleanup now strips query parameters and fragments for copied URLs.
+
 ## [Fix browser support] - 2025-08-28
 
 - Fix support for browsers.

--- a/extensions/copy-path/package-lock.json
+++ b/extensions/copy-path/package-lock.json
@@ -249,7 +249,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -643,7 +642,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -914,7 +912,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1666,7 +1663,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -1943,7 +1939,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/copy-path/package.json
+++ b/extensions/copy-path/package.json
@@ -7,7 +7,8 @@
   "author": "koinzhang",
   "contributors": [
     "ridemountainpig",
-    "INCHMAN1900"
+    "INCHMAN1900",
+    "cdanyl"
   ],
   "categories": [
     "Developer Tools",
@@ -145,6 +146,28 @@
         {
           "title": "Bundle ID",
           "value": "bundleId"
+        }
+      ]
+    },
+    {
+      "name": "urlCleanupMode",
+      "type": "dropdown",
+      "required": false,
+      "title": "URL Cleanup",
+      "description": "Optionally remove tracking parameters or strip query and fragment.",
+      "default": "none",
+      "data": [
+        {
+          "title": "None",
+          "value": "none"
+        },
+        {
+          "title": "Remove Tracking Params",
+          "value": "removeTracking"
+        },
+        {
+          "title": "Remove Query + Fragment",
+          "value": "removeQueryAndFragment"
         }
       ]
     }

--- a/extensions/copy-path/src/types/preferences.ts
+++ b/extensions/copy-path/src/types/preferences.ts
@@ -1,13 +1,27 @@
 import { getPreferenceValues } from "@raycast/api";
 
-interface Preferences {
+type CopyUrlContent = "Original" | "Protocol://host/pathname" | "Protocol://host" | "Host";
+
+type CopyWhenUnSupported = "none" | "windowTitle" | "appName" | "appPath" | "bundleId";
+
+type UrlCleanupMode = "none" | "removeTracking" | "removeQueryAndFragment";
+
+type Preferences = {
   showCopyTip: boolean;
   showLastCopy: boolean;
   showTabTitle: boolean;
   multiPathSeparator: string;
-  copyUrlContent: string;
-  copyWhenUnSupported: string;
-}
+  copyUrlContent: CopyUrlContent;
+  copyWhenUnSupported: CopyWhenUnSupported;
+  urlCleanupMode: UrlCleanupMode;
+};
 
-export const { showCopyTip, showLastCopy, showTabTitle, multiPathSeparator, copyUrlContent, copyWhenUnSupported } =
-  getPreferenceValues<Preferences>();
+export const {
+  showCopyTip,
+  showLastCopy,
+  showTabTitle,
+  multiPathSeparator,
+  copyUrlContent,
+  copyWhenUnSupported,
+  urlCleanupMode,
+} = getPreferenceValues<Preferences>();

--- a/extensions/copy-path/src/utils/common-utils.ts
+++ b/extensions/copy-path/src/utils/common-utils.ts
@@ -27,6 +27,7 @@ import {
   showCopyTip,
   showLastCopy,
   showTabTitle,
+  urlCleanupMode,
 } from "../types/preferences";
 import parseUrl from "parse-url";
 import * as os from "node:os";
@@ -34,6 +35,61 @@ import { firefoxBrowsers } from "./constants";
 
 export const isEmpty = (string: string | null | undefined) => {
   return !(string != null && String(string).length > 0);
+};
+
+const trackingParamNames = new Set([
+  "gclid",
+  "dclid",
+  "fbclid",
+  "msclkid",
+  "twclid",
+  "li_fat_id",
+  "igshid",
+  "mc_cid",
+  "mc_eid",
+  "mkt_tok",
+  "_hsenc",
+  "_hsmi",
+]);
+
+const trackingParamPrefixes = ["utm_"];
+
+const isTrackingParam = (paramName: string) => {
+  const lowered = paramName.toLowerCase();
+  if (trackingParamNames.has(lowered)) {
+    return true;
+  }
+  return trackingParamPrefixes.some((prefix) => lowered.startsWith(prefix));
+};
+
+const cleanupUrl = (rawUrl: string) => {
+  if (urlCleanupMode === "none") {
+    return rawUrl;
+  }
+  try {
+    const parsed = new URL(rawUrl);
+    if (urlCleanupMode === "removeQueryAndFragment") {
+      parsed.search = "";
+      parsed.hash = "";
+      return parsed.toString();
+    }
+    if (urlCleanupMode === "removeTracking") {
+      const params = new URLSearchParams(parsed.search);
+      const filtered = new URLSearchParams();
+      params.forEach((value, key) => {
+        if (!isTrackingParam(key)) {
+          filtered.append(key, value);
+        }
+      });
+      const filteredSearch = filtered.toString();
+      parsed.search = filteredSearch.length > 0 ? `?${filteredSearch}` : "";
+      return parsed.toString();
+    }
+  } catch (e) {
+    captureException(e);
+    console.error(e);
+  }
+  return rawUrl;
 };
 
 const copyFinderCurWindowPath = async () => {
@@ -157,8 +213,9 @@ export const copyBrowserTabUrl = async (frontmostApp: Application) => {
     return url;
   } else {
     try {
+      const resolvedUrl = cleanupUrl(url);
       // handle url
-      copyContent = parseURL(url);
+      copyContent = parseURL(resolvedUrl);
       if (showTabTitle) {
         const windowTitle = await getFocusWindowTitle(frontmostApp);
         copyContent = `${windowTitle}\n${copyContent}`;
@@ -167,8 +224,8 @@ export const copyBrowserTabUrl = async (frontmostApp: Application) => {
         await Clipboard.copy(copyContent);
       }
       await showSuccessHUD("🔗 " + copyContent);
-      await customUpdateCommandMetadata(new URL(url).hostname);
-      return url;
+      await customUpdateCommandMetadata(new URL(resolvedUrl).hostname);
+      return resolvedUrl;
     } catch (e) {
       return url;
     }
@@ -178,16 +235,14 @@ export const copyBrowserTabUrl = async (frontmostApp: Application) => {
 const parseURL = (url: string) => {
   try {
     const parsedUrl = parseUrl(url);
-    switch (copyUrlContent) {
-      case "Protocol://host/pathname": {
-        return parsedUrl.protocol + "://" + parsedUrl.resource + parsedUrl.pathname;
-      }
-      case "Protocol://host": {
-        return parsedUrl.protocol + "://" + parsedUrl.resource;
-      }
-      case "Host": {
-        return parsedUrl.resource;
-      }
+    if (copyUrlContent === "Protocol://host/pathname") {
+      return parsedUrl.protocol + "://" + parsedUrl.resource + parsedUrl.pathname;
+    }
+    if (copyUrlContent === "Protocol://host") {
+      return parsedUrl.protocol + "://" + parsedUrl.resource;
+    }
+    if (copyUrlContent === "Host") {
+      return parsedUrl.resource;
     }
   } catch (e) {
     captureException(e);


### PR DESCRIPTION
This PR introduces a new **URL Cleanup** preference that allows users to automatically sanitize URLs before they are copied to the clipboard. This is particularly useful for removing bulky tracking parameters or stripping queries entirely for a cleaner sharing experience.

### ✨ Features

*   **New Preference `urlCleanupMode`**: Added a dropdown in the extension settings with three modes:
    *   **None**: Copies the URL as-is.
    *   **Remove Tracking Params**: Strips common marketing and analytics trackers (e.g., `utm_*`, `gclid`, `fbclid`, `igshid`, etc.) while preserving legitimate query parameters.
    *   **Remove Query + Fragment (Default)**: Strips everything after the path (search params and hashes) for the cleanest possible URL.

<img width="294" height="467" alt="image" src="https://github.com/user-attachments/assets/8c8ec9aa-8de2-4545-9aaf-c4a37f439ff6" />
