### PR TITLE
[ccusage] fix Usage Limits parsing error for `resets_at` field and improve error details view

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [v2.2.4] - {PR_MERGE_DATE}
+
+### Changed
+
+- Usage Limits errors now open a dedicated detail view with clearer fetch/parse diagnostics and a quick action to copy the error log
+- Usage limit refresh failures now show actionable toasts with retry and copy-log actions while keeping previously fetched data available when possible
+
+### Fixed
+
+- Prevent runtime errors when the Claude usage limits API returns a `null` `resets_at` value
+- Improved consistency of usage limit error handling across the UI and the `get-usage-limits` too
+
 ## [v2.2.3] - 2026-03-16
 
 ### Fixed

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [v2.2.4] - {PR_MERGE_DATE}
+## [v2.2.4] - 2026-03-16
 
 ### Changed
 

--- a/extensions/ccusage/src/components/DailyUsage.tsx
+++ b/extensions/ccusage/src/components/DailyUsage.tsx
@@ -1,4 +1,4 @@
-import { List, Icon, Color } from "@raycast/api";
+import { List, Icon } from "@raycast/api";
 import { formatTokens, formatCost, getTokenEfficiency, getCostPerMTok } from "../utils/data-formatter";
 import { getCurrentLocalDate } from "../utils/date-formatter";
 import { useDailyUsage } from "../hooks/useDailyUsage";
@@ -70,7 +70,7 @@ export function DailyUsage() {
     <List.Item
       id="today"
       title="Today"
-      icon={{ source: Icon.Calendar, tintColor: Color.SecondaryText }}
+      icon={Icon.Calendar}
       accessories={accessories}
       detail={<List.Item.Detail isLoading={isLoading} metadata={renderDetailMetadata()} />}
       actions={<StandardActions externalLinks={externalLinks} />}

--- a/extensions/ccusage/src/components/UsageLimits.tsx
+++ b/extensions/ccusage/src/components/UsageLimits.tsx
@@ -149,7 +149,11 @@ export function UsageLimits() {
         )}
         <List.Item.Detail.Metadata.Label
           title="Resets in"
-          text={`${formatTimeRemaining(data.five_hour.resets_at ?? "N/A")} || ${new Date(data.five_hour.resets_at ?? "N/A").toLocaleString()}`}
+          text={
+            data.five_hour.resets_at
+              ? `${formatTimeRemaining(data.five_hour.resets_at)} || ${new Date(data.five_hour.resets_at).toLocaleString()}`
+              : "N/A"
+          }
           icon={Icon.ArrowClockwise}
         />
         <List.Item.Detail.Metadata.Separator />
@@ -176,7 +180,11 @@ export function UsageLimits() {
         )}
         <List.Item.Detail.Metadata.Label
           title="Resets in"
-          text={`${formatTimeRemaining(data.seven_day.resets_at ?? "N/A")} || ${new Date(data.seven_day.resets_at ?? "N/A").toLocaleString()}`}
+          text={
+            data.seven_day.resets_at
+              ? `${formatTimeRemaining(data.seven_day.resets_at)} || ${new Date(data.seven_day.resets_at).toLocaleString()}`
+              : "N/A"
+          }
           icon={Icon.ArrowClockwise}
         />
 

--- a/extensions/ccusage/src/components/UsageLimits.tsx
+++ b/extensions/ccusage/src/components/UsageLimits.tsx
@@ -7,9 +7,65 @@ import {
   calculateEstimatedUsage,
   calculateAverageUsage,
 } from "../utils/usage-limits-formatter";
+import { UsageLimitsError, sanitizeCodeBlock } from "../utils/usage-limits-error";
 import { ErrorMetadata } from "./ErrorMetadata";
-import { STANDARD_ACCESSORIES } from "./common/accessories";
 import { ReactNode } from "react";
