### PR TITLE
✨ feat(ccusage): progress bars, rate limits redesign, working time, and caching

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Menu bar command-specific preferences (via "Configure Command" item at bottom of dropdown):
   - **Menu Bar Status**: choose what appears next to the icon — Today's Usage (Cost + Tokens), Today's Cost, Monthly Cost, Today's Tokens, 5-Hour Limit %, 7-Day Limit %, Highest Utilization, or None
   - **Progress Bar Mode**: Remaining or Consumed
+  - **Progress Bar Style**: Solid (`█░`), Blocks (`▰▱`), or ASCII (`#-`)
+- Rate Limits section is hidden when authenticated via API key — it is only meaningful for OAuth (Claude Max plan) users
 - "Configure Command" item at the bottom of the menu bar dropdown opens command preferences directly
 
 ### Fixed

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [v2.3.0] - {PR_MERGE_DATE}
+## [v2.3.0] - 2026-03-23
 
 ### Added
 

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [v2.3.0] - {PR_MERGE_DATE}
+
+### Added
+
+- Rate Limits section restructured: each limit on a single row with inline progress bar in the title and percentage + reset time in the subtitle
+- Progress bars use `▰▱` glyphs for cleaner, more uniform rendering
+- Section header shows mode: `Rate Limits · Remaining` or `Rate Limits · Consumed`
+- Per-model usage limit tracking for Sonnet and Opus in the Rate Limits section
+- Working Time section in menu bar showing today's active coding duration vs. yesterday
+- Rate limit backoff: automatically pauses API polling for 5 minutes after a 429 response
+- Graceful handling when rate-limited: shows countdown to next retry (e.g. "Rate limited — retry in 4m 32s")
+- Persistent cache for usage data — previous state is shown immediately on Raycast restart while fresh data loads in background
+- Rate limits section shows countdown to next automatic refresh
+- Day-over-day cost and token comparison in Today's Usage menu bar section
+- Menu bar icon restored to full-color extension icon; today's usage shown as text next to it
+- Menu bar command-specific preferences (via "Configure Command" item at bottom of dropdown):
+  - **Menu Bar Status**: choose what appears next to the icon — Today's Usage (Cost + Tokens), Today's Cost, Monthly Cost, Today's Tokens, 5-Hour Limit %, 7-Day Limit %, Highest Utilization, or None
+  - **Progress Bar Mode**: Remaining or Consumed
+- "Configure Command" item at the bottom of the menu bar dropdown opens command preferences directly
+
+### Fixed
+
+- Menu bar no longer hides all usage data when a transient refresh error occurs
+- Stale data warning no longer flashes on every Raycast restart — only shown after a fetch completes and data is genuinely old (rate-limited or error state)
+- Fixed `extra_usage` schema validation failing when `used_credits` or `monthly_limit` are null
+- Fixed optional limit windows (`seven_day_opus`, `seven_day_sonnet`) failing Zod validation when API returns explicit `null` instead of omitting the field
+- `formatDuration` no longer shows seconds alongside minutes (e.g. "4m" not "4m 43s")
+
 ## [Fixed JSON parsing on first run] - 2026-03-21
 
 - Added `extractJSON` helper to strip npx stdout noise (e.g. npm warnings) before parsing JSON

--- a/extensions/ccusage/CLAUDE.md
+++ b/extensions/ccusage/CLAUDE.md
@@ -17,6 +17,7 @@ ccusage CLI tool → useCCUsage*Cli hooks → use*Usage hooks → Pure Functions
 ```
 
 #### Hook Layer Separation
+
 - **CLI Layer**: Direct command execution (`useCCUsageDailyCli`, `useCCUsageMonthlyCli`, etc.)
 - **Data Layer**: Data transformation and business logic (`useDailyUsage`, `useMonthlyUsage`, etc.)
 - **Availability Layer**: System dependency checking (`useCCUsageAvailability`)
@@ -111,14 +112,16 @@ The extension uses `date +%Y-%m-%d` command via `useCurrentDate` hook for simpli
 Each major UI section is a focused component with shared common utilities:
 
 #### Core Components
+
 - `DailyUsage`: Today's usage with intensity visualization
-- `SessionUsage`: Recent sessions with model-specific icons  
+- `SessionUsage`: Recent sessions with model-specific icons
 - `CostAnalysis`: Cost breakdown and projections with inline calculations
 - `ModelBreakdown`: Model-wise usage analysis with tier grouping
 - `ErrorState`: Initial configuration guidance for ccusage setup
 - `ErrorMetadata`: Error state metadata and categorization handling
 
 #### Common Utilities
+
 - `StandardActions`: Shared external link and action management
 - `accessories`: Standardized accessory configurations for consistent UI patterns
 
@@ -189,7 +192,7 @@ src/
 #### Pre-Modification Investigation
 
 - **Impact Analysis**: Comprehensive search to identify all affected files and usage patterns
-- **Dependency Mapping**: Create relationship maps for schemas, types, and cross-file dependencies  
+- **Dependency Mapping**: Create relationship maps for schemas, types, and cross-file dependencies
 - **Test Strategy**: Plan validation approach before beginning modifications
 - **Scope Documentation**: Document expected changes with concrete examples
 
@@ -258,11 +261,17 @@ src/
 ```typescript
 // ❌ Over-abstracted
 const getTrendIcon = (): Icon => Icon.Calendar;
-const useStandardAccessories = (error, data, formatter, icon) => { /* logic */ };
+const useStandardAccessories = (error, data, formatter, icon) => {
+  /* logic */
+};
 
 // ✅ Direct and clear
 const icon = { source: Icon.Calendar, tintColor: Color.SecondaryText };
-const accessories = error ? STANDARD_ACCESSORIES.ERROR : !data ? STANDARD_ACCESSORIES.NO_DATA : [{ text: formatCost(data.cost), icon: Icon.Coins }];
+const accessories = error
+  ? STANDARD_ACCESSORIES.ERROR
+  : !data
+    ? STANDARD_ACCESSORIES.NO_DATA
+    : [{ text: formatCost(data.cost), icon: Icon.Coins }];
 
 // ❌ Centralized config far from usage
 // utils/component-config.ts
@@ -271,7 +280,7 @@ export const CONFIGS = { daily: { message: "..." } };
 // ✅ Colocated with usage
 // components/DailyUsage.tsx
 const externalLinks: ExternalLink[] = [
-  { title: "View CCUsage Repository", url: "https://github.com/...", icon: Icon.Code }
+  { title: "View CCUsage Repository", url: "https://github.com/...", icon: Icon.Code },
 ];
 ```
 
@@ -324,6 +333,7 @@ The extension includes a simplified preference system for user customization:
 - **No Debug Code**: Remove console.log statements before commits
 
 ### Quality Verification Commands
+
 ```bash
 # Complete quality check pipeline
 npm run typecheck && npm run lint && npm run build
@@ -350,3 +360,7 @@ Before committing React component changes:
 - **Under Development**: Extension is actively being developed with experimental features
 - **Unofficial**: Not affiliated with Anthropic or ccusage maintainers
 - **Raycast Store**: Use `npm run publish` to submit to Raycast Store (not npm publish)
+
+## Conventions
+
+- **Changelog dates**: Use `{PR_MERGE_DATE}` as the date placeholder in `CHANGELOG.md` entries. The Raycast extensions repo tooling substitutes it automatically when the PR is merged.

--- a/extensions/ccusage/package.json
+++ b/extensions/ccusage/package.json
@@ -90,6 +90,28 @@
               "value": "consumed"
             }
           ]
+        },
+        {
+          "name": "progressBarStyle",
+          "type": "dropdown",
+          "required": false,
+          "title": "Progress Bar Style",
+          "description": "Visual style for rate limit progress bars",
+          "default": "solid",
+          "data": [
+            {
+              "title": "Solid (█░)",
+              "value": "solid"
+            },
+            {
+              "title": "Blocks (▰▱)",
+              "value": "blocks"
+            },
+            {
+              "title": "ASCII (#-)",
+              "value": "ascii"
+            }
+          ]
         }
       ]
     },

--- a/extensions/ccusage/package.json
+++ b/extensions/ccusage/package.json
@@ -29,7 +29,69 @@
       "title": "Claude Code Usage in Menu Bar",
       "subtitle": "ccusage",
       "description": "Show Claude Code usage in menu bar",
