### PR TITLE
GitLab: Fix JSON parse error on `Mark All as Done`

### DIFF
--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitLab Changelog
 
-## [Fix "Mark All as Done" error] - {PR_MERGE_DATE}
+## [Fix "Mark All as Done" error] - 2026-03-19
 
 - Fix JSON parse error when marking all todos as done (HTTP 204 No Content)
 

--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitLab Changelog
 
+## [Fix "Mark All as Done" error] - {PR_MERGE_DATE}
+
+- Fix JSON parse error when marking all todos as done (HTTP 204 No Content)
+
 ## [Bugfix merge requests] - 2026-02-18
 
 - Update merge request list to show approvals properly

--- a/extensions/gitlab/src/gitlabapi.ts
+++ b/extensions/gitlab/src/gitlabapi.ts
@@ -504,12 +504,16 @@ export class GitLab {
       if (s === 204 || s === 304) {
         return;
       }
+
       if (s >= 200 && s < 300) {
-        const json = await response.json();
-        return json;
-      } else if (s == 401) {
+        return await response.json();
+      }
+
+      if (s === 401) {
         throw Error("Unauthorized");
-      } else if (s == 403) {
+      }
+
+      if (s === 403) {
         const json = (await response.json()) as any;
         let msg = "Forbidden";
         if (json.error && json.error == "insufficient_scope") {
@@ -517,9 +521,13 @@ export class GitLab {
         }
         logAPI(msg);
         throw Error(msg);
-      } else if (s == 404) {
+      }
+
+      if (s === 404) {
         throw Error("Not found");
-      } else if (s >= 400 && s < 500) {
+      }
+
+      if (s >= 400 && s < 500) {
         const json = (await response.json()) as any;
         logAPI(json);
         let msg = `http status ${s}`;
@@ -528,10 +536,10 @@ export class GitLab {
           msg = JSON.stringify(json.message);
         }
         throw Error(msg);
-      } else {
-        logAPI("unknown error");
-        throw Error(`http status ${s}`);
       }
+
+      logAPI("unknown error");
+      throw Error(`http status ${s}`);
     } catch (e: any) {
       logAPI(`catch error: ${e}`);
       throw Error(e.message); // rethrow error, otherwise raycast could not catch the error

--- a/extensions/gitlab/src/gitlabapi.ts
+++ b/extensions/gitlab/src/gitlabapi.ts
@@ -501,12 +501,12 @@ export class GitLab {
       });
       const s = response.status;
       logAPI(`status code: ${s}`);
+      if (s === 204 || s === 304) {
+        return;
+      }
       if (s >= 200 && s < 300) {
         const json = await response.json();
         return json;
-      } else if (s === 304) {
-        // Not Modified
-        // ignored
       } else if (s == 401) {
         throw Error("Unauthorized");
       } else if (s == 403) {


### PR DESCRIPTION
## Description

Fix "Mark All as Done" action showing error toast (`Failed to Close All to do's: Unexpected end of JSON input`) despite successfully marking todos as done on the server.

- GitLab's `POST /todos/mark_as_done` returns HTTP 204 No Content, but `post()` unconditionally called `response.json()`, which throws on an empty body. Added an early return for 204 (and 304) responses before JSON parsing.
- Flattened `post()` status handling from an `else if` chain to just if statements for readability. Every branch returns or throws.

## Screencast

N/A, bug fix only, no UI changes.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)