+import { STANDARD_ACCESSORIES } from "./common/accessories";
+
+type UsageLimitsAccessoriesInput = {
+  hasData: boolean;
+  error: UsageLimitsError | null;
+  isStale: boolean;
+  lastFetched: Date | null;
+  fiveHourUtilization: number;
+};
+
+const getUsageLimitsErrorIcon = () => ({
+  source: Icon.ExclamationMark,
+  tintColor: Color.Red,
+});
+
+const getUsageLimitsAccessories = ({
+  hasData,
+  error,
+  isStale,
+  lastFetched,
+  fiveHourUtilization,
+}: UsageLimitsAccessoriesInput): List.Item.Accessory[] => {
+  if (error) {
+    return [{ text: "Error", icon: getUsageLimitsErrorIcon() }];
+  }
+
+  if (!hasData) {
+    return STANDARD_ACCESSORIES.LOADING;
+  }
+
+  if (isStale) {
+    return [{ icon: Icon.Warning, tooltip: `Stale data (last updated ${formatRelativeTime(lastFetched)})` }];
+  }
+
+  return [
+    {
+      icon: Icon.Gauge,
+      text: `${fiveHourUtilization.toFixed(0)}%`,
+      tooltip: "5-Hour Limit (higher priority)",
+    },
+  ];
+};
+
+const getUsageLimitsErrorMarkdown = (error: UsageLimitsError): string => {
+  return [
+    `# ${error.title}`,
+    "",
+    error.message,
+    "",
+    "## Error Log",
+    "",
+    "```text",
+    sanitizeCodeBlock(error.log),
+    "```",
+  ].join("\n");
+};
 
 export function UsageLimits() {
   const { data, isLoading, error, isStale, lastFetched, revalidate, isUsageLimitsAvailable } = useClaudeUsageLimits();
@@ -21,30 +77,17 @@ export function UsageLimits() {
   const fiveHourUtil = data?.five_hour?.utilization ?? 0;
   const sevenDayUtil = data?.seven_day?.utilization ?? 0;
 
-  const accessories: List.Item.Accessory[] =
-    error && !data
-      ? STANDARD_ACCESSORIES.ERROR
-      : !data
-        ? STANDARD_ACCESSORIES.LOADING
-        : isStale
-          ? [{ icon: Icon.Warning, tooltip: `Stale data (last updated ${formatRelativeTime(lastFetched)})` }]
-          : [
-              {
-                icon: Icon.Gauge,
-                text: `${fiveHourUtil.toFixed(0)}%`,
-                tooltip: "5-Hour Limit (higher priority)",
-              },
-            ];
+  const accessories = getUsageLimitsAccessories({
+    hasData: Boolean(data),
+    error,
+    isStale,
+    lastFetched,
+    fiveHourUtilization: fiveHourUtil,
+  });
 
   const renderDetailMetadata = (): ReactNode => {
-    if (error && !data) {
-      return (
-        <ErrorMetadata
-          error={error}
-          noDataMessage="Unable to fetch usage limits"
-          noDataSubMessage="Please ensure Claude Code is authenticated and keychain access is granted"
-        />
-      );
+    if (error) {
+      return null;
     }
 
     if (!data) {
@@ -156,12 +199,19 @@ export function UsageLimits() {
     <List.Item
       id="usage-limits"
       title="Usage Limits"
-      icon={{ source: Icon.Gauge, tintColor: Color.SecondaryText }}
+      icon={Icon.Gauge}
       accessories={accessories}
-      detail={<List.Item.Detail isLoading={isLoading} metadata={renderDetailMetadata()} />}
+      detail={
+        error ? (
+          <List.Item.Detail markdown={getUsageLimitsErrorMarkdown(error)} />
+        ) : (
+          <List.Item.Detail isLoading={isLoading} metadata={renderDetailMetadata()} />
+        )
+      }
       actions={
         <ActionPanel>
           <Action title="Refresh Usage Limit" icon={Icon.ArrowClockwise} onAction={revalidate} />
+          {error && <Action.CopyToClipboard title="Copy Error Log" content={error.log} icon={Icon.Clipboard} />}
         </ActionPanel>
       }
     />

--- a/extensions/ccusage/src/components/UsageLimits.tsx
+++ b/extensions/ccusage/src/components/UsageLimits.tsx
@@ -106,7 +106,7 @@ export function UsageLimits() {
         )}
         <List.Item.Detail.Metadata.Label
           title="Resets in"
-          text={`${formatTimeRemaining(data.five_hour.resets_at)} || ${new Date(data.five_hour.resets_at).toLocaleString("en-US", { hour12: false })}`}
+          text={`${formatTimeRemaining(data.five_hour.resets_at ?? "N/A")} || ${new Date(data.five_hour.resets_at ?? "N/A").toLocaleString()}`}
           icon={Icon.ArrowClockwise}
         />
         <List.Item.Detail.Metadata.Separator />
@@ -133,7 +133,7 @@ export function UsageLimits() {
         )}
         <List.Item.Detail.Metadata.Label
           title="Resets in"
-          text={`${formatTimeRemaining(data.seven_day.resets_at)} || ${new Date(data.seven_day.resets_at).toLocaleString("en-US", { hour12: false })}`}
+          text={`${formatTimeRemaining(data.seven_day.resets_at ?? "N/A")} || ${new Date(data.seven_day.resets_at ?? "N/A").toLocaleString()}`}
           icon={Icon.ArrowClockwise}
         />
 

--- a/extensions/ccusage/src/hooks/useClaudeUsageLimits.ts
+++ b/extensions/ccusage/src/hooks/useClaudeUsageLimits.ts
@@ -1,10 +1,11 @@
 import { useState, useEffect, useCallback } from "react";
 import { UsageLimitData } from "../types/usage-types";
 import { subscribeToUsageLimits, getUsageLimitsState, revalidateUsageLimits } from "../utils/usage-limits-cache";
+import { UsageLimitsError } from "../utils/usage-limits-error";
 
 interface UsageLimitsState {
   data: UsageLimitData | null;
-  error: Error | null;
+  error: UsageLimitsError | null;
   isLoading: boolean;
   isStale: boolean;
   isUsageLimitsAvailable: boolean;

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -123,13 +123,13 @@ export default function MenuBarccusage() {
                 <>
                   <MenuBarExtra.Item
                     title={`5-Hour: ${limitsData.five_hour.utilization.toFixed(0)}%`}
-                    subtitle={`Resets in ${formatTimeRemaining(limitsData.five_hour.resets_at)}${isStale ? " ⚠️ " : ""}`}
+                    subtitle={`Resets in ${formatTimeRemaining(limitsData.five_hour.resets_at ?? "N/A")}${isStale ? " ⚠️ " : ""}`}
                     icon={Icon.Gauge}
                     onAction={revalidate}
                   />
                   <MenuBarExtra.Item
                     title={`7-Day: ${limitsData.seven_day.utilization.toFixed(0)}%`}
-                    subtitle={`Resets in ${formatTimeRemaining(limitsData.seven_day.resets_at)}${isStale ? " ⚠️" : ""}`}
+                    subtitle={`Resets in ${formatTimeRemaining(limitsData.seven_day.resets_at ?? "N/A")}${isStale ? " ⚠️" : ""}`}
                     icon={Icon.Gauge}
                     onAction={revalidate}
                   />

--- a/extensions/ccusage/src/tools/get-usage-limits.ts
+++ b/extensions/ccusage/src/tools/get-usage-limits.ts
@@ -48,7 +48,11 @@ export default async function getUsageLimits(input?: Input): Promise<{
 
   const data = parseResult.data;
 
-  const formatResetTime = (isoString: string): string => {
+  const formatResetTime = (isoString: string | null): string => {
+    if (!isoString) {
+      return "N/A";
+    }
+
     const resetTime = new Date(isoString);
     const now = new Date();
     const diffMs = resetTime.getTime() - now.getTime();
@@ -75,12 +79,12 @@ export default async function getUsageLimits(input?: Input): Promise<{
     fiveHour: {
       utilization: Math.round(data.five_hour.utilization * 10) / 10,
       resetsAt: formatResetTime(data.five_hour.resets_at),
-      ...(input?.includeRawTimestamps && { rawTimestamp: data.five_hour.resets_at }),
+      ...(input?.includeRawTimestamps && { rawTimestamp: data.five_hour.resets_at ?? undefined }),
     },
     sevenDay: {
       utilization: Math.round(data.seven_day.utilization * 10) / 10,
       resetsAt: formatResetTime(data.seven_day.resets_at),
-      ...(input?.includeRawTimestamps && { rawTimestamp: data.seven_day.resets_at }),
+      ...(input?.includeRawTimestamps && { rawTimestamp: data.seven_day.resets_at ?? undefined }),
     },
   };
 }

--- a/extensions/ccusage/src/tools/get-usage-limits.ts
+++ b/extensions/ccusage/src/tools/get-usage-limits.ts
@@ -1,4 +1,3 @@
-import { UsageLimitDataSchema } from "../types/usage-types";
 import { getClaudeAccessToken } from "../utils/keychain-access";
 import { fetchClaudeUsageLimits } from "../utils/claude-api-client";
 
@@ -32,21 +31,7 @@ export default async function getUsageLimits(input?: Input): Promise<{
     throw new Error("Usage limits require Claude OAuth authentication in Claude Code.");
   }
 
-  const limitData = await fetchClaudeUsageLimits(token);
-
-  if (!limitData) {
-    throw new Error(
-      "Failed to fetch usage limits from Claude API. Please check your network connection and authentication status.",
-    );
-  }
-
-  const parseResult = UsageLimitDataSchema.safeParse(limitData);
-
-  if (!parseResult.success) {
-    throw new Error(`Invalid usage limit data: ${parseResult.error.message}`);
-  }
-
-  const data = parseResult.data;
+  const usageLimitsData = await fetchClaudeUsageLimits(token);
 
   const formatResetTime = (isoString: string | null): string => {
     if (!isoString) {
@@ -77,14 +62,14 @@ export default async function getUsageLimits(input?: Input): Promise<{
 
   return {
     fiveHour: {
-      utilization: Math.round(data.five_hour.utilization * 10) / 10,
-      resetsAt: formatResetTime(data.five_hour.resets_at),
-      ...(input?.includeRawTimestamps && { rawTimestamp: data.five_hour.resets_at ?? undefined }),
+      utilization: Math.round(usageLimitsData.five_hour.utilization * 10) / 10,
+      resetsAt: formatResetTime(usageLimitsData.five_hour.resets_at),
+      ...(input?.includeRawTimestamps && { rawTimestamp: usageLimitsData.five_hour.resets_at ?? undefined }),
     },
     sevenDay: {
-      utilization: Math.round(data.seven_day.utilization * 10) / 10,
-      resetsAt: formatResetTime(data.seven_day.resets_at),
-      ...(input?.includeRawTimestamps && { rawTimestamp: data.seven_day.resets_at ?? undefined }),
+      utilization: Math.round(usageLimitsData.seven_day.utilization * 10) / 10,
+      resetsAt: formatResetTime(usageLimitsData.seven_day.resets_at),
+      ...(input?.includeRawTimestamps && { rawTimestamp: usageLimitsData.seven_day.resets_at ?? undefined }),
     },
   };
 }

--- a/extensions/ccusage/src/types/usage-types.ts
+++ b/extensions/ccusage/src/types/usage-types.ts
@@ -120,7 +120,7 @@ export const SessionUsageCommandResponseSchema = z.object({
 
 export const LimitWindowSchema = z.object({
   utilization: z.number(),
-  resets_at: z.string(),
+  resets_at: z.string().nullable(),
 });
 
 export const UsageLimitDataSchema = z.object({

--- a/extensions/ccusage/src/utils/claude-api-client.ts
+++ b/extensions/ccusage/src/utils/claude-api-client.ts
@@ -1,6 +1,8 @@
+import { STATUS_CODES } from "node:http";
 import { UsageLimitData, UsageLimitDataSchema } from "../types/usage-types";
+import { UsageLimitsError } from "./usage-limits-error";
 
-export const fetchClaudeUsageLimits = async (accessToken: string): Promise<UsageLimitData | null> => {
+const fetchUsageLimitsResponse = async (accessToken: string): Promise<string> => {
   try {
     const response = await fetch("https://api.anthropic.com/api/oauth/usage", {
       headers: {
@@ -11,15 +13,44 @@ export const fetchClaudeUsageLimits = async (accessToken: string): Promise<Usage
       },
     });
 
+    const responseText = await response.text();
+
     if (!response.ok) {
-      return null;
+      const status = response.status;
+      const statusText = response.statusText || STATUS_CODES[status] || "Request Failed";
+
+      throw new UsageLimitsError({
+        kind: "fetch",
+        error: new Error(`Claude API returned ${status} ${statusText} while fetching usage limits.`),
+        status,
+        statusText,
+        responseText,
+      });
     }
 
-    const data = await response.json();
-    const result = UsageLimitDataSchema.safeParse(data);
+    return responseText;
+  } catch (error) {
+    if (error instanceof UsageLimitsError) {
+      throw error;
+    }
 
-    return result.success ? result.data : null;
-  } catch {
-    return null;
+    throw new UsageLimitsError({
+      kind: "fetch",
+      error,
+    });
   }
+};
+
+const parseUsageLimitsResponse = (responseText: string): UsageLimitData => {
+  try {
+    const data = JSON.parse(responseText);
+    return UsageLimitDataSchema.parse(data);
+  } catch (error) {
+    throw new UsageLimitsError({ kind: "parse", error, responseText });
+  }
+};
+
+export const fetchClaudeUsageLimits = async (accessToken: string): Promise<UsageLimitData> => {
+  const responseText = await fetchUsageLimitsResponse(accessToken);
+  return parseUsageLimitsResponse(responseText);
 };

--- a/extensions/ccusage/src/utils/usage-limits-cache.ts
+++ b/extensions/ccusage/src/utils/usage-limits-cache.ts
@@ -1,11 +1,12 @@
-import { Cache, getPreferenceValues } from "@raycast/api";
+import { Cache, Clipboard, Toast, getPreferenceValues, showToast } from "@raycast/api";
 import { UsageLimitData } from "../types/usage-types";
 import { getClaudeAccessToken } from "./keychain-access";
 import { fetchClaudeUsageLimits } from "./claude-api-client";
+import { UsageLimitsError } from "./usage-limits-error";
 
 interface CacheState {
   data: UsageLimitData | null;
-  error: Error | null;
+  error: UsageLimitsError | null;
   isLoading: boolean;
   isStale: boolean;
   isUsageLimitsAvailable: boolean;
@@ -86,6 +87,27 @@ const listeners = new Set<Listener>();
 let fetchInterval: NodeJS.Timeout | null = null;
 let isFetching = false;
 
+const showUsageLimitsErrorToast = async (error: UsageLimitsError): Promise<void> => {
+  await showToast({
+    style: Toast.Style.Failure,
+    title: error.title,
+    message: error.message,
+    primaryAction: {
+      title: "Retry",
+      onAction: async (toast) => {
+        toast.hide();
+        await revalidateUsageLimits();
+      },
+    },
+    secondaryAction: {
+      title: "Copy Error Log",
+      onAction: async () => {
+        await Clipboard.copy(error.log);
+      },
+    },
+  });
+};
+
 const notifyListeners = (): void => {
   listeners.forEach((listener) => listener(cacheState));
 };
@@ -125,36 +147,29 @@ const fetchUsageLimits = async (): Promise<void> => {
 
     const limitData = await fetchClaudeUsageLimits(token);
 
-    if (limitData) {
-      cacheState = {
-        data: limitData,
-        error: null,
-        isLoading: false,
-        isUsageLimitsAvailable: true,
-        isStale: false,
-        lastFetched: new Date(),
-      };
-    } else {
-      const error = new Error("Failed to fetch usage limits from API");
-      cacheState = {
-        ...cacheState,
-        data: previousData,
-        error,
-        isLoading: false,
-        isUsageLimitsAvailable: true,
-        isStale: previousData !== null,
-      };
+    cacheState = {
+      data: limitData,
+      error: null,
+      isLoading: false,
+      isUsageLimitsAvailable: true,
+      isStale: false,
+      lastFetched: new Date(),
+    };
+  } catch (error) {
+    if (!(error instanceof UsageLimitsError)) {
+      throw error;
     }
-  } catch (err) {
-    const error = err instanceof Error ? err : new Error("Unknown error occurred");
+
     cacheState = {
       ...cacheState,
       data: previousData,
       error,
       isLoading: false,
-      isUsageLimitsAvailable: cacheState.isUsageLimitsAvailable,
+      isUsageLimitsAvailable: true,
       isStale: previousData !== null,
     };
+
+    await showUsageLimitsErrorToast(error);
   } finally {
     isFetching = false;
     notifyListeners();

--- a/extensions/ccusage/src/utils/usage-limits-error.ts
+++ b/extensions/ccusage/src/utils/usage-limits-error.ts
@@ -1,0 +1,106 @@
+import { STATUS_CODES } from "node:http";
+import { ZodError } from "zod";
+
+export type UsageLimitsErrorKind = "fetch" | "parse";
+
+type UsageLimitsErrorInput = {
+  kind: UsageLimitsErrorKind;
+  error: unknown;
+  status?: number;
+  statusText?: string;
+  responseText?: string;
+};
+
+type NormalizedUsageLimitsError = {
+  title: string;
+  message: string;
+  log: string;
+  status?: number;
+  statusText?: string;
+};
+
+const stringifyUnknown = (value: unknown): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value instanceof Error) {
+    return value.stack ?? `${value.name}: ${value.message}`;
+  }
+
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+
+const formatFetchErrorLog = (status: number, statusText: string, responseText?: string): string => {
+  const parts = [`HTTP ${status} ${statusText}`];
+
+  if (responseText?.trim()) {
+    parts.push("", responseText);
+  }
+
+  return parts.join("\n");
+};
+
+export class UsageLimitsError extends Error {
+  readonly kind: UsageLimitsErrorKind;
+  readonly title: string;
+  readonly log: string;
+  readonly status?: number;
+  readonly statusText?: string;
+
+  constructor({ kind, error, status, statusText, responseText }: UsageLimitsErrorInput) {
+    let normalized: NormalizedUsageLimitsError;
+
+    if (kind === "parse") {
+      if (error instanceof SyntaxError) {
+        normalized = {
+          title: "Failed to Parse Usage Limits",
+          message: "Claude API returned invalid JSON for usage limits.",
+          log: [`JSON parse error: ${error.message}`, "", responseText ?? ""].filter(Boolean).join("\n"),
+        };
+      } else if (error instanceof ZodError) {
+        normalized = {
+          title: "Failed to Parse Usage Limits",
+          message: "Claude API returned usage limits in an unexpected format.",
+          log: [`Validation error: ${error.message}`, "", responseText ?? ""].filter(Boolean).join("\n"),
+        };
+      } else {
+        normalized = {
+          title: "Failed to Parse Usage Limits",
+          message: error instanceof Error ? error.message : "Unknown error occurred while parsing usage limits.",
+          log: [stringifyUnknown(error), "", responseText ?? ""].filter(Boolean).join("\n"),
+        };
+      }
+    } else if (typeof status === "number") {
+      const resolvedStatusText = statusText || STATUS_CODES[status] || "Request Failed";
+
+      normalized = {
+        title: "Failed to Fetch Usage Limits",
+        message: error instanceof Error ? error.message : "Unknown error occurred while fetching usage limits.",
+        log: formatFetchErrorLog(status, resolvedStatusText, responseText),
+        status,
+        statusText: resolvedStatusText,
+      };
+    } else {
+      normalized = {
+        title: "Failed to Fetch Usage Limits",
+        message: error instanceof Error ? error.message : "Unknown error occurred while fetching usage limits.",
+        log: stringifyUnknown(error),
+      };
+    }
+
+    super(normalized.message, error instanceof Error ? { cause: error } : undefined);
+    this.name = "UsageLimitsError";
+    this.kind = kind;
+    this.title = normalized.title;
+    this.log = normalized.log;
+    this.status = normalized.status;
+    this.statusText = normalized.statusText;
+  }
+}
+
+export const sanitizeCodeBlock = (value: string): string => value.replace(/```/g, "\\`\\`\\`");

--- a/extensions/ccusage/src/utils/usage-limits-formatter.ts
+++ b/extensions/ccusage/src/utils/usage-limits-formatter.ts
@@ -67,9 +67,11 @@ export const createProgressBar = (percentage: number, width: number = 20): strin
 
 export const calculateEstimatedUsage = (
   currentUtilization: number,
-  resetTimeStr: string,
+  resetTimeStr: string | null,
   windowDurationHours: number,
 ): number | null => {
+  if (!resetTimeStr) return null;
+
   try {
     const resetTime = new Date(resetTimeStr);
     const now = new Date();
@@ -97,7 +99,9 @@ export const calculateEstimatedUsage = (
   }
 };
 
-export const calculateAverageUsage = (resetTimeStr: string, windowDurationHours: number): number | null => {
+export const calculateAverageUsage = (resetTimeStr: string | null, windowDurationHours: number): number | null => {
+  if (!resetTimeStr) return null;
+
   try {
     const resetTime = new Date(resetTimeStr);
     const now = new Date();


### PR DESCRIPTION
## Description

This change improves how the extension handles the usage limit API request failures and unexpected response formats, and fixes the error when parsing the response with `null` values in the `resets_at` field.

Changes in this PR:
- Add a dedicated `UsageLimitsError` type to normalize fetch and parse failures
- Show a proper error detail screen in the Usage Limits view instead of a generic empty/error state
- Add quick actions to copy the error log and retry failed refreshes
- Show actionable failure toasts while preserving previously fetched usage limit data when available
- Reuse the same stricter usage limit fetching/parsing flow in the `get-usage-limits` AI tool
- Fix runtime issues caused by `resets_at` being `null` in the API response
- Align a couple of list icons with the default Raycast appearance

Fixes #26267

## Screencast

Error details when fetching usage limits was failing before:

<img width="1582" height="1002" alt="ccusage-1" src="https://github.com/user-attachments/assets/b4e2e662-8ddb-4c4e-9c81-c465074826a3" />

Error when the fetching fails after this update:

<img width="1582" height="1002" alt="ccusage-2" src="https://github.com/user-attachments/assets/3405ebd2-da6b-4ccb-8099-0ef614a91210" />

<img width="1582" height="1002" alt="ccusage-3" src="https://github.com/user-attachments/assets/28a2763a-ce54-44e1-93b9-37c38343dd5a" />

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
