### PR TITLE
Update terminalfinder extension

### DIFF
--- a/extensions/terminalfinder/CHANGELOG.md
+++ b/extensions/terminalfinder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Terminal Finder Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-03-27
 
 - Added support for `cmux`
 - Switched `cmux` integration to the bundled CLI for reliable workspace creation and working-directory lookup

--- a/extensions/terminalfinder/CHANGELOG.md
+++ b/extensions/terminalfinder/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Terminal Finder Changelog
 
+## [Update] - 2026-03-14
+
+- Added support for `cmux`
+- Switched `cmux` integration to the bundled CLI for reliable workspace creation and working-directory lookup
+
 ## [Better "Finder" Errors] - 2026-01-12
 
 - Show a better error message when no **Finder** window open or when trying to pass non-filesystem folder (e.g. **Recents**) (ref: [Issue #24386](https://github.com/raycast/extensions/issues/24386))

--- a/extensions/terminalfinder/CHANGELOG.md
+++ b/extensions/terminalfinder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Terminal Finder Changelog
 
-## [Update] - 2026-03-14
+## [Update] - {PR_MERGE_DATE}
 
 - Added support for `cmux`
 - Switched `cmux` integration to the bundled CLI for reliable workspace creation and working-directory lookup

--- a/extensions/terminalfinder/README.md
+++ b/extensions/terminalfinder/README.md
@@ -8,9 +8,14 @@ Open currently selected Finder (or Path Finder) window in **Terminal**<sup>*</su
 
 ### <sup>*</sup> Supported:
 
+- [cmux](https://www.cmux.dev/)
 - [Ghostty](https://ghostty.org/)
 - [iTerm2](https://iterm2.com/)
 - [kitty](https://sw.kovidgoyal.net/kitty/)
 - Terminal
 - [Warp](https://www.warp.dev/)
 - [WezTerm](https://wezterm.org/index.html)
+
+### cmux note
+
+`cmux` support uses the bundled `cmux` CLI. In `cmux`, open `Settings -> Automation` and set `Socket Mode` to `Allow all local processes` or `Password`; the default external-control mode blocks Raycast from opening new cmux workspaces or reading the active working directory.

--- a/extensions/terminalfinder/package.json
+++ b/extensions/terminalfinder/package.json
@@ -2,13 +2,14 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "terminalfinder",
   "title": "Terminal Finder",
-  "description": "Open currently selected Finder (or Path Finder) window in Terminal (or iTerm2, Warp, WezTerm) and vice versa",
+  "description": "Open currently selected Finder (or Path Finder) window in Terminal (or iTerm2, Warp, WezTerm, cmux) and vice versa",
   "icon": "command-icon.png",
   "author": "yedongze",
   "contributors": [
     "Ianvs",
     "anirudh_gupta",
-    "xmok"
+    "xmok",
+    "vatsalsanjay"
   ],
   "license": "MIT",
   "commands": [
@@ -55,6 +56,13 @@
       "mode": "no-view"
     },
     {
+      "name": "clipboardToCmux",
+      "title": "Clipboard → Cmux",
+      "subtitle": "Open Path",
+      "description": "Open current Clipboard directory in cmux",
+      "mode": "no-view"
+    },
+    {
       "name": "finderToITerm",
       "title": "Finder → iTerm",
       "subtitle": "Open Path",
@@ -94,6 +102,13 @@
       "title": "Finder → Kitty",
       "subtitle": "Open Path",
       "description": "Open current Finder directory in Kitty",
+      "mode": "no-view"
+    },
+    {
+      "name": "finderToCmux",
+      "title": "Finder → Cmux",
+      "subtitle": "Open Path",
+      "description": "Open current Finder directory in cmux",
       "mode": "no-view"
     },
     {
@@ -139,6 +154,13 @@
       "mode": "no-view"
     },
     {
+      "name": "cmuxToFinder",
+      "title": "Cmux → Finder",
+      "subtitle": "Open Path",
+      "description": "Open current cmux directory in Finder",
+      "mode": "no-view"
+    },
+    {
       "name": "index",
       "title": "X → Y",
       "subtitle": "Open Path",
@@ -158,6 +180,10 @@
             {
               "title": "Finder",
               "value": "Finder"
+            },
+            {
+              "title": "Cmux",
+              "value": "cmux"
             },
             {
               "title": "Ghostty",
@@ -194,6 +220,10 @@
             {
               "title": "Finder",
               "value": "Finder"
+            },
+            {
+              "title": "Cmux",
+              "value": "cmux"
             },
             {
               "title": "Ghostty",

--- a/extensions/terminalfinder/src/application.ts
+++ b/extensions/terminalfinder/src/application.ts
@@ -31,5 +31,7 @@ export function findApplication<T extends TerminalApplication>(applications: T[]
     return undefined;
   }
 
-  return applications.find((app) => [app.name, app.localizedName, app.bundleId].some((value) => normalize(value) === normalizedName));
+  return applications.find((app) =>
+    [app.name, app.localizedName, app.bundleId].some((value) => normalize(value) === normalizedName),
+  );
 }

--- a/extensions/terminalfinder/src/application.ts
+++ b/extensions/terminalfinder/src/application.ts
@@ -15,19 +15,21 @@ export function findApplication<T extends TerminalApplication>(applications: T[]
   const knownBundleId = KNOWN_BUNDLE_IDS[name as keyof typeof KNOWN_BUNDLE_IDS];
   const normalizedName = normalize(name);
 
-  return applications.find((app) => {
-    if (app.name === name || app.localizedName === name) {
-      return true;
-    }
+  const exactMatch = applications.find((app) => app.name === name || app.localizedName === name);
+  if (exactMatch) {
+    return exactMatch;
+  }
 
-    if (knownBundleId && app.bundleId === knownBundleId) {
-      return true;
+  if (knownBundleId) {
+    const bundleIdMatch = applications.find((app) => app.bundleId === knownBundleId);
+    if (bundleIdMatch) {
+      return bundleIdMatch;
     }
+  }
 
-    if (!normalizedName) {
-      return false;
-    }
+  if (!normalizedName) {
+    return undefined;
+  }
 
-    return [app.name, app.localizedName, app.bundleId].some((value) => normalize(value) === normalizedName);
-  });
+  return applications.find((app) => [app.name, app.localizedName, app.bundleId].some((value) => normalize(value) === normalizedName));
 }

--- a/extensions/terminalfinder/src/application.ts
+++ b/extensions/terminalfinder/src/application.ts
@@ -1,0 +1,33 @@
+import type { Application } from "@raycast/api";
+
+type TerminalApplication = Pick<Application, "name" | "localizedName" | "bundleId">;
+
+const KNOWN_BUNDLE_IDS = {
+  cmux: "com.cmuxterm.app",
+} as const;
+
+function normalize(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+export function findApplication<T extends TerminalApplication>(applications: T[], name: string): T | undefined {
+  const knownBundleId = KNOWN_BUNDLE_IDS[name as keyof typeof KNOWN_BUNDLE_IDS];
+  const normalizedName = normalize(name);
+
+  return applications.find((app) => {
+    if (app.name === name || app.localizedName === name) {
+      return true;
+    }
+
+    if (knownBundleId && app.bundleId === knownBundleId) {
+      return true;
+    }
+
+    if (!normalizedName) {
+      return false;
+    }
+
+    return [app.name, app.localizedName, app.bundleId].some((value) => normalize(value) === normalizedName);
+  });
+}

--- a/extensions/terminalfinder/src/clipboardToCmux.tsx
+++ b/extensions/terminalfinder/src/clipboardToCmux.tsx
@@ -1,0 +1,15 @@
+import { Clipboard, Toast, showToast } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { checkApplication, runCmuxCommand } from "./utils";
+
+export default async () => {
+  const directory = ((await Clipboard.readText()) || "").trim();
+
+  try {
+    await checkApplication("cmux");
+    const result = await runCmuxCommand([directory]);
+    await showToast(Toast.Style.Success, "Done", result);
+  } catch (err) {
+    await showFailureToast(err);
+  }
+};

--- a/extensions/terminalfinder/src/clipboardToCmux.tsx
+++ b/extensions/terminalfinder/src/clipboardToCmux.tsx
@@ -1,6 +1,6 @@
 import { Clipboard, Toast, showToast } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
-import { checkApplication, runCmuxCommand } from "./utils";
+import { runCmuxCommand } from "./utils";
 
 export default async () => {
   const directory = ((await Clipboard.readText()) || "").trim();
@@ -11,7 +11,6 @@ export default async () => {
   }
 
   try {
-    await checkApplication("cmux");
     const result = await runCmuxCommand([directory]);
     await showToast(Toast.Style.Success, "Done", result);
   } catch (err) {

--- a/extensions/terminalfinder/src/clipboardToCmux.tsx
+++ b/extensions/terminalfinder/src/clipboardToCmux.tsx
@@ -5,6 +5,11 @@ import { checkApplication, runCmuxCommand } from "./utils";
 export default async () => {
   const directory = ((await Clipboard.readText()) || "").trim();
 
+  if (!directory) {
+    await showToast(Toast.Style.Failure, "Clipboard doesn't contain a directory path");
+    return;
+  }
+
   try {
     await checkApplication("cmux");
     const result = await runCmuxCommand([directory]);

--- a/extensions/terminalfinder/src/cmux.ts
+++ b/extensions/terminalfinder/src/cmux.ts
@@ -1,0 +1,123 @@
+const WORKING_DIRECTORY_KEYS = ["cwd", "workingDirectory", "working_directory"] as const;
+const FOCUSED_WORKING_DIRECTORY_KEYS = [
+  "focusedCwd",
+  "focused_cwd",
+  "focusedWorkingDirectory",
+  "focused_working_directory",
+] as const;
+const FOCUS_KEYS = ["focused", "active", "isFocused", "isActive", "selected", "current"] as const;
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readFirstString(record: JsonRecord, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const candidate = record[key];
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+function findExplicitFocusedWorkingDirectory(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const match = findExplicitFocusedWorkingDirectory(item);
+      if (match) return match;
+    }
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const directMatch = readFirstString(value, FOCUSED_WORKING_DIRECTORY_KEYS);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  for (const nested of Object.values(value)) {
+    const match = findExplicitFocusedWorkingDirectory(nested);
+    if (match) return match;
+  }
+
+  return undefined;
+}
+
+function isFocusedRecord(record: JsonRecord): boolean {
+  return FOCUS_KEYS.some((key) => record[key] === true);
+}
+
+function findWorkingDirectoryInSubtree(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const match = findWorkingDirectoryInSubtree(item);
+      if (match) return match;
+    }
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const directMatch = readFirstString(value, WORKING_DIRECTORY_KEYS);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  for (const nested of Object.values(value)) {
+    const match = findWorkingDirectoryInSubtree(nested);
+    if (match) return match;
+  }
+
+  return undefined;
+}
+
+function findFocusedWorkingDirectory(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const match = findFocusedWorkingDirectory(item);
+      if (match) return match;
+    }
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (isFocusedRecord(value)) {
+    const directMatch = findWorkingDirectoryInSubtree(value);
+    if (directMatch) {
+      return directMatch;
+    }
+  }
+
+  for (const nested of Object.values(value)) {
+    const match = findFocusedWorkingDirectory(nested);
+    if (match) return match;
+  }
+
+  return undefined;
+}
+
+export function extractCmuxWorkingDirectory(sidebarState: unknown): string {
+  const explicitFocusedDirectory = findExplicitFocusedWorkingDirectory(sidebarState);
+  if (explicitFocusedDirectory) {
+    return explicitFocusedDirectory;
+  }
+
+  const focusedDirectory = findFocusedWorkingDirectory(sidebarState);
+  if (focusedDirectory) {
+    return focusedDirectory;
+  }
+
+  throw new Error("cmux did not return a focused workspace with a working directory");
+}

--- a/extensions/terminalfinder/src/cmuxToFinder.tsx
+++ b/extensions/terminalfinder/src/cmuxToFinder.tsx
@@ -1,7 +1,6 @@
-import { Toast, showToast } from "@raycast/api";
+import { Toast, showToast, open } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { getCmuxWorkingDirectory } from "./utils";
-import { open } from "@raycast/api";
 
 export default async () => {
   try {

--- a/extensions/terminalfinder/src/cmuxToFinder.tsx
+++ b/extensions/terminalfinder/src/cmuxToFinder.tsx
@@ -1,0 +1,14 @@
+import { Toast, showToast } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { getCmuxWorkingDirectory } from "./utils";
+import { open } from "@raycast/api";
+
+export default async () => {
+  try {
+    const cwd = await getCmuxWorkingDirectory();
+    await open(cwd, "Finder");
+    await showToast(Toast.Style.Success, "Done");
+  } catch (err) {
+    await showFailureToast(err);
+  }
+};

--- a/extensions/terminalfinder/src/finderToCmux.tsx
+++ b/extensions/terminalfinder/src/finderToCmux.tsx
@@ -1,6 +1,6 @@
 import { Toast, showToast } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
-import { checkApplication, runAppleScript, runCmuxCommand } from "./utils";
+import { runAppleScript, runCmuxCommand } from "./utils";
 
 export default async () => {
   const finderScript = `
@@ -20,7 +20,6 @@ export default async () => {
   `;
 
   try {
-    await checkApplication("cmux");
     const directory = (await runAppleScript(finderScript)).trim();
     const result = await runCmuxCommand([directory]);
     await showToast(Toast.Style.Success, "Done", result);

--- a/extensions/terminalfinder/src/finderToCmux.tsx
+++ b/extensions/terminalfinder/src/finderToCmux.tsx
@@ -1,0 +1,30 @@
+import { Toast, showToast } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { checkApplication, runAppleScript, runCmuxCommand } from "./utils";
+
+export default async () => {
+  const finderScript = `
+      if application "Finder" is not running then
+          error "Finder is not running"
+      end if
+
+      tell application "Finder"
+          if (count of Finder windows) = 0 then error "No Finder window open"
+          try
+              set pathList to POSIX path of (folder of the front window as alias)
+              return pathList
+          on error
+              error "Could not access Finder window path"
+          end try
+      end tell
+  `;
+
+  try {
+    await checkApplication("cmux");
+    const directory = (await runAppleScript(finderScript)).trim();
+    const result = await runCmuxCommand([directory]);
+    await showToast(Toast.Style.Success, "Done", result);
+  } catch (err) {
+    await showFailureToast(err);
+  }
+};

--- a/extensions/terminalfinder/src/index.ts
+++ b/extensions/terminalfinder/src/index.ts
@@ -1,11 +1,20 @@
 import { LaunchProps } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
+import clipboardToCmux from "./clipboardToCmux";
+import cmuxToFinder from "./cmuxToFinder";
+import finderToCmux from "./finderToCmux";
 import { applicationToFinder, clipboardToApplication, finderToApplication, isTerminal } from "./utils";
 
 export default async function (props: LaunchProps<{ arguments: Arguments.Index }>) {
   const { from, to } = props.arguments;
   try {
-    if (from === "Clipboard" && isTerminal(to)) {
+    if (from === "Clipboard" && to === "cmux") {
+      await clipboardToCmux();
+    } else if (from === "Finder" && to === "cmux") {
+      await finderToCmux();
+    } else if (from === "cmux" && to === "Finder") {
+      await cmuxToFinder();
+    } else if (from === "Clipboard" && isTerminal(to)) {
       await clipboardToApplication(to);
     } else if (from === "Finder" && isTerminal(to)) {
       await finderToApplication(to);

--- a/extensions/terminalfinder/src/utils.ts
+++ b/extensions/terminalfinder/src/utils.ts
@@ -1,6 +1,7 @@
-import { Clipboard, getApplications, open, showToast, Toast } from "@raycast/api";
+import { Application, Clipboard, getApplications, open, showToast, Toast } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { spawnSync } from "node:child_process";
+import path from "node:path";
 
 export async function runAppleScript(script: string) {
   if (process.platform !== "darwin") {
@@ -18,10 +19,81 @@ export async function runAppleScript(script: string) {
 export type Terminal = Exclude<Arguments.Index["to"], "Clipboard">;
 export const isTerminal = (val: string): val is Terminal => val !== "Clipboard" && val !== "Finder";
 
-async function checkApplication(name: Terminal) {
+export async function getApplication(name: Terminal): Promise<Application> {
   const applications = await getApplications();
   const app = applications.find((app) => app.name === name);
   if (!app) throw new Error(`${name} not found`);
+  return app;
+}
+
+export async function checkApplication(name: Terminal) {
+  await getApplication(name);
+}
+
+function formatCmuxError(message: string) {
+  if (message.includes("Access denied")) {
+    return "cmux denied external control. In cmux, open Settings -> Automation and set Socket Mode to Allow all local processes or Password.";
+  }
+
+  return message || "cmux command failed";
+}
+
+export async function runCmuxCommand(args: string[]) {
+  const app = await getApplication("cmux");
+  const cliPath = path.join(app.path, "Contents", "Resources", "bin", "cmux");
+  const result = spawnSync(cliPath, args, { encoding: "utf8" });
+  const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(formatCmuxError(output));
+  }
+
+  return result.stdout.trim();
+}
+
+function findFirstString(value: unknown, keys: string[]): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const match = findFirstString(item, keys);
+      if (match) return match;
+    }
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  for (const key of keys) {
+    const candidate = record[key];
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate;
+    }
+  }
+
+  for (const nested of Object.values(record)) {
+    const match = findFirstString(nested, keys);
+    if (match) return match;
+  }
+
+  return undefined;
+}
+
+export async function getCmuxWorkingDirectory() {
+  const stdout = await runCmuxCommand(["--json", "sidebar-state"]);
+  const parsed = JSON.parse(stdout) as unknown;
+  const cwd = findFirstString(parsed, ["cwd", "workingDirectory", "working_directory"]);
+
+  if (!cwd) {
+    throw new Error("cmux did not return a working directory for the focused workspace");
+  }
+
+  return cwd;
 }
 export async function clipboardToApplication(name: Terminal) {
   try {

--- a/extensions/terminalfinder/src/utils.ts
+++ b/extensions/terminalfinder/src/utils.ts
@@ -32,6 +32,8 @@ export async function checkApplication(name: Terminal) {
   await getApplication(name);
 }
 
+const CMUX_COMMAND_TIMEOUT_MS = 10_000;
+
 function formatCmuxError(message: string) {
   if (message.includes("Access denied")) {
     return "cmux denied external control. In cmux, open Settings -> Automation and set Socket Mode to Allow all local processes or Password.";
@@ -40,14 +42,24 @@ function formatCmuxError(message: string) {
   return message || "cmux command failed";
 }
 
+function formatCmuxProcessError(error: NodeJS.ErrnoException) {
+  if (error.code === "ETIMEDOUT") {
+    return new Error(
+      "cmux command timed out. In cmux, open Settings -> Automation and set Socket Mode to Allow all local processes or Password.",
+    );
+  }
+
+  return error;
+}
+
 export async function runCmuxCommand(args: string[]) {
   const app = await getApplication("cmux");
   const cliPath = path.join(app.path, "Contents", "Resources", "bin", "cmux");
-  const result = spawnSync(cliPath, args, { encoding: "utf8" });
+  const result = spawnSync(cliPath, args, { encoding: "utf8", timeout: CMUX_COMMAND_TIMEOUT_MS });
   const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
 
   if (result.error) {
-    throw result.error;
+    throw formatCmuxProcessError(result.error);
   }
 
   if (result.status !== 0) {

--- a/extensions/terminalfinder/src/utils.ts
+++ b/extensions/terminalfinder/src/utils.ts
@@ -2,6 +2,7 @@ import { Application, Clipboard, getApplications, open, showToast, Toast } from 
 import { showFailureToast } from "@raycast/utils";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
+import { extractCmuxWorkingDirectory } from "./cmux";
 
 export async function runAppleScript(script: string) {
   if (process.platform !== "darwin") {
@@ -55,45 +56,10 @@ export async function runCmuxCommand(args: string[]) {
   return result.stdout.trim();
 }
 
-function findFirstString(value: unknown, keys: string[]): string | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      const match = findFirstString(item, keys);
-      if (match) return match;
-    }
-    return undefined;
-  }
-
-  const record = value as Record<string, unknown>;
-  for (const key of keys) {
-    const candidate = record[key];
-    if (typeof candidate === "string" && candidate.trim()) {
-      return candidate;
-    }
-  }
-
-  for (const nested of Object.values(record)) {
-    const match = findFirstString(nested, keys);
-    if (match) return match;
-  }
-
-  return undefined;
-}
-
 export async function getCmuxWorkingDirectory() {
   const stdout = await runCmuxCommand(["--json", "sidebar-state"]);
   const parsed = JSON.parse(stdout) as unknown;
-  const cwd = findFirstString(parsed, ["cwd", "workingDirectory", "working_directory"]);
-
-  if (!cwd) {
-    throw new Error("cmux did not return a working directory for the focused workspace");
-  }
-
-  return cwd;
+  return extractCmuxWorkingDirectory(parsed);
 }
 export async function clipboardToApplication(name: Terminal) {
   try {

--- a/extensions/terminalfinder/src/utils.ts
+++ b/extensions/terminalfinder/src/utils.ts
@@ -2,6 +2,7 @@ import { Application, Clipboard, getApplications, open, showToast, Toast } from 
 import { showFailureToast } from "@raycast/utils";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
+import { findApplication } from "./application";
 import { extractCmuxWorkingDirectory } from "./cmux";
 
 export async function runAppleScript(script: string) {
@@ -22,7 +23,7 @@ export const isTerminal = (val: string): val is Terminal => val !== "Clipboard" 
 
 export async function getApplication(name: Terminal): Promise<Application> {
   const applications = await getApplications();
-  const app = applications.find((app) => app.name === name);
+  const app = findApplication(applications, name);
   if (!app) throw new Error(`${name} not found`);
   return app;
 }

--- a/extensions/terminalfinder/test/application.test.ts
+++ b/extensions/terminalfinder/test/application.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findApplication } from "../src/application";
+
+test("returns an exact application name match first", () => {
+  const applications = [
+    { name: "Cmux", localizedName: "Cmux", bundleId: "com.example.cmux" },
+    { name: "cmux", localizedName: "cmux", bundleId: "com.cmuxterm.app" },
+  ];
+
+  assert.equal(findApplication(applications, "cmux"), applications[1]);
+});
+
+test("falls back to case-insensitive matching", () => {
+  const applications = [{ name: "Cmux", localizedName: "Cmux", bundleId: "com.example.cmux" }];
+
+  assert.equal(findApplication(applications, "cmux"), applications[0]);
+});
+
+test("matches on localized name when display name differs", () => {
+  const applications = [{ name: "Terminal", localizedName: "WezTerm", bundleId: "com.github.wez.wezterm" }];
+
+  assert.equal(findApplication(applications, "WezTerm"), applications[0]);
+});
+
+test("matches cmux by bundle identifier", () => {
+  const applications = [{ name: "Terminal", localizedName: "Terminal", bundleId: "com.cmuxterm.app" }];
+
+  assert.equal(findApplication(applications, "cmux"), applications[0]);
+});

--- a/extensions/terminalfinder/test/cmux.test.ts
+++ b/extensions/terminalfinder/test/cmux.test.ts
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { extractCmuxWorkingDirectory } from "../src/cmux";
+
+test("returns the cwd for the focused workspace", () => {
+  const sidebarState = {
+    workspaces: [
+      { focused: false, cwd: "/tmp/other" },
+      { focused: true, cwd: "/tmp/focused" },
+    ],
+  };
+
+  assert.equal(extractCmuxWorkingDirectory(sidebarState), "/tmp/focused");
+});
+
+test("does not return an earlier unfocused workspace directory", () => {
+  const sidebarState = {
+    workspaces: [
+      { active: false, workingDirectory: "/tmp/first" },
+      { active: true, workingDirectory: "/tmp/second" },
+    ],
+  };
+
+  assert.equal(extractCmuxWorkingDirectory(sidebarState), "/tmp/second");
+});
+
+test("supports snake_case working directory fields", () => {
+  const sidebarState = {
+    groups: [
+      {
+        selected: true,
+        meta: {
+          working_directory: "/tmp/snake-case",
+        },
+      },
+    ],
+  };
+
+  assert.equal(extractCmuxWorkingDirectory(sidebarState), "/tmp/snake-case");
+});
+
+test("supports explicit focused working directory fields", () => {
+  const sidebarState = {
+    window: {
+      focused_cwd: "/tmp/explicit",
+      workspaces: [
+        { focused: false, cwd: "/tmp/other" },
+      ],
+    },
+  };
+
+  assert.equal(extractCmuxWorkingDirectory(sidebarState), "/tmp/explicit");
+});
+
+test("throws when no focused or active workspace is present", () => {
+  const sidebarState = {
+    workspaces: [{ cwd: "/tmp/only" }],
+  };
+
+  assert.throws(
+    () => extractCmuxWorkingDirectory(sidebarState),
+    /cmux did not return a focused workspace with a working directory/,
+  );
+});
+
+test("throws when the focused workspace has no working directory", () => {
+  const sidebarState = {
+    workspaces: [
+      { focused: true, title: "missing cwd" },
+      { focused: false, cwd: "/tmp/other" },
+    ],
+  };
+
+  assert.throws(
+    () => extractCmuxWorkingDirectory(sidebarState),
+    /cmux did not return a focused workspace with a working directory/,
+  );
+});


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Added support for [cmux terminal](https://www.cmux.dev/). It is written on libghostty - adds vertical tab support among other improvements. 

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
