### PR TITLE
[Coffee] Fix zombie process accumulation in status command

### DIFF
--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Coffee Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed zombie process accumulation caused by unreaped `caffeinate -u` child processes in the status command.
+
 ## [Fix] - 2026-03-17
 
 - Fixed caffeination not preventing display sleep on macOS 26+ when running on battery power.

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coffee Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-03-19
 
 - Fixed zombie process accumulation caused by unreaped `caffeinate -u` child processes in the status command.
 

--- a/extensions/coffee/src/status.ts
+++ b/extensions/coffee/src/status.ts
@@ -66,9 +66,9 @@ export default async function Command() {
     // every 15 seconds (this command's interval) keeps the display awake
     // without requiring elevated privileges or additional processes.
     const child = spawn("/usr/bin/caffeinate", ["-u", "-t", "1"], {
-      detached: true,
       stdio: "ignore",
     });
+    child.on("exit", () => {});
     child.unref();
   }
 

--- a/extensions/coffee/src/utils.ts
+++ b/extensions/coffee/src/utils.ts
@@ -22,6 +22,7 @@ export async function startCaffeinate(updates: Updates, hudMessage?: string, add
     detached: true,
     stdio: "ignore",
   });
+  child.on("exit", () => {});
   child.unref();
 
   await update(updates, true);


### PR DESCRIPTION
## Summary

- Fixed zombie process accumulation caused by unreaped `caffeinate -u` child processes spawned by the status command every 15 seconds
- `spawn()` with `detached: true` + `unref()` but no `exit` handler means Node.js never calls `waitpid()` — each child becomes a zombie after ~1 second
- At **4 zombies/min** this exhausts `kern.maxprocperuid` (4000 on macOS) within a day, causing system-wide **EAGAIN** errors

## Changes

- **`status.ts`**: Removed `detached: true` (unnecessary for a 1-second process) and added `child.on("exit", () => {})` to trigger `waitpid()` and reap the child
- **`utils.ts`**: Kept `detached: true` (long-running caffeinate needs to survive the extension helper) but added `child.on("exit", () => {})` to reap the zombie if the process ends while the helper is still alive

## Test plan

- [x] Run `watch -n5 'ps aux | awk "\$8 ~ /Z/" | wc -l'` with Coffee active — zombie count should stay at 0
- [x] Verify caffeination still works: enable Coffee, confirm display sleep is prevented
- [x] Verify scheduled caffeination still works
- [x] `npm run build` passes cleanly