### PR TITLE
Update easy new file extension

### DIFF
--- a/extensions/easy-new-file/CHANGELOG.md
+++ b/extensions/easy-new-file/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Easy New File Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-03-17
 
 - Fix incorrect file extension and file content when entering a plain filename with custom content
 

--- a/extensions/easy-new-file/CHANGELOG.md
+++ b/extensions/easy-new-file/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Easy New File Changelog
 
+## [Update] - {PR_MERGE_DATE}
+
+- Fix incorrect file extension and file content when entering a plain filename with custom content
+
 ## [Default Directory] - 2025-07-16
 
 - Support setting Default Directory for new file command when Finder has no window

--- a/extensions/easy-new-file/package-lock.json
+++ b/extensions/easy-new-file/package-lock.json
@@ -1288,6 +1288,7 @@
       "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -1348,6 +1349,7 @@
       "integrity": "sha512-4O3idHxhyzjClSMJ0a29AcoK0+YwnEqzI6oz3vlRf3xw0zbzt15MzXwItOlnr5nIth6zlY2RENLsOPvhyrKAQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.1",
         "@typescript-eslint/types": "8.34.1",
@@ -1552,6 +1554,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1955,6 +1958,7 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2882,6 +2886,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3131,6 +3136,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3195,6 +3201,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/easy-new-file/package.json
+++ b/extensions/easy-new-file/package.json
@@ -375,5 +375,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/easy-new-file/package.json
+++ b/extensions/easy-new-file/package.json
@@ -5,6 +5,9 @@
   "description": "Quickly create file in the open Finder window.",
   "icon": "easy-new-file-icon.png",
   "author": "koinzhang",
+  "contributors": [
+    "ridemountainpig"
+  ],
   "categories": [
     "Developer Tools",
     "Productivity"

--- a/extensions/easy-new-file/src/new-file-now.tsx
+++ b/extensions/easy-new-file/src/new-file-now.tsx
@@ -46,8 +46,8 @@ export default async (props: LaunchProps<{ arguments: NewFileWithTextArguments }
       ext = fileName.split(".").length > 1 ? fileName.split(".")[1] : "";
     } else {
       const inputFileType = getNewFileType(fileName ? fileName : defaultFileType);
-      ext = inputFileType ? inputFileType.extension : defaultFileType;
-      content = inputFileType.inputContent ? inputText : defaultFileContent;
+      ext = inputFileType && inputFileType.extension ? inputFileType.extension : defaultFileType;
+      content = fileContent ? fileContent : inputFileType.inputContent ? autoContent : "";
       name = !isEmpty(fileName)
         ? inputFileType
           ? inputFileType.name

--- a/extensions/easy-new-file/src/utils/common-utils.ts
+++ b/extensions/easy-new-file/src/utils/common-utils.ts
@@ -140,6 +140,7 @@ function findFileTypeByExtension(fileExt: string): FileType | undefined {
 
 export function getNewFileType(fileName: string): FileType {
   const { baseName, extension } = getFileDetails(fileName);
+  const hasDot = fileName.lastIndexOf(".") !== -1;
   const fileType = findFileTypeByExtension(extension.toLowerCase());
   if (fileType) {
     if (isEmpty(baseName)) {
@@ -150,6 +151,15 @@ export function getNewFileType(fileName: string): FileType {
       newFileType.name = baseName;
     }
     return newFileType;
+  } else if (!hasDot) {
+    return {
+      name: baseName,
+      extension: "",
+      languageId: baseName,
+      keywords: [baseName],
+      icon: Icon.Document,
+      inputContent: true,
+    };
   } else {
     return {
       name: baseName,
@@ -157,7 +167,7 @@ export function getNewFileType(fileName: string): FileType {
       languageId: extension,
       keywords: [extension],
       icon: Icon.Document,
-      inputContent: false,
+      inputContent: true,
     };
   }
 }


### PR DESCRIPTION
## Description
Fix incorrect file extension and file content when entering a plain filename with custom content. Close #26157.
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
