### PR TITLE
Update kaneo-for-raycast extension

### DIFF
--- a/extensions/kaneo-for-raycast/.gitignore
+++ b/extensions/kaneo-for-raycast/.gitignore
@@ -12,3 +12,6 @@ compiled_raycast_rust
 
 # misc
 .DS_Store
+
+# Editor agent config
+.agent/

--- a/extensions/kaneo-for-raycast/CHANGELOG.md
+++ b/extensions/kaneo-for-raycast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kaneo Changelog
 
-## [Assign Task] - {PR_MERGE_DATE}
+## [Assign Task] - 2026-03-08
 
 - Added "Assign to me" action for tasks
 - Added shortcut to revalidate tasks list

--- a/extensions/kaneo-for-raycast/CHANGELOG.md
+++ b/extensions/kaneo-for-raycast/CHANGELOG.md
@@ -3,3 +3,11 @@
 ## [Added Kaneo] - 2026-02-26
 
 Added Kaneo extension
+
+## [Assign Task] - {PR_MERGE_DATE}
+
+- Added "Assign to me" action for tasks
+- Added shortcut to revalidate tasks list
+- Added shortcut to self assign/unassign to a task
+- Added preference to define a request timeout
+- Added preference to display "you" instead of name as task assignee

--- a/extensions/kaneo-for-raycast/CHANGELOG.md
+++ b/extensions/kaneo-for-raycast/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Kaneo Changelog
 
-## [Added Kaneo] - 2026-02-26
-
-Added Kaneo extension
-
 ## [Assign Task] - {PR_MERGE_DATE}
 
 - Added "Assign to me" action for tasks
@@ -11,3 +7,7 @@ Added Kaneo extension
 - Added shortcut to self assign/unassign to a task
 - Added preference to define a request timeout
 - Added preference to display "you" instead of name as task assignee
+
+## [Added Kaneo] - 2026-02-26
+
+Added Kaneo extension

--- a/extensions/kaneo-for-raycast/README.md
+++ b/extensions/kaneo-for-raycast/README.md
@@ -1,13 +1,21 @@
 <div align="center">
-   <img
-      src="assets/kaneo.png"
-      alt="Kaneo for Raycast"
-      width="128"
-   />
+<img
+   src="./assets/kaneo.png"
+   alt="Kaneo for Raycast"
+   width="128"
+/>
+
+# Kaneo For Raycast
 
 ⚠️ **This extension is not created by Kaneo developers.**
 
