### PR TITLE
google-chrome-profiles: Add NirRosh as contributor

### DIFF
--- a/extensions/google-chrome-profiles/CHANGELOG.md
+++ b/extensions/google-chrome-profiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Chrome Profiles Changelog
 
+## [Fix] - 2026-03-14
+
+- Add missing contributor entry for NirRosh
+
 ## [Feature] - 2026-03-12
 
 - Add Google Chrome Canary support via a new Browser preference dropdown

--- a/extensions/google-chrome-profiles/CHANGELOG.md
+++ b/extensions/google-chrome-profiles/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Google Chrome Profiles Changelog
 
-## [Fix] - 2026-03-14
-
-- Add missing contributor entry for NirRosh
-
 ## [Feature] - 2026-03-12
 
 - Add Google Chrome Canary support via a new Browser preference dropdown

--- a/extensions/google-chrome-profiles/package.json
+++ b/extensions/google-chrome-profiles/package.json
@@ -7,7 +7,8 @@
   "author": "frouo",
   "contributors": [
     "erics118",
-    "jschmidtcordeiro"
+    "jschmidtcordeiro",
+    "NirRosh"
   ],
   "license": "MIT",
   "commands": [


### PR DESCRIPTION
## Summary

Adds `NirRosh` to the `contributors` array in `package.json` for the `google-chrome-profiles` extension.

## Why

PR #26229 (google-chrome-profiles: Add Google Chrome Canary support) was merged but the automatic contributor addition to `package.json` was either not triggered or was accidentally discarded during the merge. As a result, `NirRosh` does not appear on the extension's contributors list on the Raycast store page.

This PR corrects that by manually adding the contributor entry, as recommended in the [Raycast contribution docs](https://developers.raycast.com/basics/contribute-to-an-extension).


Made with [Cursor](https://cursor.com)