### PR TITLE
Update torbox extension

### DIFF
--- a/extensions/torbox/CHANGELOG.md
+++ b/extensions/torbox/CHANGELOG.md
@@ -1,5 +1,11 @@
 # TorBox Changelog
 
+## [Stream video files in external players] - {PR_MERGE_DATE}
+
+- Stream video files directly in VLC, IINA, Infuse, or mpv
+- Automatically detect installed video players
+- Set a default player via "Set Default Player" action
+
 ## [Add Torrent and Web Download commands] - 2026-02-01
 
 - Add "Add Torrent" command for magnet links and .torrent files

--- a/extensions/torbox/CHANGELOG.md
+++ b/extensions/torbox/CHANGELOG.md
@@ -1,6 +1,6 @@
 # TorBox Changelog
 
-## [Stream video files in external players] - {PR_MERGE_DATE}
+## [Stream video files in external players] - 2026-03-14
 
 - Stream video files directly in VLC, IINA, Infuse, or mpv
 - Automatically detect installed video players

--- a/extensions/torbox/README.md
+++ b/extensions/torbox/README.md
@@ -10,6 +10,8 @@ Control your TorBox downloads from Raycast.
 
 ## Features
 
+- Stream video files in VLC, IINA, Infuse, or mpv — automatically detects installed players
+- Set your preferred default player
 - Auto-detect magnet links and URLs from clipboard
 - Auto-detect .torrent files selected in Finder
 - Filter web URLs by supported hosters

