### PR TITLE
Music: Performance optimization for large libraries

### DIFF
--- a/extensions/music/.gitignore
+++ b/extensions/music/.gitignore
@@ -12,3 +12,5 @@ compiled_raycast_swift
 # misc
 .DS_Store
 CLAUDE.md
+.prettiercache
+.eslintcache

--- a/extensions/music/CHANGELOG.md
+++ b/extensions/music/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [Performance Optimization] - {PR_MERGE_DATE}
 
-- Faster library browsing — fetching all tracks and albums from your library is significantly faster for large collections.
-- "Play Library Album" now opens instantly and only searches when you type, instead of loading your entire library upfront.
+- "Play Library Album" now opens instantly and searches on demand, instead of loading your entire library upfront — fixing out-of-memory crashes for large libraries.
+- "Play Library Track" search is faster thanks to optimized data fetching.
 - Playlists are now cached — reopening "Start Playlist" or "Add to Playlist" is instant after the first load.
 - Switching the playlist filter dropdown (All/User/Apple Music) no longer re-fetches data.
 - Favoriting a track now confirms within 3 seconds instead of up to 10 seconds.

--- a/extensions/music/CHANGELOG.md
+++ b/extensions/music/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Apple Music Changelog
 
+## [Performance Optimization] - {PR_MERGE_DATE}
+
+- Faster library browsing — fetching all tracks and albums from your library is significantly faster for large collections.
+- "Play Library Album" now opens instantly and only searches when you type, instead of loading your entire library upfront.
+- Playlists are now cached — reopening "Start Playlist" or "Add to Playlist" is instant after the first load.
+- Switching the playlist filter dropdown (All/User/Apple Music) no longer re-fetches data.
+- Favoriting a track now confirms within 3 seconds instead of up to 10 seconds.
+- Menu bar scroll animation uses less energy with fewer screen updates.
+- Fixed a bug where the `ScriptError` type guard never matched due to a typo.
+
 ## [Menu Bar Energy Optimization] - 2026-03-12
 
 - Consolidated menu bar polling into a single AppleScript snapshot that checks whether Music is running, reads player state, and fetches current track metadata in one call — reducing subprocess count from 3 to 1 per refresh.

--- a/extensions/music/package.json
+++ b/extensions/music/package.json
@@ -16,7 +16,8 @@
     "hrishabhn",
     "bogdan_bucur",
     "xmok",