-A Raycast extension for managing your [Kaneo](https://kaneo.app/) projects and tasks directly from Raycast.
+
+<a href="https://www.raycast.com/Baldy/kaneo-for-raycast" title="Install kaneo-for-raycast Raycast Extension"><img src="https://www.raycast.com/Baldy/kaneo-for-raycast/install_button@2x.png?v=1.1" height="64" style="height: 64px;" alt="" /></a>
+
+[![Raycast](https://img.shields.io/raycast/dt/Baldy/kaneo-for-raycast?color=%23FF6363&logo=raycast)](https://www.raycast.com/Baldy/kaneo-for-raycast)
+
+***"All you need. Nothing you don't."***<br>
+***[Kaneo](https://kaneo.app) is project management that stays out of your way.***
 </div>
 
 ## Features

--- a/extensions/kaneo-for-raycast/eslint.config.js
+++ b/extensions/kaneo-for-raycast/eslint.config.js
@@ -3,4 +3,9 @@ const raycastConfig = require("@raycast/eslint-config");
 
 module.exports = defineConfig([
   ...raycastConfig,
+  {
+    rules: {
+      "@raycast/prefer-placeholders": "warn",
+    },
+  },
 ]);

--- a/extensions/kaneo-for-raycast/package.json
+++ b/extensions/kaneo-for-raycast/package.json
@@ -85,6 +85,44 @@
           "title": "Due Date"
         }
       ]
+    },
+    {
+      "name": "youAsAssignee",
+      "type": "checkbox",
+      "label": "Assigned to you",
+      "description": "Display your name or \"You\" when task is assigned to you",
+      "required": false,
+      "default": true
+    },
+    {
+      "name": "requestTimeout",
+      "type": "dropdown",
+      "title": "Request Timeout",
+      "description": "Delay before timeout requests",
+      "required": true,
+      "default": "2500",
+      "data": [
+        {
+          "value": "1000",
+          "title": "1 Seconds"
+        },
+        {
+          "value": "2500",
+          "title": "2.5 Seconds"
+        },
+        {
+          "value": "5000",
+          "title": "5 Seconds"
+        },
+        {
+          "value": "10000",
+          "title": "10 Seconds"
+        },
+        {
+          "value": "30000",
+          "title": "30 Seconds"
+        }
+      ]
     }
   ],
   "keywords": [

--- a/extensions/kaneo-for-raycast/src/api/kaneo.ts
+++ b/extensions/kaneo-for-raycast/src/api/kaneo.ts
@@ -5,32 +5,60 @@ export class KaneoAPI {
   private instanceUrl: string;
   private apiToken: string;
   private workspaceId: string;
+  private requestTimeout: number;
 
   constructor() {
     const prefs = getPreferenceValues();
     this.instanceUrl = prefs.instanceUrl;
     this.apiToken = prefs.apiToken;
     this.workspaceId = prefs.workspaceId;
+    this.requestTimeout = prefs.requestTimeout;
   }
 
-  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+  private async request<T>(path: string, init?: RequestInit, timeoutMs = this.requestTimeout): Promise<T> {
     const url = `${this.instanceUrl.replace(/\/$/, "")}${path}`;
 
-    const res = await fetch(url, {
-      ...init,
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const res = await fetch(url, {
+        ...init,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiToken}`,
+          ...init?.headers,
+        },
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        throw new Error(`Kaneo API error: ${res.status} ${res.statusText}`);
+      }
+
+      if (res.status === 204) {
+        return undefined as T;
+      }
+
+      return (await res.json()) as T;
+    } catch (error) {
+      if ((error as Error).name === "AbortError") {
+        throw new Error(`Kaneo API error: request to ${path} timed out after ${timeoutMs}ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  async assignTask(taskId: string, assigneeId: string | null) {
+    return this.request<Task>(`/api/task/assignee/${taskId}`, {
+      method: "PUT",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${this.apiToken}`,
-        ...init?.headers,
       },
+      body: JSON.stringify({ userId: assigneeId }),
     });
-
-    if (!res.ok) {
-      throw new Error(`Kaneo API error: ${res.status} ${res.statusText}`);
-    }
-
-    if (res.status === 204) return undefined as T;
-    return res.json() as Promise<T>;
   }
 
   async getProjects(workspaceId: string): Promise<Project[]> {

--- a/extensions/kaneo-for-raycast/src/api/kaneo.ts
+++ b/extensions/kaneo-for-raycast/src/api/kaneo.ts
@@ -12,7 +12,7 @@ export class KaneoAPI {
     this.instanceUrl = prefs.instanceUrl;
     this.apiToken = prefs.apiToken;
     this.workspaceId = prefs.workspaceId;
-    this.requestTimeout = prefs.requestTimeout;
+    this.requestTimeout = Number(prefs.requestTimeout);
   }
 
   private async request<T>(path: string, init?: RequestInit, timeoutMs = this.requestTimeout): Promise<T> {

--- a/extensions/kaneo-for-raycast/src/api/kaneo.ts
+++ b/extensions/kaneo-for-raycast/src/api/kaneo.ts
@@ -54,9 +54,6 @@ export class KaneoAPI {
   async assignTask(taskId: string, assigneeId: string | null) {
     return this.request<Task>(`/api/task/assignee/${taskId}`, {
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-      },
       body: JSON.stringify({ userId: assigneeId }),
     });
   }

--- a/extensions/kaneo-for-raycast/src/hooks/useAuthSession.ts
+++ b/extensions/kaneo-for-raycast/src/hooks/useAuthSession.ts
@@ -1,0 +1,86 @@
+import { getPreferenceValues } from "@raycast/api";
+import { useCachedState } from "@raycast/utils";
+import { Session } from "../types";
+
+interface Preferences {
+  apiToken: string;
+  instanceUrl: string;
+}
+
+export function useAuthSession() {
+  const prefs = getPreferenceValues<Preferences>();
+  const [sessionData, setSessionData] = useCachedState<Session | null>("auth-session", null);
+  const [lastToken, setLastToken] = useCachedState<string | null>("auth-last-token", null);
+  const [isLoading, setIsLoading] = useCachedState<boolean>("auth-loading", false);
+  const [error, setError] = useCachedState<string | null>("auth-error", null);
+
+  const hasValidToken = !!prefs.apiToken;
+  const tokenChanged = hasValidToken && prefs.apiToken !== lastToken;
+
+  const fetchSession = async (apiToken: string | null) => {
+    if (!apiToken) {
+      setSessionData(null);
+      setLastToken(null);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`${prefs.instanceUrl}/api/auth/get-session`, {
+        headers: {
+          "x-api-key": apiToken,
+        },
+      });
+
+      if (response.status === 401) {
+        throw new Error("Unauthorized: invalid or expired API token");
+      }
+      if (!response.ok) {
+        throw new Error(`Erreur API: ${response.status}`);
+      }
+
+      const session = (await response.json()) as Session;
+
+      setSessionData(session);
+      setLastToken(apiToken);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Erreur inconnue";
+      setError(errorMessage);
+      setSessionData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (tokenChanged) {
+    fetchSession(prefs.apiToken || null);
+  }
+
+  const revalidate = () => {
+    fetchSession(prefs.apiToken || null);
+  };
+
+  if (!hasValidToken && lastToken !== null) {
+    setSessionData(null);
+    setLastToken(null);
+    setError(null);
+  }
+
+  return {
+    session: sessionData,
+    isLoading,
+    error,
+    revalidate,
+    hasValidToken,
+    tokenChanged,
+    clearSession: () => {
+      setSessionData(null);
+      setLastToken(null);
+      setError(null);
+    },
+  };
+}

--- a/extensions/kaneo-for-raycast/src/hooks/useAuthSession.ts
+++ b/extensions/kaneo-for-raycast/src/hooks/useAuthSession.ts
@@ -2,11 +2,6 @@ import { getPreferenceValues } from "@raycast/api";
 import { useCachedState } from "@raycast/utils";
 import { Session } from "../types";
 
-interface Preferences {
-  apiToken: string;
-  instanceUrl: string;
-}
-
 export function useAuthSession() {
   const prefs = getPreferenceValues<Preferences>();
   const [sessionData, setSessionData] = useCachedState<Session | null>("auth-session", null);

--- a/extensions/kaneo-for-raycast/src/hooks/useAuthSession.ts
+++ b/extensions/kaneo-for-raycast/src/hooks/useAuthSession.ts
@@ -35,7 +35,7 @@ export function useAuthSession() {
         throw new Error("Unauthorized: invalid or expired API token");
       }
       if (!response.ok) {
-        throw new Error(`Erreur API: ${response.status}`);
+        throw new Error(`API Error: ${response.status}`);
       }
 
       const session = (await response.json()) as Session;

--- a/extensions/kaneo-for-raycast/src/hooks/useAuthSession.ts
+++ b/extensions/kaneo-for-raycast/src/hooks/useAuthSession.ts
@@ -43,7 +43,7 @@ export function useAuthSession() {
       setSessionData(session);
       setLastToken(apiToken);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "Erreur inconnue";
+      const errorMessage = err instanceof Error ? err.message : "Unknown error";
       setError(errorMessage);
       setSessionData(null);
     } finally {

--- a/extensions/kaneo-for-raycast/src/list-projects.tsx
+++ b/extensions/kaneo-for-raycast/src/list-projects.tsx
@@ -361,7 +361,7 @@ ${formatDate(task.createdAt)}
 
 function ProjectTasksList({ project }: { project: Project }) {
   const api = new KaneoAPI();
-  const { sort, youAsAssignee } = getPreferenceValues<{ sort: string; youAsAssignee: boolean }>();
+  const { sort, youAsAssignee } = getPreferenceValues<Preferences>();
   const {
     isLoading,
     data: dProject,

--- a/extensions/kaneo-for-raycast/src/list-projects.tsx
+++ b/extensions/kaneo-for-raycast/src/list-projects.tsx
@@ -2,6 +2,7 @@ import {
   ActionPanel,
   Action,
   Icon,
+  Image,
   List,
   getPreferenceValues,
   Detail,
@@ -15,10 +16,20 @@ import {
   Form,
   useNavigation,
 } from "@raycast/api";
-import { useForm, FormValidation, showFailureToast, usePromise } from "@raycast/utils";
-import { ChangeStatus, ChangePriority, CopyTaskTitle, CopyTaskDescription, CopyProjectName } from "./shortcut";
-import { Project, Task, CreateProjectFormValues, CreateTaskFormValues } from "./types";
+import { useForm, FormValidation, showFailureToast, usePromise, getAvatarIcon } from "@raycast/utils";
+import {
+  ChangeStatus,
+  ChangePriority,
+  CopyTaskTitle,
+  CopyTaskDescription,
+  CopyProjectName,
+  AssignTask,
+  Revalidate,
+} from "./shortcut";
+import { Project, Task, CreateProjectFormValues, CreateTaskFormValues, ProjectDetail } from "./types";
 import { KaneoAPI } from "./api/kaneo";
+import { useAuthSession } from "./hooks/useAuthSession";
+import { useEffect, useState } from "react";
 
 function formatDate(date: string | null) {
   if (!date) return "N/A";
@@ -234,20 +245,26 @@ function TaskDetailView({
 
   const markdown = `# ${task.title}
 
+
 ## Description
 ${cleanDescription(task.description)}
+
 
 ## Status
 ${status}
 
+
 ## Priority
 ${priority}
+
 
 ## Due Date
 ${formatDate(task.dueDate)}
 
+
 ## Assignee
 ${task.assigneeName || "Unassigned"}
+
 
 ## Created At
 ${formatDate(task.createdAt)}
@@ -344,14 +361,82 @@ ${formatDate(task.createdAt)}
 
 function ProjectTasksList({ project }: { project: Project }) {
   const api = new KaneoAPI();
-  const { sort } = getPreferenceValues<{
-    sort: string;
-  }>();
+  const { sort, youAsAssignee } = getPreferenceValues<{ sort: string; youAsAssignee: boolean }>();
   const {
     isLoading,
-    data: projectDetail,
+    data: dProject,
     revalidate,
   } = usePromise((id: string) => api.getProjectTasks(id), [project.id.toString()]);
+  const { session } = useAuthSession();
+  const [projectDetail, setProjectDetail] = useState<ProjectDetail | undefined>(dProject);
+
+  useEffect(() => {
+    if (dProject) {
+      setProjectDetail(dProject);
+    }
+  }, [dProject]);
+
+  if (isLoading || !projectDetail) {
+    return <List isLoading navigationTitle={`Tasks - ${project.name}`} />;
+  }
+
+  const userId = session?.user?.id ?? null;
+  const toggleAssignTask = async (task: Task) => {
+    if (!userId) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "No session",
+        message: "You must be logged in to assign tasks.",
+      });
+      return;
+    }
+
+    const isAssignedToMe = task.assigneeId === userId;
+
+    await showToast({
+      style: Toast.Style.Animated,
+      title: isAssignedToMe ? "Unassigning task..." : "Assigning task...",
+    });
+
+    try {
+      await api.assignTask(task.id, isAssignedToMe ? "" : userId);
+
+      const newAssigneeId = isAssignedToMe ? null : userId;
+      const newAssigneeName = isAssignedToMe ? null : (session?.user?.name ?? null);
+      const newAssigneeImage = isAssignedToMe ? null : (session?.user?.image ?? null);
+
+      setProjectDetail((prev) => {
+        if (!prev) return prev;
+
+        return {
+          ...prev,
+          columns: prev.columns.map((col) => ({
+            ...col,
+            tasks: col.tasks.map((t) =>
+              t.id === task.id
+                ? {
+                    ...t,
+                    assigneeId: newAssigneeId,
+                    assigneeName: newAssigneeName,
+                    assigneeImage: newAssigneeImage,
+                  }
+                : t,
+            ),
+          })),
+        };
+      });
+
+      await showToast({
+        style: Toast.Style.Success,
+        title: isAssignedToMe ? "Task unassigned" : "Task assigned to you",
+      });
+    } catch (error) {
+      await showFailureToast(error, {
+        title: isAssignedToMe ? "Failed to unassign task" : "Failed to assign task",
+        message: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  };
 
   const priorityOrder = ["urgent", "high", "medium", "low", "no-priority"];
 
@@ -504,7 +589,19 @@ function ProjectTasksList({ project }: { project: Project }) {
                   icon={column.isFinal ? Icon.CircleProgress100 : Icon.Circle}
                   title={item.title}
                   accessories={[
-                    { text: item.assigneeName || "Unassigned", icon: Icon.Person },
+                    {
+                      text:
+                        (youAsAssignee
+                          ? item.assigneeId === userId
+                            ? "You"
+                            : item.assigneeName
+                          : item.assigneeName) || "Unassigned",
+                      icon: item.assigneeName
+                        ? item.assigneeImage
+                          ? { source: item.assigneeImage, mask: Image.Mask.Circle }
+                          : getAvatarIcon(`${item.assigneeName}`)
+                        : undefined,
+                    },
                     ...(item.dueDate
                       ? [
                           {
@@ -582,6 +679,13 @@ function ProjectTasksList({ project }: { project: Project }) {
                         shortcut={Keyboard.Shortcut.Common.Remove}
                       />
 
+                      <Action
+                        title={item.assigneeId === session?.user?.id ? "Unassign from Me" : "Assign to Me"}
+                        icon={Icon.Person}
+                        shortcut={AssignTask}
+                        onAction={() => toggleAssignTask(item)}
+                      />
+
                       <ActionPanel.Submenu title="Change Status…" icon={Icon.List} shortcut={ChangeStatus}>
                         {columnStatuses
                           .filter((status) => status.id !== item.status)
@@ -631,6 +735,13 @@ function ProjectTasksList({ project }: { project: Project }) {
                           shortcut={CopyTaskDescription}
                         />
                       )}
+
+                      <Action
+                        title="Revalidate"
+                        icon={Icon.RotateAntiClockwise}
+                        shortcut={Revalidate}
+                        onAction={() => revalidate()}
+                      />
                     </ActionPanel>
                   }
                 />

--- a/extensions/kaneo-for-raycast/src/shortcut.tsx
+++ b/extensions/kaneo-for-raycast/src/shortcut.tsx
@@ -25,4 +25,14 @@ const CopyProjectName: Keyboard.Shortcut = {
   key: "p",
 };
 
-export { ChangeStatus, ChangePriority, CopyTaskTitle, CopyTaskDescription, CopyProjectName };
+const AssignTask: Keyboard.Shortcut = {
+  Windows: { modifiers: ["ctrl", "shift"], key: "enter" },
+  macOS: { modifiers: ["cmd", "shift"], key: "enter" },
+};
+
+const Revalidate: Keyboard.Shortcut = {
+  Windows: { modifiers: ["ctrl", "shift"], key: "r" },
+  macOS: { modifiers: ["cmd", "shift"], key: "r" },
+};
+
+export { ChangeStatus, ChangePriority, CopyTaskTitle, CopyTaskDescription, CopyProjectName, AssignTask, Revalidate };

--- a/extensions/kaneo-for-raycast/src/types/index.ts
+++ b/extensions/kaneo-for-raycast/src/types/index.ts
@@ -1,3 +1,23 @@
+interface Session {
+  session: {
+    id: string;
+    token: string;
+    userId: string;
+    createdAt: Date;
+    updatedAt: Date;
+    expiresAt: Date;
+  };
+  user?: {
+    id: string;
+    name: string;
+    image: string;
+    createdAt: Date;
+    updatedAt: Date;
+    isAnonymous: boolean;
+  };
+  expires?: string;
+}
+
 interface Project {
   id: number;
   name: string;
@@ -21,8 +41,9 @@ interface Task {
   position: number;
   createdAt: string;
   userId: string | null;
-  assigneeName: string | null;
   assigneeId: string | null;
+  assigneeName: string | null;
+  assigneeImage: string | null;
   projectId: string;
 }
 
@@ -85,6 +106,7 @@ interface CreateProjectFormValues {
 }
 
 export type {
+  Session,
   Project,
   Task,
   ProjectDetail,


### PR DESCRIPTION
## Description

This update introduces several improvements to interactions and personalization around assignment and request handling. It makes it easier to quickly assign/unassign to task, control how task assignee are displayed, and avoid waiting on slow or stalled requests.

#### Changes:
- Added an **"Assign to me"** action to self-assign or unassign yourself from a task.
- Added a shortcut to revalidate the tasks list manually.
- Added a shortcut to quickly assign/unassign from a task.
- Added a preference to define a request timeout for api request.
- Added a preference to display “you” instead of full username as the task assignee for a more personal UI.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [X] I checked that files in the `assets` folder are used by the extension itself
- [X] I checked that assets used by the `README` are placed outside of the `metadata` folder
