### PR TITLE
Update get-ssh-key extension

### DIFF
--- a/extensions/get-ssh-key/CHANGELOG.md
+++ b/extensions/get-ssh-key/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Get SSH Key Changelog
 
+## [Updates] - 2026-03-13
+
+- Add Windows support to the extension.
+- Fix the case of "Ssh".
+
 ## [Open In Finder] - 2025-06-29
 
 - Show number of keys in Section subtitle

--- a/extensions/get-ssh-key/CHANGELOG.md
+++ b/extensions/get-ssh-key/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Get SSH Key Changelog
 
-## [Updates] - {PR_MERGE_DATE}
+## [Updates] - 2026-03-17
 
 - Add Windows support to the extension.
 - Fix the case of "Ssh".

--- a/extensions/get-ssh-key/CHANGELOG.md
+++ b/extensions/get-ssh-key/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Get SSH Key Changelog
 
-## [Updates] - 2026-03-13
+## [Updates] - {PR_MERGE_DATE}
 
 - Add Windows support to the extension.
 - Fix the case of "Ssh".

--- a/extensions/get-ssh-key/package.json
+++ b/extensions/get-ssh-key/package.json
@@ -11,7 +11,12 @@
   "contributors": [
     "pernielsentikaer",
     "j3lte",
+    "icebrick",
     "xmok"
+  ],
+  "platforms": [
+    "macOS",
+    "Windows"
   ],
   "license": "MIT",
   "commands": [

--- a/extensions/get-ssh-key/src/list.tsx
+++ b/extensions/get-ssh-key/src/list.tsx
@@ -22,7 +22,7 @@ export default function Command() {
               subtitle={file.path}
               actions={
                 <ActionPanel>
-                  <Action.CopyToClipboard title="Copy Ssh Key" content={file.readFile()} />
+                  <Action.CopyToClipboard title="Copy SSH Key" content={file.readFile()} />
                   <Action.ShowInFinder path={file.path} />
                 </ActionPanel>
               }


### PR DESCRIPTION
## Description

Add Windows support to the extension. The current code already works on Windows 11.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
