### PR TITLE
Google Meet: Add "Create Meet and Refocus" command and Dia browser support

### DIFF
--- a/extensions/google-meet/CHANGELOG.md
+++ b/extensions/google-meet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Meet Changelog
 
+## [New Command] - 2026-03-08
+
+- Add "Create Meet and Refocus" command that creates a meeting, copies the link, and switches back to your previous app
+
 ## [Improvement] - 2026-02-13
 
 - Make delay configurable by user

--- a/extensions/google-meet/CHANGELOG.md
+++ b/extensions/google-meet/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Meet Changelog
 
-## [New Command] - {PR_MERGE_DATE}
+## [New Command] - 2026-04-12
 
 - Add "Create Meet and Refocus" command that creates a meeting, copies the link, and switches back to your previous app
 - Add Dia browser support

--- a/extensions/google-meet/CHANGELOG.md
+++ b/extensions/google-meet/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Google Meet Changelog
 
-## [New Command] - 2026-03-08
+## [New Command] - {PR_MERGE_DATE}
 
 - Add "Create Meet and Refocus" command that creates a meeting, copies the link, and switches back to your previous app
+- Add Dia browser support
 
 ## [Improvement] - 2026-02-13
 

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -8,7 +8,8 @@
   "contributors": [
     "hughlaw",
     "iwex",
-    "nexxai"
+    "nexxai",
+    "tim_gailey"
   ],
   "license": "MIT",
   "commands": [
@@ -17,6 +18,13 @@
       "title": "Create Meet",
       "subtitle": "Google Meet",
       "description": "Creates a new meeting room with your default browser and copy the link to your clipboard.",
+      "mode": "no-view"
+    },
+    {
+      "name": "default-profile-and-refocus",
+      "title": "Create Meet and Refocus",
+      "subtitle": "Google Meet",
+      "description": "Creates a new meeting room, copies the link to your clipboard, and refocuses your previous app.",
       "mode": "no-view"
     },
     {

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -75,6 +75,9 @@
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
   },
+  "categories": [
+    "Communication"
+  ],
   "platforms": [
     "macOS"
   ]

--- a/extensions/google-meet/src/default-profile-and-refocus.ts
+++ b/extensions/google-meet/src/default-profile-and-refocus.ts
@@ -1,0 +1,21 @@
+import { showHUD, Clipboard } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { getMeetTab, openMeetTabDefaultProfile, getTimeout, sleep, switchToPreviousApp } from "./helpers";
+
+export default async function main() {
+  try {
+    await openMeetTabDefaultProfile();
+
+    const timeout = getTimeout();
+    await sleep(timeout);
+
+    const meetTab = await getMeetTab();
+
+    await Clipboard.copy(meetTab);
+    await showHUD("Copied meet link to clipboard");
+
+    await switchToPreviousApp();
+  } catch {
+    await showFailureToast("Failed to create meet link. Make sure your browser is supported and try again.");
+  }
+}

--- a/extensions/google-meet/src/helpers.ts
+++ b/extensions/google-meet/src/helpers.ts
@@ -39,7 +39,12 @@ async function getOpenTabs(): Promise<string> {
     return await runAppleScript(getOpenedUrlForArc());
   }
 
-  if (browserName === "Firefox" || browserName === "Firefox Developer Edition" || browserName === "Zen") {
+  if (
+    browserName === "Firefox" ||
+    browserName === "Firefox Developer Edition" ||
+    browserName === "Zen" ||
+    browserName === "Dia"
+  ) {
     return await runAppleScript(getOpenedUrlForFirefox(browserName));
   }
 

--- a/extensions/google-meet/src/helpers.ts
+++ b/extensions/google-meet/src/helpers.ts
@@ -5,6 +5,7 @@ import {
   getOpenedUrlForArc,
   getOpenedUrlForFirefox,
   getOpenedUrlsScript,
+  getSwitchToPreviousAppScript,
   supportedBrowsers,
 } from "./utils/scripts";
 
@@ -77,6 +78,10 @@ export async function openMeetTabDefaultProfile(): Promise<void> {
   const preferredBrowser = getPreferredBrowser();
 
   await open(openMeetTabUrl, preferredBrowser?.name);
+}
+
+export async function switchToPreviousApp(): Promise<void> {
+  await runAppleScript(getSwitchToPreviousAppScript());
 }
 
 export async function openMeetTabSelectedProfile(profile: string): Promise<void> {

--- a/extensions/google-meet/src/utils/scripts.ts
+++ b/extensions/google-meet/src/utils/scripts.ts
@@ -65,6 +65,14 @@ export function getOpenedUrlForFirefox(browserName: string) {
   `;
 }
 
+export function getSwitchToPreviousAppScript(): string {
+  return `
+    tell application "System Events"
+      keystroke tab using {command down}
+    end tell
+  `;
+}
+
 export const supportedBrowsers = [
   "Arc",
   "Brave",

--- a/extensions/google-meet/src/utils/scripts.ts
+++ b/extensions/google-meet/src/utils/scripts.ts
@@ -88,6 +88,7 @@ export const supportedBrowsers = [
   "Vivaldi",
   "Yandex",
   "Zen",
+  "Dia",
 ] as const;
 
 // Easy way to access the focused window when the meet link opens


### PR DESCRIPTION
## Description

 - Adds a new "Create Meet and Refocus" no-view command that creates a meeting, copies the link to clipboard, and switches back to the previous app via Cmd+Tab
  - Adds Dia browser support using the same keystroke-based URL copy method as Firefox/Zen
 
## Screencast

https://supercut.ai/share/timgailey-design/lOnntTQ7iiE5WL3avqALkE 

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)