### PR TITLE
Update focus extension

### DIFF
--- a/extensions/focus/CHANGELOG.md
+++ b/extensions/focus/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Focus Changelog
+## [Enhancement] - 2026-03-13
+- Commands now close the Raycast window automatically on success, showing a brief HUD notification instead of keeping the window open.
+
 ## [Enhancement] - 2026-03-12
 - Fixed an issue where Focus app icon would appear in the Dock when running commands.
 - Improved profile list loading to use caching, so profiles appear instantly on repeat opens.

--- a/extensions/focus/src/open-preferences.tsx
+++ b/extensions/focus/src/open-preferences.tsx
@@ -1,4 +1,4 @@
-import { Toast } from "@raycast/api";
+import { closeMainWindow } from "@raycast/api";
 import { openPreferences } from "./utils";
 import { ensureFocusIsRunning } from "./helpers";
 
@@ -7,12 +7,6 @@ export default async function () {
     return;
   }
 
-  const toast = new Toast({
-    title: "Opening preferences",
-    style: Toast.Style.Animated,
-  });
-
-  await toast.show();
-
+  await closeMainWindow();
   await openPreferences();
 }

--- a/extensions/focus/src/start-focus-25.tsx
+++ b/extensions/focus/src/start-focus-25.tsx
@@ -1,4 +1,4 @@
-import { Toast, showToast } from "@raycast/api";
+import { Toast, showToast, showHUD } from "@raycast/api";
 import { getProfileNames, startFocusWithProfile25, startFocus25, getActiveProfileName } from "./utils";
 import { ensureFocusIsRunning } from "./helpers";
 
@@ -33,10 +33,9 @@ export default async function Command() {
       await startFocusWithProfile25(firstProfile);
     }
     await toast.hide();
