### PR TITLE
use translation as service name fallback

### DIFF
--- a/extensions/homeassistant/CHANGELOG.md
+++ b/extensions/homeassistant/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Home Assistant Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-03-15
 - use translations for services if available
   - fallback to service slug when no translation is available
 

--- a/extensions/homeassistant/CHANGELOG.md
+++ b/extensions/homeassistant/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Fix] - {PR_MERGE_DATE}
 - use translations for services if available
-  - fallback to service slug when no
+  - fallback to service slug when no translation is available
 
 ## [Fix] - 2026-02-01
 - Improved history chart contrast (axis labels and grid lines) for Raycast light/dark appearance

--- a/extensions/homeassistant/CHANGELOG.md
+++ b/extensions/homeassistant/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Home Assistant Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+- use translations for services if available
+  - fallback to service slug when no
+
 ## [Fix] - 2026-02-01
 - Improved history chart contrast (axis labels and grid lines) for Raycast light/dark appearance
 

--- a/extensions/homeassistant/src/components/services/hooks.tsx
+++ b/extensions/homeassistant/src/components/services/hooks.tsx
@@ -13,6 +13,10 @@ export interface HAServiceCall {
   meta: HAServiceMeta;
 }
 
+interface HATranslation {
+  resources: Record<string, string>;
+}
+
 export function useServiceCallsViaRest() {
   const { data, error, isLoading } = useCachedPromise(async () => {
     const result: HAServiceCall[] = [];
@@ -49,17 +53,24 @@ export function useServiceCalls(): {
       try {
         if (!hawsRef.current) {
           const con = await getHAWSConnection();
+          const translation = await con.sendMessagePromise<HATranslation>({
+            type: "frontend/get_translations",
+            language: "en",
+            category: "services",
+          });
 
           subscribeServices(con, (services: HassServices) => {
             const result: HAServiceCall[] = [];
             for (const [domain, domainValue] of Object.entries(services)) {
               for (const [serviceName, serviceData] of Object.entries(domainValue)) {
                 const meta = serviceData as HAServiceMeta | undefined;
+                const serviceTranslation = translation.resources[`component.${domain}.services.${serviceName}.name`];
+
                 if (meta) {
                   result.push({
                     domain: domain,
                     service: serviceName,
-                    name: meta.name,
+                    name: meta.name ?? serviceTranslation ?? serviceName,
                     description: meta.name,
                     meta: meta,
                   });


### PR DESCRIPTION
## Description
This PR fixes the error described in issue #26204. The display name for a service now falls back to the translation provided by Home Assistant. Or the service slug.

## Screencast
<img width="862" height="586" alt="run-service-dropdown" src="https://github.com/user-attachments/assets/9c0c1e38-029f-4d7a-86e6-f9825f18c53c" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