--- a/extensions/torbox/src/components/DownloadFiles.tsx
+++ b/extensions/torbox/src/components/DownloadFiles.tsx
@@ -12,7 +12,7 @@ interface DownloadFilesProps {
 }
 
 export const DownloadFiles = ({ download, apiKey }: DownloadFilesProps) => {
-  const isReady = download.download_finished || download.progress >= 1;
+  const isDownloadReady = download.download_finished || download.progress >= 1;
   const { players, setDefaultPlayer } = useVideoPlayers();
 
   return (
@@ -28,7 +28,7 @@ export const DownloadFiles = ({ download, apiKey }: DownloadFilesProps) => {
               subtitle={formatBytes(file.size)}
               actions={
                 <ActionPanel>
-                  {isReady &&
+                  {isDownloadReady &&
                     isVideo &&
                     players.map((player) => (
                       <Action
@@ -38,7 +38,7 @@ export const DownloadFiles = ({ download, apiKey }: DownloadFilesProps) => {
                         onAction={() => openInPlayer(apiKey, download, player, file.id)}
                       />
                     ))}
-                  {isReady && (
+                  {isDownloadReady && (
                     <Action
                       title="Copy Download Link"
                       icon={Icon.Link}

--- a/extensions/torbox/src/components/DownloadFiles.tsx
+++ b/extensions/torbox/src/components/DownloadFiles.tsx
@@ -1,48 +1,64 @@
-import { ActionPanel, Action, List, showToast, Toast, Clipboard } from "@raycast/api";
+import { ActionPanel, Action, List, Icon } from "@raycast/api";
 import { Download } from "../types";
-import { getDownloadLink } from "../api/downloads";
 import { formatBytes } from "../utils/formatters";
+import { isVideoFile } from "../utils/video";
+import { openInPlayer } from "../utils/video";
+import { copyDownloadLink } from "../utils/downloads";
+import { useVideoPlayers } from "../hooks/useVideoPlayers";
 
 interface DownloadFilesProps {
   download: Download;
   apiKey: string;
 }
 
-const copyFileDownloadLink = async (apiKey: string, download: Download, fileId: number) => {
-  try {
-    await showToast({ style: Toast.Style.Animated, title: "Getting download link..." });
-    const link = await getDownloadLink(apiKey, download.type, download.id, fileId);
-    await Clipboard.copy(link);
-    await showToast({ style: Toast.Style.Success, title: "Download link copied!" });
-  } catch (error) {
-    await showToast({
-      style: Toast.Style.Failure,
-      title: "Failed to get download link",
-      message: error instanceof Error ? error.message : "Unknown error",
-    });
-  }
-};
-
 export const DownloadFiles = ({ download, apiKey }: DownloadFilesProps) => {
   const isReady = download.download_finished || download.progress >= 1;
+  const { players, setDefaultPlayer } = useVideoPlayers();
 
   return (
     <List navigationTitle={download.name} searchBarPlaceholder="Search files...">
       <List.Section title="Files" subtitle={`${download.files.length}`}>
-        {download.files.map((file) => (
-          <List.Item
-            key={file.id}
-            title={file.short_name || file.name}
-            subtitle={formatBytes(file.size)}
-            actions={
-              <ActionPanel>
-                {isReady && (
-                  <Action title="Copy Download Link" onAction={() => copyFileDownloadLink(apiKey, download, file.id)} />
-                )}
-              </ActionPanel>
-            }
-          />
-        ))}
+        {download.files.map((file) => {
+          const filename = file.short_name || file.name;
+          const isVideo = isVideoFile(filename);
+          return (
+            <List.Item
+              key={file.id}
+              title={filename}
+              subtitle={formatBytes(file.size)}
+              actions={
+                <ActionPanel>
+                  {isReady &&
+                    isVideo &&
+                    players.map((player) => (
+                      <Action
+                        key={player.name}
+                        title={`Open in ${player.name}`}
+                        icon={Icon.Play}
+                        onAction={() => openInPlayer(apiKey, download, player, file.id)}
+                      />
+                    ))}
+                  {isReady && (
+                    <Action
+                      title="Copy Download Link"
+                      icon={Icon.Link}
+                      onAction={() => copyDownloadLink(apiKey, download, file.id)}
+                    />
+                  )}
+                  {isVideo && players.length > 1 && (
+                    <ActionPanel.Section>
+                      <ActionPanel.Submenu title="Set Default Player" icon={Icon.Star}>
+                        {players.map((player) => (
+                          <Action key={player.name} title={player.name} onAction={() => setDefaultPlayer(player)} />
+                        ))}
+                      </ActionPanel.Submenu>
+                    </ActionPanel.Section>
+                  )}
+                </ActionPanel>
+              }
+            />
+          );
+        })}
       </List.Section>
     </List>
   );

--- a/extensions/torbox/src/components/DownloadListItem.tsx
+++ b/extensions/torbox/src/components/DownloadListItem.tsx
@@ -2,15 +2,15 @@ import { ActionPanel, Action, List, Icon, Color, showToast, Toast } from "@rayca
 import { Download } from "../types";
 import { deleteDownload, deleteQueuedDownload } from "../api/downloads";
 import { formatBytes, formatTypeLabel } from "../utils/formatters";
-import { isVideoFile } from "../utils/video";
-import { openInPlayer } from "../utils/video";
+import { isVideoFile, openInPlayer } from "../utils/video";
 import { copyDownloadLink } from "../utils/downloads";
-import { useVideoPlayers } from "../hooks/useVideoPlayers";
+import { VideoPlayers } from "../hooks/useVideoPlayers";
 import { DownloadFiles } from "./DownloadFiles";
 
 interface DownloadListItemProps {
   download: Download;
   apiKey: string;
+  videoPlayers: VideoPlayers;
   onRefresh: () => void;
 }
 
@@ -64,14 +64,14 @@ const handleDelete = async (apiKey: string, download: Download, onRefresh: () =>
   }
 };
 
-export const DownloadListItem = ({ download, apiKey, onRefresh }: DownloadListItemProps) => {
+export const DownloadListItem = ({ download, apiKey, videoPlayers, onRefresh }: DownloadListItemProps) => {
   const status = getStatus(download);
   const isDownloadReady = !download.isQueued && (download.download_finished || download.progress >= 1);
   const hasMultipleFiles = download.files.length > 1;
   const isSingleVideoFile =
     download.files.length === 1 && isVideoFile(download.files[0].short_name || download.files[0].name);
   const subtitle = formatSubtitle(download);
-  const { players, setDefaultPlayer } = useVideoPlayers();
+  const { players, setDefaultPlayer } = videoPlayers;
 
   return (
     <List.Item

--- a/extensions/torbox/src/components/DownloadListItem.tsx
+++ b/extensions/torbox/src/components/DownloadListItem.tsx
@@ -66,7 +66,7 @@ const handleDelete = async (apiKey: string, download: Download, onRefresh: () =>
 
 export const DownloadListItem = ({ download, apiKey, onRefresh }: DownloadListItemProps) => {
   const status = getStatus(download);
-  const isReady = !download.isQueued && (download.download_finished || download.progress >= 1);
+  const isDownloadReady = !download.isQueued && (download.download_finished || download.progress >= 1);
   const hasMultipleFiles = download.files.length > 1;
   const isSingleVideoFile =
     download.files.length === 1 && isVideoFile(download.files[0].short_name || download.files[0].name);
@@ -81,7 +81,7 @@ export const DownloadListItem = ({ download, apiKey, onRefresh }: DownloadListIt
       actions={
         <ActionPanel>
           <ActionPanel.Section>
-            {isReady &&
+            {isDownloadReady &&
               isSingleVideoFile &&
               players.map((player) => (
                 <Action
@@ -91,7 +91,7 @@ export const DownloadListItem = ({ download, apiKey, onRefresh }: DownloadListIt
                   onAction={() => openInPlayer(apiKey, download, player)}
                 />
               ))}
-            {isReady && (
+            {isDownloadReady && (
               <Action title="Copy Download Link" icon={Icon.Link} onAction={() => copyDownloadLink(apiKey, download)} />
             )}
             {hasMultipleFiles && (

--- a/extensions/torbox/src/components/DownloadListItem.tsx
+++ b/extensions/torbox/src/components/DownloadListItem.tsx
@@ -1,7 +1,11 @@
-import { ActionPanel, Action, List, Icon, Color, showToast, Toast, Clipboard } from "@raycast/api";
+import { ActionPanel, Action, List, Icon, Color, showToast, Toast } from "@raycast/api";
 import { Download } from "../types";
-import { getDownloadLink, deleteDownload, deleteQueuedDownload } from "../api/downloads";
+import { deleteDownload, deleteQueuedDownload } from "../api/downloads";
 import { formatBytes, formatTypeLabel } from "../utils/formatters";
+import { isVideoFile } from "../utils/video";
+import { openInPlayer } from "../utils/video";
+import { copyDownloadLink } from "../utils/downloads";
+import { useVideoPlayers } from "../hooks/useVideoPlayers";
 import { DownloadFiles } from "./DownloadFiles";
 
 interface DownloadListItemProps {
@@ -39,21 +43,6 @@ const formatSubtitle = (download: Download): string => {
   return `${formatBytes(download.size)} · ${typeLabel}${fileCount}`;
 };
 
-const copyDownloadLink = async (apiKey: string, download: Download) => {
-  try {
-    await showToast({ style: Toast.Style.Animated, title: "Getting download link..." });
-    const link = await getDownloadLink(apiKey, download.type, download.id);
-    await Clipboard.copy(link);
-    await showToast({ style: Toast.Style.Success, title: "Download link copied!" });
-  } catch (error) {
-    await showToast({
-      style: Toast.Style.Failure,
-      title: "Failed to get download link",
-      message: error instanceof Error ? error.message : "Unknown error",
-    });
-  }
-};
-
 const handleDelete = async (apiKey: string, download: Download, onRefresh: () => void) => {
   try {
     await showToast({ style: Toast.Style.Animated, title: "Deleting download..." });
@@ -79,7 +68,10 @@ export const DownloadListItem = ({ download, apiKey, onRefresh }: DownloadListIt
   const status = getStatus(download);
   const isReady = !download.isQueued && (download.download_finished || download.progress >= 1);
   const hasMultipleFiles = download.files.length > 1;
+  const isSingleVideoFile =
+    download.files.length === 1 && isVideoFile(download.files[0].short_name || download.files[0].name);
   const subtitle = formatSubtitle(download);
+  const { players, setDefaultPlayer } = useVideoPlayers();
 
   return (
     <List.Item
@@ -89,7 +81,19 @@ export const DownloadListItem = ({ download, apiKey, onRefresh }: DownloadListIt
       actions={
         <ActionPanel>
           <ActionPanel.Section>
-            {isReady && <Action title="Copy Download Link" onAction={() => copyDownloadLink(apiKey, download)} />}
+            {isReady &&
+              isSingleVideoFile &&
+              players.map((player) => (
+                <Action
+                  key={player.name}
+                  title={`Open in ${player.name}`}
+                  icon={Icon.Play}
+                  onAction={() => openInPlayer(apiKey, download, player)}
+                />
+              ))}
+            {isReady && (
+              <Action title="Copy Download Link" icon={Icon.Link} onAction={() => copyDownloadLink(apiKey, download)} />
+            )}
             {hasMultipleFiles && (
               <Action.Push
                 title="View Files"
@@ -99,6 +103,15 @@ export const DownloadListItem = ({ download, apiKey, onRefresh }: DownloadListIt
               />
             )}
           </ActionPanel.Section>
+          {isSingleVideoFile && players.length > 1 && (
+            <ActionPanel.Section>
+              <ActionPanel.Submenu title="Set Default Player" icon={Icon.Star}>
+                {players.map((player) => (
+                  <Action key={player.name} title={player.name} onAction={() => setDefaultPlayer(player)} />
+                ))}
+              </ActionPanel.Submenu>
+            </ActionPanel.Section>
+          )}
           <ActionPanel.Section>
             <Action title="Refresh All Downloads" shortcut={{ modifiers: ["cmd"], key: "r" }} onAction={onRefresh} />
             <Action

--- a/extensions/torbox/src/hooks/useVideoPlayers.ts
+++ b/extensions/torbox/src/hooks/useVideoPlayers.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useState } from "react";
+import { Application, LocalStorage, showToast, Toast } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { findVideoPlayers } from "../utils/video";
+
+const STORAGE_KEY = "defaultVideoPlayer";
+
+export function useVideoPlayers() {
+  const { data: players = [] } = useCachedPromise(findVideoPlayers);
+  const [defaultPlayerName, setDefaultPlayerName] = useState<string | undefined>();
+
+  useEffect(() => {
+    LocalStorage.getItem<string>(STORAGE_KEY).then(setDefaultPlayerName);
+  }, []);
+
+  const sortedPlayers = defaultPlayerName
+    ? [...players].sort((a, b) => {
+        if (a.name === defaultPlayerName) return -1;
+        if (b.name === defaultPlayerName) return 1;
+        return 0;
+      })
+    : players;
+
+  const setDefaultPlayer = useCallback(async (player: Application) => {
+    await LocalStorage.setItem(STORAGE_KEY, player.name);
+    setDefaultPlayerName(player.name);
+    await showToast({ style: Toast.Style.Success, title: `Default player set to ${player.name}` });
+  }, []);
+
+  return { players: sortedPlayers, setDefaultPlayer };
+}

--- a/extensions/torbox/src/hooks/useVideoPlayers.ts
+++ b/extensions/torbox/src/hooks/useVideoPlayers.ts
@@ -29,3 +29,5 @@ export function useVideoPlayers() {
 
   return { players: sortedPlayers, setDefaultPlayer };
 }
+
+export type VideoPlayers = ReturnType<typeof useVideoPlayers>;

--- a/extensions/torbox/src/search-downloads.tsx
+++ b/extensions/torbox/src/search-downloads.tsx
@@ -1,12 +1,14 @@
 import { List, getPreferenceValues, showToast, Toast } from "@raycast/api";
 import { useState, useMemo } from "react";
 import { useDownloads } from "./hooks/useDownloads";
+import { useVideoPlayers } from "./hooks/useVideoPlayers";
 import { DownloadListItem } from "./components/DownloadListItem";
 
 export default function SearchDownloads() {
   const preferences = getPreferenceValues<ExtensionPreferences>();
   const [searchText, setSearchText] = useState("");
   const { data, isLoading, error, revalidate } = useDownloads();
+  const videoPlayers = useVideoPlayers();
 
   const filteredDownloads = useMemo(() => {
     if (!data) return [];
@@ -37,6 +39,7 @@ export default function SearchDownloads() {
             key={`${download.isQueued ? "queued" : download.type}-${download.id}`}
             download={download}
             apiKey={preferences.apiKey}
+            videoPlayers={videoPlayers}
             onRefresh={revalidate}
           />
         ))}

--- a/extensions/torbox/src/utils/downloads.ts
+++ b/extensions/torbox/src/utils/downloads.ts
@@ -1,0 +1,18 @@
+import { Clipboard, showToast, Toast } from "@raycast/api";
+import { Download } from "../types";
+import { getDownloadLink } from "../api/downloads";
+
+export const copyDownloadLink = async (apiKey: string, download: Download, fileId?: number) => {
+  try {
+    await showToast({ style: Toast.Style.Animated, title: "Getting download link..." });
+    const link = await getDownloadLink(apiKey, download.type, download.id, fileId);
+    await Clipboard.copy(link);
+    await showToast({ style: Toast.Style.Success, title: "Download link copied!" });
+  } catch (error) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Failed to get download link",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+};

--- a/extensions/torbox/src/utils/video.ts
+++ b/extensions/torbox/src/utils/video.ts
@@ -19,7 +19,9 @@ const VIDEO_EXTENSIONS = new Set([
 ]);
 
 export const isVideoFile = (filename: string): boolean => {
-  const ext = filename.slice(filename.lastIndexOf(".")).toLowerCase();
+  const dotIndex = filename.lastIndexOf(".");
+  if (dotIndex === -1) return false;
+  const ext = filename.slice(dotIndex).toLowerCase();
   return VIDEO_EXTENSIONS.has(ext);
 };
 

--- a/extensions/torbox/src/utils/video.ts
+++ b/extensions/torbox/src/utils/video.ts
@@ -1,0 +1,49 @@
+import { Application, getApplications, open, showToast, Toast } from "@raycast/api";
+import { Download } from "../types";
+import { getDownloadLink } from "../api/downloads";
+
+const VIDEO_EXTENSIONS = new Set([
+  ".mp4",
+  ".mkv",
+  ".avi",
+  ".mov",
+  ".wmv",
+  ".flv",
+  ".webm",
+  ".m4v",
+  ".mpg",
+  ".mpeg",
+  ".ts",
+  ".vob",
+  ".3gp",
+]);
+
+export const isVideoFile = (filename: string): boolean => {
+  const ext = filename.slice(filename.lastIndexOf(".")).toLowerCase();
+  return VIDEO_EXTENSIONS.has(ext);
+};
+
+const PLAYER_KEYWORDS = ["vlc", "iina", "infuse", "mpv"];
+
+export async function findVideoPlayers(): Promise<Application[]> {
+  const apps = await getApplications();
+  return apps.filter((app) => {
+    const name = app.name.toLowerCase();
+    return PLAYER_KEYWORDS.some((keyword) => name.includes(keyword));
+  });
+}
+
+export const openInPlayer = async (apiKey: string, download: Download, player: Application, fileId?: number) => {
+  try {
+    await showToast({ style: Toast.Style.Animated, title: `Opening in ${player.name}...` });
+    const link = await getDownloadLink(apiKey, download.type, download.id, fileId);
+    await open(link, player);
+    await showToast({ style: Toast.Style.Success, title: `Opened in ${player.name}` });
+  } catch (error) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: `Failed to open in ${player.name}`,
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+};


### PR DESCRIPTION
## Description

Video files can now be opened directly in installed media players (VLC, IINA, Infuse, mpv). The extension automatically detects which players are installed and lets users set a preferred default player.

## Screencast

<img width="862" height="586" alt="Screenshot 2026-03-15 at 01 08 12" src="https://github.com/user-attachments/assets/863e1937-8eae-4535-8e21-335542dcdd2b" />

<img width="862" height="586" alt="Screenshot 2026-03-15 at 01 08 17" src="https://github.com/user-attachments/assets/4718e28f-104a-4590-b1c3-dab35a52ab99" />

https://github.com/user-attachments/assets/6d52329b-5d37-48fc-b830-f8a01f77382e

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
