### PR TITLE
feat(kill-process): add kill all action

### DIFF
--- a/extensions/kill-process/.gitignore
+++ b/extensions/kill-process/.gitignore
@@ -8,6 +8,7 @@ raycast-env.d.ts
 .raycast-swift-build
 .swiftpm
 compiled_raycast_swift
+compiled_raycast_rust
 
 # misc
 .DS_Store

--- a/extensions/kill-process/CHANGELOG.md
+++ b/extensions/kill-process/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Kill Process Changelog
 
+## [Added Kill All action] - {PR_MERGE_DATE}
+
+- Added action to kill all processes with the same name
+
 ## [UX Improvements] - 2026-02-11
 
 - Removed the redundant **Default Sort By** preference (sorting is now persisted via the command dropdown)

--- a/extensions/kill-process/CHANGELOG.md
+++ b/extensions/kill-process/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Added Kill All action] - {PR_MERGE_DATE}
 
 - Added action to kill all processes with the same name
+- Added AI tool `killall-process` to allow natural-language "kill all <process>" commands via AI
 
 ## [UX Improvements] - 2026-02-11
 

--- a/extensions/kill-process/CHANGELOG.md
+++ b/extensions/kill-process/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kill Process Changelog
 
-## [Added Kill All action] - {PR_MERGE_DATE}
+## [Added Kill All action] - 2026-04-01
 
 - Added action to kill all processes with the same name
 - Added AI tool `killall-process` to allow natural-language "kill all <process>" commands via AI

--- a/extensions/kill-process/package-lock.json
+++ b/extensions/kill-process/package-lock.json
@@ -1187,6 +1187,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1245,6 +1246,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -1449,6 +1451,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1791,6 +1794,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2546,6 +2550,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2569,6 +2574,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2787,6 +2793,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/kill-process/package-lock.json
+++ b/extensions/kill-process/package-lock.json
@@ -1187,7 +1187,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1246,7 +1245,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -1451,7 +1449,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1794,7 +1791,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2550,7 +2546,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2574,7 +2569,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2793,7 +2787,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/kill-process/package.json
+++ b/extensions/kill-process/package.json
@@ -13,7 +13,8 @@
     "xilopaint",
     "validate",
     "dead_hikikomori",
-    "mateus_badalotti"
+    "mateus_badalotti",
+    "jomifepe"
   ],
   "platforms": [
     "macOS",
@@ -38,6 +39,11 @@
       "name": "kill-process",
       "title": "(Force) Kill Process",
       "description": "Terminates a process by its exact name or PID (Force kill requires enabling sudo authentication with touchID on macOS: https://dev.to/siddhantkcode/enable-touch-id-authentication-for-sudo-on-macos-sonoma-14x-4d28, admin rights on Windows)"
+    },
+    {
+      "name": "killall-process",
+      "title": "(Force) Kill All Processes by Name",
+      "description": "Terminates all processes matching a given name using killall (macOS) or taskkill /IM (Windows). Force kill requires enabling sudo authentication with touchID on macOS, admin rights on Windows."
     }
   ],
   "ai": {
@@ -637,6 +643,51 @@
           },
           {
             "meetsCriteria": "Kills only the main UpNote process, as no helpers and/or related processes were specified"
+          }
+        ]
+      },
+      {
+        "input": "@kill-process kill all node processes",
+        "mocks": {
+          "killall-process": {
+            "success": true,
+            "message": "Killed all \"node\" processes"
+          }
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "killall-process",
+              "arguments": {
+                "processName": "node"
+              }
+            }
+          },
+          {
+            "meetsCriteria": "Kills all node processes using the killall tool"
+          }
+        ]
+      },
+      {
+        "input": "@kill-process force kill all Google Chrome Helper processes",
+        "mocks": {
+          "killall-process": {
+            "success": true,
+            "message": "Killed all \"Google Chrome Helper\" processes"
+          }
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "killall-process",
+              "arguments": {
+                "processName": "Google Chrome Helper",
+                "force": true
+              }
+            }
+          },
+          {
+            "meetsCriteria": "Force kills all Google Chrome Helper processes using elevated privileges"
           }
         ]
       }

