### PR TITLE
Fix GitHub Copilot "Create Task" command

### DIFF
--- a/extensions/github-copilot/CHANGELOG.md
+++ b/extensions/github-copilot/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitHub Copilot Changelog
 
+## [Fix "Create Task" command error on successful creation] - {PR_MERGE_DATE}
+
+- Fix error when a task is created successfully with the "Create Task" command
+
 ## [View live agent logs] - 2026-03-17
 
 - Allow viewing the live agent logs for a task with the "View Tasks" command

--- a/extensions/github-copilot/CHANGELOG.md
+++ b/extensions/github-copilot/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Changelog
 
-## [Fix "Create Task" command error on successful creation] - {PR_MERGE_DATE}
+## [Fix "Create Task" command error on successful creation] - 2026-03-20
 
 - Fix error when a task is created successfully with the "Create Task" command
 

--- a/extensions/github-copilot/src/services/copilot.ts
+++ b/extensions/github-copilot/src/services/copilot.ts
@@ -59,11 +59,6 @@ type ListTasksResponse = {
   has_next_page: boolean;
 };
 
-// Response from creating a task
-type CreateTaskResponse = {
-  task: Task;
-};
-
 // A pull request returned from the GitHub GraphQL API
 type PullRequest = {
   globalId: string;
@@ -208,12 +203,12 @@ async function createTask(
     }
   }
 
-  const createTaskResult = (await createTaskResponse.json()) as CreateTaskResponse;
+  const task = (await createTaskResponse.json()) as Task;
 
   // URL format: https://github.com/{owner}/{repo}/tasks/{task_id}
-  const taskUrl = `https://github.com/${ownerName}/${repoName}/tasks/${createTaskResult.task.id}`;
+  const taskUrl = `https://github.com/${ownerName}/${repoName}/tasks/${task.id}`;
 
-  return { taskUrl, taskId: createTaskResult.task.id };
+  return { taskUrl, taskId: task.id };
 }
 
 const fetchTasks = async (): Promise<TaskWithPullRequest[]> => {


### PR DESCRIPTION
## Description

This fixes a bug with GitHub Copilot's "Create Task" command where the command errors when when a task is started successfully.

## Screencast

N/A

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
