### PR TITLE
fix: transcript fetching

### DIFF
--- a/extensions/summarize-youtube-video-with-ai/CHANGELOG.md
+++ b/extensions/summarize-youtube-video-with-ai/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Summarize YouTube Video Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- 🔧 Fix transcript fetching
+
 ## [Chore] - 2026-02-06
 
 - Moved AbortController inside useEffect

--- a/extensions/summarize-youtube-video-with-ai/CHANGELOG.md
+++ b/extensions/summarize-youtube-video-with-ai/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Summarize YouTube Video Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-03-17
 
 - 🔧 Fix transcript fetching
 

--- a/extensions/summarize-youtube-video-with-ai/package-lock.json
+++ b/extensions/summarize-youtube-video-with-ai/package-lock.json
@@ -75,7 +75,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1570,7 +1569,6 @@
       "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1630,7 +1628,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1861,7 +1858,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2001,7 +1997,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2292,7 +2287,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3214,7 +3208,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3401,7 +3394,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3458,7 +3450,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3657,7 +3648,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/summarize-youtube-video-with-ai/src/utils/transcriptFetcher.ts
+++ b/extensions/summarize-youtube-video-with-ai/src/utils/transcriptFetcher.ts
@@ -82,7 +82,7 @@ function parseTranscriptXml(xml: string): string {
   // Fall back to srv1 format (<text> tags)
   const textSegments = xml.match(/<text[^>]*>[\s\S]*?<\/text>/g);
 
-  const segments = pSegments?.length ? pSegments : textSegments ?? [];
+  const segments = pSegments?.length ? pSegments : (textSegments ?? []);
 
   return segments
     .map((segment: string) => {

--- a/extensions/summarize-youtube-video-with-ai/src/utils/transcriptFetcher.ts
+++ b/extensions/summarize-youtube-video-with-ai/src/utils/transcriptFetcher.ts
@@ -3,7 +3,6 @@ import ytdl from "ytdl-core";
 type CaptionTrack = {
   baseUrl: string;
   languageCode: string;
-  name?: { simpleText: string };
 };
 
 type PlayerResponse = {
@@ -17,24 +16,12 @@ type PlayerResponse = {
   };
 };
 
-const PLAYER_URL = "https://www.youtube.com/youtubei/v1/player?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
-const USER_AGENT = "com.google.android.youtube/19.09.37 (Linux; U; Android 11) gzip";
+const PLAYER_URL = "https://www.youtube.com/youtubei/v1/player?prettyPrint=false";
+const CLIENT_VERSION = "20.10.38";
+const USER_AGENT = `com.google.android.youtube/${CLIENT_VERSION} (Linux; U; Android 14)`;
 
 export async function fetchTranscript(video: string): Promise<string> {
   const videoId = ytdl.getVideoID(video);
-
-  const playerPayload = {
-    context: {
-      client: {
-        clientName: "ANDROID",
-        clientVersion: "19.09.37",
-        androidSdkVersion: 30,
-        hl: "en",
-        gl: "US",
-      },
-    },
-    videoId: videoId,
-  };
 
   const playerResponse = await fetch(PLAYER_URL, {
     method: "POST",
@@ -42,7 +29,15 @@ export async function fetchTranscript(video: string): Promise<string> {
       "Content-Type": "application/json",
       "User-Agent": USER_AGENT,
     },
-    body: JSON.stringify(playerPayload),
+    body: JSON.stringify({
+      context: {
+        client: {
+          clientName: "ANDROID",
+          clientVersion: CLIENT_VERSION,
+        },
+      },
+      videoId,
+    }),
   });
 
   if (!playerResponse.ok) {
@@ -72,12 +67,25 @@ export async function fetchTranscript(video: string): Promise<string> {
     throw new Error("Empty caption response");
   }
 
-  // YouTube srv3 format uses <p> tags (may contain nested <s> tags)
-  const segments = xml.match(/<p[^>]*>[\s\S]*?<\/p>/g) || [];
+  const transcriptText = parseTranscriptXml(xml);
 
-  const transcriptText = segments
+  if (!transcriptText) {
+    throw new Error("Transcript text is empty after parsing");
+  }
+
+  return transcriptText;
+}
+
+function parseTranscriptXml(xml: string): string {
+  // Try srv3 format first (<p> tags with nested <s> tags)
+  const pSegments = xml.match(/<p[^>]*>[\s\S]*?<\/p>/g);
+  // Fall back to srv1 format (<text> tags)
+  const textSegments = xml.match(/<text[^>]*>[\s\S]*?<\/text>/g);
+
+  const segments = pSegments?.length ? pSegments : textSegments ?? [];
+
+  return segments
     .map((segment: string) => {
-      // Strip tags to get text (handles nested elements like <s>)
       return segment
         .replace(/<[^>]+>/g, " ")
         .replace(/\s+/g, " ")
@@ -93,10 +101,4 @@ export async function fetchTranscript(video: string): Promise<string> {
     .replace(/&nbsp;/g, " ")
     .replace(/\s+/g, " ")
     .trim();
-
-  if (!transcriptText) {
-    throw new Error("Transcript text is empty after parsing");
-  }
-
-  return transcriptText;
 }


### PR DESCRIPTION
## Description

Youtube changed its inner workings on how to fetch transcripts

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
