### PR TITLE
Update betaseries extension

### DIFF
--- a/extensions/betaseries/CHANGELOG.md
+++ b/extensions/betaseries/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Betaseries Changelog
 
-## [Menu Bar Background Refresh Fix] - {PR_MERGE_DATE}
+## [Menu Bar Background Refresh Fix] - 2026-03-12
 
 - Fixed an error when marking an episode as watched from **My Shows** while **New Episodes Menu Bar** had not been activated yet.
 - The menu bar refresh is now skipped when the command is unavailable in background mode, so the episode action still succeeds without showing a failure message.

--- a/extensions/betaseries/CHANGELOG.md
+++ b/extensions/betaseries/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Betaseries Changelog
 
+## [Menu Bar Background Refresh Fix] - {PR_MERGE_DATE}
+
+- Fixed an error when marking an episode as watched from **My Shows** while **New Episodes Menu Bar** had not been activated yet.
+- The menu bar refresh is now skipped when the command is unavailable in background mode, so the episode action still succeeds without showing a failure message.
+
 ## [New Episodes Menu Bar + Planning Fix] - 2026-02-26
 
 - Added **New Episodes Menu Bar** command to see newly released unwatched episodes directly from the macOS menu bar, with a badge showing how many are available.

--- a/extensions/betaseries/package-lock.json
+++ b/extensions/betaseries/package-lock.json
@@ -1182,7 +1182,6 @@
       "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1272,7 +1271,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1563,7 +1561,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1994,7 +1991,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3041,7 +3037,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3335,7 +3330,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3429,7 +3423,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/betaseries/src/components/ShowEpisodesList.tsx
+++ b/extensions/betaseries/src/components/ShowEpisodesList.tsx
@@ -1,10 +1,4 @@
-import {
-  LaunchType,
-  List,
-  launchCommand,
-  showToast,
-  Toast,
-} from "@raycast/api";
+import { List, showToast, Toast } from "@raycast/api";
 import { useFetch } from "@raycast/utils";
 import {
   buildBetaSeriesUrl,
@@ -16,6 +10,7 @@ import { Show, Episode } from "../types/betaseries";
 import { EpisodeListItem } from "./EpisodeListItem";
 import { TokenRequiredView } from "./TokenRequiredView";
 import { useAuthToken } from "../hooks/useAuthToken";
+import { refreshNewEpisodesMenubar } from "../menubar";
 
 interface ShowEpisodesListProps {
   show: Show;
@@ -81,10 +76,7 @@ export function ShowEpisodesList({ show }: ShowEpisodesListProps) {
         style: Toast.Style.Success,
         title: "Episode marked as watched",
       });
-      await launchCommand({
-        name: "new-episodes-menubar",
-        type: LaunchType.Background,
-      });
+      await refreshNewEpisodesMenubar();
     } catch (error) {
       console.error(error);
       if (error instanceof Error) {

--- a/extensions/betaseries/src/menubar.ts
+++ b/extensions/betaseries/src/menubar.ts
@@ -1,6 +1,8 @@
 import { LaunchType, launchCommand } from "@raycast/api";
 
 const NEW_EPISODES_MENUBAR_COMMAND = "new-episodes-menubar";
+// Error thrown by Raycast's launchCommand when the target command
+// has never been opened by the user (menubar not yet activated).
 const BACKGROUND_ACTIVATION_ERROR_FRAGMENT =
   "must be activated before it can be run in the background";
 

--- a/extensions/betaseries/src/menubar.ts
+++ b/extensions/betaseries/src/menubar.ts
@@ -1,0 +1,27 @@
+import { LaunchType, launchCommand } from "@raycast/api";
+
+const NEW_EPISODES_MENUBAR_COMMAND = "new-episodes-menubar";
+const BACKGROUND_ACTIVATION_ERROR_FRAGMENT =
+  "must be activated before it can be run in the background";
+
+function isMenubarActivationError(error: unknown) {
+  return (
+    error instanceof Error &&
+    error.message.includes(BACKGROUND_ACTIVATION_ERROR_FRAGMENT)
+  );
+}
+
+export async function refreshNewEpisodesMenubar() {
+  try {
+    await launchCommand({
+      name: NEW_EPISODES_MENUBAR_COMMAND,
+      type: LaunchType.Background,
+    });
+  } catch (error) {
+    if (isMenubarActivationError(error)) {
+      return;
+    }
+
+    console.error("Failed to refresh New Episodes Menu Bar", error);
+  }
+}

--- a/extensions/betaseries/src/my-shows.tsx
+++ b/extensions/betaseries/src/my-shows.tsx
@@ -1,10 +1,4 @@
-import {
-  LaunchType,
-  List,
-  launchCommand,
-  showToast,
-  Toast,
-} from "@raycast/api";
+import { List, showToast, Toast } from "@raycast/api";
 import { useMemo, useState } from "react";
 import { useFetch, useLocalStorage } from "@raycast/utils";
 import {
@@ -20,6 +14,7 @@ import {
   DISABLED_SHOW_NOTIFICATIONS_KEY,
   normalizeNumberIds,
 } from "./notifications";
+import { refreshNewEpisodesMenubar } from "./menubar";
 
 type ShowFilter = "to-watch" | "active" | "archived";
 const SHOW_FILTERS: ShowFilter[] = ["to-watch", "active", "archived"];
@@ -148,10 +143,7 @@ export default function Command() {
                   : "Notifications disabled for this show",
               });
 
-              await launchCommand({
-                name: "new-episodes-menubar",
-                type: LaunchType.Background,
-              });
+              await refreshNewEpisodesMenubar();
             })();
           }}
           onLogout={() => void handleLogout()}
@@ -175,10 +167,7 @@ export default function Command() {
                   return [updated];
                 }),
             });
-            void launchCommand({
-              name: "new-episodes-menubar",
-              type: LaunchType.Background,
-            });
+            void refreshNewEpisodesMenubar();
           }}
         />
       ))}


### PR DESCRIPTION
## Description

- Fixed an error when marking an episode as watched from **My Shows** while **New Episodes Menu Bar** had not been activated yet.
- The menu bar refresh is now skipped gracefully when the command is unavailable in background mode, so the episode action still succeeds without showing a failure message.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