-    await showToast({
-      style: Toast.Style.Success,
-      title: firstProfile ? `Focus started with profile: ${firstProfile} (25 minutes)` : "Focus started (25 minutes)",
-    });
+    await showHUD(
+      firstProfile ? `Focus started with profile: ${firstProfile} (25 minutes)` : "Focus started (25 minutes)"
+    );
   } catch (error) {
     await toast.hide();
     await showToast({

--- a/extensions/focus/src/start-focus-custom.tsx
+++ b/extensions/focus/src/start-focus-custom.tsx
@@ -1,4 +1,4 @@
-import { Toast, showToast, LaunchProps } from "@raycast/api";
+import { Toast, showToast, showHUD, LaunchProps } from "@raycast/api";
 import { getProfileNames, startFocusCustom, getActiveProfileName } from "./utils";
 import { ensureFocusIsRunning } from "./helpers";
 
@@ -46,12 +46,11 @@ export default async function Command(props: LaunchProps<{ arguments: FocusArgum
     const success = await startFocusCustom(hours, minutes, firstProfile);
     await toast.hide();
     if (success) {
-      await showToast({
-        style: Toast.Style.Success,
-        title: firstProfile
+      await showHUD(
+        firstProfile
           ? `Focus started with profile: ${firstProfile} (${formatDuration(hours, minutes)})`
-          : `Focus started (${formatDuration(hours, minutes)})`,
-      });
+          : `Focus started (${formatDuration(hours, minutes)})`
+      );
     } else {
       await showToast({
         style: Toast.Style.Failure,

--- a/extensions/focus/src/start-focus-with-profile.tsx
+++ b/extensions/focus/src/start-focus-with-profile.tsx
@@ -1,4 +1,4 @@
-import { Toast, showToast, List, ActionPanel, Action, Icon, popToRoot } from "@raycast/api";
+import { Toast, showToast, showHUD, List, ActionPanel, Action, Icon, closeMainWindow } from "@raycast/api";
 import { getProfileNames, startFocusWithProfile, getActiveProfileName } from "./utils";
 import { useCachedPromise } from "@raycast/utils";
 import { ensureFocusIsRunning } from "./helpers";
@@ -21,10 +21,9 @@ export default function Command() {
       return;
     }
 
-    await showToast({ style: Toast.Style.Animated, title: "Starting focus..." });
     await startFocusWithProfile(profileName);
-    await showToast({ style: Toast.Style.Success, title: `Focus started with profile: ${profileName}` });
-    await popToRoot();
+    await showHUD(`Focus started with profile: ${profileName}`);
+    await closeMainWindow();
   }
 
   return (

--- a/extensions/focus/src/start-focus.tsx
+++ b/extensions/focus/src/start-focus.tsx
@@ -1,4 +1,4 @@
-import { Toast, showToast } from "@raycast/api";
+import { Toast, showToast, showHUD } from "@raycast/api";
 import { getProfileNames, startFocusWithProfile, startFocus, getActiveProfileName } from "./utils";
 import { ensureFocusIsRunning } from "./helpers";
 
@@ -31,11 +31,11 @@ export default async function Command() {
   if (profiles.length === 0) {
     await startFocus();
     await toast.hide();
-    await showToast({ style: Toast.Style.Success, title: "Focus started" });
+    await showHUD("Focus started");
   } else {
     toast.title = `Starting Focus with profile: ${firstProfile}...`;
     await startFocusWithProfile(firstProfile);
     await toast.hide();
-    await showToast({ style: Toast.Style.Success, title: `Focus started with profile: ${firstProfile}` });
+    await showHUD(`Focus started with profile: ${firstProfile}`);
   }
 }

--- a/extensions/focus/src/stop-break.tsx
+++ b/extensions/focus/src/stop-break.tsx
@@ -1,4 +1,4 @@
-import { Toast, showToast } from "@raycast/api";
+import { Toast, showToast, showHUD } from "@raycast/api";
 import { getProfileNames, stopBreak, stopBreakWithProfile } from "./utils";
 import { ensureFocusIsRunning } from "./helpers";
 
@@ -22,10 +22,7 @@ export default async function Command() {
       await stopBreakWithProfile(firstProfile);
     }
     await toast.hide();
-    await showToast({
-      style: Toast.Style.Success,
-      title: "Break stopped",
-    });
+    await showHUD("Break stopped");
   } catch (error) {
     await toast.hide();
     await showToast({

--- a/extensions/focus/src/stop-focus.tsx
+++ b/extensions/focus/src/stop-focus.tsx
@@ -1,4 +1,4 @@
-import { Toast, showToast } from "@raycast/api";
+import { Toast, showToast, showHUD } from "@raycast/api";
 import { stopFocus, isBreakRunning } from "./utils";
 import { ensureFocusIsRunning } from "./helpers";
 
@@ -20,5 +20,5 @@ export default async function () {
 
   await showToast({ style: Toast.Style.Animated, title: "Stopping focus..." });
   await stopFocus();
-  await showToast({ style: Toast.Style.Success, title: "Focus stopped" });
+  await showHUD("Focus stopped");
 }

--- a/extensions/focus/src/take-break-5.tsx
+++ b/extensions/focus/src/take-break-5.tsx
@@ -1,4 +1,4 @@
-import { Toast, showToast } from "@raycast/api";
+import { Toast, showToast, showHUD } from "@raycast/api";
 import { getProfileNames, takeBreakWithProfile5, takeBreak5, isBreakRunning } from "./utils";
 import { ensureFocusIsRunning } from "./helpers";
 
@@ -36,10 +36,9 @@ export default async function Command() {
       await takeBreakWithProfile5(firstProfile);
     }
     await toast.hide();
-    await showToast({
-      style: Toast.Style.Success,
-      title: firstProfile ? `Break started with profile: ${firstProfile} (5 minutes)` : "Break started (5 minutes)",
-    });
+    await showHUD(
+      firstProfile ? `Break started with profile: ${firstProfile} (5 minutes)` : "Break started (5 minutes)"
+    );
   } catch (error) {
     await toast.hide();
     await showToast({

--- a/extensions/focus/src/take-break-custom.tsx
+++ b/extensions/focus/src/take-break-custom.tsx
@@ -1,4 +1,4 @@
-import { Toast, showToast, LaunchProps } from "@raycast/api";
+import { Toast, showToast, showHUD, LaunchProps } from "@raycast/api";
 import { getProfileNames, takeBreakCustom, takeBreakWithProfileCustom, isBreakRunning } from "./utils";
 import { ensureFocusIsRunning } from "./helpers";
 
@@ -53,12 +53,11 @@ export default async function Command(props: LaunchProps<{ arguments: BreakArgum
     }
     await toast.hide();
     if (success) {
-      await showToast({
-        style: Toast.Style.Success,
-        title: firstProfile
+      await showHUD(
+        firstProfile
           ? `Break started with profile: ${firstProfile} (${minutes} minutes)`
-          : `Break started (${minutes} minutes)`,
-      });
+          : `Break started (${minutes} minutes)`
+      );
     } else {
       await showToast({
         style: Toast.Style.Failure,


### PR DESCRIPTION
## Description

Commands now close the Raycast window automatically after running, instead of staying open. A brief HUD notification confirms the action was successful.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
