### PR TITLE
Update focus extension

### DIFF
--- a/extensions/focus/CHANGELOG.md
+++ b/extensions/focus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Focus Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-03-18
 - Fixed a timeout error when opening Focus preferences from the "No profiles found" state.
 
 ## [Enhancement] - 2026-03-16

--- a/extensions/focus/CHANGELOG.md
+++ b/extensions/focus/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Focus Changelog
+## [Fix] - {PR_MERGE_DATE}
+- Fixed a timeout error when opening Focus preferences from the "No profiles found" state.
+
 ## [Enhancement] - {PR_MERGE_DATE}
 - Commands now close the Raycast window automatically on success, showing a brief HUD notification instead of keeping the window open.
 

--- a/extensions/focus/CHANGELOG.md
+++ b/extensions/focus/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Focus Changelog
+
 ## [Fix] - {PR_MERGE_DATE}
 - Fixed a timeout error when opening Focus preferences from the "No profiles found" state.
 
-## [Enhancement] - {PR_MERGE_DATE}
+## [Enhancement] - 2026-03-16
 - Commands now close the Raycast window automatically on success, showing a brief HUD notification instead of keeping the window open.
 
 ## [Enhancement] - 2026-03-12

--- a/extensions/focus/src/start-focus-with-profile.tsx
+++ b/extensions/focus/src/start-focus-with-profile.tsx
@@ -1,5 +1,5 @@
 import { Toast, showToast, showHUD, List, ActionPanel, Action, Icon, closeMainWindow } from "@raycast/api";
-import { getProfileNames, startFocusWithProfile, getActiveProfileName } from "./utils";
+import { getProfileNames, startFocusWithProfile, getActiveProfileName, openPreferences } from "./utils";
 import { useCachedPromise } from "@raycast/utils";
 import { ensureFocusIsRunning } from "./helpers";
 
@@ -47,7 +47,7 @@ export default function Command() {
           title="No profiles found"
           actions={
             <ActionPanel>
-              <Action.OpenInBrowser title="Open Focus Preferences" url="focus://preferences" />
+              <Action title="Open Focus Preferences" onAction={openPreferences} />
             </ActionPanel>
           }
         />


### PR DESCRIPTION
## Description

Fixed open-preferences timeout when running the "opening Focus preferences" command


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
