### PR TITLE
feat(tailscale): better status command

### DIFF
--- a/extensions/tailscale/CHANGELOG.md
+++ b/extensions/tailscale/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tailscale Changelog
 
-## [Better Status Command] - {PR_MERGE_DATE}
+## [Better Status Command] - 2026-03-18
 
 - Optionally show hostname, tailnet name, and IP in the status command
 

--- a/extensions/tailscale/CHANGELOG.md
+++ b/extensions/tailscale/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tailscale Changelog
 
-## [Better Status Command] - PR_MERGE_DATE
+## [Better Status Command] - {PR_MERGE_DATE}
 
 - Optionally show hostname, tailnet name, and IP in the status command
 

--- a/extensions/tailscale/CHANGELOG.md
+++ b/extensions/tailscale/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Tailscale Changelog
 
+## [Better Status Command] - PR_MERGE_DATE
+
+- Optionally show hostname, tailnet name, and IP in the status command
+
 ## [Show User Login Name] - 2026-02-09
 
 - Shows the user's login name as an accessory in the All Devices command

--- a/extensions/tailscale/package.json
+++ b/extensions/tailscale/package.json
@@ -84,7 +84,7 @@
           "type": "checkbox",
           "required": false,
           "title": "Status Display",
-          "label": "Show hostname",
+          "label": "Show Hostname",
           "description": "Show the device hostname in the status bar",
           "default": true
         },
@@ -92,7 +92,7 @@
           "name": "showIP",
           "type": "checkbox",
           "required": false,
-          "label": "Show IP address",
+          "label": "Show IP Address",
           "description": "Show the Tailscale IP address in the status bar",
           "default": true
         },
@@ -100,9 +100,7 @@
           "name": "showTailnetName",
           "type": "checkbox",
           "required": false,
-          "label": "Show tailnet name",
-          "description": "Show the tailnet name in the status bar",
-          "default": true
+          "label": "Show Tailnet Name",
         }
       ]
     },

--- a/extensions/tailscale/package.json
+++ b/extensions/tailscale/package.json
@@ -101,6 +101,8 @@
           "type": "checkbox",
           "required": false,
           "label": "Show Tailnet Name",
+          "description": "Show the tailnet name in the status bar",
+          "default": true
         }
       ]
     },

--- a/extensions/tailscale/package.json
+++ b/extensions/tailscale/package.json
@@ -77,7 +77,34 @@
       "subtitle": "Tailscale",
       "description": "Show Tailscale's connection status.",
       "mode": "no-view",
