### PR TITLE
[Coffee] Fix display sleep on battery for macOS 26+

### DIFF
--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coffee Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-03-17
 
 - Fixed caffeination not preventing display sleep on macOS 26+ when running on battery power.
 

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Coffee Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed caffeination not preventing display sleep on macOS 26+ when running on battery power.
+
 ## [Fix] - 2026-01-27
 
 - Fixed memory leak caused by zombie processes when starting caffeination.

--- a/extensions/coffee/src/index.tsx
+++ b/extensions/coffee/src/index.tsx
@@ -35,7 +35,13 @@ function useCaffeinateInfo(execute: boolean) {
         return { isRunning: false, timeRemaining: null };
       }
 
-      const lines = stdout.split("\n");
+      // Filter out keep-alive "caffeinate -u" processes used to reset the
+      // idle timer on battery (see status.ts), so they don't interfere with
+      // the time-remaining calculation.
+      const lines = stdout.split("\n").filter((l) => !l.includes("caffeinate -u"));
+      if (lines.length === 0) {
+        return { isRunning: false, timeRemaining: null };
+      }
       const [etime, ...cmdArgs] = lines[lines.length - 1].trim().split(/\s+/);
 
       const secondsRunning = parseEtime(etime);

--- a/extensions/coffee/src/status.ts
+++ b/extensions/coffee/src/status.ts
@@ -1,4 +1,5 @@
 import { LocalStorage, updateCommandMetadata } from "@raycast/api";
+import { spawn } from "node:child_process";
 import { Schedule, startCaffeinate, getSchedule, stopCaffeinate, isCaffeinateRunning } from "./utils";
 
 async function handleScheduledCaffeinate(schedule: Schedule): Promise<boolean> {
@@ -56,10 +57,19 @@ export default async function Command() {
 
   let subtitle = "✖ Decaffeinated";
 
-  if (isCaffeinated) {
+  if (isCaffeinated || isScheduled) {
     subtitle = "✔ Caffeinated";
-  } else if (isScheduled) {
-    subtitle = "✔ Caffeinated";
+
+    // Reset the idle timer to prevent display sleep on battery.
+    // On macOS 26+ the system/display sleep timers on battery power can
+    // override caffeinate's -d/-i assertions. Asserting user activity
+    // every 15 seconds (this command's interval) keeps the display awake
+    // without requiring elevated privileges or additional processes.
+    const child = spawn("/usr/bin/caffeinate", ["-u", "-t", "1"], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
   }
 
   updateCommandMetadata({ subtitle });


### PR DESCRIPTION
## Description

On macOS 26+, battery power management can override `caffeinate`'s `-d`/`-i` assertions, causing the display to sleep and the lock screen to engage even when caffeinated. This is because the system sleep timer (`pmset -b sleep`) takes precedence over idle sleep prevention assertions on battery power.

This fix adds a periodic user activity assertion (`caffeinate -u -t 1`) inside the existing `status` background command, which already runs every 15 seconds. The `-u` flag declares user activity and resets the idle timer, which prevents both display sleep and lock screen activation — without requiring elevated privileges or spawning additional processes.

### Changes

- `status.ts`: When caffeinate is running, spawn a detached `caffeinate -u -t 1` to assert user activity and reset the idle timer
- `index.tsx`: Filter out `caffeinate -u` processes from `ps` output so they don't interfere with the time-remaining display
- Simplified redundant `if/else if` into a single condition
- Updated `CHANGELOG.md`

### Why this approach

- **Zero persistent processes** — piggybacks on the existing `status` command (runs every 15s); the `-u -t 1` process exits after 1 second
- **No sudo required** — `caffeinate -u` doesn't need elevated privileges
- **No side effects** — `index.tsx` filters out `-u` processes so toggle, status detection, and time-remaining display are unaffected
- **Harmless on older macOS** — the `-u` assertion is a no-op when the idle timer isn't fighting the user

## Screencast

N/A — the fix is behavioral (prevents display sleep on battery). Verified locally on macOS 26.3.1 on battery power with `displaysleep 2` and `sleep 1` pmset settings.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

Fixes #25868