### PR TITLE
[Mole] Add residual file cleanup to Uninstall command

### DIFF
--- a/extensions/mole/CHANGELOG.md
+++ b/extensions/mole/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mole Changelog
 
-## [Uninstall Residual Cleanup] - {PR_MERGE_DATE}
+## [Uninstall Residual Cleanup] - 2026-03-20
 
 - Added deep residual file scanning when uninstalling apps (searches ~/Library, /Library, containers, and vendor directories)
 - Shows a confirmation dialog listing all found residuals with sizes before removal

--- a/extensions/mole/CHANGELOG.md
+++ b/extensions/mole/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Migrated error handling to `showFailureToast` from `@raycast/utils`
 - Replaced manual Preferences type with auto-generated `ExtensionPreferences`
 
-## [1.0.0] - {PR_MERGE_DATE}
+## [1.0.0] - 2026-03-18
 
 - Added System Status command with real-time health monitoring
 - Added Clean System command with streaming scan progress

--- a/extensions/mole/CHANGELOG.md
+++ b/extensions/mole/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Mole Changelog
 
-## [1.0.0] - 2026-03-18
+## [Uninstall Residual Cleanup] - {PR_MERGE_DATE}
+
+- Added deep residual file scanning when uninstalling apps (searches ~/Library, /Library, containers, and vendor directories)
+- Shows a confirmation dialog listing all found residuals with sizes before removal
+- Hides removed apps from the list after successful uninstall
+- Migrated error handling to `showFailureToast` from `@raycast/utils`
+- Replaced manual Preferences type with auto-generated `ExtensionPreferences`
+
+## [1.0.0] - {PR_MERGE_DATE}
 
 - Added System Status command with real-time health monitoring
 - Added Clean System command with streaming scan progress

--- a/extensions/mole/package.json
+++ b/extensions/mole/package.json
@@ -67,7 +67,7 @@
       "name": "uninstall",
       "title": "Uninstall App",
       "subtitle": "Mole",
-      "description": "Browse installed applications and move them to the Trash",
+      "description": "Uninstall apps and clean residual files from Library, Caches, and Preferences",
       "mode": "view",
       "keywords": ["uninstall", "remove", "delete", "app", "application"]
     },

--- a/extensions/mole/src/analyze.tsx
+++ b/extensions/mole/src/analyze.tsx
@@ -1,4 +1,5 @@
 import { List, Icon, Color, ActionPanel, Action, getPreferenceValues, trash, showToast, Toast } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
 import { execFile } from "child_process";
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { getMolePathSafe, MOLE_ENV } from "./utils/mole";
@@ -115,11 +116,7 @@ function AnalyzeList({ molePath, dirPath }: { molePath: string; dirPath: string 
                     await showToast({ style: Toast.Style.Success, title: `${entry.name} trashed` });
                     revalidate();
                   } catch (err) {
-                    await showToast({
-                      style: Toast.Style.Failure,
-                      title: "Failed",
-                      message: err instanceof Error ? err.message : String(err),
-                    });
+                    await showFailureToast(err, { title: "Move to Trash failed" });
                   }
                 }}
               />

--- a/extensions/mole/src/clean.tsx
+++ b/extensions/mole/src/clean.tsx
@@ -1,4 +1,5 @@
 import { List, Icon, Color, ActionPanel, Action, Toast, showToast, confirmAlert } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
 import { spawn, type ChildProcess } from "child_process";
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { getMolePathSafe, runMole, MOLE_ENV } from "./utils/mole";
@@ -129,9 +130,7 @@ function CleanView({ molePath }: { molePath: string }) {
           itemsCount: preCleanItems,
         });
       } catch (err) {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Clean failed";
-        toast.message = err instanceof Error ? err.message : String(err);
+        await showFailureToast(err, { title: "Clean failed" });
       }
     }
   }

--- a/extensions/mole/src/installer.tsx
+++ b/extensions/mole/src/installer.tsx
@@ -1,4 +1,5 @@
 import { List, Icon, Color, ActionPanel, Action, Toast, showToast, confirmAlert, trash } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
 import { readdirSync, statSync } from "fs";
 import { join } from "path";
 import { useState, useEffect, useMemo } from "react";
