### PR TITLE
Update apple-reminders extension

### DIFF
--- a/extensions/apple-reminders/CHANGELOG.md
+++ b/extensions/apple-reminders/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Apple Reminders Changelog
 
+## [Fix Quick Add Reminder scheduling for past time-only input] - 2026-03-14
+
+- In `Quick Add Reminder` (non-AI mode), when a time is provided without an explicit date and that time has already passed, schedule the reminder for the next day instead of earlier today.
+- Resolves: https://github.com/raycast/extensions/issues/26334
+
 ## [Prevent accidental recurring reminders from AI] - 2026-02-26
 
 - Add tool confirmations for recurring reminder creation and recurrence updates so users can approve recurrence changes.

--- a/extensions/apple-reminders/CHANGELOG.md
+++ b/extensions/apple-reminders/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Apple Reminders Changelog
 
-## [Fix Quick Add Reminder scheduling for past time-only input] - 2026-03-14
+## [Fix Quick Add Reminder scheduling for past time-only input] - {PR_MERGE_DATE}
 
 - In `Quick Add Reminder` (non-AI mode), when a time is provided without an explicit date and that time has already passed, schedule the reminder for the next day instead of earlier today.
 - Resolves: https://github.com/raycast/extensions/issues/26334

--- a/extensions/apple-reminders/CHANGELOG.md
+++ b/extensions/apple-reminders/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Apple Reminders Changelog
 
-## [Fix Quick Add Reminder scheduling for past time-only input] - {PR_MERGE_DATE}
+## [Fix Quick Add Reminder scheduling for past time-only input] - 2026-03-15
 
 - In `Quick Add Reminder` (non-AI mode), when a time is provided without an explicit date and that time has already passed, schedule the reminder for the next day instead of earlier today.
 - Resolves: https://github.com/raycast/extensions/issues/26334

--- a/extensions/apple-reminders/src/quick-add-reminder.tsx
+++ b/extensions/apple-reminders/src/quick-add-reminder.tsx
@@ -36,7 +36,19 @@ export default async function Command(props: LaunchProps<{ arguments: Arguments.
       if (dateMatch && dateMatch.length > 0) {
         const chronoDate = dateMatch[0].start;
         isDateTime = chronoDate.isCertain("hour") || chronoDate.isCertain("minute") || chronoDate.isCertain("second");
-        const date = chronoDate.date();
+        let date = chronoDate.date();
+
+        const hasExplicitDate =
+          chronoDate.isCertain("weekday") ||
+          chronoDate.isCertain("day") ||
+          chronoDate.isCertain("month") ||
+          chronoDate.isCertain("year");
+
+        // If the user only specified a time and it already passed today, schedule it for tomorrow.
+        if (isDateTime && !hasExplicitDate && date.getTime() < Date.now()) {
+          date = addDays(date, 1);
+        }
+
         dueDate = isDateTime ? date.toISOString() : format(date, "yyyy-MM-dd");
       }
 


### PR DESCRIPTION
## Description

Fixes a quick-add parsing issue where time-only input could schedule reminders in the past.

Example:
- Current time: `21:13`
- Input: `something at 9:30`
- Before: scheduled for today at 9:30 (past)
- After: scheduled for tomorrow at 9:30 (next future occurrence)

### What changed
- In `quick-add-reminder.tsx`, after parsing with `chrono`, if:
  - input has a time,
  - no explicit date is provided, and
  - parsed time is already in the past,
  then the due date is shifted by one day.

Fixes #26334

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder