### PR TITLE
[Skills] use skills list --json for full agent list

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Fix Incomplete Agent List] - {PR_MERGE_DATE}
+
+- Use `skills list --json` for structured output instead of parsing ANSI text
+- Show all supported agents in the filter dropdown and detail panel
+
 ## [Highlight Outdated Skills] - 2026-03-16
 
 - Highlight outdated skills with an orange hammer icon in the installed skills list

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix Incomplete Agent List] - {PR_MERGE_DATE}
+## [Fix Incomplete Agent List] - 2026-03-17
 
 - Use `skills list --json` for structured output instead of parsing ANSI text
 - Show all supported agents in the filter dropdown and detail panel

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -25,7 +25,7 @@ const ANSI_REGEX = /\x1B\[[0-9;]*m/g;
 
 /**
  * Strip ANSI escape codes from CLI output.
- * The skills CLI forces colors with no --no-color or --json option.
+ * Used by checkForUpdates() which does not have a --json option.
  */
 function stripAnsi(str: string): string {
   return str.replace(ANSI_REGEX, "");
@@ -39,62 +39,34 @@ function shellEscape(arg: string): string {
   return `'${arg.replace(/'/g, "'\\''")}'`;
 }
 
-/**
- * Parse `npx skills list -g` output into InstalledSkill[].
- *
- * After stripping ANSI, format is:
- *   Global Skills
- 
- *   skill-name ~/.agents/skills/skill-name
- *   Agents: Claude Code, Cline, Codex, Command Code, Continue +19 more
- */
-function parseSkillsList(raw: string): InstalledSkill[] {
-  const clean = stripAnsi(raw);
-  const skills: InstalledSkill[] = [];
-  const lines = clean.split("\n");
+/** Shape of each entry from `skills list --json` */
+interface SkillsListJsonEntry {
+  name: string;
+  path: string;
+  scope: string;
+  agents: string[];
+}
 
-  for (let i = 0; i < lines.length; i++) {
-    // Matches: "skill-name ~/path" or "skill-name /path" (macOS/Linux)
-    //      or: "skill-name C:\path" (Windows)
-    const skillMatch = lines[i].match(/^(\S+)\s+(~?\/.*|[A-Z]:\\.*)$/);
-    if (!skillMatch) continue;
-
-    const name = skillMatch[1];
-    const rawPath = skillMatch[2].trim();
-    const path = rawPath.startsWith("~") ? rawPath.replace("~", home) : rawPath;
-
-    let agents: string[] = [];
-    let agentCount = 0;
-    const nextLine = lines[i + 1]?.trim();
-    if (nextLine?.startsWith("Agents:")) {
-      agents = nextLine
-        .replace("Agents:", "")
-        .split(",")
-        .map((a) => a.trim())
-        .filter(Boolean);
-
-      // Handle "+N more" truncation from CLI output
-      // e.g. ["Antigravity", "Claude Code", "Continue +16 more"]
-      let extraCount = 0;
-      const last = agents[agents.length - 1];
-      const moreMatch = last?.match(/^(.+?)\s*\+(\d+) more$/);
-      if (moreMatch) {
-        agents[agents.length - 1] = moreMatch[1].trim();
-        extraCount = parseInt(moreMatch[2], 10);
-      }
-
-      agentCount = agents.length + extraCount;
-    }
-
-    skills.push({ name, path, agents, agentCount });
+function parseSkillsListJson(stdout: string): InstalledSkill[] {
+  const entries: unknown = JSON.parse(stdout);
+  if (!Array.isArray(entries)) {
+    throw new Error("Expected JSON array");
   }
-
-  return skills;
+  return (entries as SkillsListJsonEntry[]).map((entry) => ({
+    name: entry.name,
+    path: entry.path.startsWith("~") ? entry.path.replace("~", home) : entry.path,
+    agents: entry.agents,
+    agentCount: entry.agents.length,
+  }));
 }
 
 export async function listInstalledSkills(): Promise<InstalledSkill[]> {
-  const { stdout } = await execWithPath(`${SKILLS_CLI} list -g`);
-  return parseSkillsList(stdout);
+  const { stdout } = await execWithPath(`${SKILLS_CLI} list -g --json`);
+  try {
+    return parseSkillsListJson(stdout);
+  } catch {
+    throw new Error("Failed to parse skills list: unexpected output from `skills list --json`");
+  }
 }
 
 export async function installSkill(skill: Skill): Promise<void> {


### PR DESCRIPTION
## Description

We added support for installing/removing skills in PR #25373, but the implementation wasn't great because the skills CLI only supported the text output with ANSI codes at that time. I reached out to the Vercel team about this issue, and they added support for the JSON output in vercel-labs/skills#558.

This PR uses `skills list --json` to retrieve the complete, structured data directly. This will resolve #26378 by providing the full agent list in the Manage Skills command.

## Screencast

- Before

<img width="1496" height="942" alt="2026-03-16 at 17 11 38" src="https://github.com/user-attachments/assets/00db0af1-6db7-4c8d-aa23-b0a6afeb6b95" />

- After 

<img width="1496" height="940" alt="2026-03-16 at 17 12 03" src="https://github.com/user-attachments/assets/f9d0263f-d89a-463a-8e72-7a719083f083" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
