### PR TITLE
Spotify Player: Fix OAuth PKCE invalid_grant by clearing corrupted tokens

### DIFF
--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Spotify Player Changelog
 
-## [Fix OAuth PKCE invalid_grant] - {PR_MERGE_DATE}
+## [Fix OAuth PKCE invalid_grant] - 2026-04-04
 
 - Clear corrupted tokens on invalid_grant error so the user is prompted to re-authenticate instead of being stuck
 

--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Spotify Player Changelog
 
+## [Fix OAuth PKCE invalid_grant] - {PR_MERGE_DATE}
+
+- Clear corrupted tokens on invalid_grant error so the user is prompted to re-authenticate instead of being stuck
+
 ## [Reduce API Rate Limiting] - 2026-03-18
 
 - Added tiered API-level caching (short/medium/long TTL) to reduce redundant Spotify API calls

--- a/extensions/spotify-player/src/api/oauth.ts
+++ b/extensions/spotify-player/src/api/oauth.ts
@@ -35,3 +35,17 @@ export const provider = new OAuthService({
   refreshTokenUrl: "https://accounts.spotify.com/api/token",
   bodyEncoding: "url-encoded",
 });
+
+// Handle corrupted PKCE tokens: clear and retry on invalid_grant
+const _originalAuthorize = provider.authorize.bind(provider);
+provider.authorize = async () => {
+  try {
+    return await _originalAuthorize();
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("invalid_grant")) {
+      await oauthClient.removeTokens();
+      return await _originalAuthorize();
+    }
+    throw err;
+  }
+};


### PR DESCRIPTION
## Description

Fixes an issue where corrupted OAuth PKCE tokens leave the user stuck in a broken state. When the Spotify token refresh fails with an `invalid_grant` error, the stored tokens are now cleared so the user is prompted to re-authenticate instead of silently failing on every subsequent request.

## Screencast

<!-- No new UI — this is a bug fix for an edge case in the OAuth flow -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)