### PR TITLE
System Monitor: Fix stale pinned stats in menubar

### DIFF
--- a/extensions/system-monitor/CHANGELOG.md
+++ b/extensions/system-monitor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # System Monitor Changelog
 
-## [Fix Temperature Polling] - {PR_MERGE_DATE}
+## [Fix Temperature Polling] - 2026-03-04
 
 - Moved temperature sensor polling to a dedicated 3s interval to prevent stale readings
 

--- a/extensions/system-monitor/CHANGELOG.md
+++ b/extensions/system-monitor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # System Monitor Changelog
 
+## [Fix Stale Menubar Readings] - {PR_MERGE_DATE}
+
+- Enable background refresh for the menubar command so pinned stats stay up to date
+
 ## [Fix Temperature Polling] - 2026-03-04
 
 - Moved temperature sensor polling to a dedicated 3s interval to prevent stale readings

--- a/extensions/system-monitor/CHANGELOG.md
+++ b/extensions/system-monitor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # System Monitor Changelog
 
-## [Fix Temperature Polling] - 2026-03-04
+## [Fix Temperature Polling] - {PR_MERGE_DATE}
 
 - Moved temperature sensor polling to a dedicated 3s interval to prevent stale readings
 

--- a/extensions/system-monitor/CHANGELOG.md
+++ b/extensions/system-monitor/CHANGELOG.md
@@ -1,10 +1,10 @@
 # System Monitor Changelog
 
-## [Fix Stale Menubar Readings] - {PR_MERGE_DATE}
+## [Fix Stale Menubar Readings] - 2026-03-16
 
 - Enable background refresh for the menubar command so pinned stats stay up to date
 
-## [Fix Temperature Polling] - {PR_MERGE_DATE}
+## [Fix Temperature Polling] - 2026-03-16
 
 - Moved temperature sensor polling to a dedicated 3s interval to prevent stale readings
 

--- a/extensions/system-monitor/CHANGELOG.md
+++ b/extensions/system-monitor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Enable background refresh for the menubar command so pinned stats stay up to date
 
-## [Fix Temperature Polling] - 2026-03-04
+## [Fix Temperature Polling] - {PR_MERGE_DATE}
 
 - Moved temperature sensor polling to a dedicated 3s interval to prevent stale readings
 

--- a/extensions/system-monitor/package.json
+++ b/extensions/system-monitor/package.json
@@ -85,7 +85,8 @@
           "placeholder": "<PERCENT> %",
           "default": "<PERCENT> %"
         }
-      ]
+      ],
+      "interval": "10s"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
## Summary
- Pinned stats in the menubar were going stale and only updating when you clicked the icon. A few people noticed this, myself included.
- The root cause: the menubar command had no `interval` configured in package.json. Without it, Raycast doesn't re-launch the command in the background, so the title never gets refreshed while the menu is closed.
- Added `"interval": "10s"` to enable Raycast's background refresh. This is the same pattern used by other menubar extensions with dynamic titles. The existing `useInterval` hooks still handle faster in-process updates when the menu is actually open.
- This fixes all pinned stats, not just temperature.

## Test plan
- [ ] Pin any stat (CPU, temperature, memory, etc.) to the menubar
- [ ] Leave it for 30+ seconds without clicking the icon
- [ ] Verify the value continues updating on its own
- [ ] Click the icon and verify dropdown values are still accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)