@@ -104,9 +105,7 @@ function InstallerView() {
         toast.message = `${formatBytes(totalSize)} freed`;
         revalidate();
       } catch (err) {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Remove failed";
-        toast.message = err instanceof Error ? err.message : String(err);
+        await showFailureToast(err, { title: "Remove failed" });
       }
     }
   }
@@ -173,11 +172,7 @@ function InstallerView() {
                           await showToast({ style: Toast.Style.Success, title: `${file.name} removed` });
                           revalidate();
                         } catch (err) {
-                          await showToast({
-                            style: Toast.Style.Failure,
-                            title: "Failed",
-                            message: err instanceof Error ? err.message : String(err),
-                          });
+                          await showFailureToast(err, { title: "Remove failed" });
                         }
                       }
                     }}

--- a/extensions/mole/src/optimize.tsx
+++ b/extensions/mole/src/optimize.tsx
@@ -1,5 +1,5 @@
 import { List, Icon, Color, ActionPanel, Action, Toast, showToast, confirmAlert } from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
+import { useCachedPromise, showFailureToast } from "@raycast/utils";
 import { useMemo } from "react";
 import { getMolePathSafe, runMole } from "./utils/mole";
 import { parseOptimizeDryRun } from "./utils/parsers";
@@ -43,9 +43,7 @@ function OptimizeView() {
         toast.title = "System optimized successfully";
         revalidate();
       } catch (error) {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Optimization failed";
-        toast.message = error instanceof Error ? error.message : String(error);
+        await showFailureToast(error, { title: "Optimization failed" });
       }
     }
   }

--- a/extensions/mole/src/purge.tsx
+++ b/extensions/mole/src/purge.tsx
@@ -1,4 +1,5 @@
 import { List, Icon, Color, ActionPanel, Action, Toast, showToast, confirmAlert, trash } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
 import { execFile } from "child_process";
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { getMolePathSafe, getMolePath, runMole, MOLE_ENV } from "./utils/mole";
@@ -85,9 +86,7 @@ function PurgeView() {
         toast.message = `${data?.totalSpace ?? ""} recovered`;
         revalidate();
       } catch (err) {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Purge failed";
-        toast.message = err instanceof Error ? err.message : String(err);
+        await showFailureToast(err, { title: "Purge failed" });
       }
     }
   }
@@ -161,9 +160,7 @@ function PurgeView() {
                           t.message = `${item.size} freed from ${item.projectName}`;
                           revalidate();
                         } catch (err) {
-                          t.style = Toast.Style.Failure;
-                          t.title = "Remove failed";
-                          t.message = err instanceof Error ? err.message : String(err);
+                          await showFailureToast(err, { title: "Remove failed" });
                         }
                       }
                     }}

--- a/extensions/mole/src/uninstall.tsx
+++ b/extensions/mole/src/uninstall.tsx
@@ -1,6 +1,7 @@
 import { List, Icon, ActionPanel, Action, Alert, showToast, Toast, confirmAlert, trash } from "@raycast/api";
-import { readdirSync, statSync } from "fs";
-import { join } from "path";
+import { readdirSync, statSync, existsSync, readFileSync, writeFileSync, unlinkSync } from "fs";
+import { join, basename } from "path";
+import { showFailureToast } from "@raycast/utils";
 import { useState, useEffect, useMemo } from "react";
 import { getMolePathSafe } from "./utils/mole";
 import { formatBytes } from "./utils/parsers";
@@ -13,12 +14,381 @@ interface AppInfo {
   lastModified: Date;
 }
 