-      "mode": "menu-bar"
+      "mode": "menu-bar",
+      "preferences": [
+        {
+          "name": "menuBarTitle",
+          "type": "dropdown",
+          "required": false,
+          "title": "Menu Bar Status",
+          "description": "What to display as text next to the icon in the menu bar",
+          "default": "todayUsage",
+          "data": [
+            {
+              "title": "Today's Usage (Cost + Tokens)",
+              "value": "todayUsage"
+            },
+            {
+              "title": "Today's Cost",
+              "value": "todayCost"
+            },
+            {
+              "title": "Monthly Cost",
+              "value": "monthlyCost"
+            },
+            {
+              "title": "Today's Tokens",
+              "value": "todayTokens"
+            },
+            {
+              "title": "5-Hour Limit",
+              "value": "fiveHour"
+            },
+            {
+              "title": "7-Day Limit",
+              "value": "sevenDay"
+            },
+            {
+              "title": "Highest Utilization",
+              "value": "utilization"
+            },
+            {
+              "title": "None",
+              "value": "none"
+            }
+          ]
+        },
+        {
+          "name": "showRemainingUsage",
+          "type": "dropdown",
+          "required": false,
+          "title": "Progress Bar Mode",
+          "description": "Whether progress bars show remaining capacity or consumed usage",
+          "default": "remaining",
+          "data": [
+            {
+              "title": "Remaining",
+              "value": "remaining"
+            },
+            {
+              "title": "Consumed",
+              "value": "consumed"
+            }
+          ]
+        }
+      ]
     },
     {
       "name": "claude-code-stats",

--- a/extensions/ccusage/src/claude-code-stats.tsx
+++ b/extensions/ccusage/src/claude-code-stats.tsx
@@ -86,10 +86,10 @@ const fetchUsageLimit = async () => {
   const token = await getClaudeAccessToken();
   if (!token) return null;
 
-  const data = await fetchClaudeUsageLimits(token);
-  if (!data) return null;
+  const result = await fetchClaudeUsageLimits(token);
+  if (result.status !== "ok") return null;
 
-  return Math.round(data.five_hour.utilization * 10) / 10;
+  return Math.round(result.data.five_hour.utilization * 10) / 10;
 };
 
 export default async function Command() {

--- a/extensions/ccusage/src/components/DailyUsage.tsx
+++ b/extensions/ccusage/src/components/DailyUsage.tsx
@@ -1,5 +1,12 @@
-import { List, Icon } from "@raycast/api";
-import { formatTokens, formatCost, getTokenEfficiency, getCostPerMTok } from "../utils/data-formatter";
+import { List, Icon, Color } from "@raycast/api";
+import {
+  formatTokens,
+  formatCost,
+  formatCostDelta,
+  formatTokenDelta,
+  getTokenEfficiency,
+  getCostPerMTok,
+} from "../utils/data-formatter";
 import { getCurrentLocalDate } from "../utils/date-formatter";
 import { useDailyUsage } from "../hooks/useDailyUsage";
 import { ErrorMetadata } from "./ErrorMetadata";
@@ -13,7 +20,7 @@ const externalLinks: ExternalLink[] = [
 ];
 
 export function DailyUsage() {
-  const { data: dailyUsage, isLoading, error } = useDailyUsage();
+  const { data: dailyUsage, previousDayData, isLoading, error } = useDailyUsage();
   const currentDate = getCurrentLocalDate();
 
   const efficiency = useMemo(
@@ -62,6 +69,25 @@ export function DailyUsage() {
 
         <List.Item.Detail.Metadata.Label title="Efficiency Metrics" />
         <List.Item.Detail.Metadata.Label title="Output/Input Ratio" text={efficiency} />
+
+        {previousDayData && dailyUsage && (
+          <>
+            <List.Item.Detail.Metadata.Separator />
+            <List.Item.Detail.Metadata.Label title="Day-over-Day" text={previousDayData.date} />
+            <List.Item.Detail.Metadata.Label
+              title="Cost Delta"
+              text={formatCostDelta(dailyUsage.totalCost, previousDayData.totalCost)}
+              icon={{
+                source: dailyUsage.totalCost >= previousDayData.totalCost ? Icon.ArrowUp : Icon.ArrowDown,
+                tintColor: dailyUsage.totalCost >= previousDayData.totalCost ? Color.Red : Color.Green,
+              }}
+            />
+            <List.Item.Detail.Metadata.Label
+              title="Token Delta"
+              text={formatTokenDelta(dailyUsage.totalTokens, previousDayData.totalTokens)}
+            />
+          </>
+        )}
       </List.Item.Detail.Metadata>
     );
   };

--- a/extensions/ccusage/src/components/SessionUsage.tsx
+++ b/extensions/ccusage/src/components/SessionUsage.tsx
@@ -78,7 +78,7 @@ export function SessionUsage() {
         <List.Item.Detail.Metadata.Label title="Latest Sessions" />
         {sessions.slice(0, MAX_SESSIONS_DISPLAY).map((session, index) => (
           <List.Item.Detail.Metadata.Label
-            key={session.sessionId || index}
+            key={`${session.sessionId || "unknown"}-${index}`}
             title={session.sessionId}
             text={`${formatTokens(session.totalTokens)} • ${formatCost(session.totalCost)} • ${formatDistanceToNow(new Date(session.lastActivity), { addSuffix: true })}`}
           />

--- a/extensions/ccusage/src/components/UsageLimits.tsx
+++ b/extensions/ccusage/src/components/UsageLimits.tsx
@@ -6,69 +6,15 @@ import {
   getUtilizationColor,
   calculateEstimatedUsage,
   calculateAverageUsage,
+  createProgressBar,
 } from "../utils/usage-limits-formatter";
-import { UsageLimitsError, sanitizeCodeBlock } from "../utils/usage-limits-error";
 import { ErrorMetadata } from "./ErrorMetadata";
-import { ReactNode } from "react";
 import { STANDARD_ACCESSORIES } from "./common/accessories";
-
-type UsageLimitsAccessoriesInput = {
-  hasData: boolean;
-  error: UsageLimitsError | null;
-  isStale: boolean;
-  lastFetched: Date | null;
-  fiveHourUtilization: number;
-};
-
-const getUsageLimitsErrorIcon = () => ({
-  source: Icon.ExclamationMark,
-  tintColor: Color.Red,
-});
-
-const getUsageLimitsAccessories = ({
-  hasData,
-  error,
-  isStale,
-  lastFetched,
-  fiveHourUtilization,
-}: UsageLimitsAccessoriesInput): List.Item.Accessory[] => {
-  if (error) {
-    return [{ text: "Error", icon: getUsageLimitsErrorIcon() }];
-  }
-
-  if (!hasData) {
-    return STANDARD_ACCESSORIES.LOADING;
-  }
-
-  if (isStale) {
-    return [{ icon: Icon.Warning, tooltip: `Stale data (last updated ${formatRelativeTime(lastFetched)})` }];
-  }
-
-  return [
-    {
-      icon: Icon.Gauge,
-      text: `${fiveHourUtilization.toFixed(0)}%`,
-      tooltip: "5-Hour Limit (higher priority)",
-    },
-  ];
-};
-
-const getUsageLimitsErrorMarkdown = (error: UsageLimitsError): string => {
-  return [
-    `# ${error.title}`,
-    "",
-    error.message,
-    "",
-    "## Error Log",
-    "",
-    "```text",
-    sanitizeCodeBlock(error.log),
-    "```",
-  ].join("\n");
-};
+import { ReactNode } from "react";
 
 export function UsageLimits() {
-  const { data, isLoading, error, isStale, lastFetched, revalidate, isUsageLimitsAvailable } = useClaudeUsageLimits();
+  const { data, isLoading, error, isStale, isRateLimited, lastFetched, revalidate, isUsageLimitsAvailable } =
+    useClaudeUsageLimits();
 
   if (!isUsageLimitsAvailable) {
     return null;
@@ -77,27 +23,44 @@ export function UsageLimits() {
   const fiveHourUtil = data?.five_hour?.utilization ?? 0;
   const sevenDayUtil = data?.seven_day?.utilization ?? 0;
 
-  const accessories = getUsageLimitsAccessories({
-    hasData: Boolean(data),
-    error,
-    isStale,
-    lastFetched,
-    fiveHourUtilization: fiveHourUtil,
-  });
+  const accessories: List.Item.Accessory[] =
+    error && !data
+      ? STANDARD_ACCESSORIES.ERROR
+      : isRateLimited && !data
+        ? [{ icon: Icon.Clock, text: "Rate limited" }]
+        : !data
+          ? STANDARD_ACCESSORIES.LOADING
+          : isStale && !isLoading
+            ? [{ icon: Icon.Warning, tooltip: `Stale data (last updated ${formatRelativeTime(lastFetched)})` }]
+            : [
+                {
+                  icon: Icon.Gauge,
+                  text: `${fiveHourUtil.toFixed(0)}%`,
+                  tooltip: "5-Hour Limit (higher priority)",
+                },
+              ];
 
   const renderDetailMetadata = (): ReactNode => {
-    if (error) {
-      return null;
+    if (error && !data) {
+      return (
+        <ErrorMetadata
+          noDataMessage="Unable to fetch usage limits"
+          noDataSubMessage="Re-authenticate by running: claude login"
+        />
+      );
+    }
+
+    if (isRateLimited && !data) {
+      return (
+        <ErrorMetadata
+          noDataMessage="Rate limited by Anthropic API"
+          noDataSubMessage="Retrying automatically — click Refresh to try now"
+        />
+      );
     }
 
     if (!data) {
-      return (
-        <ErrorMetadata
-          error={undefined}
-          noDataMessage="Loading usage limits..."
-          noDataSubMessage="Fetching data from Claude API"
-        />
-      );
+      return <ErrorMetadata noDataMessage="Loading usage limits..." noDataSubMessage="Fetching data from Claude API" />;
     }
 
     const fiveHourColor = getUtilizationColor(fiveHourUtil);
@@ -133,6 +96,7 @@ export function UsageLimits() {
           text={`${fiveHourUtil.toFixed(1)}%`}
           icon={{ source: Icon.BarChart, tintColor: fiveHourColor }}
         />
+        <List.Item.Detail.Metadata.Label title="Progress" text={createProgressBar(fiveHourUtil)} />
         {fiveHourAverage !== null && (
           <List.Item.Detail.Metadata.Label
             title="Average Usage"
@@ -151,7 +115,7 @@ export function UsageLimits() {
           title="Resets in"
           text={
             data.five_hour.resets_at
-              ? `${formatTimeRemaining(data.five_hour.resets_at)} || ${new Date(data.five_hour.resets_at).toLocaleString()}`
+              ? `${formatTimeRemaining(data.five_hour.resets_at)} || ${new Date(data.five_hour.resets_at).toLocaleString("en-US", { hour12: false })}`
               : "N/A"
           }
           icon={Icon.ArrowClockwise}
@@ -164,6 +128,7 @@ export function UsageLimits() {
           text={`${sevenDayUtil.toFixed(1)}%`}
           icon={{ source: Icon.BarChart, tintColor: sevenDayColor }}
         />
+        <List.Item.Detail.Metadata.Label title="Progress" text={createProgressBar(sevenDayUtil)} />
         {sevenDayAverage !== null && (
           <List.Item.Detail.Metadata.Label
             title="Average Usage"
@@ -182,13 +147,13 @@ export function UsageLimits() {
           title="Resets in"
           text={
             data.seven_day.resets_at
-              ? `${formatTimeRemaining(data.seven_day.resets_at)} || ${new Date(data.seven_day.resets_at).toLocaleString()}`
+              ? `${formatTimeRemaining(data.seven_day.resets_at)} || ${new Date(data.seven_day.resets_at).toLocaleString("en-US", { hour12: false })}`
               : "N/A"
           }
           icon={Icon.ArrowClockwise}
         />
 
-        {isStale && (
+        {isStale && !isLoading && (
           <>
             <List.Item.Detail.Metadata.Separator />
             <List.Item.Detail.Metadata.Label
@@ -207,19 +172,12 @@ export function UsageLimits() {
     <List.Item
       id="usage-limits"
       title="Usage Limits"
-      icon={Icon.Gauge}
+      icon={{ source: Icon.Gauge, tintColor: Color.SecondaryText }}
       accessories={accessories}
-      detail={
-        error ? (
-          <List.Item.Detail markdown={getUsageLimitsErrorMarkdown(error)} />
-        ) : (
-          <List.Item.Detail isLoading={isLoading} metadata={renderDetailMetadata()} />
-        )
-      }
+      detail={<List.Item.Detail isLoading={isLoading} metadata={renderDetailMetadata()} />}
       actions={
         <ActionPanel>
           <Action title="Refresh Usage Limit" icon={Icon.ArrowClockwise} onAction={revalidate} />
-          {error && <Action.CopyToClipboard title="Copy Error Log" content={error.log} icon={Icon.Clipboard} />}
         </ActionPanel>
       }
     />

--- a/extensions/ccusage/src/hooks/useCCUsageBlocksCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageBlocksCli.ts
@@ -1,37 +1,37 @@
 import { useState } from "react";
 import { Cache } from "@raycast/api";
 import { useExec } from "@raycast/utils";
-import { MonthlyUsageCommandResponse, MonthlyUsageCommandResponseSchema } from "../types/usage-types";
+import { BlocksCommandResponse, BlocksCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
 import { preferences } from "../preferences";
 
 const cache = new Cache();
-const CACHE_KEY = "ccusage-monthly";
+const CACHE_KEY = "ccusage-blocks";
 
-export const useCCUsageMonthlyCli = () => {
+export const useCCUsageBlocksCli = () => {
   const useDirectCommand = preferences.useDirectCcusageCommand;
 
-  const [initialData] = useState<MonthlyUsageCommandResponse | undefined>(() => {
+  const [initialData] = useState<BlocksCommandResponse | undefined>(() => {
     const cached = cache.get(CACHE_KEY);
-    return cached ? (JSON.parse(cached) as MonthlyUsageCommandResponse) : undefined;
+    return cached ? (JSON.parse(cached) as BlocksCommandResponse) : undefined;
   });
 
   const command = useDirectCommand ? "ccusage" : "npx";
-  const args = useDirectCommand ? ["monthly", "--json"] : ["ccusage@latest", "monthly", "--json"];
+  const args = useDirectCommand ? ["blocks", "--json"] : ["ccusage@latest", "blocks", "--json"];
 
   const result = useExec(command, args, {
     ...getExecOptions(),
     initialData,
     parseOutput: ({ stdout }) => {
       if (!stdout) {
-        throw new Error("No output received from ccusage monthly command");
+        return { blocks: [] };
       }
 
-      const parseResult = stringToJSON.pipe(MonthlyUsageCommandResponseSchema).safeParse(stdout.toString());
+      const parseResult = stringToJSON.pipe(BlocksCommandResponseSchema).safeParse(stdout.toString());
 
       if (!parseResult.success) {
-        throw new Error(`Invalid monthly usage data: ${parseResult.error.message}`);
+        throw new Error(`Invalid blocks data: ${parseResult.error.message}`);
       }
 
       cache.set(CACHE_KEY, JSON.stringify(parseResult.data));
@@ -39,7 +39,7 @@ export const useCCUsageMonthlyCli = () => {
     },
     keepPreviousData: true,
     failureToastOptions: {
-      title: "Failed to fetch monthly usage data",
+      title: "Failed to fetch blocks data",
       primaryAction: {
         title: "Retry",
         onAction: (toast) => {

--- a/extensions/ccusage/src/hooks/useCCUsageDailyCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageDailyCli.ts
@@ -1,19 +1,27 @@
+import { useState } from "react";
+import { Cache } from "@raycast/api";
 import { useExec } from "@raycast/utils";
-import { DailyUsageCommandResponseSchema } from "../types/usage-types";
+import { DailyUsageCommandResponse, DailyUsageCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
 import { preferences } from "../preferences";
 
-/**
- * Hook for executing `ccusage daily --json` command
- */
+const cache = new Cache();
+const CACHE_KEY = "ccusage-daily";
+
 export const useCCUsageDailyCli = () => {
   const useDirectCommand = preferences.useDirectCcusageCommand;
+
+  const [initialData] = useState<DailyUsageCommandResponse | undefined>(() => {
+    const cached = cache.get(CACHE_KEY);
+    return cached ? (JSON.parse(cached) as DailyUsageCommandResponse) : undefined;
+  });
 
   const command = useDirectCommand ? "ccusage" : "npx";
   const args = useDirectCommand ? ["daily", "--json"] : ["ccusage@latest", "daily", "--json"];
   const result = useExec(command, args, {
     ...getExecOptions(),
+    initialData,
     parseOutput: ({ stdout }) => {
       if (!stdout) {
         throw new Error("No output received from ccusage daily command");
@@ -25,6 +33,7 @@ export const useCCUsageDailyCli = () => {
         throw new Error(`Invalid daily usage data: ${parseResult.error.message}`);
       }
 
+      cache.set(CACHE_KEY, JSON.stringify(parseResult.data));
       return parseResult.data;
     },
     keepPreviousData: true,

--- a/extensions/ccusage/src/hooks/useCCUsageSessionCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageSessionCli.ts
@@ -1,20 +1,28 @@
+import { useState } from "react";
+import { Cache } from "@raycast/api";
 import { useExec } from "@raycast/utils";
-import { SessionUsageCommandResponseSchema } from "../types/usage-types";
+import { SessionUsageCommandResponse, SessionUsageCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
 import { preferences } from "../preferences";
 
-/**
- * Hook for executing `ccusage session --json` command
- */
+const cache = new Cache();
+const CACHE_KEY = "ccusage-session";
+
 export const useCCUsageSessionCli = () => {
   const useDirectCommand = preferences.useDirectCcusageCommand;
+
+  const [initialData] = useState<SessionUsageCommandResponse | undefined>(() => {
+    const cached = cache.get(CACHE_KEY);
+    return cached ? (JSON.parse(cached) as SessionUsageCommandResponse) : undefined;
+  });
 
   const command = useDirectCommand ? "ccusage" : "npx";
   const args = useDirectCommand ? ["session", "--json"] : ["ccusage@latest", "session", "--json"];
 
   const result = useExec(command, args, {
     ...getExecOptions(),
+    initialData,
     parseOutput: ({ stdout }) => {
       if (!stdout) {
         return { sessions: [] };
@@ -26,6 +34,7 @@ export const useCCUsageSessionCli = () => {
         throw new Error(`Invalid session usage data: ${parseResult.error.message}`);
       }
 
+      cache.set(CACHE_KEY, JSON.stringify(parseResult.data));
       return parseResult.data;
     },
     keepPreviousData: true,

--- a/extensions/ccusage/src/hooks/useCCUsageTotalCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageTotalCli.ts
@@ -1,20 +1,28 @@
+import { useState } from "react";
+import { Cache } from "@raycast/api";
 import { useExec } from "@raycast/utils";
-import { TotalUsageResponseSchema } from "../types/usage-types";
+import { TotalUsageResponse, TotalUsageResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
 import { preferences } from "../preferences";
 
-/**
- * Hook for executing `ccusage --json` command
- */
+const cache = new Cache();
+const CACHE_KEY = "ccusage-total";
+
 export const useCCUsageTotalCli = () => {
   const useDirectCommand = preferences.useDirectCcusageCommand;
+
+  const [initialData] = useState<TotalUsageResponse | undefined>(() => {
+    const cached = cache.get(CACHE_KEY);
+    return cached ? (JSON.parse(cached) as TotalUsageResponse) : undefined;
+  });
 
   const command = useDirectCommand ? "ccusage" : "npx";
   const args = useDirectCommand ? ["--json"] : ["ccusage@latest", "--json"];
 
   const result = useExec(command, args, {
     ...getExecOptions(),
+    initialData,
     parseOutput: ({ stdout }) => {
       if (!stdout) {
         throw new Error("No output received from ccusage command");
@@ -26,6 +34,7 @@ export const useCCUsageTotalCli = () => {
         throw new Error(`Invalid total usage data: ${parseResult.error.message}`);
       }
 
+      cache.set(CACHE_KEY, JSON.stringify(parseResult.data));
       return parseResult.data;
     },
     keepPreviousData: true,

--- a/extensions/ccusage/src/hooks/useClaudeUsageLimits.ts
+++ b/extensions/ccusage/src/hooks/useClaudeUsageLimits.ts
@@ -1,15 +1,17 @@
 import { useState, useEffect, useCallback } from "react";
 import { UsageLimitData } from "../types/usage-types";
 import { subscribeToUsageLimits, getUsageLimitsState, revalidateUsageLimits } from "../utils/usage-limits-cache";
-import { UsageLimitsError } from "../utils/usage-limits-error";
 
 interface UsageLimitsState {
   data: UsageLimitData | null;
-  error: UsageLimitsError | null;
+  error: Error | null;
   isLoading: boolean;
   isStale: boolean;
+  isRateLimited: boolean;
   isUsageLimitsAvailable: boolean;
   lastFetched: Date | null;
+  rateLimitedUntil: number | null;
+  nextRefreshAt: number | null;
   revalidate: () => void;
 }
 

--- a/extensions/ccusage/src/hooks/useDailyUsage.ts
+++ b/extensions/ccusage/src/hooks/useDailyUsage.ts
@@ -1,9 +1,11 @@
+import { subDays, format } from "date-fns";
 import { useCCUsageDailyCli } from "./useCCUsageDailyCli";
 import { DailyUsageData } from "../types/usage-types";
 import { getCurrentLocalDate } from "../utils/date-formatter";
 
 export const useDailyUsage = (): {
   data: DailyUsageData | undefined;
+  previousDayData: DailyUsageData | undefined;
   isLoading: boolean;
   error: Error | undefined;
   revalidate: () => void;
@@ -26,8 +28,26 @@ export const useDailyUsage = (): {
     return latest;
   })();
 
+  const previousDayData: DailyUsageData | undefined = (() => {
+    if (!rawData || !rawData.daily || rawData.daily.length === 0) {
+      return undefined;
+    }
+
+    const yesterday = format(subDays(new Date(), 1), "yyyy-MM-dd");
+    const yesterdayEntry = rawData.daily.find((entry) => entry.date === yesterday);
+
+    if (yesterdayEntry) {
+      return yesterdayEntry;
+    }
+
+    const today = getCurrentLocalDate();
+    const priorEntries = rawData.daily.filter((entry) => entry.date < today);
+    return priorEntries.length > 0 ? priorEntries[priorEntries.length - 1] : undefined;
+  })();
+
   return {
     data,
+    previousDayData,
     isLoading,
     error,
     revalidate,

--- a/extensions/ccusage/src/hooks/useWorkingTime.ts
+++ b/extensions/ccusage/src/hooks/useWorkingTime.ts
@@ -1,0 +1,41 @@
+import { subDays, format } from "date-fns";
+import { useCCUsageBlocksCli } from "./useCCUsageBlocksCli";
+import { Block } from "../types/usage-types";
+
+type WorkingTimeResult = {
+  todayMs: number;
+  yesterdayMs: number;
+  isLoading: boolean;
+  error: Error | undefined;
+  revalidate: () => void;
+};
+
+const localDateStr = (isoString: string): string => {
+  const d = new Date(isoString);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+};
+
+const blockDurationMs = (block: Block, now: Date): number => {
+  const start = new Date(block.startTime);
+  const end = block.isActive ? now : block.actualEndTime ? new Date(block.actualEndTime) : new Date(block.endTime);
+  return Math.max(0, end.getTime() - start.getTime());
+};
+
+const workingMsForDate = (blocks: Block[], dateStr: string, now: Date): number =>
+  blocks
+    .filter((b) => !b.isGap && localDateStr(b.startTime) === dateStr)
+    .reduce((sum, b) => sum + blockDurationMs(b, now), 0);
+
+export const useWorkingTime = (): WorkingTimeResult => {
+  const { data, isLoading, error, revalidate } = useCCUsageBlocksCli();
+
+  const now = new Date();
+  const todayStr = format(now, "yyyy-MM-dd");
+  const yesterdayStr = format(subDays(now, 1), "yyyy-MM-dd");
+
+  const blocks = data?.blocks ?? [];
+  const todayMs = workingMsForDate(blocks, todayStr, now);
+  const yesterdayMs = workingMsForDate(blocks, yesterdayStr, now);
+
+  return { todayMs, yesterdayMs, isLoading, error, revalidate };
+};

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -7,7 +7,7 @@ import { useClaudeUsageLimits } from "./hooks/useClaudeUsageLimits";
 import { useWorkingTime } from "./hooks/useWorkingTime";
 import { formatCost, formatCostDelta, formatDuration, formatTokensAsMTok } from "./utils/data-formatter";
 import { formatTimeRemaining, createProgressBar } from "./utils/usage-limits-formatter";
-import { showRemainingUsage, getMenuBarTitle } from "./preferences";
+import { showRemainingUsage, getMenuBarTitle, getProgressBarStyle } from "./preferences";
 import { TotalUsageData } from "./types/usage-types";
 
 const MOCK_LIMITS_ENABLED = false;
@@ -80,16 +80,17 @@ export default function MenuBarccusage() {
   };
 
   const preferRemaining = showRemainingUsage();
+  const progressBarStyle = getProgressBarStyle();
 
   const rateLimitsSectionTitle = `Rate Limits · ${preferRemaining ? "Remaining" : "Consumed"}`;
 
-  const limitInfo = (utilization: number, resetsAt: string): string => {
+  const limitInfo = (utilization: number, resetsAt: string | null): string => {
     const value = preferRemaining ? 100 - utilization : utilization;
-    return `${value.toFixed(0)}%  ↻ ${formatTimeRemaining(resetsAt)}`;
+    return `${value.toFixed(0)}%  ↻ ${resetsAt ? formatTimeRemaining(resetsAt) : "N/A"}`;
   };
 
   const limitBar = (utilization: number): string =>
-    createProgressBar(preferRemaining ? 100 - utilization : utilization, 22);
+    createProgressBar(preferRemaining ? 100 - utilization : utilization, 22, progressBarStyle);
 
   const limitTitle = (label: string, utilization: number): string => `${label.padEnd(6)}  ${limitBar(utilization)}`;
 

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -1,36 +1,57 @@
-import { MenuBarExtra, Icon, Color, open, openExtensionPreferences } from "@raycast/api";
+import { MenuBarExtra, Icon, open, openCommandPreferences } from "@raycast/api";
+import { useState, useEffect, useRef } from "react";
 import { useDailyUsage } from "./hooks/useDailyUsage";
 import { useMonthlyUsage } from "./hooks/useMonthlyUsage";
 import { useTotalUsage } from "./hooks/useTotalUsage";
 import { useClaudeUsageLimits } from "./hooks/useClaudeUsageLimits";
-import { formatCost, formatTokensAsMTok } from "./utils/data-formatter";
-import { formatTimeRemaining } from "./utils/usage-limits-formatter";
+import { useWorkingTime } from "./hooks/useWorkingTime";
+import { formatCost, formatCostDelta, formatDuration, formatTokensAsMTok } from "./utils/data-formatter";
+import { formatTimeRemaining, createProgressBar } from "./utils/usage-limits-formatter";
+import { showRemainingUsage, getMenuBarTitle } from "./preferences";
 import { TotalUsageData } from "./types/usage-types";
 
+const MOCK_LIMITS_ENABLED = false;
+const MOCK_LIMITS_DATA = {
+  five_hour: { utilization: 28, resets_at: new Date(Date.now() + 23 * 60 * 1000).toISOString() },
+  seven_day: {
+    utilization: 61,
+    resets_at: new Date(Date.now() + 6 * 24 * 3600 * 1000 + 2 * 3600 * 1000).toISOString(),
+  },
+  seven_day_sonnet: { utilization: 45, resets_at: new Date(Date.now() + 6 * 24 * 3600 * 1000).toISOString() },
+  seven_day_opus: { utilization: 82, resets_at: new Date(Date.now() + 5 * 24 * 3600 * 1000).toISOString() },
+};
+
 export default function MenuBarccusage() {
-  const { data: todayUsage, isLoading: dailyLoading, error: dailyError } = useDailyUsage();
+  const [, forceRender] = useState(0);
+  const { data: todayUsage, previousDayData, isLoading: dailyLoading, error: dailyError } = useDailyUsage();
   const { data: monthlyUsage, isLoading: monthlyLoading, error: monthlyError } = useMonthlyUsage();
   const { data: totalUsage, isLoading: totalLoading, error: totalError } = useTotalUsage();
   const {
     data: limitsData,
     error: limitsError,
     isLoading: limitsLoading,
-    isStale,
+    isRateLimited: limitsRateLimited,
     isUsageLimitsAvailable,
+    rateLimitedUntil,
+    nextRefreshAt,
     revalidate,
   } = useClaudeUsageLimits();
+  const workingTime = useWorkingTime();
+  const tickRef = useRef(() => forceRender((n) => n + 1));
+  useEffect(() => {
+    if (!limitsRateLimited && nextRefreshAt === null) return;
+    const id = setInterval(tickRef.current, 1000);
+    return () => clearInterval(id);
+  }, [limitsRateLimited, nextRefreshAt]);
 
-  const hasError = dailyError || monthlyError || totalError;
+  const effectiveLimitsData = MOCK_LIMITS_ENABLED ? MOCK_LIMITS_DATA : limitsData;
+
+  const hasData = todayUsage || monthlyUsage || totalUsage;
+  const hasError = !hasData && (dailyError || monthlyError || totalError);
   const isLoading = dailyLoading || monthlyLoading || totalLoading;
 
   if (isLoading) {
-    return (
-      <MenuBarExtra
-        icon={{ source: Icon.Clock, tintColor: Color.SecondaryText }}
-        tooltip="Loading Claude usage..."
-        isLoading={true}
-      />
-    );
+    return <MenuBarExtra icon={{ source: Icon.Clock }} tooltip="Loading Claude usage..." isLoading={true} />;
   }
 
   const getTooltip = (): string => {
@@ -58,21 +79,70 @@ export default function MenuBarccusage() {
     return fallbackText;
   };
 
+  const preferRemaining = showRemainingUsage();
+
+  const rateLimitsSectionTitle = `Rate Limits · ${preferRemaining ? "Remaining" : "Consumed"}`;
+
+  const limitInfo = (utilization: number, resetsAt: string): string => {
+    const value = preferRemaining ? 100 - utilization : utilization;
+    return `${value.toFixed(0)}%  ↻ ${formatTimeRemaining(resetsAt)}`;
+  };
+
+  const limitBar = (utilization: number): string =>
+    createProgressBar(preferRemaining ? 100 - utilization : utilization, 22);
+
+  const limitTitle = (label: string, utilization: number): string => `${label.padEnd(6)}  ${limitBar(utilization)}`;
+
+  const menuBarTitlePref = getMenuBarTitle();
+  const highestUtilization = effectiveLimitsData
+    ? Math.max(
+        effectiveLimitsData.five_hour.utilization,
+        effectiveLimitsData.seven_day.utilization,
+        effectiveLimitsData.seven_day_sonnet?.utilization ?? 0,
+        effectiveLimitsData.seven_day_opus?.utilization ?? 0,
+      )
+    : null;
+  const menuBarTitle = (() => {
+    if (menuBarTitlePref === "none") return undefined;
+    if (menuBarTitlePref === "todayUsage")
+      return todayUsage
+        ? `${formatCost(todayUsage.totalCost)} · ${formatTokensAsMTok(todayUsage.totalTokens)}`
+        : undefined;
+    if (menuBarTitlePref === "todayCost") return todayUsage ? formatCost(todayUsage.totalCost) : undefined;
+    if (menuBarTitlePref === "monthlyCost") return monthlyUsage ? formatCost(monthlyUsage.totalCost) : undefined;
+    if (menuBarTitlePref === "todayTokens") return todayUsage ? formatTokensAsMTok(todayUsage.totalTokens) : undefined;
+    if (menuBarTitlePref === "fiveHour")
+      return effectiveLimitsData
+        ? `${(preferRemaining ? 100 - effectiveLimitsData.five_hour.utilization : effectiveLimitsData.five_hour.utilization).toFixed(0)}%`
+        : undefined;
+    if (menuBarTitlePref === "sevenDay")
+      return effectiveLimitsData
+        ? `${(preferRemaining ? 100 - effectiveLimitsData.seven_day.utilization : effectiveLimitsData.seven_day.utilization).toFixed(0)}%`
+        : undefined;
+    if (menuBarTitlePref === "utilization")
+      return highestUtilization !== null
+        ? `${(preferRemaining ? 100 - highestUtilization : highestUtilization).toFixed(0)}%`
+        : undefined;
+    return todayUsage
+      ? `${formatCost(todayUsage.totalCost)} · ${formatTokensAsMTok(todayUsage.totalTokens)}`
+      : undefined;
+  })();
+
   return (
-    <MenuBarExtra icon={{ source: "extension-icon.png" }} tooltip={getTooltip()}>
+    <MenuBarExtra icon={{ source: "extension-icon.png" }} title={menuBarTitle} tooltip={getTooltip()}>
       {hasError && (
         <MenuBarExtra.Section title="Error">
           <MenuBarExtra.Item
             title={typeof hasError === "string" ? hasError : hasError.message}
             subtitle="ccusage command failed"
             icon={Icon.ExclamationMark}
-            onAction={openExtensionPreferences}
+            onAction={openCommandPreferences}
           />
           <MenuBarExtra.Item
             title="Open Preferences"
             subtitle="Configure custom npx path"
             icon={Icon.Gear}
-            onAction={openExtensionPreferences}
+            onAction={openCommandPreferences}
           />
           <MenuBarExtra.Item
             title="Learn more about ccusage"
@@ -85,9 +155,91 @@ export default function MenuBarccusage() {
 
       {!hasError && (
         <>
+          {isUsageLimitsAvailable && (
+            <MenuBarExtra.Section title={rateLimitsSectionTitle}>
+              {limitsRateLimited && !limitsData && (
+                <MenuBarExtra.Item
+                  title={`Rate limited — retry in ${rateLimitedUntil ? formatDuration(Math.max(0, rateLimitedUntil - Date.now())) : "…"}`}
+                  icon={Icon.Clock}
+                  onAction={revalidate}
+                />
+              )}
+              {limitsError && !limitsData && !limitsRateLimited && (
+                <MenuBarExtra.Item
+                  title="Unable to fetch limits"
+                  subtitle="Check Claude Code authentication"
+                  icon={Icon.ExclamationMark}
+                  onAction={() => open("raycast://extensions/nyatinte/ccusage/ccusage")}
+                />
+              )}
+              {effectiveLimitsData && (
+                <>
+                  <MenuBarExtra.Item
+                    title={limitTitle("5-Hour", effectiveLimitsData.five_hour.utilization)}
+                    subtitle={limitInfo(
+                      effectiveLimitsData.five_hour.utilization,
+                      effectiveLimitsData.five_hour.resets_at,
+                    )}
+                    icon={Icon.Gauge}
+                    onAction={revalidate}
+                  />
+                  <MenuBarExtra.Item
+                    title={limitTitle("7-Day", effectiveLimitsData.seven_day.utilization)}
+                    subtitle={limitInfo(
+                      effectiveLimitsData.seven_day.utilization,
+                      effectiveLimitsData.seven_day.resets_at,
+                    )}
+                    icon={Icon.Gauge}
+                    onAction={revalidate}
+                  />
+                  {effectiveLimitsData.seven_day_sonnet && (
+                    <MenuBarExtra.Item
+                      title={limitTitle("Sonnet", effectiveLimitsData.seven_day_sonnet.utilization)}
+                      subtitle={limitInfo(
+                        effectiveLimitsData.seven_day_sonnet.utilization,
+                        effectiveLimitsData.seven_day_sonnet.resets_at,
+                      )}
+                      icon={Icon.Gauge}
+                      onAction={revalidate}
+                    />
+                  )}
+                  {effectiveLimitsData.seven_day_opus && (
+                    <MenuBarExtra.Item
+                      title={limitTitle("Opus", effectiveLimitsData.seven_day_opus.utilization)}
+                      subtitle={limitInfo(
+                        effectiveLimitsData.seven_day_opus.utilization,
+                        effectiveLimitsData.seven_day_opus.resets_at,
+                      )}
+                      icon={Icon.Gauge}
+                      onAction={revalidate}
+                    />
+                  )}
+                  {!limitsRateLimited && (
+                    <MenuBarExtra.Item
+                      title="Refresh"
+                      subtitle={
+                        nextRefreshAt ? `next in ${formatDuration(Math.max(0, nextRefreshAt - Date.now()))}` : undefined
+                      }
+                      icon={Icon.ArrowClockwise}
+                      onAction={revalidate}
+                    />
+                  )}
+                </>
+              )}
+              {!limitsData && !limitsError && limitsLoading && (
+                <MenuBarExtra.Item title="Loading limits..." icon={Icon.Clock} />
+              )}
+            </MenuBarExtra.Section>
+          )}
+
           <MenuBarExtra.Section title="Today's Usage">
             <MenuBarExtra.Item
               title={formatUsageTitle(dailyLoading, todayUsage, "No usage data available")}
+              subtitle={
+                todayUsage && previousDayData
+                  ? `vs yesterday: ${formatCostDelta(todayUsage.totalCost, previousDayData.totalCost)}`
+                  : undefined
+              }
               icon={Icon.Calendar}
               onAction={() => open("raycast://extensions/nyatinte/ccusage/ccusage")}
             />
@@ -109,45 +261,26 @@ export default function MenuBarccusage() {
             />
           </MenuBarExtra.Section>
 
-          {isUsageLimitsAvailable && (
-            <MenuBarExtra.Section title="Usage Limits">
-              {limitsError && !limitsData && (
-                <MenuBarExtra.Item
-                  title="Unable to fetch limits"
-                  subtitle="Check Claude Code authentication"
-                  icon={Icon.ExclamationMark}
-                  onAction={() => open("raycast://extensions/nyatinte/ccusage/ccusage")}
-                />
-              )}
-              {limitsData && (
-                <>
-                  <MenuBarExtra.Item
-                    title={`5-Hour: ${limitsData.five_hour.utilization.toFixed(0)}%`}
-                    subtitle={`Resets in ${formatTimeRemaining(limitsData.five_hour.resets_at ?? "N/A")}${isStale ? " ⚠️ " : ""}`}
-                    icon={Icon.Gauge}
-                    onAction={revalidate}
-                  />
-                  <MenuBarExtra.Item
-                    title={`7-Day: ${limitsData.seven_day.utilization.toFixed(0)}%`}
-                    subtitle={`Resets in ${formatTimeRemaining(limitsData.seven_day.resets_at ?? "N/A")}${isStale ? " ⚠️" : ""}`}
-                    icon={Icon.Gauge}
-                    onAction={revalidate}
-                  />
-                  {isStale && (
-                    <MenuBarExtra.Item
-                      title="Refresh Limits"
-                      subtitle="Data may be stale"
-                      icon={Icon.ArrowClockwise}
-                      onAction={revalidate}
-                    />
-                  )}
-                </>
-              )}
-              {!limitsData && !limitsError && limitsLoading && (
-                <MenuBarExtra.Item title="Loading limits..." icon={Icon.Clock} />
-              )}
-            </MenuBarExtra.Section>
-          )}
+          <MenuBarExtra.Section title="Working Time">
+            <MenuBarExtra.Item
+              title={
+                workingTime.isLoading
+                  ? "Loading..."
+                  : workingTime.todayMs > 0
+                    ? formatDuration(workingTime.todayMs)
+                    : "No activity today"
+              }
+              subtitle={
+                workingTime.yesterdayMs > 0 ? `vs yesterday: ${formatDuration(workingTime.yesterdayMs)}` : undefined
+              }
+              icon={Icon.Clock}
+              onAction={() => open("raycast://extensions/nyatinte/ccusage/ccusage")}
+            />
+          </MenuBarExtra.Section>
+
+          <MenuBarExtra.Section>
+            <MenuBarExtra.Item title="Configure Command" icon={Icon.Gear} onAction={openCommandPreferences} />
+          </MenuBarExtra.Section>
         </>
       )}
     </MenuBarExtra>

--- a/extensions/ccusage/src/preferences.ts
+++ b/extensions/ccusage/src/preferences.ts
@@ -1,6 +1,7 @@
 import { getPreferenceValues } from "@raycast/api";
 import { homedir } from "os";
 import { sep } from "path";
+import type { ProgressBarStyle } from "./utils/usage-limits-formatter";
 
 export const preferences = getPreferenceValues<Preferences>();
 const menuBarPreferences = getPreferenceValues<Preferences.MenubarCcusage>();
@@ -25,6 +26,9 @@ export const getMenuBarTitle = ():
     | "sevenDay"
     | "utilization"
     | "none") ?? "todayUsage";
+
+export const getProgressBarStyle = (): ProgressBarStyle =>
+  (menuBarPreferences.progressBarStyle as ProgressBarStyle) ?? "solid";
 
 export const getCustomNpxPath = (): string | undefined => {
   const customPath = preferences.customNpxPath?.trim();

--- a/extensions/ccusage/src/preferences.ts
+++ b/extensions/ccusage/src/preferences.ts
@@ -3,6 +3,28 @@ import { homedir } from "os";
 import { sep } from "path";
 
 export const preferences = getPreferenceValues<Preferences>();
+const menuBarPreferences = getPreferenceValues<Preferences.MenubarCcusage>();
+
+export const showRemainingUsage = (): boolean => (menuBarPreferences.showRemainingUsage as string) !== "consumed";
+
+export const getMenuBarTitle = ():
+  | "todayUsage"
+  | "todayCost"
+  | "monthlyCost"
+  | "todayTokens"
+  | "fiveHour"
+  | "sevenDay"
+  | "utilization"
+  | "none" =>
+  (menuBarPreferences.menuBarTitle as
+    | "todayUsage"
+    | "todayCost"
+    | "monthlyCost"
+    | "todayTokens"
+    | "fiveHour"
+    | "sevenDay"
+    | "utilization"
+    | "none") ?? "todayUsage";
 
 export const getCustomNpxPath = (): string | undefined => {
   const customPath = preferences.customNpxPath?.trim();

--- a/extensions/ccusage/src/tools/get-usage-limits.ts
+++ b/extensions/ccusage/src/tools/get-usage-limits.ts
@@ -31,7 +31,16 @@ export default async function getUsageLimits(input?: Input): Promise<{
     throw new Error("Usage limits require Claude OAuth authentication in Claude Code.");
   }
 
-  const usageLimitsData = await fetchClaudeUsageLimits(token);
+  const result = await fetchClaudeUsageLimits(token);
+
+  if (result.status === "rate_limited") {
+    throw new Error("Rate limited by Anthropic API. Please try again later.");
+  }
+  if (result.status === "error") {
+    throw new Error(result.message);
+  }
+
+  const usageLimitsData = result.data;
 
   const formatResetTime = (isoString: string | null): string => {
     if (!isoString) {

--- a/extensions/ccusage/src/types/usage-types.ts
+++ b/extensions/ccusage/src/types/usage-types.ts
@@ -126,7 +126,35 @@ export const LimitWindowSchema = z.object({
 export const UsageLimitDataSchema = z.object({
   five_hour: LimitWindowSchema,
   seven_day: LimitWindowSchema,
+  seven_day_sonnet: LimitWindowSchema.nullish(),
+  seven_day_opus: LimitWindowSchema.nullish(),
+  extra_usage: z
+    .object({
+      is_enabled: z.boolean(),
+      used_credits: z.number().nullable(),
+      monthly_limit: z.number().nullable(),
+    })
+    .nullish(),
 });
+
+export const BlockSchema = z.object({
+  id: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  actualEndTime: z.string().nullable(),
+  isActive: z.boolean(),
+  isGap: z.boolean(),
+  totalTokens: z.number(),
+  costUSD: z.number(),
+  models: z.array(z.string()),
+});
+
+export const BlocksCommandResponseSchema = z.object({
+  blocks: z.array(BlockSchema),
+});
+
+export type Block = z.infer<typeof BlockSchema>;
+export type BlocksCommandResponse = z.infer<typeof BlocksCommandResponseSchema>;
 
 export type DailyUsageData = z.infer<typeof DailyUsageDataSchema>;
 export type MonthlyUsageData = z.infer<typeof MonthlyUsageDataSchema>;

--- a/extensions/ccusage/src/utils/claude-api-client.ts
+++ b/extensions/ccusage/src/utils/claude-api-client.ts
@@ -1,8 +1,11 @@
-import { STATUS_CODES } from "node:http";
 import { UsageLimitData, UsageLimitDataSchema } from "../types/usage-types";
-import { UsageLimitsError } from "./usage-limits-error";
 
-const fetchUsageLimitsResponse = async (accessToken: string): Promise<string> => {
+export type UsageLimitsResult =
+  | { status: "ok"; data: UsageLimitData }
+  | { status: "rate_limited" }
+  | { status: "error"; message: string };
+
+export const fetchClaudeUsageLimits = async (accessToken: string): Promise<UsageLimitsResult> => {
   try {
     const response = await fetch("https://api.anthropic.com/api/oauth/usage", {
       headers: {
@@ -13,44 +16,21 @@ const fetchUsageLimitsResponse = async (accessToken: string): Promise<string> =>
       },
     });
 
-    const responseText = await response.text();
+    if (response.status === 429) {
+      return { status: "rate_limited" };
+    }
 
     if (!response.ok) {
-      const status = response.status;
-      const statusText = response.statusText || STATUS_CODES[status] || "Request Failed";
-
-      throw new UsageLimitsError({
-        kind: "fetch",
-        error: new Error(`Claude API returned ${status} ${statusText} while fetching usage limits.`),
-        status,
-        statusText,
-        responseText,
-      });
+      return { status: "error", message: `API returned ${response.status}` };
     }
 
-    return responseText;
-  } catch (error) {
-    if (error instanceof UsageLimitsError) {
-      throw error;
-    }
+    const data = await response.json();
+    const result = UsageLimitDataSchema.safeParse(data);
 
-    throw new UsageLimitsError({
-      kind: "fetch",
-      error,
-    });
+    return result.success
+      ? { status: "ok", data: result.data }
+      : { status: "error", message: "Unexpected API response format" };
+  } catch (err) {
+    return { status: "error", message: err instanceof Error ? err.message : "Network error" };
   }
-};
-
-const parseUsageLimitsResponse = (responseText: string): UsageLimitData => {
-  try {
-    const data = JSON.parse(responseText);
-    return UsageLimitDataSchema.parse(data);
-  } catch (error) {
-    throw new UsageLimitsError({ kind: "parse", error, responseText });
-  }
-};
-
-export const fetchClaudeUsageLimits = async (accessToken: string): Promise<UsageLimitData> => {
-  const responseText = await fetchUsageLimitsResponse(accessToken);
-  return parseUsageLimitsResponse(responseText);
 };

--- a/extensions/ccusage/src/utils/data-formatter.ts
+++ b/extensions/ccusage/src/utils/data-formatter.ts
@@ -64,3 +64,31 @@ export const copyToClipboard = async (text: string, message: string): Promise<vo
 export const getCCUsageCommand = (): string => {
   return "npx ccusage@latest";
 };
+
+export const formatDuration = (ms: number): string => {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m`;
+  return `${seconds}s`;
+};
+
+export const formatCostDelta = (todayCost: number, yesterdayCost: number): string => {
+  const delta = todayCost - yesterdayCost;
+  const sign = delta >= 0 ? "+" : "-";
+  const formatted = formatCost(Math.abs(delta));
+  if (yesterdayCost === 0) return `${sign}${formatted}`;
+  const pct = (Math.abs(delta) / yesterdayCost) * 100;
+  return `${sign}${formatted} (${pct.toFixed(1)}%)`;
+};
+
+export const formatTokenDelta = (todayTokens: number, yesterdayTokens: number): string => {
+  const delta = todayTokens - yesterdayTokens;
+  const sign = delta >= 0 ? "+" : "-";
+  const formatted = formatTokens(Math.abs(delta));
+  if (yesterdayTokens === 0) return `${sign}${formatted}`;
+  const pct = (Math.abs(delta) / yesterdayTokens) * 100;
+  return `${sign}${formatted} (${pct.toFixed(1)}%)`;
+};

--- a/extensions/ccusage/src/utils/keychain-access.ts
+++ b/extensions/ccusage/src/utils/keychain-access.ts
@@ -1,5 +1,8 @@
 import { exec } from "child_process";
 import { promisify } from "util";
+import { readFile } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
 
 const execAsync = promisify(exec);
 
@@ -9,13 +12,29 @@ type ClaudeCredentials = {
   };
 };
 
-export const getClaudeCredentials = async (): Promise<ClaudeCredentials | null> => {
+const readCredentialsFile = async (): Promise<ClaudeCredentials | null> => {
+  try {
+    const filePath = join(homedir(), ".claude", ".credentials.json");
+    const content = await readFile(filePath, "utf-8");
+    return JSON.parse(content) as ClaudeCredentials;
+  } catch {
+    return null;
+  }
+};
+
+const readCredentialsKeychain = async (): Promise<ClaudeCredentials | null> => {
   try {
     const { stdout } = await execAsync('security find-generic-password -s "Claude Code-credentials" -w');
     return JSON.parse(stdout.trim()) as ClaudeCredentials;
   } catch {
     return null;
   }
+};
+
+export const getClaudeCredentials = async (): Promise<ClaudeCredentials | null> => {
+  const fromFile = await readCredentialsFile();
+  if (fromFile?.claudeAiOauth?.accessToken) return fromFile;
+  return readCredentialsKeychain();
 };
 
 export const getClaudeAccessToken = async (): Promise<string | null> => {

--- a/extensions/ccusage/src/utils/usage-limits-cache.ts
+++ b/extensions/ccusage/src/utils/usage-limits-cache.ts
@@ -1,112 +1,55 @@
-import { Cache, Clipboard, Toast, getPreferenceValues, showToast } from "@raycast/api";
+import { Cache, getPreferenceValues } from "@raycast/api";
 import { UsageLimitData } from "../types/usage-types";
 import { getClaudeAccessToken } from "./keychain-access";
 import { fetchClaudeUsageLimits } from "./claude-api-client";
-import { UsageLimitsError } from "./usage-limits-error";
+import type { UsageLimitsResult } from "./claude-api-client";
 
 interface CacheState {
   data: UsageLimitData | null;
-  error: UsageLimitsError | null;
+  error: Error | null;
   isLoading: boolean;
   isStale: boolean;
+  isRateLimited: boolean;
   isUsageLimitsAvailable: boolean;
   lastFetched: Date | null;
+  rateLimitedUntil: number | null;
+  nextRefreshAt: number | null;
 }
 
 type Listener = (state: CacheState) => void;
 
-interface PersistedUsageLimitsAvailability {
-  isAvailable: boolean;
-  lastCheckedAt: string;
-}
+const raycastCache = new Cache();
+const LIMITS_CACHE_KEY = "usage-limits-data";
 
-const availabilityCache = new Cache();
-const USAGE_LIMITS_AVAILABILITY_CACHE_KEY = "usage-limits-availability";
-
-const readPersistedAvailability = (): PersistedUsageLimitsAvailability | null => {
-  const cachedValue = availabilityCache.get(USAGE_LIMITS_AVAILABILITY_CACHE_KEY);
-
-  if (!cachedValue) {
-    return null;
-  }
-
+const restoredData = ((): UsageLimitData | null => {
+  const cached = raycastCache.get(LIMITS_CACHE_KEY);
+  if (!cached) return null;
   try {
-    const parsedValue = JSON.parse(cachedValue) as Partial<PersistedUsageLimitsAvailability>;
-
-    if (typeof parsedValue.isAvailable !== "boolean" || typeof parsedValue.lastCheckedAt !== "string") {
-      availabilityCache.remove(USAGE_LIMITS_AVAILABILITY_CACHE_KEY);
-      return null;
-    }
-
-    return {
-      isAvailable: parsedValue.isAvailable,
-      lastCheckedAt: parsedValue.lastCheckedAt,
-    };
+    return JSON.parse(cached) as UsageLimitData;
   } catch {
-    availabilityCache.remove(USAGE_LIMITS_AVAILABILITY_CACHE_KEY);
     return null;
   }
+})();
+
+let cacheState: CacheState = {
+  data: restoredData,
+  error: null,
+  isLoading: true,
+  isStale: restoredData !== null,
+  isRateLimited: false,
+  isUsageLimitsAvailable: false,
+  lastFetched: null,
+  rateLimitedUntil: null,
+  nextRefreshAt: null,
 };
 
-const persistAvailability = (isAvailable: boolean): void => {
-  const persistedValue: PersistedUsageLimitsAvailability = {
-    isAvailable,
-    lastCheckedAt: new Date().toISOString(),
-  };
-
-  availabilityCache.set(USAGE_LIMITS_AVAILABILITY_CACHE_KEY, JSON.stringify(persistedValue));
-};
-
-const createInitialCacheState = (): CacheState => {
-  const persistedAvailability = readPersistedAvailability();
-
-  if (!persistedAvailability) {
-    return {
-      data: null,
-      error: null,
-      isLoading: true,
-      isStale: false,
-      isUsageLimitsAvailable: false,
-      lastFetched: null,
-    };
-  }
-
-  return {
-    data: null,
-    error: null,
-    isLoading: persistedAvailability.isAvailable,
-    isStale: false,
-    isUsageLimitsAvailable: persistedAvailability.isAvailable,
-    lastFetched: null,
-  };
-};
-
-let cacheState: CacheState = createInitialCacheState();
+const RATE_LIMIT_BACKOFF_MS = 5 * 60 * 1000;
 
 const listeners = new Set<Listener>();
 let fetchInterval: NodeJS.Timeout | null = null;
 let isFetching = false;
-
-const showUsageLimitsErrorToast = async (error: UsageLimitsError): Promise<void> => {
-  await showToast({
-    style: Toast.Style.Failure,
-    title: error.title,
-    message: error.message,
-    primaryAction: {
-      title: "Retry",
-      onAction: async (toast) => {
-        toast.hide();
-        await revalidateUsageLimits();
-      },
-    },
-    secondaryAction: {
-      title: "Copy Error Log",
-      onAction: async () => {
-        await Clipboard.copy(error.log);
-      },
-    },
-  });
-};
+let rateLimitedUntil: number | null = null;
+let fetchIntervalMs = 60 * 1000;
 
 const notifyListeners = (): void => {
   listeners.forEach((listener) => listener(cacheState));
@@ -114,15 +57,14 @@ const notifyListeners = (): void => {
 
 const fetchUsageLimits = async (): Promise<void> => {
   if (isFetching) return;
+  if (rateLimitedUntil !== null && Date.now() < rateLimitedUntil) return;
 
   isFetching = true;
   const previousData = cacheState.data;
 
   try {
     const token = await getClaudeAccessToken();
-
     const isUsageLimitsAvailable = typeof token === "string" && token.trim().length > 0;
-    persistAvailability(isUsageLimitsAvailable);
 
     if (!isUsageLimitsAvailable) {
       cacheState = {
@@ -130,46 +72,65 @@ const fetchUsageLimits = async (): Promise<void> => {
         error: null,
         isLoading: false,
         isStale: false,
+        isRateLimited: false,
         isUsageLimitsAvailable: false,
         lastFetched: null,
+        rateLimitedUntil: null,
+        nextRefreshAt: null,
       };
       notifyListeners();
       return;
     }
 
-    cacheState = {
-      ...cacheState,
-      error: null,
-      isLoading: previousData === null,
-      isUsageLimitsAvailable: true,
-    };
-    notifyListeners();
+    const result: UsageLimitsResult = await fetchClaudeUsageLimits(token);
 
-    const limitData = await fetchClaudeUsageLimits(token);
-
-    cacheState = {
-      data: limitData,
-      error: null,
-      isLoading: false,
-      isUsageLimitsAvailable: true,
-      isStale: false,
-      lastFetched: new Date(),
-    };
-  } catch (error) {
-    if (!(error instanceof UsageLimitsError)) {
-      throw error;
+    if (result.status === "ok") {
+      rateLimitedUntil = null;
+      raycastCache.set(LIMITS_CACHE_KEY, JSON.stringify(result.data));
+      cacheState = {
+        data: result.data,
+        error: null,
+        isLoading: false,
+        isRateLimited: false,
+        isUsageLimitsAvailable: true,
+        isStale: false,
+        lastFetched: new Date(),
+        rateLimitedUntil: null,
+        nextRefreshAt: Date.now() + fetchIntervalMs,
+      };
+    } else if (result.status === "rate_limited") {
+      rateLimitedUntil = Date.now() + RATE_LIMIT_BACKOFF_MS;
+      cacheState = {
+        ...cacheState,
+        data: previousData,
+        error: null,
+        isLoading: false,
+        isRateLimited: true,
+        isUsageLimitsAvailable: true,
+        isStale: previousData !== null,
+        rateLimitedUntil,
+      };
+    } else {
+      cacheState = {
+        ...cacheState,
+        data: previousData,
+        error: new Error(result.message),
+        isLoading: false,
+        isRateLimited: false,
+        isUsageLimitsAvailable: true,
+        isStale: previousData !== null,
+      };
     }
-
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error("Unknown error occurred");
     cacheState = {
       ...cacheState,
       data: previousData,
       error,
       isLoading: false,
-      isUsageLimitsAvailable: true,
+      isUsageLimitsAvailable: cacheState.isUsageLimitsAvailable,
       isStale: previousData !== null,
     };
-
-    await showUsageLimitsErrorToast(error);
   } finally {
     isFetching = false;
     notifyListeners();
@@ -182,6 +143,7 @@ const startFetching = (): void => {
   const preferences = getPreferenceValues<Preferences>();
   const intervalSeconds = parseInt(preferences.usageLimitsRefreshInterval || "60", 10);
   const intervalMs = intervalSeconds * 1000;
+  fetchIntervalMs = intervalMs;
 
   const shouldFetchImmediately = (): boolean => {
     if (!cacheState.data || !cacheState.lastFetched) {
@@ -226,5 +188,6 @@ export const subscribeToUsageLimits = (listener: Listener): (() => void) => {
 export const getUsageLimitsState = (): CacheState => cacheState;
 
 export const revalidateUsageLimits = async (): Promise<void> => {
+  rateLimitedUntil = null;
   await fetchUsageLimits();
 };

--- a/extensions/ccusage/src/utils/usage-limits-formatter.ts
+++ b/extensions/ccusage/src/utils/usage-limits-formatter.ts
@@ -62,7 +62,7 @@ export const getUtilizationIcon = (utilization: number): string => {
 export const createProgressBar = (percentage: number, width: number = 20): string => {
   const filled = Math.round((percentage / 100) * width);
   const empty = width - filled;
-  return "█".repeat(Math.max(0, filled)) + "░".repeat(Math.max(0, empty));
+  return "▰".repeat(Math.max(0, filled)) + "▱".repeat(Math.max(0, empty));
 };
 
 export const calculateEstimatedUsage = (

--- a/extensions/ccusage/src/utils/usage-limits-formatter.ts
+++ b/extensions/ccusage/src/utils/usage-limits-formatter.ts
@@ -59,10 +59,23 @@ export const getUtilizationIcon = (utilization: number): string => {
   return "✅";
 };
 
-export const createProgressBar = (percentage: number, width: number = 20): string => {
+export type ProgressBarStyle = "blocks" | "solid" | "ascii";
+
+const PROGRESS_BAR_CHARS: Record<ProgressBarStyle, [string, string]> = {
+  blocks: ["▰", "▱"],
+  solid: ["█", "░"],
+  ascii: ["#", "-"],
+};
+
+export const createProgressBar = (
+  percentage: number,
+  width: number = 20,
+  style: ProgressBarStyle = "blocks",
+): string => {
+  const [filledChar, emptyChar] = PROGRESS_BAR_CHARS[style];
   const filled = Math.round((percentage / 100) * width);
   const empty = width - filled;
-  return "▰".repeat(Math.max(0, filled)) + "▱".repeat(Math.max(0, empty));
+  return filledChar.repeat(Math.max(0, filled)) + emptyChar.repeat(Math.max(0, empty));
 };
 
 export const calculateEstimatedUsage = (


### PR DESCRIPTION
## Description

Overhaul of the `ccusage` menu bar extension with a redesigned rate limits display, working time tracking, persistent caching, configurable progress bars, and day-over-day comparisons.

### Rate Limits redesign

- Each limit row shows an inline progress bar in the title and `%  ↻ reset time` in the subtitle
- Section header reflects the current mode: `Rate Limits · Remaining` or `Rate Limits · Consumed`
- Per-model limits for Sonnet and Opus shown when available from the API
- Section is hidden entirely when authenticated via API key — only meaningful for OAuth (Claude Max plan) users

### Menu bar preferences

All preferences are now command-specific (accessible via "Configure Command" at the bottom of the dropdown):

- **Menu Bar Status** — what appears next to the icon: Today's Usage, Today's Cost, Monthly Cost, Today's Tokens, 5-Hour %, 7-Day %, Highest Utilization, or None
- **Progress Bar Mode** — Remaining or Consumed
- **Progress Bar Style** — Solid (`█░`), Blocks (`▰▱`), or ASCII (`#-`)

### Working time tracking

- New `useWorkingTime` hook derives today's and yesterday's active coding duration from billing blocks
- Menu bar shows a Working Time section with vs-yesterday comparison

### Caching & reliability

- `fetchClaudeUsageLimits` now returns a discriminated union (`ok` / `rate_limited` / `error`) — no thrown errors
- 5-minute backoff after a 429; manual Refresh bypasses it immediately
- All CLI hooks persist the last successful response via Raycast `Cache` — data visible instantly on restart
- Credentials read from `~/.claude/.credentials.json` first, then macOS keychain fallback
- Stale warning only shown after a fetch completes with genuinely old data

### Day-over-day comparison

- Today's Usage section shows cost delta vs yesterday
- `formatDuration` drops seconds when over a minute (`4m` not `4m 43s`)

### Bug fixes

- Fixed `seven_day_opus` / `seven_day_sonnet` Zod validation: API returns explicit `null` for absent windows — changed `.optional()` → `.nullish()`
- Fixed `extra_usage.used_credits` / `monthly_limit` nullable validation (was causing "Unable to fetch usage limits" for all users)
- Menu bar no longer hides all data on a transient refresh error

<img width="1054" height="1114" alt="image" src="https://github.com/user-attachments/assets/afe9b604-4984-4fb0-9f81-0a0d2b9e20bc" />
<img width="1028" height="858" alt="image" src="https://github.com/user-attachments/assets/116a5482-1d45-4ad3-895e-3be861df5387" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
