### PR TITLE
Update toothpick extension

### DIFF
--- a/extensions/toothpick/CHANGELOG.md
+++ b/extensions/toothpick/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Toothpick Changelog
 
-## [Refresh Device and Refresh All Commands] - {PR_MERGE_DATE}
+## [Refresh Device and Refresh All Commands] - 2026-05-05
 
 - Added a **Refresh** action in Manage Bluetooth Connections which disconnects and reconnects a device.
 - Added commands: **Refresh Device**, **Refresh Favorite Device #1/#2/#3**.

--- a/extensions/toothpick/CHANGELOG.md
+++ b/extensions/toothpick/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Toothpick Changelog
 
+## [Refresh Device and Refresh All Commands] - {PR_MERGE_DATE}
+
+- Added a **Refresh** action in Manage Bluetooth Connections which disconnects and reconnects a device.
+- Added commands: **Refresh Device**, **Refresh Favorite Device #1/#2/#3**.
+- Added command **Refresh All** (`blueutil` only).
+
 ## [Keyboard Shortcuts to Copy] - 2026-01-08
 
 - Added `Keyboard` `Shortcut`s to copy `Action`s

--- a/extensions/toothpick/package.json
+++ b/extensions/toothpick/package.json
@@ -12,7 +12,8 @@
     "rspeicher",
     "roele",
     "AntonNiklasson",
-    "xmok"
+    "xmok",
+    "merchako"
   ],
   "repository": {
     "type": "git",
@@ -97,6 +98,30 @@
       "disabledByDefault": true
     },
     {
+      "name": "refresh-device",
+      "title": "Refresh Device",
+      "subtitle": "Toothpick",
+      "description": "Shortcut for refreshing a specific device connection.",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "nameOrMacAddress",
+          "placeholder": "Name or Mac Address",
+          "type": "text",
+          "required": true
+        }
+      ],
+      "disabledByDefault": true
+    },
+    {
+      "name": "refresh-all",
+      "title": "Refresh All",
+      "subtitle": "Toothpick",
+      "description": "Turns Bluetooth off and on again.",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
       "name": "connect-favorite-device-1",
       "title": "Connect Favorite Device #1",
       "description": "Shortcut for connecting to favorite device #1.",
@@ -156,6 +181,27 @@
       "name": "toggle-favorite-device-3",
       "title": "Toggle Favorite Device #3",
       "description": "Shortcut for toggling a connection to favorite device #3.",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
+      "name": "refresh-favorite-device-1",
+      "title": "Refresh Favorite Device #1",
+      "description": "Shortcut for refreshing favorite device #1.",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
+      "name": "refresh-favorite-device-2",
+      "title": "Refresh Favorite Device #2",
+      "description": "Shortcut for refreshing favorite device #2.",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
+      "name": "refresh-favorite-device-3",
+      "title": "Refresh Favorite Device #3",
+      "description": "Shortcut for refreshing favorite device #3.",
       "mode": "no-view",
       "disabledByDefault": true
     },

--- a/extensions/toothpick/src/core/devices/devices.model.tsx
+++ b/extensions/toothpick/src/core/devices/devices.model.tsx
@@ -4,6 +4,7 @@ import { DevicesMap } from "src/core/devices/constants/specifications";
 import { DeviceBatteryLevels } from "./devices.types";
 import { disconnectDevice } from "src/core/devices/handlers/disconnect-device";
 import { connectDevice } from "./handlers/connect-device";