+interface ResidualFile {
+  path: string;
+  size: number;
+  location: string;
+}
+
+interface AppIdentifiers {
+  bundleId: string | null;
+  bundleName: string | null;
+  displayName: string | null;
+  executableName: string | null;
+}
+
+const HOME = process.env.HOME || "";
+
+const USER_LIBRARY_DIRS = [
+  "Application Scripts",
+  "Application Support",
+  "Application Support/CrashReporter",
+  "Caches",
+  "Containers",
+  "Cookies",
+  "Group Containers",
+  "HTTPStorages",
+  "Internet Plug-Ins",
+  "LaunchAgents",
+  "Logs",
+  "Logs/DiagnosticReports",
+  "Preferences",
+  "Preferences/ByHost",
+  "PreferencePanes",
+  "Saved Application State",
+  "Services",
+  "WebKit",
+];
+
+const SYSTEM_LIBRARY_DIRS = [
+  "/Library/Application Support",
+  "/Library/Application Support/CrashReporter",
+  "/Library/Caches",
+  "/Library/Extensions",
+  "/Library/Internet Plug-Ins",
+  "/Library/LaunchAgents",
+  "/Library/LaunchDaemons",
+  "/Library/Logs",
+  "/Library/Logs/DiagnosticReports",
+  "/Library/Preferences",
+  "/Library/PreferencePanes",
+  "/Library/PrivilegedHelperTools",
+];
+
+const EXTRA_SEARCH_PATHS = [
+  join(HOME, ".config"),
+  "/private/var/db/receipts",
+  "/private/tmp",
+  "/usr/local/bin",
+  "/usr/local/etc",
+  "/usr/local/opt",
+  "/usr/local/share",
+];
+
+const SKIP_DEEP_SEARCH = new Set([
+  "accounts",
+  "addressbook",
+  "appletv",
+  "assistant",
+  "assistants",
+  "audio",
+  "autosave information",
+  "biome",
+  "calendars",
+  "callservices",
+  "cloudstorage",
+  "colorpickers",
+  "colors",
+  "compositions",
+  "contacts",
+  "containermanager",
+  "daemon containers",
+  "datadeliveryservices",
+  "developer",
+  "donotdisturb",
+  "favorites",
+  "finance",
+  "fontcollections",
+  "fonts",
+  "frontboard",
+  "gamekit",
+  "homekit",
+  "identityservices",
+  "input methods",
+  "intents",
+  "keychains",
+  "keyboard layouts",
+  "keyboardservices",
+  "languagemodeling",
+  "lockdownmode",
+  "mail",
+  "messages",
+  "metadata",
+  "mobile documents",
+  "passes",
+  "photos",
+  "printers",
+  "responsekit",
+  "safari",
+  "sharing",
+  "shortcuts",
+  "sounds",
+  "spelling",
+  "spotlight",
+  "suggestions",
+  "translation",
+  "trial",
+  "weather",
+]);
+
+function trashWithAdmin(paths: string[]): Promise<void> {
+  const trashDir = join(HOME, ".Trash");
+  const scriptPath = join(process.env.TMPDIR || "/tmp", `mole-trash-${Date.now()}.sh`);
+  const lines = paths.map((p) => `mv '${p.replace(/'/g, "'\\''")}' '${trashDir}/'`);
+  writeFileSync(scriptPath, lines.join("\n"), { mode: 0o755 });
+
+  const appleScript = `do shell script "${scriptPath}" with administrator privileges`;
+  return new Promise((resolve, reject) => {
+    execFile("/usr/bin/osascript", ["-e", appleScript], (err) => {
+      try {
+        unlinkSync(scriptPath);
+      } catch {
+        /* ignore */
+      }
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+}
+
+function normalize(str: string): string {
+  return str.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function readPlistKey(plistPath: string, key: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile("/usr/bin/defaults", ["read", plistPath, key], (err, stdout) => {
+      if (err) return resolve(null);
+      resolve(stdout.trim() || null);
+    });
+  });
+}
+
+async function getAppIdentifiers(appPath: string): Promise<AppIdentifiers> {
+  const plistPath = join(appPath, "Contents", "Info.plist");
+  if (!existsSync(plistPath)) {
+    return { bundleId: null, bundleName: null, displayName: null, executableName: null };
+  }
+
+  const [bundleId, bundleName, displayName, executableName] = await Promise.all([
+    readPlistKey(plistPath, "CFBundleIdentifier"),
+    readPlistKey(plistPath, "CFBundleName"),
+    readPlistKey(plistPath, "CFBundleDisplayName"),
+    readPlistKey(plistPath, "CFBundleExecutable"),
+  ]);
+
+  return { bundleId, bundleName, displayName, executableName };
+}
+
+function getDirSize(dirPath: string): Promise<number> {
+  return new Promise((resolve) => {
+    execFile("du", ["-sk", dirPath], (err, stdout) => {
+      if (err) return resolve(0);
+      resolve(parseInt(stdout.split("\t")[0] || "0") * 1024);
+    });
+  });
+}
+
+function buildSearchTerms(appName: string, identifiers: AppIdentifiers): string[] {
+  const terms = new Set<string>();
+
+  terms.add(normalize(appName));
+
+  const nameStripped = appName.replace(/\s*\d+(\.\d+)*\s*$/, "");
+  if (nameStripped !== appName) terms.add(normalize(nameStripped));
+
+  if (identifiers.bundleId) {
+    terms.add(normalize(identifiers.bundleId));
+
+    const parts = identifiers.bundleId.split(".");
+    if (parts.length >= 3) {
+      terms.add(normalize(parts.slice(-2).join("")));
+    }
+
+    const baseBundleId = identifiers.bundleId.replace(
+      /\.(helper|agent|daemon|service|xpc|launcher|updater|installer|uninstaller|login|extension|plugin|shipit)$/i,
+      "",
+    );
+    if (baseBundleId !== identifiers.bundleId) terms.add(normalize(baseBundleId));
+  }
+
+  if (identifiers.bundleName) terms.add(normalize(identifiers.bundleName));
+  if (identifiers.displayName) terms.add(normalize(identifiers.displayName));
+  if (identifiers.executableName) terms.add(normalize(identifiers.executableName));
+
+  return [...terms].filter((t) => t.length >= 3);
+}
+
+function extractVendorName(bundleId: string | null): string | null {
+  if (!bundleId) return null;
+  const parts = bundleId.split(".");
+  if (parts.length < 3) return null;
+  const vendor = parts[1];
+  if (!vendor || vendor.length < 2) return null;
+  return vendor.toLowerCase();
+}
+
+function matchesApp(entry: string, searchTerms: string[], bundleId: string | null): boolean {
+  const entryNormalized = normalize(entry.replace(/\.plist$/, ""));
+
+  if (entryNormalized.length < 3) return false;
+
+  for (const term of searchTerms) {
+    if (entryNormalized === term) return true;
+    if (term.length >= 5 && entryNormalized.includes(term)) return true;
+  }
+
+  if (bundleId) {
+    const bundleNorm = normalize(bundleId);
+    if (entryNormalized.includes(bundleNorm)) return true;
+  }
+
+  return false;
+}
+
+function safeReaddir(dirPath: string): string[] {
+  try {
+    return readdirSync(dirPath);
+  } catch {
+    return [];
+  }
+}
+
+function scanFlat(dirPath: string, searchTerms: string[], bundleId: string | null): string[] {
+  if (!existsSync(dirPath)) return [];
+  return safeReaddir(dirPath)
+    .filter((entry) => matchesApp(entry, searchTerms, bundleId))
+    .map((entry) => join(dirPath, entry));
+}
+
+function scanDeep(dirPath: string, searchTerms: string[], bundleId: string | null): string[] {
+  if (!existsSync(dirPath)) return [];
+  const results = scanFlat(dirPath, searchTerms, bundleId);
+
+  for (const entry of safeReaddir(dirPath)) {
+    if (SKIP_DEEP_SEARCH.has(entry.toLowerCase())) continue;
+
+    const subPath = join(dirPath, entry);
+    try {
+      if (!statSync(subPath).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    const subMatches = safeReaddir(subPath)
+      .filter((sub) => matchesApp(sub, searchTerms, bundleId))
+      .map((sub) => join(subPath, sub));
+
+    results.push(...subMatches);
+  }
+
+  return results;
+}
+
+function scanContainersByBundleId(bundleId: string): string[] {
+  const containersDir = join(HOME, "Library", "Containers");
+  if (!existsSync(containersDir)) return [];
+  const results: string[] = [];
+
+  for (const entry of safeReaddir(containersDir)) {
+    if (/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(entry)) {
+      const metadataPath = join(containersDir, entry, ".com.apple.containermanagerd.metadata.plist");
+      if (!existsSync(metadataPath)) continue;
+      try {
+        const content = readFileSync(metadataPath, "utf-8");
+        if (content.includes(bundleId)) {
+          results.push(join(containersDir, entry));
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return results;
+}
+
+async function findResidualFiles(appName: string, identifiers: AppIdentifiers): Promise<ResidualFile[]> {
+  const residuals: ResidualFile[] = [];
+  const foundPaths = new Set<string>();
+  const searchTerms = buildSearchTerms(appName, identifiers);
+
+  const addMatch = async (fullPath: string, location: string) => {
+    if (foundPaths.has(fullPath)) return;
+    foundPaths.add(fullPath);
+    try {
+      const size = await getDirSize(fullPath);
+      residuals.push({ path: fullPath, size, location });
+    } catch {
+      /* empty */
+    }
+  };
+
+  for (const dir of USER_LIBRARY_DIRS) {
+    const libraryDir = join(HOME, "Library", dir);
+    const matches = scanFlat(libraryDir, searchTerms, identifiers.bundleId);
+    for (const match of matches) await addMatch(match, dir);
+  }
+
+  const deepScanDirs = [join(HOME, "Library"), "/Library"];
+  for (const dir of deepScanDirs) {
+    if (!existsSync(dir)) continue;
+    const label = dir === "/Library" ? "System Library" : "Library";
+    const matches = scanDeep(dir, searchTerms, identifiers.bundleId);
+    for (const match of matches) {
+      if (foundPaths.has(match)) continue;
+      const parentName = basename(join(match, ".."));
+      const locationLabel = parentName === basename(dir) ? label : `${label}/${parentName}`;
+      await addMatch(match, locationLabel);
+    }
+  }
+
+  for (const dir of SYSTEM_LIBRARY_DIRS) {
+    if (!existsSync(dir)) continue;
+    const matches = scanFlat(dir, searchTerms, identifiers.bundleId);
+    const label = dir.replace("/Library/", "System ");
+    for (const match of matches) await addMatch(match, label);
+  }
+
+  for (const dir of EXTRA_SEARCH_PATHS) {
+    if (!existsSync(dir)) continue;
+    const matches = scanFlat(dir, searchTerms, identifiers.bundleId);
+    const label = dir.startsWith(HOME) ? dir.replace(HOME, "~") : dir;
+    for (const match of matches) await addMatch(match, label);
+  }
+
+  if (identifiers.bundleId) {
+    const vendorName = extractVendorName(identifiers.bundleId);
+    if (vendorName) {
+      const vendorSearchDirs = [
+        join(HOME, "Library", "Application Support"),
+        join(HOME, "Library", "Caches"),
+        join(HOME, "Library", "Logs"),
+        "/Library/Application Support",
+        "/Library/Caches",
+      ];
+      for (const dir of vendorSearchDirs) {
+        const vendorDir = join(dir, vendorName.charAt(0).toUpperCase() + vendorName.slice(1));
+        if (!existsSync(vendorDir)) continue;
+        const matches = scanFlat(vendorDir, searchTerms, identifiers.bundleId);
+        const label = dir.startsWith("/Library") ? `System ${basename(dir)}` : basename(dir);
+        for (const match of matches) await addMatch(match, `${label}/${basename(vendorDir)}`);
+      }
+    }
+
+    const containerMatches = scanContainersByBundleId(identifiers.bundleId);
+    for (const match of containerMatches) await addMatch(match, "Containers");
+  }
+
+  return residuals.sort((a, b) => b.size - a.size);
+}
+
 function useInstalledApps() {
   const [apps, setApps] = useState<AppInfo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const appDirs = ["/Applications", join(process.env.HOME || "", "Applications")];
+    const appDirs = ["/Applications", join(HOME, "Applications")];
     const found: AppInfo[] = [];
 
     for (const dir of appDirs) {
@@ -51,12 +421,7 @@ function useInstalledApps() {
     const calcSizes = async () => {
       const updated = await Promise.all(
         found.map(async (app) => {
-          const size = await new Promise<number>((resolve) => {
-            execFile("du", ["-sk", app.path], (err, stdout) => {
-              if (err) return resolve(0);
-              resolve(parseInt(stdout.split("\t")[0] || "0") * 1024);
-            });
-          });
+          const size = await getDirSize(app.path);
           return { ...app, size };
         }),
       );
@@ -90,24 +455,59 @@ export default function UninstallApp() {
 
 function UninstallView() {
   const { apps, isLoading } = useInstalledApps();
+  const [removedPaths, setRemovedPaths] = useState<Set<string>>(new Set());
 
   async function handleUninstall(app: AppInfo) {
+    const toast = await showToast({ style: Toast.Style.Animated, title: `Scanning ${app.name} residual files...` });
+
+    const identifiers = await getAppIdentifiers(app.path);
+    const residuals = await findResidualFiles(app.name, identifiers);
+    const residualsTotalSize = residuals.reduce((sum, r) => sum + r.size, 0);
+
+    toast.hide();
+
+    const residualsMessage =
+      residuals.length > 0
+        ? `\n\nFound ${residuals.length} residual item${residuals.length > 1 ? "s" : ""} (${formatBytes(residualsTotalSize)}):\n${residuals.map((r) => `  - ${basename(r.path)} (${r.location})`).join("\n")}`
+        : "\n\nNo residual files found.";
+
+    const totalSize = app.size + residualsTotalSize;
+
     if (
       await confirmAlert({
         title: `Uninstall ${app.name}?`,
-        message: `This will move ${app.name}.app to the Trash.${app.size > 0 ? ` App size: ${formatBytes(app.size)}.` : ""}`,
-        primaryAction: { title: "Move to Trash", style: Alert.ActionStyle.Destructive },
+        message: `This will move ${app.name}.app and all related files to the Trash.${totalSize > 0 ? ` Total size: ${formatBytes(totalSize)}.` : ""}${residualsMessage}`,
+        primaryAction: { title: "Uninstall & Clean Residuals", style: Alert.ActionStyle.Destructive },
       })
     ) {
-      const toast = await showToast({ style: Toast.Style.Animated, title: `Removing ${app.name}...` });
+      const progressToast = await showToast({ style: Toast.Style.Animated, title: `Removing ${app.name}...` });
       try {
-        await trash(app.path);
-        toast.style = Toast.Style.Success;
-        toast.title = `${app.name} moved to Trash`;
+        const allPaths = [app.path, ...residuals.map((r) => r.path)].filter((p) => existsSync(p));
+        const failedPaths: string[] = [];
+
+        for (const p of allPaths) {
+          try {
+            await trash(p);
+          } catch {
+            failedPaths.push(p);
+          }
+        }
+
+        if (failedPaths.length > 0) {
+          progressToast.title = "Requesting admin privileges...";
+          await trashWithAdmin(failedPaths);
+        }
+
+        setRemovedPaths((prev) => new Set([...prev, app.path]));
+        const residualsRemoved = allPaths.length - 1;
+        progressToast.style = Toast.Style.Success;
+        progressToast.title = `${app.name} moved to Trash`;
+        progressToast.message =
+          residualsRemoved > 0
+            ? `App + ${residualsRemoved} residual item${residualsRemoved > 1 ? "s" : ""} moved to Trash`
+            : "No residual files removed";
       } catch (err) {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Uninstall failed";
-        toast.message = err instanceof Error ? err.message : String(err);
+        await showFailureToast(err, { title: "Uninstall failed" });
       }
     }
   }
@@ -121,9 +521,11 @@ function UninstallView() {
     return `${Math.floor(days / 365)}y ago`;
   };
 
+  const visibleApps = apps.filter((app) => !removedPaths.has(app.path));
+
   return (
     <List isLoading={isLoading} searchBarPlaceholder="Search applications...">
-      {apps.map((app) => (
+      {visibleApps.map((app) => (
         <List.Item
           key={app.path}
           title={app.name}

--- a/extensions/mole/src/uninstall.tsx
+++ b/extensions/mole/src/uninstall.tsx
@@ -161,7 +161,7 @@ async function getAppIdentifiers(appPath: string): Promise<AppIdentifiers> {
 
 function getDirSize(dirPath: string): Promise<number> {
   return new Promise((resolve) => {
-    execFile("du", ["-sk", dirPath], (err, stdout) => {
+    execFile("/usr/bin/du", ["-sk", dirPath], (err, stdout) => {
       if (err) return resolve(0);
       resolve(parseInt(stdout.split("\t")[0] || "0") * 1024);
     });
@@ -469,7 +469,9 @@ function UninstallView() {
         }
 
         const removedCount = allPaths.length - failedPaths.length;
-        setRemovedPaths((prev) => new Set([...prev, app.path]));
+        if (!failedPaths.includes(app.path)) {
+          setRemovedPaths((prev) => new Set([...prev, app.path]));
+        }
         progressToast.style = Toast.Style.Success;
         progressToast.title = `${app.name} moved to Trash`;
 

--- a/extensions/mole/src/uninstall.tsx
+++ b/extensions/mole/src/uninstall.tsx
@@ -1,5 +1,5 @@
 import { List, Icon, ActionPanel, Action, Alert, showToast, Toast, confirmAlert, trash } from "@raycast/api";
-import { readdirSync, statSync, existsSync, readFileSync, writeFileSync, unlinkSync } from "fs";
+import { readdirSync, statSync, existsSync, readFileSync } from "fs";
 import { join, basename } from "path";
 import { showFailureToast } from "@raycast/utils";
 import { useState, useEffect, useMemo } from "react";
@@ -130,26 +130,6 @@ const SKIP_DEEP_SEARCH = new Set([
   "trial",
   "weather",
 ]);
-
-function trashWithAdmin(paths: string[]): Promise<void> {
-  const trashDir = join(HOME, ".Trash");
-  const scriptPath = join(process.env.TMPDIR || "/tmp", `mole-trash-${Date.now()}.sh`);
-  const lines = paths.map((p) => `mv '${p.replace(/'/g, "'\\''")}' '${trashDir}/'`);
-  writeFileSync(scriptPath, lines.join("\n"), { mode: 0o755 });
-
-  const appleScript = `do shell script "${scriptPath}" with administrator privileges`;
-  return new Promise((resolve, reject) => {
-    execFile("/usr/bin/osascript", ["-e", appleScript], (err) => {
-      try {
-        unlinkSync(scriptPath);
-      } catch {
-        /* ignore */
-      }
-      if (err) return reject(err);
-      resolve();
-    });
-  });
-}
 
 function normalize(str: string): string {
   return str.replace(/[^a-z0-9]/gi, "").toLowerCase();
@@ -493,19 +473,20 @@ function UninstallView() {
           }
         }
 
-        if (failedPaths.length > 0) {
-          progressToast.title = "Requesting admin privileges...";
-          await trashWithAdmin(failedPaths);
-        }
-
+        const removedCount = allPaths.length - failedPaths.length;
         setRemovedPaths((prev) => new Set([...prev, app.path]));
-        const residualsRemoved = allPaths.length - 1;
         progressToast.style = Toast.Style.Success;
         progressToast.title = `${app.name} moved to Trash`;
-        progressToast.message =
-          residualsRemoved > 0
-            ? `App + ${residualsRemoved} residual item${residualsRemoved > 1 ? "s" : ""} moved to Trash`
-            : "No residual files removed";
+
+        if (failedPaths.length > 0) {
+          progressToast.message = `${removedCount} item${removedCount > 1 ? "s" : ""} removed, ${failedPaths.length} skipped (permission denied)`;
+        } else {
+          const residualsRemoved = removedCount - 1;
+          progressToast.message =
+            residualsRemoved > 0
+              ? `App + ${residualsRemoved} residual item${residualsRemoved > 1 ? "s" : ""} moved to Trash`
+              : undefined;
+        }
       } catch (err) {
         await showFailureToast(err, { title: "Uninstall failed" });
       }

--- a/extensions/mole/src/uninstall.tsx
+++ b/extensions/mole/src/uninstall.tsx
@@ -1,5 +1,5 @@
 import { List, Icon, ActionPanel, Action, Alert, showToast, Toast, confirmAlert, trash } from "@raycast/api";
-import { readdirSync, statSync, existsSync, readFileSync } from "fs";
+import { readdirSync, statSync, existsSync } from "fs";
 import { join, basename } from "path";
 import { showFailureToast } from "@raycast/utils";
 import { useState, useEffect, useMemo } from "react";
@@ -69,7 +69,6 @@ const EXTRA_SEARCH_PATHS = [
   join(HOME, ".config"),
   "/private/var/db/receipts",
   "/private/tmp",
-  "/usr/local/bin",
   "/usr/local/etc",
   "/usr/local/opt",
   "/usr/local/share",
@@ -215,7 +214,7 @@ function matchesApp(entry: string, searchTerms: string[], bundleId: string | nul
 
   for (const term of searchTerms) {
     if (entryNormalized === term) return true;
-    if (term.length >= 5 && entryNormalized.includes(term)) return true;
+    if (term.length >= 8 && entryNormalized.includes(term)) return true;
   }
 
   if (bundleId) {
@@ -265,7 +264,7 @@ function scanDeep(dirPath: string, searchTerms: string[], bundleId: string | nul
   return results;
 }
 
-function scanContainersByBundleId(bundleId: string): string[] {
+async function scanContainersByBundleId(bundleId: string): Promise<string[]> {
   const containersDir = join(HOME, "Library", "Containers");
   if (!existsSync(containersDir)) return [];
   const results: string[] = [];
@@ -274,13 +273,9 @@ function scanContainersByBundleId(bundleId: string): string[] {
     if (/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(entry)) {
       const metadataPath = join(containersDir, entry, ".com.apple.containermanagerd.metadata.plist");
       if (!existsSync(metadataPath)) continue;
-      try {
-        const content = readFileSync(metadataPath, "utf-8");
-        if (content.includes(bundleId)) {
-          results.push(join(containersDir, entry));
-        }
-      } catch {
-        continue;
+      const metaId = await readPlistKey(metadataPath, "MCMMetadataIdentifier");
+      if (metaId && metaId === bundleId) {
+        results.push(join(containersDir, entry));
       }
     }
   }
@@ -356,7 +351,7 @@ async function findResidualFiles(appName: string, identifiers: AppIdentifiers): 
       }
     }
 
-    const containerMatches = scanContainersByBundleId(identifiers.bundleId);
+    const containerMatches = await scanContainersByBundleId(identifiers.bundleId);
     for (const match of containerMatches) await addMatch(match, "Containers");
   }
 

--- a/extensions/mole/src/update-mole.tsx
+++ b/extensions/mole/src/update-mole.tsx
@@ -1,4 +1,5 @@
 import { showToast, Toast } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
 import { runMole } from "./utils/mole";
 
 export default async function UpdateMole() {
@@ -8,8 +9,6 @@ export default async function UpdateMole() {
     toast.style = Toast.Style.Success;
     toast.title = output.includes("already") ? "Already up to date" : "Mole updated successfully";
   } catch (err) {
-    toast.style = Toast.Style.Failure;
-    toast.title = "Update failed";
-    toast.message = err instanceof Error ? err.message : String(err);
+    await showFailureToast(err, { title: "Update failed" });
   }
 }

--- a/extensions/mole/src/utils/mole.ts
+++ b/extensions/mole/src/utils/mole.ts
@@ -12,7 +12,7 @@ export class MoleNotInstalledError extends Error {
 }
 
 export function getMolePath(): string {
-  const prefs = getPreferenceValues<{ molePath?: string }>();
+  const prefs = getPreferenceValues<ExtensionPreferences>();
 
   if (prefs.molePath && existsSync(prefs.molePath)) {
     return prefs.molePath;


### PR DESCRIPTION
Fixes https://github.com/raycast/extensions/issues/26467

## Summary

- Added deep residual file scanning when uninstalling apps (searches `~/Library`, `/Library`, containers, and vendor directories)
- Matches residual files by bundle ID, app name, display name, and executable name
- Shows a detailed confirmation dialog listing all found residuals with sizes before removal
- Falls back to admin privileges via osascript for protected system files
- Hides removed apps from the list after successful uninstall

## Code quality improvements

- Migrated all error handling from manual `Toast.Style.Failure` to `showFailureToast` from `@raycast/utils`
- Replaced manual Preferences type with auto-generated `ExtensionPreferences` from `raycast-env.d.ts`
- Updated `uninstall` command description to reflect new residual scanning functionality
- Removed unused `exec` import
- Fixed Prettier formatting

## Type of change

- [x] Bug fix
- [x] New feature

## Test plan

- [ ] Open "Uninstall App" command and search for an app
- [ ] Press Enter to uninstall — verify residual files are listed in the confirmation dialog
- [ ] Confirm uninstall — verify app + residuals are moved to Trash
- [ ] Verify app disappears from the list after uninstall
- [ ] Test with an app that has no residuals — verify "No residual files found" message
- [ ] Test canceling the confirmation — verify nothing is removed