### PR TITLE
Spotify Player: Reduce API rate limiting with tiered caching and fewer redundant calls

### DIFF
--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Spotify Player Changelog
 
+## [Reduce API Rate Limiting] - {PR_MERGE_DATE}
+
+- Added tiered API-level caching (short/medium/long TTL) to reduce redundant Spotify API calls
+- Removed cascading background command launches from playback commands (next, previous, like, dislike, skip15, back15)
+- Lazy-load Your Library sections by selected category instead of fetching all upfront
+- Increased menu bar polling interval and added debouncing to prevent refresh bursts
+- Replaced retry-based rate limit handling with immediate error propagation for clearer feedback
+
 ## [Fix Rate Limiting from Spotify API Changes] - 2026-03-08
 
 - Added 429 Retry-After middleware — all API calls now automatically retry on rate limit with proper backoff

--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Removed cascading background command launches from playback commands (next, previous, like, dislike, skip15, back15)
 - Lazy-load Your Library sections by selected category instead of fetching all upfront
 - Increased menu bar polling interval and added debouncing to prevent refresh bursts
-- Replaced retry-based rate limit handling with immediate error propagation for clearer feedback
+- Simplified rate limit middleware to a single retry after honouring Retry-After
 
 ## [Fix Rate Limiting from Spotify API Changes] - 2026-03-08
 

--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Spotify Player Changelog
 
-## [Reduce API Rate Limiting] - {PR_MERGE_DATE}
+## [Reduce API Rate Limiting] - 2026-03-18
 
 - Added tiered API-level caching (short/medium/long TTL) to reduce redundant Spotify API calls
 - Removed cascading background command launches from playback commands (next, previous, like, dislike, skip15, back15)

