### PR TITLE
[Netease-Music] feat: update Netease Music extension to support English and improve app launch handling

### DIFF
--- a/extensions/netease-music/CHANGELOG.md
+++ b/extensions/netease-music/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Netease-Music Changelog
 
+## [Add English Support] - {PR_MERGE_DATE}
+
+- update upstream package to v0.7.0 which added English support.
+- auto launch the app if not running when executing commands.
+
 ## [Add New Commands] - 2025-12-17
 
 - Added support for more operations, including toggle playing state, volume up/down, toggle lyrics.

--- a/extensions/netease-music/package.json
+++ b/extensions/netease-music/package.json
@@ -89,7 +89,7 @@
     }
   ],
   "dependencies": {
-    "@chyroc/netease-music-controller": "^0.6.0",
+    "@chyroc/netease-music-controller": "^0.7.0",
     "@raycast/api": "^1.32.1"
   },
   "devDependencies": {

--- a/extensions/netease-music/src/toggle-play.tsx
+++ b/extensions/netease-music/src/toggle-play.tsx
@@ -1,15 +1,13 @@
-import { controlMusic } from "./util";
 import NeteaseMusicController, { NeteaseMusic } from "@chyroc/netease-music-controller";
+import { controlMusic } from "./util";
 
 export default async () => {
-  const state = await NeteaseMusicController.getPlayState();
-  if (state === NeteaseMusic.PlayState.Playing) {
-    await controlMusic(NeteaseMusicController.pause);
-  } else if (state === NeteaseMusic.PlayState.Paused) {
-    await controlMusic(NeteaseMusicController.play);
-  } else if (state === NeteaseMusic.PlayState.Exit) {
-    throw new Error("Netease Music is not running.");
-  } else {
-    throw new Error("Unknown play state.");
-  }
+  await controlMusic(async () => {
+    const state = await NeteaseMusicController.getPlayState();
+    if (state === NeteaseMusic.PlayState.Playing) {
+      await NeteaseMusicController.pause();
+    } else {
+      await NeteaseMusicController.play();
+    }
+  });
 };

--- a/extensions/netease-music/src/util.tsx
+++ b/extensions/netease-music/src/util.tsx
@@ -1,7 +1,38 @@
+import NeteaseMusicController, { NeteaseMusic } from "@chyroc/netease-music-controller";
 import { showHUD } from "@raycast/api";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+async function ensureAppRunning(): Promise<void> {
+  let needsLaunch = false;
+  try {
+    const state = await NeteaseMusicController.getPlayState();
+    needsLaunch = state === NeteaseMusic.PlayState.Exit;
+  } catch {
+    // App is not running (process killed or other error)
+    needsLaunch = true;
+  }
+
+  if (needsLaunch) {
+    await execAsync("open -a 'NeteaseMusic'");
+    // Wait for the app to be fully ready (retry until menu bar is accessible)
+    for (let i = 0; i < 20; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      try {
+        await NeteaseMusicController.getPlayState();
+        return; // App is ready
+      } catch {
+        // App not ready yet, continue waiting
+      }
+    }
+  }
+}
 
 export async function controlMusic(f: () => Promise<void>) {
   try {
+    await ensureAppRunning();
     await f();
     await showHUD("✅ success");
   } catch (e) {

--- a/extensions/netease-music/src/util.tsx
+++ b/extensions/netease-music/src/util.tsx
@@ -21,15 +21,17 @@ async function ensureAppRunning(): Promise<void> {
     for (let i = 0; i < 20; i++) {
       await new Promise((resolve) => setTimeout(resolve, 500));
       try {
-        const state = await NeteaseMusicController.getPlayState();
-        if (state !== NeteaseMusic.PlayState.Exit) {
-          return; // App is ready
-        }
-        // State is still Exit; continue waiting
+    for (let i = 0; i < 20; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      try {
+        await NeteaseMusicController.getPlayState();
+        return; // App is ready
       } catch {
         // App not ready yet, continue waiting
       }
     }
+    throw new Error("NeteaseMusic failed to launch within 10 seconds");
+  }
     throw new Error("Timed out waiting for NeteaseMusic to be ready");
   }
 }

--- a/extensions/netease-music/src/util.tsx
+++ b/extensions/netease-music/src/util.tsx
@@ -1,9 +1,9 @@
 import NeteaseMusicController, { NeteaseMusic } from "@chyroc/netease-music-controller";
 import { showHUD } from "@raycast/api";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 async function ensureAppRunning(): Promise<void> {
   let needsLaunch = false;
@@ -16,17 +16,21 @@ async function ensureAppRunning(): Promise<void> {
   }
 
   if (needsLaunch) {
-    await execAsync("open -a 'NeteaseMusic'");
+    await execFileAsync("open", ["-a", "NeteaseMusic"]);
     // Wait for the app to be fully ready (retry until menu bar is accessible)
     for (let i = 0; i < 20; i++) {
       await new Promise((resolve) => setTimeout(resolve, 500));
       try {
-        await NeteaseMusicController.getPlayState();
-        return; // App is ready
+        const state = await NeteaseMusicController.getPlayState();
+        if (state !== NeteaseMusic.PlayState.Exit) {
+          return; // App is ready
+        }
+        // State is still Exit; continue waiting
       } catch {
         // App not ready yet, continue waiting
       }
     }
+    throw new Error("Timed out waiting for NeteaseMusic to be ready");
   }
 }
 


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

- update upstream package that support English control menus [PR](https://github.com/chyroc/netease-music-controller/pull/4)
- Automatically launch the app if it is not running.


## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
