### PR TITLE
[ccusage] prevent list item flicker by caching the Usage Limits item availability

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [v2.2.3] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Persisted usage limits availability between refreshes so the "Usage Limits" section does not flicker or disappear while OAuth authentication is being rechecked
+
 ## [v2.2.2] - 2026-03-04
 
 ### Fixed

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [v2.2.3] - {PR_MERGE_DATE}
+## [v2.2.3] - 2026-03-16
 
 ### Fixed
 

--- a/extensions/ccusage/src/utils/usage-limits-cache.ts
+++ b/extensions/ccusage/src/utils/usage-limits-cache.ts
@@ -1,4 +1,4 @@
-import { getPreferenceValues } from "@raycast/api";
+import { Cache, getPreferenceValues } from "@raycast/api";
 import { UsageLimitData } from "../types/usage-types";
 import { getClaudeAccessToken } from "./keychain-access";
 import { fetchClaudeUsageLimits } from "./claude-api-client";
@@ -14,14 +14,73 @@ interface CacheState {
 
 type Listener = (state: CacheState) => void;
 
-let cacheState: CacheState = {
-  data: null,
-  error: null,
-  isLoading: true,
-  isStale: false,
-  isUsageLimitsAvailable: false,
-  lastFetched: null,
+interface PersistedUsageLimitsAvailability {
+  isAvailable: boolean;
+  lastCheckedAt: string;
+}
+
+const availabilityCache = new Cache();
+const USAGE_LIMITS_AVAILABILITY_CACHE_KEY = "usage-limits-availability";
+
+const readPersistedAvailability = (): PersistedUsageLimitsAvailability | null => {
+  const cachedValue = availabilityCache.get(USAGE_LIMITS_AVAILABILITY_CACHE_KEY);
+
+  if (!cachedValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue = JSON.parse(cachedValue) as Partial<PersistedUsageLimitsAvailability>;
+
+    if (typeof parsedValue.isAvailable !== "boolean" || typeof parsedValue.lastCheckedAt !== "string") {
+      availabilityCache.remove(USAGE_LIMITS_AVAILABILITY_CACHE_KEY);
+      return null;
+    }
+
+    return {
+      isAvailable: parsedValue.isAvailable,
+      lastCheckedAt: parsedValue.lastCheckedAt,
+    };
+  } catch {
+    availabilityCache.remove(USAGE_LIMITS_AVAILABILITY_CACHE_KEY);
+    return null;
+  }
 };
+
+const persistAvailability = (isAvailable: boolean): void => {
+  const persistedValue: PersistedUsageLimitsAvailability = {
+    isAvailable,
+    lastCheckedAt: new Date().toISOString(),
+  };
+
+  availabilityCache.set(USAGE_LIMITS_AVAILABILITY_CACHE_KEY, JSON.stringify(persistedValue));
+};
+
+const createInitialCacheState = (): CacheState => {
+  const persistedAvailability = readPersistedAvailability();
+
+  if (!persistedAvailability) {
+    return {
+      data: null,
+      error: null,
+      isLoading: true,
+      isStale: false,
+      isUsageLimitsAvailable: false,
+      lastFetched: null,
+    };
+  }
+
+  return {
+    data: null,
+    error: null,
+    isLoading: persistedAvailability.isAvailable,
+    isStale: false,
+    isUsageLimitsAvailable: persistedAvailability.isAvailable,
+    lastFetched: null,
+  };
+};
+
+let cacheState: CacheState = createInitialCacheState();
 
 const listeners = new Set<Listener>();
 let fetchInterval: NodeJS.Timeout | null = null;
@@ -39,7 +98,9 @@ const fetchUsageLimits = async (): Promise<void> => {
 
   try {
     const token = await getClaudeAccessToken();
+
     const isUsageLimitsAvailable = typeof token === "string" && token.trim().length > 0;
+    persistAvailability(isUsageLimitsAvailable);
 
     if (!isUsageLimitsAvailable) {
       cacheState = {
@@ -53,6 +114,14 @@ const fetchUsageLimits = async (): Promise<void> => {
       notifyListeners();
       return;
     }
+
+    cacheState = {
+      ...cacheState,
+      error: null,
+      isLoading: previousData === null,
+      isUsageLimitsAvailable: true,
+    };
+    notifyListeners();
 
     const limitData = await fetchClaudeUsageLimits(token);
 


### PR DESCRIPTION
## Description

This change persist the "Usage Limits" availability state in cache and uses it to initialize the command state on load.

The "Usage Limits" list item is displayed only when Claude Code is authenticated via OAuth. Previously, the availability check ran with every command load, causing the item to be initially hidden and then appear after the authentication method was re-evaluated, resulting in a noticeable flicker.

By caching the last known availability state, the extension can render the item consistently while the fresh check is still in progress.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
