### PR TITLE
[Android] Add cold boot option for emulators

### DIFF
--- a/extensions/android/CHANGELOG.md
+++ b/extensions/android/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Android Changelog
 
-## [Feature Update] - {PR_MERGE_DATE}
+## [Feature Update] - 2026-03-24
 
 - Add "Start (Cold Boot)" emulator action
 

--- a/extensions/android/CHANGELOG.md
+++ b/extensions/android/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Android Changelog
 
+## [Feature Update] - {PR_MERGE_DATE}
+
+- Add "Start (Cold Boot)" emulator action
+
 ## [Feature Update] - 2025-01-14
 
 - Add shake emulator action

--- a/extensions/android/package.json
+++ b/extensions/android/package.json
@@ -77,5 +77,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/android/src/list-emulators.tsx
+++ b/extensions/android/src/list-emulators.tsx
@@ -273,11 +273,19 @@ export default function Command() {
               )}
 
               {emulator.state === EmulatorState.Shutdown && (
-                <Action
-                  title="Start"
-                  icon={Icon.Power}
-                  onAction={() => openEmulator(emulator.name)}
-                />
+                <ActionPanel.Section title="Start">
+                  <Action
+                    title="Start"
+                    icon={Icon.Power}
+                    onAction={() => openEmulator(emulator.name)}
+                  />
+                  <Action
+                    title="Start (Cold Boot)"
+                    icon={Icon.Power}
+                    shortcut={{ modifiers: ["cmd", "shift"], key: "enter" }}
+                    onAction={() => openEmulatorColdBoot(emulator.name)}
+                  />
+                </ActionPanel.Section>
               )}
             </ActionPanel>
           }
@@ -288,13 +296,18 @@ export default function Command() {
 }
 
 function openEmulator(emulator: string) {
+  startEmulator(emulator, undefined, (error) => {
+    showToast(Toast.Style.Failure, "Failed to start emulator", error);
+  });
+}
+
+function openEmulatorColdBoot(emulator: string) {
   startEmulator(
     emulator,
-    (data) => {
-      popToRoot;
-    },
+    undefined,
     (error) => {
-      // showToast(Toast.Style.Failure, error);
-    }
+      showToast(Toast.Style.Failure, "Failed to start emulator", error);
+    },
+    ["-no-snapshot-load"]
   );
 }

--- a/extensions/android/src/util/emulatorUtil.ts
+++ b/extensions/android/src/util/emulatorUtil.ts
@@ -95,7 +95,9 @@ export async function getEmulators(): Promise<Emulator[]> {
 export async function startEmulator(
   emulatorName: string,
   output: ((out: string) => void) | undefined,
-  error: ((error: string) => void) | undefined
+  error: ((error: string) => void) | undefined,
+  extraArgs?: string[]
 ) {
-  runCommand(`${emulatorPath} @${emulatorName}`, output, error);
+  const args = extraArgs ? ` ${extraArgs.join(" ")}` : "";
+  runCommand(`${emulatorPath} @${emulatorName}${args}`, output, error);
 }


### PR DESCRIPTION
## Description

Add a "Start (Cold Boot)" action to the emulator list for shutdown emulators, which launches with the `-no-snapshot-load` flag.

## Screencast

https://github.com/user-attachments/assets/abc048bc-1d75-45cd-8614-3372351b8743

(Truncated due to GitHub upload size limits)

✅ "Start" — starts emulator, resumes saved state (default)
✅ "Start (cold boot)" [new option] — starts emulator without saved state

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