--- a/extensions/kill-process/src/index.tsx
+++ b/extensions/kill-process/src/index.tsx
@@ -208,10 +208,10 @@ export default function ProcessList() {
         title: `Killed ${processName}`,
         style: Toast.Style.Success,
       });
-    });
 
-    setFetchResult((prev) => prev.filter((p) => p.id !== process.id));
-    performPostKillActions();
+      setFetchResult((prev) => prev.filter((p) => p.id !== process.id));
+      performPostKillActions();
+    });
   };
 
   const killAllProcesses = async (process: Process, force: boolean = false) => {
@@ -250,10 +250,10 @@ export default function ProcessList() {
         title: `Killed all "${processName}" processes`,
         style: Toast.Style.Success,
       });
-    });
 
-    setFetchResult((prev) => prev.filter((p) => p.processName !== processName));
-    performPostKillActions();
+      setFetchResult((prev) => prev.filter((p) => p.processName !== processName));
+      performPostKillActions();
+    });
   };
 
   const subtitleString = (process: Process): string | undefined => {

--- a/extensions/kill-process/src/index.tsx
+++ b/extensions/kill-process/src/index.tsx
@@ -20,7 +20,13 @@ import prettyBytes from "pretty-bytes";
 import { useEffect, useState } from "react";
 import useInterval from "./hooks/use-interval";
 import { Process } from "./types";
-import { getFileIcon, getKillCommand, getPlatformSpecificErrorHelp, isWindows } from "./utils/platform";
+import {
+  getFileIcon,
+  getKillAllCommand,
+  getKillCommand,
+  getPlatformSpecificErrorHelp,
+  isWindows,
+} from "./utils/platform";
 import { fetchProcessPerformance, fetchRunningProcesses } from "./utils/process";
 
 type SortBy = "cpu" | "memory";
@@ -148,6 +154,32 @@ export default function ProcessList() {
     return getFileIcon(process);
   };
 
+  const handleKillError = (force: boolean) => {
+    const errorHelp = getPlatformSpecificErrorHelp(force);
+    if (force && errorHelp.helpUrl) {
+      confirmAlert({
+        title: errorHelp.title,
+        message: errorHelp.message,
+        primaryAction: {
+          title: "Open Help",
+          onAction: () => open(errorHelp.helpUrl!),
+        },
+      });
+    } else {
+      showToast({
+        title: errorHelp.title,
+        message: errorHelp.message,
+        style: Toast.Style.Failure,
+      });
+    }
+  };
+
+  const performPostKillActions = () => {
+    if (closeWindowAfterKill) closeMainWindow();
+    if (goToRootAfterKill) popToRoot({ clearSearchBar: clearSearchBarAfterKill });
+    if (clearSearchBarAfterKill) clearSearchBar({ forceScrollToTop: true });
+  };
+
   const killProcess = async (process: Process, force: boolean = false) => {
     const processName = process.processName === "-" ? `process ${process.id}?` : process.processName;
     if (!skipConfirmation) {
@@ -168,24 +200,7 @@ export default function ProcessList() {
     const command = getKillCommand(process.id, force);
     exec(command, (error) => {
       if (error) {
-        const errorHelp = getPlatformSpecificErrorHelp(force);
-
-        if (force && errorHelp.helpUrl) {
-          confirmAlert({
-            title: errorHelp.title,
-            message: errorHelp.message,
-            primaryAction: {
-              title: "Open Help",
-              onAction: () => open(errorHelp.helpUrl!),
-            },
-          });
-        } else {
-          showToast({
-            title: errorHelp.title,
-            message: errorHelp.message,
-            style: Toast.Style.Failure,
-          });
-        }
+        handleKillError(force);
         return;
       }
 
@@ -195,16 +210,50 @@ export default function ProcessList() {
       });
     });
 
-    setFetchResult(state.filter((p) => p.id !== process.id));
-    if (closeWindowAfterKill) {
-      closeMainWindow();
+    setFetchResult((prev) => prev.filter((p) => p.id !== process.id));
+    performPostKillActions();
+  };
+
+  const killAllProcesses = async (process: Process, force: boolean = false) => {
+    const processName = process.processName;
+    if (processName === "-") {
+      showToast({
+        title: "Cannot Kill All for unnamed processes",
+        style: Toast.Style.Failure,
+      });
+      return;
     }
-    if (goToRootAfterKill) {
-      popToRoot({ clearSearchBar: clearSearchBarAfterKill });
+
+    if (!skipConfirmation) {
+      if (
+        !(await confirmAlert({
+          title: `${force ? "Force " : ""}Kill all "${processName}" processes?`,
+          rememberUserChoice: true,
+        }))
+      ) {
+        showToast({
+          title: `Cancelled Kill All ${processName}`,
+          style: Toast.Style.Failure,
+        });
+        return;
+      }
     }
-    if (clearSearchBarAfterKill) {
-      clearSearchBar({ forceScrollToTop: true });
-    }
+
+    const command = getKillAllCommand(processName, force);
+    exec(command, (error) => {
+      if (error) {
+        handleKillError(force);
+        return;
+      }
+
+      showToast({
+        title: `Killed all "${processName}" processes`,
+        style: Toast.Style.Success,
+      });
+    });
+
+    setFetchResult((prev) => prev.filter((p) => p.processName !== processName));
+    performPostKillActions();
   };
 
   const subtitleString = (process: Process): string | undefined => {
@@ -416,6 +465,18 @@ export default function ProcessList() {
                   <ActionPanel>
                     <Action title="Kill" icon={Icon.XMarkCircle} onAction={() => killProcess(process)} />
                     <Action title="Force Kill" icon={Icon.XMarkCircle} onAction={() => killProcess(process, true)} />
+                    <Action
+                      title="Kill All"
+                      icon={Icon.XMarkCircleFilled}
+                      shortcut={{ modifiers: ["opt"], key: "return" }}
+                      onAction={() => killAllProcesses(process)}
+                    />
+                    <Action
+                      title="Force Kill All"
+                      icon={Icon.XMarkCircleFilled}
+                      shortcut={{ modifiers: ["opt", "shift"], key: "return" }}
+                      onAction={() => killAllProcesses(process, true)}
+                    />
                     {process.path == null ? null : (
                       <Action.CopyToClipboard
                         title="Copy Path"

--- a/extensions/kill-process/src/tools/killall-process.ts
+++ b/extensions/kill-process/src/tools/killall-process.ts
@@ -1,0 +1,53 @@
+import { exec } from "child_process";
+import { Tool } from "@raycast/api";
+import { getKillAllCommand, getPlatformSpecificErrorHelp } from "../utils/platform";
+
+type Input = {
+  /**
+   * Exact process name to kill all instances of (e.g. "node", "Google Chrome Helper")
+   */
+  processName: string;
+
+  /**
+   * Whether to force kill with elevated privileges
+   */
+  force?: boolean;
+};
+
+/**
+ * Kill all processes matching a given name using killall (macOS) or taskkill /IM (Windows).
+ * Provide the exact process name. All running instances with that name will be terminated.
+ */
+export default async function killAllProcesses(input: Input) {
+  const processName = input.processName.trim();
+  if (!processName || processName === "-") {
+    throw new Error("A valid process name is required");
+  }
+
+  return new Promise((resolve, reject) => {
+    const command = getKillAllCommand(processName, input.force);
+
+    exec(command, (err) => {
+      if (err) {
+        const errorHelp = getPlatformSpecificErrorHelp(input.force ?? false);
+        reject(new Error(`${errorHelp.title}: ${err.message}`));
+        return;
+      }
+
+      resolve({
+        success: true,
+        message: `Killed all "${processName}" processes`,
+      });
+    });
+  });
+}
+
+export const confirmation: Tool.Confirmation<Input> = async (input: Input) => {
+  const info: { name: string; value: string }[] = [{ name: "Process Name", value: input.processName }];
+
+  if (input.force) {
+    info.push({ name: "Force", value: "Yes (elevated privileges)" });
+  }
+
+  return { info };
+};

--- a/extensions/kill-process/src/utils/platform.ts
+++ b/extensions/kill-process/src/utils/platform.ts
@@ -96,7 +96,7 @@ export function getKillAllCommand(processName: string, force = false): string {
     return force ? `taskkill /F /IM "${escaped}"` : `taskkill /IM "${escaped}"`;
   }
   const escaped = processName.replace(/'/g, "'\\''");
-  return force ? `zsh -c 'sudo killall '"'"'${escaped}'"'"''` : `killall '${escaped}'`;
+  return force ? `PROC_NAME='${escaped}' zsh -c 'sudo killall "$PROC_NAME"'` : `killall '${escaped}'`;
 }
 
 /**

--- a/extensions/kill-process/src/utils/platform.ts
+++ b/extensions/kill-process/src/utils/platform.ts
@@ -85,6 +85,21 @@ export function getKillCommand(pid: number, force = false): string {
 }
 
 /**
+ * Get command to kill all processes matching a name.
+ *
+ * It shell-escapes the process name quotes to avoid breakage with names
+ * containing quotes or special characters (e.g. "Foo's Bar").
+ */
+export function getKillAllCommand(processName: string, force = false): string {
+  if (isWindows) {
+    const escaped = processName.replace(/"/g, '\\"');
+    return force ? `taskkill /F /IM "${escaped}"` : `taskkill /IM "${escaped}"`;
+  }
+  const escaped = processName.replace(/'/g, "'\\''");
+  return force ? `zsh -c 'sudo killall '"'"'${escaped}'"'"''` : `killall '${escaped}'`;
+}
+
+/**
  * Parse macOS ps command output line
  * Format: pid ppid cpu mem path
  */

--- a/extensions/kill-process/src/utils/platform.ts
+++ b/extensions/kill-process/src/utils/platform.ts
@@ -92,8 +92,14 @@ export function getKillCommand(pid: number, force = false): string {
  */
 export function getKillAllCommand(processName: string, force = false): string {
   if (isWindows) {
-    const escaped = processName.replace(/"/g, '\\"');
-    return force ? `taskkill /F /IM "${escaped}"` : `taskkill /IM "${escaped}"`;
+    // Use PowerShell Stop-Process by name which accepts the process name without needing the
+    // .exe suffix and handles common name matching (e.g. names from Get-Process).
+    // Escape single quotes for a safe single-quoted PowerShell string.
+    const psName = processName.replace(/'/g, "''");
+    const psScript = `Get-Process -Name '${psName}' -ErrorAction SilentlyContinue | Stop-Process ${
+      force ? "-Force" : ""
+    }`;
+    return `powershell -NoLogo -NoProfile -EncodedCommand ${encodePowerShellCommand(psScript)}`;
   }
   const escaped = processName.replace(/'/g, "'\\''");
   return force ? `PROC_NAME='${escaped}' zsh -c 'sudo killall "$PROC_NAME"'` : `killall '${escaped}'`;


### PR DESCRIPTION
## Description

- New Kill All (⌥+Return) and Force Kill All (⌥ +⇧+Return) actions that terminate every process matching the selected name using `killall` (macOS) / `taskkill /IM` (Windows)
- New `killall-process` AI tool
- Refactored shared kill error-handling and post-kill logic to reduce duplication

## Screencast

https://github.com/user-attachments/assets/caecfa28-fc85-4035-b875-afc334a0b1fb

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [X] I checked that files in the `assets` folder are used by the extension itself
- [X] I checked that assets used by the `README` are placed outside of the `metadata` folder