-      "interval": "30s"
+      "interval": "30s",
+      "preferences": [
+        {
+          "name": "showHostname",
+          "type": "checkbox",
+          "required": false,
+          "title": "Status Display",
+          "label": "Show hostname",
+          "description": "Show the device hostname in the status bar",
+          "default": true
+        },
+        {
+          "name": "showIP",
+          "type": "checkbox",
+          "required": false,
+          "label": "Show IP address",
+          "description": "Show the Tailscale IP address in the status bar",
+          "default": true
+        },
+        {
+          "name": "showTailnetName",
+          "type": "checkbox",
+          "required": false,
+          "label": "Show tailnet name",
+          "description": "Show the tailnet name in the status bar",
+          "default": true
+        }
+      ]
     },
     {
       "name": "connect",

--- a/extensions/tailscale/src/shared.tsx
+++ b/extensions/tailscale/src/shared.tsx
@@ -39,20 +39,44 @@ export class ENOBUFSError extends Error {}
 export class MaxBufferNaNError extends Error {}
 
 export type StatusDevice = {
-  Active: boolean;
   ID: string;
+  PublicKey: string;
+  HostName: string;
   DNSName: string;
+  OS: string;
+  UserID: number;
+  TailscaleIPs: string[];
+  AllowedIPs: string[];
+  Addrs: string[] | null;
+  CurAddr: string;
+  Relay: string;
+  PeerRelay: string;
+  RxBytes: number;
+  TxBytes: number;
+  Created: string;
+  LastWrite: string;
+  LastSeen: string;
+  LastHandshake: string;
+  Online: boolean;
   ExitNode: boolean;
   ExitNodeOption: boolean;
-  Online: boolean;
-  OS: string;
-  TailscaleIPs: string[];
-  LastSeen: string;
-  UserID: number;
-  HostName: string;
+  Active: boolean;
+  PeerAPIURL: string[] | null;
+  TaildropTarget: number;
+  NoFileSharingReason: string;
+  InNetworkMap: boolean;
+  InMagicSock: boolean;
+  InEngine: boolean;
+  /** Only present when the key has expired. */
+  Expired?: boolean;
+  KeyExpiry?: string;
   /** Present when the device advertises Tailscale SSH (sshHostKeys in status --json). */
   sshHostKeys?: string[];
   Tags?: string[];
+  /** Only present on Self. */
+  Capabilities?: string[];
+  /** Only present on Self. */
+  CapMap?: Record<string, null | string[]>;
   Location?: Location;
 };
 
@@ -61,9 +85,19 @@ export type StatusDevice = {
  */
 export type StatusResponse = {
   Version: string;
+  BackendState: string;
+  HaveNodeKey: boolean;
+  AuthURL: string;
   TailscaleIPs: string[];
   Self: StatusDevice;
+  Health: string[];
   MagicDNSSuffix: string;
+  CurrentTailnet: {
+    Name: string;
+    MagicDNSSuffix: string;
+    MagicDNSEnabled: boolean;
+  };
+  CertDomains: string[] | null;
   Peer: Record<string, StatusDevice>;
   User: Record<
     string,
@@ -71,9 +105,10 @@ export type StatusResponse = {
       ID: number;
       DisplayName: string;
       LoginName: string;
-      ProfilePictureURL: string;
+      ProfilePicURL?: string;
     }
   >;
+  ClientVersion: null | unknown;
 };
 
 /**
@@ -81,11 +116,14 @@ export type StatusResponse = {
  * These are mentioned to not be stable and may change in the future. Doubtful, but possible.
  */
 export type NetcheckResponse = {
+  Now: string;
   UDP: boolean;
-  IPv4: boolean;
-  GlobalV4: string;
   IPv6: boolean;
-  GlobalV6: string;
+  IPv4: boolean;
+  IPv6CanSend: boolean;
+  IPv4CanSend: boolean;
+  OSHasIPv6: boolean;
+  ICMPv4: boolean;
   MappingVariesByDestIP: boolean;
   UPnP: boolean;
   PMP: boolean;
@@ -94,10 +132,15 @@ export type NetcheckResponse = {
   RegionLatency: Record<string, number>;
   RegionV4Latency: Record<string, number>;
   RegionV6Latency: Record<string, number>;
+  GlobalV4Counters: Record<string, number>;
+  GlobalV6Counters: Record<string, number> | null;
+  GlobalV4: string;
+  GlobalV6: string;
+  CaptivePortal: boolean;
 };
 
 export type DerpRegion = {
-  RegionId: number;
+  RegionID: number;
   RegionCode: string;
   RegionName: string;
   Latitude: number;
@@ -141,11 +184,11 @@ export function getNetcheck() {
 }
 
 /**
- * This funtion relies on a debug command, so it may not be stable on the returned value.
+ * This function relies on a debug command, so it may not be stable on the returned value.
  */
 export function getDerpMap() {
   const resp = tailscale("debug netmap");
-  return JSON.parse(resp).DERPMap.Regions as DerpRegion[];
+  return JSON.parse(resp).DERPMap.Regions as Record<string, DerpRegion>;
 }
 
 export function getDevices(status: StatusResponse) {

--- a/extensions/tailscale/src/status.tsx
+++ b/extensions/tailscale/src/status.tsx
@@ -1,4 +1,4 @@
-import { updateCommandMetadata } from "@raycast/api";
+import { getPreferenceValues, updateCommandMetadata } from "@raycast/api";
 import { getDevices, getErrorDetails, getStatus } from "./shared";
 
 export default async function Status() {
@@ -8,14 +8,20 @@ export default async function Status() {
 
     // tailscale is guaranteed to be online because getStatus throws if it isn't
 
-    const magicDNSSuffix = data.MagicDNSSuffix;
-    const devices = getDevices(data);
-    const activeExitNode = devices.find((d) => d.exitnode);
+    const prefs = getPreferenceValues<Preferences.Status>();
 
-    subtitle = `✅ Connected on ${magicDNSSuffix}`;
-    if (activeExitNode) {
-      subtitle += ` via ${activeExitNode.name}`;
-    }
+    const hostname = data.Self.HostName;
+    const ip = data.Self.TailscaleIPs[0];
+    const tailnetName = data.CurrentTailnet.Name;
+
+    const activeExitNode = getDevices(data).find((d) => d.exitnode);
+
+    subtitle = "✅ Connected";
+
+    if (prefs.showHostname) subtitle += ` as ${hostname}`;
+    if (prefs.showIP) subtitle += ` (${ip})`;
+    if (activeExitNode) subtitle += ` via ${activeExitNode.name}`;
+    if (prefs.showTailnetName) subtitle += ` on ${tailnetName}`;
   } catch (err) {
     subtitle = "❌ " + getErrorDetails(err, "").title;
   }


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

adds customization to the status command. it can now show/hide:
- tailscale ip
- hostname
- tailnet (useful if u have more than one account)

It previously showed the magicDNS suffix, which isn't really helpful.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

<img width="988" height="78" alt="CleanShot 2026-03-17 at 20 55 08" src="https://github.com/user-attachments/assets/1ac0ebce-e3b1-4760-b965-ce19444c9acf" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
