### PR TITLE
Add paste last transcript command to Wispr Flow

### DIFF
--- a/extensions/wispr-flow/CHANGELOG.md
+++ b/extensions/wispr-flow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Wispr Flow Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-03-23
 
 ### Transcription History
 - Added a Paste Last Transcript command to paste the latest unarchived Wispr Flow transcript into the active app

--- a/extensions/wispr-flow/CHANGELOG.md
+++ b/extensions/wispr-flow/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Wispr Flow Changelog
 
+## [Update] - {PR_MERGE_DATE}
+
+### Transcription History
+- Added a Paste Last Transcript command to paste the latest unarchived Wispr Flow transcript into the active app
+
 ## [Initial Release] - 2026-03-04
 
 ### Transcription History
@@ -22,8 +27,3 @@
 - Start and stop voice recording via Raycast commands
 - Open Wispr Flow app
 - Automatic install detection with download prompt
-
-## [Update] - 2026-03-10
-
-### Transcription History
-- Added a Paste Last Transcript command to paste the latest unarchived Wispr Flow transcript into the active app

--- a/extensions/wispr-flow/CHANGELOG.md
+++ b/extensions/wispr-flow/CHANGELOG.md
@@ -22,3 +22,8 @@
 - Start and stop voice recording via Raycast commands
 - Open Wispr Flow app
 - Automatic install detection with download prompt
+
+## [Update] - 2026-03-10
+
+### Transcription History
+- Added a Paste Last Transcript command to paste the latest unarchived Wispr Flow transcript into the active app