+import { refreshDevice } from "./handlers/refresh-device";
 
 export class Device {
   name: string;
@@ -66,6 +67,7 @@ export class Device {
           icon={{ source: "icons/connect.svg", tintColor: Color.PrimaryText }}
         />
       ),
+      <Action title="Refresh" key="refresh-action" onAction={() => refreshDevice(this)} icon={Icon.ArrowClockwise} />,
       <Action
         title={`Copy Mac Address: ${this.macAddress}`}
         key="copy-mac-address"

--- a/extensions/toothpick/src/core/devices/devices.model.tsx
+++ b/extensions/toothpick/src/core/devices/devices.model.tsx
@@ -67,13 +67,13 @@ export class Device {
           icon={{ source: "icons/connect.svg", tintColor: Color.PrimaryText }}
         />
       ),
-      <Action title="Refresh" key="refresh-action" onAction={() => refreshDevice(this)} icon={Icon.ArrowClockwise} />,
       <Action
         title={`Copy Mac Address: ${this.macAddress}`}
         key="copy-mac-address"
         onAction={() => Clipboard.copy(this.macAddress)}
         icon={Icon.Hammer}
       />,
+      <Action title="Refresh" key="refresh-action" onAction={() => refreshDevice(this)} icon={Icon.ArrowClockwise} />,
       <Action
         title={`Copy Device Data`}
         key="copy-device-data"

--- a/extensions/toothpick/src/core/devices/devices.model.tsx
+++ b/extensions/toothpick/src/core/devices/devices.model.tsx
@@ -73,7 +73,6 @@ export class Device {
         onAction={() => Clipboard.copy(this.macAddress)}
         icon={Icon.Hammer}
       />,
-      <Action title="Refresh" key="refresh-action" onAction={() => refreshDevice(this)} icon={Icon.ArrowClockwise} />,
       <Action
         title={`Copy Device Data`}
         key="copy-device-data"
@@ -88,6 +87,7 @@ export class Device {
         icon={Icon.Pencil}
         shortcut={Keyboard.Shortcut.Common.CopyName}
       />,
+      <Action title="Refresh" key="refresh-action" onAction={() => refreshDevice(this)} icon={Icon.ArrowClockwise} />,
       ...additionalActions,
     ];
   }

--- a/extensions/toothpick/src/core/devices/devices.service.applescript.ts
+++ b/extensions/toothpick/src/core/devices/devices.service.applescript.ts
@@ -58,6 +58,10 @@ export default class ApplescriptDevicesService implements DevicesService {
     return exitCode === "0";
   }
 
+  refreshBluetooth(): boolean {
+    return false;
+  }
+
   private _fetchRawDevicesData(): RawDeviceData[] {
     // Fetch Bluetooth data
     const script = readFileSync(

--- a/extensions/toothpick/src/core/devices/devices.service.blueutil.ts
+++ b/extensions/toothpick/src/core/devices/devices.service.blueutil.ts
@@ -80,13 +80,7 @@ export default class BlueutilDevicesService extends ApplescriptDevicesService {
   }
 
   refreshBluetooth(): boolean {
-    try {
-      execSync(`blueutil -p 0 && blueutil -p 1`, {
-        env: this.envVars,
-      });
-      return true;
-    } catch {
-      return false;
-    }
+    execSync(`blueutil -p 0 && /bin/sleep 1 && blueutil -p 1`, { env: this.envVars });
+    return true;
   }
 }

--- a/extensions/toothpick/src/core/devices/devices.service.blueutil.ts
+++ b/extensions/toothpick/src/core/devices/devices.service.blueutil.ts
@@ -78,4 +78,15 @@ export default class BlueutilDevicesService extends ApplescriptDevicesService {
       return false;
     }
   }
+
+  refreshBluetooth(): boolean {
+    try {
+      execSync(`blueutil -p 0 && blueutil -p 1`, {
+        env: this.envVars,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
 }

--- a/extensions/toothpick/src/core/devices/devices.service.ts
+++ b/extensions/toothpick/src/core/devices/devices.service.ts
@@ -6,6 +6,7 @@ export interface DevicesService {
   getDevices(): Device[];
   connectDevice(mac: string): boolean;
   disconnectDevice(mac: string): boolean;
+  refreshBluetooth(): boolean;
 }
 
 let currentServiceType: string;

--- a/extensions/toothpick/src/core/devices/handlers/connect-device.ts
+++ b/extensions/toothpick/src/core/devices/handlers/connect-device.ts
@@ -1,7 +1,7 @@
 import { getPreferenceValues, closeMainWindow } from "@raycast/api";
 import { Device } from "../devices.model";
 import { getDevicesService } from "../devices.service";
-import { showAnimatedMessage, showSuccessMessage } from "src/utils";
+import { showAnimatedMessage, showErrorMessage, showSuccessMessage } from "src/utils";
 
 export async function connectDevice(device: Device) {
   const { closeOnSuccessfulConnection, bluetoothBackend } = getPreferenceValues<ExtensionPreferences>();
@@ -12,9 +12,11 @@ export async function connectDevice(device: Device) {
   if (result) {
     await showSuccessMessage("Device connected successfully.");
   } else {
-    await showSuccessMessage("Failed to connect.");
+    await showErrorMessage("Failed to connect.");
   }
   if (closeOnSuccessfulConnection) {
     closeMainWindow();
   }
+
+  return !!result;
 }

--- a/extensions/toothpick/src/core/devices/handlers/disconnect-device.ts
+++ b/extensions/toothpick/src/core/devices/handlers/disconnect-device.ts
@@ -14,4 +14,6 @@ export async function disconnectDevice(device: Device) {
   } else {
     await showErrorMessage("Failed to disconnect");
   }
+
+  return !!result;
 }

--- a/extensions/toothpick/src/core/devices/handlers/refresh-bluetooth.ts
+++ b/extensions/toothpick/src/core/devices/handlers/refresh-bluetooth.ts
@@ -1,0 +1,24 @@
+import { getDevicesService } from "src/core/devices/devices.service";
+import { DevicesService } from "src/core/devices/devices.service";
+import { showAnimatedMessage, showErrorMessage, showSuccessMessage } from "src/utils";
+
+export default async function refreshBluetooth() {
+  let devicesService: DevicesService;
+  try {
+    devicesService = getDevicesService("blueutil");
+  } catch {
+    await showErrorMessage(
+      "Refresh All requires blueutil. Install it with Homebrew or set Blueutil Directory in preferences.",
+    );
+    return;
+  }
+
+  await showAnimatedMessage("Refreshing Bluetooth...");
+  const result = devicesService?.refreshBluetooth();
+
+  if (result) {
+    await showSuccessMessage("Bluetooth refreshed successfully");
+  } else {
+    await showErrorMessage("Failed to refresh Bluetooth");
+  }
+}

--- a/extensions/toothpick/src/core/devices/handlers/refresh-bluetooth.ts
+++ b/extensions/toothpick/src/core/devices/handlers/refresh-bluetooth.ts
@@ -1,9 +1,8 @@
 import { getDevicesService } from "src/core/devices/devices.service";
-import { DevicesService } from "src/core/devices/devices.service";
 import { showAnimatedMessage, showErrorMessage, showSuccessMessage } from "src/utils";
 
 export default async function refreshBluetooth() {
-  let devicesService: DevicesService;
+  let devicesService: ReturnType<typeof getDevicesService>;
   try {
     devicesService = getDevicesService("blueutil");
   } catch {

--- a/extensions/toothpick/src/core/devices/handlers/refresh-bluetooth.ts
+++ b/extensions/toothpick/src/core/devices/handlers/refresh-bluetooth.ts
@@ -1,4 +1,5 @@
-import { getDevicesService, DevicesService } from "src/core/devices/devices.service";
+import { getDevicesService } from "src/core/devices/devices.service";
+import { DevicesService } from "src/core/devices/devices.service";
 import { showAnimatedMessage, showErrorMessage, showSuccessMessage } from "src/utils";
 
 export default async function refreshBluetooth() {
@@ -12,12 +13,11 @@ export default async function refreshBluetooth() {
     return;
   }
 
-  await showAnimatedMessage("Refreshing Bluetooth...");
-  const result = devicesService?.refreshBluetooth();
-
-  if (result) {
+  try {
+    await showAnimatedMessage("Refreshing Bluetooth...");
+    devicesService.refreshBluetooth();
     await showSuccessMessage("Bluetooth refreshed successfully");
-  } else {
-    await showErrorMessage("Failed to refresh Bluetooth");
+  } catch (error) {
+    await showErrorMessage(`Failed to refresh Bluetooth: ${error instanceof Error ? error.message : error}`);
   }
 }

--- a/extensions/toothpick/src/core/devices/handlers/refresh-bluetooth.ts
+++ b/extensions/toothpick/src/core/devices/handlers/refresh-bluetooth.ts
@@ -17,6 +17,8 @@ export default async function refreshBluetooth() {
     devicesService.refreshBluetooth();
     await showSuccessMessage("Bluetooth refreshed successfully");
   } catch (error) {
-    await showErrorMessage(`Failed to refresh Bluetooth: ${error instanceof Error ? error.message : error}`);
+    // Provide guidance that Bluetooth may be disabled after failure
+    const errorMessage = `Failed to refresh Bluetooth: ${error instanceof Error ? error.message : error}. Bluetooth may have been disabled; please re‑enable it manually.`;
+    await showErrorMessage(errorMessage);
   }
 }

--- a/extensions/toothpick/src/core/devices/handlers/refresh-bluetooth.ts
+++ b/extensions/toothpick/src/core/devices/handlers/refresh-bluetooth.ts
@@ -1,5 +1,4 @@
-import { getDevicesService } from "src/core/devices/devices.service";
-import { DevicesService } from "src/core/devices/devices.service";
+import { getDevicesService, DevicesService } from "src/core/devices/devices.service";
 import { showAnimatedMessage, showErrorMessage, showSuccessMessage } from "src/utils";
 
 export default async function refreshBluetooth() {

--- a/extensions/toothpick/src/core/devices/handlers/refresh-device.ts
+++ b/extensions/toothpick/src/core/devices/handlers/refresh-device.ts
@@ -1,0 +1,31 @@
+import { getPreferenceValues, closeMainWindow } from "@raycast/api";
+import { Device } from "../devices.model";
+import { getDevicesService } from "../devices.service";
+import { showAnimatedMessage, showErrorMessage, showSuccessMessage, showWarningMessage } from "src/utils";
+
+export async function refreshDevice(device: Device) {
+  const { closeOnSuccessfulConnection, bluetoothBackend } = getPreferenceValues<ExtensionPreferences>();
+  const devicesService = getDevicesService(bluetoothBackend);
+
+  await showAnimatedMessage("Disconnecting...");
+  const disconnectResult = devicesService?.disconnectDevice(device.macAddress);
+  if (disconnectResult) {
+    await showSuccessMessage("Device disconnected successfully");
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await showAnimatedMessage("Reconnecting...");
+  } else {
+    await showWarningMessage("Failed to disconnect. Reconnecting anyway…");
+  }
+
+  const connectResult = devicesService?.connectDevice(device.macAddress);
+  if (connectResult) {
+    await showSuccessMessage("Device connected successfully.");
+  } else {
+    await showErrorMessage("Failed to connect.");
+  }
+  if (closeOnSuccessfulConnection) {
+    closeMainWindow();
+  }
+
+  return !!disconnectResult && connectResult;
+}

--- a/extensions/toothpick/src/core/devices/handlers/refresh-device.ts
+++ b/extensions/toothpick/src/core/devices/handlers/refresh-device.ts
@@ -27,5 +27,5 @@ export async function refreshDevice(device: Device) {
     closeMainWindow();
   }
 
-  return !!disconnectResult && connectResult;
+  return !!disconnectResult && !!connectResult;
 }

--- a/extensions/toothpick/src/core/devices/handlers/refresh-device.ts
+++ b/extensions/toothpick/src/core/devices/handlers/refresh-device.ts
@@ -1,31 +1,19 @@
-import { getPreferenceValues, closeMainWindow } from "@raycast/api";
 import { Device } from "../devices.model";
-import { getDevicesService } from "../devices.service";
-import { showAnimatedMessage, showErrorMessage, showSuccessMessage, showWarningMessage } from "src/utils";
+import { disconnectDevice } from "./disconnect-device";
+import { connectDevice } from "./connect-device";
+import { showAnimatedMessage, showWarningMessage } from "src/utils";
 
-export async function refreshDevice(device: Device) {
-  const { closeOnSuccessfulConnection, bluetoothBackend } = getPreferenceValues<ExtensionPreferences>();
-  const devicesService = getDevicesService(bluetoothBackend);
+const RECONNECT_DELAY_MS = 2000;
 
-  await showAnimatedMessage("Disconnecting...");
-  const disconnectResult = devicesService?.disconnectDevice(device.macAddress);
-  if (disconnectResult) {
-    await showSuccessMessage("Device disconnected successfully");
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+export async function refreshDevice(device: Device): Promise<boolean> {
+  const disconnected = await disconnectDevice(device);
+
+  if (disconnected) {
     await showAnimatedMessage("Reconnecting...");
+    await new Promise((resolve) => setTimeout(resolve, RECONNECT_DELAY_MS));
   } else {
     await showWarningMessage("Failed to disconnect. Reconnecting anyway…");
   }
 
-  const connectResult = devicesService?.connectDevice(device.macAddress);
-  if (connectResult) {
-    await showSuccessMessage("Device connected successfully.");
-  } else {
-    await showErrorMessage("Failed to connect.");
-  }
-  if (closeOnSuccessfulConnection) {
-    closeMainWindow();
-  }
-
-  return !!disconnectResult && !!connectResult;
+  return connectDevice(device);
 }

--- a/extensions/toothpick/src/refresh-all.ts
+++ b/extensions/toothpick/src/refresh-all.ts
@@ -1,0 +1,5 @@
+import refreshBluetooth from "./core/devices/handlers/refresh-bluetooth";
+
+export default async function Command() {
+  await refreshBluetooth();
+}

--- a/extensions/toothpick/src/refresh-device.ts
+++ b/extensions/toothpick/src/refresh-device.ts
@@ -4,7 +4,7 @@ import { refreshDevice } from "./core/devices/handlers/refresh-device";
 import { getDevicesService } from "./core/devices/devices.service";
 import { showErrorMessage } from "./utils";
 
-export default async (props: { arguments: { nameOrMacAddress: string | undefined } }) => {
+export default async function Command(props: { arguments: { nameOrMacAddress: string | undefined } }) {
   const { fuzzyRatio, bluetoothBackend } = getPreferenceValues<ExtensionPreferences>();
 
   if (props.arguments.nameOrMacAddress === undefined) {
@@ -31,4 +31,4 @@ export default async (props: { arguments: { nameOrMacAddress: string | undefined
   } catch (error) {
     await showErrorMessage(`${error}`);
   }
-};
+}

--- a/extensions/toothpick/src/refresh-device.ts
+++ b/extensions/toothpick/src/refresh-device.ts
@@ -1,0 +1,34 @@
+import { getPreferenceValues } from "@raycast/api";
+import { ratio } from "fuzzball";
+import { refreshDevice } from "./core/devices/handlers/refresh-device";
+import { getDevicesService } from "./core/devices/devices.service";
+import { showErrorMessage } from "./utils";
+
+export default async (props: { arguments: { nameOrMacAddress: string | undefined } }) => {
+  const { fuzzyRatio, bluetoothBackend } = getPreferenceValues<ExtensionPreferences>();
+
+  if (props.arguments.nameOrMacAddress === undefined) {
+    await showErrorMessage("Undefined value. Check extension preferences.");
+    return;
+  }
+
+  if (isNaN(parseFloat(fuzzyRatio))) {
+    await showErrorMessage("Invalid fuzzy ratio. Check extension preferences.");
+    return;
+  }
+
+  try {
+    const devices = getDevicesService(bluetoothBackend)?.getDevices() ?? [];
+
+    const device = devices.find(
+      (device) =>
+        ratio(device.name, props.arguments.nameOrMacAddress || "") > parseFloat(fuzzyRatio) ||
+        device.macAddress === props.arguments.nameOrMacAddress,
+    );
+
+    if (!device) throw new Error("Device not found");
+    await refreshDevice(device);
+  } catch (error) {
+    await showErrorMessage(`${error}`);
+  }
+};

--- a/extensions/toothpick/src/refresh-favorite-device-1.ts
+++ b/extensions/toothpick/src/refresh-favorite-device-1.ts
@@ -1,0 +1,8 @@
+import { getPreferenceValues, updateCommandMetadata } from "@raycast/api";
+import refreshFavoriteDevice from "./refresh-device";
+
+export default async () => {
+  const { favoriteDevice1 } = getPreferenceValues<ExtensionPreferences>();
+  await updateCommandMetadata({ subtitle: favoriteDevice1 });
+  await refreshFavoriteDevice({ arguments: { nameOrMacAddress: favoriteDevice1 } });
+};

--- a/extensions/toothpick/src/refresh-favorite-device-1.ts
+++ b/extensions/toothpick/src/refresh-favorite-device-1.ts
@@ -1,8 +1,8 @@
 import { getPreferenceValues, updateCommandMetadata } from "@raycast/api";
 import refreshFavoriteDevice from "./refresh-device";
 
-export default async () => {
+export default async function Command() {
   const { favoriteDevice1 } = getPreferenceValues<ExtensionPreferences>();
   await updateCommandMetadata({ subtitle: favoriteDevice1 });
   await refreshFavoriteDevice({ arguments: { nameOrMacAddress: favoriteDevice1 } });
-};
+}

--- a/extensions/toothpick/src/refresh-favorite-device-2.ts
+++ b/extensions/toothpick/src/refresh-favorite-device-2.ts
@@ -1,8 +1,8 @@
 import { getPreferenceValues, updateCommandMetadata } from "@raycast/api";
 import refreshFavoriteDevice from "./refresh-device";
 
-export default async () => {
+export default async function Command() {
   const { favoriteDevice2 } = getPreferenceValues<ExtensionPreferences>();
   await updateCommandMetadata({ subtitle: favoriteDevice2 });
   await refreshFavoriteDevice({ arguments: { nameOrMacAddress: favoriteDevice2 } });
-};
+}

--- a/extensions/toothpick/src/refresh-favorite-device-2.ts
+++ b/extensions/toothpick/src/refresh-favorite-device-2.ts
@@ -1,0 +1,8 @@
+import { getPreferenceValues, updateCommandMetadata } from "@raycast/api";
+import refreshFavoriteDevice from "./refresh-device";
+
+export default async () => {
+  const { favoriteDevice2 } = getPreferenceValues<ExtensionPreferences>();
+  await updateCommandMetadata({ subtitle: favoriteDevice2 });
+  await refreshFavoriteDevice({ arguments: { nameOrMacAddress: favoriteDevice2 } });
+};

--- a/extensions/toothpick/src/refresh-favorite-device-3.ts
+++ b/extensions/toothpick/src/refresh-favorite-device-3.ts
@@ -1,8 +1,8 @@
 import { getPreferenceValues, updateCommandMetadata } from "@raycast/api";
 import refreshFavoriteDevice from "./refresh-device";
 
-export default async () => {
+export default async function Command() {
   const { favoriteDevice3 } = getPreferenceValues<ExtensionPreferences>();
   await updateCommandMetadata({ subtitle: favoriteDevice3 });
   await refreshFavoriteDevice({ arguments: { nameOrMacAddress: favoriteDevice3 } });
-};
+}

--- a/extensions/toothpick/src/refresh-favorite-device-3.ts
+++ b/extensions/toothpick/src/refresh-favorite-device-3.ts
@@ -1,0 +1,8 @@
+import { getPreferenceValues, updateCommandMetadata } from "@raycast/api";
+import refreshFavoriteDevice from "./refresh-device";
+
+export default async () => {
+  const { favoriteDevice3 } = getPreferenceValues<ExtensionPreferences>();
+  await updateCommandMetadata({ subtitle: favoriteDevice3 });
+  await refreshFavoriteDevice({ arguments: { nameOrMacAddress: favoriteDevice3 } });
+};

--- a/extensions/toothpick/src/utils.ts
+++ b/extensions/toothpick/src/utils.ts
@@ -21,3 +21,11 @@ export async function showAnimatedMessage(message: string) {
     await showToast({ style: Toast.Style.Animated, title: message });
   }
 }
+
+export async function showWarningMessage(message: string) {
+  if (environment.launchType === LaunchType.Background) {
+    await showHUD(`⚠️ ${message}`);
+  } else {
+    await showToast({ style: Toast.Style.Animated, title: `⚠️ ${message}` });
+  }
+}

--- a/extensions/toothpick/src/utils.ts
+++ b/extensions/toothpick/src/utils.ts
@@ -26,6 +26,6 @@ export async function showWarningMessage(message: string) {
   if (environment.launchType === LaunchType.Background) {
     await showHUD(`⚠️ ${message}`);
   } else {
-    await showToast({ style: Toast.Style.Animated, title: `⚠️ ${message}` });
+    await showToast({ style: Toast.Style.Failure, title: `⚠️ ${message}` });
   }
 }


### PR DESCRIPTION
## Description

### Motivation
- Provide a single action to "refresh" Bluetooth when a device becomes unresponsive by briefly reconnecting a device or toggling Bluetooth power, as requested in issue https://github.com/raycast/extensions/issues/26144.

### Implementation Details
- Add a per-device "Refresh" action in the Manage Bluetooth Connections panel that runs connect → wait → disconnect by introducing `src/core/devices/handlers/refresh-device.ts` and wiring it into `Device` actions (`src/core/devices/devices.model.tsx`).
- Add a `refresh-device` command and three favorite shortcuts (`refresh-favorite-device-1/2/3`) that reuse the existing fuzzy name/MAC lookup flow (`src/refresh-device.ts`, `src/refresh-favorite-device-1.ts`, `src/refresh-favorite-device-2.ts`, `src/refresh-favorite-device-3.ts`).
- Add a `refresh-all` command to toggle Bluetooth power off/on via a new handler `src/core/devices/handlers/refresh-bluetooth.ts` and command `src/refresh-all.ts`.
- Extend the devices service interface with `refreshBluetooth()` and implement it in blueutil only (`blueutil -p 0 && blueutil -p 1` in `src/core/devices/devices.service.blueutil.ts`).
- Register the new commands in `package.json` and add consistent user-facing messages via existing `showAnimatedMessage` / `showSuccessMessage` / `showErrorMessage` utilities.

### Limitations
- "Refresh All" requires `blueutil`

### Testing
- Passed `npm run lint`
- Hand-tested on macOS

### AI Disclosure
- Used ~12-15 prompts to [Codex](https://chatgpt.com/codex/tasks/task_e_69adee7705348331a79c11336a2ea1ee) and hand-modified the end result.

## Screencast
https://github.com/user-attachments/assets/d3a4ab68-6c89-4c09-942f-ed3f402db9c2

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] ~~I checked that files in the `assets` folder are used by the extension itself~~ not changed
- [x] ~~I checked that assets used by the `README` are placed outside of the `metadata` folder~~ not changed
