### PR TITLE
[Coffee] Fix zombie process leak in status command

### DIFF
--- a/extensions/coffee/src/status.ts
+++ b/extensions/coffee/src/status.ts
@@ -1,5 +1,5 @@
 import { LocalStorage, updateCommandMetadata } from "@raycast/api";
-import { spawn } from "node:child_process";
+import { execFile } from "node:child_process";
 import { Schedule, startCaffeinate, getSchedule, stopCaffeinate, isCaffeinateRunning } from "./utils";
 
 async function handleScheduledCaffeinate(schedule: Schedule): Promise<boolean> {
@@ -65,11 +65,9 @@ export default async function Command() {
     // override caffeinate's -d/-i assertions. Asserting user activity
     // every 15 seconds (this command's interval) keeps the display awake
     // without requiring elevated privileges or additional processes.
-    const child = spawn("/usr/bin/caffeinate", ["-u", "-t", "1"], {
-      stdio: "ignore",
-    });
-    child.on("exit", () => {});
-    child.unref();
+    // Uses execFile (not spawn+unref) to guarantee the child is reaped
+    // and doesn't become a zombie in the persistent extension daemon.
+    execFile("/usr/bin/caffeinate", ["-u", "-t", "1"], () => {});
   }
 
   updateCommandMetadata({ subtitle });


### PR DESCRIPTION
## Description

Hardens the `status` background command's idle-timer reset (`caffeinate -u -t 1`) against zombie process creation in the Raycast extension daemon.

Multiple users [reported](https://www.reddit.com/r/raycastapp/comments/1rx6kzx/raycast_creates_defunct_processes_continually/) zombie processes accumulating under `Raycast Helper (Extensions)` after #26390 was merged. Credit to u/thepante for tracing the root cause to that PR.

### Investigation

- The current code on `main` uses `spawn()` + `child.on("exit", () => {})` + `child.unref()` (without `detached: true`). In standalone Node.js testing — including with forced GC — this pattern does **not** produce zombies.
- The original #26390 diff included `detached: true`, which was subsequently removed. Users who received the extension update before this change may still be running the version with `detached: true`, which is the likely cause of the zombie accumulation.
- We were unable to reproduce the zombie flood with the current `main` code, but the `spawn` + `unref` pattern remains fragile — its safety depends on Node.js/libuv internals and the Raycast runtime's event loop behavior.

### Fix

Replace `spawn()` + `unref()` with `execFile()` + callback:

```ts
// Before:
const child = spawn("/usr/bin/caffeinate", ["-u", "-t", "1"], { stdio: "ignore" });
child.on("exit", () => {});
child.unref();

// After:
execFile("/usr/bin/caffeinate", ["-u", "-t", "1"], () => {});
```

`execFile()` with a callback maintains an internal reference to the child process and guarantees `waitpid()` is called when it exits. This eliminates any possibility of zombie creation regardless of runtime behavior.

### Why this approach

- **Guaranteed reaping** — `execFile` callback-based lifecycle ensures `waitpid()` always runs
- **Non-blocking** — doesn't stall the background command
- **Same functionality** — still asserts user activity via `caffeinate -u -t 1`
- **Simpler** — one line vs five

Related: #9410, #20456, #26420 (same pattern in System Monitor)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build
- [x] I checked that files in the `assets` folder are used by the extension itself

Fixes #26463