--- a/extensions/wispr-flow/README.md
+++ b/extensions/wispr-flow/README.md
@@ -18,6 +18,7 @@ The all-in-one [Wispr Flow](https://wisprflow.ai) companion for Raycast. Search 
 | **Manage Dictionary** | View, edit, search, and delete dictionary entries |
 | **Start Recording** | Begin voice dictation instantly |
 | **Stop Recording** | End voice dictation |
+| **Paste Last Transcript** | Paste your latest unarchived transcript into the active app |
 | **Open Wispr Flow** | Launch the Wispr Flow app |
 
 ## Transcription History

--- a/extensions/wispr-flow/package.json
+++ b/extensions/wispr-flow/package.json
@@ -101,6 +101,13 @@
       "subtitle": "Wispr Flow",
       "description": "Open the Wispr Flow app",
       "mode": "no-view"
+    },
+    {
+      "name": "paste-last-transcript",
+      "title": "Paste Last Transcript",
+      "subtitle": "Wispr Flow",
+      "description": "Paste the most recent Wispr Flow transcript into the active app",
+      "mode": "no-view"
     }
   ],
   "dependencies": {

--- a/extensions/wispr-flow/src/history.ts
+++ b/extensions/wispr-flow/src/history.ts
@@ -1,0 +1,46 @@
+import { executeSQL } from "@raycast/utils";
+import { getDbPath } from "./db";
+import { Transcript } from "./types";
+import { getDisplayText } from "./utils";
+
+type TranscriptTextRow = Pick<
+  Transcript,
+  "editedText" | "formattedText" | "asrText"
+>;
+
+const LATEST_TRANSCRIPT_QUERY = `
+  SELECT editedText, formattedText, asrText
+  FROM History
+  WHERE (isArchived = 0 OR isArchived IS NULL)
+    AND (
+      (editedText IS NOT NULL AND TRIM(editedText) != '')
+      OR (formattedText IS NOT NULL AND TRIM(formattedText) != '')
+      OR (asrText IS NOT NULL AND TRIM(asrText) != '')
+    )
+  ORDER BY timestamp DESC
+  LIMIT 1
+`;
+
+export async function getLatestTranscript(
+  dbPath = getDbPath(),
+): Promise<TranscriptTextRow | null> {
+  const [transcript] = await executeSQL<TranscriptTextRow>(
+    dbPath,
+    LATEST_TRANSCRIPT_QUERY,
+  );
+
+  return transcript ?? null;
+}
+
+export async function getLatestTranscriptText(
+  dbPath = getDbPath(),
+): Promise<string | null> {
+  const latestTranscript = await getLatestTranscript(dbPath);
+
+  if (!latestTranscript) {
+    return null;
+  }
+
+  const displayText = getDisplayText(latestTranscript).trim();
+  return displayText.length > 0 ? displayText : null;
+}

--- a/extensions/wispr-flow/src/history.ts
+++ b/extensions/wispr-flow/src/history.ts
@@ -17,16 +17,26 @@ const LATEST_TRANSCRIPT_QUERY = `
       OR (formattedText IS NOT NULL AND TRIM(formattedText) != '')
       OR (asrText IS NOT NULL AND TRIM(asrText) != '')
     )
-  ORDER BY timestamp DESC
-  LIMIT 1
 `;
+
+function buildLatestTranscriptQuery(minDuration: number): string {
+  const durationCondition =
+    minDuration > 0 ? `AND duration >= ${minDuration}` : "";
+
+  return `${LATEST_TRANSCRIPT_QUERY}
+  ${durationCondition}
+  ORDER BY timestamp DESC
+  LIMIT 1`;
+}
 
 export async function getLatestTranscript(
   dbPath = getDbPath(),
+  minimumDuration = 0,
 ): Promise<TranscriptTextRow | null> {
+  const minDuration = Number(minimumDuration) || 0;
   const [transcript] = await executeSQL<TranscriptTextRow>(
     dbPath,
-    LATEST_TRANSCRIPT_QUERY,
+    buildLatestTranscriptQuery(minDuration),
   );
 
   return transcript ?? null;
@@ -34,8 +44,9 @@ export async function getLatestTranscript(
 
 export async function getLatestTranscriptText(
   dbPath = getDbPath(),
+  minimumDuration = 0,
 ): Promise<string | null> {
-  const latestTranscript = await getLatestTranscript(dbPath);
+  const latestTranscript = await getLatestTranscript(dbPath, minimumDuration);
 
   if (!latestTranscript) {
     return null;

--- a/extensions/wispr-flow/src/paste-last-transcript.ts
+++ b/extensions/wispr-flow/src/paste-last-transcript.ts
@@ -1,9 +1,17 @@
-import { Clipboard, closeMainWindow, showToast, Toast } from "@raycast/api";
+import {
+  Clipboard,
+  closeMainWindow,
+  getPreferenceValues,
+  showToast,
+  Toast,
+} from "@raycast/api";
 import { dbExists, getDbPath } from "./db";
 import { getLatestTranscriptText } from "./history";
 
 export default async function main() {
   const dbPath = getDbPath();
+  const { minimumDuration } = getPreferenceValues<Preferences>();
+  const minDuration = Number(minimumDuration) || 0;
 
   if (!dbExists()) {
     await showToast({
@@ -15,7 +23,10 @@ export default async function main() {
   }
 
   try {
-    const latestTranscriptText = await getLatestTranscriptText(dbPath);
+    const latestTranscriptText = await getLatestTranscriptText(
+      dbPath,
+      minDuration,
+    );
 
     if (!latestTranscriptText) {
       await showToast({

--- a/extensions/wispr-flow/src/paste-last-transcript.ts
+++ b/extensions/wispr-flow/src/paste-last-transcript.ts
@@ -1,0 +1,43 @@
+import { Clipboard, closeMainWindow, showToast, Toast } from "@raycast/api";
+import { dbExists, getDbPath } from "./db";
+import { getLatestTranscriptText } from "./history";
+
+export default async function main() {
+  const dbPath = getDbPath();
+
+  if (!dbExists()) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Wispr Flow database not found",
+      message: dbPath,
+    });
+    return;
+  }
+
+  try {
+    const latestTranscriptText = await getLatestTranscriptText(dbPath);
+
+    if (!latestTranscriptText) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "No transcript to paste",
+        message: "No non-archived transcript with text was found.",
+      });
+      return;
+    }
+
+    await closeMainWindow();
+    await Clipboard.paste(latestTranscriptText);
+    await showToast({
+      style: Toast.Style.Success,
+      title: "Latest transcript pasted",
+      message: "Pasted to active app",
+    });
+  } catch (error) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Failed to paste transcript",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/extensions/wispr-flow/src/utils.ts
+++ b/extensions/wispr-flow/src/utils.ts
@@ -40,7 +40,9 @@ export function getAppName(bundleId: string | null): string {
   return APP_NAMES[bundleId] ?? bundleId.split(".").pop() ?? bundleId;
 }
 
-export function getDisplayText(transcript: Transcript): string {
+export function getDisplayText(
+  transcript: Pick<Transcript, "editedText" | "formattedText" | "asrText">,
+): string {
   return (
     transcript.editedText ||
     transcript.formattedText ||


### PR DESCRIPTION
## Summary
- add a no-view command to paste the latest Wispr Flow transcript into the active app
- centralize latest-transcript lookup in a small history data helper
- document the new command in the extension README

## Testing
- npm run lint
- npm run build

_Generated with ChatGPT Codex._