### PR TITLE
Add ClickUp "View Default List"

### DIFF
--- a/extensions/clickup/CHANGELOG.md
+++ b/extensions/clickup/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ClickUp Changelog
 
-## [New "View Default List" Command] - {PR_MERGE_DATE}
+## [New "View Default List" Command] - 2026-04-03
 
 ### New Feature
 - Add "View Default List" command to quickly view your default list

--- a/extensions/clickup/CHANGELOG.md
+++ b/extensions/clickup/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ClickUp Changelog
 
-## [New "View Default List" Command] - 2026-03-13
+## [New "View Default List" Command] - {PR_MERGE_DATE}
 
 ### New Feature
 - Add "View Default List" command to quickly view your default list

--- a/extensions/clickup/CHANGELOG.md
+++ b/extensions/clickup/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ClickUp Changelog
 
+## [New "View Default List" Command] - 2026-03-13
+
+### New Feature
+- Add "View Default List" command to quickly view your default list
+
 ## [New Commands and Major Refactor] - 2026-01-09
 
 ### New Features

--- a/extensions/clickup/package.json
+++ b/extensions/clickup/package.json
@@ -8,7 +8,8 @@
   "contributors": [
     "aesadde",
     "joltcode",
-    "xmok"
+    "xmok",
+    "macbookandrew"
   ],
   "license": "MIT",
   "commands": [
@@ -24,6 +25,13 @@
       "title": "Quick Capture",
       "subtitle": "ClickUp",
       "description": "Quickly capture tasks to your default ClickUp list",
+      "mode": "view"
+    },
+    {
+      "name": "view-default-list",
+      "title": "View Default List",
+      "subtitle": "ClickUp",
+      "description": "View your default ClickUp list",
       "mode": "view"
     },
     {

--- a/extensions/clickup/src/view-default-list.tsx
+++ b/extensions/clickup/src/view-default-list.tsx
@@ -1,0 +1,27 @@
+import { List, Icon, getPreferenceValues } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { getClickUpClient } from "./api/clickup";
+import { ListTasksView } from "./views/ListTasksView";
+
+export default function ViewDefaultList() {
+  const { listId } = getPreferenceValues<Preferences>();
+
+  const { isLoading, error, data: list } = useCachedPromise(
+    async (id: string) => getClickUpClient().getList(id),
+    [listId],
+  );
+
+  if (error && !isLoading && !list) {
+    return (
+      <List>
+        <List.EmptyView description={error.message} icon={Icon.ExclamationMark} title="Failed to load list" />
+      </List>
+    );
+  }
+
+  if (list) {
+    return <ListTasksView list={list} />;
+  }
+
+  return <List isLoading={isLoading} />;
+}

--- a/extensions/clickup/src/view-default-list.tsx
+++ b/extensions/clickup/src/view-default-list.tsx
@@ -6,10 +6,11 @@ import { ListTasksView } from "./views/ListTasksView";
 export default function ViewDefaultList() {
   const { listId } = getPreferenceValues<Preferences>();
 
-  const { isLoading, error, data: list } = useCachedPromise(
-    async (id: string) => getClickUpClient().getList(id),
-    [listId],
-  );
+  const {
+    isLoading,
+    error,
+    data: list,
+  } = useCachedPromise(async (id: string) => getClickUpClient().getList(id), [listId]);
 
   if (error && !isLoading && !list) {
     return (


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Adds a new "View Default List" command to the Clickup tools

## Screencast

Sorry, I can't show a screenshot with internal company ticket details, but it looks just the same as if you browse to the list using the existing "Tasks Explorer" command.

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