-    "byheaven"
+    "byheaven",
+    "espenbye"
   ],
   "license": "MIT",
   "keywords": [

--- a/extensions/music/src/add-to-playlist.tsx
+++ b/extensions/music/src/add-to-playlist.tsx
@@ -1,8 +1,8 @@
 import { Action, ActionPanel, closeMainWindow, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
 import { flow, pipe } from "fp-ts/lib/function";
 import * as A from "fp-ts/ReadonlyNonEmptyArray";
 import * as TE from "fp-ts/TaskEither";
-import { useEffect, useState } from "react";
 
 import { Playlist } from "./util/models";
 import { parseResult } from "./util/parser";
@@ -10,9 +10,8 @@ import * as music from "./util/scripts";
 import { handleTaskEitherError } from "./util/utils";
 
 enum PlaylistKind {
-  ALL = "all",
-  USER = "user",
   SUBSCRIPTION = "subscription",
+  USER = "user",
 }
 
 type PlaylistSections = Readonly<Record<string, A.ReadonlyNonEmptyArray<Playlist>>>;
@@ -29,33 +28,32 @@ const kindToString = (kind: PlaylistKind) => {
 };
 
 export default function AddToPlaylist() {
-  const [isLoading, setIsLoading] = useState(false);
-  const [playlists, setPlaylists] = useState<PlaylistSections | null>(null);
   const { pop } = useNavigation();
 
-  useEffect(() => {
-    pipe(
-      music.playlists.getPlaylists(PlaylistKind.USER),
-      TE.mapLeft((e) => {
-        console.error(e);
-        showToast(Toast.Style.Failure, "Could not get your playlists");
-        setIsLoading(false);
-      }),
-      TE.map(
-        flow(
-          parseResult<Playlist>(),
-          (data) => A.groupBy<Playlist>((playlist) => playlist.kind?.split(" ")?.[0] ?? "Other")(data),
-          (data) => {
-            setPlaylists(data);
-            setIsLoading(false);
-          },
+  const { isLoading, data: playlists } = useCachedPromise(
+    () =>
+      pipe(
+        music.playlists.getPlaylists(PlaylistKind.USER),
+        TE.map(
+          flow(parseResult<Playlist>(), (data) =>
+            A.groupBy<Playlist>((playlist) => playlist.kind?.split(" ")?.[0] ?? "Other")(data),
+          ),
         ),
-      ),
-    )();
-  }, []);
+        TE.matchW(
+          (e) => {
+            console.error(e);
+            showToast(Toast.Style.Failure, "Could not get your playlists");
+            return {} as PlaylistSections;
+          },
+          (data) => data,
+        ),
+      )(),
+    [],
+    { keepPreviousData: true },
+  );
 
   return (
-    <List isLoading={playlists === null || isLoading} searchBarPlaceholder="Search A Playlist">
+    <List isLoading={isLoading} searchBarPlaceholder="Search A Playlist">
       {Object.entries(playlists ?? {})
         .filter(([section]) => section !== "library")
         .map(([section, data]) => (

--- a/extensions/music/src/currently-playing-menu-bar.tsx
+++ b/extensions/music/src/currently-playing-menu-bar.tsx
@@ -2,15 +2,18 @@ import { getPreferenceValues, Icon, Keyboard, MenuBarExtra, open, openCommandPre
 import { useCachedPromise } from "@raycast/utils";
 import { pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/TaskEither";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-import * as music from "./util/scripts";
 import { PlayerState } from "./util/models";
+import * as music from "./util/scripts";
 import { formatTitle } from "./util/track";
 import { handleTaskEitherError } from "./util/utils";
 
 const { hideArtistName, maxTextLength, cleanupTitle, hideIconWhenIdle } =
   getPreferenceValues<Preferences.CurrentlyPlayingMenuBar>();
+
+const DROPDOWN_MAX = 40;
+const SEPARATOR = "   ·   ";
 
 function toMutationPromise<E extends Error, T>(taskEither: TE.TaskEither<E, T>, error: string, success: string) {
   const handledTask = pipe(
@@ -57,7 +60,6 @@ export default function CurrentlyPlayingMenuBarCommand() {
       })
     : "";
 
-  const DROPDOWN_MAX = 40;
   const fullTitle = currentTrack
     ? formatTitle({
         name: currentTrack.name,
@@ -68,8 +70,9 @@ export default function CurrentlyPlayingMenuBarCommand() {
       })
     : "";
   const needsScroll = fullTitle.length > DROPDOWN_MAX;
-  const SEPARATOR = "   ·   ";
   const paddedTitle = needsScroll ? fullTitle + SEPARATOR : fullTitle;
+
+  const doubledTitle = useMemo(() => paddedTitle + paddedTitle, [paddedTitle]);
 
   const [scrollOffset, setScrollOffset] = useState(0);
 
@@ -82,14 +85,12 @@ export default function CurrentlyPlayingMenuBarCommand() {
 
     const interval = setInterval(() => {
       setScrollOffset((prev) => (prev + 1) % paddedTitle.length);
-    }, 200);
+    }, 400);
 
     return () => clearInterval(interval);
   }, [needsScroll, paddedTitle.length]);
 
-  const dropdownTitle = needsScroll
-    ? (paddedTitle + paddedTitle).substring(scrollOffset, scrollOffset + DROPDOWN_MAX)
-    : fullTitle;
+  const dropdownTitle = needsScroll ? doubledTitle.substring(scrollOffset, scrollOffset + DROPDOWN_MAX) : fullTitle;
 
   if (!snapshot || snapshot.kind === "not-running") {
     return <NothingPlaying title="Music needs to be opened" isLoading={isLoading} />;

--- a/extensions/music/src/play-library-album.tsx
+++ b/extensions/music/src/play-library-album.tsx
@@ -1,54 +1,32 @@
 import { Action, ActionPanel, closeMainWindow, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
-import { flow, pipe } from "fp-ts/lib/function";
-import * as O from "fp-ts/Option";
+import { pipe } from "fp-ts/lib/function";
 import * as S from "fp-ts/string";
 import * as T from "fp-ts/Task";
 import * as TE from "fp-ts/TaskEither";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Album, Track } from "./util/models";
-import { fromEmptyOrNullable } from "./util/option";
-import { parseResult } from "./util/parser";
 import * as music from "./util/scripts";
 import { handleTaskEitherError } from "./util/utils";
-import { usePromise } from "@raycast/utils";
 
 const EMPTY_TEXT = " "; // Visually empty but non-empty to prevent jumping around
 
 export default function PlayLibraryAlbum() {
-  const [albums, setAlbums] = useState<readonly Album[] | null>(null);
+  const [albums, setAlbums] = useState<readonly Album[]>([]);
   const [currentTrack, setCurrentTrack] = useState<Track | null>(null);
   const { pop } = useNavigation();
 
-  const loadAll = pipe(
-    music.albums.getAll,
-    TE.map(parseResult<Album>()),
-    TE.matchW(
-      () => {
-        showToast(Toast.Style.Failure, "Could not get albums");
-        return [] as ReadonlyArray<Album>;
-      },
-      flow(
-        fromEmptyOrNullable,
-        O.matchW(() => setAlbums([]), setAlbums),
-      ),
-    ),
-  );
+  useEffect(() => {
+    pipe(music.currentTrack.getCurrentTrack(), TE.map(setCurrentTrack))();
+  }, []);
 
-  const { isLoading: isLoadingAll, revalidate: revalidateAll } = usePromise(loadAll);
-
-  const { isLoading: isLoadingCurrentTrack } = usePromise(() =>
-    pipe(music.currentTrack.getCurrentTrack(), TE.map(setCurrentTrack))(),
-  );
-
-  const onSearch = async (next: string) => {
-    setAlbums(null); // start loading
-
-    if (!next || next?.length < 1) {
-      setAlbums(null);
-      await revalidateAll();
+  const onSearch = useCallback(async (next: string) => {
+    if (!next || next.length < 1) {
+      setAlbums([]);
       return;
     }
+
+    setAlbums([]); // clear previous results
 
     await pipe(
       next,
@@ -59,28 +37,21 @@ export default function PlayLibraryAlbum() {
           showToast(Toast.Style.Failure, "Could not get albums");
           return [] as ReadonlyArray<Album>;
         },
-        (tracks) =>
-          pipe(
-            tracks,
-            fromEmptyOrNullable,
-            O.matchW(() => [] as ReadonlyArray<Album>, parseResult<Album>()),
-          ),
+        (albums) => albums,
       ),
       T.map(setAlbums),
     )();
-  };
-
-  const albumList = albums ?? [];
+  }, []);
 
   return (
     <List
-      isLoading={isLoadingAll || isLoadingCurrentTrack}
+      isLoading={false}
       searchBarPlaceholder="Search A Song By Album Or Artist"
       onSearchTextChange={onSearch}
       throttle
     >
-      {albumList.length > 0 ? (
-        albumList.map(({ id, name, artist, count }) => (
+      {albums.length > 0 ? (
+        albums.map(({ id, name, artist, count }) => (
           <List.Item
             key={id}
             title={name ?? "--"}

--- a/extensions/music/src/play-library-album.tsx
+++ b/extensions/music/src/play-library-album.tsx
@@ -1,4 +1,5 @@
 import { Action, ActionPanel, closeMainWindow, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
 import { pipe } from "fp-ts/lib/function";
 import * as S from "fp-ts/string";
 import * as T from "fp-ts/Task";
@@ -12,9 +13,25 @@ import { handleTaskEitherError } from "./util/utils";
 const EMPTY_TEXT = " "; // Visually empty but non-empty to prevent jumping around
 
 export default function PlayLibraryAlbum() {
-  const [albums, setAlbums] = useState<readonly Album[]>([]);
+  const [searchResults, setSearchResults] = useState<readonly Album[] | null>(null);
   const [currentTrack, setCurrentTrack] = useState<Track | null>(null);
   const { pop } = useNavigation();
+
+  const { isLoading: isLoadingAll, data: allAlbums } = useCachedPromise(
+    () =>
+      pipe(
+        music.albums.getAll,
+        TE.matchW(
+          () => {
+            showToast(Toast.Style.Failure, "Could not get albums");
+            return [] as ReadonlyArray<Album>;
+          },
+          (albums) => albums,
+        ),
+      )(),
+    [],
+    { keepPreviousData: true },
+  );
 
   useEffect(() => {
     pipe(music.currentTrack.getCurrentTrack(), TE.map(setCurrentTrack))();
@@ -22,11 +39,9 @@ export default function PlayLibraryAlbum() {
 
   const onSearch = useCallback(async (next: string) => {
     if (!next || next.length < 1) {
-      setAlbums([]);
+      setSearchResults(null); // back to showing all albums
       return;
     }
-
-    setAlbums([]); // clear previous results
 
     await pipe(
       next,
@@ -39,13 +54,15 @@ export default function PlayLibraryAlbum() {
         },
         (albums) => albums,
       ),
-      T.map(setAlbums),
+      T.map((results) => setSearchResults(results)),
     )();
   }, []);
 
+  const albums = searchResults ?? allAlbums ?? [];
+
   return (
     <List
-      isLoading={false}
+      isLoading={isLoadingAll}
       searchBarPlaceholder="Search A Song By Album Or Artist"
       onSearchTextChange={onSearch}
       throttle

--- a/extensions/music/src/play-library-album.tsx
+++ b/extensions/music/src/play-library-album.tsx
@@ -1,5 +1,4 @@
 import { Action, ActionPanel, closeMainWindow, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
 import { pipe } from "fp-ts/lib/function";
 import * as S from "fp-ts/string";
 import * as T from "fp-ts/Task";
@@ -13,25 +12,10 @@ import { handleTaskEitherError } from "./util/utils";
 const EMPTY_TEXT = " "; // Visually empty but non-empty to prevent jumping around
 
 export default function PlayLibraryAlbum() {
-  const [searchResults, setSearchResults] = useState<readonly Album[] | null>(null);
+  const [albums, setAlbums] = useState<readonly Album[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
   const [currentTrack, setCurrentTrack] = useState<Track | null>(null);
   const { pop } = useNavigation();
-
-  const { isLoading: isLoadingAll, data: allAlbums } = useCachedPromise(
-    () =>
-      pipe(
-        music.albums.getAll,
-        TE.matchW(
-          () => {
-            showToast(Toast.Style.Failure, "Could not get albums");
-            return [] as ReadonlyArray<Album>;
-          },
-          (albums) => albums,
-        ),
-      )(),
-    [],
-    { keepPreviousData: true },
-  );
 
   useEffect(() => {
     pipe(music.currentTrack.getCurrentTrack(), TE.map(setCurrentTrack))();
@@ -39,9 +23,12 @@ export default function PlayLibraryAlbum() {
 
   const onSearch = useCallback(async (next: string) => {
     if (!next || next.length < 1) {
-      setSearchResults(null); // back to showing all albums
+      setAlbums([]);
+      setIsSearching(false);
       return;
     }
+
+    setIsSearching(true);
 
     await pipe(
       next,
@@ -54,15 +41,16 @@ export default function PlayLibraryAlbum() {
         },
         (albums) => albums,
       ),
-      T.map((results) => setSearchResults(results)),
+      T.map((results) => {
+        setAlbums(results);
+        setIsSearching(false);
+      }),
     )();
   }, []);
 
-  const albums = searchResults ?? allAlbums ?? [];
-
   return (
     <List
-      isLoading={isLoadingAll}
+      isLoading={isSearching}
       searchBarPlaceholder="Search A Song By Album Or Artist"
       onSearchTextChange={onSearch}
       throttle

--- a/extensions/music/src/play-library-track.tsx
+++ b/extensions/music/src/play-library-track.tsx
@@ -27,6 +27,7 @@ export default function PlayLibraryTrack() {
   const onSearch = useCallback(async (next: string) => {
     if (!next || next.length < 1) {
       setTracks([]);
+      setIsSearching(false);
       return;
     }
 

--- a/extensions/music/src/play-library-track.tsx
+++ b/extensions/music/src/play-library-track.tsx
@@ -4,7 +4,7 @@ import * as O from "fp-ts/Option";
 import * as S from "fp-ts/string";
 import * as T from "fp-ts/Task";
 import * as TE from "fp-ts/TaskEither";
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Track } from "./util/models";
 import { fromEmptyOrNullable } from "./util/option";
@@ -14,7 +14,7 @@ import * as music from "./util/scripts";
 const EMPTY_TEXT = " "; // Visually empty but non-empty to prevent jumping around
 
 export default function PlayLibraryTrack() {
-  const [tracks, setTracks] = useState<readonly Track[] | null>([]);
+  const [tracks, setTracks] = useState<readonly Track[]>([]);
   const [currentTrack, setCurrentTrack] = useState<Track | null>(null);
   const { pop } = useNavigation();
 
@@ -22,48 +22,48 @@ export default function PlayLibraryTrack() {
     pipe(music.currentTrack.getCurrentTrack(), TE.map(setCurrentTrack))();
   }, []);
 
-  const onSearch = useCallback(
-    async (next: string) => {
-      setTracks(null); // start loading
+  const [isSearching, setIsSearching] = useState(false);
 
-      if (!next || next?.length < 1) {
-        setTracks([]);
-        return;
-      }
+  const onSearch = useCallback(async (next: string) => {
+    if (!next || next.length < 1) {
+      setTracks([]);
+      return;
+    }
 
-      await pipe(
-        next,
-        S.trim,
-        music.track.search,
-        TE.matchW(
-          () => {
-            showToast(Toast.Style.Failure, "Could not get tracks");
-            return [] as ReadonlyArray<Track>;
-          },
-          (tracks) =>
-            pipe(
-              tracks,
-              fromEmptyOrNullable,
-              O.matchW(() => [] as ReadonlyArray<Track>, parseResult<Track>()),
-            ),
-        ),
-        T.map(setTracks),
-      )();
-    },
-    [setTracks],
-  );
+    setIsSearching(true);
 
-  const trackList = tracks ?? [];
+    await pipe(
+      next,
+      S.trim,
+      music.track.search,
+      TE.matchW(
+        () => {
+          showToast(Toast.Style.Failure, "Could not get tracks");
+          return [] as ReadonlyArray<Track>;
+        },
+        (tracks) =>
+          pipe(
+            tracks,
+            fromEmptyOrNullable,
+            O.matchW(() => [] as ReadonlyArray<Track>, parseResult<Track>()),
+          ),
+      ),
+      T.map((result) => {
+        setTracks(result);
+        setIsSearching(false);
+      }),
+    )();
+  }, []);
 
   return (
     <List
-      isLoading={tracks === null || currentTrack === null}
+      isLoading={isSearching || currentTrack === null}
       searchBarPlaceholder="Search A Song By Title Or Artist"
       onSearchTextChange={onSearch}
       throttle
     >
-      {trackList.length > 0 ? (
-        trackList.map(({ id, name, artist, album }) => (
+      {tracks.length > 0 ? (
+        tracks.map(({ id, name, artist, album }) => (
           <List.Item
             key={id}
             title={name}

--- a/extensions/music/src/start-playlist.tsx
+++ b/extensions/music/src/start-playlist.tsx
@@ -1,18 +1,14 @@
-import { Action, Icon, ActionPanel, closeMainWindow, List, showToast, Toast, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, closeMainWindow, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
 import { flow, pipe } from "fp-ts/lib/function";
 import * as A from "fp-ts/ReadonlyNonEmptyArray";
 import * as TE from "fp-ts/TaskEither";
-import { useEffect, useState } from "react";
+import { useMemo, useState } from "react";
 
 import { Playlist } from "./util/models";
 import { parseResult } from "./util/parser";
 import * as music from "./util/scripts";
-
-enum PlaylistKind {
-  ALL = "all",
-  USER = "user",
-  SUBSCRIPTION = "subscription",
-}
+import { PlaylistKind } from "./util/scripts/playlists";
 
 type PlaylistSections = Readonly<Record<string, A.ReadonlyNonEmptyArray<Playlist>>>;
 
@@ -27,32 +23,51 @@ const kindToString = (kind: PlaylistKind) => {
   }
 };
 
+const kindToPlaylistClass: Record<PlaylistKind, string | null> = {
+  [PlaylistKind.ALL]: null,
+  [PlaylistKind.USER]: "user",
+  [PlaylistKind.SUBSCRIPTION]: "subscription",
+};
+
 export default function PlaySelected() {
   const [playlistKind, setPlaylistKind] = useState<PlaylistKind>(PlaylistKind.ALL);
-  const [playlists, setPlaylists] = useState<PlaylistSections | null>(null);
   const { pop } = useNavigation();
 
-  useEffect(() => {
-    pipe(
-      playlistKind,
-      music.playlists.getPlaylists,
-      TE.mapLeft((e) => {
-        console.error(e);
-        showToast(Toast.Style.Failure, "Could not get your playlists");
-      }),
-      TE.map(
-        flow(
-          parseResult<Playlist>(),
-          (data) => A.groupBy<Playlist>((playlist) => playlist.kind?.split(" ")?.[0] ?? "Other")(data),
-          setPlaylists,
+  const { isLoading, data: allPlaylists } = useCachedPromise(
+    () =>
+      pipe(
+        music.playlists.getPlaylists(PlaylistKind.ALL),
+        TE.map(
+          flow(parseResult<Playlist>(), (data) =>
+            A.groupBy<Playlist>((playlist) => playlist.kind?.split(" ")?.[0] ?? "Other")(data),
+          ),
         ),
-      ),
-    )();
-  }, [playlistKind]);
+        TE.matchW(
+          (e) => {
+            console.error(e);
+            showToast(Toast.Style.Failure, "Could not get your playlists");
+            return {} as PlaylistSections;
+          },
+          (data) => data,
+        ),
+      )(),
+    [],
+    { keepPreviousData: true },
+  );
+
+  const filteredPlaylists = useMemo(() => {
+    if (!allPlaylists) return {};
+    const filterClass = kindToPlaylistClass[playlistKind];
+    if (!filterClass) return allPlaylists;
+
+    return Object.fromEntries(
+      Object.entries(allPlaylists).filter(([section]) => section === filterClass),
+    ) as PlaylistSections;
+  }, [allPlaylists, playlistKind]);
 
   return (
     <List
-      isLoading={playlists === null}
+      isLoading={isLoading}
       searchBarPlaceholder="Search A Playlist"
       searchBarAccessory={
         <List.Dropdown
@@ -67,7 +82,7 @@ export default function PlaySelected() {
         </List.Dropdown>
       }
     >
-      {Object.entries(playlists ?? {})
+      {Object.entries(filteredPlaylists)
         .filter(([section]) => section !== "library")
         .map(([section, data]) => (
           <List.Section title={kindToString(section as PlaylistKind)} key={section}>
@@ -75,9 +90,7 @@ export default function PlaySelected() {
               <List.Item
                 key={playlist.id}
                 title={playlist.name ?? "Unknown Playlist"}
-                accessories={[
-                  { text: `${playlist.count} songs ·` + ` ${Math.floor(Number(playlist.duration) / 60)} min` },
-                ]}
+                accessories={[{ text: `${playlist.count} songs · ${Math.floor(Number(playlist.duration) / 60)} min` }]}
                 icon={{ source: "../assets/icon.png" }}
                 actions={<Actions playlist={playlist} pop={pop} />}
               />

--- a/extensions/music/src/tools/get-library-albums.ts
+++ b/extensions/music/src/tools/get-library-albums.ts
@@ -5,11 +5,8 @@
  */
 import { pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/TaskEither";
-import * as O from "fp-ts/Option";
-import { parseResult } from "../util/parser";
-import { fromEmptyOrNullable } from "../util/option";
-import * as music from "../util/scripts";
 import { Album } from "../util/models";
+import * as music from "../util/scripts";
 
 type Input = {
   /**
@@ -21,32 +18,10 @@ type Input = {
 export default async function getLibraryAlbums(input?: Input) {
   const searchTerm = input?.search?.trim();
 
-  const albumsTE = searchTerm
-    ? pipe(
-        searchTerm,
-        music.albums.search,
-        TE.map((albumsString) =>
-          pipe(
-            albumsString,
-            fromEmptyOrNullable,
-            O.getOrElse(() => ""),
-          ),
-        ),
-      )
-    : music.albums.getAll;
+  const albumsTE = searchTerm ? music.albums.search(searchTerm) : music.albums.getAll;
 
   return await pipe(
     albumsTE,
-    TE.map(parseResult<Album>()),
-    TE.map((albums) =>
-      pipe(
-        albums,
-        fromEmptyOrNullable,
-        O.getOrElse(() => [] as readonly Album[]),
-      ),
-    ),
-    TE.mapLeft((error) => {
-      throw new Error(`Could not retrieve albums: ${error}`);
-    }),
+    TE.getOrElse(() => async () => [] as readonly Album[]),
   )();
 }

--- a/extensions/music/src/util/models.ts
+++ b/extensions/music/src/util/models.ts
@@ -24,9 +24,6 @@ export interface Playlist {
   name: string;
   duration: string;
   count: string;
-
-  time: string;
-  description: string;
   kind: `${"subscription" | "user" | "library"} playlist`;
 }
 
@@ -44,7 +41,7 @@ export interface ScriptError extends Error {
 }
 
 export const ScriptError = {
-  is: (error: Error): error is ScriptError => "shortMessaage" in error,
+  is: (error: Error): error is ScriptError => "shortMessage" in error,
 };
 
 export interface Preferences {

--- a/extensions/music/src/util/scripts/albums.ts
+++ b/extensions/music/src/util/scripts/albums.ts
@@ -34,14 +34,18 @@ function groupTracksByAlbum(raw: string): ReadonlyArray<Album> {
 export const getAll: TE.TaskEither<Error, ReadonlyArray<Album>> = pipe(
   runScript(`
 	set output to ""
+	set seenAlbums to {}
 	tell application "Music"
-		set allTracks to every track of playlist 1
-		set allIds to id of allTracks
-		set allAlbums to album of allTracks
-		set allArtists to artist of allTracks
-		set trackCount to count of allIds
+		set allAlbums to album of every track of (library playlist 1)
+		set allIds to id of every track of (library playlist 1)
+		set allArtists to artist of every track of (library playlist 1)
+		set trackCount to count of allAlbums
 		repeat with i from 1 to trackCount
-			set output to output & "id=" & (item i of allIds) & "$BREAKname=" & (item i of allAlbums) & "$BREAKartist=" & (item i of allArtists) & "\\n"
+			set aName to item i of allAlbums
+			if seenAlbums does not contain aName then
+				set end of seenAlbums to aName
+				set output to output & "id=" & (item i of allIds) & "$BREAKname=" & aName & "$BREAKartist=" & (item i of allArtists) & "\\n"
+			end if
 		end repeat
 	end tell
 	return output

--- a/extensions/music/src/util/scripts/albums.ts
+++ b/extensions/music/src/util/scripts/albums.ts
@@ -44,7 +44,7 @@ export const getAll: TE.TaskEither<Error, ReadonlyArray<Album>> = pipe(
 			set aName to item i of allAlbums
 			if seenAlbums does not contain aName then
 				set end of seenAlbums to aName
-				set output to output & "id=" & (item i of allIds) & "$BREAKname=" & aName & "$BREAKartist=" & (item i of allArtists) & "\\n"
+				set output to output & "id=" & (item i of allIds) & "$BREAKname=" & aName & "$BREAKartist=" & (item i of allArtists) & "\n"
 			end if
 		end repeat
 	end tell
@@ -60,7 +60,7 @@ export const search = (term: string): TE.TaskEither<Error, ReadonlyArray<Album>>
 	tell application "Music"
 		set results to (search (library playlist 1) for "${term}")
 		repeat with aTrack in results
-			set output to output & "id=" & (id of aTrack) & "$BREAKname=" & (album of aTrack) & "$BREAKartist=" & (artist of aTrack) & "\\n"
+			set output to output & "id=" & (id of aTrack) & "$BREAKname=" & (album of aTrack) & "$BREAKartist=" & (artist of aTrack) & "\n"
 		end repeat
 	end tell
 	return output

--- a/extensions/music/src/util/scripts/albums.ts
+++ b/extensions/music/src/util/scripts/albums.ts
@@ -1,61 +1,68 @@
 import { pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/TaskEither";
 
-import { createQueryString, runScript } from "../apple-script";
+import { parseQueryString, runScript } from "../apple-script";
+import { Album } from "../models";
 
 import { general } from ".";
 
-export const getAll = runScript(`
+/** Deduplicate tracks by album name, counting tracks per album */
+function groupTracksByAlbum(raw: string): ReadonlyArray<Album> {
+  const lines = raw.trim().split("\n").filter(Boolean);
+  const albumMap = new Map<string, Album>();
+
+  for (const line of lines) {
+    const parts = parseQueryString<Record<string, string>>()(line);
+    const albumName = parts.name ?? "";
+    const existing = albumMap.get(albumName);
+
+    if (existing) {
+      existing.count = String(Number(existing.count ?? "0") + 1);
+    } else {
+      albumMap.set(albumName, {
+        id: parts.id ?? "",
+        name: albumName,
+        artist: parts.artist ?? "",
+        count: "1",
+      });
+    }
+  }
+
+  return Array.from(albumMap.values());
+}
+
+export const getAll: TE.TaskEither<Error, ReadonlyArray<Album>> = pipe(
+  runScript(`
 	set output to ""
-	set albumList to {}
 	tell application "Music"
-		set results to (every track of playlist 1)
-		repeat with aTrack in results
-			set albumName to the album of aTrack
-			set trackCount to count (every track of playlist 1 whose album contains albumName)
-			tell album of aTrack to if albumList does not contain it then
-				set end of albumList to it
-				set trackId to the id of aTrack
-				set artistName to the artist of aTrack
-				set output to output & ${createQueryString({
-          id: "trackId",
-          name: "albumName",
-          artist: "artistName",
-          count: "trackCount",
-        })} & "\n"
-			end if
+		set allTracks to every track of playlist 1
+		set allIds to id of allTracks
+		set allAlbums to album of allTracks
+		set allArtists to artist of allTracks
+		set trackCount to count of allIds
+		repeat with i from 1 to trackCount
+			set output to output & "id=" & (item i of allIds) & "$BREAKname=" & (item i of allAlbums) & "$BREAKartist=" & (item i of allArtists) & "\\n"
 		end repeat
 	end tell
 	return output
-`);
+  `),
+  TE.map(groupTracksByAlbum),
+);
 
-export const search = (search: string) => {
-  const query = createQueryString({
-    id: "trackId",
-    name: "albumName",
-    artist: "artistName",
-    count: "trackCount",
-  });
-
-  return runScript(`
-		set output to ""
-		set albumList to {}
-		tell application "Music"
-			set results to (search (library playlist 1) for "${search}")
-			repeat with aTrack in results
-				set albumName to the album of aTrack
-				set trackCount to count (every track of playlist 1 whose album contains albumName)
-				tell album of aTrack to if albumList does not contain it then
-					set end of albumList to it
-					set trackId to the id of aTrack
-					set artistName to the artist of aTrack
-					set output to output & ${query} & "\n"
-				end if
-			end repeat
-		end tell
-		return output
-	`);
-};
+export const search = (term: string): TE.TaskEither<Error, ReadonlyArray<Album>> =>
+  pipe(
+    runScript(`
+	set output to ""
+	tell application "Music"
+		set results to (search (library playlist 1) for "${term}")
+		repeat with aTrack in results
+			set output to output & "id=" & (id of aTrack) & "$BREAKname=" & (album of aTrack) & "$BREAKartist=" & (artist of aTrack) & "\\n"
+		end repeat
+	end tell
+	return output
+    `),
+    TE.map(groupTracksByAlbum),
+  );
 
 export const play =
   (shuffle = false) =>
@@ -64,14 +71,14 @@ export const play =
       general.setShuffle(shuffle),
       TE.chain(() =>
         runScript(`
-			tell application "Music"
-				if (exists playlist "Raycast DJ") then
-					delete playlist "Raycast DJ"
-				end if
-				make new user playlist with properties {name:"Raycast DJ", shuffle:false, song repeat:one}
-				duplicate (every track of playlist 1 whose album contains "${album}") to playlist "Raycast DJ"
-				play playlist "Raycast DJ"
-			end tell
-		`),
+		tell application "Music"
+			if (exists playlist "Raycast DJ") then
+				delete playlist "Raycast DJ"
+			end if
+			make new user playlist with properties {name:"Raycast DJ", shuffle:false, song repeat:one}
+			duplicate (every track of playlist 1 whose album contains "${album}") to playlist "Raycast DJ"
+			play playlist "Raycast DJ"
+		end tell
+	`),
       ),
     );

--- a/extensions/music/src/util/scripts/current-track.ts
+++ b/extensions/music/src/util/scripts/current-track.ts
@@ -5,14 +5,14 @@ import * as RTE from "fp-ts/ReaderTaskEither";
 import * as TE from "fp-ts/TaskEither";
 import { match } from "ts-pattern";
 
-import { getLibraryName } from "./general";
 import { createQueryString, parseQueryString, runScript, tell } from "../apple-script";
 import { STAR_VALUE } from "../constants";
 import { getMacosVersion } from "../get-macos-version";
 import { MenuBarSnapshot, PlayerState, ScriptError, Track } from "../models";
+import { getLibraryName } from "./general";
 
-const FAVORITE_CONFIRMATION_TIMEOUT_MS = 10_000;
-const FAVORITE_POLL_INTERVAL_MS = 250;
+const FAVORITE_CONFIRMATION_TIMEOUT_MS = 3_000;
+const FAVORITE_POLL_INTERVAL_MS = 500;
 const FAVORITE_TRACK_ID_MISMATCH = "__TRACK_ID_MISMATCH__";
 
 const isSonomaOrNewer = (versionMajor: number) => versionMajor >= 14;

--- a/extensions/music/src/util/scripts/playlists.ts
+++ b/extensions/music/src/util/scripts/playlists.ts
@@ -21,7 +21,7 @@ const loopThroughPlaylists = (kind: PlaylistKind) => `
 		set pDuration to the duration of selectedPlaylist
 		set pCount to count (tracks of selectedPlaylist)
 		set pKind to the class of selectedPlaylist
-		set output to output & "id=" & pId & "$BREAKname=" & pName & "$BREAKduration=" & pDuration & "$BREAKcount=" & pCount & "$BREAKkind=" & pKind & "\\n"
+		set output to output & "id=" & pId & "$BREAKname=" & pName & "$BREAKduration=" & pDuration & "$BREAKcount=" & pCount & "$BREAKkind=" & pKind & "\n"
 	end repeat
 `;
 

--- a/extensions/music/src/util/scripts/playlists.ts
+++ b/extensions/music/src/util/scripts/playlists.ts
@@ -1,38 +1,28 @@
 import { pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/TaskEither";
 
-import { tell, runScript, createQueryString } from "../apple-script";
+import { runScript, tell } from "../apple-script";
 import { ScriptError } from "../models";
 
 import { general } from ".";
 
-const outputQuery = createQueryString({
-  id: "pId",
-  name: "pName",
-  duration: "pDuration",
-  count: "pCount",
-  time: "pTime",
-  kind: "pKind",
-});
-
-enum PlaylistKind {
+export enum PlaylistKind {
   ALL = "all",
   USER = "user",
   SUBSCRIPTION = "subscription",
 }
 
-const playListKindToString = (kind: PlaylistKind) => (kind === PlaylistKind.ALL ? "" : kind);
+const playlistRef = (kind: PlaylistKind) => (kind === PlaylistKind.ALL ? "" : kind);
 
 const loopThroughPlaylists = (kind: PlaylistKind) => `
-	repeat with selectedPlaylist in ${playListKindToString(kind)} playlists
+	repeat with selectedPlaylist in ${playlistRef(kind)} playlists
 		set pId to the id of selectedPlaylist
 		set pName to the name of selectedPlaylist
 		set pDuration to the duration of selectedPlaylist
 		set pCount to count (tracks of selectedPlaylist)
-		set pTime to the time of selectedPlaylist
 		set pKind to the class of selectedPlaylist
-		set output to output & ${outputQuery} & "\n"
-    end repeat
+		set output to output & "id=" & pId & "$BREAKname=" & pName & "$BREAKduration=" & pDuration & "$BREAKcount=" & pCount & "$BREAKkind=" & pKind & "\\n"
+	end repeat
 `;
 
 export const play =
@@ -56,8 +46,8 @@ export const getPlaylistId = (name: string) => tell("Music", `get id of playlist
 export const getPlaylists = (kind: PlaylistKind): TE.TaskEither<Error, string> =>
   runScript(`
 	set output to ""
-        tell application "Music"
-			${kind === PlaylistKind.ALL ? loopThroughPlaylists(PlaylistKind.ALL) : loopThroughPlaylists(kind)}
-        end tell
+	tell application "Music"
+		${loopThroughPlaylists(kind)}
+	end tell
 	return output
 `);

--- a/extensions/music/src/util/scripts/track.ts
+++ b/extensions/music/src/util/scripts/track.ts
@@ -1,43 +1,30 @@
-import { createQueryString, runScript, tell } from "../apple-script";
+import { runScript, tell } from "../apple-script";
 
-export const search = (search: string) => {
-  const outputQuery = createQueryString({
-    id: "trackId",
-    name: "trackName",
-    artist: "artistName",
-    album: "albumName",
-    duration: "trackDuration",
-  });
-
-  return runScript(`
+export const search = (search: string) =>
+  runScript(`
 		set output to ""
 			tell application "Music"
 				set results to (search (library playlist 1) for "${search}")
 				repeat with selectedTrack in results
-					set trackId to the id of selectedTrack
-					set trackName to the name of selectedTrack
-					set albumName to the album of selectedTrack
-					set artistName to the artist of selectedTrack
-					set trackDuration to the duration of selectedTrack
-					set output to output & ${outputQuery} & "\n"
+					set output to output & "id=" & (id of selectedTrack) & "$BREAKname=" & (name of selectedTrack) & "$BREAKartist=" & (artist of selectedTrack) & "$BREAKalbum=" & (album of selectedTrack) & "$BREAKduration=" & (duration of selectedTrack) & "\\n"
 				end repeat
 			end tell
 		return output
 	`);
-};
 
 export const getAll = () =>
   runScript(`
     set output to ""
     tell application "Music"
-      set results to (every track of (library playlist 1))
-      repeat with selectedTrack in results
-        set trackId to the id of selectedTrack
-        set trackName to the name of selectedTrack
-        set albumName to the album of selectedTrack
-        set artistName to the artist of selectedTrack
-        set trackDuration to the duration of selectedTrack
-        set output to output & "id=" & trackId & "$BREAKname=" & trackName & "$BREAKartist=" & artistName & "$BREAKalbum=" & albumName & "$BREAKduration=" & trackDuration & "\n"
+      set allTracks to every track of (library playlist 1)
+      set allIds to id of allTracks
+      set allNames to name of allTracks
+      set allAlbums to album of allTracks
+      set allArtists to artist of allTracks
+      set allDurations to duration of allTracks
+      set trackCount to count of allIds
+      repeat with i from 1 to trackCount
+        set output to output & "id=" & (item i of allIds) & "$BREAKname=" & (item i of allNames) & "$BREAKartist=" & (item i of allArtists) & "$BREAKalbum=" & (item i of allAlbums) & "$BREAKduration=" & (item i of allDurations) & "\\n"
       end repeat
     end tell
     return output

--- a/extensions/music/src/util/scripts/track.ts
+++ b/extensions/music/src/util/scripts/track.ts
@@ -16,12 +16,11 @@ export const getAll = () =>
   runScript(`
     set output to ""
     tell application "Music"
-      set allTracks to every track of (library playlist 1)
-      set allIds to id of allTracks
-      set allNames to name of allTracks
-      set allAlbums to album of allTracks
-      set allArtists to artist of allTracks
-      set allDurations to duration of allTracks
+      set allIds to id of every track of (library playlist 1)
+      set allNames to name of every track of (library playlist 1)
+      set allAlbums to album of every track of (library playlist 1)
+      set allArtists to artist of every track of (library playlist 1)
+      set allDurations to duration of every track of (library playlist 1)
       set trackCount to count of allIds
       repeat with i from 1 to trackCount
         set output to output & "id=" & (item i of allIds) & "$BREAKname=" & (item i of allNames) & "$BREAKartist=" & (item i of allArtists) & "$BREAKalbum=" & (item i of allAlbums) & "$BREAKduration=" & (item i of allDurations) & "\\n"

--- a/extensions/music/src/util/scripts/track.ts
+++ b/extensions/music/src/util/scripts/track.ts
@@ -6,7 +6,7 @@ export const search = (search: string) =>
 			tell application "Music"
 				set results to (search (library playlist 1) for "${search}")
 				repeat with selectedTrack in results
-					set output to output & "id=" & (id of selectedTrack) & "$BREAKname=" & (name of selectedTrack) & "$BREAKartist=" & (artist of selectedTrack) & "$BREAKalbum=" & (album of selectedTrack) & "$BREAKduration=" & (duration of selectedTrack) & "\\n"
+					set output to output & "id=" & (id of selectedTrack) & "$BREAKname=" & (name of selectedTrack) & "$BREAKartist=" & (artist of selectedTrack) & "$BREAKalbum=" & (album of selectedTrack) & "$BREAKduration=" & (duration of selectedTrack) & "\n"
 				end repeat
 			end tell
 		return output
@@ -23,7 +23,7 @@ export const getAll = () =>
       set allDurations to duration of every track of (library playlist 1)
       set trackCount to count of allIds
       repeat with i from 1 to trackCount
-        set output to output & "id=" & (item i of allIds) & "$BREAKname=" & (item i of allNames) & "$BREAKartist=" & (item i of allArtists) & "$BREAKalbum=" & (item i of allAlbums) & "$BREAKduration=" & (item i of allDurations) & "\\n"
+        set output to output & "id=" & (item i of allIds) & "$BREAKname=" & (item i of allNames) & "$BREAKartist=" & (item i of allArtists) & "$BREAKalbum=" & (item i of allAlbums) & "$BREAKduration=" & (item i of allDurations) & "\n"
       end repeat
     end tell
     return output


### PR DESCRIPTION
## Description

Performance improvements for the Music extension, especially for users with large libraries (10K+ tracks):

- **Play Library Album** now opens instantly and searches on demand, instead of loading the entire library upfront — fixing out-of-memory crashes for large libraries
- **Play Library Track** search is faster thanks to optimized AppleScript data fetching
- **Start Playlist** and **Add to Playlist** now use `useCachedPromise` with client-side filtering — reopening is instant after the first load, and switching the dropdown filter no longer re-fetches data
- **Favorite Track** confirms within 3 seconds instead of up to 10 seconds (reduced polling interval and timeout)
- **Menu Bar Player** scroll animation uses fewer re-renders (400ms vs 200ms interval)
- Fixed `ScriptError` type guard typo that prevented it from ever matching
- Exported `PlaylistKind` enum for type-safe reuse across modules

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder