### PR TITLE
Update raindrop-io extension

### DIFF
--- a/extensions/raindrop-io/CHANGELOG.md
+++ b/extensions/raindrop-io/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Raindrop.io Extension Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Fix loading collections in the Save Browser Tab form by building the dropdown options directly from the collections API response.
+
 ## [Windows/Linux Compatibility] - 2026-01-07
 
 - Add Windows to the list of supported platforms.

--- a/extensions/raindrop-io/CHANGELOG.md
+++ b/extensions/raindrop-io/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Raindrop.io Extension Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-03-31
 
 - Fix loading collections in the Save Browser Tab form by building the dropdown options directly from the collections API response.
 

--- a/extensions/raindrop-io/package-lock.json
+++ b/extensions/raindrop-io/package-lock.json
@@ -1257,7 +1257,6 @@
       "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1317,7 +1316,6 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -1523,7 +1521,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1897,7 +1894,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2784,7 +2780,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3040,7 +3035,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3111,7 +3105,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/raindrop-io/package.json
+++ b/extensions/raindrop-io/package.json
@@ -19,7 +19,8 @@
     "GLaDO8",
     "xmok",
     "luiscarlospando",
-    "janrokita"
+    "janrokita",
+    "lemikeone"
   ],
   "pastContributors": [
     "sh-cho"

--- a/extensions/raindrop-io/src/components/BookmarkForm.tsx
+++ b/extensions/raindrop-io/src/components/BookmarkForm.tsx
@@ -59,7 +59,7 @@ type BookmarkFormProps = {
 export const BookmarkForm = (props: BookmarkFormProps) => {
   const mode = props.bookmarkId ? "edit" : "create";
   const preferences = getPreferenceValues<Preferences>();
-  const { data: collectionsData, isLoading: isLoadingCollections } = useCollections();
+  const { data: collectionsData, isLoading: isLoadingCollections, error: collectionsError } = useCollections();
   const { data: tags } = useTags();
   const [dropdownValue, setDropdownValue] = useState(props.defaultValues?.collection ?? "-1");
   const [showCollectionCreation, setShowCollectionCreation] = useState(false);
@@ -176,14 +176,23 @@ export const BookmarkForm = (props: BookmarkFormProps) => {
         <Form.Dropdown.Item key="-2" value="-2" title="Create Collection" icon={Icon.Plus} />
         <Form.Dropdown.Item key="-1" value="-1" title="Unsorted" icon={Icon.Tray} />
         <Form.Dropdown.Section title="Collections">
-          {collections.map(({ value, label, name, cover }) => (
+          {collectionsError ? (
             <Form.Dropdown.Item
-              key={value}
-              value={`${value ?? "-1"}`}
-              title={name && name !== label ? `${name} (${label})` : label}
-              icon={cover ? { source: cover } : { source: Icon.Folder }}
+              key="collections-error"
+              value="-1"
+              title="Unable to load collections"
+              icon={Icon.ExclamationMark}
             />
-          ))}
+          ) : (
+            collections.map(({ value, label, name, cover }) => (
+              <Form.Dropdown.Item
+                key={value}
+                value={`${value ?? "-1"}`}
+                title={name && name !== label ? `${name} (${label})` : label}
+                icon={cover ? { source: cover } : { source: Icon.Folder }}
+              />
+            ))
+          )}
         </Form.Dropdown.Section>
       </Form.Dropdown>
       {showCollectionCreation && (

--- a/extensions/raindrop-io/src/components/BookmarkForm.tsx
+++ b/extensions/raindrop-io/src/components/BookmarkForm.tsx
@@ -1,9 +1,10 @@
 import { Action, ActionPanel, Form, getPreferenceValues, Icon } from "@raycast/api";
-import { FormValidation, useCachedState, useForm } from "@raycast/utils";
-import { useEffect, useRef, useState } from "react";
+import { FormValidation, useForm } from "@raycast/utils";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { FormValues } from "../types";
 
-import { useRequest } from "../hooks/useRequest";
+import { buildCollectionsOptions } from "../helpers/collections";
+import { useCollections } from "../hooks/useCollections";
 import { useTags } from "../hooks/useTags";
 import { createCollection, createBookmark, getLinkTitle } from "../helpers/utils";
 
@@ -58,12 +59,14 @@ type BookmarkFormProps = {
 export const BookmarkForm = (props: BookmarkFormProps) => {
   const mode = props.bookmarkId ? "edit" : "create";
   const preferences = getPreferenceValues<Preferences>();
-  const [collection] = useCachedState("selected-collection", "0");
-  const { collections } = useRequest({ collection });
+  const { data: collectionsData, isLoading: isLoadingCollections } = useCollections();
   const { data: tags } = useTags();
   const [dropdownValue, setDropdownValue] = useState(props.defaultValues?.collection ?? "-1");
   const [showCollectionCreation, setShowCollectionCreation] = useState(false);
   const linkRef = useRef<string>(props.defaultValues?.link ?? "");
+  const collections = useMemo(() => {
+    return collectionsData?.result ? buildCollectionsOptions(collectionsData) : [];
+  }, [collectionsData]);
   const { handleSubmit, itemProps, setValue, reset, focus } = useForm<FormValues>({
     async onSubmit(values) {
       props.onWillSave?.();
@@ -163,6 +166,7 @@ export const BookmarkForm = (props: BookmarkFormProps) => {
       <Form.Dropdown
         {...itemProps.collection}
         title="Collection"
+        isLoading={isLoadingCollections}
         value={dropdownValue}
         onChange={(newValue: string) => {
           setShowCollectionCreation(newValue === "-2");
@@ -176,7 +180,7 @@ export const BookmarkForm = (props: BookmarkFormProps) => {
             <Form.Dropdown.Item
               key={value}
               value={`${value ?? "-1"}`}
-              title={name ? `${name} (${label})` : label}
+              title={name ?? label}
               icon={cover ? { source: cover } : { source: Icon.Folder }}
             />
           ))}

--- a/extensions/raindrop-io/src/components/BookmarkForm.tsx
+++ b/extensions/raindrop-io/src/components/BookmarkForm.tsx
@@ -180,7 +180,7 @@ export const BookmarkForm = (props: BookmarkFormProps) => {
             <Form.Dropdown.Item
               key={value}
               value={`${value ?? "-1"}`}
-              title={name ?? label}
+              title={name && name !== label ? `${name} (${label})` : label}
               icon={cover ? { source: cover } : { source: Icon.Folder }}
             />
           ))}

--- a/extensions/raindrop-io/src/helpers/collections.ts
+++ b/extensions/raindrop-io/src/helpers/collections.ts
@@ -1,96 +1,54 @@
-import { Collection, CollectionItem, CollectionsResponse, Group, UserResponse } from "../types";
+import { Collection, CollectionItem, CollectionsResponse, UserResponse } from "../types";
 
-const collectionsTree: Collection[] = [];
-const treeFlat: CollectionItem[] = [];
+type CollectionNode = Collection & { children: CollectionNode[] };
 
-function buildCollectionTree(treeObject: Collection[], sourceArray: Collection[], level: number) {
-  const nodes = sourceArray.filter((item) => {
-    return (level == 0 && !item.parent) || (item.parent && item.parent["$id"] == level);
-  });
+function normalizeCollections(collections: Collection[] = []) {
+  const nodes = new Map<number, CollectionNode>();
 
-  for (const node of nodes) {
-    const id = node._id;
-    node.children = [];
-    buildCollectionTree(node.children, sourceArray, id);
-    treeObject.push(node);
-  }
-}
-
-type OrderCollectionItem = [string | null, number];
-type OrderedCollections = [string | null, number, Collection | undefined][];
-
-function buildGroupsAndOrder(groups: Group[]) {
-  const output: OrderCollectionItem[] = [];
-
-  if (groups.length > 1) {
-    groups.forEach((group) => {
-      group.collections?.forEach((coll) => {
-        output.push([group.title, coll]);
-      });
-    });
-  } else {
-    groups[0]?.collections?.forEach((coll) => {
-      output.push([null, coll]);
+  for (const collection of collections) {
+    nodes.set(collection._id, {
+      ...collection,
+      children: [],
     });
   }
-  return output;
-}
 
-function orderCollections(tree: Collection[], orderedCollections: OrderCollectionItem[]) {
-  const mappedCollections: OrderedCollections = [];
-  orderedCollections.forEach((coll) => {
-    const c = tree.find((el) => el._id == coll[1]);
-    mappedCollections.push([...coll, c]);
-  });
-  return mappedCollections;
-}
+  const roots: CollectionNode[] = [];
 
-const flatChildCollections = (childColls: Collection[], prefix = "") => {
-  for (let i = 0; i < childColls.length; i++) {
-    const elem = childColls[i];
-    const title = `${prefix} > ${elem.title}`;
-    treeFlat.push({
-      value: elem._id,
-      label: title,
-      name: elem.title,
-      cover: Array.isArray(elem.cover) && elem.cover.length > 0 ? elem.cover[0] : undefined,
-    });
+  for (const node of nodes.values()) {
+    const parentId = node.parent?.$id;
+    const parent = parentId ? nodes.get(parentId) : undefined;
 
-    if (elem.children) {
-      flatChildCollections(elem.children, title);
+    if (parent) {
+      parent.children.push(node);
+    } else {
+      roots.push(node);
     }
   }
-};
 
-const flatCollections = (sortedColls: OrderedCollections) => {
-  sortedColls.forEach((coll) => {
-    const group = coll[0] ? `${coll[0]} - ` : "";
-    const title = `${group}${coll[2]?.title}`;
+  return roots;
+}
 
-    treeFlat.push({
-      value: coll[2]?._id,
-      label: title,
-      name: coll[2]?.title,
-      cover:
-        Array.isArray(coll[2]?.cover) && (coll[2]?.cover as unknown as string[])?.length > 0
-          ? (coll[2]?.cover as unknown as string[])[0]
-          : undefined,
-    });
+function flattenCollections(collections: CollectionNode[], prefix?: string): CollectionItem[] {
+  return collections.flatMap((collection) => {
+    const label = prefix ? `${prefix} > ${collection.title}` : collection.title;
+    const current: CollectionItem = {
+      value: collection._id,
+      label,
+      name: collection.title,
+      cover: Array.isArray(collection.cover) && collection.cover.length > 0 ? collection.cover[0] : undefined,
+    };
 
-    if (coll[2]?.children) {
-      flatChildCollections(coll[2]?.children, title);
-    }
+    return [current, ...flattenCollections(collection.children, label)];
   });
-};
+}
 
-const buildCollectionsOptions = (userData: UserResponse, collections: CollectionsResponse) => {
-  buildCollectionTree(collectionsTree, collections.items, 0);
-  const groups = buildGroupsAndOrder(userData.user.groups);
-  const orderedCollections = orderCollections(collectionsTree, groups);
-
-  treeFlat.splice(0, treeFlat.length);
-  flatCollections(orderedCollections);
-  return treeFlat;
-};
+function buildCollectionsOptions(
+  userOrCollections: UserResponse | CollectionsResponse,
+  collectionsResponse?: CollectionsResponse,
+) {
+  const collections = collectionsResponse ?? (userOrCollections as CollectionsResponse);
+  const roots = normalizeCollections(collections.items);
+  return flattenCollections(roots);
+}
 
 export { buildCollectionsOptions };

--- a/extensions/raindrop-io/src/helpers/collections.ts
+++ b/extensions/raindrop-io/src/helpers/collections.ts
@@ -1,6 +1,7 @@
-import { Collection, CollectionItem, CollectionsResponse, UserResponse } from "../types";
+import { Collection, CollectionItem, CollectionsResponse, Group, UserResponse } from "../types";
 
 type CollectionNode = Collection & { children: CollectionNode[] };
+type OrderedRoot = { collection: CollectionNode; groupTitle?: string };
 
 function normalizeCollections(collections: Collection[] = []) {
   const nodes = new Map<number, CollectionNode>();
@@ -28,27 +29,73 @@ function normalizeCollections(collections: Collection[] = []) {
   return roots;
 }
 
-function flattenCollections(collections: CollectionNode[], prefix?: string): CollectionItem[] {
-  return collections.flatMap((collection) => {
-    const label = prefix ? `${prefix} > ${collection.title}` : collection.title;
-    const current: CollectionItem = {
-      value: collection._id,
-      label,
-      name: collection.title,
-      cover: Array.isArray(collection.cover) && collection.cover.length > 0 ? collection.cover[0] : undefined,
-    };
+function buildOrderedRoots(roots: CollectionNode[], groups: Group[] = []): OrderedRoot[] {
+  if (groups.length === 0) {
+    return roots.map((collection) => ({ collection }));
+  }
 
-    return [current, ...flattenCollections(collection.children, label)];
+  const rootMap = new Map<number, CollectionNode>(roots.map((root) => [root._id, root] as const));
+  const seen = new Set<number>();
+  const orderedRoots: OrderedRoot[] = [];
+  const includeGroupTitle = groups.length > 1;
+
+  for (const group of groups) {
+    for (const collectionId of group.collections ?? []) {
+      const collection = rootMap.get(collectionId);
+
+      if (!collection || seen.has(collectionId)) {
+        continue;
+      }
+
+      seen.add(collectionId);
+      orderedRoots.push({
+        collection,
+        groupTitle: includeGroupTitle ? group.title : undefined,
+      });
+    }
+  }
+
+  for (const root of roots) {
+    if (!seen.has(root._id)) {
+      orderedRoots.push({ collection: root });
+    }
+  }
+
+  return orderedRoots;
+}
+
+function flattenCollectionBranch(collection: CollectionNode, prefix?: string): CollectionItem[] {
+  const label = prefix ? `${prefix} > ${collection.title}` : collection.title;
+  const current: CollectionItem = {
+    value: collection._id,
+    label,
+    name: collection.title,
+    cover: Array.isArray(collection.cover) && collection.cover.length > 0 ? collection.cover[0] : undefined,
+  };
+
+  const children = collection.children as CollectionNode[];
+  return [current, ...children.flatMap((child) => flattenCollectionBranch(child, label))];
+}
+
+function flattenCollections(orderedRoots: OrderedRoot[]): CollectionItem[] {
+  return orderedRoots.flatMap(({ collection, groupTitle }) => {
+    const prefix = groupTitle ? `${groupTitle} - ` : undefined;
+    return flattenCollectionBranch(collection, prefix);
   });
 }
 
+function buildCollectionsOptions(collections: CollectionsResponse): CollectionItem[];
+function buildCollectionsOptions(user: UserResponse, collections: CollectionsResponse): CollectionItem[];
 function buildCollectionsOptions(
   userOrCollections: UserResponse | CollectionsResponse,
   collectionsResponse?: CollectionsResponse,
 ) {
+  const user = collectionsResponse ? (userOrCollections as UserResponse) : undefined;
   const collections = collectionsResponse ?? (userOrCollections as CollectionsResponse);
   const roots = normalizeCollections(collections.items);
-  return flattenCollections(roots);
+  const orderedRoots = buildOrderedRoots(roots, user?.user.groups);
+
+  return flattenCollections(orderedRoots);
 }
 
 export { buildCollectionsOptions };


### PR DESCRIPTION
## Description

Fix loading collections in the Save Browser Tab form by building the dropdown options directly from the collections API response.

This PR follows the issue that I raised here: https://github.com/raycast/extensions/issues/26089

## Screencast

In the screencast below, the first command I open is from the extension currently on the Store, where no collections appear. The second command is from the modified version proposed in this PR, where the collections display correctly.

https://github.com/user-attachments/assets/8d8e2ec0-7319-41fe-bbde-37d34389599c

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