--- a/extensions/spotify-player/package.json
+++ b/extensions/spotify-player/package.json
@@ -396,7 +396,7 @@
     },
     {
       "name": "volumeUp",
-      "title": "Turn Volume up",
+      "title": "Turn Volume Up",
       "subtitle": "Spotify",
       "description": "Turn the volume up by 10%.",
       "mode": "no-view",

--- a/extensions/spotify-player/package.json
+++ b/extensions/spotify-player/package.json
@@ -396,7 +396,7 @@
     },
     {
       "name": "volumeUp",
-      "title": "Turn Volume Up",
+      "title": "Turn Volume up",
       "subtitle": "Spotify",
       "description": "Turn the volume up by 10%.",
       "mode": "no-view",

--- a/extensions/spotify-player/src/api/addToMySavedTracks.ts
+++ b/extensions/spotify-player/src/api/addToMySavedTracks.ts
@@ -1,3 +1,4 @@
+import { invalidateCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
@@ -10,6 +11,8 @@ export async function addToMySavedTracks({ trackIds }: AddToMySavedTracksProps) 
 
   try {
     const response = await spotifyClient.putMeTracks(trackIds.join());
+    invalidateCache("api:library:tracks");
+    invalidateCache("api:currently-playing");
     return response;
   } catch (err) {
     const error = getErrorMessage(err);

--- a/extensions/spotify-player/src/api/addToMySavedTracks.ts
+++ b/extensions/spotify-player/src/api/addToMySavedTracks.ts
@@ -13,6 +13,7 @@ export async function addToMySavedTracks({ trackIds }: AddToMySavedTracksProps) 
     const response = await spotifyClient.putMeTracks(trackIds.join());
     invalidateCache("api:library:tracks");
     invalidateCache("api:currently-playing");
+    invalidateCache(`api:liked:${trackIds.join(",")}`);
     return response;
   } catch (err) {
     const error = getErrorMessage(err);

--- a/extensions/spotify-player/src/api/addToPlaylist.ts
+++ b/extensions/spotify-player/src/api/addToPlaylist.ts
@@ -1,3 +1,4 @@
+import { invalidateCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
@@ -11,6 +12,7 @@ export async function addToPlaylist({ playlistId, trackUris }: AddToMyPlaylistPr
 
   try {
     const response = await spotifyClient.postPlaylistsByPlaylistIdTracks(playlistId, { uris: trackUris });
+    invalidateCache("api:playlists", "api:user-playlists");
     return response;
   } catch (err) {
     const error = getErrorMessage(err);

--- a/extensions/spotify-player/src/api/containsMySavedTrack.ts
+++ b/extensions/spotify-player/src/api/containsMySavedTrack.ts
@@ -1,11 +1,14 @@
+import { Cache } from "@raycast/api";
 import { getErrorMessage } from "../helpers/getError";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
+
+const cache = new Cache();
 
 type ContainsMySavedTracksProps = {
   trackIds: string[];
 };
 
-export async function containsMySavedTracks({ trackIds }: ContainsMySavedTracksProps) {
+async function _containsMySavedTracks({ trackIds }: ContainsMySavedTracksProps) {
   const { spotifyClient } = getSpotifyClient();
 
   try {
@@ -16,4 +19,20 @@ export async function containsMySavedTracks({ trackIds }: ContainsMySavedTracksP
     console.log("containsMySavedTracks.ts Error:", error);
     throw new Error(error);
   }
+}
+
+export async function containsMySavedTracks({ trackIds }: ContainsMySavedTracksProps) {
+  const key = `api:liked:${trackIds.join(",")}`;
+  const raw = cache.get(key);
+  if (raw) {
+    try {
+      const entry = JSON.parse(raw);
+      if (Date.now() - entry.timestamp < 30000) return entry.data;
+    } catch {
+      /* proceed */
+    }
+  }
+  const data = await _containsMySavedTracks({ trackIds });
+  cache.set(key, JSON.stringify({ data, timestamp: Date.now() }));
+  return data;
 }

--- a/extensions/spotify-player/src/api/getCurrentlyPlaying.ts
+++ b/extensions/spotify-player/src/api/getCurrentlyPlaying.ts
@@ -1,8 +1,9 @@
+import { withCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { EpisodeObject, TrackObject } from "../helpers/spotify.api";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
-export async function getCurrentlyPlaying() {
+async function _getCurrentlyPlaying() {
   const { spotifyClient } = getSpotifyClient();
 
   try {
@@ -20,3 +21,5 @@ export async function getCurrentlyPlaying() {
     throw new Error(error);
   }
 }
+
+export const getCurrentlyPlaying = withCache("api:currently-playing", 10000, _getCurrentlyPlaying);

--- a/extensions/spotify-player/src/api/getFollowedArtists.ts
+++ b/extensions/spotify-player/src/api/getFollowedArtists.ts
@@ -1,9 +1,10 @@
+import { withCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
 type GetFollowedArtistsProps = { limit?: number };
 
-export async function getFollowedArtists({ limit = 50 }: GetFollowedArtistsProps = {}) {
+async function _getFollowedArtists({ limit = 50 }: GetFollowedArtistsProps = {}) {
   const { spotifyClient } = getSpotifyClient();
 
   try {
@@ -15,3 +16,5 @@ export async function getFollowedArtists({ limit = 50 }: GetFollowedArtistsProps
     throw new Error(error);
   }
 }
+
+export const getFollowedArtists = withCache("api:library:artists", 300000, _getFollowedArtists);

--- a/extensions/spotify-player/src/api/getMe.ts
+++ b/extensions/spotify-player/src/api/getMe.ts
@@ -1,7 +1,8 @@
+import { withCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
-export async function getMe() {
+async function _getMe() {
   const { spotifyClient } = getSpotifyClient();
 
   try {
@@ -13,3 +14,5 @@ export async function getMe() {
     throw new Error(error);
   }
 }
+
+export const getMe = withCache("api:me", 3600000, _getMe);

--- a/extensions/spotify-player/src/api/getMyDevices.ts
+++ b/extensions/spotify-player/src/api/getMyDevices.ts
@@ -1,7 +1,8 @@
+import { withCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
-export async function getMyDevices() {
+async function _getMyDevices() {
   const { spotifyClient } = getSpotifyClient();
 
   try {
@@ -13,3 +14,5 @@ export async function getMyDevices() {
     throw new Error(error);
   }
 }
+
+export const getMyDevices = withCache("api:devices", 30000, _getMyDevices);

--- a/extensions/spotify-player/src/api/getMyPlaylists.ts
+++ b/extensions/spotify-player/src/api/getMyPlaylists.ts
@@ -1,9 +1,10 @@
+import { withCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
 type GetUserPlaylistsProps = { limit?: number };
 
-export async function getMyPlaylists({ limit = 50 }: GetUserPlaylistsProps = {}) {
+async function _getMyPlaylists({ limit = 50 }: GetUserPlaylistsProps = {}) {
   const { spotifyClient } = getSpotifyClient();
   let response = null;
   let nextUrl = null;
@@ -29,3 +30,5 @@ export async function getMyPlaylists({ limit = 50 }: GetUserPlaylistsProps = {})
     throw new Error(error);
   }
 }
+
+export const getMyPlaylists = withCache("api:playlists", 300000, _getMyPlaylists);

--- a/extensions/spotify-player/src/api/getMySavedAlbums.ts
+++ b/extensions/spotify-player/src/api/getMySavedAlbums.ts
@@ -1,10 +1,11 @@
+import { withCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { SimplifiedAlbumObject } from "../helpers/spotify.api";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
 type GetMySavedAlbumsProps = { limit?: number };
 
-export async function getMySavedAlbums({ limit = 50 }: GetMySavedAlbumsProps = {}) {
+async function _getMySavedAlbums({ limit = 50 }: GetMySavedAlbumsProps = {}) {
   const { spotifyClient } = getSpotifyClient();
 
   try {
@@ -27,3 +28,5 @@ export async function getMySavedAlbums({ limit = 50 }: GetMySavedAlbumsProps = {
     throw new Error(error);
   }
 }
+
+export const getMySavedAlbums = withCache("api:library:albums", 300000, _getMySavedAlbums);

--- a/extensions/spotify-player/src/api/getMySavedEpisodes.ts
+++ b/extensions/spotify-player/src/api/getMySavedEpisodes.ts
@@ -1,10 +1,11 @@
+import { withCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { SimplifiedEpisodeObject } from "../helpers/spotify.api";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
 type GetMySavedEpisodesProps = { limit?: number };
 
-export async function getMySavedEpisodes({ limit = 50 }: GetMySavedEpisodesProps = {}) {
+async function _getMySavedEpisodes({ limit = 50 }: GetMySavedEpisodesProps = {}) {
   const { spotifyClient } = getSpotifyClient();
 
   try {
@@ -25,3 +26,5 @@ export async function getMySavedEpisodes({ limit = 50 }: GetMySavedEpisodesProps
     throw new Error(error);
   }
 }
+
+export const getMySavedEpisodes = withCache("api:library:episodes", 300000, _getMySavedEpisodes);

--- a/extensions/spotify-player/src/api/getMySavedShows.ts
+++ b/extensions/spotify-player/src/api/getMySavedShows.ts
@@ -1,10 +1,11 @@
+import { withCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { SimplifiedShowObject } from "../helpers/spotify.api";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
 type GetMySavedShowsProps = { limit?: number };
 
-export async function getMySavedShows({ limit = 50 }: GetMySavedShowsProps = {}) {
+async function _getMySavedShows({ limit = 50 }: GetMySavedShowsProps = {}) {
   const { spotifyClient } = getSpotifyClient();
 
   try {
@@ -25,3 +26,5 @@ export async function getMySavedShows({ limit = 50 }: GetMySavedShowsProps = {})
     throw new Error(error);
   }
 }
+
+export const getMySavedShows = withCache("api:library:shows", 300000, _getMySavedShows);

--- a/extensions/spotify-player/src/api/getMySavedTracks.ts
+++ b/extensions/spotify-player/src/api/getMySavedTracks.ts
@@ -1,10 +1,11 @@
+import { withCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { SimplifiedTrackObject } from "../helpers/spotify.api";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
 type GetMySavedTracksProps = { limit?: number };
 
-export async function getMySavedTracks({ limit = 50 }: GetMySavedTracksProps = {}) {
+async function _getMySavedTracks({ limit = 50 }: GetMySavedTracksProps = {}) {
   const { spotifyClient } = getSpotifyClient();
 
   try {
@@ -25,3 +26,5 @@ export async function getMySavedTracks({ limit = 50 }: GetMySavedTracksProps = {
     throw new Error(error);
   }
 }
+
+export const getMySavedTracks = withCache("api:library:tracks", 300000, _getMySavedTracks);

--- a/extensions/spotify-player/src/api/getUserPlaylists.ts
+++ b/extensions/spotify-player/src/api/getUserPlaylists.ts
@@ -1,9 +1,10 @@
+import { withCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
 type GetUserPlaylistsProps = { limit?: number };
 
-export async function getUserPlaylists({ limit = 50 }: GetUserPlaylistsProps = {}) {
+async function _getUserPlaylists({ limit = 50 }: GetUserPlaylistsProps = {}) {
   const { spotifyClient } = getSpotifyClient();
 
   try {
@@ -15,3 +16,5 @@ export async function getUserPlaylists({ limit = 50 }: GetUserPlaylistsProps = {
     throw new Error(error);
   }
 }
+
+export const getUserPlaylists = withCache("api:user-playlists", 300000, _getUserPlaylists);

--- a/extensions/spotify-player/src/api/removeFromMySavedTracks.ts
+++ b/extensions/spotify-player/src/api/removeFromMySavedTracks.ts
@@ -1,3 +1,4 @@
+import { invalidateCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
@@ -10,6 +11,8 @@ export async function removeFromMySavedTracks({ trackIds }: RemoveFromMySavedTra
 
   try {
     const response = await spotifyClient.deleteMeTracks(trackIds.join());
+    invalidateCache("api:library:tracks");
+    invalidateCache("api:currently-playing");
     return response;
   } catch (err) {
     const error = getErrorMessage(err);

--- a/extensions/spotify-player/src/api/removeFromMySavedTracks.ts
+++ b/extensions/spotify-player/src/api/removeFromMySavedTracks.ts
@@ -13,6 +13,7 @@ export async function removeFromMySavedTracks({ trackIds }: RemoveFromMySavedTra
     const response = await spotifyClient.deleteMeTracks(trackIds.join());
     invalidateCache("api:library:tracks");
     invalidateCache("api:currently-playing");
+    invalidateCache(`api:liked:${trackIds.join(",")}`);
     return response;
   } catch (err) {
     const error = getErrorMessage(err);

--- a/extensions/spotify-player/src/api/removeFromPlaylist.ts
+++ b/extensions/spotify-player/src/api/removeFromPlaylist.ts
@@ -1,3 +1,4 @@
+import { invalidateCache } from "../helpers/apiCache";
 import { getErrorMessage } from "../helpers/getError";
 import { getSpotifyClient } from "../helpers/withSpotifyClient";
 
@@ -15,6 +16,7 @@ export async function removeFromPlaylist({ playlistId, trackUris: tracks }: Remo
     const response = await spotifyClient.deletePlaylistsByPlaylistIdTracks(playlistId, {
       tracks,
     });
+    invalidateCache("api:playlists", "api:user-playlists");
     return response;
   } catch (err) {
     const error = getErrorMessage(err);

--- a/extensions/spotify-player/src/back15.ts
+++ b/extensions/spotify-player/src/back15.ts
@@ -1,7 +1,6 @@
 import { showHUD } from "@raycast/api";
 import { setSpotifyClient } from "./helpers/withSpotifyClient";
 import { getCurrentlyPlaying } from "./api/getCurrentlyPlaying";
-import { safeLaunchCommandInBackground } from "./helpers/safeCommandLauncher";
 import { seek } from "./api/seek";
 
 export default async function Command() {
@@ -18,7 +17,6 @@ export default async function Command() {
     const currentPositionSeconds = (currentlyPlayingData?.progress_ms || 0) / 1000;
     await seek(Math.max(currentPositionSeconds - 15, 0), currentlyPlayingData?.item?.duration_ms);
     await showHUD("Skipped back 15 seconds");
-    await safeLaunchCommandInBackground("current-track");
   } catch {
     await showHUD("Nothing is currently playing");
   }

--- a/extensions/spotify-player/src/dislike.ts
+++ b/extensions/spotify-player/src/dislike.ts
@@ -2,7 +2,6 @@ import { showHUD } from "@raycast/api";
 import { setSpotifyClient } from "./helpers/withSpotifyClient";
 import { getCurrentlyPlaying } from "./api/getCurrentlyPlaying";
 import { removeFromMySavedTracks } from "./api/removeFromMySavedTracks";
-import { safeLaunchCommandInBackground } from "./helpers/safeCommandLauncher";
 
 export default async function Command() {
   await setSpotifyClient();
@@ -25,7 +24,6 @@ export default async function Command() {
       trackIds: trackId ? [trackId] : [],
     });
     await showHUD(`Disliked ${currentlyPlayingData?.item.name}`);
-    await safeLaunchCommandInBackground("current-track");
   } catch {
     await showHUD("Nothing is currently playing");
   }

--- a/extensions/spotify-player/src/helpers/apiCache.ts
+++ b/extensions/spotify-player/src/helpers/apiCache.ts
@@ -10,7 +10,8 @@ export function withCache<TArgs extends unknown[], TResult>(
   fn: (...args: TArgs) => Promise<TResult>,
 ): (...args: TArgs) => Promise<TResult> {
   return async (...args) => {
-    const raw = cache.get(key);
+    const cacheKey = args.length > 0 ? `${key}:${JSON.stringify(args)}` : key;
+    const raw = cache.get(cacheKey);
     if (raw) {
       try {
         const entry: CacheEntry<TResult> = JSON.parse(raw);
@@ -20,7 +21,7 @@ export function withCache<TArgs extends unknown[], TResult>(
       }
     }
     const data = await fn(...args);
-    cache.set(key, JSON.stringify({ data, timestamp: Date.now() }));
+    cache.set(cacheKey, JSON.stringify({ data, timestamp: Date.now() }));
     return data;
   };
 }

--- a/extensions/spotify-player/src/helpers/apiCache.ts
+++ b/extensions/spotify-player/src/helpers/apiCache.ts
@@ -1,0 +1,30 @@
+import { Cache } from "@raycast/api";
+
+const cache = new Cache();
+
+type CacheEntry<T> = { data: T; timestamp: number };
+
+export function withCache<TArgs extends unknown[], TResult>(
+  key: string,
+  ttlMs: number,
+  fn: (...args: TArgs) => Promise<TResult>,
+): (...args: TArgs) => Promise<TResult> {
+  return async (...args) => {
+    const raw = cache.get(key);
+    if (raw) {
+      try {
+        const entry: CacheEntry<TResult> = JSON.parse(raw);
+        if (Date.now() - entry.timestamp < ttlMs) return entry.data;
+      } catch {
+        /* corrupted cache, proceed to fetch */
+      }
+    }
+    const data = await fn(...args);
+    cache.set(key, JSON.stringify({ data, timestamp: Date.now() }));
+    return data;
+  };
+}
+
+export function invalidateCache(...keys: string[]) {
+  for (const key of keys) cache.remove(key);
+}

--- a/extensions/spotify-player/src/helpers/rateLimitRetry.ts
+++ b/extensions/spotify-player/src/helpers/rateLimitRetry.ts
@@ -1,6 +1,3 @@
-import { showHUD } from "@raycast/api";
-import retry from "async-retry";
-
 type FetchFn = (url: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 // Global rate limit state shared across all requests.
@@ -17,38 +14,18 @@ export function withRateLimitRetry(fetchFn: FetchFn): FetchFn {
       await new Promise((resolve) => setTimeout(resolve, waitMs));
     }
 
-    return retry(
-      async () => {
-        const response = await fetchFn(url, init);
+    const response = await fetchFn(url, init);
 
-        if (response.status === 429) {
-          const retryAfter = response.headers.get("Retry-After");
-          const baseSeconds = retryAfter ? parseInt(retryAfter, 10) : 1;
-          // Add 2s buffer to avoid hitting the limit again immediately after retry
-          const waitSeconds = (isNaN(baseSeconds) ? 1 : baseSeconds) + 2;
-          const waitMs = waitSeconds * 1000;
+    if (response.status === 429) {
+      const retryAfter = response.headers.get("Retry-After");
+      const waitSeconds = retryAfter ? parseInt(retryAfter, 10) : 1;
 
-          // Set global rate limit so other concurrent requests also wait
-          rateLimitedUntil = Date.now() + waitMs;
+      // Set global rate limit so other concurrent requests also wait
+      rateLimitedUntil = Date.now() + (isNaN(waitSeconds) ? 1 : waitSeconds) * 1000;
 
-          showHUD(`Spotify rate limited — retrying in ${waitSeconds}s`);
-          await new Promise((resolve) => setTimeout(resolve, waitMs));
-          throw new Error(`Rate limited, retrying after ${waitSeconds}s`);
-        }
+      throw new Error(`Spotify API rate limit exceeded (retry after ${waitSeconds}s)`);
+    }
 
-        // Don't retry other errors — let oazapfts handle them
-        return response;
-      },
-      {
-        retries: 2,
-        // We handle our own delays via Retry-After, so keep these minimal
-        minTimeout: 0,
-        maxTimeout: 0,
-        onRetry: (err, attempt) => {
-          const message = err instanceof Error ? err.message : String(err);
-          console.log(`Rate limit retry attempt ${attempt}: ${message}`);
-        },
-      },
-    );
+    return response;
   };
 }

--- a/extensions/spotify-player/src/helpers/rateLimitRetry.ts
+++ b/extensions/spotify-player/src/helpers/rateLimitRetry.ts
@@ -19,11 +19,14 @@ export function withRateLimitRetry(fetchFn: FetchFn): FetchFn {
     if (response.status === 429) {
       const retryAfter = response.headers.get("Retry-After");
       const waitSeconds = retryAfter ? parseInt(retryAfter, 10) : 1;
+      const waitMs = (isNaN(waitSeconds) ? 1 : waitSeconds) * 1000;
 
       // Set global rate limit so other concurrent requests also wait
-      rateLimitedUntil = Date.now() + (isNaN(waitSeconds) ? 1 : waitSeconds) * 1000;
+      rateLimitedUntil = Date.now() + waitMs;
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
 
-      throw new Error(`Spotify API rate limit exceeded (retry after ${waitSeconds}s)`);
+      // Retry once after honouring the Retry-After window
+      return fetchFn(url, init);
     }
 
     return response;

--- a/extensions/spotify-player/src/hooks/useYourLibrary.ts
+++ b/extensions/spotify-player/src/hooks/useYourLibrary.ts
@@ -6,42 +6,61 @@ import { getMySavedTracks } from "../api/getMySavedTracks";
 import { getMySavedShows } from "../api/getMySavedShows";
 import { getMySavedEpisodes } from "../api/getMySavedEpisodes";
 
+export type LibraryCategory = "all" | "playlists" | "albums" | "artists" | "tracks" | "shows" | "episodes";
+
 type UseMyLibraryProps = {
-  execute?: boolean;
+  category?: LibraryCategory;
   keepPreviousData?: boolean;
 };
 
-export function useYourLibrary(options: UseMyLibraryProps = {}) {
-  const {
-    data = [],
-    error,
-    isLoading,
-  } = useCachedPromise(
-    () =>
-      Promise.all([
-        getUserPlaylists(),
-        getMySavedAlbums(),
-        getFollowedArtists(),
-        getMySavedTracks(),
-        getMySavedShows(),
-        getMySavedEpisodes(),
-      ]),
-    [],
-    {
-      keepPreviousData: options?.keepPreviousData,
-    },
-  );
+type LibraryData = {
+  playlists?: Awaited<ReturnType<typeof getUserPlaylists>>;
+  albums?: Awaited<ReturnType<typeof getMySavedAlbums>>;
+  artists?: Awaited<ReturnType<typeof getFollowedArtists>>;
+  tracks?: Awaited<ReturnType<typeof getMySavedTracks>>;
+  shows?: Awaited<ReturnType<typeof getMySavedShows>>;
+  episodes?: Awaited<ReturnType<typeof getMySavedEpisodes>>;
+};
 
-  const [playlistsData, albumsData, artistsData, tracksData, showsData, episodesData] = data;
+async function fetchLibraryData(category: LibraryCategory): Promise<LibraryData> {
+  if (category === "all") {
+    const [playlists, albums, artists, tracks, shows, episodes] = await Promise.all([
+      getUserPlaylists(),
+      getMySavedAlbums(),
+      getFollowedArtists(),
+      getMySavedTracks(),
+      getMySavedShows(),
+      getMySavedEpisodes(),
+    ]);
+    return { playlists, albums, artists, tracks, shows, episodes };
+  }
+
+  const fetchers: Record<Exclude<LibraryCategory, "all">, () => Promise<LibraryData>> = {
+    playlists: async () => ({ playlists: await getUserPlaylists() }),
+    albums: async () => ({ albums: await getMySavedAlbums() }),
+    artists: async () => ({ artists: await getFollowedArtists() }),
+    tracks: async () => ({ tracks: await getMySavedTracks() }),
+    shows: async () => ({ shows: await getMySavedShows() }),
+    episodes: async () => ({ episodes: await getMySavedEpisodes() }),
+  };
+
+  return fetchers[category]();
+}
+
+export function useYourLibrary(options: UseMyLibraryProps = {}) {
+  const category = options.category ?? "all";
+  const { data, error, isLoading } = useCachedPromise(fetchLibraryData, [category], {
+    keepPreviousData: options?.keepPreviousData,
+  });
 
   return {
     myLibraryData: {
-      playlists: playlistsData,
-      albums: albumsData,
-      artists: artistsData,
-      tracks: tracksData,
-      shows: showsData,
-      episodes: episodesData,
+      playlists: data?.playlists,
+      albums: data?.albums,
+      artists: data?.artists,
+      tracks: data?.tracks,
+      shows: data?.shows,
+      episodes: data?.episodes,
     },
     myLibraryError: error,
     myLibraryIsLoading: isLoading,

--- a/extensions/spotify-player/src/like.ts
+++ b/extensions/spotify-player/src/like.ts
@@ -3,7 +3,6 @@ import { setSpotifyClient } from "./helpers/withSpotifyClient";
 import { getCurrentlyPlaying } from "./api/getCurrentlyPlaying";
 import { addToMySavedTracks } from "./api/addToMySavedTracks";
 import { containsMySavedTracks } from "./api/containsMySavedTrack";
-import { safeLaunchCommandInBackground } from "./helpers/safeCommandLauncher";
 import { TrackObject } from "./helpers/spotify.api";
 
 export default async function Command() {
@@ -40,7 +39,6 @@ export default async function Command() {
       trackIds: [trackId],
     });
     await showHUD(`Liked ${item.name}${artistNameSuffix}`);
-    await safeLaunchCommandInBackground("current-track");
   } catch {
     await showHUD("Nothing is currently playing");
   }

--- a/extensions/spotify-player/src/next.ts
+++ b/extensions/spotify-player/src/next.ts
@@ -2,7 +2,6 @@ import { showHUD } from "@raycast/api";
 import { setSpotifyClient } from "./helpers/withSpotifyClient";
 import { getCurrentlyPlaying } from "./api/getCurrentlyPlaying";
 import { skipToNext } from "./api/skipToNext";
-import { safeLaunchCommandInBackground } from "./helpers/safeCommandLauncher";
 
 export default async function Command() {
   await setSpotifyClient();
@@ -22,7 +21,6 @@ export default async function Command() {
   try {
     await skipToNext();
     await showHUD("Skipped to next");
-    await safeLaunchCommandInBackground("current-track");
   } catch (error) {
     console.error(error);
     await showHUD("Nothing is currently playing");

--- a/extensions/spotify-player/src/previous.ts
+++ b/extensions/spotify-player/src/previous.ts
@@ -2,7 +2,6 @@ import { showHUD } from "@raycast/api";
 import { setSpotifyClient } from "./helpers/withSpotifyClient";
 import { getCurrentlyPlaying } from "./api/getCurrentlyPlaying";
 import { skipToPrevious } from "./api/skipToPrevious";
-import { safeLaunchCommandInBackground } from "./helpers/safeCommandLauncher";
 
 export default async function Command() {
   await setSpotifyClient();
@@ -22,7 +21,6 @@ export default async function Command() {
   try {
     await skipToPrevious();
     await showHUD("Skipped to previous");
-    await safeLaunchCommandInBackground("current-track");
   } catch {
     await showHUD("Nothing is currently playing");
   }

--- a/extensions/spotify-player/src/skip15.ts
+++ b/extensions/spotify-player/src/skip15.ts
@@ -1,7 +1,6 @@
 import { showHUD } from "@raycast/api";
 import { setSpotifyClient } from "./helpers/withSpotifyClient";
 import { getCurrentlyPlaying } from "./api/getCurrentlyPlaying";
-import { safeLaunchCommandInBackground } from "./helpers/safeCommandLauncher";
 import { seek } from "./api/seek";
 
 export default async function Command() {
@@ -18,7 +17,6 @@ export default async function Command() {
     const currentPositionSeconds = (currentlyPlayingData?.progress_ms || 0) / 1000;
     await seek(currentPositionSeconds + 15, currentlyPlayingData?.item?.duration_ms);
     await showHUD("Skipped ahead 15 seconds");
-    await safeLaunchCommandInBackground("current-track");
   } catch {
     await showHUD("Nothing is currently playing");
   }

--- a/extensions/spotify-player/src/yourLibrary.tsx
+++ b/extensions/spotify-player/src/yourLibrary.tsx
@@ -26,6 +26,7 @@ function YourLibraryCommand() {
   const [searchText, setSearchText] = useState("");
   const [searchFilter, setSearchFilter] = useState<FilterValue>(getPreferenceValues()["Default-View"] ?? filters.all);
   const { myLibraryData, myLibraryIsLoading } = useYourLibrary({
+    category: searchFilter,
     keepPreviousData: true,
   });
 


### PR DESCRIPTION
## Description

Closes #25899

Reduces Spotify API rate limiting through four targeted changes:

1. **Add tiered API-level caching layer** — introduces an `apiCache` helper with short (10s), medium (30s), and long (5min) TTL tiers to reduce redundant Spotify API calls across all GET endpoints, with automatic cache invalidation on mutating operations (add/remove tracks, playlist modifications)
2. **Remove cascading background command launches** — stops playback commands (next, previous, like, dislike, skip15, back15) from launching additional `safeLaunchCommandInBackground("current-track")` calls on completion, eliminating chains of redundant API calls
3. **Lazy-load yourLibrary sections by category** — only fetches library data for the currently selected category tab instead of all categories upfront
4. **Reduce menu bar polling interval and debounce refreshes** — increases the menu bar polling interval and adds debouncing to `triggerMenuBarRefresh` to prevent bursts of refresh calls

## Screencast

<!-- No new UI commands — this is a performance/reliability improvement to reduce 429 rate-limit errors -->
If you can see I'm spamming the "Menu Bar Player" command using the Enter key to force refresh.

https://github.com/user-attachments/assets/2e55d6c6-0ac3-4111-a6fc-8798e83ea18b

<img width="2534" height="1084" alt="image" src="https://github.com/user-attachments/assets/12d2ac9f-eab8-4528-83e4-d169b9c0d3a3" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)