### PR TITLE
Update trustmrr extension

### DIFF
--- a/extensions/trustmrr/CHANGELOG.md
+++ b/extensions/trustmrr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # TrustMRR Changelog
 
+## [Add New API Metrics + Metric-Based Sorting] - {PR_MERGE_DATE}
+
+- Add support for new API fields in extension data models: `growthMRR30d`, `visitorsLast30Days`, `googleSearchImpressionsLast30Days`, `revenuePerVisitor`, and `rank`
+- Surface new metrics in startup details metadata: revenue rank, MRR growth (30d), revenue per visitor, visitors (30d), and search impressions (30d)
+- Enhance startup list items with metric accessories for rank, MRR momentum, and revenue-per-visitor efficiency
+- Add new list sorting presets: `Top Ranked`, `MRR Momentum`, and `High Efficiency`
+
 ## [Add Startup Category Labels] - 2026-03-06
 
 - Add startup category labels to the list startups command

--- a/extensions/trustmrr/src/components/startup-detail.tsx
+++ b/extensions/trustmrr/src/components/startup-detail.tsx
@@ -37,7 +37,37 @@ function formatPercent(value: number | null): string {
     return "-";
   }
 
+  if (Math.abs(value) > 1) {
+    return `${value.toFixed(1)}%`;
+  }
+
   return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatDecimal(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatRevenuePerVisitor(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+
+  return `$${value.toFixed(2)}`;
+}
+
+function formatRank(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+
+  return `#${value}`;
 }
 
 function startupUrl(slug: string): string {
@@ -71,16 +101,24 @@ export function StartupDetailView({ slug, onReset }: StartupDetailViewProps) {
       <Detail.Metadata.Label title="Revenue (30d)" text={formatUsd(data.revenue.last30Days)} />
       <Detail.Metadata.Label title="MRR" text={formatUsd(data.revenue.mrr)} />
       <Detail.Metadata.Label title="Asking Price" text={formatUsd(data.askingPrice)} />
+      <Detail.Metadata.Label title="Revenue Rank" text={formatRank(data.rank)} />
       <Detail.Metadata.Label title="Growth (30d)" text={formatPercent(data.growth30d)} />
+      <Detail.Metadata.Label title="MRR Growth (30d)" text={formatPercent(data.growthMRR30d)} />
       <Detail.Metadata.Label
         title="Profit Margin"
         text={data.profitMarginLast30Days === null ? "-" : `${data.profitMarginLast30Days}%`}
       />
+      <Detail.Metadata.Label title="Revenue / Visitor" text={formatRevenuePerVisitor(data.revenuePerVisitor)} />
       <Detail.Metadata.Separator />
       <Detail.Metadata.Label title="Payment Provider" text={data.paymentProvider} />
       <Detail.Metadata.Label title="Merchant of Record" text={data.isMerchantOfRecord ? "Yes" : "No"} />
       <Detail.Metadata.Label title="Customers" text={String(data.customers)} />
       <Detail.Metadata.Label title="Active Subscriptions" text={String(data.activeSubscriptions)} />
+      <Detail.Metadata.Label title="Visitors (30d)" text={formatDecimal(data.visitorsLast30Days)} />
+      <Detail.Metadata.Label
+        title="Search Impressions (30d)"
+        text={formatDecimal(data.googleSearchImpressionsLast30Days)}
+      />
       <Detail.Metadata.Separator />
       <Detail.Metadata.TagList title="Tech">
         {data.techStack.map((tech: StartupDetail["techStack"][number]) => (

--- a/extensions/trustmrr/src/lib/api.ts
+++ b/extensions/trustmrr/src/lib/api.ts
@@ -40,7 +40,12 @@ export type Startup = {
   askingPrice: number | null;
   profitMarginLast30Days: number | null;
   growth30d: number | null;
+  growthMRR30d: number | null;
   multiple: number | null;
+  rank: number | null;
+  visitorsLast30Days: number | null;
+  googleSearchImpressionsLast30Days: number | null;
+  revenuePerVisitor: number | null;
   onSale: boolean;
   firstListedForSaleAt: string | null;
   xHandle: string | null;

--- a/extensions/trustmrr/src/list-startups.tsx
+++ b/extensions/trustmrr/src/list-startups.tsx
@@ -6,7 +6,7 @@ import { formatUsd, listStartups, type Startup } from "./lib/api";
 
 const PAGE_SIZE = 50;
 
-const SORT_OPTIONS = [
+const API_SORT_OPTIONS = [
   { value: "revenue-desc", title: "Revenue: High to Low" },
   { value: "revenue-asc", title: "Revenue: Low to High" },
   { value: "price-desc", title: "Price: High to Low" },
@@ -20,7 +20,17 @@ const SORT_OPTIONS = [
   { value: "best-deal", title: "Best Deal" },
 ] as const;
 
+const LOCAL_SORT_OPTIONS = [
+  { value: "rank-asc", title: "Top Ranked" },
+  { value: "mrr-growth-desc", title: "MRR Momentum" },
+  { value: "revenue-per-visitor-desc", title: "High Efficiency" },
+] as const;
+
+const SORT_OPTIONS = [...API_SORT_OPTIONS, ...LOCAL_SORT_OPTIONS] as const;
+
 type SortValue = (typeof SORT_OPTIONS)[number]["value"];
+type ApiSortValue = (typeof API_SORT_OPTIONS)[number]["value"];
+type LocalSortValue = (typeof LOCAL_SORT_OPTIONS)[number]["value"];
 const CATEGORY_LABELS = {
   all: "All Categories",
   ai: "AI",
@@ -59,6 +69,7 @@ const CATEGORY_LABELS = {
 type CategoryValue = keyof typeof CATEGORY_LABELS;
 
 const CATEGORY_VALUES = Object.keys(CATEGORY_LABELS) as CategoryValue[];
+const LOCAL_SORT_VALUES = new Set<LocalSortValue>(LOCAL_SORT_OPTIONS.map((option) => option.value));
 
 type PaginatedData = {
   data: Startup[];
@@ -92,12 +103,56 @@ function SortSubmenu({ sort, onSelectSort }: SortSubmenuProps) {
   );
 }
 
+function toApiSortValue(sort: SortValue): ApiSortValue {
+  if (LOCAL_SORT_VALUES.has(sort as LocalSortValue)) {
+    return "revenue-desc";
+  }
+
+  return sort as ApiSortValue;
+}
+
+function compareNullableNumber(a: number | null, b: number | null, descending: boolean): number {
+  if (a === null && b === null) {
+    return 0;
+  }
+
+  if (a === null) {
+    return 1;
+  }
+
+  if (b === null) {
+    return -1;
+  }
+
+  if (descending) {
+    return b - a;
+  }
+
+  return a - b;
+}
+
+function sortStartups(startups: Startup[], sort: SortValue): Startup[] {
+  if (sort === "rank-asc") {
+    return [...startups].sort((a, b) => compareNullableNumber(a.rank, b.rank, false));
+  }
+
+  if (sort === "mrr-growth-desc") {
+    return [...startups].sort((a, b) => compareNullableNumber(a.growthMRR30d, b.growthMRR30d, true));
+  }
+
+  if (sort === "revenue-per-visitor-desc") {
+    return [...startups].sort((a, b) => compareNullableNumber(a.revenuePerVisitor, b.revenuePerVisitor, true));
+  }
+
+  return startups;
+}
+
 const fetchStartupsPage = withCache(
   async (page: number, sort: SortValue, category: CategoryValue): Promise<PaginatedData> => {
     const response = await listStartups({
       page,
       limit: PAGE_SIZE,
-      sort,
+      sort: toApiSortValue(sort),
       category: category === "all" ? undefined : category,
     });
 
@@ -140,6 +195,59 @@ function mergeStartups(existing: Startup[], incoming: Startup[]): Startup[] {
   }
 
   return merged;
+}
+
+function formatRank(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+
+  return `#${value}`;
+}
+
+function formatGrowthPercent(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+
+  if (Math.abs(value) <= 1) {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+
+  return `${value.toFixed(1)}%`;
+}
+
+function formatRevenuePerVisitor(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+
+  return `$${value.toFixed(2)}`;
+}
+
+function accessoriesForStartup(startup: Startup) {
+  return [
+    {
+      tag: formatRank(startup.rank),
+      tooltip: "Revenue rank",
+    },
+    {
+      text: formatUsd(startup.revenue.last30Days),
+      tooltip: "Revenue (30d)",
+    },
+    {
+      text: `MRR ${formatGrowthPercent(startup.growthMRR30d)}`,
+      tooltip: "MRR growth (30d)",
+    },
+    {
+      text: `Rev/Visit ${formatRevenuePerVisitor(startup.revenuePerVisitor)}`,
+      tooltip: "Revenue per visitor",
+    },
+    {
+      tag: startup.onSale ? "For Sale" : "Private",
+      tooltip: "Sale status",
+    },
+  ];
 }
 
 export default function Command() {
@@ -206,6 +314,7 @@ export default function Command() {
   );
 
   const startups = useMemo(() => mergeStartups(cachedStartups, data ?? []), [cachedStartups, data]);
+  const displayedStartups = useMemo(() => sortStartups(startups, sort), [startups, sort]);
   const totalCount = cachedTotalsByQuery[cacheScopeKey] ?? startups.length;
 
   async function refreshStartups() {
@@ -271,22 +380,13 @@ export default function Command() {
         </ActionPanel>
       }
     >
-      {startups.map((startup) => (
+      {displayedStartups.map((startup) => (
         <List.Item
           key={startup.slug}
           title={startup.name}
           subtitle={subtitle(startup)}
           icon={startup.icon ?? Icon.Building}
-          accessories={[
-            {
-              text: formatUsd(startup.revenue.last30Days),
-              tooltip: "Revenue (30d)",
-            },
-            {
-              tag: startup.onSale ? "For Sale" : "Private",
-              tooltip: "Sale status",
-            },
-          ]}
+          accessories={accessoriesForStartup(startup)}
           actions={
             <ActionPanel>
               <Action.Push


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

### Add New API Metrics + Metric-Based Sorting

[updates the extension with the latest API changes](https://x.com/marclou/status/2032135840906850757)

- Add support for new API fields in extension data models: `growthMRR30d`, `visitorsLast30Days`, `googleSearchImpressionsLast30Days`, `revenuePerVisitor`, and `rank`
- Surface new metrics in startup details metadata: revenue rank, MRR growth (30d), revenue per visitor, visitors (30d), and search impressions (30d)
- Enhance startup list items with metric accessories for rank, MRR momentum, and revenue-per-visitor efficiency
- Add new list sorting presets: `Top Ranked`, `MRR Momentum`, and `High Efficiency`

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
