### PR TITLE
Update aws extension

### DIFF
--- a/extensions/amazon-aws/.gitignore
+++ b/extensions/amazon-aws/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .idea
 .claude/settings.local.json
 CLAUDE.local.md
+.eslintcache
+.prettiercache

--- a/extensions/amazon-aws/CHANGELOG.md
+++ b/extensions/amazon-aws/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Browse and manage Athena work groups, named queries, and query executions
 - Browse QuickSight dashboards, analyses, and datasets with region override support
 - Search and list Cognito user pool users
-- Ask Raycast AI about your Lambda functions, S3 buckets, DynamoDB tables, secrets, pipelines, log groups, and QuickSight dashboards
+- Browse CloudWatch dashboards with name, ARN, last modified date, and size
+- Ask Raycast AI about your Lambda functions, S3 buckets, DynamoDB tables, secrets, pipelines, log groups, QuickSight dashboards, and CloudWatch dashboards
 - Improved Amplify build view with status icons, duration, job type, and one-click log downloads
 - Copy and export raw API responses for any Amplify resource
 - Fixed large accounts causing out-of-memory errors when loading paginated resources

--- a/extensions/amazon-aws/CHANGELOG.md
+++ b/extensions/amazon-aws/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Amazon AWS Changelog
 
+## [Athena, QuickSight, AI Tools & More] - {PR_MERGE_DATE}
+
+- Browse and manage Athena work groups, named queries, and query executions
+- Browse QuickSight dashboards, analyses, and datasets with region override support
+- Search and list Cognito user pool users
+- Ask Raycast AI about your Lambda functions, S3 buckets, DynamoDB tables, secrets, pipelines, log groups, and QuickSight dashboards
+- Improved Amplify build view with status icons, duration, job type, and one-click log downloads
+- Copy and export raw API responses for any Amplify resource
+- Fixed large accounts causing out-of-memory errors when loading paginated resources
+- Fixed Lambda log groups pointing to wrong CloudWatch group name
+- Clearer error messages across all services
+
 ## [Bug fix for Amplify] - 2025-09-30
 
-- Replace '/' in branch name with '-' when building branch url 
+- Replace '/' in branch name with '-' when building branch url
 
 ## [API Gateway, AppSync & Amplify Enhancements] - 2025-08-25
 

--- a/extensions/amazon-aws/CLAUDE.md
+++ b/extensions/amazon-aws/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a **Raycast extension** for AWS that provides quick access to AWS resources and services directly from Raycast. It uses the AWS SDK v3 for TypeScript and the Raycast API.
+
+## Common Commands
+
+```bash
+npm run dev          # Start development mode (watches for changes)
+npm run build        # Build for production
+npm run lint         # Run linting
+npm run fix-lint     # Auto-fix linting issues
+```
+
+## Architecture
+
+### Entry Points
+
+Each AWS service has a dedicated entry point in `src/`. New commands must be registered in `package.json` under the `commands` array.
+
+### Hooks Pattern
+
+All AWS API calls are wrapped in custom hooks (`src/hooks/use-*.ts`) using `useCachedPromise` from `@raycast/utils`:
+
+- Hooks handle pagination automatically with recursive fetching
+- Toast notifications show loading progress
+- Use `isReadyToFetch()` from `src/util/index.ts` to check if AWS credentials are available
+
+Example pattern:
+
+```typescript
+export function useAmplifyApps() {
+  const { data, error, isLoading, revalidate } = useCachedPromise(
+    async () => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading..." });
+      return await fetchAmplifyApps(toast);
+    },
+    [],
+    { execute: isReadyToFetch(), failureToastOptions: { title: "Failed to load" } },
+  );
+  return { apps: data, error, isLoading: (!data && !error) || isLoading, revalidate };
+}
+```
+
+### AWS Client Factory
+
+Use `AWSClients` from `src/services/aws-clients.ts` for all AWS SDK client instances:
+
+```typescript
+import { AWSClients } from "../services/aws-clients";
+
+const client = AWSClients.amplify(); // Returns cached AmplifyClient
+const response = await client.send(new ListAppsCommand({}));
+```
+
+Clients are cached per profile/region combination for better performance.
+
+### AWS Profile Management
+
+The `AWSProfileDropdown` component (`src/components/searchbar/aws-profile-dropdown.tsx`):
+
+- Reads AWS profiles from `~/.aws/config` and `~/.aws/credentials`
+- Supports AWS Vault integration (configured via extension preferences)
+- Supports AWS SSO with automatic SSO login URL generation
+- Sets environment variables: `AWS_PROFILE`, `AWS_REGION`, `AWS_SSO_*`
+
+### Console Links
+
+`resourceToConsoleLink()` in `src/util/index.ts` generates AWS Console URLs for different resource types. When adding a new resource type, add a case to this switch statement.
+
+### Common Actions
+
+`AwsAction` class in `src/components/common/action.tsx`:
+
+- `AwsAction.Console` - Opens resource in AWS Console (with SSO support)
+- `AwsAction.ExportResponse` - Copies raw AWS API response
+- `AwsAction.SwitchResourceType` - For views with multiple resource types
+
+### AI Tools
+
+The extension includes Raycast AI tools (`package.json` → `tools` array) for natural language interaction with AWS resources. Each tool has a corresponding implementation in `src/tools/`. Tools are standalone functions that export a default async function.
+
+### Error Handling
+
+Custom error types are available in `src/errors/index.ts`:
+
+- `AWSClientError` - For AWS API failures
+- `ValidationError` - For input validation failures
+- `ResourceNotFoundError` - For missing resources
+- Use `getAWSErrorMessage()` to extract user-friendly messages
+
+## Constants
+
+- `AWS_URL_BASE` in `src/constants.ts` - Base URL for AWS Console links
+- Region is read from `process.env.AWS_REGION` (set by profile dropdown)
+
+## Environment Variables Used
+
+- `AWS_PROFILE` - Selected AWS profile name
+- `AWS_REGION` - AWS region for API calls and console links
+- `AWS_VAULT` - Set when using AWS Vault
+- `AWS_SSO_START_URL`, `AWS_SSO_ACCOUNT_ID`, `AWS_SSO_ROLE_NAME` - For SSO integration

--- a/extensions/amazon-aws/CLAUDE.md
+++ b/extensions/amazon-aws/CLAUDE.md
@@ -47,16 +47,16 @@ export function useAmplifyApps() {
 
 ### AWS Client Factory
 
-Use `AWSClients` from `src/services/aws-clients.ts` for all AWS SDK client instances:
+Each AWS service has a dedicated client module in `src/services/clients/` for tree-shaking. Import only the client you need:
 
 ```typescript
-import { AWSClients } from "../services/aws-clients";
+import { getAmplifyClient } from "../services/clients/amplify";
 
-const client = AWSClients.amplify(); // Returns cached AmplifyClient
+const client = getAmplifyClient(); // Returns cached AmplifyClient
 const response = await client.send(new ListAppsCommand({}));
 ```
 
-Clients are cached per profile/region combination for better performance.
+Clients are cached per profile/region combination via the shared `ClientCache` in `src/services/client-cache.ts`.
 
 ### AWS Profile Management
 

--- a/extensions/amazon-aws/package-lock.json
+++ b/extensions/amazon-aws/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-sdk/client-appsync": "^3.940.0",
         "@aws-sdk/client-athena": "^3.940.0",
         "@aws-sdk/client-cloudformation": "^3.940.0",
+        "@aws-sdk/client-cloudwatch": "^3.940.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.940.0",
         "@aws-sdk/client-codeartifact": "^3.940.0",
         "@aws-sdk/client-codepipeline": "^3.940.0",
@@ -980,6 +981,58 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-cloudwatch": {
+      "version": "3.1013.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1013.0.tgz",
+      "integrity": "sha512-fnCgnuL1v8pF42g4FCDp+l5ZDhBKZLLqb4/ONIXYlxxBS09UJwb45LvCJ5ys5uluMRGyweQMPSNEUCOJtjnVgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/credential-provider-node": "^3.972.23",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.9",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-compression": "^4.3.41",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.13",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-cloudwatch-logs": {
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.940.0.tgz",
@@ -1031,6 +1084,435 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/core": {
+      "version": "3.973.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.22.tgz",
+      "integrity": "sha512-lY6g5L95jBNgOUitUhfV2N/W+i08jHEl3xuLODYSQH5Sf50V+LkVYBSyZRLtv2RyuXZXiV7yQ+acpswK1tlrOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.14",
+        "@smithy/core": "^3.23.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.20.tgz",
+      "integrity": "sha512-vI0QN96DFx3g9AunfOWF3CS4cMkqFiR/WM/FyP9QHr5rZ2dKPkYwP3tCgAOvGuu9CXI7dC1vU2FVUuZ+tfpNvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.22.tgz",
+      "integrity": "sha512-aS/81smalpe7XDnuQfOq4LIPuaV2PRKU2aMTrHcqO5BD4HwO5kESOHNcec2AYfBtLtIDqgF6RXisgBnfK/jt0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.22.tgz",
+      "integrity": "sha512-rpF8fBT0LllMDp78s62aL2A/8MaccjyJ0ORzqu+ZADeECLSrrCWIeeXsuRam+pxiAMkI1uIyDZJmgLGdadkPXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/credential-provider-env": "^3.972.20",
+        "@aws-sdk/credential-provider-http": "^3.972.22",
+        "@aws-sdk/credential-provider-login": "^3.972.22",
+        "@aws-sdk/credential-provider-process": "^3.972.20",
+        "@aws-sdk/credential-provider-sso": "^3.972.22",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.22.tgz",
+      "integrity": "sha512-u33CO9zeNznlVSg9tWTCRYxaGkqr1ufU6qeClpmzAabXZa8RZxQoVXxL5T53oZJFzQYj+FImORCSsi7H7B77gQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.23.tgz",
+      "integrity": "sha512-U8tyLbLOZItuVWTH0ay9gWo4xMqZwqQbg1oMzdU4FQSkTpqXemm4X0uoKBR6llqAStgBp30ziKFJHTA43l4qMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.20",
+        "@aws-sdk/credential-provider-http": "^3.972.22",
+        "@aws-sdk/credential-provider-ini": "^3.972.22",
+        "@aws-sdk/credential-provider-process": "^3.972.20",
+        "@aws-sdk/credential-provider-sso": "^3.972.22",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.20.tgz",
+      "integrity": "sha512-QRfk7GbA4/HDRjhP3QYR6QBr/QKreVoOzvvlRHnOuGgYJkeoPgPY3LAI1kK1ZMgZ4hH9KiGp757/ntol+INAig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.22.tgz",
+      "integrity": "sha512-4vqlSaUbBj4aNPVKfB6yXuIQ2Z2mvLfIGba2OzzF6zUkN437/PGWsxBU2F8QPSFHti6seckvyCXidU3H+R8NvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/token-providers": "3.1013.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.22.tgz",
+      "integrity": "sha512-/wN1CYg2rVLhW8/jLxMWacQrkpaynnL+4j/Z+e6X1PfoE6NiC0BeOw3i0JmtZrKun85wNV5GmspvuWJihfeeUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+      "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.23.tgz",
+      "integrity": "sha512-HQu8QoqGZZTvg0Spl9H39QTsSMFwgu+8yz/QGKndXFLk9FZMiCiIgBCVlTVKMDvVbgqIzD9ig+/HmXsIL2Rb+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.12.tgz",
+      "integrity": "sha512-KLdQGJPSm98uLINolQ0Tol8OAbk7g0Y7zplHJ1K83vbMIH13aoCvR6Tho66xueW4l4aZlEgVGLWBnD8ifUMsGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.9",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.8.tgz",
+      "integrity": "sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1013.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1013.0.tgz",
+      "integrity": "sha512-IL1c54UvbuERrs9oLm5rvkzMciwhhpn1FL0SlC3XUMoLlFhdBsWJgQKK8O5fsQLxbFVqjbjFx9OBkrn44X9PHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.9.tgz",
+      "integrity": "sha512-jeFqqp8KD/P5O+qeKxyGeu7WEVIZFNprnkaDjGmBOjwxYwafCBhpxTgV1TlW6L8e76Vh/siNylNmN/OmSIFBUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.14.tgz",
+      "integrity": "sha512-G/Yd8Bnnyh8QrqLf8jWJbixEnScUFW24e/wOBGYdw1Cl4r80KX/DvHyM2GVZ2vTp7J4gTEr8IXJlTadA8+UfuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/fast-xml-parser": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/client-codeartifact": {
@@ -5395,6 +5877,27 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/middleware-compression": {
+      "version": "4.3.41",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.3.41.tgz",
+      "integrity": "sha512-lJ/yTWaPQZfvT5GJUgGpjjmG4ZgNhlPmvAN+SfQKcsNBApY+CaW2vg/x7GhsD3g/liKlo7suMAAZNK5RVQ9OIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "fflate": "0.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/middleware-content-length": {
       "version": "4.2.12",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
@@ -5842,13 +6345,13 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.5.tgz",
-      "integrity": "sha512-Dbun99A3InifQdIrsXZ+QLcC0PGBPAdrl4cj1mTgJvyc9N2zf7QSxg8TBkzsCmGJdE3TLbO9ycwpY0EkWahQ/g==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.13.tgz",
+      "integrity": "sha512-2zdZ9DTHngRtcYxJK1GUDxruNr53kv5W2Lupe0LMU+Imr6ohQg8M2T14MNkj1Y0wS3FFwpgpGQyvuaMF7CiTmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6857,6 +7360,12 @@
       "engines": {
         "node": ">= 4.9.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
+      "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/extensions/amazon-aws/package-lock.json
+++ b/extensions/amazon-aws/package-lock.json
@@ -7,37 +7,41 @@
       "name": "aws",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-amplify": "^3.864.0",
-        "@aws-sdk/client-api-gateway": "^3.864.0",
-        "@aws-sdk/client-apigatewayv2": "^3.864.0",
-        "@aws-sdk/client-appsync": "^3.859.0",
-        "@aws-sdk/client-cloudformation": "^3.864.0",
-        "@aws-sdk/client-cloudwatch-logs": "^3.864.0",
-        "@aws-sdk/client-codeartifact": "^3.864.0",
-        "@aws-sdk/client-codepipeline": "^3.864.0",
-        "@aws-sdk/client-dynamodb": "^3.868.0",
-        "@aws-sdk/client-ec2": "^3.868.0",
-        "@aws-sdk/client-ecr": "^3.864.0",
-        "@aws-sdk/client-ecs": "^3.864.0",
-        "@aws-sdk/client-glue": "^3.868.0",
-        "@aws-sdk/client-lambda": "^3.865.0",
-        "@aws-sdk/client-s3": "^3.864.0",
-        "@aws-sdk/client-secrets-manager": "^3.864.0",
-        "@aws-sdk/client-sfn": "^3.864.0",
-        "@aws-sdk/client-sqs": "^3.864.0",
-        "@aws-sdk/client-ssm": "^3.864.0",
+        "@aws-sdk/client-amplify": "^3.940.0",
+        "@aws-sdk/client-api-gateway": "^3.940.0",
+        "@aws-sdk/client-apigatewayv2": "^3.940.0",
+        "@aws-sdk/client-appsync": "^3.940.0",
+        "@aws-sdk/client-athena": "^3.940.0",
+        "@aws-sdk/client-cloudformation": "^3.940.0",
+        "@aws-sdk/client-cloudwatch-logs": "^3.940.0",
+        "@aws-sdk/client-codeartifact": "^3.940.0",
+        "@aws-sdk/client-codepipeline": "^3.940.0",
+        "@aws-sdk/client-cognito-identity-provider": "^3.953.0",
+        "@aws-sdk/client-dynamodb": "^3.940.0",
+        "@aws-sdk/client-ec2": "^3.940.0",
+        "@aws-sdk/client-ecr": "^3.940.0",
+        "@aws-sdk/client-ecs": "^3.940.0",
+        "@aws-sdk/client-glue": "^3.942.0",
+        "@aws-sdk/client-lambda": "^3.942.0",
+        "@aws-sdk/client-quicksight": "^3.940.0",
+        "@aws-sdk/client-s3": "^3.940.0",
+        "@aws-sdk/client-secrets-manager": "^3.940.0",
+        "@aws-sdk/client-sfn": "^3.940.0",
+        "@aws-sdk/client-sqs": "^3.940.0",
+        "@aws-sdk/client-ssm": "^3.940.0",
+        "@aws-sdk/client-sts": "^3.940.0",
         "@aws-sdk/shared-ini-file-loader": "^3.374.0",
-        "@aws-sdk/util-dynamodb": "^3.868.0",
-        "@raycast/api": "^1.102.4",
-        "@raycast/utils": "^2.2.0",
+        "@aws-sdk/util-dynamodb": "^3.940.0",
+        "@raycast/api": "^1.103.10",
+        "@raycast/utils": "^2.2.2",
         "util": "^0.12.5"
       },
       "devDependencies": {
-        "@raycast/eslint-config": "^2.0.4",
-        "@types/react": "^19.1.10",
-        "eslint": "^9.33.0",
-        "prettier": "^3.6.2",
-        "typescript": "^5.9.2"
+        "@raycast/eslint-config": "^2.1.1",
+        "@types/react": "^19.2.7",
+        "eslint": "^9.39.1",
+        "prettier": "^3.7.3",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -243,303 +247,249 @@
       }
     },
     "node_modules/@aws-sdk/client-amplify": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-amplify/-/client-amplify-3.1011.0.tgz",
-      "integrity": "sha512-7856KkIGFf1f14LbAFsk/Zj/NYtCw6cZXzKFuLj1wYwXQICtLp+TmaXhq9UO4hJAg8M3Jns1jHtiB8hf2QAkEg==",
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-amplify/-/client-amplify-3.940.0.tgz",
+      "integrity": "sha512-EdwmYADAZoF0tnIkVal15ys/+5bZwyJj7L44dExjFvBnvRsd7Igwu7EqopQwrLqbSt+no1mfonyIeQxtiXDGSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-api-gateway": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-api-gateway/-/client-api-gateway-3.1011.0.tgz",
-      "integrity": "sha512-IV8iqz1fLXlG1/Sl2XehgBEOBEjVOtC4mCOE12rHZHegEHsUQdb42Y9GHJAM/ki9cSFMzV4ZsC7dRkqNtnkL5A==",
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-api-gateway/-/client-api-gateway-3.940.0.tgz",
+      "integrity": "sha512-nx1Ao4F4OJxvRCt92L8Ob9kymqhAUdry2S3pUn2Upts8llovb9i8qY2uEUJKmCPykOWYfkUANMOWxj3yAssGzg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-sdk-api-gateway": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-sdk-api-gateway": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewayv2/-/client-apigatewayv2-3.1011.0.tgz",
-      "integrity": "sha512-TkYijfkD+QwByW81dpUG3AZc/CZ2DB51gsrAT0KVLKsnE15GGBcnkNN+Sbs5ICQ5VyHOzNBYntRo9yeMO1icww==",
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewayv2/-/client-apigatewayv2-3.940.0.tgz",
+      "integrity": "sha512-LXhnwRm5+nxT6SAkQCWQjpHKjd4bTf1BN7pBMoPjum38aKKjruwZQOiwCoIa7KW2sEdVPJwap0fJuFVMCzlCzw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-appsync": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appsync/-/client-appsync-3.1011.0.tgz",
-      "integrity": "sha512-Hi0n7+LQ+Xrc30dRjmoN3kH2cIa7FiCODySMiwmIpqgBRUbx9TYTyKhQsYfnftRWt+du8SnRkSDb7CzttP4pzQ==",
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appsync/-/client-appsync-3.940.0.tgz",
+      "integrity": "sha512-oigzt0omQKa2uL2RGz08L5zvGbG3YmH7eGOeHyKc8Mmf1fzcu8Dq5W9TC1lxrSJdep5j7iGsnKgrD/iPVbhtMw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cloudformation": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1011.0.tgz",
-      "integrity": "sha512-v7qixZ+o2+t5f+Y+9qN5EyEejdkGpeDxhkRBaW9xOlE41owhsv7y1EmCsW1Lo5W+0krm0r/09w/TWy7rLHa57Q==",
+    "node_modules/@aws-sdk/client-athena": {
+      "version": "3.1012.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.1012.0.tgz",
+      "integrity": "sha512-R2h0Quw/iAPpRWbVqdFE8KKR4BX+gFbBwsXhMIi+SsoEsvV4xYVksyDSDZWPhStM2dxrA4HfhqZsX7CTdtw8qA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/credential-provider-node": "^3.972.22",
         "@aws-sdk/middleware-host-header": "^3.972.8",
         "@aws-sdk/middleware-logger": "^3.972.8",
         "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/middleware-user-agent": "^3.972.22",
         "@aws-sdk/region-config-resolver": "^3.972.8",
         "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/util-endpoints": "^3.996.5",
         "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.8",
         "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
+        "@smithy/core": "^3.23.12",
         "@smithy/fetch-http-handler": "^5.3.15",
         "@smithy/hash-node": "^4.2.12",
         "@smithy/invalid-dependency": "^4.2.12",
         "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
         "@smithy/middleware-stack": "^4.2.12",
         "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/node-http-handler": "^4.5.0",
         "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/smithy-client": "^4.12.6",
         "@smithy/types": "^4.13.1",
         "@smithy/url-parser": "^4.2.12",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.13",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cloudwatch-logs": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1011.0.tgz",
-      "integrity": "sha512-5cFA4T8dtVLuVt+w3vq29hir7dgiImW2LeYxnJl/RSD4pcucem9CwXDip9gHTdqUyavzzHN7BGCjfrtAcHx13w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/eventstream-serde-browser": "^4.2.12",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
-        "@smithy/eventstream-serde-node": "^4.2.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
         "@smithy/util-endpoints": "^3.3.3",
         "@smithy/util-middleware": "^4.2.12",
         "@smithy/util-retry": "^4.2.12",
@@ -550,703 +500,20 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-codeartifact": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-codeartifact/-/client-codeartifact-3.1011.0.tgz",
-      "integrity": "sha512-FvlMaDXgNHYJDEkV6IHDR+MtySYp+54tjCLXuMyCFR8cGB0Uq2uyCNRGh5fmNmU9ZAio6M15OU7jpkhqBQCj1A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codepipeline": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-codepipeline/-/client-codepipeline-3.1011.0.tgz",
-      "integrity": "sha512-jSM+PJ6bUbfAlyl6GGu4eZwACu+bCYEyo8O7qZb95/m8MDkN8m+x+qMvdBkHkyc5DA9QORK2yQBPyGL2nFX46w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1011.0.tgz",
-      "integrity": "sha512-oCYlsiLR0qESxmr6LWeUDZH2qITGL69mgFxqFPzrblBfKSZPw6jEzVSB/T6JUqzSQrARnusiLNHxn6eph0rSHQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/dynamodb-codec": "^3.972.21",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.8",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.13",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.1011.0.tgz",
-      "integrity": "sha512-naplpjRv20ZgJX2sUGVhypzeE9Qb8qnlTBTxJkxCSV84IiXhwwJy+0SutsH0br8xktQ0oSjAIIq7Cipvok00+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-sdk-ec2": "^3.972.15",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.13",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecr": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.1011.0.tgz",
-      "integrity": "sha512-lG1cP5ySh77UGvipwJZiVeq1oIVcYAbYPjuwmOT7zXk/LRobQwKMFCL4rRu/+pW+qFceeyKvFhYyxbDWKGBPag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.13",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.1011.0.tgz",
-      "integrity": "sha512-PRNsRQFYPK4b0KPnfpdIRMTpHJOwfha56R/myeR2M1BJMRrk5DjbGLFxx30W2r8ay/M7vcCaoylrzfe3k6gd/w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.13",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-glue": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-glue/-/client-glue-3.1011.0.tgz",
-      "integrity": "sha512-xajd6FUk+yyHOMkMIfBZ+322QlgYB2EAlK97fPLHZTM04w4b8nMGzsdOWBTPKt6j/S3Rab7u7Am5OkkdHCY7FQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1011.0.tgz",
-      "integrity": "sha512-qX8QYpTU4jSiYQB/zEguvGLKAkwhFf60Gp+xtkO4yJNpu6680DsXHX3UND/seYXL5zOyUXIwsiH14oUditvu4Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/eventstream-serde-browser": "^4.2.12",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
-        "@smithy/eventstream-serde-node": "^4.2.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.13",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1011.0.tgz",
-      "integrity": "sha512-jY7CGX+vfM/DSi4K8UwaZKoXnhqchmAbKFB1kIuHMfPPqW7l3jC/fUVDb95/njMsB2ymYOTusZEzoCTeUB/4qA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "5.2.0",
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.8",
-        "@aws-sdk/middleware-expect-continue": "^3.972.8",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.0",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-location-constraint": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.20",
-        "@aws-sdk/middleware-ssec": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/eventstream-serde-browser": "^4.2.12",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
-        "@smithy/eventstream-serde-node": "^4.2.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-blob-browser": "^4.2.13",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/hash-stream-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/md5-js": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.13",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1011.0.tgz",
-      "integrity": "sha512-1tQqovjWamefbC3ot+1stXOT+OP/DrTMvhYjENAIlcshT9vzekmFIGbPtErzAllga4Y2uhXyoI4Rm5YdPqx8LA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sfn": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.1011.0.tgz",
-      "integrity": "sha512-oMgFO8mhkLbJRMWD4+Lm1nOBrs+H2uONwuMGnyRC/1PX1WvS/ZidRis77LAbAkC9Mz/K53BcMNonleIV9LqWug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1011.0.tgz",
-      "integrity": "sha512-PPNHwT3737xmHqC3liSIHYl0sE23UYvnXnajvhNmFlOmjeZthzi1ZiYcuuoSwyaFUX1gInxv+/C8NdfmZcdsfg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-sdk-sqs": "^3.972.15",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/md5-js": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.1011.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1011.0.tgz",
-      "integrity": "sha512-XFrixqhD4Lp9Bq/ZefbeYLp9oOL+4htqo7UxDCgrON0HBoj5u/3bDQPPse7CrfaYVw986mvoDJVRnIY2g+TDjA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.13",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.973.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.20.tgz",
-      "integrity": "sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==",
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/core": {
+      "version": "3.973.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.21.tgz",
+      "integrity": "sha512-OTUcDX9Yfz/FLKbHjiMaP9D4Hs44lYJzN7zBcrK2nDmBt0Wr8D6nYt12QoBkZsW0nVMFsTIGaZCrsU9zCcIMXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.11",
-        "@smithy/core": "^3.23.11",
+        "@aws-sdk/xml-builder": "^3.972.12",
+        "@smithy/core": "^3.23.12",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/smithy-client": "^4.12.6",
         "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.12",
@@ -1257,26 +524,13 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.5.tgz",
-      "integrity": "sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==",
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.19.tgz",
+      "integrity": "sha512-33NpkQtmnsjLr9QdZvL3w8bjy+WoBJ+jY8JwuzxIq38rDNi1kwpBWW7Yjh+8bMlksd+ZAWW0fH4S/6OeoAdU5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.18.tgz",
-      "integrity": "sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/core": "^3.973.21",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/types": "^4.13.1",
@@ -1286,41 +540,41 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.20.tgz",
-      "integrity": "sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==",
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.21.tgz",
+      "integrity": "sha512-xFke7yjbON4unNOG0TApQwz+o1LH5VhVLgWlUuiLRWNDyBfeHIFje2ck8qHybvJ8Fkm5m3SsN+pvHtVo6PGWlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/core": "^3.973.21",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/node-http-handler": "^4.5.0",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/smithy-client": "^4.12.6",
         "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.19",
+        "@smithy/util-stream": "^4.5.20",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.20.tgz",
-      "integrity": "sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==",
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.21.tgz",
+      "integrity": "sha512-fmJN7KhB7CoG65w9fC2LVOd2wZbR2d1yJIpZNe2J5CeDPu7nUHSmavuJAeGEoE3OL5UIBVPNhmK/fV/NQrs3Hw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-env": "^3.972.18",
-        "@aws-sdk/credential-provider-http": "^3.972.20",
-        "@aws-sdk/credential-provider-login": "^3.972.20",
-        "@aws-sdk/credential-provider-process": "^3.972.18",
-        "@aws-sdk/credential-provider-sso": "^3.972.20",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.20",
-        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/credential-provider-env": "^3.972.19",
+        "@aws-sdk/credential-provider-http": "^3.972.21",
+        "@aws-sdk/credential-provider-login": "^3.972.21",
+        "@aws-sdk/credential-provider-process": "^3.972.19",
+        "@aws-sdk/credential-provider-sso": "^3.972.21",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/credential-provider-imds": "^4.2.12",
         "@smithy/property-provider": "^4.2.12",
@@ -1332,14 +586,14 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.20.tgz",
-      "integrity": "sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==",
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.21.tgz",
+      "integrity": "sha512-ENU+YCiuQocQjfIf9bPxZ+ZY0wIBkl3SMH22optBQwy8UFpSfonHynXzGT27xQxer4cYTNOpwDqbfo57BusbpQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
@@ -1351,18 +605,18 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.21.tgz",
-      "integrity": "sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==",
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.22.tgz",
+      "integrity": "sha512-VE6i8nkmrRyhKut7nnfCWRbdDf+CfyRr8ixSwdaPDguYlgvkAO2pHu9oK11XzbSuatB0io1ozI/vpYhelXn8Pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.18",
-        "@aws-sdk/credential-provider-http": "^3.972.20",
-        "@aws-sdk/credential-provider-ini": "^3.972.20",
-        "@aws-sdk/credential-provider-process": "^3.972.18",
-        "@aws-sdk/credential-provider-sso": "^3.972.20",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.20",
+        "@aws-sdk/credential-provider-env": "^3.972.19",
+        "@aws-sdk/credential-provider-http": "^3.972.21",
+        "@aws-sdk/credential-provider-ini": "^3.972.21",
+        "@aws-sdk/credential-provider-process": "^3.972.19",
+        "@aws-sdk/credential-provider-sso": "^3.972.21",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.21",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/credential-provider-imds": "^4.2.12",
         "@smithy/property-provider": "^4.2.12",
@@ -1374,13 +628,13 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.18.tgz",
-      "integrity": "sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==",
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.19.tgz",
+      "integrity": "sha512-hjj5bFo4kf5/WzAMjDEFByVOMbq5gZiagIpJexf7Kp9nIDaGzhCphMsx03NCA8s9zUJzHlD1lXazd7MS+e03Lg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/core": "^3.973.21",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/shared-ini-file-loader": "^4.4.7",
@@ -1391,101 +645,36 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.20.tgz",
-      "integrity": "sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/nested-clients": "^3.996.10",
-        "@aws-sdk/token-providers": "3.1009.0",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.20.tgz",
-      "integrity": "sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/nested-clients": "^3.996.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/dynamodb-codec": {
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.972.21.tgz",
-      "integrity": "sha512-6wsIKQWJx87F1SZyQ/SfV7ovdvP0R2l5vpgSxT1+b9Qmx2IYnvWNNJfmpd3HJRN7aokEh/IV/eFlVnsZF2NXCQ==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.21.tgz",
+      "integrity": "sha512-9jWRCuMZpZKlqCZ46bvievqdfswsyB2yPAr9rOiN+FxaGgf8jrR5iYDqJgscvk1jrbAxiK4cIjHv3XjIAWAhzQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@smithy/core": "^3.23.11",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.4.tgz",
-      "integrity": "sha512-GdASDnWanLnHxKK0hqV97xz23QmfA/C8yGe0PiuEmWiHSe+x+x+mFEj4sXqx9IbfyPncWz8f4EhNwBSG9cgYCg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mnemonist": "0.38.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.8.tgz",
-      "integrity": "sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==",
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
+        "@aws-sdk/token-providers": "3.1012.0",
         "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
         "@smithy/types": "^4.13.1",
-        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.8.tgz",
-      "integrity": "sha512-S0oXx1QbSpMDBMJn4P0hOxW8ieGAdRT+G9NbL+ESWkkoCGf9D++fKYD2fyBGtIy88OrP7wgECpXgGLAcGpIj0A==",
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.21.tgz",
+      "integrity": "sha512-ShWQO/cQVZ+j3zUDK7Kj+m7grPzQCVA2iaZdJ+hJTGvVH5lR32Ip/rgZZ+zBdH6D6wczP9Upa4NMXoqJdGpK1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/endpoint-cache": "^3.972.4",
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
         "@aws-sdk/types": "^3.973.6",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
         "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
@@ -1493,47 +682,7 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.8.tgz",
-      "integrity": "sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.0.tgz",
-      "integrity": "sha512-BmdDjqvnuYaC4SY7ypHLXfCSsGYGUZkjCLSZyUAAYn1YT28vbNMJNDwhlfkvvE+hQHG5RJDlEmYuvBxcB9jX1g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@aws-crypto/crc32c": "5.2.0",
-        "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/crc64-nvme": "^3.972.5",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.972.8",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
       "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
@@ -1548,21 +697,7 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.8.tgz",
-      "integrity": "sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.972.8",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
       "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
@@ -1576,7 +711,7 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.972.8",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
       "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
@@ -1592,106 +727,16 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-api-gateway": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-api-gateway/-/middleware-sdk-api-gateway-3.972.8.tgz",
-      "integrity": "sha512-G5gqn4TPkFdCBo/I9bC1D3GoFLLsRoPDrxxqqzGhLIpmiQvEXIAYmWFV/sJer7ImbWdjsSMW0+/STt8XKbq6BQ==",
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.22.tgz",
+      "integrity": "sha512-pZPNGWZVQvgUIO/P9PXZNz7ciq9mLYb/wQEurg3phKTa3DiBIunIRcgA0eBNwmog6S3oy0KR1bv4EJ4ld9A5sQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-ec2": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.972.15.tgz",
-      "integrity": "sha512-7lGK3pEOhu7LTaB681DNS5m4xX+emTdrJUH+dPKyQTqQmCX36MVAxRMNGFoeNEV6swZf8k88K36PSsWqro+gtw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-format-url": "^3.972.8",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.20.tgz",
-      "integrity": "sha512-yhva/xL5H4tWQgsBjwV+RRD0ByCzg0TcByDCLp3GXdn/wlyRNfy8zsswDtCvr1WSKQkSQYlyEzPuWkJG0f5HvQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.11",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.15.tgz",
-      "integrity": "sha512-X7yt+gJzZEK247nppuUVWS1i83q8zhZdBk1H2b6/qeXNv1ILgw0bQLNbFNG4gJi3P7vZV+PhtPkax0nwXAvRtg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.8.tgz",
-      "integrity": "sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.21.tgz",
-      "integrity": "sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/core": "^3.973.21",
         "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/util-endpoints": "^3.996.5",
-        "@smithy/core": "^3.23.11",
+        "@smithy/core": "^3.23.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/types": "^4.13.1",
         "@smithy/util-retry": "^4.2.12",
@@ -1701,45 +746,45 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.10.tgz",
-      "integrity": "sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==",
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.11.tgz",
+      "integrity": "sha512-i7SwoSR4JB/79JoGDUACnFUQOZwXGLWNX35lIb1Pq72nUGlVV+RFZp+BLa8S+mog2pbXU9+6Kc5YwGiMi5bKhQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/core": "^3.973.21",
         "@aws-sdk/middleware-host-header": "^3.972.8",
         "@aws-sdk/middleware-logger": "^3.972.8",
         "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/middleware-user-agent": "^3.972.22",
         "@aws-sdk/region-config-resolver": "^3.972.8",
         "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/util-endpoints": "^3.996.5",
         "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.8",
         "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
+        "@smithy/core": "^3.23.12",
         "@smithy/fetch-http-handler": "^5.3.15",
         "@smithy/hash-node": "^4.2.12",
         "@smithy/invalid-dependency": "^4.2.12",
         "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
         "@smithy/middleware-stack": "^4.2.12",
         "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/node-http-handler": "^4.5.0",
         "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/smithy-client": "^4.12.6",
         "@smithy/types": "^4.13.1",
         "@smithy/url-parser": "^4.2.12",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
         "@smithy/util-endpoints": "^3.3.3",
         "@smithy/util-middleware": "^4.2.12",
         "@smithy/util-retry": "^4.2.12",
@@ -1750,7 +795,7 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/region-config-resolver": {
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.972.8",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.8.tgz",
       "integrity": "sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==",
@@ -1764,6 +809,2923 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1012.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1012.0.tgz",
+      "integrity": "sha512-vzKwy020zjuiF4WTJzejx5nYcXJnRhHpb6i3lyZHIwfFwXG1yX4bzBVNMWYWF+bz1i2Pp2VhJbPyzpqj4VuJXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.8.tgz",
+      "integrity": "sha512-Kvb96TafGPLYo4Z2GRCzQTne77epXgiZEo0DDXwavzkWmgDV/1XD1tMA766gzRcHHFUraWsE+4T8DKtPTZUxgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.13.tgz",
+      "integrity": "sha512-I/+BMxM4WE/6xL0tyV7tAUDOAXmyw/va1oGr/eSly43HmLUcD1G+v96vEKAA8VoLcZ03ZQo/PWzjmN9zQErqPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/fast-xml-parser": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.940.0.tgz",
+      "integrity": "sha512-6/vI/3FfvcO95Uki93pFfrRnZNC2N0jVrQRxxCgN+B5WA+Lc+vh+zIphpKMtUIK5+vHpyc/ATQ/X1kOp3tsFQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.940.0.tgz",
+      "integrity": "sha512-7dEIO3D98IxA9IhqixPJbzQsBkk4TchHHpFdd0JOhlSlihWhiwbf3ijUePJVXYJxcpRRtMmAMtDRLDzCSO+ZHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/eventstream-serde-browser": "^4.2.5",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
+        "@smithy/eventstream-serde-node": "^4.2.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-codeartifact": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-codeartifact/-/client-codeartifact-3.940.0.tgz",
+      "integrity": "sha512-3H3E4/qJe9d1dqY7/AwmdByBeEmAP86/cVgNRQo77wgSpBMOcF+u+nvLoQYzzSUssOHVXtAKOrCJJGzpmDZazg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-codepipeline": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-codepipeline/-/client-codepipeline-3.940.0.tgz",
+      "integrity": "sha512-B8YjiBdfiG2brAYwMTRYi0vf2D6YPDarjk8cJeiFgQ9iPHgyde3zxjsNyh9oASPTxnxLXBp+sjLEizFBMZutzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.953.0.tgz",
+      "integrity": "sha512-1AW66gx3piI0a7xl10nW6tTAUhivQltv2xYiskoYZrQOUn04xcDk93Y87//l7qMlLBwsszUs8cF0/kkQccdsaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.953.0",
+        "@aws-sdk/credential-provider-node": "3.953.0",
+        "@aws-sdk/middleware-host-header": "3.953.0",
+        "@aws-sdk/middleware-logger": "3.953.0",
+        "@aws-sdk/middleware-recursion-detection": "3.953.0",
+        "@aws-sdk/middleware-user-agent": "3.953.0",
+        "@aws-sdk/region-config-resolver": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@aws-sdk/util-endpoints": "3.953.0",
+        "@aws-sdk/util-user-agent-browser": "3.953.0",
+        "@aws-sdk/util-user-agent-node": "3.953.0",
+        "@smithy/config-resolver": "^4.4.4",
+        "@smithy/core": "^3.19.0",
+        "@smithy/fetch-http-handler": "^5.3.7",
+        "@smithy/hash-node": "^4.2.6",
+        "@smithy/invalid-dependency": "^4.2.6",
+        "@smithy/middleware-content-length": "^4.2.6",
+        "@smithy/middleware-endpoint": "^4.3.15",
+        "@smithy/middleware-retry": "^4.4.15",
+        "@smithy/middleware-serde": "^4.2.7",
+        "@smithy/middleware-stack": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.6",
+        "@smithy/node-http-handler": "^4.4.6",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/smithy-client": "^4.10.0",
+        "@smithy/types": "^4.10.0",
+        "@smithy/url-parser": "^4.2.6",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.14",
+        "@smithy/util-defaults-mode-node": "^4.2.17",
+        "@smithy/util-endpoints": "^3.2.6",
+        "@smithy/util-middleware": "^4.2.6",
+        "@smithy/util-retry": "^4.2.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/client-sso": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.953.0.tgz",
+      "integrity": "sha512-WU8XtORGnhy1JjTLflcGcNGU329pmwl/2claTVGp7vrgUKyreQV9Ke3BkMuUPYLOGO/Znstzc1VbUT9ORH3+WQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.953.0",
+        "@aws-sdk/middleware-host-header": "3.953.0",
+        "@aws-sdk/middleware-logger": "3.953.0",
+        "@aws-sdk/middleware-recursion-detection": "3.953.0",
+        "@aws-sdk/middleware-user-agent": "3.953.0",
+        "@aws-sdk/region-config-resolver": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@aws-sdk/util-endpoints": "3.953.0",
+        "@aws-sdk/util-user-agent-browser": "3.953.0",
+        "@aws-sdk/util-user-agent-node": "3.953.0",
+        "@smithy/config-resolver": "^4.4.4",
+        "@smithy/core": "^3.19.0",
+        "@smithy/fetch-http-handler": "^5.3.7",
+        "@smithy/hash-node": "^4.2.6",
+        "@smithy/invalid-dependency": "^4.2.6",
+        "@smithy/middleware-content-length": "^4.2.6",
+        "@smithy/middleware-endpoint": "^4.3.15",
+        "@smithy/middleware-retry": "^4.4.15",
+        "@smithy/middleware-serde": "^4.2.7",
+        "@smithy/middleware-stack": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.6",
+        "@smithy/node-http-handler": "^4.4.6",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/smithy-client": "^4.10.0",
+        "@smithy/types": "^4.10.0",
+        "@smithy/url-parser": "^4.2.6",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.14",
+        "@smithy/util-defaults-mode-node": "^4.2.17",
+        "@smithy/util-endpoints": "^3.2.6",
+        "@smithy/util-middleware": "^4.2.6",
+        "@smithy/util-retry": "^4.2.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/core": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
+      "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@aws-sdk/xml-builder": "3.953.0",
+        "@smithy/core": "^3.19.0",
+        "@smithy/node-config-provider": "^4.3.6",
+        "@smithy/property-provider": "^4.2.6",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/signature-v4": "^5.3.6",
+        "@smithy/smithy-client": "^4.10.0",
+        "@smithy/types": "^4.10.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.953.0.tgz",
+      "integrity": "sha512-ahOxDxvaKUf99LU9iRmRtPW2HLmsR+ix2WyzRGl1PpLltiRLMbKJHj5Tu2xyOsgLxs8tefK9D1j0SUgPk8GJ6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/property-provider": "^4.2.6",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.953.0.tgz",
+      "integrity": "sha512-kYQEcJpJLiT+1ZdsQDMrIs2o3YydxdAIDdLUxbIwks1+WQz2sCr9b94ld19aMZ0rejosASO0J3dfY0lt3Tfl+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/fetch-http-handler": "^5.3.7",
+        "@smithy/node-http-handler": "^4.4.6",
+        "@smithy/property-provider": "^4.2.6",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/smithy-client": "^4.10.0",
+        "@smithy/types": "^4.10.0",
+        "@smithy/util-stream": "^4.5.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.953.0.tgz",
+      "integrity": "sha512-5cy6b3VntBvhRCanwohRtR0wbKKUd6JfIsnuXImB4JcZa2iMW5tDW0LhNangYZ9wrrM7sJol6cKHtUW9LNemFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.953.0",
+        "@aws-sdk/credential-provider-env": "3.953.0",
+        "@aws-sdk/credential-provider-http": "3.953.0",
+        "@aws-sdk/credential-provider-login": "3.953.0",
+        "@aws-sdk/credential-provider-process": "3.953.0",
+        "@aws-sdk/credential-provider-sso": "3.953.0",
+        "@aws-sdk/credential-provider-web-identity": "3.953.0",
+        "@aws-sdk/nested-clients": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/credential-provider-imds": "^4.2.6",
+        "@smithy/property-provider": "^4.2.6",
+        "@smithy/shared-ini-file-loader": "^4.4.1",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.953.0.tgz",
+      "integrity": "sha512-Drf4v7uBKnU/nY/qgQD9ZA2zD5gjQEatxQajQHUN54erDSQ2rB5ApNuTnc2cyNwaxURnQvO1J72mwO6P5lIpsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.953.0",
+        "@aws-sdk/nested-clients": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/property-provider": "^4.2.6",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/shared-ini-file-loader": "^4.4.1",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.953.0.tgz",
+      "integrity": "sha512-/3gUap/QwAV/U3RPStcSjdiksDboTdcz82qajfhURhtAe9iEdoKJy7vTYqg75eX7IjpgBwLGajt0URasUofrPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.953.0",
+        "@aws-sdk/credential-provider-http": "3.953.0",
+        "@aws-sdk/credential-provider-ini": "3.953.0",
+        "@aws-sdk/credential-provider-process": "3.953.0",
+        "@aws-sdk/credential-provider-sso": "3.953.0",
+        "@aws-sdk/credential-provider-web-identity": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/credential-provider-imds": "^4.2.6",
+        "@smithy/property-provider": "^4.2.6",
+        "@smithy/shared-ini-file-loader": "^4.4.1",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.953.0.tgz",
+      "integrity": "sha512-YeqzqxzBzXnqdzn4pBuoXeCmWrXOLIu5owAowUc4dOvHmtlpXxB3beJdQ9g/Ky6fG6iaAPKO1vrCEoHNjM85Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/property-provider": "^4.2.6",
+        "@smithy/shared-ini-file-loader": "^4.4.1",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.953.0.tgz",
+      "integrity": "sha512-Kp/49vAJweixMo3q85eVpq1JO9KgKc6A+f8/8WDkN5CkMsfKQcGJZbO5JtuJfzar4pPmRKbgOeOP1qQsOmfyfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.953.0",
+        "@aws-sdk/core": "3.953.0",
+        "@aws-sdk/token-providers": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/property-provider": "^4.2.6",
+        "@smithy/shared-ini-file-loader": "^4.4.1",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.953.0.tgz",
+      "integrity": "sha512-V8SpGVtNjQZboHjb/GLM4L3/6O/AZJFtwJ8fiBaemKMTntl8haioZlQHDklWixR9s9zthOdFsCDs1+92ndUBRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.953.0",
+        "@aws-sdk/nested-clients": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/property-provider": "^4.2.6",
+        "@smithy/shared-ini-file-loader": "^4.4.1",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.953.0.tgz",
+      "integrity": "sha512-jTGhfkONav+r4E6HLOrl5SzBqDmPByUYCkyB/c/3TVb8jX3wAZx8/q9bphKpCh+G5ARi3IdbSisgkZrJYqQ19Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.953.0.tgz",
+      "integrity": "sha512-PlWdVYgcuptkIC0ZKqVUhWNtSHXJSx7U9V8J7dJjRmsXC40X7zpEycvrkzDMJjeTDGcCceYbyYAg/4X1lkcIMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.953.0.tgz",
+      "integrity": "sha512-cmIJx0gWeesUKK4YwgE+VQL3mpACr3/J24fbwnc1Z5tntC86b+HQFzU5vsBDw6lLwyD46dBgWdsXFh1jL+ZaFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.953.0.tgz",
+      "integrity": "sha512-xZSU54cEHlIvRTUewyTAajb4WJPdbBd1mIaDYOzac07+vsfMuCREQ5CheQ3inoBfqske7QOX+mIjLpVV4azAnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@aws-sdk/util-endpoints": "3.953.0",
+        "@smithy/core": "^3.19.0",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.953.0.tgz",
+      "integrity": "sha512-YEBI0b/4ezNkw5W4+RBRUoueFzqEPPrnkh/3LBqeJ7RWZTymBhxlpoLo6Gfxw9LxtDgv2vZ5K5rgC4/6Ly8ADg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.953.0",
+        "@aws-sdk/middleware-host-header": "3.953.0",
+        "@aws-sdk/middleware-logger": "3.953.0",
+        "@aws-sdk/middleware-recursion-detection": "3.953.0",
+        "@aws-sdk/middleware-user-agent": "3.953.0",
+        "@aws-sdk/region-config-resolver": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@aws-sdk/util-endpoints": "3.953.0",
+        "@aws-sdk/util-user-agent-browser": "3.953.0",
+        "@aws-sdk/util-user-agent-node": "3.953.0",
+        "@smithy/config-resolver": "^4.4.4",
+        "@smithy/core": "^3.19.0",
+        "@smithy/fetch-http-handler": "^5.3.7",
+        "@smithy/hash-node": "^4.2.6",
+        "@smithy/invalid-dependency": "^4.2.6",
+        "@smithy/middleware-content-length": "^4.2.6",
+        "@smithy/middleware-endpoint": "^4.3.15",
+        "@smithy/middleware-retry": "^4.4.15",
+        "@smithy/middleware-serde": "^4.2.7",
+        "@smithy/middleware-stack": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.6",
+        "@smithy/node-http-handler": "^4.4.6",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/smithy-client": "^4.10.0",
+        "@smithy/types": "^4.10.0",
+        "@smithy/url-parser": "^4.2.6",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.14",
+        "@smithy/util-defaults-mode-node": "^4.2.17",
+        "@smithy/util-endpoints": "^3.2.6",
+        "@smithy/util-middleware": "^4.2.6",
+        "@smithy/util-retry": "^4.2.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.953.0.tgz",
+      "integrity": "sha512-5MJgnsc+HLO+le0EK1cy92yrC7kyhGZSpaq8PcQvKs9qtXCXT5Tb6tMdkr5Y07JxYsYOV1omWBynvL6PWh08tQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/config-resolver": "^4.4.4",
+        "@smithy/node-config-provider": "^4.3.6",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/token-providers": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.953.0.tgz",
+      "integrity": "sha512-4FWWR3lDDuIftmCEWpGejfkJu2J1VG2MUktChQshADXABfVfM0fsT7OYlO7Sy106nOe9upE4uQTWXg9YT/6ssw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.953.0",
+        "@aws-sdk/nested-clients": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/property-provider": "^4.2.6",
+        "@smithy/shared-ini-file-loader": "^4.4.1",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/types": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
+      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.953.0.tgz",
+      "integrity": "sha512-rjaS6jrFksopXvNg6YeN+D1lYwhcByORNlFuYesFvaQNtPOufbE5tJL4GJ3TMXyaY0uFR28N5BHHITPyWWfH/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/types": "^4.10.0",
+        "@smithy/url-parser": "^4.2.6",
+        "@smithy/util-endpoints": "^3.2.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.953.0.tgz",
+      "integrity": "sha512-UF5NeqYesWuFao+u7LJvpV1SJCaLml5BtFZKUdTnNNMeN6jvV+dW/eQoFGpXF94RCqguX0XESmRuRRPQp+/rzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/types": "^4.10.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.953.0.tgz",
+      "integrity": "sha512-HjJ0Nq/57kg0QCjt8mwBAK6C34njKezy9ItUNcrWITzrBZv7ikQtyqM1pindAIzgLaBb7ly/0kbJqMY+NPbcJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/node-config-provider": "^4.3.6",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.953.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.953.0.tgz",
+      "integrity": "sha512-Zmrj21jQ2OeOJGr9spPiN00aQvXa/WUqRXcTVENhrMt+OFoSOfDFpYhUj9NQ09QmQ8KMWFoWuWW6iKurNqLvAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.10.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
+      "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.936.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.940.0.tgz",
+      "integrity": "sha512-x5xDOJbJEHvPK/6MhMKxc4dfsiAk7VsMw1syoGzgwDF29/RJpSsgvV1c5c9cUiN8hlhyp03mvIXt/FEJRt1wXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-sdk-ec2": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ecr": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.940.0.tgz",
+      "integrity": "sha512-t1346KaZ4RE2adaDWEaSWggzxniMIsJ13KUZtBoRDaOflEZ86j4jSKnel5a4z/mQxZVfy6d3Oy0d/RvvNHXWOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ecs": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.940.0.tgz",
+      "integrity": "sha512-doguXFYxXJgC7gKdeaKClPA/kUHUNmmwxYKxrD4ecwEPDCqPP1Ty268TrCikO0PtXPfQNsjBFB1JlV6Xw6rGtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-glue": {
+      "version": "3.942.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-glue/-/client-glue-3.942.0.tgz",
+      "integrity": "sha512-NX5mdVhVcqDImYUc9neOVpuKEGcK7KJrx6EWJ/0PSFvpOFHXBSNt5NURKkpaCadjEYvLgi3FgSApvW9Ax2Q+Nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.942.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.942.0.tgz",
+      "integrity": "sha512-zRcbiYuvvLi+cHyMNz4q3VlyEZmnGCt0HzOVCicWA31ITz7+F8z9/tm0Sa/0clEOnllHPW2WQmjZepcHJ5/L6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/eventstream-serde-browser": "^4.2.5",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
+        "@smithy/eventstream-serde-node": "^4.2.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight": {
+      "version": "3.1012.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-quicksight/-/client-quicksight-3.1012.0.tgz",
+      "integrity": "sha512-ihc86JuYpisNZWi+p9FqwOr6m4ejjAGdCEzsQcNquVBOW/pgkciB3VDRcAy0qVBJjLlFAHTzA6z6EsboJzS7qQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/credential-provider-node": "^3.972.22",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.22",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/core": {
+      "version": "3.973.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.21.tgz",
+      "integrity": "sha512-OTUcDX9Yfz/FLKbHjiMaP9D4Hs44lYJzN7zBcrK2nDmBt0Wr8D6nYt12QoBkZsW0nVMFsTIGaZCrsU9zCcIMXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.12",
+        "@smithy/core": "^3.23.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.19.tgz",
+      "integrity": "sha512-33NpkQtmnsjLr9QdZvL3w8bjy+WoBJ+jY8JwuzxIq38rDNi1kwpBWW7Yjh+8bMlksd+ZAWW0fH4S/6OeoAdU5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.21.tgz",
+      "integrity": "sha512-xFke7yjbON4unNOG0TApQwz+o1LH5VhVLgWlUuiLRWNDyBfeHIFje2ck8qHybvJ8Fkm5m3SsN+pvHtVo6PGWlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.21.tgz",
+      "integrity": "sha512-fmJN7KhB7CoG65w9fC2LVOd2wZbR2d1yJIpZNe2J5CeDPu7nUHSmavuJAeGEoE3OL5UIBVPNhmK/fV/NQrs3Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/credential-provider-env": "^3.972.19",
+        "@aws-sdk/credential-provider-http": "^3.972.21",
+        "@aws-sdk/credential-provider-login": "^3.972.21",
+        "@aws-sdk/credential-provider-process": "^3.972.19",
+        "@aws-sdk/credential-provider-sso": "^3.972.21",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.21.tgz",
+      "integrity": "sha512-ENU+YCiuQocQjfIf9bPxZ+ZY0wIBkl3SMH22optBQwy8UFpSfonHynXzGT27xQxer4cYTNOpwDqbfo57BusbpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.22.tgz",
+      "integrity": "sha512-VE6i8nkmrRyhKut7nnfCWRbdDf+CfyRr8ixSwdaPDguYlgvkAO2pHu9oK11XzbSuatB0io1ozI/vpYhelXn8Pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.19",
+        "@aws-sdk/credential-provider-http": "^3.972.21",
+        "@aws-sdk/credential-provider-ini": "^3.972.21",
+        "@aws-sdk/credential-provider-process": "^3.972.19",
+        "@aws-sdk/credential-provider-sso": "^3.972.21",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.19.tgz",
+      "integrity": "sha512-hjj5bFo4kf5/WzAMjDEFByVOMbq5gZiagIpJexf7Kp9nIDaGzhCphMsx03NCA8s9zUJzHlD1lXazd7MS+e03Lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.21.tgz",
+      "integrity": "sha512-9jWRCuMZpZKlqCZ46bvievqdfswsyB2yPAr9rOiN+FxaGgf8jrR5iYDqJgscvk1jrbAxiK4cIjHv3XjIAWAhzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
+        "@aws-sdk/token-providers": "3.1012.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.21.tgz",
+      "integrity": "sha512-ShWQO/cQVZ+j3zUDK7Kj+m7grPzQCVA2iaZdJ+hJTGvVH5lR32Ip/rgZZ+zBdH6D6wczP9Upa4NMXoqJdGpK1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+      "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.22.tgz",
+      "integrity": "sha512-pZPNGWZVQvgUIO/P9PXZNz7ciq9mLYb/wQEurg3phKTa3DiBIunIRcgA0eBNwmog6S3oy0KR1bv4EJ4ld9A5sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.11.tgz",
+      "integrity": "sha512-i7SwoSR4JB/79JoGDUACnFUQOZwXGLWNX35lIb1Pq72nUGlVV+RFZp+BLa8S+mog2pbXU9+6Kc5YwGiMi5bKhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.22",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.8.tgz",
+      "integrity": "sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1012.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1012.0.tgz",
+      "integrity": "sha512-vzKwy020zjuiF4WTJzejx5nYcXJnRhHpb6i3lyZHIwfFwXG1yX4bzBVNMWYWF+bz1i2Pp2VhJbPyzpqj4VuJXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.8.tgz",
+      "integrity": "sha512-Kvb96TafGPLYo4Z2GRCzQTne77epXgiZEo0DDXwavzkWmgDV/1XD1tMA766gzRcHHFUraWsE+4T8DKtPTZUxgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.13.tgz",
+      "integrity": "sha512-I/+BMxM4WE/6xL0tyV7tAUDOAXmyw/va1oGr/eSly43HmLUcD1G+v96vEKAA8VoLcZ03ZQo/PWzjmN9zQErqPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-quicksight/node_modules/fast-xml-parser": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.940.0.tgz",
+      "integrity": "sha512-Wi4qnBT6shRRMXuuTgjMFTU5mu2KFWisgcigEMPptjPGUtJvBVi4PTGgS64qsLoUk/obqDAyOBOfEtRZ2ddC2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.936.0",
+        "@aws-sdk/middleware-expect-continue": "3.936.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-location-constraint": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-sdk-s3": "3.940.0",
+        "@aws-sdk/middleware-ssec": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/signature-v4-multi-region": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/eventstream-serde-browser": "^4.2.5",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
+        "@smithy/eventstream-serde-node": "^4.2.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-blob-browser": "^4.2.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/hash-stream-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/md5-js": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.940.0.tgz",
+      "integrity": "sha512-fpxSRsGyuXmyNqEwdGJUDWVgN0v8xR7tr32Quls3K+HnYlnBGFmISu5Pcc+BfwmrZHnPaVpPc+S3PUzTnFpOJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.940.0.tgz",
+      "integrity": "sha512-NH+Rps0bOQgdjmx+4WZ6rxx0MxreV634nbkKKDrtg4jvqfLLL+4ZrmXJRmch+rGPDjb6wOrWhcjwk9vAqC2IBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.940.0.tgz",
+      "integrity": "sha512-tXPi9OlELbiewGDb9maXDMhdYW617I9osGo/C1GAR6eLYwj40/TfOBeOQf3tX9EcH8NpDBuMksxoAvkpvqYIKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/md5-js": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.940.0.tgz",
+      "integrity": "sha512-4w5fpNw2BB2OyrDABMHcOOSZrJfZF7CUmxCvFr811orCgwUf+4JYS0Hx9yQr8FYFV01jMhyG9VRlk3y92XCA0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.940.0.tgz",
+      "integrity": "sha512-SdqJGWVhmIURvCSgkDditHRO+ozubwZk9aCX9MK8qxyOndhobCndW1ozl3hX9psvMAo9Q4bppjuqy/GHWpjB+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.1012.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1012.0.tgz",
+      "integrity": "sha512-oIbN4eOdeU4kMOofTfQBjXsDGU5vjYcYEXvRJd01uaCRMW3L8kio7HP8k+8+rZdAj/XdjvByloxH0nDVp/efmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/credential-provider-node": "^3.972.22",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.22",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/core": {
+      "version": "3.973.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.21.tgz",
+      "integrity": "sha512-OTUcDX9Yfz/FLKbHjiMaP9D4Hs44lYJzN7zBcrK2nDmBt0Wr8D6nYt12QoBkZsW0nVMFsTIGaZCrsU9zCcIMXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.12",
+        "@smithy/core": "^3.23.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.19.tgz",
+      "integrity": "sha512-33NpkQtmnsjLr9QdZvL3w8bjy+WoBJ+jY8JwuzxIq38rDNi1kwpBWW7Yjh+8bMlksd+ZAWW0fH4S/6OeoAdU5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.21.tgz",
+      "integrity": "sha512-xFke7yjbON4unNOG0TApQwz+o1LH5VhVLgWlUuiLRWNDyBfeHIFje2ck8qHybvJ8Fkm5m3SsN+pvHtVo6PGWlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.21.tgz",
+      "integrity": "sha512-fmJN7KhB7CoG65w9fC2LVOd2wZbR2d1yJIpZNe2J5CeDPu7nUHSmavuJAeGEoE3OL5UIBVPNhmK/fV/NQrs3Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/credential-provider-env": "^3.972.19",
+        "@aws-sdk/credential-provider-http": "^3.972.21",
+        "@aws-sdk/credential-provider-login": "^3.972.21",
+        "@aws-sdk/credential-provider-process": "^3.972.19",
+        "@aws-sdk/credential-provider-sso": "^3.972.21",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.21.tgz",
+      "integrity": "sha512-ENU+YCiuQocQjfIf9bPxZ+ZY0wIBkl3SMH22optBQwy8UFpSfonHynXzGT27xQxer4cYTNOpwDqbfo57BusbpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.22.tgz",
+      "integrity": "sha512-VE6i8nkmrRyhKut7nnfCWRbdDf+CfyRr8ixSwdaPDguYlgvkAO2pHu9oK11XzbSuatB0io1ozI/vpYhelXn8Pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.19",
+        "@aws-sdk/credential-provider-http": "^3.972.21",
+        "@aws-sdk/credential-provider-ini": "^3.972.21",
+        "@aws-sdk/credential-provider-process": "^3.972.19",
+        "@aws-sdk/credential-provider-sso": "^3.972.21",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.19.tgz",
+      "integrity": "sha512-hjj5bFo4kf5/WzAMjDEFByVOMbq5gZiagIpJexf7Kp9nIDaGzhCphMsx03NCA8s9zUJzHlD1lXazd7MS+e03Lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.21.tgz",
+      "integrity": "sha512-9jWRCuMZpZKlqCZ46bvievqdfswsyB2yPAr9rOiN+FxaGgf8jrR5iYDqJgscvk1jrbAxiK4cIjHv3XjIAWAhzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
+        "@aws-sdk/token-providers": "3.1012.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.21.tgz",
+      "integrity": "sha512-ShWQO/cQVZ+j3zUDK7Kj+m7grPzQCVA2iaZdJ+hJTGvVH5lR32Ip/rgZZ+zBdH6D6wczP9Upa4NMXoqJdGpK1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+      "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.22.tgz",
+      "integrity": "sha512-pZPNGWZVQvgUIO/P9PXZNz7ciq9mLYb/wQEurg3phKTa3DiBIunIRcgA0eBNwmog6S3oy0KR1bv4EJ4ld9A5sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.11.tgz",
+      "integrity": "sha512-i7SwoSR4JB/79JoGDUACnFUQOZwXGLWNX35lIb1Pq72nUGlVV+RFZp+BLa8S+mog2pbXU9+6Kc5YwGiMi5bKhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.22",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.8.tgz",
+      "integrity": "sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1012.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1012.0.tgz",
+      "integrity": "sha512-vzKwy020zjuiF4WTJzejx5nYcXJnRhHpb6i3lyZHIwfFwXG1yX4bzBVNMWYWF+bz1i2Pp2VhJbPyzpqj4VuJXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.21",
+        "@aws-sdk/nested-clients": "^3.996.11",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.8.tgz",
+      "integrity": "sha512-Kvb96TafGPLYo4Z2GRCzQTne77epXgiZEo0DDXwavzkWmgDV/1XD1tMA766gzRcHHFUraWsE+4T8DKtPTZUxgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.13.tgz",
+      "integrity": "sha512-I/+BMxM4WE/6xL0tyV7tAUDOAXmyw/va1oGr/eSly43HmLUcD1G+v96vEKAA8VoLcZ03ZQo/PWzjmN9zQErqPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/fast-xml-parser": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.940.0.tgz",
+      "integrity": "sha512-KsGD2FLaX5ngJao1mHxodIVU9VYd1E8810fcYiGwO1PFHDzf5BEkp6D9IdMeQwT8Q6JLYtiiT1Y/o3UCScnGoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.940.0.tgz",
+      "integrity": "sha512-/G3l5/wbZYP2XEQiOoIkRJmlv15f1P3MSd1a0gz27lHEMrOJOGq66rF1Ca4OJLzapWt3Fy9BPrZAepoAX11kMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.940.0.tgz",
+      "integrity": "sha512-dOrc03DHElNBD6N9Okt4U0zhrG4Wix5QUBSZPr5VN8SvmjD9dkrrxOkkJaMCl/bzrW7kbQEp7LuBdbxArMmOZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.940.0.tgz",
+      "integrity": "sha512-gn7PJQEzb/cnInNFTOaDoCN/hOKqMejNmLof1W5VW95Qk0TPO52lH8R4RmJPnRrwFMswOWswTOpR1roKNLIrcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-env": "3.940.0",
+        "@aws-sdk/credential-provider-http": "3.940.0",
+        "@aws-sdk/credential-provider-login": "3.940.0",
+        "@aws-sdk/credential-provider-process": "3.940.0",
+        "@aws-sdk/credential-provider-sso": "3.940.0",
+        "@aws-sdk/credential-provider-web-identity": "3.940.0",
+        "@aws-sdk/nested-clients": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.940.0.tgz",
+      "integrity": "sha512-fOKC3VZkwa9T2l2VFKWRtfHQPQuISqqNl35ZhcXjWKVwRwl/o7THPMkqI4XwgT2noGa7LLYVbWMwnsgSsBqglg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/nested-clients": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.940.0.tgz",
+      "integrity": "sha512-M8NFAvgvO6xZjiti5kztFiAYmSmSlG3eUfr4ZHSfXYZUA/KUdZU/D6xJyaLnU8cYRWBludb6K9XPKKVwKfqm4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.940.0",
+        "@aws-sdk/credential-provider-http": "3.940.0",
+        "@aws-sdk/credential-provider-ini": "3.940.0",
+        "@aws-sdk/credential-provider-process": "3.940.0",
+        "@aws-sdk/credential-provider-sso": "3.940.0",
+        "@aws-sdk/credential-provider-web-identity": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.940.0.tgz",
+      "integrity": "sha512-pILBzt5/TYCqRsJb7vZlxmRIe0/T+FZPeml417EK75060ajDGnVJjHcuVdLVIeKoTKm9gmJc9l45gon6PbHyUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.940.0.tgz",
+      "integrity": "sha512-q6JMHIkBlDCOMnA3RAzf8cGfup+8ukhhb50fNpghMs1SNBGhanmaMbZSgLigBRsPQW7fOk2l8jnzdVLS+BB9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.940.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/token-providers": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.940.0.tgz",
+      "integrity": "sha512-9QLTIkDJHHaYL0nyymO41H8g3ui1yz6Y3GmAN1gYQa6plXisuFBnGAbmKVj7zNvjWaOKdF0dV3dd3AFKEDoJ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/nested-clients": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.893.0.tgz",
+      "integrity": "sha512-KSwTfyLZyNLszz5f/yoLC+LC+CRKpeJii/+zVAy7JUOQsKhSykiRUPYUx7o2Sdc4oJfqqUl26A/jSttKYnYtAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.936.0.tgz",
+      "integrity": "sha512-XLSVVfAorUxZh6dzF+HTOp4R1B5EQcdpGcPliWr0KUj2jukgjZEcqbBmjyMF/p9bmyQsONX80iURF1HLAlW0qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.936.0.tgz",
+      "integrity": "sha512-wNJZ8PDw0eQK2x4z1q8JqiDvw9l9xd36EoklVT2CIBt8FnqGdrMGjAx93RRbH3G6Fmvwoe+D3VJXbWHBlhD0Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "3.893.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.936.0.tgz",
+      "integrity": "sha512-Eb4ELAC23bEQLJmUMYnPWcjD3FZIsmz2svDiXEcxRkQU9r7NRID7pM7C5NPH94wOfiCk0b2Y8rVyFXW0lGQwbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.940.0.tgz",
+      "integrity": "sha512-WdsxDAVj5qaa5ApAP+JbpCOMHFGSmzjs2Y2OBSbWPeR9Ew7t/Okj+kUub94QJPsgzhvU1/cqNejhsw5VxeFKSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
+      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.936.0.tgz",
+      "integrity": "sha512-SCMPenDtQMd9o5da9JzkHz838w3327iqXk3cbNnXWqnNRx6unyW8FL0DZ84gIY12kAyVHz5WEqlWuekc15ehfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
+      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.936.0.tgz",
+      "integrity": "sha512-l4aGbHpXM45YNgXggIux1HgsCVAvvBoqHPkqLnqMl9QVapfuSTjJHfDYDsx1Xxct6/m7qSMUzanBALhiaGO2fA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws/lambda-invoke-store": "^0.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-api-gateway": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-api-gateway/-/middleware-sdk-api-gateway-3.936.0.tgz",
+      "integrity": "sha512-j5sE0+7QX1khzy2tm08tYZjRvIYfhtFLNDYk7Ogs1bO9oCxDPkKvzaNcnazVReaO1uRCNRlsm7iDwRDGnraF0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.936.0.tgz",
+      "integrity": "sha512-8TaXLPUhAsTsJMPRGSVBL+wwqoM7mNLn8Ad2V26H00Ude5pyw1CYe7BxAjO3VY92Z3SCh4pOcxnlbDmB2IT4oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-format-url": "3.936.0",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.940.0.tgz",
+      "integrity": "sha512-JYkLjgS1wLoKHJ40G63+afM1ehmsPsjcmrHirKh8+kSCx4ip7+nL1e/twV4Zicxr8RJi9Y0Ahq5mDvneilDDKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.936.0.tgz",
+      "integrity": "sha512-39WohFCCPeD6LV8zLQq7CyYbIieetEDDNLsEPeGJSh2Uv9qpY9r6zJRSTjb8hTuQbHDSEOGntHMYKpLoHdoxdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.936.0.tgz",
+      "integrity": "sha512-/GLC9lZdVp05ozRik5KsuODR/N7j+W+2TbfdFL3iS+7un+gnP6hC8RDOZd6WhpZp7drXQ9guKiTAxkZQwzS8DA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.940.0.tgz",
+      "integrity": "sha512-nJbLrUj6fY+l2W2rIB9P4Qvpiy0tnTdg/dmixRxrU1z3e8wBdspJlyE+AZN4fuVbeL6rrRrO/zxQC1bB3cw5IA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.940.0.tgz",
+      "integrity": "sha512-x0mdv6DkjXqXEcQj3URbCltEzW6hoy/1uIL+i8gExP6YKrnhiZ7SzuB4gPls2UOpK5UqLiqXjhRLfBb1C9i4Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
+      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
@@ -1806,69 +3768,69 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.8.tgz",
-      "integrity": "sha512-n1qYFD+tbqZuyskVaxUE+t10AUz9g3qzDw3Tp6QZDKmqsjfDmZBd4GIk2EKJJNtcCBtE5YiUjDYA+3djFAFBBg==",
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.940.0.tgz",
+      "integrity": "sha512-ugHZEoktD/bG6mdgmhzLDjMP2VrYRAUPRPF1DpCyiZexkH7DCU7XrSJyXMvkcf0DHV+URk0q2sLf/oqn1D2uYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.20",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/middleware-sdk-s3": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1009.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1009.0.tgz",
-      "integrity": "sha512-KCPLuTqN9u0Rr38Arln78fRG9KXpzsPWmof+PZzfAHMMQq2QED6YjQrkrfiH7PDefLWEposY1o4/eGwrmKA4JA==",
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.940.0.tgz",
+      "integrity": "sha512-k5qbRe/ZFjW9oWEdzLIa2twRVIEx7p/9rutofyrRysrtEnYh3HAWCngAnwbgKMoiwa806UzcTRx0TjyEpnKcCg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/nested-clients": "^3.996.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/nested-clients": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
+      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.868.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.868.0.tgz",
-      "integrity": "sha512-Y+SBOBtAcLdRbBv8T2WtVOVYvTHxH23M0Ssm9WPQgJXiYtBDHvB4i1pgw/ECu/F4KRHKrkxzn4lwrF2XlryldA==",
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.940.0.tgz",
+      "integrity": "sha512-T8UTYtCYSPxktnk68fKBdWztnqdTQItJwi/8N9lsvp20alJ15wCQsvQR+GKB5p4TCKxOPyNEirkcrNlf5TKppA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1877,38 +3839,38 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.868.0"
+        "@aws-sdk/client-dynamodb": "^3.940.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
+      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-endpoints": "^3.3.3",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
-      "integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.936.0.tgz",
+      "integrity": "sha512-MS5eSEtDUFIAMHrJaMERiHAvDPdfxc/T869ZjDNFAIiZhyc037REw0aoTNeimNXDNy2txRNZJaAUn/kE4RwN+g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
@@ -1924,32 +3886,31 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
-      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
+      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.7.tgz",
-      "integrity": "sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA==",
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.940.0.tgz",
+      "integrity": "sha512-dlD/F+L/jN26I8Zg5x0oDGJiA+/WEQmnSE27fi5ydvYnpfQLwThtQo9SsNS47XSR/SOULaaoC9qx929rZuo74A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-config-provider": "^4.2.2",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -1961,32 +3922,32 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.11.tgz",
-      "integrity": "sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.4.1",
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
+      "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
-      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
@@ -2000,9 +3961,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
-      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
@@ -2016,9 +3977,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
-      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
@@ -2032,9 +3993,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
-      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
@@ -2048,9 +4009,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
-      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
@@ -2064,9 +4025,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
-      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -2080,9 +4041,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
@@ -2096,9 +4057,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
-      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
@@ -2112,9 +4073,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
-      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
@@ -2128,9 +4089,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
-      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
@@ -2144,9 +4105,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
-      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
@@ -2160,9 +4121,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
-      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
@@ -2176,9 +4137,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
-      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
@@ -2192,9 +4153,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
-      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
@@ -2208,9 +4169,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
-      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
@@ -2224,9 +4185,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
-      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
@@ -2240,9 +4201,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
-      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -2256,9 +4217,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
       ],
@@ -2272,9 +4233,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
@@ -2288,9 +4249,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
       ],
@@ -2304,9 +4265,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
@@ -2320,9 +4281,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
-      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
       "cpu": [
         "arm64"
       ],
@@ -2336,9 +4297,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
-      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
@@ -2352,9 +4313,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
-      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
@@ -2368,9 +4329,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
-      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
@@ -2384,9 +4345,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
-      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
@@ -2400,9 +4361,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2429,13 +4390,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -2455,9 +4416,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2468,19 +4429,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
-      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2539,9 +4503,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2552,9 +4516,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
-      "integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
+      "version": "9.39.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
+      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2565,9 +4529,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2575,13 +4539,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.2",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -2654,17 +4618,26 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.1.tgz",
-      "integrity": "sha512-bevKGO6kX1eM/N+pdh9leS5L7TBF4ICrzi9a+cbWkrxeAeIcwlo/7OfWGCDERdRCI2/Q6tjltX4bt07ALHDwFw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -2679,13 +4652,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
-      "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -2700,19 +4673,19 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
-      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
         "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -2741,14 +4714,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.17",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.17.tgz",
-      "integrity": "sha512-r6bQLsyPSzbWrZZ9ufoWL+CztkSatnJ6uSxqd6N+o41EZC51sQeWOzI6s5jLb+xxTWxl7PlUppqm8/sow241gg==",
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/external-editor": "^1.0.1",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -2763,14 +4736,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.17.tgz",
-      "integrity": "sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -2785,13 +4758,13 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
-      "integrity": "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
       "license": "MIT",
       "dependencies": {
-        "chardet": "^2.1.0",
-        "iconv-lite": "^0.6.3"
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
       },
       "engines": {
         "node": ">=18"
@@ -2806,22 +4779,22 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
-      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.1.tgz",
-      "integrity": "sha512-tVC+O1rBl0lJpoUZv4xY+WGWY8V5b0zxU1XDsMsIHYregdh7bN5X5QnIONNBAl0K765FYlAfNHS2Bhn7SSOVow==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -2836,13 +4809,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.17.tgz",
-      "integrity": "sha512-GcvGHkyIgfZgVnnimURdOueMk0CztycfC8NZTiIY9arIAkeOgt6zG57G+7vC59Jns3UX27LMkPKnKWAOF5xEYg==",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -2857,14 +4830,14 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.17.tgz",
-      "integrity": "sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2"
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -2879,21 +4852,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.2.tgz",
-      "integrity": "sha512-nqhDw2ZcAUrKNPwhjinJny903bRhI0rQhiDz1LksjeRxqa36i3l75+4iXbOy0rlDpLJGxqtgoPavQjmmyS5UJw==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.2.1",
-        "@inquirer/confirm": "^5.1.14",
-        "@inquirer/editor": "^4.2.17",
-        "@inquirer/expand": "^4.0.17",
-        "@inquirer/input": "^4.2.1",
-        "@inquirer/number": "^3.0.17",
-        "@inquirer/password": "^4.0.17",
-        "@inquirer/rawlist": "^4.1.5",
-        "@inquirer/search": "^3.1.0",
-        "@inquirer/select": "^4.3.1"
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
       },
       "engines": {
         "node": ">=18"
@@ -2908,14 +4881,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.5.tgz",
-      "integrity": "sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -2930,15 +4903,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.1.0.tgz",
-      "integrity": "sha512-PMk1+O/WBcYJDq2H7foV0aAZSmDdkzZB9Mw2v/DmONRJopwA/128cS9M/TXWLKKdEQKZnKwBzqu2G4x/2Nqx8Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -2953,16 +4926,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.1.tgz",
-      "integrity": "sha512-Gfl/5sqOF5vS/LIrSndFgOh7jgoe0UXEizDqahFRkq5aJBLegZ6WjuMh/hVEJwlFQjyLq1z9fRtvUMkb7jM1LA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -2977,9 +4950,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
-      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2993,62 +4966,24 @@
         }
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@oclif/core": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.5.2.tgz",
-      "integrity": "sha512-eQcKyrEcDYeZJKu4vUWiu0ii/1Gfev6GF4FsLSgNez5/+aQyAUCjg3ZWlurf491WiYZTXCWyKAxyPWk8DKv2MA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.0.tgz",
+      "integrity": "sha512-jteNUQKgJHLHFbbz806aGZqf+RJJ7t4gwF4MYa8fCwCxQ8/klJNWc0MvaJiBebk7Mc+J39mdlsB4XraaCKznFw==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
         "ansis": "^3.17.0",
         "clean-stack": "^3.0.1",
         "cli-spinners": "^2.9.2",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "ejs": "^3.1.10",
         "get-package-type": "^0.1.0",
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
         "minimatch": "^9.0.5",
-        "semver": "^7.6.3",
+        "semver": "^7.7.3",
         "string-width": "^4.2.3",
         "supports-color": "^8",
         "tinyglobby": "^0.2.14",
@@ -3061,9 +4996,9 @@
       }
     },
     "node_modules/@oclif/plugin-autocomplete": {
-      "version": "3.2.34",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.34.tgz",
-      "integrity": "sha512-KhbPcNjitAU7jUojMXJ3l7duWVub0L0pEr3r3bLrpJBNuIJhoIJ7p56Ropcb7OMH2xcaz5B8HGq56cTOe1FHEg==",
+      "version": "3.2.39",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.39.tgz",
+      "integrity": "sha512-OwAZNnSpuDjKyhAwoOJkFWxGswPFKBB4hpNIMsj6PUtbKwGBPmD+2wGGPgTsDioVwLmUELSb2bZ+1dxHfvXmvg==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
@@ -3076,9 +5011,9 @@
       }
     },
     "node_modules/@oclif/plugin-help": {
-      "version": "6.2.32",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.32.tgz",
-      "integrity": "sha512-LrmMdo9EMJciOvF8UurdoTcTMymv5npKtxMAyonZvhSvGR8YwCKnuHIh00+SO2mNtGOYam7f4xHnUmj2qmanyA==",
+      "version": "6.2.36",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.36.tgz",
+      "integrity": "sha512-NBQIg5hEMhvdbi4mSrdqRGl5XJ0bqTAHq6vDCCCDXUcfVtdk3ZJbSxtRVWyVvo9E28vwqu6MZyHOJylevqcHbA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4"
@@ -3088,13 +5023,13 @@
       }
     },
     "node_modules/@oclif/plugin-not-found": {
-      "version": "3.2.64",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.64.tgz",
-      "integrity": "sha512-WDCPkFw5Qi9ALVODnGWdFDcm49iBOg7G2/u1C/o/KB4eSxlQn0JEDhLaMGcLmwOYKQnQdI9x35K77vhR1JrwDg==",
+      "version": "3.2.73",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.73.tgz",
+      "integrity": "sha512-2bQieTGI9XNFe9hKmXQjJmHV5rZw+yn7Rud1+C5uLEo8GaT89KZbiLTJgL35tGILahy/cB6+WAs812wjw7TK6w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/prompts": "^7.8.1",
-        "@oclif/core": "^4.5.2",
+        "@inquirer/prompts": "^7.10.1",
+        "@oclif/core": "^4.8.0",
         "ansis": "^3.17.0",
         "fast-levenshtein": "^3.0.0"
       },
@@ -3103,18 +5038,18 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.102.4",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.102.4.tgz",
-      "integrity": "sha512-oaD3DW6oisEwqf68AB7VYQMnNBT68JAqaTI9VBoAnLjjlkUpIH8nc2mUbZOhSI9JkZPWkKkgOq3mS1GOukRsuQ==",
+      "version": "1.103.10",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.103.10.tgz",
+      "integrity": "sha512-FOxqq47+YVCo4+Eq8eU8+esoLNwcxHHBVhw/JmZwsViTqMB3DF8WorXL+ZwrXW/8srruuzyyx9+ACyRdZ+zbSg==",
       "license": "MIT",
       "dependencies": {
-        "@oclif/core": "^4.4.1",
-        "@oclif/plugin-autocomplete": "^3.2.31",
-        "@oclif/plugin-help": "^6.2.29",
-        "@oclif/plugin-not-found": "^3.2.57",
+        "@oclif/core": "^4.5.4",
+        "@oclif/plugin-autocomplete": "^3.2.35",
+        "@oclif/plugin-help": "^6.2.33",
+        "@oclif/plugin-not-found": "^3.2.68",
         "@types/node": "22.13.10",
         "@types/react": "19.0.10",
-        "esbuild": "^0.25.5",
+        "esbuild": "^0.25.10",
         "react": "19.0.0"
       },
       "bin": {
@@ -3150,17 +5085,17 @@
       }
     },
     "node_modules/@raycast/eslint-config": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.0.4.tgz",
-      "integrity": "sha512-Sz5Q0HVY8pW21Sv7CDcJw882OGubSM3zx5uiDRQMkgt7Hui3I+IZOqxDInnhLsGG52prSdU7sg3R097hMJkkQw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.1.1.tgz",
+      "integrity": "sha512-W0kxF+FJ+BYQn0EKIV739j2ZrHEtjo/LclsoZgUWg3t364Dq75XKcjqYFYx+59/DBaamY0amdajlfuDAf6veAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint/js": "^9.22.0",
-        "@raycast/eslint-plugin": "^2.0.4",
-        "eslint-config-prettier": "^10.1.1",
-        "globals": "^16.0.0",
-        "typescript-eslint": "^8.26.1"
+        "@eslint/js": "^9.36.0",
+        "@raycast/eslint-plugin": "^2.1.1",
+        "eslint-config-prettier": "^10.1.8",
+        "globals": "^16.4.0",
+        "typescript-eslint": "^8.45.0"
       },
       "peerDependencies": {
         "eslint": ">=8.23.0",
@@ -3169,9 +5104,9 @@
       }
     },
     "node_modules/@raycast/eslint-plugin": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-2.0.7.tgz",
-      "integrity": "sha512-4dAdua+TFQu7ay3EuDmg5nT7boIAj3Rjf0V1aQ3w5uAx/j98DvI91h/zbbkVb4mIXCom1w7SfRrZQzYIOE+tZw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-2.1.1.tgz",
+      "integrity": "sha512-r2gs8uIlNp6I2mLOyN/kReGlvigzEeuyQPl4yw7nwLy8Zxjfjhg8txMViaBux8juBWBxbSWq/IfW6ZA50oeOHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3182,9 +5117,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.0.tgz",
-      "integrity": "sha512-K7ffrYh9bktLqrXVP/+QjcxwFoibJ9ADaTyoHEJMON7Qqq05/uJC4hw+q0Gr15pHi8X0w6kTzv3r2cBe8OEWMQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.2.tgz",
+      "integrity": "sha512-tZcyWCHZvz4L/i1CGEnSZkBoK6wwX1pzlTKjcWWugbrQyG0QCMOxjKJfRC/iNkD+hHaqhMWUj4Y0LNo/NknvFw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -3213,9 +5148,9 @@
       }
     },
     "node_modules/@smithy/chunked-blob-reader": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
-      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.0.tgz",
+      "integrity": "sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3225,12 +5160,12 @@
       }
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
-      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.1.tgz",
+      "integrity": "sha512-lX9Ay+6LisTfpLid2zZtIhSEjHMZoAR5hHCR4H7tBz/Zkfr5ea8RcQ7Tk4mi0P76p4cN+Btz16Ffno7YHpKXnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3292,14 +5227,14 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
-      "integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.5.tgz",
+      "integrity": "sha512-Ogt4Zi9hEbIP17oQMd68qYOHUzmH47UkK7q7Gl55iIm9oKt27MUGrC5JfpMroeHjdkOliOA4Qt3NQ1xMq/nrlA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3307,13 +5242,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
-      "integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.5.tgz",
+      "integrity": "sha512-HohfmCQZjppVnKX2PnXlf47CW3j92Ki6T/vkAT2DhBR47e89pen3s4fIa7otGTtrVxmj7q+IhH0RnC5kpR8wtw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/eventstream-serde-universal": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3321,12 +5256,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
-      "integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.5.tgz",
+      "integrity": "sha512-ibjQjM7wEXtECiT6my1xfiMH9IcEczMOS6xiCQXoUIYSj5b1CpBbJ3VYbdwDy8Vcg5JHN7eFpOCGk8nyZAltNQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3334,13 +5269,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
-      "integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.5.tgz",
+      "integrity": "sha512-+elOuaYx6F2H6x1/5BQP5ugv12nfJl66GhxON8+dWVUEDJ9jah/A0tayVdkLRP0AeSac0inYkDz5qBFKfVp2Gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/eventstream-serde-universal": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3348,13 +5283,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
-      "integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.5.tgz",
+      "integrity": "sha512-G9WSqbST45bmIFaeNuP/EnC19Rhp54CcVdX9PDL1zyEB514WsDVXhlyihKlGXnRycmHNmVv88Bvvt4EYxWef/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/eventstream-codec": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3378,14 +5313,14 @@
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.13.tgz",
-      "integrity": "sha512-YrF4zWKh+ghLuquldj6e/RzE3xZYL8wIPfkt0MqCRphVICjyyjH8OwKD7LLlKpVEbk4FLizFfC1+gwK6XQdR3g==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.6.tgz",
+      "integrity": "sha512-8P//tA8DVPk+3XURk2rwcKgYwFvwGwmJH/wJqQiSKwXZtf/LiZK+hbUZmPj/9KzM+OVSwe4o85KTp5x9DUZTjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/chunked-blob-reader": "^5.2.2",
-        "@smithy/chunked-blob-reader-native": "^4.2.3",
-        "@smithy/types": "^4.13.1",
+        "@smithy/chunked-blob-reader": "^5.2.0",
+        "@smithy/chunked-blob-reader-native": "^4.2.1",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3408,13 +5343,13 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.12.tgz",
-      "integrity": "sha512-O3YbmGExeafuM/kP7Y8r6+1y0hIh3/zn6GROx0uNlB54K9oihAL75Qtc+jFfLNliTi6pxOAYZrRKD9A7iA6UFw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.5.tgz",
+      "integrity": "sha512-6+do24VnEyvWcGdHXomlpd0m8bfZePpUKBy7m311n+JuRwug8J4dCanJdTymx//8mi0nlkflZBvJe+dEO/O12Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3447,13 +5382,13 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.12.tgz",
-      "integrity": "sha512-W/oIpHCpWU2+iAkfZYyGWE+qkpuf3vEXHLxQQDx9FPNZTTdnul0dZ2d/gUFrtQ5je1G2kp4cjG0/24YueG2LbQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.5.tgz",
+      "integrity": "sha512-Bt6jpSTMWfjCtC0s79gZ/WZ1w90grfmopVOWqkI2ovhjpD5Q2XRXuecIPB9689L2+cCySMbaXDhBPU56FKNDNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3907,13 +5842,13 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.13.tgz",
-      "integrity": "sha512-2zdZ9DTHngRtcYxJK1GUDxruNr53kv5W2Lupe0LMU+Imr6ohQg8M2T14MNkj1Y0wS3FFwpgpGQyvuaMF7CiTmQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.5.tgz",
+      "integrity": "sha512-Dbun99A3InifQdIrsXZ+QLcC0PGBPAdrl4cj1mTgJvyc9N2zf7QSxg8TBkzsCmGJdE3TLbO9ycwpY0EkWahQ/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3951,33 +5886,32 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.1.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
-      "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
-      "integrity": "sha512-yYegZ5n3Yr6eOcqgj2nJH8cH/ZZgF+l0YIdKILSDjYFRjgYQMgv/lRjV5Z7Up04b9VYUondt8EPMqg7kTWgJ2g==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.48.0.tgz",
+      "integrity": "sha512-XxXP5tL1txl13YFtrECECQYeZjBZad4fyd3cFV4a19LkAY/bIp9fev3US4S5fDVV2JaYFiKAZ/GRTOLer+mbyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.39.1",
-        "@typescript-eslint/type-utils": "8.39.1",
-        "@typescript-eslint/utils": "8.39.1",
-        "@typescript-eslint/visitor-keys": "8.39.1",
+        "@typescript-eslint/scope-manager": "8.48.0",
+        "@typescript-eslint/type-utils": "8.48.0",
+        "@typescript-eslint/utils": "8.48.0",
+        "@typescript-eslint/visitor-keys": "8.48.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -3991,7 +5925,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.39.1",
+        "@typescript-eslint/parser": "^8.48.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -4007,17 +5941,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.1.tgz",
-      "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.48.0.tgz",
+      "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.39.1",
-        "@typescript-eslint/types": "8.39.1",
-        "@typescript-eslint/typescript-estree": "8.39.1",
-        "@typescript-eslint/visitor-keys": "8.39.1",
+        "@typescript-eslint/scope-manager": "8.48.0",
+        "@typescript-eslint/types": "8.48.0",
+        "@typescript-eslint/typescript-estree": "8.48.0",
+        "@typescript-eslint/visitor-keys": "8.48.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4033,14 +5966,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.1.tgz",
-      "integrity": "sha512-8fZxek3ONTwBu9ptw5nCKqZOSkXshZB7uAxuFF0J/wTMkKydjXCzqqga7MlFMpHi9DoG4BadhmTkITBcg8Aybw==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.48.0.tgz",
+      "integrity": "sha512-Ne4CTZyRh1BecBf84siv42wv5vQvVmgtk8AuiEffKTUo3DrBaGYZueJSxxBZ8fjk/N3DrgChH4TOdIOwOwiqqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.39.1",
-        "@typescript-eslint/types": "^8.39.1",
+        "@typescript-eslint/tsconfig-utils": "^8.48.0",
+        "@typescript-eslint/types": "^8.48.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4055,14 +5988,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.1.tgz",
-      "integrity": "sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.48.0.tgz",
+      "integrity": "sha512-uGSSsbrtJrLduti0Q1Q9+BF1/iFKaxGoQwjWOIVNJv0o6omrdyR8ct37m4xIl5Zzpkp69Kkmvom7QFTtue89YQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.1",
-        "@typescript-eslint/visitor-keys": "8.39.1"
+        "@typescript-eslint/types": "8.48.0",
+        "@typescript-eslint/visitor-keys": "8.48.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4073,9 +6006,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.1.tgz",
-      "integrity": "sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.48.0.tgz",
+      "integrity": "sha512-WNebjBdFdyu10sR1M4OXTt2OkMd5KWIL+LLfeH9KhgP+jzfDV/LI3eXzwJ1s9+Yc0Kzo2fQCdY/OpdusCMmh6w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4090,15 +6023,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.1.tgz",
-      "integrity": "sha512-gu9/ahyatyAdQbKeHnhT4R+y3YLtqqHyvkfDxaBYk97EcbfChSJXyaJnIL3ygUv7OuZatePHmQvuH5ru0lnVeA==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.48.0.tgz",
+      "integrity": "sha512-zbeVaVqeXhhab6QNEKfK96Xyc7UQuoFWERhEnj3mLVnUWrQnv15cJNseUni7f3g557gm0e46LZ6IJ4NJVOgOpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.1",
-        "@typescript-eslint/typescript-estree": "8.39.1",
-        "@typescript-eslint/utils": "8.39.1",
+        "@typescript-eslint/types": "8.48.0",
+        "@typescript-eslint/typescript-estree": "8.48.0",
+        "@typescript-eslint/utils": "8.48.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -4115,9 +6048,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
-      "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.48.0.tgz",
+      "integrity": "sha512-cQMcGQQH7kwKoVswD1xdOytxQR60MWKM1di26xSUtxehaDs/32Zpqsu5WJlXTtTTqyAVK8R7hvsUnIXRS+bjvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4129,21 +6062,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.1.tgz",
-      "integrity": "sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.48.0.tgz",
+      "integrity": "sha512-ljHab1CSO4rGrQIAyizUS6UGHHCiAYhbfcIZ1zVJr5nMryxlXMVWS3duFPSKvSUbFPwkXMFk1k0EMIjub4sRRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.39.1",
-        "@typescript-eslint/tsconfig-utils": "8.39.1",
-        "@typescript-eslint/types": "8.39.1",
-        "@typescript-eslint/visitor-keys": "8.39.1",
+        "@typescript-eslint/project-service": "8.48.0",
+        "@typescript-eslint/tsconfig-utils": "8.48.0",
+        "@typescript-eslint/types": "8.48.0",
+        "@typescript-eslint/visitor-keys": "8.48.0",
         "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
+        "tinyglobby": "^0.2.15",
         "ts-api-utils": "^2.1.0"
       },
       "engines": {
@@ -4158,16 +6090,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.1.tgz",
-      "integrity": "sha512-VF5tZ2XnUSTuiqZFXCZfZs1cgkdd3O/sSYmdo2EpSyDlC86UM/8YytTmKnehOW3TGAlivqTDT6bS87B/GQ/jyg==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.48.0.tgz",
+      "integrity": "sha512-yTJO1XuGxCsSfIVt1+1UrLHtue8xz16V8apzPYI06W0HbEbEWHxHXgZaAgavIkoh+GeV6hKKd5jm0sS6OYxWXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.39.1",
-        "@typescript-eslint/types": "8.39.1",
-        "@typescript-eslint/typescript-estree": "8.39.1"
+        "@typescript-eslint/scope-manager": "8.48.0",
+        "@typescript-eslint/types": "8.48.0",
+        "@typescript-eslint/typescript-estree": "8.48.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4182,13 +6114,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.1.tgz",
-      "integrity": "sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.48.0.tgz",
+      "integrity": "sha512-T0XJMaRPOH3+LBbAfzR2jalckP1MSG/L9eUtY0DEzUyVaXJ/t6zN0nR7co5kz0Jko/nkSYCBRkz1djvjajVTTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/types": "8.48.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -4218,7 +6150,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4237,9 +6168,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4336,31 +6267,18 @@
       "license": "MIT"
     },
     "node_modules/bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
+      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -4423,9 +6341,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
-      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
     },
     "node_modules/clean-stack": {
@@ -4505,15 +6423,15 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4603,9 +6521,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
-      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -4615,32 +6533,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.9",
-        "@esbuild/android-arm": "0.25.9",
-        "@esbuild/android-arm64": "0.25.9",
-        "@esbuild/android-x64": "0.25.9",
-        "@esbuild/darwin-arm64": "0.25.9",
-        "@esbuild/darwin-x64": "0.25.9",
-        "@esbuild/freebsd-arm64": "0.25.9",
-        "@esbuild/freebsd-x64": "0.25.9",
-        "@esbuild/linux-arm": "0.25.9",
-        "@esbuild/linux-arm64": "0.25.9",
-        "@esbuild/linux-ia32": "0.25.9",
-        "@esbuild/linux-loong64": "0.25.9",
-        "@esbuild/linux-mips64el": "0.25.9",
-        "@esbuild/linux-ppc64": "0.25.9",
-        "@esbuild/linux-riscv64": "0.25.9",
-        "@esbuild/linux-s390x": "0.25.9",
-        "@esbuild/linux-x64": "0.25.9",
-        "@esbuild/netbsd-arm64": "0.25.9",
-        "@esbuild/netbsd-x64": "0.25.9",
-        "@esbuild/openbsd-arm64": "0.25.9",
-        "@esbuild/openbsd-x64": "0.25.9",
-        "@esbuild/openharmony-arm64": "0.25.9",
-        "@esbuild/sunos-x64": "0.25.9",
-        "@esbuild/win32-arm64": "0.25.9",
-        "@esbuild/win32-ia32": "0.25.9",
-        "@esbuild/win32-x64": "0.25.9"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -4656,26 +6574,24 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
-      "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
+      "version": "9.39.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
+      "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.3.1",
-        "@eslint/core": "^0.15.2",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.33.0",
-        "@eslint/plugin-kit": "^0.3.5",
+        "@eslint/js": "9.39.1",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
@@ -4788,9 +6704,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4884,36 +6800,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4946,9 +6832,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
       "funding": [
         {
           "type": "github",
@@ -4957,8 +6843,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "strnum": "^2.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4971,16 +6856,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
-      }
-    },
-    "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
       }
     },
     "node_modules/file-entry-cache": {
@@ -5006,28 +6881,15 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -5062,9 +6924,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
     },
@@ -5128,9 +6990,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
-      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5232,15 +7094,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -5385,16 +7251,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/is-typed-array": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
@@ -5447,9 +7303,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5539,37 +7395,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5726,19 +7558,6 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -5759,12 +7578,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.3.tgz",
+      "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5785,27 +7603,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/react": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
@@ -5825,41 +7622,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5867,9 +7629,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5997,13 +7759,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -6034,25 +7796,11 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6100,12 +7848,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6115,16 +7862,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.1.tgz",
-      "integrity": "sha512-GDUv6/NDYngUlNvwaHM1RamYftxf782IyEDbdj3SeaIHHv8fNQVRC++fITT7kUJV/5rIA/tkoRSSskt6osEfqg==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.48.0.tgz",
+      "integrity": "sha512-fcKOvQD9GUn3Xw63EgiDqhvWJ5jsyZUaekl3KVpGsDJnN46WJTe3jWxtQP9lMZm1LJNkFLlTaWAxK2vUQR+cqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.39.1",
-        "@typescript-eslint/parser": "8.39.1",
-        "@typescript-eslint/typescript-estree": "8.39.1",
-        "@typescript-eslint/utils": "8.39.1"
+        "@typescript-eslint/eslint-plugin": "8.48.0",
+        "@typescript-eslint/parser": "8.48.0",
+        "@typescript-eslint/typescript-estree": "8.48.0",
+        "@typescript-eslint/utils": "8.48.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6261,9 +8008,9 @@
       }
     },
     "node_modules/yoctocolors-cjs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
-      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/extensions/amazon-aws/package.json
+++ b/extensions/amazon-aws/package.json
@@ -89,6 +89,12 @@
       "mode": "view"
     },
     {
+      "name": "cognito",
+      "title": "Cognito User Pools",
+      "description": "Manage Cognito user pools, users, and groups",
+      "mode": "view"
+    },
+    {
       "name": "lambda",
       "title": "Lambda Functions",
       "description": "Find and open a function",
@@ -169,6 +175,28 @@
       "title": "API Gateway",
       "description": "Manage REST APIs, resources, stages, and API keys",
       "mode": "view"
+    },
+    {
+      "name": "athena",
+      "title": "Athena",
+      "description": "Manage Athena work groups, named queries, and query executions",
+      "mode": "view"
+    },
+    {
+      "name": "quicksight",
+      "title": "QuickSight",
+      "description": "Manage QuickSight dashboards, analyses, and datasets",
+      "mode": "view",
+      "preferences": [
+        {
+          "name": "quicksightRegion",
+          "type": "textfield",
+          "required": false,
+          "title": "QuickSight Region",
+          "description": "Override region for QuickSight (e.g., us-east-1). Leave empty to use the profile's default region.",
+          "placeholder": "us-east-1"
+        }
+      ]
     }
   ],
   "tools": [
@@ -221,6 +249,61 @@
       "name": "get-amplify-webhook",
       "title": "Get Amplify Webhook",
       "description": "Gets detailed information for an Amplify webhook"
+    },
+    {
+      "name": "list-lambda-functions",
+      "title": "List Lambda Functions",
+      "description": "Lists all Lambda functions in the current account and region"
+    },
+    {
+      "name": "get-lambda-function-details",
+      "title": "Get Lambda Function Details",
+      "description": "Gets detailed information for a specific Lambda function"
+    },
+    {
+      "name": "invoke-lambda-function",
+      "title": "Invoke Lambda Function",
+      "description": "Invokes a Lambda function with an optional payload"
+    },
+    {
+      "name": "list-s3-buckets",
+      "title": "List S3 Buckets",
+      "description": "Lists all S3 buckets in the current account"
+    },
+    {
+      "name": "list-s3-objects",
+      "title": "List S3 Objects",
+      "description": "Lists objects in an S3 bucket with optional prefix filter"
+    },
+    {
+      "name": "list-dynamodb-tables",
+      "title": "List DynamoDB Tables",
+      "description": "Lists all DynamoDB table names in the current account and region"
+    },
+    {
+      "name": "describe-dynamodb-table",
+      "title": "Describe DynamoDB Table",
+      "description": "Gets detailed information for a specific DynamoDB table"
+    },
+    {
+      "name": "list-secrets",
+      "title": "List Secrets",
+      "description": "Lists secrets in AWS Secrets Manager"
+    },
+    {
+      "name": "list-codepipeline-pipelines",
+      "title": "List CodePipeline Pipelines",
+      "description": "Lists all CodePipeline pipelines in the current account and region"
+    },
+    {
+      "name": "list-cloudwatch-log-groups",
+      "title": "List CloudWatch Log Groups",
+      "description": "Lists CloudWatch log groups in the current account and region"
+    },
+    {
+      "name": "list-quicksight-dashboards",
+      "title": "List QuickSight Dashboards",
+      "description": "Lists all QuickSight dashboards in the current account"
     }
   ],
   "ai": {
@@ -323,41 +406,133 @@
           "list-amplify-project",
           "start-amplify-build"
         ]
+      },
+      {
+        "input": "What Lambda functions do I have?",
+        "output": "I'll list all your Lambda functions for you.",
+        "tools": [
+          "list-lambda-functions"
+        ]
+      },
+      {
+        "input": "Show me details about my auth function",
+        "output": "I'll help you find your auth function. Let me first list your Lambda functions to identify the right one.",
+        "tools": [
+          "list-lambda-functions",
+          "get-lambda-function-details"
+        ]
+      },
+      {
+        "input": "Invoke my data-processor Lambda with a test event",
+        "output": "I'll help you invoke the data-processor function. Let me first list your functions to identify it, then invoke it with your test payload.",
+        "tools": [
+          "list-lambda-functions",
+          "invoke-lambda-function"
+        ]
+      },
+      {
+        "input": "List my S3 buckets",
+        "output": "I'll list all your S3 buckets for you.",
+        "tools": [
+          "list-s3-buckets"
+        ]
+      },
+      {
+        "input": "What files are in my uploads bucket?",
+        "output": "I'll help you browse your uploads bucket. Let me first list your buckets to identify it, then show its contents.",
+        "tools": [
+          "list-s3-buckets",
+          "list-s3-objects"
+        ]
+      },
+      {
+        "input": "What DynamoDB tables do I have?",
+        "output": "I'll list all your DynamoDB tables for you.",
+        "tools": [
+          "list-dynamodb-tables"
+        ]
+      },
+      {
+        "input": "Show me the schema for my users table",
+        "output": "I'll help you get the details of your users table. Let me first list your tables to identify it.",
+        "tools": [
+          "list-dynamodb-tables",
+          "describe-dynamodb-table"
+        ]
+      },
+      {
+        "input": "What secrets do I have stored?",
+        "output": "I'll list all your secrets in AWS Secrets Manager.",
+        "tools": [
+          "list-secrets"
+        ]
+      },
+      {
+        "input": "Show me my CodePipeline pipelines",
+        "output": "I'll list all your CodePipeline pipelines for you.",
+        "tools": [
+          "list-codepipeline-pipelines"
+        ]
+      },
+      {
+        "input": "What log groups do I have in CloudWatch?",
+        "output": "I'll list all your CloudWatch log groups for you.",
+        "tools": [
+          "list-cloudwatch-log-groups"
+        ]
+      },
+      {
+        "input": "What QuickSight dashboards do I have?",
+        "output": "I'll list all your QuickSight dashboards for you.",
+        "tools": [
+          "list-quicksight-dashboards"
+        ]
+      },
+      {
+        "input": "Show me my BI dashboards",
+        "output": "I'll list your QuickSight dashboards to show your BI resources.",
+        "tools": [
+          "list-quicksight-dashboards"
+        ]
       }
     ]
   },
   "dependencies": {
-    "@aws-sdk/client-amplify": "^3.864.0",
-    "@aws-sdk/client-api-gateway": "^3.864.0",
-    "@aws-sdk/client-apigatewayv2": "^3.864.0",
-    "@aws-sdk/client-appsync": "^3.859.0",
-    "@aws-sdk/client-cloudformation": "^3.864.0",
-    "@aws-sdk/client-cloudwatch-logs": "^3.864.0",
-    "@aws-sdk/client-codeartifact": "^3.864.0",
-    "@aws-sdk/client-codepipeline": "^3.864.0",
-    "@aws-sdk/client-dynamodb": "^3.868.0",
-    "@aws-sdk/client-ec2": "^3.868.0",
-    "@aws-sdk/client-ecr": "^3.864.0",
-    "@aws-sdk/client-ecs": "^3.864.0",
-    "@aws-sdk/client-glue": "^3.868.0",
-    "@aws-sdk/client-lambda": "^3.865.0",
-    "@aws-sdk/client-s3": "^3.864.0",
-    "@aws-sdk/client-secrets-manager": "^3.864.0",
-    "@aws-sdk/client-sfn": "^3.864.0",
-    "@aws-sdk/client-sqs": "^3.864.0",
-    "@aws-sdk/client-ssm": "^3.864.0",
+    "@aws-sdk/client-amplify": "^3.940.0",
+    "@aws-sdk/client-api-gateway": "^3.940.0",
+    "@aws-sdk/client-apigatewayv2": "^3.940.0",
+    "@aws-sdk/client-appsync": "^3.940.0",
+    "@aws-sdk/client-athena": "^3.940.0",
+    "@aws-sdk/client-cloudformation": "^3.940.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.940.0",
+    "@aws-sdk/client-codeartifact": "^3.940.0",
+    "@aws-sdk/client-codepipeline": "^3.940.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.953.0",
+    "@aws-sdk/client-dynamodb": "^3.940.0",
+    "@aws-sdk/client-ec2": "^3.940.0",
+    "@aws-sdk/client-ecr": "^3.940.0",
+    "@aws-sdk/client-ecs": "^3.940.0",
+    "@aws-sdk/client-glue": "^3.942.0",
+    "@aws-sdk/client-lambda": "^3.942.0",
+    "@aws-sdk/client-quicksight": "^3.940.0",
+    "@aws-sdk/client-s3": "^3.940.0",
+    "@aws-sdk/client-secrets-manager": "^3.940.0",
+    "@aws-sdk/client-sfn": "^3.940.0",
+    "@aws-sdk/client-sqs": "^3.940.0",
+    "@aws-sdk/client-ssm": "^3.940.0",
+    "@aws-sdk/client-sts": "^3.940.0",
     "@aws-sdk/shared-ini-file-loader": "^3.374.0",
-    "@aws-sdk/util-dynamodb": "^3.868.0",
-    "@raycast/api": "^1.102.4",
-    "@raycast/utils": "^2.2.0",
+    "@aws-sdk/util-dynamodb": "^3.940.0",
+    "@raycast/api": "^1.103.10",
+    "@raycast/utils": "^2.2.2",
     "util": "^0.12.5"
   },
   "devDependencies": {
-    "@raycast/eslint-config": "^2.0.4",
-    "@types/react": "^19.1.10",
-    "eslint": "^9.33.0",
-    "prettier": "^3.6.2",
-    "typescript": "^5.9.2"
+    "@raycast/eslint-config": "^2.1.1",
+    "@types/react": "^19.2.7",
+    "eslint": "^9.39.1",
+    "prettier": "^3.7.3",
+    "typescript": "^5.9.3"
   },
   "scripts": {
     "build": "ray build -e dist",

--- a/extensions/amazon-aws/package.json
+++ b/extensions/amazon-aws/package.json
@@ -120,8 +120,8 @@
     },
     {
       "name": "cloudwatch",
-      "title": "CloudWatch Log Groups",
-      "description": "Find and open a log group",
+      "title": "CloudWatch",
+      "description": "Browse CloudWatch log groups and dashboards",
       "mode": "view"
     },
     {
@@ -299,6 +299,11 @@
       "name": "list-cloudwatch-log-groups",
       "title": "List CloudWatch Log Groups",
       "description": "Lists CloudWatch log groups in the current account and region"
+    },
+    {
+      "name": "list-cloudwatch-dashboards",
+      "title": "List CloudWatch Dashboards",
+      "description": "Lists CloudWatch dashboards in the current account and region"
     },
     {
       "name": "list-quicksight-dashboards",
@@ -482,6 +487,13 @@
         ]
       },
       {
+        "input": "What CloudWatch dashboards do I have?",
+        "output": "I'll list all your CloudWatch dashboards for you.",
+        "tools": [
+          "list-cloudwatch-dashboards"
+        ]
+      },
+      {
         "input": "What QuickSight dashboards do I have?",
         "output": "I'll list all your QuickSight dashboards for you.",
         "tools": [
@@ -504,6 +516,7 @@
     "@aws-sdk/client-appsync": "^3.940.0",
     "@aws-sdk/client-athena": "^3.940.0",
     "@aws-sdk/client-cloudformation": "^3.940.0",
+    "@aws-sdk/client-cloudwatch": "^3.940.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.940.0",
     "@aws-sdk/client-codeartifact": "^3.940.0",
     "@aws-sdk/client-codepipeline": "^3.940.0",

--- a/extensions/amazon-aws/src/actions/ecr.ts
+++ b/extensions/amazon-aws/src/actions/ecr.ts
@@ -1,14 +1,7 @@
-import {
-  ECRClient,
-  DescribeRepositoriesCommand,
-  Repository,
-  ListImagesCommand,
-  ImageIdentifier,
-} from "@aws-sdk/client-ecr";
+import { DescribeRepositoriesCommand, Repository, ListImagesCommand, ImageIdentifier } from "@aws-sdk/client-ecr";
 import { AWS_URL_BASE } from "../constants";
 import { isReadyToFetch } from "../util";
-
-const ecrClient = new ECRClient({});
+import { getECRClient } from "../services/clients/ecr";
 
 export async function fetchRepositories(): Promise<Repository[]> {
   if (!isReadyToFetch()) return [];
@@ -25,7 +18,7 @@ export async function fetchImages(registryId: string, repositoryName: string): P
 }
 
 async function fetchAllRepositories(token?: string, accRepositories?: Repository[]): Promise<Repository[]> {
-  const { repositories, nextToken } = await ecrClient.send(new DescribeRepositoriesCommand({ nextToken: token }));
+  const { repositories, nextToken } = await getECRClient().send(new DescribeRepositoriesCommand({ nextToken: token }));
   const combinedRepositories = [...(accRepositories || []), ...(repositories || [])];
 
   if (nextToken) {
@@ -41,7 +34,7 @@ async function fetchRepositoryImages(
   token?: string,
   accImages?: ImageIdentifier[],
 ): Promise<ImageIdentifier[]> {
-  const { imageIds, nextToken } = await ecrClient.send(
+  const { imageIds, nextToken } = await getECRClient().send(
     new ListImagesCommand({ registryId, repositoryName, nextToken: token }),
   );
 

--- a/extensions/amazon-aws/src/actions/ecs.ts
+++ b/extensions/amazon-aws/src/actions/ecs.ts
@@ -5,7 +5,6 @@ import {
   DescribeServicesCommand,
   DescribeTaskDefinitionCommand,
   DescribeTasksCommand,
-  ECSClient,
   ListClustersCommand,
   ListServicesCommand,
   ListTasksCommand,
@@ -14,14 +13,13 @@ import {
 } from "@aws-sdk/client-ecs";
 import { AWS_URL_BASE } from "../constants";
 import { isReadyToFetch } from "../util";
-
-const ecsClient = new ECSClient({});
+import { getECSClient } from "../services/clients/ecs";
 
 export async function fetchClusters(): Promise<Cluster[]> {
   if (!isReadyToFetch()) return [];
   const clustersArns = await fetchClusterArns();
 
-  const { clusters } = await ecsClient.send(new DescribeClustersCommand({ clusters: clustersArns }));
+  const { clusters } = await getECSClient().send(new DescribeClustersCommand({ clusters: clustersArns }));
   return clusters || [];
 }
 
@@ -32,7 +30,9 @@ export async function fetchServices(clusterArn: string): Promise<Service[]> {
   const serviceChunks: string[][] = getChunks(servicesArns, 10);
 
   const services = await Promise.all(
-    serviceChunks.map((chunk) => ecsClient.send(new DescribeServicesCommand({ cluster: clusterArn, services: chunk }))),
+    serviceChunks.map((chunk) =>
+      getECSClient().send(new DescribeServicesCommand({ cluster: clusterArn, services: chunk })),
+    ),
   );
 
   return services.map((entry) => entry.services || []).flat(2);
@@ -45,7 +45,7 @@ export async function fetchTasks(clusterArn: string, serviceName: string): Promi
   const taskChunks: string[][] = getChunks(taskArns, 100);
 
   const tasks = await Promise.all(
-    taskChunks.map((chunk) => ecsClient.send(new DescribeTasksCommand({ cluster: clusterArn, tasks: chunk }))),
+    taskChunks.map((chunk) => getECSClient().send(new DescribeTasksCommand({ cluster: clusterArn, tasks: chunk }))),
   );
 
   return tasks.map((entry) => entry.tasks || []).flat(2);
@@ -54,7 +54,9 @@ export async function fetchTasks(clusterArn: string, serviceName: string): Promi
 export async function fetchTaskContainers(taskDefArn: string): Promise<ContainerDefinition[]> {
   if (!isReadyToFetch()) return [];
 
-  const { taskDefinition } = await ecsClient.send(new DescribeTaskDefinitionCommand({ taskDefinition: taskDefArn }));
+  const { taskDefinition } = await getECSClient().send(
+    new DescribeTaskDefinitionCommand({ taskDefinition: taskDefArn }),
+  );
 
   return taskDefinition?.containerDefinitions || [];
 }
@@ -71,7 +73,7 @@ function getChunks(arr: string[], chunkSize: number): string[][] {
 }
 
 async function fetchClusterArns(token?: string, accClusters?: string[]): Promise<string[]> {
-  const { clusterArns, nextToken } = await ecsClient.send(new ListClustersCommand({ nextToken: token }));
+  const { clusterArns, nextToken } = await getECSClient().send(new ListClustersCommand({ nextToken: token }));
   const combinedClusters = [...(accClusters || []), ...(clusterArns || [])];
 
   if (nextToken) {
@@ -82,7 +84,7 @@ async function fetchClusterArns(token?: string, accClusters?: string[]): Promise
 }
 
 async function fetchServiceArns(clusterArn: string, token?: string, accServices?: string[]): Promise<string[]> {
-  const { serviceArns, nextToken } = await ecsClient.send(
+  const { serviceArns, nextToken } = await getECSClient().send(
     new ListServicesCommand({ cluster: clusterArn, nextToken: token }),
   );
 
@@ -101,7 +103,7 @@ async function fetchTasksArns(
   token?: string,
   accTasks?: string[],
 ): Promise<string[]> {
-  const { taskArns, nextToken } = await ecsClient.send(
+  const { taskArns, nextToken } = await getECSClient().send(
     new ListTasksCommand({ cluster: clusterArn, serviceName, nextToken: token }),
   );
 

--- a/extensions/amazon-aws/src/actions/logs.ts
+++ b/extensions/amazon-aws/src/actions/logs.ts
@@ -1,14 +1,12 @@
 import {
-  CloudWatchLogsClient,
   DescribeLogStreamsCommand,
   FilteredLogEvent,
   FilterLogEventsCommand,
   LogStream,
 } from "@aws-sdk/client-cloudwatch-logs";
 import { LogStartTimes } from "../interfaces";
+import { getCloudWatchLogsClient } from "../services/clients/cloudwatch-logs";
 import { isReadyToFetch } from "../util";
-
-const cloudWatchLogsClient = new CloudWatchLogsClient({});
 export async function fetchLogs(
   logGroupName: string,
   startTime: LogStartTimes,
@@ -22,24 +20,24 @@ export async function fetchLogs(
 export async function fetchLogStreams(
   logGroupName: string,
   token?: string,
-  accEvents?: LogStream[],
+  accStreams?: LogStream[],
 ): Promise<LogStream[]> {
   if (!isReadyToFetch()) return [];
-  const { logStreams, nextToken } = await cloudWatchLogsClient.send(
-    new DescribeLogStreamsCommand({ logGroupName, nextToken: token }),
+  const { logStreams, nextToken } = await getCloudWatchLogsClient().send(
+    new DescribeLogStreamsCommand({
+      logGroupName,
+      nextToken: token,
+      limit: 50,
+    }),
   );
 
-  const combinedEvents = [...(accEvents || []), ...(logStreams || [])];
-
-  if (combinedEvents.length > 300) {
-    return combinedEvents;
-  }
+  const combinedStreams = [...(accStreams || []), ...(logStreams || [])];
 
   if (nextToken) {
-    return fetchLogStreams(logGroupName, nextToken, combinedEvents);
+    return fetchLogStreams(logGroupName, nextToken, combinedStreams);
   }
 
-  return combinedEvents;
+  return combinedStreams;
 }
 
 async function fetchAllLogs(
@@ -52,7 +50,7 @@ async function fetchAllLogs(
 ): Promise<FilteredLogEvent[]> {
   const secondsSinceEpoch = getMiliSecondsSinceEpoch(startTime);
 
-  const { events, nextToken } = await cloudWatchLogsClient.send(
+  const { events, nextToken } = await getCloudWatchLogsClient().send(
     new FilterLogEventsCommand({
       logGroupName,
       logStreamNamePrefix,

--- a/extensions/amazon-aws/src/amplify.tsx
+++ b/extensions/amazon-aws/src/amplify.tsx
@@ -1,8 +1,10 @@
 import { App, Branch, CustomRule, JobStatus, JobSummary, Webhook } from "@aws-sdk/client-amplify";
 import { Action, ActionPanel, Color, Form, Icon, Image, List, showToast, Toast, useNavigation } from "@raycast/api";
+import { runAppleScript } from "@raycast/utils";
 import { useCallback, useState } from "react";
 import { AwsAction } from "./components/common/action";
 import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
+import { getAWSErrorMessage } from "./errors";
 import {
   downloadAmplifyBuildLogs,
   startAmplifyBuild,
@@ -11,8 +13,8 @@ import {
   updateAmplifyEnvironmentVariables,
   useAmplifyAppDetails,
   useAmplifyApps,
-  useAmplifyArtifacts,
   useAmplifyBranches,
+  useAmplifyJobDetails,
   useAmplifyJobs,
   useAmplifyWebhooks,
 } from "./hooks/use-amplify";
@@ -96,9 +98,12 @@ function AmplifyApp({ app }: { app: App }) {
             />
             <Action.OpenInBrowser title="Metrics" url={monitoringUrls.metrics} icon={Icon.LineChart} />
           </ActionPanel.Submenu>
-          <Action.CopyToClipboard title="Copy App ID" content={app.appId || ""} />
-          <Action.CopyToClipboard title="Copy App URL" content={appUrl} />
-          {app.repository && <Action.CopyToClipboard title="Copy Repository" content={app.repository} />}
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard title="Copy App ID" content={app.appId || ""} />
+            <Action.CopyToClipboard title="Copy App URL" content={appUrl} />
+            {app.repository && <Action.CopyToClipboard title="Copy Repository" content={app.repository} />}
+            <AwsAction.ExportResponse response={app} />
+          </ActionPanel.Section>
         </ActionPanel>
       }
       accessories={[
@@ -174,7 +179,7 @@ function AmplifyBranch({ branch, app, webhooks }: { branch: Branch; app: App; we
     } catch (error) {
       toast.style = Toast.Style.Failure;
       toast.title = "❌ Failed to trigger webhook";
-      toast.message = error instanceof Error ? error.message : "Unknown error occurred";
+      toast.message = getAWSErrorMessage(error);
     }
   }, []);
 
@@ -213,8 +218,11 @@ function AmplifyBranch({ branch, app, webhooks }: { branch: Branch; app: App; we
             />
             <Action.OpenInBrowser title="Access Logs" url={branchMonitoringUrls.accessLogs} icon={Icon.Document} />
           </ActionPanel.Submenu>
-          <Action.CopyToClipboard title="Copy Branch Name" content={branch.branchName || ""} />
-          <Action.CopyToClipboard title="Copy Branch URL" content={branchUrl} />
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard title="Copy Branch Name" content={branch.branchName || ""} />
+            <Action.CopyToClipboard title="Copy Branch URL" content={branchUrl} />
+            <AwsAction.ExportResponse response={branch} />
+          </ActionPanel.Section>
           {branchWebhooks.length > 0 && (
             <ActionPanel.Submenu title="Webhooks" icon={Icon.Link}>
               {branchWebhooks.flatMap((webhook) => [
@@ -255,15 +263,49 @@ function AmplifyBranch({ branch, app, webhooks }: { branch: Branch; app: App; we
   );
 }
 
+/**
+ * Patterns that indicate a sensitive environment variable
+ */
+const SENSITIVE_PATTERNS = ["API_KEY", "SECRET", "PASSWORD", "TOKEN", "KEY", "CREDENTIAL", "AUTH", "PRIVATE"];
+
+/**
+ * Checks if an environment variable key indicates sensitive data
+ */
+function isSensitiveKey(key: string): boolean {
+  const upperKey = key.toUpperCase();
+  return SENSITIVE_PATTERNS.some((pattern) => upperKey.includes(pattern));
+}
+
+/**
+ * Masks a sensitive value for display, showing only first and last 4 characters
+ */
+function maskValue(value: string): string {
+  if (value.length <= 8) {
+    return "••••••••";
+  }
+  return `${value.substring(0, 4)}${"•".repeat(Math.min(value.length - 8, 16))}${value.substring(value.length - 4)}`;
+}
+
 function AmplifyEnvironmentVariables({ appId }: { appId: string }) {
   const { app, error, isLoading } = useAmplifyAppDetails(appId);
+  const [showSensitiveValues, setShowSensitiveValues] = useState(false);
 
-  const environmentVariables = app?.environmentVariables || {};
-  const envVarEntries = Object.entries(environmentVariables);
+  const environmentVariables: Record<string, string> = app?.environmentVariables ?? {};
+  const envVarEntries: [string, string][] = Object.entries(environmentVariables);
 
   // Direct console link to environment variables page (without home and hash routing)
   const AWS_REGION = process.env.AWS_REGION;
   const envVarsConsoleUrl = `https://${AWS_REGION}.console.aws.amazon.com/amplify/apps/${appId}/variables`;
+
+  /**
+   * Gets the display value for an environment variable, masking if sensitive
+   */
+  function getDisplayValue(key: string, value: string): string {
+    if (showSensitiveValues || !isSensitiveKey(key)) {
+      return value;
+    }
+    return maskValue(value);
+  }
 
   return (
     <List
@@ -294,11 +336,19 @@ function AmplifyEnvironmentVariables({ appId }: { appId: string }) {
           <List.Item
             key={key}
             title={key}
-            subtitle={value}
-            icon={Icon.Code}
+            subtitle={getDisplayValue(key, value)}
+            icon={isSensitiveKey(key) ? Icon.Lock : Icon.Code}
             actions={
               <ActionPanel>
                 <Action.CopyToClipboard title="Copy Value" content={value} />
+                {isSensitiveKey(key) && (
+                  <Action
+                    title={showSensitiveValues ? "Hide Sensitive Values" : "Show Sensitive Values"}
+                    icon={showSensitiveValues ? Icon.EyeDisabled : Icon.Eye}
+                    onAction={() => setShowSensitiveValues(!showSensitiveValues)}
+                    shortcut={{ modifiers: ["cmd"], key: "s" }}
+                  />
+                )}
                 <Action.Push
                   title="Edit Variable"
                   icon={Icon.Pencil}
@@ -341,7 +391,10 @@ function AmplifyEnvironmentVariables({ appId }: { appId: string }) {
                 <Action.OpenInBrowser title="Open in AWS Console" url={envVarsConsoleUrl} icon={Icon.Globe} />
               </ActionPanel>
             }
-            accessories={[{ text: `${value.length} chars` }]}
+            accessories={[
+              ...(isSensitiveKey(key) ? [{ icon: Icon.Lock, tooltip: "Sensitive value" }] : []),
+              { text: `${value.length} chars` },
+            ]}
           />
         ))
       )}
@@ -474,6 +527,57 @@ function EditEnvironmentVariable({
   );
 }
 
+function getJobStatusIcon(status?: JobStatus): { source: Icon; tintColor: Color } {
+  switch (status) {
+    case "PENDING":
+      return { source: Icon.Clock, tintColor: Color.Yellow };
+    case "PROVISIONING":
+      return { source: Icon.Cog, tintColor: Color.Blue };
+    case "RUNNING":
+      return { source: Icon.Play, tintColor: Color.Blue };
+    case "SUCCEED":
+      return { source: Icon.CheckCircle, tintColor: Color.Green };
+    case "FAILED":
+      return { source: Icon.XMarkCircle, tintColor: Color.Red };
+    case "CANCELLING":
+      return { source: Icon.Stop, tintColor: Color.Orange };
+    case "CANCELLED":
+      return { source: Icon.MinusCircle, tintColor: Color.SecondaryText };
+    default:
+      return { source: Icon.QuestionMark, tintColor: Color.SecondaryText };
+  }
+}
+
+function formatDuration(startTime?: Date, endTime?: Date): string {
+  if (!startTime) return "";
+  const start = new Date(startTime).getTime();
+  const end = endTime ? new Date(endTime).getTime() : Date.now();
+  const duration = Math.floor((end - start) / 1000);
+
+  if (duration < 60) return `${duration}s`;
+  const minutes = Math.floor(duration / 60);
+  const seconds = duration % 60;
+  if (minutes < 60) return `${minutes}m ${seconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+function getJobTypeTag(jobType?: string): { value: string; color: Color } | undefined {
+  switch (jobType) {
+    case "RELEASE":
+      return { value: "Release", color: Color.Green };
+    case "RETRY":
+      return { value: "Retry", color: Color.Orange };
+    case "WEB_HOOK":
+      return { value: "Webhook", color: Color.Purple };
+    case "MANUAL":
+      return { value: "Manual", color: Color.Blue };
+    default:
+      return undefined;
+  }
+}
+
 function AmplifyBuildHistory({ app, branch }: { app: App; branch: Branch }) {
   if (!app.appId || !branch.branchName) {
     return (
@@ -484,42 +588,6 @@ function AmplifyBuildHistory({ app, branch }: { app: App; branch: Branch }) {
   }
 
   const { jobs, error, isLoading, revalidate } = useAmplifyJobs(app.appId, branch.branchName);
-
-  function getJobStatusIcon(status?: JobStatus): { source: Icon; tintColor: Color } {
-    switch (status) {
-      case "PENDING":
-        return { source: Icon.Clock, tintColor: Color.Yellow };
-      case "PROVISIONING":
-        return { source: Icon.Cog, tintColor: Color.Blue };
-      case "RUNNING":
-        return { source: Icon.Play, tintColor: Color.Blue };
-      case "SUCCEED":
-        return { source: Icon.CheckCircle, tintColor: Color.Green };
-      case "FAILED":
-        return { source: Icon.XMarkCircle, tintColor: Color.Red };
-      case "CANCELLING":
-        return { source: Icon.Stop, tintColor: Color.Orange };
-      case "CANCELLED":
-        return { source: Icon.MinusCircle, tintColor: Color.SecondaryText };
-      default:
-        return { source: Icon.QuestionMark, tintColor: Color.SecondaryText };
-    }
-  }
-
-  function formatDuration(startTime?: Date, endTime?: Date): string {
-    if (!startTime) return "";
-    const start = new Date(startTime).getTime();
-    const end = endTime ? new Date(endTime).getTime() : Date.now();
-    const duration = Math.floor((end - start) / 1000);
-
-    if (duration < 60) return `${duration}s`;
-    const minutes = Math.floor(duration / 60);
-    const seconds = duration % 60;
-    if (minutes < 60) return `${minutes}m ${seconds}s`;
-    const hours = Math.floor(minutes / 60);
-    const remainingMinutes = minutes % 60;
-    return `${hours}h ${remainingMinutes}m`;
-  }
 
   const handleRetryBuild = useCallback(
     async (job: JobSummary) => {
@@ -578,8 +646,6 @@ function AmplifyBuildHistory({ app, branch }: { app: App; branch: Branch }) {
             branch={branch}
             onRetry={() => handleRetryBuild(job)}
             onCancel={() => handleCancelBuild(job)}
-            getJobStatusIcon={getJobStatusIcon}
-            formatDuration={formatDuration}
           />
         ))
       )}
@@ -593,23 +659,25 @@ function AmplifyBuildJob({
   branch,
   onRetry,
   onCancel,
-  getJobStatusIcon,
-  formatDuration,
 }: {
   job: JobSummary;
   app: App;
   branch: Branch;
   onRetry: () => Promise<void>;
   onCancel: () => Promise<void>;
-  getJobStatusIcon: (status?: JobStatus) => { source: Icon; tintColor: Color };
-  formatDuration: (startTime?: Date, endTime?: Date) => string;
 }) {
   const AWS_REGION = process.env.AWS_REGION;
   const isRunning = job.status === "RUNNING" || job.status === "PROVISIONING" || job.status === "PENDING";
   const isFailed = job.status === "FAILED";
   const buildLogUrl = `https://${AWS_REGION}.console.aws.amazon.com/amplify/apps/${app.appId}/branches/${branch.branchName}/deployments/${job.jobId}`;
 
+  const logGroupName = `/aws/amplify/${app.appId}`;
+  const liveTailUrl = `https://${AWS_REGION}.console.aws.amazon.com/cloudwatch/home?region=${AWS_REGION}#logsV2:live-tail$3FlogGroupArns$3D${encodeURIComponent(`arn:aws:logs:${AWS_REGION}:*:log-group:${logGroupName}`)}`;
+  const tailCommand = `aws logs tail "${logGroupName}" --follow`;
+
   const statusIcon = getJobStatusIcon(job.status);
+  const jobTypeTag = getJobTypeTag(job.jobType);
+  const duration = formatDuration(job.startTime, job.endTime);
 
   return (
     <List.Item
@@ -625,6 +693,12 @@ function AmplifyBuildJob({
             target={<AmplifyBuildDetails job={job} app={app} branch={branch} />}
           />
           <Action.OpenInBrowser title="View Build Logs" url={buildLogUrl} icon={Icon.Terminal} />
+          <Action.OpenInBrowser
+            title="Tail Logs in Console"
+            url={liveTailUrl}
+            icon={Icon.Livestream}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
+          />
           <Action
             title="Download Build Logs"
             icon={Icon.Download}
@@ -672,20 +746,107 @@ function AmplifyBuildJob({
             }}
             shortcut={{ modifiers: ["cmd"], key: "b" }}
           />
-          <ActionPanel.Section>
+          <Action
+            title="Run Tail Command in Terminal"
+            icon={Icon.Terminal}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "t" }}
+            onAction={async () => {
+              const escapedCommand = tailCommand.replace(/"/g, '\\"');
+              const appleScript = `
+                tell application "Terminal"
+                  do script "${escapedCommand}"
+                  activate
+                end tell
+              `;
+              try {
+                await runAppleScript(appleScript);
+                await showToast({ style: Toast.Style.Success, title: "Opened in Terminal" });
+              } catch (error) {
+                await showToast({
+                  style: Toast.Style.Failure,
+                  title: "Failed to open Terminal",
+                  message: getAWSErrorMessage(error),
+                });
+              }
+            }}
+          />
+          <ActionPanel.Section title="Copy">
             <Action.CopyToClipboard title="Copy Job ID" content={job.jobId || ""} />
             {job.commitId && <Action.CopyToClipboard title="Copy Commit ID" content={job.commitId} />}
+            <Action.CopyToClipboard
+              title="Copy Tail Command"
+              content={tailCommand}
+              icon={Icon.Terminal}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+            />
+            <AwsAction.ExportResponse response={job} />
           </ActionPanel.Section>
         </ActionPanel>
       }
       accessories={[
-        { text: job.status },
-        { text: formatDuration(job.startTime, job.endTime) },
+        ...(jobTypeTag ? [{ tag: jobTypeTag }] : []),
+        { icon: statusIcon, tooltip: job.status },
+        ...(duration ? [{ text: duration, tooltip: "Duration" }] : []),
         ...(job.commitId ? [{ text: job.commitId.substring(0, 7), tooltip: job.commitId }] : []),
         ...(job.startTime ? [{ date: new Date(job.startTime) }] : []),
       ]}
     />
   );
+}
+
+function buildDetailMarkdown(
+  job: JobSummary,
+  steps?: { stepName?: string; status?: string; startTime?: Date; endTime?: Date; statusReason?: string }[],
+): string {
+  const lines: string[] = [];
+
+  lines.push(`## Build #${job.jobId}`);
+  lines.push("");
+
+  const statusEmoji =
+    job.status === "SUCCEED" ? "✅" : job.status === "FAILED" ? "❌" : job.status === "RUNNING" ? "🔄" : "⏳";
+  lines.push(`**Status:** ${statusEmoji} ${job.status}`);
+  lines.push(`**Type:** ${job.jobType ?? "Unknown"}`);
+  if (job.commitId) {
+    lines.push(`**Commit:** \`${job.commitId.substring(0, 7)}\` ${job.commitMessage ?? ""}`);
+  }
+  if (job.startTime) {
+    lines.push(`**Started:** ${new Date(job.startTime).toLocaleString()}`);
+  }
+  if (job.endTime) {
+    lines.push(`**Completed:** ${new Date(job.endTime).toLocaleString()}`);
+  }
+  const duration = formatDuration(job.startTime, job.endTime);
+  if (duration) {
+    lines.push(`**Duration:** ${duration}`);
+  }
+
+  if (steps && steps.length > 0) {
+    lines.push("");
+    lines.push("---");
+    lines.push("");
+    lines.push("### Build Steps");
+    lines.push("");
+    lines.push("| Step | Status | Duration |");
+    lines.push("|------|--------|----------|");
+    for (const step of steps) {
+      const stepStatus =
+        step.status === "SUCCEED" ? "✅" : step.status === "FAILED" ? "❌" : step.status === "RUNNING" ? "🔄" : "⏳";
+      const stepDuration = formatDuration(step.startTime, step.endTime);
+      lines.push(`| ${step.stepName ?? "Unknown"} | ${stepStatus} ${step.status ?? ""} | ${stepDuration} |`);
+    }
+
+    const failedSteps = steps.filter((s) => s.status === "FAILED" && s.statusReason);
+    if (failedSteps.length > 0) {
+      lines.push("");
+      lines.push("### Failure Details");
+      for (const step of failedSteps) {
+        lines.push(`- **${step.stepName}:** ${step.statusReason}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
 }
 
 function AmplifyBuildDetails({ job, app, branch }: { job: JobSummary; app: App; branch: Branch }) {
@@ -697,96 +858,84 @@ function AmplifyBuildDetails({ job, app, branch }: { job: JobSummary; app: App; 
     );
   }
 
-  const { artifacts, isLoading } = useAmplifyArtifacts(app.appId, branch.branchName, job.jobId);
+  const { job: jobDetails, isLoading } = useAmplifyJobDetails(app.appId, branch.branchName, job.jobId);
   const AWS_REGION = process.env.AWS_REGION;
   const buildLogUrl = `https://${AWS_REGION}.console.aws.amazon.com/amplify/apps/${app.appId}/branches/${branch.branchName}/deployments/${job.jobId}`;
+
+  const steps = jobDetails?.steps ?? [];
+  const markdown = buildDetailMarkdown(job, steps);
 
   return (
     <List
       isLoading={isLoading}
       navigationTitle={`Build #${job.jobId} Details`}
-      searchBarPlaceholder="Filter artifacts..."
+      searchBarPlaceholder="Filter steps..."
+      isShowingDetail
     >
-      <List.Section title="Build Information">
-        <List.Item
-          title="Status"
-          subtitle={job.status}
-          icon={Icon.Info}
-          actions={
-            <ActionPanel>
-              <Action.OpenInBrowser title="View Build Logs" url={buildLogUrl} icon={Icon.Terminal} />
-              <Action
-                title="Download Build Logs"
-                icon={Icon.Download}
-                onAction={async () => {
-                  if (!app.appId || !branch.branchName || !job.jobId) {
-                    await showToast({
-                      style: Toast.Style.Failure,
-                      title: "Cannot download logs",
-                      message: "Missing required parameters",
-                    });
-                    return;
-                  }
-                  try {
-                    await downloadAmplifyBuildLogs(app.appId, branch.branchName, job.jobId);
-                  } catch (error) {
-                    // Error is already handled in downloadAmplifyBuildLogs
-                  }
-                }}
-                shortcut={{ modifiers: ["cmd"], key: "d" }}
-              />
-            </ActionPanel>
-          }
-          accessories={[{ text: job.status }]}
-        />
-        {job.commitId && (
+      <List.Section title="Build Steps">
+        {steps.length === 0 && !isLoading && (
           <List.Item
-            title="Commit"
-            subtitle={job.commitMessage || "No message"}
-            icon={Icon.Code}
+            title="No steps available"
+            icon={Icon.Info}
+            detail={<List.Item.Detail markdown={markdown} />}
             actions={
               <ActionPanel>
-                <Action.CopyToClipboard title="Copy Commit ID" content={job.commitId} />
+                <Action.OpenInBrowser title="View Build Logs" url={buildLogUrl} icon={Icon.Terminal} />
               </ActionPanel>
             }
-            accessories={[{ text: job.commitId.substring(0, 7) }]}
           />
         )}
-        {job.startTime && (
-          <List.Item
-            title="Started"
-            subtitle={new Date(job.startTime).toLocaleString()}
-            icon={Icon.Clock}
-            accessories={[{ date: new Date(job.startTime) }]}
-          />
-        )}
-        {job.endTime && (
-          <List.Item
-            title="Completed"
-            subtitle={new Date(job.endTime).toLocaleString()}
-            icon={Icon.CheckCircle}
-            accessories={[{ date: new Date(job.endTime) }]}
-          />
-        )}
-      </List.Section>
+        {steps.map((step, index) => {
+          const stepIcon = getJobStatusIcon(step.status as JobStatus);
+          const stepDuration = formatDuration(step.startTime, step.endTime);
 
-      {artifacts && artifacts.length > 0 && (
-        <List.Section title="Build Artifacts">
-          {artifacts.map((artifact) => (
+          return (
             <List.Item
-              key={artifact.artifactId}
-              title={artifact.artifactFileName || "Unnamed artifact"}
-              subtitle={artifact.artifactId}
-              icon={Icon.Document}
+              key={`${step.stepName}-${index}`}
+              title={step.stepName ?? `Step ${index + 1}`}
+              icon={stepIcon}
+              detail={<List.Item.Detail markdown={markdown} />}
+              accessories={[
+                { icon: stepIcon, tooltip: step.status },
+                ...(stepDuration ? [{ text: stepDuration }] : []),
+              ]}
               actions={
                 <ActionPanel>
-                  <Action.CopyToClipboard title="Copy Artifact ID" content={artifact.artifactId || ""} />
+                  <Action.OpenInBrowser title="View Build Logs" url={buildLogUrl} icon={Icon.Terminal} />
+                  <Action
+                    title="Download Build Logs"
+                    icon={Icon.Download}
+                    onAction={async () => {
+                      try {
+                        await downloadAmplifyBuildLogs(app.appId!, branch.branchName!, job.jobId!);
+                      } catch (error) {
+                        // Error is already handled in downloadAmplifyBuildLogs
+                      }
+                    }}
+                    shortcut={{ modifiers: ["cmd"], key: "d" }}
+                  />
+                  {step.logUrl && (
+                    <Action.OpenInBrowser
+                      title="Open Step Log"
+                      url={step.logUrl}
+                      icon={Icon.Document}
+                      shortcut={{ modifiers: ["cmd"], key: "l" }}
+                    />
+                  )}
+                  <ActionPanel.Section title="Copy">
+                    <Action.CopyToClipboard title="Copy Job ID" content={job.jobId ?? ""} />
+                    {job.commitId && <Action.CopyToClipboard title="Copy Commit ID" content={job.commitId} />}
+                    {step.statusReason && (
+                      <Action.CopyToClipboard title="Copy Failure Reason" content={step.statusReason} />
+                    )}
+                    <AwsAction.ExportResponse response={jobDetails ?? job} />
+                  </ActionPanel.Section>
                 </ActionPanel>
               }
             />
-          ))}
-        </List.Section>
-      )}
+          );
+        })}
+      </List.Section>
     </List>
   );
 }
@@ -831,7 +980,7 @@ function AmplifyCustomHeaders({ app }: { app: App }) {
           }
         />
       ) : (
-        customRules.map((rule, index) => (
+        customRules.map((rule: CustomRule, index: number) => (
           <List.Item
             key={index}
             title={rule.source || "No source"}

--- a/extensions/amazon-aws/src/apigateway.tsx
+++ b/extensions/amazon-aws/src/apigateway.tsx
@@ -2,7 +2,9 @@ import { RestApi } from "@aws-sdk/client-api-gateway";
 import { Api } from "@aws-sdk/client-apigatewayv2";
 import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
 import ApiGatewayApiKeys from "./components/apigateway/ApiGatewayApiKeys";
+import ApiGatewayAuthorizers from "./components/apigateway/ApiGatewayAuthorizers";
 import ApiGatewayDeployments from "./components/apigateway/ApiGatewayDeployments";
+import ApiGatewayDomains from "./components/apigateway/ApiGatewayDomains";
 import ApiGatewayResources from "./components/apigateway/ApiGatewayResources";
 import ApiGatewayStages from "./components/apigateway/ApiGatewayStages";
 import ApiGatewayUsagePlans from "./components/apigateway/ApiGatewayUsagePlans";
@@ -100,18 +102,31 @@ function RestApiItem({ api }: { api: RestApi }) {
             shortcut={{ modifiers: ["cmd"], key: "u" }}
             target={<ApiGatewayUsagePlans apiId={api.id || ""} apiName={api.name || ""} />}
           />
+          <Action.Push
+            title="View Authorizers"
+            icon={Icon.Shield}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "a" }}
+            target={<ApiGatewayAuthorizers apiId={api.id || ""} apiName={api.name || ""} />}
+          />
+          <Action.Push
+            title="View Custom Domains"
+            icon={Icon.Globe}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
+            target={<ApiGatewayDomains />}
+          />
           <ActionPanel.Section>
             <AwsAction.Console url={resourceToConsoleLink(api.id, "AWS::ApiGateway::RestApi")} />
             <Action.OpenInBrowser
               icon={Icon.Document}
               title="Open API Documentation"
               url={resourceToConsoleLink(api.id, "AWS::ApiGateway::RestApi::Documentation")}
-              shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
             />
           </ActionPanel.Section>
           <ActionPanel.Section title={"Copy"}>
             <Action.CopyToClipboard title="Copy API ID" content={api.id || ""} />
             <Action.CopyToClipboard title="Copy API Name" content={api.name || ""} />
+            <AwsAction.ExportResponse response={api} />
           </ActionPanel.Section>
         </ActionPanel>
       }
@@ -171,6 +186,7 @@ function HttpApiItem({ api }: { api: Api }) {
             <Action.CopyToClipboard title="Copy API ID" content={api.ApiId || ""} />
             <Action.CopyToClipboard title="Copy API Name" content={api.Name || ""} />
             {api.ApiEndpoint && <Action.CopyToClipboard title="Copy API Endpoint" content={api.ApiEndpoint} />}
+            <AwsAction.ExportResponse response={api} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/appsync.tsx
+++ b/extensions/amazon-aws/src/appsync.tsx
@@ -78,6 +78,7 @@ function AppSyncApi({ api }: { api: GraphqlApi }) {
             <Action.CopyToClipboard title="Copy GraphQL Endpoint" content={apiEndpoint} />
             <Action.CopyToClipboard title="Copy API ID" content={api.apiId || ""} />
             <Action.CopyToClipboard title="Copy API ARN" content={api.arn || ""} />
+            <AwsAction.ExportResponse response={api} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/athena.tsx
+++ b/extensions/amazon-aws/src/athena.tsx
@@ -1,0 +1,253 @@
+import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
+import { useCachedState, useFrecencySorting } from "@raycast/utils";
+import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
+import { resourceToConsoleLink } from "./util";
+import { AwsAction } from "./components/common/action";
+import { useAthenaWorkGroups, useAthenaNamedQueries, useAthenaQueryExecutions } from "./hooks/use-athena";
+
+enum ResourceType {
+  WorkGroups = "WorkGroups",
+  NamedQueries = "NamedQueries",
+  QueryExecutions = "QueryExecutions",
+}
+type SetResourceType = { setResourceType: (value: ResourceType) => void };
+
+export default function Athena() {
+  const [resourceType, setResourceType] = useCachedState<ResourceType>("resource-type", ResourceType.WorkGroups, {
+    cacheNamespace: "aws-athena",
+  });
+
+  if (resourceType === ResourceType.NamedQueries) {
+    return <AthenaNamedQueries {...{ setResourceType }} />;
+  }
+  if (resourceType === ResourceType.QueryExecutions) {
+    return <AthenaQueryExecutions {...{ setResourceType }} />;
+  }
+  return <AthenaWorkGroups {...{ setResourceType }} />;
+}
+
+const AthenaWorkGroups = ({ setResourceType }: SetResourceType) => {
+  const { workGroups, error, isLoading, revalidate } = useAthenaWorkGroups();
+
+  const {
+    data: sortedWorkGroups,
+    visitItem: visit,
+    resetRanking,
+  } = useFrecencySorting(workGroups, {
+    namespace: "aws-athena-workgroups",
+    key: (wg) => wg.Name!,
+    sortUnvisited: (a, b) => (a.Name ?? "").localeCompare(b.Name ?? ""),
+  });
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Filter work groups by name..."
+      filtering
+      navigationTitle="Athena Work Groups"
+      searchBarAccessory={<AWSProfileDropdown onProfileSelected={revalidate} />}
+    >
+      {error && (
+        <List.EmptyView
+          title={error.name}
+          description={error.message}
+          icon={{ source: Icon.Warning, tintColor: Color.Red }}
+        />
+      )}
+      {!error && sortedWorkGroups.length === 0 && (
+        <List.EmptyView title="No work groups found!" icon={{ source: Icon.Warning, tintColor: Color.Orange }} />
+      )}
+      {sortedWorkGroups.map((wg) => (
+        <List.Item
+          key={wg.Name}
+          icon={"aws-icons/athena.png"}
+          title={wg.Name ?? ""}
+          subtitle={wg.Description}
+          keywords={[wg.Name ?? "", wg.State ?? "", wg.EngineVersion?.EffectiveEngineVersion ?? ""]}
+          actions={
+            <ActionPanel>
+              <AwsAction.Console
+                url={resourceToConsoleLink(wg.Name, "AWS::Athena::WorkGroup")}
+                onAction={() => visit(wg)}
+              />
+              <ActionPanel.Section title="Work Group Actions">
+                <Action.CopyToClipboard title="Copy Work Group Name" content={wg.Name ?? ""} onCopy={() => visit(wg)} />
+                <AwsAction.ExportResponse response={wg} />
+                <Action title="Reset Ranking" icon={Icon.ArrowCounterClockwise} onAction={() => resetRanking(wg)} />
+              </ActionPanel.Section>
+              <AwsAction.SwitchResourceType
+                {...{ setResourceType, current: ResourceType.WorkGroups, enumType: ResourceType }}
+              />
+            </ActionPanel>
+          }
+          accessories={[
+            { date: wg.CreationTime, icon: Icon.Calendar, tooltip: "Created" },
+            { icon: workGroupStateToIcon(wg.State ?? ""), tooltip: wg.State },
+            ...(wg.EngineVersion?.EffectiveEngineVersion ? [{ tag: wg.EngineVersion.EffectiveEngineVersion }] : []),
+          ]}
+        />
+      ))}
+    </List>
+  );
+};
+
+const AthenaNamedQueries = ({ setResourceType }: SetResourceType) => {
+  const { namedQueries, error, isLoading, revalidate } = useAthenaNamedQueries();
+
+  const {
+    data: sortedQueries,
+    visitItem: visit,
+    resetRanking,
+  } = useFrecencySorting(namedQueries, {
+    namespace: "aws-athena-named-queries",
+    key: (q) => q.NamedQueryId!,
+    sortUnvisited: (a, b) => (a.Name ?? "").localeCompare(b.Name ?? ""),
+  });
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Filter named queries by name or database..."
+      filtering
+      navigationTitle="Athena Named Queries"
+      searchBarAccessory={<AWSProfileDropdown onProfileSelected={revalidate} />}
+    >
+      {error && (
+        <List.EmptyView
+          title={error.name}
+          description={error.message}
+          icon={{ source: Icon.Warning, tintColor: Color.Red }}
+        />
+      )}
+      {!error && sortedQueries.length === 0 && (
+        <List.EmptyView title="No named queries found!" icon={{ source: Icon.Warning, tintColor: Color.Orange }} />
+      )}
+      {sortedQueries.map((q) => (
+        <List.Item
+          key={q.NamedQueryId}
+          icon={"aws-icons/athena.png"}
+          title={q.Name ?? ""}
+          subtitle={q.Description}
+          keywords={[q.Name ?? "", q.Database ?? "", q.WorkGroup ?? "", q.NamedQueryId ?? ""]}
+          actions={
+            <ActionPanel>
+              <AwsAction.Console
+                url={resourceToConsoleLink(q.NamedQueryId, "AWS::Athena::NamedQuery")}
+                onAction={() => visit(q)}
+              />
+              <ActionPanel.Section title="Query Actions">
+                <Action.CopyToClipboard
+                  title="Copy Query String"
+                  content={q.QueryString ?? ""}
+                  onCopy={() => visit(q)}
+                />
+                <Action.CopyToClipboard title="Copy Query ID" content={q.NamedQueryId ?? ""} onCopy={() => visit(q)} />
+                <AwsAction.ExportResponse response={q} />
+                <Action title="Reset Ranking" icon={Icon.ArrowCounterClockwise} onAction={() => resetRanking(q)} />
+              </ActionPanel.Section>
+              <AwsAction.SwitchResourceType
+                {...{ setResourceType, current: ResourceType.NamedQueries, enumType: ResourceType }}
+              />
+            </ActionPanel>
+          }
+          accessories={[
+            { tag: q.Database ?? "", tooltip: `Database: ${q.Database}` },
+            { tag: q.WorkGroup ?? "", tooltip: `Work Group: ${q.WorkGroup}` },
+          ]}
+        />
+      ))}
+    </List>
+  );
+};
+
+const AthenaQueryExecutions = ({ setResourceType }: SetResourceType) => {
+  const { queryExecutions, error, isLoading, revalidate } = useAthenaQueryExecutions();
+
+  const {
+    data: sortedExecutions,
+    visitItem: visit,
+    resetRanking,
+  } = useFrecencySorting(queryExecutions, {
+    namespace: "aws-athena-query-executions",
+    key: (e) => e.QueryExecutionId!,
+    sortUnvisited: (a, b) => {
+      const dateA = a.Status?.SubmissionDateTime?.getTime() ?? 0;
+      const dateB = b.Status?.SubmissionDateTime?.getTime() ?? 0;
+      return dateB - dateA;
+    },
+  });
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Filter query executions by query, status or work group..."
+      filtering
+      navigationTitle="Athena Query Executions"
+      searchBarAccessory={<AWSProfileDropdown onProfileSelected={revalidate} />}
+    >
+      {error && (
+        <List.EmptyView
+          title={error.name}
+          description={error.message}
+          icon={{ source: Icon.Warning, tintColor: Color.Red }}
+        />
+      )}
+      {!error && sortedExecutions.length === 0 && (
+        <List.EmptyView title="No query executions found!" icon={{ source: Icon.Warning, tintColor: Color.Orange }} />
+      )}
+      {sortedExecutions.map((e) => {
+        const query = e.Query ?? "";
+        const truncatedQuery = query.length > 80 ? `${query.substring(0, 80)}...` : query;
+
+        return (
+          <List.Item
+            key={e.QueryExecutionId}
+            icon={"aws-icons/athena.png"}
+            title={truncatedQuery}
+            subtitle={e.WorkGroup}
+            keywords={[e.Query ?? "", e.QueryExecutionId ?? "", e.Status?.State ?? "", e.WorkGroup ?? ""]}
+            actions={
+              <ActionPanel>
+                <AwsAction.Console
+                  url={resourceToConsoleLink(e.QueryExecutionId, "AWS::Athena::QueryExecution")}
+                  onAction={() => visit(e)}
+                />
+                <ActionPanel.Section title="Execution Actions">
+                  <Action.CopyToClipboard title="Copy Query String" content={e.Query ?? ""} onCopy={() => visit(e)} />
+                  <Action.CopyToClipboard
+                    title="Copy Execution ID"
+                    content={e.QueryExecutionId ?? ""}
+                    onCopy={() => visit(e)}
+                  />
+                  <AwsAction.ExportResponse response={e} />
+                  <Action title="Reset Ranking" icon={Icon.ArrowCounterClockwise} onAction={() => resetRanking(e)} />
+                </ActionPanel.Section>
+                <AwsAction.SwitchResourceType
+                  {...{ setResourceType, current: ResourceType.QueryExecutions, enumType: ResourceType }}
+                />
+              </ActionPanel>
+            }
+            accessories={[
+              { date: e.Status?.SubmissionDateTime, icon: Icon.Calendar, tooltip: "Submitted" },
+              { icon: executionStateToIcon(e.Status?.State ?? ""), tooltip: e.Status?.State },
+            ]}
+          />
+        );
+      })}
+    </List>
+  );
+};
+
+const workGroupStateToIcon = (state: string) => {
+  if (state === "ENABLED") return { source: Icon.CheckCircle, tintColor: Color.Green };
+  if (state === "DISABLED") return { source: Icon.XMarkCircle, tintColor: Color.Red };
+  return { source: Icon.Warning, tintColor: Color.Orange };
+};
+
+const executionStateToIcon = (state: string) => {
+  if (state === "SUCCEEDED") return { source: Icon.CheckCircle, tintColor: Color.Green };
+  if (state === "FAILED") return { source: Icon.XMarkCircle, tintColor: Color.Red };
+  if (state === "CANCELLED") return { source: Icon.XMarkCircle, tintColor: Color.Orange };
+  if (state === "RUNNING" || state === "QUEUED") return { source: Icon.CircleProgress50, tintColor: Color.Blue };
+  return { source: Icon.Warning, tintColor: Color.Orange };
+};

--- a/extensions/amazon-aws/src/cloudformation.tsx
+++ b/extensions/amazon-aws/src/cloudformation.tsx
@@ -13,11 +13,11 @@ import {
   Keyboard,
 } from "@raycast/api";
 import {
-  CloudFormationClient,
   DescribeStacksCommand,
   StackSummary,
   UpdateTerminationProtectionCommand,
 } from "@aws-sdk/client-cloudformation";
+import { getCloudFormationClient } from "./services/clients/cloudformation";
 import { useCachedState, useFrecencySorting } from "@raycast/utils";
 import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
 import { getErrorMessage, resourceToConsoleLink } from "./util";
@@ -104,6 +104,7 @@ const CloudFormationStacks = ({ setResourceType }: SetResourceType) => {
                 />
                 <Action.CopyToClipboard title="Copy Stack ID" content={s.StackId || ""} onCopy={() => visit(s)} />
                 <Action.CopyToClipboard title="Copy Stack Name" content={s.StackName || ""} onCopy={() => visit(s)} />
+                <AwsAction.ExportResponse response={s} />
                 <Action title="Reset Ranking" icon={Icon.ArrowCounterClockwise} onAction={() => resetRanking(s)} />
               </ActionPanel.Section>
               <AwsAction.SwitchResourceType
@@ -155,7 +156,10 @@ const CloudFormationStackResources = ({ stack }: { stack: StackSummary }) => {
             actions={
               <ActionPanel>
                 {consoleLink && <AwsAction.Console url={consoleLink} />}
-                <Action.CopyToClipboard title="Copy Resource ID" content={r.PhysicalResourceId || ""} />
+                <ActionPanel.Section title="Copy">
+                  <Action.CopyToClipboard title="Copy Resource ID" content={r.PhysicalResourceId || ""} />
+                  <AwsAction.ExportResponse response={r} />
+                </ActionPanel.Section>
               </ActionPanel>
             }
           />
@@ -209,6 +213,7 @@ const CloudFormationExports = ({ setResourceType }: SetResourceType) => {
               <ActionPanel.Section>
                 <Action.CopyToClipboard title="Copy Export Name" content={e.Name || ""} onCopy={() => visit(e)} />
                 <Action.CopyToClipboard title="Copy Export Value" content={e.Value || ""} onCopy={() => visit(e)} />
+                <AwsAction.ExportResponse response={e} />
                 <Action title="Reset Ranking" icon={Icon.ArrowCounterClockwise} onAction={() => resetRanking(e)} />
               </ActionPanel.Section>
               <AwsAction.SwitchResourceType
@@ -224,7 +229,7 @@ const CloudFormationExports = ({ setResourceType }: SetResourceType) => {
 
 const updateTerminationProtection = async (stackName: string) => {
   const toast = await showToast({ style: Toast.Style.Animated, title: `⏳ Getting stack details for ${stackName}` });
-  new CloudFormationClient({})
+  getCloudFormationClient()
     .send(new DescribeStacksCommand({ StackName: stackName }))
     .then(async ({ Stacks }) => {
       const terminationProtection = !Stacks![0].EnableTerminationProtection;
@@ -237,7 +242,7 @@ const updateTerminationProtection = async (stackName: string) => {
           style: terminationProtection ? Alert.ActionStyle.Default : Alert.ActionStyle.Destructive,
           onAction: async () => {
             toast.title = `⏳ ${terminationProtection ? "Enabling" : "Disabling"} Termination Protection`;
-            new CloudFormationClient({})
+            getCloudFormationClient()
               .send(
                 new UpdateTerminationProtectionCommand({
                   EnableTerminationProtection: terminationProtection,

--- a/extensions/amazon-aws/src/cloudwatch.tsx
+++ b/extensions/amazon-aws/src/cloudwatch.tsx
@@ -1,18 +1,47 @@
-import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
-import { useState } from "react";
+import { Action, ActionPanel, Color, Icon, List, showToast, Toast } from "@raycast/api";
+import { runAppleScript, useCachedState, useFrecencySorting } from "@raycast/utils";
+import { LogGroup } from "@aws-sdk/client-cloudwatch-logs";
 import { AwsAction } from "./components/common/action";
 import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
+import { getAWSErrorMessage } from "./errors";
 import { useLogGroups } from "./hooks/use-logs";
 import { formatBytes, resourceToConsoleLink } from "./util";
-import { useCachedState, useFrecencySorting } from "@raycast/utils";
-import { LogGroup } from "@aws-sdk/client-cloudwatch-logs";
+
+function getLiveTailUrl(logGroupName: string) {
+  const region = process.env.AWS_REGION;
+  return `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#logsV2:live-tail$3FlogGroupArns$3D${encodeURIComponent(`arn:aws:logs:${region}:*:log-group:${logGroupName}`)}`;
+}
+
+function getTailCommand(logGroupName: string) {
+  return `aws logs tail "${logGroupName}" --follow`;
+}
+
+async function runTailInTerminal(logGroupName: string) {
+  const tailCommand = getTailCommand(logGroupName);
+  const escapedCommand = tailCommand.replace(/"/g, '\\"');
+  const appleScript = `
+    tell application "Terminal"
+      do script "${escapedCommand}"
+      activate
+    end tell
+  `;
+  try {
+    await runAppleScript(appleScript);
+    await showToast({ style: Toast.Style.Success, title: "Opened in Terminal" });
+  } catch (error) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Failed to open Terminal",
+      message: getAWSErrorMessage(error),
+    });
+  }
+}
 
 export default function CloudWatch() {
-  const [prefixQuery, setPrefixQuery] = useState<string>("");
   const [isDetailsEnabled, setDetailsEnabled] = useCachedState<boolean>("show-details", false, {
     cacheNamespace: "aws-logs",
   });
-  const { logGroups, error, isLoading, mutate } = useLogGroups(prefixQuery);
+  const { logGroups, error, isLoading, mutate } = useLogGroups();
 
   const {
     data: sortedLogGroups,
@@ -27,11 +56,9 @@ export default function CloudWatch() {
   return (
     <List
       isLoading={isLoading}
-      searchBarPlaceholder="Search log group by name prefix (>2 characters)"
+      searchBarPlaceholder="Filter log groups..."
       searchBarAccessory={<AWSProfileDropdown onProfileSelected={mutate} />}
-      onSearchTextChange={setPrefixQuery}
       isShowingDetail={!isLoading && !error && (logGroups || []).length > 0 && isDetailsEnabled}
-      throttle
     >
       {error && (
         <List.EmptyView
@@ -100,7 +127,27 @@ export default function CloudWatch() {
                 url={resourceToConsoleLink(logGroup.logGroupName, "AWS::Logs::LogGroup")}
                 onAction={() => visit(logGroup)}
               />
-              <ActionPanel.Section title={"Logs Actions"}>
+              <ActionPanel.Section title="Tail Logs">
+                <Action.OpenInBrowser
+                  icon={Icon.Livestream}
+                  title="Tail Logs in Console"
+                  url={getLiveTailUrl(logGroup.logGroupName!)}
+                  shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
+                />
+                <Action
+                  title="Run Tail Command in Terminal"
+                  icon={Icon.Terminal}
+                  shortcut={{ modifiers: ["cmd", "shift"], key: "t" }}
+                  onAction={() => runTailInTerminal(logGroup.logGroupName!)}
+                />
+                <Action.CopyToClipboard
+                  title="Copy Tail Command"
+                  content={getTailCommand(logGroup.logGroupName!)}
+                  icon={Icon.Terminal}
+                  shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+                />
+              </ActionPanel.Section>
+              <ActionPanel.Section title="Logs Actions">
                 <Action.CopyToClipboard
                   title="Copy Log Group Name"
                   content={logGroup.logGroupName || ""}

--- a/extensions/amazon-aws/src/cloudwatch.tsx
+++ b/extensions/amazon-aws/src/cloudwatch.tsx
@@ -1,11 +1,19 @@
 import { Action, ActionPanel, Color, Icon, List, showToast, Toast } from "@raycast/api";
 import { runAppleScript, useCachedState, useFrecencySorting } from "@raycast/utils";
 import { LogGroup } from "@aws-sdk/client-cloudwatch-logs";
+import { DashboardEntry } from "@aws-sdk/client-cloudwatch";
 import { AwsAction } from "./components/common/action";
 import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
 import { getAWSErrorMessage } from "./errors";
 import { useLogGroups } from "./hooks/use-logs";
+import { useDashboards } from "./hooks/use-cloudwatch-dashboards";
 import { formatBytes, resourceToConsoleLink } from "./util";
+
+enum ResourceType {
+  LogGroups = "LogGroups",
+  Dashboards = "Dashboards",
+}
+type SetResourceType = { setResourceType: (value: ResourceType) => void };
 
 function getLiveTailUrl(logGroupName: string) {
   const region = process.env.AWS_REGION;
@@ -38,6 +46,17 @@ async function runTailInTerminal(logGroupName: string) {
 }
 
 export default function CloudWatch() {
+  const [resourceType, setResourceType] = useCachedState<ResourceType>("resource-type", ResourceType.LogGroups, {
+    cacheNamespace: "aws-cloudwatch",
+  });
+
+  if (resourceType === ResourceType.Dashboards) {
+    return <CloudWatchDashboards {...{ setResourceType }} />;
+  }
+  return <CloudWatchLogGroups {...{ setResourceType }} />;
+}
+
+const CloudWatchLogGroups = ({ setResourceType }: SetResourceType) => {
   const [isDetailsEnabled, setDetailsEnabled] = useCachedState<boolean>("show-details", false, {
     cacheNamespace: "aws-logs",
   });
@@ -57,6 +76,7 @@ export default function CloudWatch() {
     <List
       isLoading={isLoading}
       searchBarPlaceholder="Filter log groups..."
+      navigationTitle="CloudWatch Log Groups"
       searchBarAccessory={<AWSProfileDropdown onProfileSelected={mutate} />}
       isShowingDetail={!isLoading && !error && (logGroups || []).length > 0 && isDetailsEnabled}
     >
@@ -68,7 +88,7 @@ export default function CloudWatch() {
         />
       )}
       {!error && logGroups?.length === 0 && (
-        <List.EmptyView title="No queues found!" icon={{ source: Icon.Warning, tintColor: Color.Orange }} />
+        <List.EmptyView title="No log groups found!" icon={{ source: Icon.Warning, tintColor: Color.Orange }} />
       )}
       {sortedLogGroups.map((logGroup) => (
         <List.Item
@@ -147,7 +167,7 @@ export default function CloudWatch() {
                   shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
                 />
               </ActionPanel.Section>
-              <ActionPanel.Section title="Logs Actions">
+              <ActionPanel.Section title="Log Group Actions">
                 <Action.CopyToClipboard
                   title="Copy Log Group Name"
                   content={logGroup.logGroupName || ""}
@@ -164,10 +184,131 @@ export default function CloudWatch() {
                   onAction={() => resetRanking(logGroup)}
                 />
               </ActionPanel.Section>
+              <AwsAction.SwitchResourceType
+                {...{ setResourceType, current: ResourceType.LogGroups, enumType: ResourceType }}
+              />
             </ActionPanel>
           }
         />
       ))}
     </List>
   );
-}
+};
+
+const CloudWatchDashboards = ({ setResourceType }: SetResourceType) => {
+  const [isDetailsEnabled, setDetailsEnabled] = useCachedState<boolean>("show-details", false, {
+    cacheNamespace: "aws-cloudwatch-dashboards",
+  });
+  const { dashboards, error, isLoading, mutate } = useDashboards();
+
+  const {
+    data: sortedDashboards,
+    resetRanking,
+    visitItem: visit,
+  } = useFrecencySorting(dashboards, {
+    namespace: "aws-cloudwatch-dashboards-sort",
+    key: (dashboard: DashboardEntry) => dashboard.DashboardName!,
+    sortUnvisited: (a, b) => (a.DashboardName ?? "").localeCompare(b.DashboardName ?? ""),
+  });
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Filter dashboards by name..."
+      filtering
+      navigationTitle="CloudWatch Dashboards"
+      searchBarAccessory={<AWSProfileDropdown onProfileSelected={mutate} />}
+      isShowingDetail={!isLoading && !error && (dashboards || []).length > 0 && isDetailsEnabled}
+    >
+      {error && (
+        <List.EmptyView
+          title={error.name}
+          description={error.message}
+          icon={{ source: Icon.Warning, tintColor: Color.Red }}
+        />
+      )}
+      {!error && dashboards?.length === 0 && (
+        <List.EmptyView title="No dashboards found!" icon={{ source: Icon.Warning, tintColor: Color.Orange }} />
+      )}
+      {sortedDashboards.map((dashboard) => (
+        <List.Item
+          key={dashboard.DashboardArn!}
+          icon="aws-icons/cw/logs.png"
+          title={dashboard.DashboardName ?? ""}
+          keywords={[dashboard.DashboardName ?? ""]}
+          accessories={
+            isDetailsEnabled
+              ? []
+              : [
+                  ...(dashboard.LastModified
+                    ? [{ date: dashboard.LastModified, icon: Icon.Calendar, tooltip: "Last Modified" }]
+                    : []),
+                  ...(dashboard.Size
+                    ? [
+                        {
+                          tag: { value: formatBytes(dashboard.Size), color: Color.Blue },
+                          tooltip: "Size",
+                          icon: Icon.Document,
+                        },
+                      ]
+                    : []),
+                ]
+          }
+          detail={
+            <List.Item.Detail
+              metadata={
+                <List.Item.Detail.Metadata>
+                  <List.Item.Detail.Metadata.Label title="Dashboard Name" text={dashboard.DashboardName} />
+                  <List.Item.Detail.Metadata.Label title="Dashboard ARN" text={dashboard.DashboardArn} />
+                  {dashboard.LastModified && (
+                    <List.Item.Detail.Metadata.Label
+                      title="Last Modified"
+                      text={dashboard.LastModified.toISOString()}
+                      icon={Icon.Calendar}
+                    />
+                  )}
+                  <List.Item.Detail.Metadata.Separator />
+                  {dashboard.Size && (
+                    <List.Item.Detail.Metadata.Label
+                      title="Size"
+                      text={formatBytes(dashboard.Size)}
+                      icon={{ source: Icon.Document, tintColor: Color.Blue }}
+                    />
+                  )}
+                </List.Item.Detail.Metadata>
+              }
+            />
+          }
+          actions={
+            <ActionPanel>
+              <AwsAction.Console
+                url={resourceToConsoleLink(dashboard.DashboardName, "AWS::CloudWatch::Dashboard")}
+                onAction={() => visit(dashboard)}
+              />
+              <ActionPanel.Section title="Dashboard Actions">
+                <Action.CopyToClipboard
+                  title="Copy Dashboard Name"
+                  content={dashboard.DashboardName ?? ""}
+                  onCopy={() => visit(dashboard)}
+                />
+                <Action
+                  title={`${isDetailsEnabled ? "Hide" : "Show"} Details`}
+                  onAction={() => setDetailsEnabled(!isDetailsEnabled)}
+                  icon={isDetailsEnabled ? Icon.EyeDisabled : Icon.Eye}
+                />
+                <Action
+                  title="Reset Ranking"
+                  icon={Icon.ArrowCounterClockwise}
+                  onAction={() => resetRanking(dashboard)}
+                />
+              </ActionPanel.Section>
+              <AwsAction.SwitchResourceType
+                {...{ setResourceType, current: ResourceType.Dashboards, enumType: ResourceType }}
+              />
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
+  );
+};

--- a/extensions/amazon-aws/src/codepipeline.tsx
+++ b/extensions/amazon-aws/src/codepipeline.tsx
@@ -87,6 +87,7 @@ export default function CodePipeline() {
                   icon={Icon.ArrowCounterClockwise}
                   onAction={() => resetRanking(pipeline)}
                 />
+                <AwsAction.ExportResponse response={pipeline} />
               </ActionPanel.Section>
             </ActionPanel>
           }

--- a/extensions/amazon-aws/src/cognito.tsx
+++ b/extensions/amazon-aws/src/cognito.tsx
@@ -1,0 +1,784 @@
+import {
+  GroupType,
+  UserPoolDescriptionType,
+  UserStatusType,
+  UserType,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  Action,
+  ActionPanel,
+  Alert,
+  Color,
+  confirmAlert,
+  Form,
+  Icon,
+  Image,
+  List,
+  showToast,
+  Toast,
+  useNavigation,
+} from "@raycast/api";
+import { useCallback, useState } from "react";
+import { AwsAction } from "./components/common/action";
+import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
+import {
+  addCognitoUserToGroup,
+  CreateUserInput,
+  createCognitoUser,
+  deleteCognitoUser,
+  disableCognitoUser,
+  enableCognitoUser,
+  getCustomAttributes,
+  getUserAttribute,
+  poolUsesEmailAsUsername,
+  poolUsesPhoneAsUsername,
+  removeCognitoUserFromGroup,
+  resetCognitoUserPassword,
+  useCognitoGroups,
+  useCognitoUserDetails,
+  useCognitoUserGroups,
+  useCognitoUserPoolDetails,
+  useCognitoUserPools,
+  useCognitoUsers,
+} from "./hooks/use-cognito";
+import { resourceToConsoleLink } from "./util";
+
+export default function Cognito() {
+  const { userPools, error, isLoading, revalidate } = useCognitoUserPools();
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Filter user pools by name..."
+      searchBarAccessory={<AWSProfileDropdown onProfileSelected={revalidate} />}
+    >
+      {error ? (
+        <List.EmptyView title={error.name} description={error.message} icon={Icon.Warning} />
+      ) : (
+        userPools?.map((pool) => <CognitoUserPoolItem key={pool.Id} pool={pool} />)
+      )}
+    </List>
+  );
+}
+
+function CognitoUserPoolItem({ pool }: { pool: UserPoolDescriptionType }) {
+  if (!pool.Id) {
+    return (
+      <List.Item
+        title={pool.Name || "Unknown Pool"}
+        subtitle="Invalid pool - missing ID"
+        icon={{ source: "aws-icons/c.png", mask: Image.Mask.RoundedRectangle }}
+        accessories={[{ text: "Error", icon: Icon.Warning }]}
+      />
+    );
+  }
+
+  return (
+    <List.Item
+      key={pool.Id}
+      title={pool.Name || ""}
+      subtitle={pool.Id}
+      icon={{ source: "aws-icons/c.png", mask: Image.Mask.RoundedRectangle }}
+      actions={
+        <ActionPanel>
+          <Action.Push target={<CognitoUsers pool={pool} />} title="View Users" icon={Icon.Person} />
+          <Action.Push target={<CognitoGroups pool={pool} />} title="View Groups" icon={Icon.TwoPeople} />
+          <AwsAction.Console url={resourceToConsoleLink(pool.Id, "AWS::Cognito::UserPool")} />
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard title="Copy Pool ID" content={pool.Id} />
+            <AwsAction.ExportResponse response={pool} />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+      accessories={[
+        ...(pool.Status ? [{ text: pool.Status }] : []),
+        ...(pool.LastModifiedDate ? [{ date: new Date(pool.LastModifiedDate) }] : []),
+      ]}
+    />
+  );
+}
+
+function CognitoUsers({ pool }: { pool: UserPoolDescriptionType }) {
+  const [searchText, setSearchText] = useState("");
+  const filter = searchText ? `username ^= "${searchText}"` : undefined;
+  const { users, error, isLoading, revalidate } = useCognitoUsers(pool.Id!, filter);
+
+  if (!pool.Id) {
+    return (
+      <List isLoading={false} navigationTitle="Users">
+        <List.EmptyView title="Invalid Pool" description="Pool ID is missing" icon={Icon.Warning} />
+      </List>
+    );
+  }
+
+  return (
+    <List
+      isLoading={isLoading}
+      navigationTitle={`${pool.Name} - Users`}
+      searchBarPlaceholder="Search users by username..."
+      onSearchTextChange={setSearchText}
+      throttle
+    >
+      {error ? (
+        <List.EmptyView title={error.name} description={error.message} icon={Icon.Warning} />
+      ) : users?.length === 0 ? (
+        <List.EmptyView
+          title="No Users"
+          description={searchText ? `No users matching "${searchText}"` : "No users in this pool"}
+          icon={Icon.Person}
+          actions={
+            <ActionPanel>
+              <Action.Push
+                target={<CreateUserForm poolId={pool.Id!} poolName={pool.Name} onUserCreated={revalidate} />}
+                title="Create User"
+                icon={Icon.Plus}
+              />
+            </ActionPanel>
+          }
+        />
+      ) : (
+        users?.map((user) => <CognitoUserItem key={user.Username} user={user} pool={pool} revalidate={revalidate} />)
+      )}
+    </List>
+  );
+}
+
+function CognitoUserItem({
+  user,
+  pool,
+  revalidate,
+}: {
+  user: UserType;
+  pool: UserPoolDescriptionType;
+  revalidate: () => void;
+}) {
+  const email = getUserAttribute(user.Attributes, "email");
+  const statusIcon = getUserStatusIcon(user.UserStatus);
+  const enabledIcon = user.Enabled
+    ? { source: Icon.CheckCircle, tintColor: Color.Green }
+    : { source: Icon.XMarkCircle, tintColor: Color.Red };
+
+  const handleToggleEnabled = useCallback(async () => {
+    if (!pool.Id || !user.Username) return;
+
+    if (user.Enabled) {
+      await confirmAlert({
+        icon: { source: Icon.PersonCircle, tintColor: Color.Orange },
+        title: "Disable User?",
+        message: `Disabling "${user.Username}" will prevent them from signing in. You can re-enable them later.`,
+        primaryAction: {
+          title: "Disable",
+          style: Alert.ActionStyle.Destructive,
+          onAction: async () => {
+            await disableCognitoUser(pool.Id!, user.Username!);
+            revalidate();
+          },
+        },
+      });
+    } else {
+      await enableCognitoUser(pool.Id, user.Username);
+      revalidate();
+    }
+  }, [pool.Id, user.Username, user.Enabled, revalidate]);
+
+  const handleResetPassword = useCallback(async () => {
+    if (!pool.Id || !user.Username) return;
+
+    await confirmAlert({
+      icon: { source: Icon.Key, tintColor: Color.Orange },
+      title: "Reset Password?",
+      message: `This will invalidate the current password for "${user.Username}" and trigger a password reset flow.`,
+      primaryAction: {
+        title: "Reset Password",
+        onAction: async () => {
+          await resetCognitoUserPassword(pool.Id!, user.Username!);
+          revalidate();
+        },
+      },
+    });
+  }, [pool.Id, user.Username, revalidate]);
+
+  const handleDeleteUser = useCallback(async () => {
+    if (!pool.Id || !user.Username) return;
+
+    await confirmAlert({
+      icon: { source: Icon.Trash, tintColor: Color.Red },
+      title: "Delete User?",
+      message: `Are you sure you want to permanently delete "${user.Username}"? This action cannot be undone.`,
+      primaryAction: {
+        title: "Delete",
+        style: Alert.ActionStyle.Destructive,
+        onAction: async () => {
+          await deleteCognitoUser(pool.Id!, user.Username!);
+          revalidate();
+        },
+      },
+    });
+  }, [pool.Id, user.Username, revalidate]);
+
+  return (
+    <List.Item
+      key={user.Username}
+      title={user.Username || ""}
+      subtitle={email}
+      icon={statusIcon}
+      actions={
+        <ActionPanel>
+          <Action.Push
+            target={<CognitoUserDetails user={user} pool={pool} revalidate={revalidate} />}
+            title="View Details"
+            icon={Icon.Eye}
+          />
+          <Action.Push
+            target={<ManageUserGroups user={user} pool={pool} />}
+            title="Manage Groups"
+            icon={Icon.TwoPeople}
+          />
+          <Action.Push
+            target={<CreateUserForm poolId={pool.Id!} poolName={pool.Name} onUserCreated={revalidate} />}
+            title="Create User"
+            icon={Icon.Plus}
+            shortcut={{ modifiers: ["cmd"], key: "n" }}
+          />
+          <Action
+            title={user.Enabled ? "Disable User" : "Enable User"}
+            icon={user.Enabled ? Icon.XMarkCircle : Icon.CheckCircle}
+            onAction={handleToggleEnabled}
+          />
+          <Action title="Reset Password" icon={Icon.Key} onAction={handleResetPassword} />
+          <AwsAction.Console url={resourceToConsoleLink(`${pool.Id}/${user.Username}`, "AWS::Cognito::User")} />
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard title="Copy Username" content={user.Username || ""} />
+            {email && <Action.CopyToClipboard title="Copy Email" content={email} />}
+            <AwsAction.ExportResponse response={user} />
+          </ActionPanel.Section>
+          <Action
+            title="Delete User"
+            icon={Icon.Trash}
+            style={Action.Style.Destructive}
+            onAction={handleDeleteUser}
+            shortcut={{ modifiers: ["cmd"], key: "backspace" }}
+          />
+        </ActionPanel>
+      }
+      accessories={[
+        { icon: enabledIcon, tooltip: user.Enabled ? "Enabled" : "Disabled" },
+        { text: user.UserStatus, tooltip: "User Status" },
+        ...(user.UserLastModifiedDate ? [{ date: new Date(user.UserLastModifiedDate) }] : []),
+      ]}
+    />
+  );
+}
+
+function CognitoUserDetails({
+  user,
+  pool,
+  revalidate,
+}: {
+  user: UserType;
+  pool: UserPoolDescriptionType;
+  revalidate: () => void;
+}) {
+  const { user: userDetails, isLoading: detailsLoading } = useCognitoUserDetails(pool.Id!, user.Username!);
+  const { groups, isLoading: groupsLoading } = useCognitoUserGroups(pool.Id!, user.Username!);
+
+  const isLoading = detailsLoading || groupsLoading;
+  const email = getUserAttribute(userDetails?.UserAttributes, "email");
+  const emailVerified = getUserAttribute(userDetails?.UserAttributes, "email_verified");
+  const phone = getUserAttribute(userDetails?.UserAttributes, "phone_number");
+  const phoneVerified = getUserAttribute(userDetails?.UserAttributes, "phone_number_verified");
+  const sub = getUserAttribute(userDetails?.UserAttributes, "sub");
+
+  // Get custom attributes (those starting with "custom:")
+  const customAttributes =
+    userDetails?.UserAttributes?.filter((attr) => attr.Name?.startsWith("custom:")).map((attr) => ({
+      name: attr.Name?.replace("custom:", "") || "",
+      value: attr.Value || "",
+      fullName: attr.Name || "",
+    })) || [];
+
+  const handleToggleEnabled = useCallback(async () => {
+    if (!pool.Id || !user.Username) return;
+
+    if (userDetails?.Enabled) {
+      await confirmAlert({
+        icon: { source: Icon.PersonCircle, tintColor: Color.Orange },
+        title: "Disable User?",
+        message: `Disabling "${user.Username}" will prevent them from signing in.`,
+        primaryAction: {
+          title: "Disable",
+          style: Alert.ActionStyle.Destructive,
+          onAction: async () => {
+            await disableCognitoUser(pool.Id!, user.Username!);
+            revalidate();
+          },
+        },
+      });
+    } else {
+      await enableCognitoUser(pool.Id, user.Username);
+      revalidate();
+    }
+  }, [pool.Id, user.Username, userDetails?.Enabled, revalidate]);
+
+  const handleResetPassword = useCallback(async () => {
+    if (!pool.Id || !user.Username) return;
+
+    await confirmAlert({
+      icon: { source: Icon.Key, tintColor: Color.Orange },
+      title: "Reset Password?",
+      message: `This will trigger a password reset flow for "${user.Username}".`,
+      primaryAction: {
+        title: "Reset Password",
+        onAction: async () => {
+          await resetCognitoUserPassword(pool.Id!, user.Username!);
+        },
+      },
+    });
+  }, [pool.Id, user.Username]);
+
+  return (
+    <List isLoading={isLoading} navigationTitle={`User: ${user.Username}`}>
+      <List.Section title="User Information">
+        <List.Item title="Username" accessories={[{ text: user.Username }]} icon={Icon.Person} />
+        <List.Item
+          title="Status"
+          accessories={[{ text: userDetails?.UserStatus, icon: getUserStatusIcon(userDetails?.UserStatus) }]}
+          icon={Icon.Info}
+        />
+        <List.Item
+          title="Enabled"
+          accessories={[
+            {
+              text: userDetails?.Enabled ? "Yes" : "No",
+              icon: userDetails?.Enabled
+                ? { source: Icon.CheckCircle, tintColor: Color.Green }
+                : { source: Icon.XMarkCircle, tintColor: Color.Red },
+            },
+          ]}
+          icon={Icon.Power}
+          actions={
+            <ActionPanel>
+              <Action
+                title={userDetails?.Enabled ? "Disable User" : "Enable User"}
+                icon={userDetails?.Enabled ? Icon.XMarkCircle : Icon.CheckCircle}
+                onAction={handleToggleEnabled}
+              />
+            </ActionPanel>
+          }
+        />
+        {sub && <List.Item title="Sub (ID)" accessories={[{ text: sub }]} icon={Icon.Key} />}
+      </List.Section>
+
+      <List.Section title="Contact">
+        {email && (
+          <List.Item
+            title="Email"
+            accessories={[
+              { text: email },
+              {
+                icon: emailVerified === "true" ? Icon.CheckCircle : Icon.XMarkCircle,
+                tooltip: emailVerified === "true" ? "Verified" : "Not verified",
+              },
+            ]}
+            icon={Icon.Envelope}
+            actions={
+              <ActionPanel>
+                <Action.CopyToClipboard title="Copy Email" content={email} />
+              </ActionPanel>
+            }
+          />
+        )}
+        {phone && (
+          <List.Item
+            title="Phone"
+            accessories={[
+              { text: phone },
+              {
+                icon: phoneVerified === "true" ? Icon.CheckCircle : Icon.XMarkCircle,
+                tooltip: phoneVerified === "true" ? "Verified" : "Not verified",
+              },
+            ]}
+            icon={Icon.Phone}
+            actions={
+              <ActionPanel>
+                <Action.CopyToClipboard title="Copy Phone" content={phone} />
+              </ActionPanel>
+            }
+          />
+        )}
+      </List.Section>
+
+      {customAttributes.length > 0 && (
+        <List.Section title="Custom Attributes">
+          {customAttributes.map((attr) => (
+            <List.Item
+              key={attr.fullName}
+              title={attr.name}
+              accessories={[{ text: attr.value }]}
+              icon={Icon.Tag}
+              actions={
+                <ActionPanel>
+                  <Action.CopyToClipboard title={`Copy ${attr.name}`} content={attr.value} />
+                </ActionPanel>
+              }
+            />
+          ))}
+        </List.Section>
+      )}
+
+      <List.Section title={`Groups (${groups?.length || 0})`}>
+        {groups && groups.length > 0 ? (
+          groups.map((group) => (
+            <List.Item
+              key={group.GroupName}
+              title={group.GroupName || ""}
+              subtitle={group.Description}
+              icon={Icon.TwoPeople}
+            />
+          ))
+        ) : (
+          <List.Item title="No groups" subtitle="User is not a member of any groups" icon={Icon.TwoPeople} />
+        )}
+      </List.Section>
+
+      <List.Section title="Timestamps">
+        {userDetails?.UserCreateDate && (
+          <List.Item
+            title="Created"
+            accessories={[{ date: new Date(userDetails.UserCreateDate) }]}
+            icon={Icon.Calendar}
+          />
+        )}
+        {userDetails?.UserLastModifiedDate && (
+          <List.Item
+            title="Last Modified"
+            accessories={[{ date: new Date(userDetails.UserLastModifiedDate) }]}
+            icon={Icon.Clock}
+          />
+        )}
+      </List.Section>
+
+      <List.Section title="Actions">
+        <List.Item
+          title="Reset Password"
+          icon={Icon.Key}
+          actions={
+            <ActionPanel>
+              <Action title="Reset Password" icon={Icon.Key} onAction={handleResetPassword} />
+            </ActionPanel>
+          }
+        />
+        <List.Item
+          title="Manage Groups"
+          icon={Icon.TwoPeople}
+          actions={
+            <ActionPanel>
+              <Action.Push
+                target={<ManageUserGroups user={user} pool={pool} />}
+                title="Manage Groups"
+                icon={Icon.TwoPeople}
+              />
+            </ActionPanel>
+          }
+        />
+      </List.Section>
+    </List>
+  );
+}
+
+function CognitoGroups({ pool }: { pool: UserPoolDescriptionType }) {
+  const { groups, error, isLoading } = useCognitoGroups(pool.Id!);
+
+  if (!pool.Id) {
+    return (
+      <List isLoading={false} navigationTitle="Groups">
+        <List.EmptyView title="Invalid Pool" description="Pool ID is missing" icon={Icon.Warning} />
+      </List>
+    );
+  }
+
+  return (
+    <List
+      isLoading={isLoading}
+      navigationTitle={`${pool.Name} - Groups`}
+      searchBarPlaceholder="Filter groups by name..."
+    >
+      {error ? (
+        <List.EmptyView title={error.name} description={error.message} icon={Icon.Warning} />
+      ) : groups?.length === 0 ? (
+        <List.EmptyView title="No Groups" description="No groups in this pool" icon={Icon.TwoPeople} />
+      ) : (
+        groups?.map((group) => <CognitoGroupItem key={group.GroupName} group={group} pool={pool} />)
+      )}
+    </List>
+  );
+}
+
+function CognitoGroupItem({ group, pool }: { group: GroupType; pool: UserPoolDescriptionType }) {
+  return (
+    <List.Item
+      key={group.GroupName}
+      title={group.GroupName || ""}
+      subtitle={group.Description}
+      icon={Icon.TwoPeople}
+      actions={
+        <ActionPanel>
+          <AwsAction.Console url={resourceToConsoleLink(pool.Id, "AWS::Cognito::UserPoolGroups")} />
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard title="Copy Group Name" content={group.GroupName || ""} />
+            {group.RoleArn && <Action.CopyToClipboard title="Copy Role ARN" content={group.RoleArn} />}
+            <AwsAction.ExportResponse response={group} />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+      accessories={[
+        ...(group.Precedence !== undefined ? [{ text: `Precedence: ${group.Precedence}` }] : []),
+        ...(group.LastModifiedDate ? [{ date: new Date(group.LastModifiedDate) }] : []),
+      ]}
+    />
+  );
+}
+
+function ManageUserGroups({ user, pool }: { user: UserType; pool: UserPoolDescriptionType }) {
+  const {
+    groups: userGroups,
+    isLoading: userGroupsLoading,
+    revalidate,
+  } = useCognitoUserGroups(pool.Id!, user.Username!);
+  const { groups: allGroups, isLoading: allGroupsLoading } = useCognitoGroups(pool.Id!);
+
+  const isLoading = userGroupsLoading || allGroupsLoading;
+  const userGroupNames = new Set(userGroups?.map((g) => g.GroupName) || []);
+  const availableGroups = allGroups?.filter((g) => !userGroupNames.has(g.GroupName)) || [];
+
+  const handleRemoveFromGroup = useCallback(
+    async (groupName: string) => {
+      if (!pool.Id || !user.Username) return;
+
+      await confirmAlert({
+        icon: { source: Icon.TwoPeople, tintColor: Color.Orange },
+        title: "Remove from Group?",
+        message: `Remove "${user.Username}" from group "${groupName}"?`,
+        primaryAction: {
+          title: "Remove",
+          style: Alert.ActionStyle.Destructive,
+          onAction: async () => {
+            await removeCognitoUserFromGroup(pool.Id!, user.Username!, groupName);
+            revalidate();
+          },
+        },
+      });
+    },
+    [pool.Id, user.Username, revalidate],
+  );
+
+  const handleAddToGroup = useCallback(
+    async (groupName: string) => {
+      if (!pool.Id || !user.Username) return;
+      await addCognitoUserToGroup(pool.Id, user.Username, groupName);
+      revalidate();
+    },
+    [pool.Id, user.Username, revalidate],
+  );
+
+  return (
+    <List isLoading={isLoading} navigationTitle={`${user.Username} - Groups`}>
+      <List.Section title="Current Groups">
+        {userGroups && userGroups.length > 0 ? (
+          userGroups.map((group) => (
+            <List.Item
+              key={group.GroupName}
+              title={group.GroupName || ""}
+              subtitle={group.Description}
+              icon={{ source: Icon.TwoPeople, tintColor: Color.Green }}
+              actions={
+                <ActionPanel>
+                  <Action
+                    title="Remove from Group"
+                    icon={Icon.Minus}
+                    style={Action.Style.Destructive}
+                    onAction={() => handleRemoveFromGroup(group.GroupName!)}
+                  />
+                </ActionPanel>
+              }
+            />
+          ))
+        ) : (
+          <List.Item title="No groups" subtitle="User is not a member of any groups" icon={Icon.TwoPeople} />
+        )}
+      </List.Section>
+
+      {availableGroups.length > 0 && (
+        <List.Section title="Available Groups">
+          {availableGroups.map((group) => (
+            <List.Item
+              key={group.GroupName}
+              title={group.GroupName || ""}
+              subtitle={group.Description}
+              icon={{ source: Icon.TwoPeople, tintColor: Color.SecondaryText }}
+              actions={
+                <ActionPanel>
+                  <Action title="Add to Group" icon={Icon.Plus} onAction={() => handleAddToGroup(group.GroupName!)} />
+                </ActionPanel>
+              }
+            />
+          ))}
+        </List.Section>
+      )}
+    </List>
+  );
+}
+
+function CreateUserForm({
+  poolId,
+  poolName,
+  onUserCreated,
+}: {
+  poolId: string;
+  poolName?: string;
+  onUserCreated: () => void;
+}) {
+  const { pop } = useNavigation();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { pool, isLoading: poolLoading } = useCognitoUserPoolDetails(poolId);
+
+  const usesEmailAsUsername = poolUsesEmailAsUsername(pool);
+  const usesPhoneAsUsername = poolUsesPhoneAsUsername(pool);
+  const customAttributes = getCustomAttributes(pool);
+
+  const handleSubmit = useCallback(
+    async (values: Record<string, string | boolean>) => {
+      // Determine the actual username based on pool configuration
+      let username = values.username as string;
+      if (usesEmailAsUsername && values.email) {
+        username = values.email as string;
+      } else if (usesPhoneAsUsername && values.phoneNumber) {
+        username = values.phoneNumber as string;
+      }
+
+      if (!username) {
+        showToast({
+          style: Toast.Style.Failure,
+          title: usesEmailAsUsername ? "Missing email" : usesPhoneAsUsername ? "Missing phone" : "Missing username",
+          message: usesEmailAsUsername
+            ? "Email is required (used as username)"
+            : usesPhoneAsUsername
+              ? "Phone number is required (used as username)"
+              : "Username is required",
+        });
+        return;
+      }
+
+      // Check required custom attributes
+      for (const attr of customAttributes) {
+        if (attr.required && !values[attr.name]) {
+          showToast({
+            style: Toast.Style.Failure,
+            title: `Missing ${attr.displayName}`,
+            message: `${attr.displayName} is required`,
+          });
+          return;
+        }
+      }
+
+      // Collect custom attribute values
+      const customAttrValues: Record<string, string> = {};
+      for (const attr of customAttributes) {
+        const value = values[attr.name] as string;
+        if (value) {
+          customAttrValues[attr.name] = value;
+        }
+      }
+
+      setIsSubmitting(true);
+      try {
+        const userData: CreateUserInput = {
+          username,
+          email: usesEmailAsUsername ? undefined : (values.email as string) || undefined,
+          phoneNumber: usesPhoneAsUsername ? undefined : (values.phoneNumber as string) || undefined,
+          temporaryPassword: (values.temporaryPassword as string) || undefined,
+          sendInvitation: values.sendInvitation as boolean,
+          customAttributes: Object.keys(customAttrValues).length > 0 ? customAttrValues : undefined,
+        };
+
+        await createCognitoUser(poolId, userData);
+        onUserCreated();
+        pop();
+      } catch {
+        // Error is already handled in createCognitoUser
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [poolId, onUserCreated, pop, usesEmailAsUsername, usesPhoneAsUsername, customAttributes],
+  );
+
+  return (
+    <Form
+      isLoading={isSubmitting || poolLoading}
+      navigationTitle={`Create User - ${poolName || poolId}`}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Create User" onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      {usesEmailAsUsername ? (
+        <Form.TextField id="email" title="Email (Username)" placeholder="john@example.com" autoFocus />
+      ) : usesPhoneAsUsername ? (
+        <Form.TextField id="phoneNumber" title="Phone Number (Username)" placeholder="+1234567890" autoFocus />
+      ) : (
+        <>
+          <Form.TextField id="username" title="Username" placeholder="johndoe" autoFocus />
+          <Form.TextField id="email" title="Email" placeholder="john@example.com" />
+          <Form.TextField id="phoneNumber" title="Phone Number" placeholder="+1234567890" />
+        </>
+      )}
+
+      {customAttributes.length > 0 && (
+        <>
+          <Form.Separator />
+          <Form.Description title="Custom Attributes" text="Pool-specific attributes" />
+          {customAttributes.map((attr) => (
+            <Form.TextField
+              key={attr.name}
+              id={attr.name}
+              title={`${attr.displayName}${attr.required ? " *" : ""}${!attr.mutable ? " (immutable)" : ""}`}
+              placeholder={attr.required ? "Required" : "Optional"}
+              info={!attr.mutable ? "Cannot be changed after user creation" : undefined}
+            />
+          ))}
+        </>
+      )}
+
+      <Form.Separator />
+      <Form.PasswordField
+        id="temporaryPassword"
+        title="Temporary Password"
+        placeholder="Leave empty for auto-generated"
+      />
+      <Form.Checkbox id="sendInvitation" label="Send invitation email" defaultValue={true} />
+      <Form.Description text="If a temporary password is set and invitation is disabled, the user must be told their password manually." />
+    </Form>
+  );
+}
+
+function getUserStatusIcon(status?: UserStatusType | string): { source: Icon; tintColor: Color } {
+  switch (status) {
+    case "CONFIRMED":
+      return { source: Icon.CheckCircle, tintColor: Color.Green };
+    case "FORCE_CHANGE_PASSWORD":
+      return { source: Icon.Key, tintColor: Color.Orange };
+    case "UNCONFIRMED":
+      return { source: Icon.Clock, tintColor: Color.Yellow };
+    case "RESET_REQUIRED":
+      return { source: Icon.Warning, tintColor: Color.Red };
+    case "ARCHIVED":
+      return { source: Icon.Bookmark, tintColor: Color.SecondaryText };
+    case "COMPROMISED":
+      return { source: Icon.ExclamationMark, tintColor: Color.Red };
+    case "UNKNOWN":
+    default:
+      return { source: Icon.QuestionMark, tintColor: Color.SecondaryText };
+  }
+}

--- a/extensions/amazon-aws/src/components/apigateway/ApiGatewayApiKeys.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/ApiGatewayApiKeys.tsx
@@ -65,6 +65,7 @@ function ApiKeyItem({ apiKey, apiId }: { apiKey: ApiKey & { isAssociated?: boole
             <Action.CopyToClipboard title="Copy API Key ID" content={apiKey.id || ""} />
             <Action.CopyToClipboard title="Copy API Key Name" content={apiKey.name || ""} />
             {apiKey.value && <Action.CopyToClipboard title="Copy API Key Value" content={apiKey.value} />}
+            <AwsAction.ExportResponse response={apiKey} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/apigateway/ApiGatewayAuthorizers.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/ApiGatewayAuthorizers.tsx
@@ -1,0 +1,163 @@
+import { Authorizer } from "@aws-sdk/client-api-gateway";
+import { Action, ActionPanel, Icon, List, Color } from "@raycast/api";
+import { useApiGatewayAuthorizers } from "../../hooks/use-apigateway";
+import AWSProfileDropdown from "../searchbar/aws-profile-dropdown";
+import { resourceToConsoleLink } from "../../util";
+import { AwsAction } from "../common/action";
+
+interface ApiGatewayAuthorizersProps {
+  apiId: string;
+  apiName: string;
+}
+
+/**
+ * Component to display and manage API Gateway authorizers for a REST API
+ */
+export default function ApiGatewayAuthorizers({ apiId, apiName }: ApiGatewayAuthorizersProps) {
+  const { authorizers, error, isLoading, revalidate } = useApiGatewayAuthorizers(apiId);
+
+  const navigationTitle = `Authorizers for ${apiName}`;
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Filter authorizers by name..."
+      navigationTitle={navigationTitle}
+      searchBarAccessory={<AWSProfileDropdown onProfileSelected={revalidate} />}
+    >
+      {error ? (
+        <List.EmptyView title={error.name} description={error.message} icon={Icon.Warning} />
+      ) : authorizers?.length === 0 ? (
+        <List.EmptyView
+          title="No Authorizers"
+          description="No authorizers configured for this API"
+          icon={Icon.Shield}
+        />
+      ) : (
+        authorizers?.map((authorizer) => <AuthorizerItem key={authorizer.id} authorizer={authorizer} apiId={apiId} />)
+      )}
+    </List>
+  );
+}
+
+interface AuthorizerItemProps {
+  authorizer: Authorizer;
+  apiId: string;
+}
+
+function AuthorizerItem({ authorizer, apiId }: AuthorizerItemProps) {
+  const authorizerType = authorizer.type || "UNKNOWN";
+  const ttlSeconds = authorizer.authorizerResultTtlInSeconds;
+
+  return (
+    <List.Item
+      key={authorizer.id}
+      icon={getAuthorizerIcon(authorizerType)}
+      title={authorizer.name || ""}
+      subtitle={getAuthorizerSubtitle(authorizer)}
+      actions={
+        <ActionPanel>
+          <AwsAction.Console
+            url={resourceToConsoleLink(`${apiId}/authorizers/${authorizer.id}`, "AWS::ApiGateway::Authorizer")}
+          />
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard title="Copy Authorizer ID" content={authorizer.id || ""} />
+            <Action.CopyToClipboard title="Copy Authorizer Name" content={authorizer.name || ""} />
+            {authorizer.authorizerUri && (
+              <Action.CopyToClipboard title="Copy Authorizer URI" content={authorizer.authorizerUri} />
+            )}
+            {authorizer.providerARNs && authorizer.providerARNs.length > 0 && (
+              <Action.CopyToClipboard
+                title="Copy Cognito User Pool ARNs"
+                content={authorizer.providerARNs.join(", ")}
+              />
+            )}
+            <AwsAction.ExportResponse response={authorizer} />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+      accessories={[
+        {
+          text: formatAuthorizerType(authorizerType),
+          icon: getAuthorizerIcon(authorizerType),
+          tooltip: "Authorizer Type",
+        },
+        ...(ttlSeconds !== undefined
+          ? [
+              {
+                text: `TTL: ${ttlSeconds}s`,
+                icon: Icon.Clock,
+                tooltip: "Result Cache TTL",
+              },
+            ]
+          : []),
+        ...(authorizer.identitySource
+          ? [
+              {
+                text: authorizer.identitySource,
+                icon: Icon.Key,
+                tooltip: "Identity Source",
+              },
+            ]
+          : []),
+      ]}
+    />
+  );
+}
+
+/**
+ * Returns the appropriate icon for an authorizer type
+ */
+function getAuthorizerIcon(type: string): { source: Icon; tintColor: Color } {
+  switch (type) {
+    case "TOKEN":
+      return { source: Icon.Bolt, tintColor: Color.Yellow };
+    case "REQUEST":
+      return { source: Icon.Key, tintColor: Color.Blue };
+    case "COGNITO_USER_POOLS":
+      return { source: Icon.Person, tintColor: Color.Purple };
+    default:
+      return { source: Icon.Shield, tintColor: Color.SecondaryText };
+  }
+}
+
+/**
+ * Formats the authorizer type for display
+ */
+function formatAuthorizerType(type: string): string {
+  switch (type) {
+    case "TOKEN":
+      return "Lambda Token";
+    case "REQUEST":
+      return "Lambda Request";
+    case "COGNITO_USER_POOLS":
+      return "Cognito";
+    default:
+      return type;
+  }
+}
+
+/**
+ * Returns a subtitle based on authorizer configuration
+ */
+function getAuthorizerSubtitle(authorizer: Authorizer): string {
+  if (authorizer.authorizerUri) {
+    // Extract Lambda function name from URI
+    const lambdaMatch = authorizer.authorizerUri.match(/function:([^/]+)/);
+    if (lambdaMatch) {
+      return `Lambda: ${lambdaMatch[1]}`;
+    }
+    return authorizer.authorizerUri;
+  }
+
+  if (authorizer.providerARNs && authorizer.providerARNs.length > 0) {
+    // Extract Cognito User Pool name from ARN
+    const poolMatch = authorizer.providerARNs[0].match(/userpool\/([^/]+)/);
+    if (poolMatch) {
+      return `User Pool: ${poolMatch[1]}`;
+    }
+    return `${authorizer.providerARNs.length} User Pool(s)`;
+  }
+
+  return authorizer.id || "";
+}

--- a/extensions/amazon-aws/src/components/apigateway/ApiGatewayBasePaths.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/ApiGatewayBasePaths.tsx
@@ -1,0 +1,83 @@
+import { BasePathMapping } from "@aws-sdk/client-api-gateway";
+import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import { useApiGatewayBasePathMappings } from "../../hooks/use-apigateway";
+import AWSProfileDropdown from "../searchbar/aws-profile-dropdown";
+import { resourceToConsoleLink } from "../../util";
+import { AwsAction } from "../common/action";
+
+interface ApiGatewayBasePathsProps {
+  domainName: string;
+}
+
+/**
+ * Component to display base path mappings for a custom domain
+ */
+export default function ApiGatewayBasePaths({ domainName }: ApiGatewayBasePathsProps) {
+  const { basePathMappings, error, isLoading, revalidate } = useApiGatewayBasePathMappings(domainName);
+
+  const navigationTitle = `Base Path Mappings for ${domainName}`;
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Filter mappings by path..."
+      navigationTitle={navigationTitle}
+      searchBarAccessory={<AWSProfileDropdown onProfileSelected={revalidate} />}
+    >
+      {error ? (
+        <List.EmptyView title={error.name} description={error.message} icon={Icon.Warning} />
+      ) : basePathMappings?.length === 0 ? (
+        <List.EmptyView
+          title="No Base Path Mappings"
+          description="No base path mappings configured for this domain"
+          icon={Icon.Link}
+        />
+      ) : (
+        basePathMappings?.map((mapping) => (
+          <BasePathMappingItem key={`${mapping.basePath}-${mapping.restApiId}`} mapping={mapping} />
+        ))
+      )}
+    </List>
+  );
+}
+
+interface BasePathMappingItemProps {
+  mapping: BasePathMapping;
+}
+
+function BasePathMappingItem({ mapping }: BasePathMappingItemProps) {
+  const basePath = mapping.basePath || "(none)";
+  const displayPath = basePath === "(none)" ? "/" : `/${basePath}`;
+
+  return (
+    <List.Item
+      key={`${mapping.basePath}-${mapping.restApiId}`}
+      icon={Icon.Link}
+      title={displayPath}
+      subtitle={`API: ${mapping.restApiId || "Unknown"} → Stage: ${mapping.stage || "Unknown"}`}
+      actions={
+        <ActionPanel>
+          <AwsAction.Console url={resourceToConsoleLink(mapping.restApiId, "AWS::ApiGateway::RestApi")} />
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard title="Copy Base Path" content={basePath} />
+            <Action.CopyToClipboard title="Copy API ID" content={mapping.restApiId || ""} />
+            <Action.CopyToClipboard title="Copy Stage" content={mapping.stage || ""} />
+            <AwsAction.ExportResponse response={mapping} />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+      accessories={[
+        {
+          text: mapping.restApiId || "",
+          icon: Icon.Code,
+          tooltip: "REST API ID",
+        },
+        {
+          text: mapping.stage || "",
+          icon: Icon.Layers,
+          tooltip: "Stage",
+        },
+      ]}
+    />
+  );
+}

--- a/extensions/amazon-aws/src/components/apigateway/ApiGatewayDeployments.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/ApiGatewayDeployments.tsx
@@ -56,6 +56,7 @@ function DeploymentItem({ deployment, apiId, isLatest }: { deployment: Deploymen
             {deployment.description && (
               <Action.CopyToClipboard title="Copy Description" content={deployment.description} />
             )}
+            <AwsAction.ExportResponse response={deployment} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/apigateway/ApiGatewayDomains.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/ApiGatewayDomains.tsx
@@ -1,0 +1,137 @@
+import { DomainName } from "@aws-sdk/client-api-gateway";
+import { Action, ActionPanel, Icon, List, Color } from "@raycast/api";
+import { useApiGatewayDomainNames } from "../../hooks/use-apigateway";
+import AWSProfileDropdown from "../searchbar/aws-profile-dropdown";
+import { resourceToConsoleLink } from "../../util";
+import { AwsAction } from "../common/action";
+import ApiGatewayBasePaths from "./ApiGatewayBasePaths";
+
+/**
+ * Component to display and manage API Gateway custom domain names
+ */
+export default function ApiGatewayDomains() {
+  const { domainNames, error, isLoading, revalidate } = useApiGatewayDomainNames();
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Filter domains by name..."
+      navigationTitle="Custom Domain Names"
+      searchBarAccessory={<AWSProfileDropdown onProfileSelected={revalidate} />}
+    >
+      {error ? (
+        <List.EmptyView title={error.name} description={error.message} icon={Icon.Warning} />
+      ) : domainNames?.length === 0 ? (
+        <List.EmptyView title="No Custom Domains" description="No custom domain names configured" icon={Icon.Globe} />
+      ) : (
+        domainNames?.map((domain) => <DomainItem key={domain.domainName} domain={domain} />)
+      )}
+    </List>
+  );
+}
+
+interface DomainItemProps {
+  domain: DomainName;
+}
+
+function DomainItem({ domain }: DomainItemProps) {
+  const endpointType = domain.endpointConfiguration?.types?.[0] || "EDGE";
+  const securityPolicy = domain.securityPolicy || "TLS_1_0";
+  const certificateExpiry = getCertificateExpiryInfo(domain);
+
+  return (
+    <List.Item
+      key={domain.domainName}
+      icon={Icon.Globe}
+      title={domain.domainName || ""}
+      subtitle={domain.distributionDomainName || domain.regionalDomainName || ""}
+      actions={
+        <ActionPanel>
+          <Action.Push
+            title="View Base Path Mappings"
+            icon={Icon.Link}
+            target={<ApiGatewayBasePaths domainName={domain.domainName || ""} />}
+          />
+          <AwsAction.Console url={resourceToConsoleLink(domain.domainName, "AWS::ApiGateway::DomainName")} />
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard title="Copy Domain Name" content={domain.domainName || ""} />
+            {domain.distributionDomainName && (
+              <Action.CopyToClipboard title="Copy CloudFront Domain" content={domain.distributionDomainName} />
+            )}
+            {domain.regionalDomainName && (
+              <Action.CopyToClipboard title="Copy Regional Domain" content={domain.regionalDomainName} />
+            )}
+            {domain.certificateArn && (
+              <Action.CopyToClipboard title="Copy Certificate ARN" content={domain.certificateArn} />
+            )}
+            {domain.regionalCertificateArn && (
+              <Action.CopyToClipboard title="Copy Regional Certificate ARN" content={domain.regionalCertificateArn} />
+            )}
+            <AwsAction.ExportResponse response={domain} />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+      accessories={[
+        {
+          text: endpointType,
+          icon: getEndpointIcon(endpointType),
+          tooltip: "Endpoint Type",
+        },
+        {
+          text: securityPolicy,
+          icon: Icon.Shield,
+          tooltip: "Security Policy (TLS Version)",
+        },
+        ...(certificateExpiry.text
+          ? [
+              {
+                text: certificateExpiry.text,
+                icon: certificateExpiry.icon,
+                tooltip: certificateExpiry.tooltip,
+              },
+            ]
+          : []),
+      ]}
+    />
+  );
+}
+
+/**
+ * Returns the appropriate icon for an endpoint type
+ */
+function getEndpointIcon(type: string): { source: Icon; tintColor: Color } {
+  switch (type) {
+    case "EDGE":
+      return { source: Icon.Globe, tintColor: Color.Blue };
+    case "REGIONAL":
+      return { source: Icon.Building, tintColor: Color.Green };
+    case "PRIVATE":
+      return { source: Icon.Lock, tintColor: Color.Orange };
+    default:
+      return { source: Icon.Globe, tintColor: Color.SecondaryText };
+  }
+}
+
+/**
+ * Returns certificate expiry information for display
+ */
+function getCertificateExpiryInfo(domain: DomainName): {
+  text: string;
+  icon: { source: Icon; tintColor: Color };
+  tooltip: string;
+} {
+  const expirationDate = domain.certificateUploadDate;
+
+  if (!expirationDate) {
+    return { text: "", icon: { source: Icon.Calendar, tintColor: Color.SecondaryText }, tooltip: "" };
+  }
+
+  const uploadDate = new Date(expirationDate);
+  const formattedDate = uploadDate.toLocaleDateString();
+
+  return {
+    text: formattedDate,
+    icon: { source: Icon.Calendar, tintColor: Color.SecondaryText },
+    tooltip: `Certificate uploaded: ${formattedDate}`,
+  };
+}

--- a/extensions/amazon-aws/src/components/apigateway/ApiGatewayInvoke.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/ApiGatewayInvoke.tsx
@@ -1,0 +1,312 @@
+import { useState, useEffect } from "react";
+import {
+  Action,
+  ActionPanel,
+  Form,
+  useNavigation,
+  showToast,
+  Toast,
+  Clipboard,
+  LocalStorage,
+  Detail,
+} from "@raycast/api";
+import { TestInvokeMethodCommand } from "@aws-sdk/client-api-gateway";
+import { getApiGatewayClient } from "../../services/clients/api-gateway";
+import { getAWSErrorMessage } from "../../errors";
+
+interface ApiGatewayInvokeProps {
+  apiId: string;
+  apiName: string;
+  resourceId: string;
+  resourcePath: string;
+  httpMethod: string;
+}
+
+interface SavedTestCase {
+  name: string;
+  body: string;
+  headers: string;
+  queryString: string;
+}
+
+interface TestResult {
+  status: number;
+  body: string;
+  headers: Record<string, string>;
+  latency: number;
+}
+
+/**
+ * Component to test invoke an API Gateway method
+ */
+export default function ApiGatewayInvoke({
+  apiId,
+  apiName,
+  resourceId,
+  resourcePath,
+  httpMethod,
+}: ApiGatewayInvokeProps) {
+  const [body, setBody] = useState("{}");
+  const [headers, setHeaders] = useState("{}");
+  const [queryString, setQueryString] = useState("");
+  const [savedTestCases, setSavedTestCases] = useState<SavedTestCase[]>([]);
+  const [saveName, setSaveName] = useState("");
+  const [testResult, setTestResult] = useState<TestResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const { pop } = useNavigation();
+
+  const storageKey = `apigateway_test_${apiId}_${resourceId}_${httpMethod}`;
+
+  useEffect(() => {
+    LocalStorage.getItem<string>(`${storageKey}_last`).then((lastTestCase) => {
+      if (lastTestCase) {
+        const parsed = JSON.parse(lastTestCase);
+        setBody(parsed.body || "{}");
+        setHeaders(parsed.headers || "{}");
+        setQueryString(parsed.queryString || "");
+      }
+    });
+
+    LocalStorage.getItem<string>(`${storageKey}_saved`).then((savedTestCasesString) => {
+      if (savedTestCasesString) {
+        setSavedTestCases(JSON.parse(savedTestCasesString));
+      }
+    });
+  }, [storageKey]);
+
+  async function handleSubmit(values: { body: string; headers: string; queryString: string }) {
+    setIsLoading(true);
+    try {
+      const client = getApiGatewayClient();
+
+      let parsedHeaders: Record<string, string> = {};
+      try {
+        parsedHeaders = JSON.parse(values.headers);
+      } catch {
+        // If headers are not valid JSON, ignore them
+      }
+
+      const pathWithQueryString = values.queryString ? `${resourcePath}?${values.queryString}` : resourcePath;
+
+      const command = new TestInvokeMethodCommand({
+        restApiId: apiId,
+        resourceId: resourceId,
+        httpMethod: httpMethod,
+        body: values.body !== "{}" ? values.body : undefined,
+        headers: Object.keys(parsedHeaders).length > 0 ? parsedHeaders : undefined,
+        pathWithQueryString: pathWithQueryString,
+      });
+
+      const response = await client.send(command);
+
+      const result: TestResult = {
+        status: response.status || 0,
+        body: response.body || "",
+        headers: response.headers || {},
+        latency: response.latency || 0,
+      };
+
+      setTestResult(result);
+
+      // Save the last test case
+      await LocalStorage.setItem(
+        `${storageKey}_last`,
+        JSON.stringify({
+          body: values.body,
+          headers: values.headers,
+          queryString: values.queryString,
+        }),
+      );
+
+      const statusStyle = result.status >= 200 && result.status < 300 ? Toast.Style.Success : Toast.Style.Failure;
+
+      await showToast({
+        style: statusStyle,
+        title: `Status: ${result.status}`,
+        message: `Latency: ${result.latency}ms`,
+      });
+    } catch (error) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Error Testing Method",
+        message: getAWSErrorMessage(error),
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function handleSaveTestCase() {
+    const trimmedName = saveName.trim();
+    if (trimmedName) {
+      const newTestCase: SavedTestCase = {
+        name: trimmedName,
+        body: body,
+        headers: headers,
+        queryString: queryString,
+      };
+
+      const existingIndex = savedTestCases.findIndex((tc) => tc.name === trimmedName);
+      let newSavedTestCases;
+      if (existingIndex !== -1) {
+        newSavedTestCases = [...savedTestCases];
+        newSavedTestCases[existingIndex] = newTestCase;
+      } else {
+        newSavedTestCases = [...savedTestCases, newTestCase];
+      }
+
+      setSavedTestCases(newSavedTestCases);
+      await LocalStorage.setItem(`${storageKey}_saved`, JSON.stringify(newSavedTestCases));
+      setSaveName("");
+
+      await showToast({
+        style: Toast.Style.Success,
+        title: "Test Case Saved",
+        message: `Saved as "${trimmedName}"`,
+      });
+    }
+  }
+
+  async function handleDeleteTestCase(nameToDelete: string) {
+    const newSavedTestCases = savedTestCases.filter((tc) => tc.name !== nameToDelete);
+    setSavedTestCases(newSavedTestCases);
+    await LocalStorage.setItem(`${storageKey}_saved`, JSON.stringify(newSavedTestCases));
+
+    await showToast({
+      style: Toast.Style.Success,
+      title: "Test Case Deleted",
+      message: `Deleted "${nameToDelete}"`,
+    });
+  }
+
+  function handleLoadTestCase(testCase: SavedTestCase) {
+    setBody(testCase.body);
+    setHeaders(testCase.headers);
+    setQueryString(testCase.queryString);
+  }
+
+  async function handleCopyResponse() {
+    if (testResult) {
+      await Clipboard.copy(testResult.body);
+      await showToast({
+        style: Toast.Style.Success,
+        title: "Response Copied",
+        message: "Response body copied to clipboard",
+      });
+    }
+  }
+
+  // Show result view if we have a test result
+  if (testResult) {
+    const statusColor =
+      testResult.status >= 200 && testResult.status < 300
+        ? "green"
+        : testResult.status >= 400 && testResult.status < 500
+          ? "orange"
+          : "red";
+
+    let formattedBody = testResult.body;
+    try {
+      formattedBody = JSON.stringify(JSON.parse(testResult.body), null, 2);
+    } catch {
+      // Keep original if not JSON
+    }
+
+    const markdown = `# Test Result
+
+## ${httpMethod} ${resourcePath}
+
+**Status:** \`${testResult.status}\` ${statusColor === "green" ? "✅" : statusColor === "orange" ? "⚠️" : "❌"}
+
+**Latency:** ${testResult.latency}ms
+
+### Response Headers
+\`\`\`json
+${JSON.stringify(testResult.headers, null, 2)}
+\`\`\`
+
+### Response Body
+\`\`\`json
+${formattedBody}
+\`\`\`
+`;
+
+    return (
+      <Detail
+        markdown={markdown}
+        navigationTitle={`${httpMethod} ${resourcePath} - Result`}
+        actions={
+          <ActionPanel>
+            <Action title="Test Again" onAction={() => setTestResult(null)} />
+            <Action title="Copy Response" onAction={handleCopyResponse} shortcut={{ modifiers: ["cmd"], key: "c" }} />
+            <Action title="Go Back" onAction={pop} shortcut={{ modifiers: ["cmd"], key: "escape" }} />
+          </ActionPanel>
+        }
+      />
+    );
+  }
+
+  return (
+    <Form
+      isLoading={isLoading}
+      navigationTitle={`Test ${httpMethod} ${resourcePath}`}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Test Invoke" onSubmit={handleSubmit} />
+          <Action title="Save Test Case" onAction={handleSaveTestCase} shortcut={{ modifiers: ["cmd"], key: "s" }} />
+          {savedTestCases.length > 0 && (
+            <ActionPanel.Submenu title="Load Test Case" shortcut={{ modifiers: ["cmd"], key: "l" }}>
+              {savedTestCases.map((testCase) => (
+                <Action key={testCase.name} title={testCase.name} onAction={() => handleLoadTestCase(testCase)} />
+              ))}
+            </ActionPanel.Submenu>
+          )}
+          {savedTestCases.length > 0 && (
+            <ActionPanel.Submenu title="Delete Test Case" shortcut={{ modifiers: ["cmd"], key: "d" }}>
+              {savedTestCases.map((testCase) => (
+                <Action
+                  key={testCase.name}
+                  title={testCase.name}
+                  onAction={() => handleDeleteTestCase(testCase.name)}
+                />
+              ))}
+            </ActionPanel.Submenu>
+          )}
+        </ActionPanel>
+      }
+    >
+      <Form.Description title="API" text={`${apiName} (${apiId})`} />
+      <Form.Description title="Endpoint" text={`${httpMethod} ${resourcePath}`} />
+      <Form.Separator />
+      <Form.TextArea
+        id="body"
+        title="Request Body"
+        placeholder='Enter JSON body, e.g., {"key": "value"}'
+        value={body}
+        onChange={setBody}
+      />
+      <Form.TextArea
+        id="headers"
+        title="Headers (JSON)"
+        placeholder='Enter headers as JSON, e.g., {"Content-Type": "application/json"}'
+        value={headers}
+        onChange={setHeaders}
+      />
+      <Form.TextField
+        id="queryString"
+        title="Query String"
+        placeholder="e.g., param1=value1&param2=value2"
+        value={queryString}
+        onChange={setQueryString}
+      />
+      <Form.Separator />
+      <Form.TextField
+        id="saveName"
+        title="Save As"
+        placeholder="Enter a name to save this test case"
+        value={saveName}
+        onChange={setSaveName}
+      />
+    </Form>
+  );
+}

--- a/extensions/amazon-aws/src/components/apigateway/ApiGatewayLogs.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/ApiGatewayLogs.tsx
@@ -1,0 +1,16 @@
+import CloudwatchLogStreams from "../cloudwatch/CloudwatchLogStreams";
+
+interface ApiGatewayLogsProps {
+  apiId: string;
+  stageName: string;
+}
+
+/**
+ * Component to display CloudWatch logs for an API Gateway stage.
+ * API Gateway execution logs use the format: API-Gateway-Execution-Logs_{rest-api-id}/{stage-name}
+ */
+export default function ApiGatewayLogs({ apiId, stageName }: ApiGatewayLogsProps) {
+  const logGroupName = `API-Gateway-Execution-Logs_${apiId}/${stageName}`;
+
+  return <CloudwatchLogStreams logGroupName={logGroupName} />;
+}

--- a/extensions/amazon-aws/src/components/apigateway/ApiGatewayMethodDetail.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/ApiGatewayMethodDetail.tsx
@@ -45,6 +45,7 @@ export default function ApiGatewayMethodDetail({
             {method.methodIntegration?.uri && (
               <Action.CopyToClipboard title="Copy Integration URI" content={method.methodIntegration.uri} />
             )}
+            <AwsAction.ExportResponse response={method} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/apigateway/ApiGatewayResources.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/ApiGatewayResources.tsx
@@ -4,9 +4,15 @@ import { useApiGatewayResources } from "../../hooks/use-apigateway";
 import AWSProfileDropdown from "../searchbar/aws-profile-dropdown";
 import { resourceToConsoleLink } from "../../util";
 import { AwsAction } from "../common/action";
+import ApiGatewayInvoke from "./ApiGatewayInvoke";
 import ApiGatewayMethodDetail from "./ApiGatewayMethodDetail";
 
-export default function ApiGatewayResources({ apiId, apiName }: { apiId: string; apiName: string }) {
+interface ApiGatewayResourcesProps {
+  apiId: string;
+  apiName: string;
+}
+
+export default function ApiGatewayResources({ apiId, apiName }: ApiGatewayResourcesProps) {
   const { resources, error, isLoading, revalidate } = useApiGatewayResources(apiId);
 
   const navigationTitle = `Resources for ${apiName}`;
@@ -21,13 +27,21 @@ export default function ApiGatewayResources({ apiId, apiName }: { apiId: string;
       {error ? (
         <List.EmptyView title={error.name} description={error.message} icon={Icon.Warning} />
       ) : (
-        resources?.map((resource) => <ResourceItem key={resource.id} resource={resource} apiId={apiId} />)
+        resources?.map((resource) => (
+          <ResourceItem key={resource.id} resource={resource} apiId={apiId} apiName={apiName} />
+        ))
       )}
     </List>
   );
 }
 
-function ResourceItem({ resource, apiId }: { resource: Resource; apiId: string }) {
+interface ResourceItemProps {
+  resource: Resource;
+  apiId: string;
+  apiName: string;
+}
+
+function ResourceItem({ resource, apiId, apiName }: ResourceItemProps) {
   const methods = Object.keys(resource.resourceMethods || {});
   const methodsText = methods.join(", ") || "No methods";
 
@@ -40,10 +54,10 @@ function ResourceItem({ resource, apiId }: { resource: Resource; apiId: string }
       actions={
         <ActionPanel>
           {methods.length > 0 && (
-            <ActionPanel.Section title="Methods">
+            <ActionPanel.Section title="View Details">
               {methods.map((method) => (
                 <Action.Push
-                  key={method}
+                  key={`view-${method}`}
                   title={`View ${method} Details`}
                   icon={Icon.Eye}
                   target={
@@ -58,6 +72,27 @@ function ResourceItem({ resource, apiId }: { resource: Resource; apiId: string }
               ))}
             </ActionPanel.Section>
           )}
+          {methods.length > 0 && (
+            <ActionPanel.Section title="Test Invoke">
+              {methods.map((method) => (
+                <Action.Push
+                  key={`test-${method}`}
+                  title={`Test ${method}`}
+                  icon={Icon.Play}
+                  shortcut={method === "GET" ? { modifiers: ["cmd"], key: "t" } : undefined}
+                  target={
+                    <ApiGatewayInvoke
+                      apiId={apiId}
+                      apiName={apiName}
+                      resourceId={resource.id || ""}
+                      resourcePath={resource.path || "/"}
+                      httpMethod={method}
+                    />
+                  }
+                />
+              ))}
+            </ActionPanel.Section>
+          )}
           <AwsAction.Console
             url={resourceToConsoleLink(`${apiId}/resources/${resource.id}`, "AWS::ApiGateway::Resource")}
           />
@@ -65,6 +100,7 @@ function ResourceItem({ resource, apiId }: { resource: Resource; apiId: string }
             <Action.CopyToClipboard title="Copy Resource Path" content={resource.path || "/"} />
             <Action.CopyToClipboard title="Copy Resource ID" content={resource.id || ""} />
             <Action.CopyToClipboard title="Copy Parent ID" content={resource.parentId || ""} />
+            <AwsAction.ExportResponse response={resource} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/apigateway/ApiGatewayStages.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/ApiGatewayStages.tsx
@@ -4,6 +4,7 @@ import { useApiGatewayStages } from "../../hooks/use-apigateway";
 import AWSProfileDropdown from "../searchbar/aws-profile-dropdown";
 import { resourceToConsoleLink } from "../../util";
 import { AwsAction } from "../common/action";
+import ApiGatewayLogs from "./ApiGatewayLogs";
 
 export default function ApiGatewayStages({ apiId, apiName }: { apiId: string; apiName: string }) {
   const { stages, error, isLoading, revalidate } = useApiGatewayStages(apiId);
@@ -40,6 +41,12 @@ function StageItem({ stage, apiId, region }: { stage: Stage; apiId: string; regi
       actions={
         <ActionPanel>
           <Action.OpenInBrowser title="Open Invoke URL" url={invokeUrl} icon={Icon.Globe} />
+          <Action.Push
+            title="View Logs"
+            icon={Icon.Terminal}
+            shortcut={{ modifiers: ["cmd"], key: "l" }}
+            target={<ApiGatewayLogs apiId={apiId} stageName={stage.stageName || ""} />}
+          />
           <AwsAction.Console
             url={resourceToConsoleLink(`${apiId}/stages/${stage.stageName}`, "AWS::ApiGateway::Stage")}
           />
@@ -47,6 +54,7 @@ function StageItem({ stage, apiId, region }: { stage: Stage; apiId: string; regi
             <Action.CopyToClipboard title="Copy Invoke URL" content={invokeUrl} />
             <Action.CopyToClipboard title="Copy Stage Name" content={stage.stageName || ""} />
             <Action.CopyToClipboard title="Copy Deployment ID" content={stage.deploymentId || ""} />
+            <AwsAction.ExportResponse response={stage} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/apigateway/ApiGatewayUsagePlans.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/ApiGatewayUsagePlans.tsx
@@ -59,6 +59,7 @@ function UsagePlanItem({ usagePlan, apiId }: { usagePlan: UsagePlan; apiId: stri
           <ActionPanel.Section title={"Copy"}>
             <Action.CopyToClipboard title="Copy Usage Plan ID" content={usagePlan.id || ""} />
             <Action.CopyToClipboard title="Copy Usage Plan Name" content={usagePlan.name || ""} />
+            <AwsAction.ExportResponse response={usagePlan} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/apigateway/HttpApiRoutes.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/HttpApiRoutes.tsx
@@ -54,6 +54,7 @@ function RouteItem({ route, apiId }: { route: Route; apiId: string }) {
             <Action.CopyToClipboard title="Copy Route Key" content={route.RouteKey || ""} />
             <Action.CopyToClipboard title="Copy Route ID" content={route.RouteId || ""} />
             {route.Target && <Action.CopyToClipboard title="Copy Integration Target" content={route.Target} />}
+            <AwsAction.ExportResponse response={route} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/apigateway/HttpApiStages.tsx
+++ b/extensions/amazon-aws/src/components/apigateway/HttpApiStages.tsx
@@ -51,6 +51,7 @@ function StageItem({ stage, apiId, region }: { stage: Stage; apiId: string; regi
             <Action.CopyToClipboard title="Copy Invoke URL" content={invokeUrl} />
             <Action.CopyToClipboard title="Copy Stage Name" content={stage.StageName || ""} />
             {stage.DeploymentId && <Action.CopyToClipboard title="Copy Deployment ID" content={stage.DeploymentId} />}
+            <AwsAction.ExportResponse response={stage} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/appsync/AppSyncApiDetail.tsx
+++ b/extensions/amazon-aws/src/components/appsync/AppSyncApiDetail.tsx
@@ -127,6 +127,7 @@ ${Object.entries(api.tags)
             {realtimeEndpoint && <Action.CopyToClipboard title="Copy Realtime Endpoint" content={realtimeEndpoint} />}
             <Action.CopyToClipboard title="Copy API ID" content={api.apiId || ""} />
             <Action.CopyToClipboard title="Copy API ARN" content={api.arn || ""} />
+            <AwsAction.ExportResponse response={api} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/appsync/AppSyncApiKeys.tsx
+++ b/extensions/amazon-aws/src/components/appsync/AppSyncApiKeys.tsx
@@ -1,6 +1,7 @@
 import { ApiKey } from "@aws-sdk/client-appsync";
 import { Action, ActionPanel, Icon, List, Color } from "@raycast/api";
 import { useAppSyncApiKeys } from "../../hooks/use-appsync";
+import { AwsAction } from "../common/action";
 
 export default function AppSyncApiKeys({ apiId, apiName }: { apiId: string; apiName: string }) {
   const { apiKeys, error, isLoading } = useAppSyncApiKeys(apiId);
@@ -37,6 +38,7 @@ function ApiKeyItem({ apiKey }: { apiKey: ApiKey }) {
         <ActionPanel>
           <Action.CopyToClipboard title="Copy API Key ID" content={apiKey.id || ""} />
           {apiKey.description && <Action.CopyToClipboard title="Copy Description" content={apiKey.description} />}
+          <AwsAction.ExportResponse response={apiKey} />
         </ActionPanel>
       }
       accessories={[

--- a/extensions/amazon-aws/src/components/appsync/AppSyncDataSources.tsx
+++ b/extensions/amazon-aws/src/components/appsync/AppSyncDataSources.tsx
@@ -48,6 +48,7 @@ function DataSourceItem({ dataSource, apiId }: { dataSource: DataSource; apiId: 
             {dataSource.httpConfig?.endpoint && (
               <Action.CopyToClipboard title="Copy HTTP Endpoint" content={dataSource.httpConfig.endpoint} />
             )}
+            <AwsAction.ExportResponse response={dataSource} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/appsync/AppSyncResolvers.tsx
+++ b/extensions/amazon-aws/src/components/appsync/AppSyncResolvers.tsx
@@ -43,6 +43,7 @@ function ResolverItem({ resolver, apiId }: { resolver: Resolver; apiId: string }
             <Action.CopyToClipboard title="Copy Type Name" content={resolver.typeName || ""} />
             <Action.CopyToClipboard title="Copy Field Name" content={resolver.fieldName || ""} />
             <Action.CopyToClipboard title="Copy Data Source Name" content={resolver.dataSourceName || ""} />
+            <AwsAction.ExportResponse response={resolver} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/appsync/AppSyncSchema.tsx
+++ b/extensions/amazon-aws/src/components/appsync/AppSyncSchema.tsx
@@ -31,8 +31,11 @@ ${schemaString}
       actions={
         <ActionPanel>
           <AwsAction.Console url={resourceToConsoleLink(apiId, "AWS::AppSync::Schema")} />
-          <Action.CopyToClipboard title="Copy Schema" content={schemaString} />
-          <Action.Paste title="Paste Schema" content={schemaString} />
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard title="Copy Schema" content={schemaString} />
+            <Action.Paste title="Paste Schema" content={schemaString} />
+            <AwsAction.ExportResponse response={schema} />
+          </ActionPanel.Section>
         </ActionPanel>
       }
     />

--- a/extensions/amazon-aws/src/components/cloudwatch/CloudwatchLogStreams.tsx
+++ b/extensions/amazon-aws/src/components/cloudwatch/CloudwatchLogStreams.tsx
@@ -1,22 +1,52 @@
+import { Action, ActionPanel, Icon, List, showToast, Toast } from "@raycast/api";
+import { runAppleScript, useCachedPromise } from "@raycast/utils";
 import { useState } from "react";
-import { Action, ActionPanel, Icon, List } from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
 import { fetchLogStreams } from "../../actions";
-import { getFilterPlaceholder, resourceToConsoleLink } from "../../util";
+import { getAWSErrorMessage } from "../../errors";
 import { LogStartTimes } from "../../interfaces";
-import CloudwatchLogs from "./CloudwatchLogs";
-import CloudwatchLogsTimeDropdown from "../searchbar/CloudwatchLogsTimeDropdown";
+import { getFilterPlaceholder, resourceToConsoleLink } from "../../util";
 import { AwsAction } from "../common/action";
+import CloudwatchLogsTimeDropdown from "../searchbar/CloudwatchLogsTimeDropdown";
+import CloudwatchLogs from "./CloudwatchLogs";
 
 function CloudwatchLogStreams({ logGroupName }: { logGroupName: string }) {
   const [logStartTime, setLogStartTime] = useState<LogStartTimes>(LogStartTimes.OneHour);
-  const { data: streams, isLoading } = useCachedPromise(fetchLogStreams, [logGroupName], { keepPreviousData: true });
+  const {
+    data: streams,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(fetchLogStreams, [logGroupName], { keepPreviousData: true });
+
+  const AWS_REGION = process.env.AWS_REGION;
+  const liveTailUrl = `https://${AWS_REGION}.console.aws.amazon.com/cloudwatch/home?region=${AWS_REGION}#logsV2:live-tail$3FlogGroupArns$3D${encodeURIComponent(`arn:aws:logs:${AWS_REGION}:*:log-group:${logGroupName}`)}`;
+  const tailCommand = `aws logs tail "${logGroupName}" --follow`;
+
+  async function runTailInTerminal() {
+    const escapedCommand = tailCommand.replace(/"/g, '\\"');
+    const appleScript = `
+      tell application "Terminal"
+        do script "${escapedCommand}"
+        activate
+      end tell
+    `;
+    try {
+      await runAppleScript(appleScript);
+      await showToast({ style: Toast.Style.Success, title: "Opened in Terminal" });
+    } catch (error) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Failed to open Terminal",
+        message: getAWSErrorMessage(error),
+      });
+    }
+  }
 
   return (
     <List
       isLoading={isLoading}
       searchBarPlaceholder={getFilterPlaceholder("stream")}
       searchBarAccessory={<CloudwatchLogsTimeDropdown logStartTime={logStartTime} onChange={setLogStartTime} />}
+      navigationTitle={streams ? `${streams.length} streams` : "Loading..."}
     >
       {streams ? (
         streams.map((s) => (
@@ -39,11 +69,40 @@ function CloudwatchLogStreams({ logGroupName }: { logGroupName: string }) {
                   }
                 />
                 <AwsAction.Console url={resourceToConsoleLink(logGroupName, "AWS::Logs::LogGroup")} />
+                <ActionPanel.Section title="Tail Logs">
+                  <Action.OpenInBrowser
+                    icon={Icon.Livestream}
+                    title="Tail Logs in Console"
+                    url={liveTailUrl}
+                    shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
+                  />
+                  <Action
+                    title="Run Tail Command in Terminal"
+                    icon={Icon.Terminal}
+                    shortcut={{ modifiers: ["cmd", "shift"], key: "t" }}
+                    onAction={runTailInTerminal}
+                  />
+                </ActionPanel.Section>
                 <ActionPanel.Section title="Copy">
                   <Action.CopyToClipboard
                     title="Copy Stream ARN"
                     content={s.arn || ""}
                     shortcut={{ modifiers: ["opt"], key: "c" }}
+                  />
+                  <Action.CopyToClipboard
+                    title="Copy Tail Command"
+                    content={tailCommand}
+                    icon={Icon.Terminal}
+                    shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+                  />
+                  <AwsAction.ExportResponse response={s} />
+                </ActionPanel.Section>
+                <ActionPanel.Section>
+                  <Action
+                    title="Refresh"
+                    icon={Icon.ArrowClockwise}
+                    shortcut={{ modifiers: ["cmd"], key: "r" }}
+                    onAction={revalidate}
                   />
                 </ActionPanel.Section>
               </ActionPanel>

--- a/extensions/amazon-aws/src/components/cloudwatch/CloudwatchLogs.tsx
+++ b/extensions/amazon-aws/src/components/cloudwatch/CloudwatchLogs.tsx
@@ -1,8 +1,9 @@
-import { ActionPanel, Detail } from "@raycast/api";
+import { Action, ActionPanel, Detail, Icon, showToast, Toast } from "@raycast/api";
+import { runAppleScript, usePromise } from "@raycast/utils";
 import { fetchLogs } from "../../actions";
-import { usePromise } from "@raycast/utils";
-import { resourceToConsoleLink } from "../../util";
+import { getAWSErrorMessage } from "../../errors";
 import { LogStartTimes } from "../../interfaces";
+import { resourceToConsoleLink } from "../../util";
 import { AwsAction } from "../common/action";
 
 function CloudwatchLogs({
@@ -23,6 +24,30 @@ function CloudwatchLogs({
     logGroupStreamName ? [logGroupStreamName] : undefined,
   ]);
 
+  const AWS_REGION = process.env.AWS_REGION;
+  const liveTailUrl = `https://${AWS_REGION}.console.aws.amazon.com/cloudwatch/home?region=${AWS_REGION}#logsV2:live-tail$3FlogGroupArns$3D${encodeURIComponent(`arn:aws:logs:${AWS_REGION}:*:log-group:${logGroupName}`)}`;
+  const tailCommand = `aws logs tail "${logGroupName}" --follow`;
+
+  async function runTailInTerminal() {
+    const escapedCommand = tailCommand.replace(/"/g, '\\"');
+    const appleScript = `
+      tell application "Terminal"
+        do script "${escapedCommand}"
+        activate
+      end tell
+    `;
+    try {
+      await runAppleScript(appleScript);
+      await showToast({ style: Toast.Style.Success, title: "Opened in Terminal" });
+    } catch (error) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Failed to open Terminal",
+        message: getAWSErrorMessage(error),
+      });
+    }
+  }
+
   return (
     <Detail
       markdown={logs?.reduce(
@@ -33,8 +58,28 @@ function CloudwatchLogs({
       actions={
         <ActionPanel>
           <AwsAction.Console url={resourceToConsoleLink(logGroupName, "AWS::Logs::LogGroup")} />
+          <ActionPanel.Section title="Tail Logs">
+            <Action.OpenInBrowser
+              icon={Icon.Livestream}
+              title="Tail Logs in Console"
+              url={liveTailUrl}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
+            />
+            <Action
+              title="Run Tail Command in Terminal"
+              icon={Icon.Terminal}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "t" }}
+              onAction={runTailInTerminal}
+            />
+          </ActionPanel.Section>
           <ActionPanel.Section title="Copy">
             <AwsAction.ExportResponse response={logs} />
+            <Action.CopyToClipboard
+              title="Copy Tail Command"
+              content={tailCommand}
+              icon={Icon.Terminal}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+            />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/codepipeline/retry-stage-execution-action.tsx
+++ b/extensions/amazon-aws/src/components/codepipeline/retry-stage-execution-action.tsx
@@ -1,12 +1,12 @@
 import { Action, ActionPanel, captureException, Color, confirmAlert, Icon, showToast, Toast } from "@raycast/api";
 import {
-  CodePipelineClient,
   PipelineExecutionStatus,
   RetryStageExecutionCommand,
   RetryStageExecutionCommandInput,
   StageExecutionStatus,
   StageRetryMode,
 } from "@aws-sdk/client-codepipeline";
+import { getCodePipelineClient } from "../../services/clients/codepipeline";
 import { getErrorMessage } from "../../util";
 import { Pipeline, PipelineStage } from "../../codepipeline";
 import { MutatePromise } from "@raycast/utils";
@@ -101,7 +101,7 @@ const retry = async (
     `Retrying ${stage.retryMode === StageRetryMode.ALL_ACTIONS ? "all actions" : "failed actions"} in ${stage.stageName}`,
   );
 
-  mutate(new CodePipelineClient({}).send(new RetryStageExecutionCommand(input)), {
+  mutate(getCodePipelineClient().send(new RetryStageExecutionCommand(input)), {
     optimisticUpdate: (pipelines) => {
       if (!pipelines) {
         return;

--- a/extensions/amazon-aws/src/components/codepipeline/stop-execution-action.tsx
+++ b/extensions/amazon-aws/src/components/codepipeline/stop-execution-action.tsx
@@ -1,11 +1,11 @@
 import { Action, ActionPanel, captureException, Color, confirmAlert, Icon, showToast, Toast } from "@raycast/api";
 import {
-  CodePipelineClient,
   PipelineExecutionStatus,
   PipelineExecutionSummary,
   StopPipelineExecutionCommand,
   StopPipelineExecutionCommandInput,
 } from "@aws-sdk/client-codepipeline";
+import { getCodePipelineClient } from "../../services/clients/codepipeline";
 import { getErrorMessage } from "../../util";
 import { Pipeline } from "../../codepipeline";
 import { MutatePromise } from "@raycast/utils";
@@ -82,7 +82,7 @@ const stop = async (
     `Execution ID: ${execution.pipelineExecutionId}`,
   );
 
-  mutate(new CodePipelineClient({}).send(new StopPipelineExecutionCommand(input)), {
+  mutate(getCodePipelineClient().send(new StopPipelineExecutionCommand(input)), {
     optimisticUpdate: (pipelines) => {
       if (!pipelines) {
         return;

--- a/extensions/amazon-aws/src/components/codepipeline/toggle-stage-transition-action.tsx
+++ b/extensions/amazon-aws/src/components/codepipeline/toggle-stage-transition-action.tsx
@@ -1,11 +1,11 @@
 import { Action, ActionPanel, captureException, Color, Icon, showToast, Toast } from "@raycast/api";
 import {
-  CodePipelineClient,
   DisableStageTransitionCommand,
   EnableStageTransitionCommand,
   PipelineExecutionStatus,
   StageTransitionType,
 } from "@aws-sdk/client-codepipeline";
+import { getCodePipelineClient } from "../../services/clients/codepipeline";
 import { getErrorMessage } from "../../util";
 import { MutatePromise } from "@raycast/utils";
 import { Pipeline, PipelineStage } from "../../codepipeline";
@@ -67,7 +67,7 @@ const toggleStageTransition = async (
     `between ${stage.stageName} -> ${stage.nextStage!.stageName}`,
   );
 
-  const client = new CodePipelineClient({});
+  const client = getCodePipelineClient();
   const promise = transitionEnabled
     ? client.send(
         new DisableStageTransitionCommand({

--- a/extensions/amazon-aws/src/components/dynamodb/delete-item-form.tsx
+++ b/extensions/amazon-aws/src/components/dynamodb/delete-item-form.tsx
@@ -14,9 +14,10 @@ import {
   Clipboard,
   Keyboard,
 } from "@raycast/api";
-import { DeleteItemCommand, DeleteItemCommandInput, DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DeleteItemCommand, DeleteItemCommandInput } from "@aws-sdk/client-dynamodb";
 import { Table } from "../../dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
+import { getDynamoDBClient } from "../../services/clients/dynamodb";
 import { getErrorMessage } from "../../util";
 
 interface DeleteItemFormValues {
@@ -77,7 +78,7 @@ export const DeleteItemForm = ({
               title: `❗Deleting item in ${table.TableName}`,
             });
 
-            mutate(new DynamoDBClient({}).send(new DeleteItemCommand(input)), {
+            mutate(getDynamoDBClient().send(new DeleteItemCommand(input)), {
               optimisticUpdate: (tables) => {
                 if (!tables) return undefined;
                 return tables.map((t) =>

--- a/extensions/amazon-aws/src/components/dynamodb/query-form.tsx
+++ b/extensions/amazon-aws/src/components/dynamodb/query-form.tsx
@@ -13,9 +13,10 @@ import {
   Clipboard,
   Keyboard,
 } from "@raycast/api";
-import { DynamoDBClient, QueryCommand, QueryCommandInput } from "@aws-sdk/client-dynamodb";
+import { type DynamoDBClient, QueryCommand, QueryCommandInput } from "@aws-sdk/client-dynamodb";
 import { Table } from "../../dynamodb";
 import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
+import { getDynamoDBClient } from "../../services/clients/dynamodb";
 import React from "react";
 import { getErrorMessage, sortRecord } from "../../util";
 
@@ -41,7 +42,7 @@ export const QueryForm = ({ table }: { table: Table }) => {
   const { push, pop } = useNavigation();
   const { values, handleSubmit, itemProps } = useForm<QueryFormValues>({
     onSubmit: async (values) => {
-      const client = new DynamoDBClient({});
+      const client = getDynamoDBClient();
       const hasRangeKey = table.keys[values.indexName].rangeKey !== undefined;
       const primaryKey = table.keys[values.indexName];
       const input: QueryCommandInput = {

--- a/extensions/amazon-aws/src/components/dynamodb/update-item-form.tsx
+++ b/extensions/amazon-aws/src/components/dynamodb/update-item-form.tsx
@@ -12,9 +12,10 @@ import {
   Clipboard,
   Keyboard,
 } from "@raycast/api";
-import { DynamoDBClient, UpdateItemCommand, UpdateItemCommandInput } from "@aws-sdk/client-dynamodb";
+import { UpdateItemCommand, UpdateItemCommandInput } from "@aws-sdk/client-dynamodb";
 import { Table } from "../../dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
+import { getDynamoDBClient } from "../../services/clients/dynamodb";
 import { getErrorMessage } from "../../util";
 
 interface UpdateItemFormValues {
@@ -69,7 +70,7 @@ export const UpdateItemForm = ({
         title: `🚀 Updating item in table ${table.TableName}`,
       });
 
-      mutate(new DynamoDBClient({}).send(new UpdateItemCommand(input)), {
+      mutate(getDynamoDBClient().send(new UpdateItemCommand(input)), {
         optimisticUpdate: (tables) => {
           if (!tables) return undefined;
           return tables.map((t) => (t.TableName !== table.TableName ? t : { ...t, ItemCount: (t.ItemCount ?? 0) + 1 }));

--- a/extensions/amazon-aws/src/components/ecr/ECRImage.tsx
+++ b/extensions/amazon-aws/src/components/ecr/ECRImage.tsx
@@ -55,6 +55,7 @@ function ECRImage({ repository }: { repository: Repository }) {
                     content={repository.repositoryUri || ""}
                     shortcut={{ modifiers: ["opt"], key: "c" }}
                   />
+                  <AwsAction.ExportResponse response={image} />
                 </ActionPanel.Section>
               </ActionPanel>
             }

--- a/extensions/amazon-aws/src/components/ecr/ECRRepository.tsx
+++ b/extensions/amazon-aws/src/components/ecr/ECRRepository.tsx
@@ -44,6 +44,7 @@ function ECRRepository({ repository }: { repository: Repository }) {
               content={repository.repositoryUri || ""}
               shortcut={{ modifiers: ["opt"], key: "c" }}
             />
+            <AwsAction.ExportResponse response={repository} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/ecs/ECSClusterServices.tsx
+++ b/extensions/amazon-aws/src/components/ecs/ECSClusterServices.tsx
@@ -1,10 +1,11 @@
-import { ECSClient, Service, UpdateServiceCommand } from "@aws-sdk/client-ecs";
+import { Service, UpdateServiceCommand } from "@aws-sdk/client-ecs";
 import { Action, ActionPanel, confirmAlert, Icon, List, showToast, Toast } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { fetchServices, getServiceUrl } from "../../actions";
 import { getFilterPlaceholder } from "../../util";
 import ECSClusterServiceTasks from "./ECSClusterServiceTasks";
 import { AwsAction } from "../common/action";
+import { getECSClient } from "../../services/clients/ecs";
 
 function ECSClusterServices({ clusterArn }: { clusterArn: string }) {
   const { data: services, isLoading } = useCachedPromise(fetchServices, [clusterArn], { keepPreviousData: true });
@@ -92,7 +93,7 @@ function forceNewDeployment(service: Service) {
         const toast = await showToast({ style: Toast.Style.Animated, title: "Force deploying..." });
 
         try {
-          await new ECSClient({}).send(
+          await getECSClient().send(
             new UpdateServiceCommand({
               cluster: service.clusterArn,
               service: service.serviceName,

--- a/extensions/amazon-aws/src/components/lambda/InvokeLambdaFunction.tsx
+++ b/extensions/amazon-aws/src/components/lambda/InvokeLambdaFunction.tsx
@@ -1,6 +1,9 @@
-import { useState, useEffect } from "react";
-import { Action, ActionPanel, Form, useNavigation, showToast, Toast, Clipboard, LocalStorage } from "@raycast/api";
-import { LambdaClient, InvokeCommand, InvokeCommandInput } from "@aws-sdk/client-lambda";
+import { InvokeCommand, InvokeCommandInput } from "@aws-sdk/client-lambda";
+import { Action, ActionPanel, Clipboard, Form, showToast, Toast, useNavigation } from "@raycast/api";
+import { useLocalStorage } from "@raycast/utils";
+import { useState } from "react";
+import { getLambdaClient } from "../../services/clients/lambda";
+import { getAWSErrorMessage } from "../../errors";
 
 interface InvokeLambdaFunctionProps {
   functionName: string;
@@ -12,28 +15,36 @@ interface SavedPayload {
 }
 
 export default function InvokeLambdaFunction({ functionName }: InvokeLambdaFunctionProps) {
-  const [payload, setPayload] = useState("{}");
-  const [savedPayloads, setSavedPayloads] = useState<SavedPayload[]>([]);
+  const {
+    value: lastPayload,
+    setValue: setLastPayload,
+    isLoading: isLoadingPayload,
+  } = useLocalStorage<string>(`lastPayload_${functionName}`, "{}");
+
+  const {
+    value: savedPayloads,
+    setValue: setSavedPayloads,
+    isLoading: isLoadingSavedPayloads,
+  } = useLocalStorage<SavedPayload[]>(`savedPayloads_${functionName}`, []);
+
+  const [payload, setPayload] = useState<string | null>(null);
   const [saveName, setSaveName] = useState("");
   const { pop } = useNavigation();
 
-  useEffect(() => {
-    LocalStorage.getItem<string>(`lastPayload_${functionName}`).then((lastPayload) => {
-      if (lastPayload) {
-        setPayload(lastPayload);
-      }
-    });
+  const isLoading = isLoadingPayload || isLoadingSavedPayloads;
 
-    LocalStorage.getItem<string>(`savedPayloads_${functionName}`).then((savedPayloadsString) => {
-      if (savedPayloadsString) {
-        setSavedPayloads(JSON.parse(savedPayloadsString));
-      }
-    });
-  }, [functionName]);
+  // Return loading form until LocalStorage data is ready
+  if (isLoading) {
+    return <Form isLoading={true} />;
+  }
 
-  const handleSubmit = async (values: { payload: string }) => {
+  // Use local state if user has edited, otherwise use stored value
+  const currentPayload = payload ?? lastPayload ?? "{}";
+  const currentSavedPayloads = savedPayloads ?? [];
+
+  async function handleSubmit(values: { payload: string }) {
     try {
-      const client = new LambdaClient({});
+      const client = getLambdaClient();
       const input: InvokeCommandInput = {
         FunctionName: functionName,
         Payload: values.payload,
@@ -67,32 +78,31 @@ export default function InvokeLambdaFunction({ functionName }: InvokeLambdaFunct
       }
 
       // Save the last invoked payload
-      await LocalStorage.setItem(`lastPayload_${functionName}`, values.payload);
+      await setLastPayload(values.payload);
 
       pop();
     } catch (error) {
       await showToast({
         style: Toast.Style.Failure,
         title: "Error Invoking Function",
-        message: error instanceof Error ? error.message : String(error),
+        message: getAWSErrorMessage(error),
       });
     }
-  };
+  }
 
-  const handleSavePayload = async () => {
+  async function handleSavePayload() {
     const trimmedName = saveName.trim();
-    const trimmedPayload = payload.trim();
+    const trimmedPayload = currentPayload.trim();
     if (trimmedName && trimmedPayload) {
-      const existingIndex = savedPayloads.findIndex((sp) => sp.name === trimmedName);
+      const existingIndex = currentSavedPayloads.findIndex((sp) => sp.name === trimmedName);
       let newSavedPayloads;
       if (existingIndex !== -1) {
-        newSavedPayloads = [...savedPayloads];
+        newSavedPayloads = [...currentSavedPayloads];
         newSavedPayloads[existingIndex] = { name: trimmedName, payload: trimmedPayload };
       } else {
-        newSavedPayloads = [...savedPayloads, { name: trimmedName, payload: trimmedPayload }];
+        newSavedPayloads = [...currentSavedPayloads, { name: trimmedName, payload: trimmedPayload }];
       }
-      setSavedPayloads(newSavedPayloads);
-      await LocalStorage.setItem(`savedPayloads_${functionName}`, JSON.stringify(newSavedPayloads));
+      await setSavedPayloads(newSavedPayloads);
       setSaveName("");
       await showToast({
         style: Toast.Style.Success,
@@ -100,22 +110,21 @@ export default function InvokeLambdaFunction({ functionName }: InvokeLambdaFunct
         message: `Saved as "${trimmedName}"`,
       });
     }
-  };
+  }
 
-  const handleDeletePayload = async (nameToDelete: string) => {
-    const newSavedPayloads = savedPayloads.filter((sp) => sp.name !== nameToDelete);
-    setSavedPayloads(newSavedPayloads);
-    await LocalStorage.setItem(`savedPayloads_${functionName}`, JSON.stringify(newSavedPayloads));
+  async function handleDeletePayload(nameToDelete: string) {
+    const newSavedPayloads = currentSavedPayloads.filter((sp) => sp.name !== nameToDelete);
+    await setSavedPayloads(newSavedPayloads);
     await showToast({
       style: Toast.Style.Success,
       title: "Payload Deleted",
       message: `Deleted "${nameToDelete}"`,
     });
-  };
+  }
 
-  const handleLoadPayload = (savedPayload: SavedPayload) => {
+  function handleLoadPayload(savedPayload: SavedPayload) {
     setPayload(savedPayload.payload);
-  };
+  }
 
   return (
     <Form
@@ -124,7 +133,7 @@ export default function InvokeLambdaFunction({ functionName }: InvokeLambdaFunct
           <Action.SubmitForm title="Invoke" onSubmit={handleSubmit} />
           <Action title="Save Payload" onAction={handleSavePayload} shortcut={{ modifiers: ["cmd"], key: "s" }} />
           <ActionPanel.Submenu title="Load Payload" shortcut={{ modifiers: ["cmd"], key: "l" }}>
-            {savedPayloads.map((savedPayload) => (
+            {currentSavedPayloads.map((savedPayload) => (
               <Action
                 key={savedPayload.name}
                 title={savedPayload.name}
@@ -133,7 +142,7 @@ export default function InvokeLambdaFunction({ functionName }: InvokeLambdaFunct
             ))}
           </ActionPanel.Submenu>
           <ActionPanel.Submenu title="Delete Payload" shortcut={{ modifiers: ["cmd"], key: "d" }}>
-            {savedPayloads.map((savedPayload) => (
+            {currentSavedPayloads.map((savedPayload) => (
               <Action
                 key={savedPayload.name}
                 title={savedPayload.name}
@@ -148,7 +157,7 @@ export default function InvokeLambdaFunction({ functionName }: InvokeLambdaFunct
         id="payload"
         title="Payload"
         placeholder='Enter JSON payload, e.g., {"key": "value"}'
-        value={payload}
+        value={currentPayload}
         onChange={setPayload}
       />
       <Form.TextField

--- a/extensions/amazon-aws/src/components/searchbar/CloudwatchLogsTimeDropdown.tsx
+++ b/extensions/amazon-aws/src/components/searchbar/CloudwatchLogsTimeDropdown.tsx
@@ -1,5 +1,5 @@
-import { LogStartTimes } from "../../interfaces";
 import { List } from "@raycast/api";
+import { LogStartTimes } from "../../interfaces";
 
 function CloudwatchLogsTimeDropdown({
   logStartTime,

--- a/extensions/amazon-aws/src/components/secrets/secret-policy-details.tsx
+++ b/extensions/amazon-aws/src/components/secrets/secret-policy-details.tsx
@@ -19,6 +19,7 @@ export const SecretPolicyDetails = ({ secret }: SecretProps) => {
           <AwsAction.Console url={resourceToConsoleLink(secret.Name, "AWS::SecretsManager::Secret")} />
           <ActionPanel.Section title={"Secret Actions"}>
             <SecretCopyActions {...{ secret }} />
+            <AwsAction.ExportResponse response={policy} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/secrets/secret-value-details.tsx
+++ b/extensions/amazon-aws/src/components/secrets/secret-value-details.tsx
@@ -26,6 +26,7 @@ export const SecretValueDetails = ({ secret }: SecretProps) => {
           )}
           <ActionPanel.Section title={"Secret Actions"}>
             <SecretCopyActions {...{ secret }} />
+            <AwsAction.ExportResponse response={sec} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/amazon-aws/src/components/sqs/send-message-form.tsx
+++ b/extensions/amazon-aws/src/components/sqs/send-message-form.tsx
@@ -12,9 +12,10 @@ import {
   captureException,
   Keyboard,
 } from "@raycast/api";
-import { MessageAttributeValue, SendMessageCommand, SendMessageCommandInput, SQSClient } from "@aws-sdk/client-sqs";
+import { MessageAttributeValue, SendMessageCommand, SendMessageCommandInput } from "@aws-sdk/client-sqs";
 import { Queue } from "../../sqs";
 import Style = Toast.Style;
+import { getSQSClient } from "../../services/clients/sqs";
 import { getErrorMessage } from "../../util";
 
 interface SendMessageFormValues {
@@ -62,7 +63,7 @@ export const SendMessageForm = ({
             };
 
             const toast = await showToast({ style: Style.Animated, title: "🚧 Sending message..." });
-            mutate(new SQSClient({}).send(new SendMessageCommand(input)), {
+            mutate(getSQSClient().send(new SendMessageCommand(input)), {
               optimisticUpdate: (queues) => {
                 if (!queues) {
                   return;

--- a/extensions/amazon-aws/src/console.tsx
+++ b/extensions/amazon-aws/src/console.tsx
@@ -5,6 +5,15 @@ import { AwsAction } from "./components/common/action";
 import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
 import { AWS_URL_BASE } from "./constants";
 
+function isValidUrl(arg: string): boolean {
+  try {
+    new URL(arg);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export default function Console() {
   const { data: services, isLoading, revalidate } = useCachedPromise(loadJSON);
   const {
@@ -16,21 +25,13 @@ export default function Console() {
     sortUnvisited: (a, b) => a.title.localeCompare(b.title),
   });
 
-  const isValidUrl = (arg: string) => {
-    try {
-      new URL(arg);
-      return true;
-    } catch {
-      return false;
-    }
-  };
-
   return (
     <List
       isLoading={isLoading}
       searchBarPlaceholder="Filter services by name..."
       searchBarAccessory={<AWSProfileDropdown onProfileSelected={revalidate} />}
     >
+      <List.EmptyView title="No Services Found" description="No AWS services match your search" icon={Icon.Cloud} />
       {sortedServices?.map((service) => {
         const consoleUrl = isValidUrl(service.arg) ? service.arg : `${AWS_URL_BASE}${service.arg}`;
         return (

--- a/extensions/amazon-aws/src/dynamodb.tsx
+++ b/extensions/amazon-aws/src/dynamodb.tsx
@@ -17,7 +17,8 @@ import { MutatePromise, useCachedState, useFrecencySorting } from "@raycast/util
 import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
 import { getErrorMessage, resourceToConsoleLink } from "./util";
 import { AwsAction } from "./components/common/action";
-import { DynamoDBClient, TableDescription, UpdateTableCommand } from "@aws-sdk/client-dynamodb";
+import { TableDescription, UpdateTableCommand } from "@aws-sdk/client-dynamodb";
+import { getDynamoDBClient } from "./services/clients/dynamodb";
 import { DeleteItemForm } from "./components/dynamodb/delete-item-form";
 import { UpdateItemForm } from "./components/dynamodb/update-item-form";
 import { QueryForm } from "./components/dynamodb/query-form";
@@ -272,6 +273,7 @@ export default function DynamoDb() {
                 />
               </ActionPanel.Section>
               <ActionPanel.Section>
+                <AwsAction.ExportResponse response={table} />
                 <Action title="Reset Ranking" icon={Icon.ArrowCounterClockwise} onAction={() => resetRanking(table)} />
               </ActionPanel.Section>
             </ActionPanel>
@@ -323,7 +325,7 @@ const tryUpdateDeletionProtection = async ({
   });
 
   mutate(
-    new DynamoDBClient({}).send(
+    getDynamoDBClient().send(
       new UpdateTableCommand({ TableName, DeletionProtectionEnabled: !DeletionProtectionEnabled }),
     ),
     {

--- a/extensions/amazon-aws/src/ec2.tsx
+++ b/extensions/amazon-aws/src/ec2.tsx
@@ -1,9 +1,10 @@
-import { DescribeInstancesCommand, EC2Client, Instance } from "@aws-sdk/client-ec2";
+import { DescribeInstancesCommand, Instance } from "@aws-sdk/client-ec2";
 import { ActionPanel, List, Action, Icon } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
 import { isReadyToFetch, resourceToConsoleLink } from "./util";
 import { AwsAction } from "./components/common/action";
+import { getEC2Client } from "./services/clients/ec2";
 
 export default function EC2() {
   const { data: instances, error, isLoading, revalidate } = useCachedPromise(fetchEC2Instances);
@@ -34,13 +35,16 @@ function EC2Instance({ instance }: { instance: Instance }) {
       actions={
         <ActionPanel>
           <AwsAction.Console url={resourceToConsoleLink(instance.InstanceId, "AWS::EC2::Instance")} />
-          <Action.CopyToClipboard title="Copy Instance ID" content={instance.InstanceId || ""} />
-          {instance.PrivateIpAddress && (
-            <Action.CopyToClipboard title="Copy Private IP" content={instance.PrivateIpAddress} />
-          )}
-          {instance.PublicIpAddress && (
-            <Action.CopyToClipboard title="Copy Public IP" content={instance.PublicIpAddress} />
-          )}
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard title="Copy Instance ID" content={instance.InstanceId || ""} />
+            {instance.PrivateIpAddress && (
+              <Action.CopyToClipboard title="Copy Private IP" content={instance.PrivateIpAddress} />
+            )}
+            {instance.PublicIpAddress && (
+              <Action.CopyToClipboard title="Copy Public IP" content={instance.PublicIpAddress} />
+            )}
+            <AwsAction.ExportResponse response={instance} />
+          </ActionPanel.Section>
         </ActionPanel>
       }
       accessories={[{ text: instance.InstanceType }]}
@@ -50,7 +54,7 @@ function EC2Instance({ instance }: { instance: Instance }) {
 
 async function fetchEC2Instances(token?: string, accInstances?: Instance[]): Promise<Instance[]> {
   if (!isReadyToFetch()) return [];
-  const { NextToken, Reservations } = await new EC2Client({}).send(new DescribeInstancesCommand({ NextToken: token }));
+  const { NextToken, Reservations } = await getEC2Client().send(new DescribeInstancesCommand({ NextToken: token }));
   const instances = (Reservations || []).reduce<Instance[]>(
     (acc, reservation) => [...acc, ...(reservation.Instances || [])],
     [],

--- a/extensions/amazon-aws/src/errors/index.ts
+++ b/extensions/amazon-aws/src/errors/index.ts
@@ -1,0 +1,98 @@
+/**
+ * Custom error types for AWS operations in the Raycast extension
+ */
+
+/**
+ * Error thrown when an AWS API call fails
+ */
+export class AWSClientError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly service: string,
+    public readonly context?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "AWSClientError";
+  }
+}
+
+/**
+ * Error thrown when input validation fails
+ */
+export class ValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly field: string,
+    public readonly value: unknown,
+  ) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}
+
+/**
+ * Error thrown when a required resource is not found
+ */
+export class ResourceNotFoundError extends Error {
+  constructor(
+    message: string,
+    public readonly resourceType: string,
+    public readonly resourceId: string,
+  ) {
+    super(message);
+    this.name = "ResourceNotFoundError";
+  }
+}
+
+/**
+ * Extracts a user-friendly error message from AWS SDK errors
+ * @param error - The error to extract a message from
+ * @returns A user-friendly error message
+ */
+export function getAWSErrorMessage(error: unknown): string {
+  if (error instanceof AWSClientError) {
+    return `${error.service}: ${error.message} (${error.code})`;
+  }
+
+  if (error instanceof ValidationError) {
+    return `Validation failed for ${error.field}: ${error.message}`;
+  }
+
+  if (error instanceof ResourceNotFoundError) {
+    return `${error.resourceType} not found: ${error.resourceId}`;
+  }
+
+  if (error instanceof Error) {
+    // Try to parse AWS SDK error structure
+    const awsError = error as Error & { code?: string; $metadata?: { httpStatusCode?: number } };
+    if (awsError.code) {
+      return `${awsError.code}: ${error.message}`;
+    }
+    return error.message;
+  }
+
+  return String(error);
+}
+
+/**
+ * Creates an AWSClientError from an unknown error
+ * @param error - The original error
+ * @param service - The AWS service that threw the error
+ * @returns An AWSClientError instance
+ */
+export function toAWSClientError(error: unknown, service: string): AWSClientError {
+  if (error instanceof AWSClientError) {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    const awsError = error as Error & { code?: string; $metadata?: { httpStatusCode?: number } };
+    return new AWSClientError(error.message, awsError.code ?? "UnknownError", service, {
+      originalError: error.name,
+      httpStatusCode: awsError.$metadata?.httpStatusCode,
+    });
+  }
+
+  return new AWSClientError(String(error), "UnknownError", service);
+}

--- a/extensions/amazon-aws/src/glue.tsx
+++ b/extensions/amazon-aws/src/glue.tsx
@@ -1,10 +1,11 @@
-import { GlueClient, JobRun, GetJobCommand, StartJobRunCommand, GetJobCommandOutput } from "@aws-sdk/client-glue";
+import { JobRun, GetJobCommand, StartJobRunCommand, GetJobCommandOutput } from "@aws-sdk/client-glue";
 import { Action, ActionPanel, Icon, List, Image, Color, Detail, showToast, Toast } from "@raycast/api";
 import { MutatePromise, showFailureToast, useCachedPromise, useCachedState } from "@raycast/utils";
 import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
 import { resourceToConsoleLink } from "./util";
 import { AwsAction } from "./components/common/action";
 import { useGlueJobRuns, useGlueJobs } from "./hooks/use-glue";
+import { getGlueClient } from "./services/clients/glue";
 
 export interface GlueJobRun extends JobRun {
   accessoriesText?: string;
@@ -92,6 +93,7 @@ function GlueJob({
           <AwsAction.Console url={resourceToConsoleLink(glueJobRun.JobName, "AWS::Glue::JobRuns")} />
           <ActionPanel.Section title={"Copy"}>
             <Action.CopyToClipboard title="Copy Job Name" content={glueJobRun.JobName || ""} />
+            <AwsAction.ExportResponse response={glueJobRun} />
           </ActionPanel.Section>
           <Action
             title={`${isDetailsEnabled ? "Hide" : "Show"} Details`}
@@ -135,6 +137,7 @@ function GlueJobRuns({ glueJobName: glueJobName }: { glueJobName: string }) {
               <AwsAction.Console url={resourceToConsoleLink(jobRun.JobName, "AWS::Glue::JobRun", jobRun.Id)} />
               <ActionPanel.Section title={"Copy"}>
                 <Action.CopyToClipboard title="Copy Job Run Id" content={jobRun.Id || ""} />
+                <AwsAction.ExportResponse response={jobRun} />
               </ActionPanel.Section>
             </ActionPanel>
           }
@@ -201,7 +204,7 @@ function GlueJobRunDetails({ jobRun: glueJobRun }: { jobRun: GlueJobRun }) {
 }
 
 async function RunGlueJob(glueJobName: string, mutate: MutatePromise<GlueJobRun[] | undefined>) {
-  mutate(new GlueClient({}).send(new StartJobRunCommand({ JobName: glueJobName })), {
+  mutate(getGlueClient().send(new StartJobRunCommand({ JobName: glueJobName })), {
     optimisticUpdate(data) {
       return data;
     },
@@ -237,12 +240,15 @@ function GlueJobDefinition({ glueJobName: glueJobName }: { glueJobName: string }
       actions={
         <ActionPanel title="title">
           <AwsAction.Console url={resourceToConsoleLink(glueJobDetails?.Job?.Name, "AWS::Glue::JobRuns")} />
-          <Action.CopyToClipboard content={JSON.stringify(glueJobDetails?.Job?.Name)} title="Copy Job Name" />
-          <Action.CopyToClipboard
-            content={JSON.stringify(glueJobDetails?.Job?.DefaultArguments)}
-            title="Copy Default Arguments"
-          />
-          <Action.CopyToClipboard content={JSON.stringify(glueJobDetails?.Job)} title="Copy Job Definition" />
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard content={JSON.stringify(glueJobDetails?.Job?.Name)} title="Copy Job Name" />
+            <Action.CopyToClipboard
+              content={JSON.stringify(glueJobDetails?.Job?.DefaultArguments)}
+              title="Copy Default Arguments"
+            />
+            <Action.CopyToClipboard content={JSON.stringify(glueJobDetails?.Job)} title="Copy Job Definition" />
+            <AwsAction.ExportResponse response={glueJobDetails} />
+          </ActionPanel.Section>
         </ActionPanel>
       }
       metadata={
@@ -287,7 +293,7 @@ function GlueJobDefinition({ glueJobName: glueJobName }: { glueJobName: string }
 }
 
 async function fetchJobDetails(glueJobName: string): Promise<GetJobCommandOutput> {
-  const client = new GlueClient({});
+  const client = getGlueClient();
   const input = {
     JobName: glueJobName, // required
   };

--- a/extensions/amazon-aws/src/hooks/use-amplify.ts
+++ b/extensions/amazon-aws/src/hooks/use-amplify.ts
@@ -1,5 +1,4 @@
 import {
-  AmplifyClient,
   App,
   Branch,
   CustomRule,
@@ -12,12 +11,15 @@ import {
   ListJobsCommand,
   ListWebhooksCommand,
   StartJobCommand,
+  Step,
   StopJobCommand,
   UpdateAppCommand,
   Webhook,
 } from "@aws-sdk/client-amplify";
 import { showToast, Toast } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
+import { getAWSErrorMessage } from "../errors";
+import { getAmplifyClient } from "../services/clients/amplify";
 import { isReadyToFetch } from "../util";
 
 /**
@@ -46,23 +48,26 @@ export function useAmplifyApps() {
   return { apps, error, isLoading: (!apps && !error) || isLoading, revalidate };
 }
 
-async function fetchAmplifyApps(toast: Toast, nextToken?: string, aggregate?: App[]): Promise<App[]> {
-  const client = new AmplifyClient({});
-  const { apps, nextToken: cursor } = await client.send(new ListAppsCommand({ nextToken }));
+async function fetchAmplifyApps(toast: Toast, maxResults = 100): Promise<App[]> {
+  const client = getAmplifyClient();
+  const apps: App[] = [];
+  let nextToken: string | undefined;
 
-  const filteredApps = apps ?? [];
-  const agg = [...(aggregate ?? []), ...filteredApps];
+  do {
+    const { apps: appsList, nextToken: cursor } = await client.send(new ListAppsCommand({ nextToken }));
 
-  toast.message = `${agg.length} apps`;
+    if (appsList) {
+      apps.push(...appsList);
+    }
 
-  if (cursor) {
-    return await fetchAmplifyApps(toast, cursor, agg);
-  }
+    toast.message = `${apps.length} apps`;
+    nextToken = cursor;
+  } while (nextToken && apps.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded Amplify apps";
-  toast.message = `${agg.length} apps`;
-  return agg;
+  toast.message = `${apps.length} apps`;
+  return apps;
 }
 
 /**
@@ -91,28 +96,28 @@ export function useAmplifyBranches(appId: string) {
   return { branches, error, isLoading: (!branches && !error) || isLoading };
 }
 
-async function fetchAmplifyBranches(
-  appId: string,
-  toast: Toast,
-  nextToken?: string,
-  aggregate?: Branch[],
-): Promise<Branch[]> {
-  const client = new AmplifyClient({});
-  const { branches, nextToken: cursor } = await client.send(new ListBranchesCommand({ appId, nextToken }));
+async function fetchAmplifyBranches(appId: string, toast: Toast, maxResults = 100): Promise<Branch[]> {
+  const client = getAmplifyClient();
+  const branches: Branch[] = [];
+  let nextToken: string | undefined;
 
-  const filteredBranches = branches ?? [];
-  const agg = [...(aggregate ?? []), ...filteredBranches];
+  do {
+    const { branches: branchList, nextToken: cursor } = await client.send(
+      new ListBranchesCommand({ appId, nextToken }),
+    );
 
-  toast.message = `${agg.length} branches`;
+    if (branchList) {
+      branches.push(...branchList);
+    }
 
-  if (cursor) {
-    return await fetchAmplifyBranches(appId, toast, cursor, agg);
-  }
+    toast.message = `${branches.length} branches`;
+    nextToken = cursor;
+  } while (nextToken && branches.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded branches";
-  toast.message = `${agg.length} branches`;
-  return agg;
+  toast.message = `${branches.length} branches`;
+  return branches;
 }
 
 /**
@@ -131,7 +136,7 @@ export function useAmplifyAppDetails(appId: string) {
     isLoading,
   } = useCachedPromise(
     async (id: string) => {
-      const client = new AmplifyClient({});
+      const client = getAmplifyClient();
       const { app } = await client.send(new GetAppCommand({ appId: id }));
       return app;
     },
@@ -168,28 +173,28 @@ export function useAmplifyWebhooks(appId: string) {
   return { webhooks, error, isLoading: (!webhooks && !error) || isLoading };
 }
 
-async function fetchAmplifyWebhooks(
-  appId: string,
-  toast: Toast,
-  nextToken?: string,
-  aggregate?: Webhook[],
-): Promise<Webhook[]> {
-  const client = new AmplifyClient({});
-  const { webhooks, nextToken: cursor } = await client.send(new ListWebhooksCommand({ appId, nextToken }));
+async function fetchAmplifyWebhooks(appId: string, toast: Toast, maxResults = 100): Promise<Webhook[]> {
+  const client = getAmplifyClient();
+  const webhooks: Webhook[] = [];
+  let nextToken: string | undefined;
 
-  const filteredWebhooks = webhooks ?? [];
-  const agg = [...(aggregate ?? []), ...filteredWebhooks];
+  do {
+    const { webhooks: webhookList, nextToken: cursor } = await client.send(
+      new ListWebhooksCommand({ appId, nextToken }),
+    );
 
-  toast.message = `${agg.length} webhooks`;
+    if (webhookList) {
+      webhooks.push(...webhookList);
+    }
 
-  if (cursor) {
-    return await fetchAmplifyWebhooks(appId, toast, cursor, agg);
-  }
+    toast.message = `${webhooks.length} webhooks`;
+    nextToken = cursor;
+  } while (nextToken && webhooks.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded webhooks";
-  toast.message = `${agg.length} webhooks`;
-  return agg;
+  toast.message = `${webhooks.length} webhooks`;
+  return webhooks;
 }
 
 /**
@@ -227,27 +232,34 @@ async function fetchAmplifyJobs(
   appId: string,
   branchName: string,
   toast: Toast,
-  nextToken?: string,
-  aggregate?: JobSummary[],
+  maxResults = 100,
 ): Promise<JobSummary[]> {
-  const client = new AmplifyClient({});
-  const { jobSummaries, nextToken: cursor } = await client.send(
-    new ListJobsCommand({ appId, branchName, nextToken, maxResults: 50 }),
-  );
+  const client = getAmplifyClient();
+  const jobs: JobSummary[] = [];
+  let nextToken: string | undefined;
 
-  const filteredJobs = jobSummaries ?? [];
-  const agg = [...(aggregate ?? []), ...filteredJobs];
+  do {
+    const { jobSummaries, nextToken: cursor } = await client.send(
+      new ListJobsCommand({
+        appId,
+        branchName,
+        nextToken,
+        maxResults: Math.min(maxResults - jobs.length, 50),
+      }),
+    );
 
-  toast.message = `${agg.length} builds`;
+    if (jobSummaries) {
+      jobs.push(...jobSummaries);
+    }
 
-  if (cursor) {
-    return await fetchAmplifyJobs(appId, branchName, toast, cursor, agg);
-  }
+    toast.message = `${jobs.length} builds`;
+    nextToken = cursor;
+  } while (nextToken && jobs.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded build history";
-  toast.message = `${agg.length} builds`;
-  return agg;
+  toast.message = `${jobs.length} builds`;
+  return jobs;
 }
 
 /**
@@ -268,7 +280,7 @@ export function useAmplifyArtifacts(appId: string, branchName: string, jobId: st
     isLoading,
   } = useCachedPromise(
     async (appId: string, branchName: string, jobId: string) => {
-      const client = new AmplifyClient({});
+      const client = getAmplifyClient();
       const { artifacts } = await client.send(new ListArtifactsCommand({ appId, branchName, jobId }));
       return artifacts;
     },
@@ -280,6 +292,34 @@ export function useAmplifyArtifacts(appId: string, branchName: string, jobId: st
   );
 
   return { artifacts, error, isLoading: (!artifacts && !error) || isLoading };
+}
+
+/**
+ * Hook to fetch full job details including build steps
+ * @param appId - The Amplify app ID
+ * @param branchName - The branch name
+ * @param jobId - The job ID
+ * @returns Object containing the full job with steps, error state, and loading state
+ */
+export function useAmplifyJobDetails(appId: string, branchName: string, jobId: string) {
+  const {
+    data: job,
+    error,
+    isLoading,
+  } = useCachedPromise(
+    async (appId: string, branchName: string, jobId: string) => {
+      const client = getAmplifyClient();
+      const { job } = await client.send(new GetJobCommand({ appId, branchName, jobId }));
+      return job;
+    },
+    [appId, branchName, jobId],
+    {
+      execute: isReadyToFetch() && !!appId && !!branchName && !!jobId,
+      failureToastOptions: { title: "❌ Failed to load job details" },
+    },
+  );
+
+  return { job, error, isLoading: (!job && !error) || isLoading };
 }
 
 /**
@@ -311,7 +351,7 @@ export async function startAmplifyBuild(
   });
 
   try {
-    const client = new AmplifyClient({});
+    const client = getAmplifyClient();
     const { jobSummary } = await client.send(
       new StartJobCommand({
         appId,
@@ -330,7 +370,7 @@ export async function startAmplifyBuild(
   } catch (error) {
     toast.style = Toast.Style.Failure;
     toast.title = "❌ Failed to start build";
-    toast.message = error instanceof Error ? error.message : "Unknown error";
+    toast.message = getAWSErrorMessage(error);
     throw error;
   }
 }
@@ -359,7 +399,7 @@ export async function stopAmplifyBuild(
   });
 
   try {
-    const client = new AmplifyClient({});
+    const client = getAmplifyClient();
     const { jobSummary } = await client.send(
       new StopJobCommand({
         appId,
@@ -375,7 +415,7 @@ export async function stopAmplifyBuild(
   } catch (error) {
     toast.style = Toast.Style.Failure;
     toast.title = "❌ Failed to cancel build";
-    toast.message = error instanceof Error ? error.message : "Unknown error";
+    toast.message = getAWSErrorMessage(error);
     throw error;
   }
 }
@@ -399,7 +439,7 @@ export async function updateAmplifyCustomRules(appId: string, customRules: Custo
   });
 
   try {
-    const client = new AmplifyClient({});
+    const client = getAmplifyClient();
     const { app } = await client.send(
       new UpdateAppCommand({
         appId,
@@ -413,7 +453,7 @@ export async function updateAmplifyCustomRules(appId: string, customRules: Custo
   } catch (error) {
     toast.style = Toast.Style.Failure;
     toast.title = "❌ Failed to update custom rules";
-    toast.message = error instanceof Error ? error.message : "Unknown error";
+    toast.message = getAWSErrorMessage(error);
     throw error;
   }
 }
@@ -440,7 +480,7 @@ export async function updateAmplifyEnvironmentVariables(
   });
 
   try {
-    const client = new AmplifyClient({});
+    const client = getAmplifyClient();
     const { app } = await client.send(
       new UpdateAppCommand({
         appId,
@@ -454,7 +494,7 @@ export async function updateAmplifyEnvironmentVariables(
   } catch (error) {
     toast.style = Toast.Style.Failure;
     toast.title = "❌ Failed to update environment variables";
-    toast.message = error instanceof Error ? error.message : "Unknown error";
+    toast.message = getAWSErrorMessage(error);
     throw error;
   }
 }
@@ -479,7 +519,7 @@ export async function downloadAmplifyBuildLogs(appId: string, branchName: string
   });
 
   try {
-    const client = new AmplifyClient({});
+    const client = getAmplifyClient();
     const { job } = await client.send(
       new GetJobCommand({
         appId,
@@ -494,8 +534,8 @@ export async function downloadAmplifyBuildLogs(appId: string, branchName: string
 
     // Extract log URLs from execution steps
     const logUrls = job.steps
-      .filter((step) => step.logUrl)
-      .map((step, index) => ({
+      .filter((step: Step) => step.logUrl)
+      .map((step: Step, index: number) => ({
         stepName: step.stepName || `step-${index}`,
         logUrl: step.logUrl as string, // Safe since we filtered for step.logUrl above
         status: step.status,
@@ -514,14 +554,13 @@ export async function downloadAmplifyBuildLogs(appId: string, branchName: string
     const logsDir = join(homedir(), "Downloads", "amplify-logs");
     await mkdir(logsDir, { recursive: true });
 
-    // Download each log file
-    for (const logInfo of logUrls) {
-      try {
+    // Download all log files in parallel for better performance
+    const downloadResults = await Promise.allSettled(
+      logUrls.map(async (logInfo) => {
         const response = await fetch(logInfo.logUrl);
 
         if (!response.ok) {
-          console.warn(`Failed to download log for ${logInfo.stepName}: ${response.status}`);
-          continue;
+          throw new Error(`HTTP ${response.status}`);
         }
 
         const logContent = await response.text();
@@ -529,10 +568,17 @@ export async function downloadAmplifyBuildLogs(appId: string, branchName: string
         const filePath = join(logsDir, fileName);
 
         await writeFile(filePath, logContent);
-      } catch (error) {
-        // Log download failed for this step, continue with others
-      }
+        return logInfo.stepName;
+      }),
+    );
+
+    // Log any failures
+    const failures = downloadResults.filter((result): result is PromiseRejectedResult => result.status === "rejected");
+    if (failures.length > 0) {
+      console.warn(`Failed to download ${failures.length} log files`);
     }
+
+    const successCount = downloadResults.filter((r) => r.status === "fulfilled").length;
 
     // Show logs directory in Finder
     const { showInFinder } = await import("@raycast/api");
@@ -540,11 +586,11 @@ export async function downloadAmplifyBuildLogs(appId: string, branchName: string
 
     toast.style = Toast.Style.Success;
     toast.title = "✅ Build logs downloaded";
-    toast.message = `${logUrls.length} log files saved`;
+    toast.message = `${successCount} of ${logUrls.length} log files saved`;
   } catch (error) {
     toast.style = Toast.Style.Failure;
     toast.title = "❌ Failed to download build logs";
-    toast.message = error instanceof Error ? error.message : "Unknown error";
+    toast.message = getAWSErrorMessage(error);
     throw error;
   }
 }

--- a/extensions/amazon-aws/src/hooks/use-apigateway.ts
+++ b/extensions/amazon-aws/src/hooks/use-apigateway.ts
@@ -1,5 +1,4 @@
 import {
-  APIGatewayClient,
   RestApi,
   GetRestApisCommand,
   GetResourcesCommand,
@@ -13,9 +12,14 @@ import {
   GetMethodCommand,
   GetDeploymentsCommand,
   Deployment,
+  GetAuthorizersCommand,
+  Authorizer,
+  GetDomainNamesCommand,
+  DomainName,
+  GetBasePathMappingsCommand,
+  BasePathMapping,
 } from "@aws-sdk/client-api-gateway";
 import {
-  ApiGatewayV2Client,
   GetApisCommand,
   Api,
   GetStagesCommand as GetStagesV2Command,
@@ -26,6 +30,7 @@ import {
 import { showToast, Toast } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { isReadyToFetch } from "../util";
+import { getApiGatewayClient, getApiGatewayV2Client } from "../services/clients/api-gateway";
 
 /**
  * Hook to fetch and manage API Gateway REST APIs
@@ -48,23 +53,28 @@ export function useApiGatewayAPIs() {
   return { apis, error, isLoading: (!apis && !error) || isLoading, revalidate };
 }
 
-async function fetchApiGatewayAPIs(toast: Toast, position?: string, aggregate?: RestApi[]): Promise<RestApi[]> {
-  const client = new APIGatewayClient({});
-  const { items, position: nextPosition } = await client.send(new GetRestApisCommand({ position, limit: 500 }));
+async function fetchApiGatewayAPIs(toast: Toast, maxResults = 500): Promise<RestApi[]> {
+  const client = getApiGatewayClient();
+  const apis: RestApi[] = [];
+  let position: string | undefined;
 
-  const filteredApis = items ?? [];
-  const agg = [...(aggregate ?? []), ...filteredApis];
+  do {
+    const { items, position: nextPosition } = await client.send(
+      new GetRestApisCommand({ position, limit: Math.min(maxResults - apis.length, 500) }),
+    );
 
-  toast.message = `${agg.length} APIs`;
+    if (items) {
+      apis.push(...items);
+    }
 
-  if (nextPosition) {
-    return await fetchApiGatewayAPIs(toast, nextPosition, agg);
-  }
+    toast.message = `${apis.length} APIs`;
+    position = nextPosition;
+  } while (position && apis.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded REST APIs";
-  toast.message = `${agg.length} APIs`;
-  return agg;
+  toast.message = `${apis.length} APIs`;
+  return apis;
 }
 
 /**
@@ -88,30 +98,28 @@ export function useApiGatewayResources(apiId: string) {
   return { resources, error, isLoading: (!resources && !error) || isLoading, revalidate };
 }
 
-async function fetchApiGatewayResources(
-  apiId: string,
-  toast: Toast,
-  position?: string,
-  aggregate?: Resource[],
-): Promise<Resource[]> {
-  const client = new APIGatewayClient({});
-  const { items, position: nextPosition } = await client.send(
-    new GetResourcesCommand({ restApiId: apiId, position, limit: 500 }),
-  );
+async function fetchApiGatewayResources(apiId: string, toast: Toast, maxResults = 500): Promise<Resource[]> {
+  const client = getApiGatewayClient();
+  const resources: Resource[] = [];
+  let position: string | undefined;
 
-  const filteredResources = items ?? [];
-  const agg = [...(aggregate ?? []), ...filteredResources];
+  do {
+    const { items, position: nextPosition } = await client.send(
+      new GetResourcesCommand({ restApiId: apiId, position, limit: Math.min(maxResults - resources.length, 500) }),
+    );
 
-  toast.message = `${agg.length} resources`;
+    if (items) {
+      resources.push(...items);
+    }
 
-  if (nextPosition) {
-    return await fetchApiGatewayResources(apiId, toast, nextPosition, agg);
-  }
+    toast.message = `${resources.length} resources`;
+    position = nextPosition;
+  } while (position && resources.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded resources";
-  toast.message = `${agg.length} resources`;
-  return agg;
+  toast.message = `${resources.length} resources`;
+  return resources;
 }
 
 /**
@@ -136,7 +144,7 @@ export function useApiGatewayStages(apiId: string) {
 }
 
 async function fetchApiGatewayStages(apiId: string, toast: Toast): Promise<Stage[]> {
-  const client = new APIGatewayClient({});
+  const client = getApiGatewayClient();
   const { item: stages } = await client.send(new GetStagesCommand({ restApiId: apiId }));
 
   const filteredStages = stages ?? [];
@@ -168,23 +176,28 @@ export function useApiGatewayApiKeys() {
   return { apiKeys, error, isLoading: (!apiKeys && !error) || isLoading, revalidate };
 }
 
-async function fetchApiGatewayApiKeys(toast: Toast, position?: string, aggregate?: ApiKey[]): Promise<ApiKey[]> {
-  const client = new APIGatewayClient({});
-  const { items, position: nextPosition } = await client.send(new GetApiKeysCommand({ position, limit: 500 }));
+async function fetchApiGatewayApiKeys(toast: Toast, maxResults = 500): Promise<ApiKey[]> {
+  const client = getApiGatewayClient();
+  const apiKeys: ApiKey[] = [];
+  let position: string | undefined;
 
-  const filteredApiKeys = items ?? [];
-  const agg = [...(aggregate ?? []), ...filteredApiKeys];
+  do {
+    const { items, position: nextPosition } = await client.send(
+      new GetApiKeysCommand({ position, limit: Math.min(maxResults - apiKeys.length, 500) }),
+    );
 
-  toast.message = `${agg.length} API keys`;
+    if (items) {
+      apiKeys.push(...items);
+    }
 
-  if (nextPosition) {
-    return await fetchApiGatewayApiKeys(toast, nextPosition, agg);
-  }
+    toast.message = `${apiKeys.length} API keys`;
+    position = nextPosition;
+  } while (position && apiKeys.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded API keys";
-  toast.message = `${agg.length} API keys`;
-  return agg;
+  toast.message = `${apiKeys.length} API keys`;
+  return apiKeys;
 }
 
 /**
@@ -208,27 +221,28 @@ export function useApiGatewayUsagePlans() {
   return { usagePlans, error, isLoading: (!usagePlans && !error) || isLoading, revalidate };
 }
 
-async function fetchApiGatewayUsagePlans(
-  toast: Toast,
-  position?: string,
-  aggregate?: UsagePlan[],
-): Promise<UsagePlan[]> {
-  const client = new APIGatewayClient({});
-  const { items, position: nextPosition } = await client.send(new GetUsagePlansCommand({ position, limit: 500 }));
+async function fetchApiGatewayUsagePlans(toast: Toast, maxResults = 500): Promise<UsagePlan[]> {
+  const client = getApiGatewayClient();
+  const usagePlans: UsagePlan[] = [];
+  let position: string | undefined;
 
-  const filteredUsagePlans = items ?? [];
-  const agg = [...(aggregate ?? []), ...filteredUsagePlans];
+  do {
+    const { items, position: nextPosition } = await client.send(
+      new GetUsagePlansCommand({ position, limit: Math.min(maxResults - usagePlans.length, 500) }),
+    );
 
-  toast.message = `${agg.length} usage plans`;
+    if (items) {
+      usagePlans.push(...items);
+    }
 
-  if (nextPosition) {
-    return await fetchApiGatewayUsagePlans(toast, nextPosition, agg);
-  }
+    toast.message = `${usagePlans.length} usage plans`;
+    position = nextPosition;
+  } while (position && usagePlans.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded usage plans";
-  toast.message = `${agg.length} usage plans`;
-  return agg;
+  toast.message = `${usagePlans.length} usage plans`;
+  return usagePlans;
 }
 
 /**
@@ -241,7 +255,7 @@ export function useApiGatewayMethod(apiId: string, resourceId: string, httpMetho
     isLoading,
   } = useCachedPromise(
     async (restApiId: string, resId: string, method: string) => {
-      const client = new APIGatewayClient({});
+      const client = getApiGatewayClient();
       const response = await client.send(
         new GetMethodCommand({
           restApiId,
@@ -282,23 +296,28 @@ export function useHttpAPIs() {
   return { apis, error, isLoading: (!apis && !error) || isLoading, revalidate };
 }
 
-async function fetchHttpAPIs(toast: Toast, nextToken?: string, aggregate?: Api[]): Promise<Api[]> {
-  const client = new ApiGatewayV2Client({});
-  const { Items, NextToken } = await client.send(new GetApisCommand({ NextToken: nextToken, MaxResults: "100" }));
+async function fetchHttpAPIs(toast: Toast, maxResults = 500): Promise<Api[]> {
+  const client = getApiGatewayV2Client();
+  const apis: Api[] = [];
+  let nextToken: string | undefined;
 
-  const filteredApis = Items ?? [];
-  const agg = [...(aggregate ?? []), ...filteredApis];
+  do {
+    const { Items, NextToken } = await client.send(
+      new GetApisCommand({ NextToken: nextToken, MaxResults: String(Math.min(maxResults - apis.length, 100)) }),
+    );
 
-  toast.message = `${agg.length} HTTP APIs`;
+    if (Items) {
+      apis.push(...Items);
+    }
 
-  if (NextToken) {
-    return await fetchHttpAPIs(toast, NextToken, agg);
-  }
+    toast.message = `${apis.length} HTTP APIs`;
+    nextToken = NextToken;
+  } while (nextToken && apis.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded HTTP APIs";
-  toast.message = `${agg.length} HTTP APIs`;
-  return agg;
+  toast.message = `${apis.length} HTTP APIs`;
+  return apis;
 }
 
 /**
@@ -322,30 +341,28 @@ export function useApiGatewayDeployments(apiId: string) {
   return { deployments, error, isLoading: (!deployments && !error) || isLoading, revalidate };
 }
 
-async function fetchApiGatewayDeployments(
-  apiId: string,
-  toast: Toast,
-  position?: string,
-  aggregate?: Deployment[],
-): Promise<Deployment[]> {
-  const client = new APIGatewayClient({});
-  const { items, position: nextPosition } = await client.send(
-    new GetDeploymentsCommand({ restApiId: apiId, position, limit: 500 }),
-  );
+async function fetchApiGatewayDeployments(apiId: string, toast: Toast, maxResults = 500): Promise<Deployment[]> {
+  const client = getApiGatewayClient();
+  const deployments: Deployment[] = [];
+  let position: string | undefined;
 
-  const filteredDeployments = items ?? [];
-  const agg = [...(aggregate ?? []), ...filteredDeployments];
+  do {
+    const { items, position: nextPosition } = await client.send(
+      new GetDeploymentsCommand({ restApiId: apiId, position, limit: Math.min(maxResults - deployments.length, 500) }),
+    );
 
-  toast.message = `${agg.length} deployments`;
+    if (items) {
+      deployments.push(...items);
+    }
 
-  if (nextPosition) {
-    return await fetchApiGatewayDeployments(apiId, toast, nextPosition, agg);
-  }
+    toast.message = `${deployments.length} deployments`;
+    position = nextPosition;
+  } while (position && deployments.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded deployments";
-  toast.message = `${agg.length} deployments`;
-  return agg;
+  toast.message = `${deployments.length} deployments`;
+  return deployments;
 }
 
 /**
@@ -369,30 +386,32 @@ export function useHttpApiRoutes(apiId: string) {
   return { routes, error, isLoading: (!routes && !error) || isLoading, revalidate };
 }
 
-async function fetchHttpApiRoutes(
-  apiId: string,
-  toast: Toast,
-  nextToken?: string,
-  aggregate?: Route[],
-): Promise<Route[]> {
-  const client = new ApiGatewayV2Client({});
-  const { Items, NextToken } = await client.send(
-    new GetRoutesCommand({ ApiId: apiId, NextToken: nextToken, MaxResults: "100" }),
-  );
+async function fetchHttpApiRoutes(apiId: string, toast: Toast, maxResults = 500): Promise<Route[]> {
+  const client = getApiGatewayV2Client();
+  const routes: Route[] = [];
+  let nextToken: string | undefined;
 
-  const filteredRoutes = Items ?? [];
-  const agg = [...(aggregate ?? []), ...filteredRoutes];
+  do {
+    const { Items, NextToken } = await client.send(
+      new GetRoutesCommand({
+        ApiId: apiId,
+        NextToken: nextToken,
+        MaxResults: String(Math.min(maxResults - routes.length, 100)),
+      }),
+    );
 
-  toast.message = `${agg.length} routes`;
+    if (Items) {
+      routes.push(...Items);
+    }
 
-  if (NextToken) {
-    return await fetchHttpApiRoutes(apiId, toast, NextToken, agg);
-  }
+    toast.message = `${routes.length} routes`;
+    nextToken = NextToken;
+  } while (nextToken && routes.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded routes";
-  toast.message = `${agg.length} routes`;
-  return agg;
+  toast.message = `${routes.length} routes`;
+  return routes;
 }
 
 /**
@@ -416,28 +435,176 @@ export function useHttpApiStages(apiId: string) {
   return { stages, error, isLoading: (!stages && !error) || isLoading, revalidate };
 }
 
-async function fetchHttpApiStages(
-  apiId: string,
-  toast: Toast,
-  nextToken?: string,
-  aggregate?: StageV2[],
-): Promise<StageV2[]> {
-  const client = new ApiGatewayV2Client({});
-  const { Items, NextToken } = await client.send(
-    new GetStagesV2Command({ ApiId: apiId, NextToken: nextToken, MaxResults: "100" }),
-  );
+async function fetchHttpApiStages(apiId: string, toast: Toast, maxResults = 500): Promise<StageV2[]> {
+  const client = getApiGatewayV2Client();
+  const stages: StageV2[] = [];
+  let nextToken: string | undefined;
 
-  const filteredStages = Items ?? [];
-  const agg = [...(aggregate ?? []), ...filteredStages];
+  do {
+    const { Items, NextToken } = await client.send(
+      new GetStagesV2Command({
+        ApiId: apiId,
+        NextToken: nextToken,
+        MaxResults: String(Math.min(maxResults - stages.length, 100)),
+      }),
+    );
 
-  toast.message = `${agg.length} stages`;
+    if (Items) {
+      stages.push(...Items);
+    }
 
-  if (NextToken) {
-    return await fetchHttpApiStages(apiId, toast, NextToken, agg);
-  }
+    toast.message = `${stages.length} stages`;
+    nextToken = NextToken;
+  } while (nextToken && stages.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded stages";
-  toast.message = `${agg.length} stages`;
-  return agg;
+  toast.message = `${stages.length} stages`;
+  return stages;
+}
+
+/**
+ * Hook to fetch authorizers for a specific API Gateway REST API
+ */
+export function useApiGatewayAuthorizers(apiId: string) {
+  const {
+    data: authorizers,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async (id: string) => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading authorizers" });
+      return await fetchApiGatewayAuthorizers(id, toast);
+    },
+    [apiId],
+    { execute: isReadyToFetch() && !!apiId, failureToastOptions: { title: "❌ Failed to load authorizers" } },
+  );
+
+  return { authorizers, error, isLoading: (!authorizers && !error) || isLoading, revalidate };
+}
+
+async function fetchApiGatewayAuthorizers(apiId: string, toast: Toast, maxResults = 500): Promise<Authorizer[]> {
+  const client = getApiGatewayClient();
+  const authorizers: Authorizer[] = [];
+  let position: string | undefined;
+
+  do {
+    const { items, position: nextPosition } = await client.send(
+      new GetAuthorizersCommand({
+        restApiId: apiId,
+        position,
+        limit: Math.min(maxResults - authorizers.length, 500),
+      }),
+    );
+
+    if (items) {
+      authorizers.push(...items);
+    }
+
+    toast.message = `${authorizers.length} authorizers`;
+    position = nextPosition;
+  } while (position && authorizers.length < maxResults);
+
+  toast.style = Toast.Style.Success;
+  toast.title = "✅ Loaded authorizers";
+  toast.message = `${authorizers.length} authorizers`;
+  return authorizers;
+}
+
+/**
+ * Hook to fetch custom domain names for API Gateway
+ */
+export function useApiGatewayDomainNames() {
+  const {
+    data: domainNames,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async () => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading domain names" });
+      return await fetchApiGatewayDomainNames(toast);
+    },
+    [],
+    { execute: isReadyToFetch(), failureToastOptions: { title: "❌ Failed to load domain names" } },
+  );
+
+  return { domainNames, error, isLoading: (!domainNames && !error) || isLoading, revalidate };
+}
+
+async function fetchApiGatewayDomainNames(toast: Toast, maxResults = 500): Promise<DomainName[]> {
+  const client = getApiGatewayClient();
+  const domainNames: DomainName[] = [];
+  let position: string | undefined;
+
+  do {
+    const { items, position: nextPosition } = await client.send(
+      new GetDomainNamesCommand({ position, limit: Math.min(maxResults - domainNames.length, 500) }),
+    );
+
+    if (items) {
+      domainNames.push(...items);
+    }
+
+    toast.message = `${domainNames.length} domain names`;
+    position = nextPosition;
+  } while (position && domainNames.length < maxResults);
+
+  toast.style = Toast.Style.Success;
+  toast.title = "✅ Loaded domain names";
+  toast.message = `${domainNames.length} domain names`;
+  return domainNames;
+}
+
+/**
+ * Hook to fetch base path mappings for a custom domain
+ */
+export function useApiGatewayBasePathMappings(domainName: string) {
+  const {
+    data: basePathMappings,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async (domain: string) => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading base path mappings" });
+      return await fetchApiGatewayBasePathMappings(domain, toast);
+    },
+    [domainName],
+    {
+      execute: isReadyToFetch() && !!domainName,
+      failureToastOptions: { title: "❌ Failed to load base path mappings" },
+    },
+  );
+
+  return { basePathMappings, error, isLoading: (!basePathMappings && !error) || isLoading, revalidate };
+}
+
+async function fetchApiGatewayBasePathMappings(
+  domainName: string,
+  toast: Toast,
+  maxResults = 500,
+): Promise<BasePathMapping[]> {
+  const client = getApiGatewayClient();
+  const mappings: BasePathMapping[] = [];
+  let position: string | undefined;
+
+  do {
+    const { items, position: nextPosition } = await client.send(
+      new GetBasePathMappingsCommand({ domainName, position, limit: Math.min(maxResults - mappings.length, 500) }),
+    );
+
+    if (items) {
+      mappings.push(...items);
+    }
+
+    toast.message = `${mappings.length} mappings`;
+    position = nextPosition;
+  } while (position && mappings.length < maxResults);
+
+  toast.style = Toast.Style.Success;
+  toast.title = "✅ Loaded base path mappings";
+  toast.message = `${mappings.length} mappings`;
+  return mappings;
 }

--- a/extensions/amazon-aws/src/hooks/use-appsync.ts
+++ b/extensions/amazon-aws/src/hooks/use-appsync.ts
@@ -1,5 +1,4 @@
 import {
-  AppSyncClient,
   GraphqlApi,
   DataSource,
   Resolver,
@@ -16,6 +15,7 @@ import {
 import { showToast, Toast } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { isReadyToFetch } from "../util";
+import { getAppSyncClient } from "../services/clients/appsync";
 
 /**
  * Hook to fetch and manage AppSync GraphQL APIs
@@ -38,23 +38,26 @@ export function useAppSyncAPIs() {
   return { apis, error, isLoading: (!apis && !error) || isLoading, revalidate };
 }
 
-async function fetchAppSyncAPIs(toast: Toast, nextToken?: string, aggregate?: GraphqlApi[]): Promise<GraphqlApi[]> {
-  const client = new AppSyncClient({});
-  const { graphqlApis, nextToken: cursor } = await client.send(new ListGraphqlApisCommand({ nextToken }));
+async function fetchAppSyncAPIs(toast: Toast, maxResults = 100): Promise<GraphqlApi[]> {
+  const client = getAppSyncClient();
+  const apis: GraphqlApi[] = [];
+  let nextToken: string | undefined;
 
-  const filteredApis = graphqlApis ?? [];
-  const agg = [...(aggregate ?? []), ...filteredApis];
+  do {
+    const { graphqlApis, nextToken: cursor } = await client.send(new ListGraphqlApisCommand({ nextToken }));
 
-  toast.message = `${agg.length} APIs`;
+    if (graphqlApis) {
+      apis.push(...graphqlApis);
+    }
 
-  if (cursor) {
-    return await fetchAppSyncAPIs(toast, cursor, agg);
-  }
+    toast.message = `${apis.length} APIs`;
+    nextToken = cursor;
+  } while (nextToken && apis.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded GraphQL APIs";
-  toast.message = `${agg.length} APIs`;
-  return agg;
+  toast.message = `${apis.length} APIs`;
+  return apis;
 }
 
 /**
@@ -78,28 +81,28 @@ export function useAppSyncDataSources(apiId: string) {
   return { dataSources, error, isLoading: (!dataSources && !error) || isLoading, revalidate };
 }
 
-async function fetchAppSyncDataSources(
-  apiId: string,
-  toast: Toast,
-  nextToken?: string,
-  aggregate?: DataSource[],
-): Promise<DataSource[]> {
-  const client = new AppSyncClient({});
-  const { dataSources, nextToken: cursor } = await client.send(new ListDataSourcesCommand({ apiId, nextToken }));
+async function fetchAppSyncDataSources(apiId: string, toast: Toast, maxResults = 100): Promise<DataSource[]> {
+  const client = getAppSyncClient();
+  const dataSources: DataSource[] = [];
+  let nextToken: string | undefined;
 
-  const filteredDataSources = dataSources ?? [];
-  const agg = [...(aggregate ?? []), ...filteredDataSources];
+  do {
+    const { dataSources: dataSourceList, nextToken: cursor } = await client.send(
+      new ListDataSourcesCommand({ apiId, nextToken }),
+    );
 
-  toast.message = `${agg.length} data sources`;
+    if (dataSourceList) {
+      dataSources.push(...dataSourceList);
+    }
 
-  if (cursor) {
-    return await fetchAppSyncDataSources(apiId, toast, cursor, agg);
-  }
+    toast.message = `${dataSources.length} data sources`;
+    nextToken = cursor;
+  } while (nextToken && dataSources.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded data sources";
-  toast.message = `${agg.length} data sources`;
-  return agg;
+  toast.message = `${dataSources.length} data sources`;
+  return dataSources;
 }
 
 /**
@@ -134,9 +137,8 @@ async function fetchAllResolvers(apiId: string, toast: Toast): Promise<Resolver[
     try {
       const resolversForType = await fetchResolversForType(apiId, typeName, toast);
       allResolvers.push(...resolversForType);
-    } catch (error) {
-      // Type might not exist, continue with others
-      console.log(`No ${typeName} type found`);
+    } catch {
+      // Type might not exist in this API, continue with other types
     }
   }
 
@@ -150,30 +152,31 @@ async function fetchResolversForType(
   apiId: string,
   typeName: string,
   toast: Toast,
-  nextToken?: string,
-  aggregate?: Resolver[],
+  maxResults = 100,
 ): Promise<Resolver[]> {
-  const client = new AppSyncClient({});
+  const client = getAppSyncClient();
+  const resolvers: Resolver[] = [];
+  let nextToken: string | undefined;
 
-  const { resolvers, nextToken: cursor } = await client.send(
-    new ListResolversCommand({
-      apiId,
-      typeName,
-      nextToken,
-      maxResults: 25,
-    }),
-  );
+  do {
+    const { resolvers: resolverList, nextToken: cursor } = await client.send(
+      new ListResolversCommand({
+        apiId,
+        typeName,
+        nextToken,
+        maxResults: Math.min(maxResults - resolvers.length, 25),
+      }),
+    );
 
-  const filteredResolvers = resolvers ?? [];
-  const agg = [...(aggregate ?? []), ...filteredResolvers];
+    if (resolverList) {
+      resolvers.push(...resolverList);
+    }
 
-  toast.message = `Loading ${typeName} resolvers... ${agg.length} found`;
+    toast.message = `Loading ${typeName} resolvers... ${resolvers.length} found`;
+    nextToken = cursor;
+  } while (nextToken && resolvers.length < maxResults);
 
-  if (cursor) {
-    return await fetchResolversForType(apiId, typeName, toast, cursor, agg);
-  }
-
-  return agg;
+  return resolvers;
 }
 
 /**
@@ -197,28 +200,26 @@ export function useAppSyncApiKeys(apiId: string) {
   return { apiKeys, error, isLoading: (!apiKeys && !error) || isLoading, revalidate };
 }
 
-async function fetchAppSyncApiKeys(
-  apiId: string,
-  toast: Toast,
-  nextToken?: string,
-  aggregate?: ApiKey[],
-): Promise<ApiKey[]> {
-  const client = new AppSyncClient({});
-  const { apiKeys, nextToken: cursor } = await client.send(new ListApiKeysCommand({ apiId, nextToken }));
+async function fetchAppSyncApiKeys(apiId: string, toast: Toast, maxResults = 100): Promise<ApiKey[]> {
+  const client = getAppSyncClient();
+  const apiKeys: ApiKey[] = [];
+  let nextToken: string | undefined;
 
-  const filteredApiKeys = apiKeys ?? [];
-  const agg = [...(aggregate ?? []), ...filteredApiKeys];
+  do {
+    const { apiKeys: apiKeyList, nextToken: cursor } = await client.send(new ListApiKeysCommand({ apiId, nextToken }));
 
-  toast.message = `${agg.length} API keys`;
+    if (apiKeyList) {
+      apiKeys.push(...apiKeyList);
+    }
 
-  if (cursor) {
-    return await fetchAppSyncApiKeys(apiId, toast, cursor, agg);
-  }
+    toast.message = `${apiKeys.length} API keys`;
+    nextToken = cursor;
+  } while (nextToken && apiKeys.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded API keys";
-  toast.message = `${agg.length} API keys`;
-  return agg;
+  toast.message = `${apiKeys.length} API keys`;
+  return apiKeys;
 }
 
 /**
@@ -231,7 +232,7 @@ export function useAppSyncApiDetails(apiId: string) {
     isLoading,
   } = useCachedPromise(
     async (id: string) => {
-      const client = new AppSyncClient({});
+      const client = getAppSyncClient();
       const { graphqlApi } = await client.send(new GetGraphqlApiCommand({ apiId: id }));
       return graphqlApi;
     },
@@ -252,7 +253,7 @@ export function useAppSyncSchema(apiId: string, format: "SDL" | "JSON" = "SDL") 
     isLoading,
   } = useCachedPromise(
     async (id: string, schemaFormat: "SDL" | "JSON") => {
-      const client = new AppSyncClient({});
+      const client = getAppSyncClient();
       const { schema } = await client.send(new GetIntrospectionSchemaCommand({ apiId: id, format: schemaFormat }));
       return schema;
     },
@@ -284,26 +285,26 @@ export function useAppSyncFunctions(apiId: string) {
   return { functions, error, isLoading: (!functions && !error) || isLoading, revalidate };
 }
 
-async function fetchAppSyncFunctions(
-  apiId: string,
-  toast: Toast,
-  nextToken?: string,
-  aggregate?: FunctionConfiguration[],
-): Promise<FunctionConfiguration[]> {
-  const client = new AppSyncClient({});
-  const { functions, nextToken: cursor } = await client.send(new ListFunctionsCommand({ apiId, nextToken }));
+async function fetchAppSyncFunctions(apiId: string, toast: Toast, maxResults = 100): Promise<FunctionConfiguration[]> {
+  const client = getAppSyncClient();
+  const functions: FunctionConfiguration[] = [];
+  let nextToken: string | undefined;
 
-  const filteredFunctions = functions ?? [];
-  const agg = [...(aggregate ?? []), ...filteredFunctions];
+  do {
+    const { functions: functionList, nextToken: cursor } = await client.send(
+      new ListFunctionsCommand({ apiId, nextToken }),
+    );
 
-  toast.message = `${agg.length} functions`;
+    if (functionList) {
+      functions.push(...functionList);
+    }
 
-  if (cursor) {
-    return await fetchAppSyncFunctions(apiId, toast, cursor, agg);
-  }
+    toast.message = `${functions.length} functions`;
+    nextToken = cursor;
+  } while (nextToken && functions.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded functions";
-  toast.message = `${agg.length} functions`;
-  return agg;
+  toast.message = `${functions.length} functions`;
+  return functions;
 }

--- a/extensions/amazon-aws/src/hooks/use-athena.ts
+++ b/extensions/amazon-aws/src/hooks/use-athena.ts
@@ -1,0 +1,170 @@
+import { useCachedPromise } from "@raycast/utils";
+import { isReadyToFetch } from "../util";
+import {
+  ListWorkGroupsCommand,
+  ListNamedQueriesCommand,
+  ListQueryExecutionsCommand,
+  BatchGetNamedQueryCommand,
+  BatchGetQueryExecutionCommand,
+  WorkGroupSummary,
+  NamedQuery,
+  QueryExecution,
+} from "@aws-sdk/client-athena";
+import { showToast, Toast } from "@raycast/api";
+import { getAthenaClient } from "../services/clients/athena";
+
+export const useAthenaWorkGroups = () => {
+  const {
+    data: workGroups,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async () => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading work groups" });
+      return await fetchWorkGroups(toast);
+    },
+    [],
+    { execute: isReadyToFetch(), failureToastOptions: { title: "❌Failed to load work groups" } },
+  );
+
+  return { workGroups, error, isLoading: (!workGroups && !error) || isLoading, revalidate };
+};
+
+export const useAthenaNamedQueries = () => {
+  const {
+    data: namedQueries,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async () => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading named queries" });
+      return await fetchNamedQueries(toast);
+    },
+    [],
+    { execute: isReadyToFetch(), failureToastOptions: { title: "❌Failed to load named queries" } },
+  );
+
+  return { namedQueries, error, isLoading: (!namedQueries && !error) || isLoading, revalidate };
+};
+
+export const useAthenaQueryExecutions = () => {
+  const {
+    data: queryExecutions,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async () => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading query executions" });
+      return await fetchQueryExecutions(toast);
+    },
+    [],
+    { execute: isReadyToFetch(), failureToastOptions: { title: "❌Failed to load query executions" } },
+  );
+
+  return { queryExecutions, error, isLoading: (!queryExecutions && !error) || isLoading, revalidate };
+};
+
+async function fetchWorkGroups(toast: Toast, maxResults = 100): Promise<WorkGroupSummary[]> {
+  const client = getAthenaClient();
+  const allWorkGroups: WorkGroupSummary[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const { WorkGroups, NextToken } = await client.send(
+      new ListWorkGroupsCommand({
+        NextToken: nextToken,
+        MaxResults: Math.min(maxResults - allWorkGroups.length, 50),
+      }),
+    );
+
+    allWorkGroups.push(...(WorkGroups ?? []));
+    toast.message = `${allWorkGroups.length} work groups`;
+    nextToken = NextToken;
+  } while (nextToken && allWorkGroups.length < maxResults);
+
+  toast.style = Toast.Style.Success;
+  toast.title = "✅ Loaded work groups";
+  toast.message = `${allWorkGroups.length} work groups`;
+  return allWorkGroups;
+}
+
+async function fetchNamedQueries(toast: Toast, maxResults = 100): Promise<NamedQuery[]> {
+  const client = getAthenaClient();
+  const allQueryIds: string[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const { NamedQueryIds, NextToken } = await client.send(
+      new ListNamedQueriesCommand({
+        NextToken: nextToken,
+        MaxResults: Math.min(maxResults - allQueryIds.length, 50),
+      }),
+    );
+
+    allQueryIds.push(...(NamedQueryIds ?? []));
+    toast.message = `${allQueryIds.length} query IDs`;
+    nextToken = NextToken;
+  } while (nextToken && allQueryIds.length < maxResults);
+
+  if (allQueryIds.length === 0) {
+    toast.style = Toast.Style.Success;
+    toast.title = "✅ Loaded named queries";
+    toast.message = "0 named queries";
+    return [];
+  }
+
+  const allNamedQueries: NamedQuery[] = [];
+  for (let i = 0; i < allQueryIds.length; i += 50) {
+    const batch = allQueryIds.slice(i, i + 50);
+    const { NamedQueries } = await client.send(new BatchGetNamedQueryCommand({ NamedQueryIds: batch }));
+    allNamedQueries.push(...(NamedQueries ?? []));
+    toast.message = `${allNamedQueries.length} named queries`;
+  }
+
+  toast.style = Toast.Style.Success;
+  toast.title = "✅ Loaded named queries";
+  toast.message = `${allNamedQueries.length} named queries`;
+  return allNamedQueries;
+}
+
+async function fetchQueryExecutions(toast: Toast, maxResults = 50): Promise<QueryExecution[]> {
+  const client = getAthenaClient();
+  const allExecutionIds: string[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const { QueryExecutionIds, NextToken } = await client.send(
+      new ListQueryExecutionsCommand({
+        NextToken: nextToken,
+        MaxResults: Math.min(maxResults - allExecutionIds.length, 50),
+      }),
+    );
+
+    allExecutionIds.push(...(QueryExecutionIds ?? []));
+    toast.message = `${allExecutionIds.length} execution IDs`;
+    nextToken = NextToken;
+  } while (nextToken && allExecutionIds.length < maxResults);
+
+  if (allExecutionIds.length === 0) {
+    toast.style = Toast.Style.Success;
+    toast.title = "✅ Loaded query executions";
+    toast.message = "0 query executions";
+    return [];
+  }
+
+  const allExecutions: QueryExecution[] = [];
+  for (let i = 0; i < allExecutionIds.length; i += 50) {
+    const batch = allExecutionIds.slice(i, i + 50);
+    const { QueryExecutions } = await client.send(new BatchGetQueryExecutionCommand({ QueryExecutionIds: batch }));
+    allExecutions.push(...(QueryExecutions ?? []));
+    toast.message = `${allExecutions.length} query executions`;
+  }
+
+  toast.style = Toast.Style.Success;
+  toast.title = "✅ Loaded query executions";
+  toast.message = `${allExecutions.length} query executions`;
+  return allExecutions;
+}

--- a/extensions/amazon-aws/src/hooks/use-cfn.ts
+++ b/extensions/amazon-aws/src/hooks/use-cfn.ts
@@ -1,7 +1,6 @@
 import { useCachedPromise } from "@raycast/utils";
 import { isReadyToFetch } from "../util";
 import {
-  CloudFormationClient,
   Export,
   ListExportsCommand,
   ListStackResourcesCommand,
@@ -10,6 +9,7 @@ import {
   StackSummary,
 } from "@aws-sdk/client-cloudformation";
 import { showToast, Toast } from "@raycast/api";
+import { getCloudFormationClient } from "../services/clients/cloudformation";
 
 export const useStacks = () => {
   const {
@@ -29,24 +29,27 @@ export const useStacks = () => {
   return { stacks, error, isLoading: (!stacks && !error) || isLoading, mutate };
 };
 
-const fetchStacks = async (toast: Toast, nextToken?: string, aggregate?: StackSummary[]): Promise<StackSummary[]> => {
-  const { NextToken: cursor, StackSummaries } = await new CloudFormationClient({}).send(
-    new ListStacksCommand({ NextToken: nextToken }),
-  );
+async function fetchStacks(toast: Toast, maxResults = 500): Promise<StackSummary[]> {
+  const stacks: StackSummary[] = [];
+  let nextToken: string | undefined;
 
-  const stacks = (StackSummaries ?? []).filter((s) => s.StackStatus !== "DELETE_COMPLETE");
+  do {
+    const { NextToken: cursor, StackSummaries } = await getCloudFormationClient().send(
+      new ListStacksCommand({ NextToken: nextToken }),
+    );
 
-  const agg = [...(aggregate ?? []), ...stacks];
-  toast.message = `${agg.length} stacks`;
-  if (cursor) {
-    return await fetchStacks(toast, cursor, agg);
-  }
+    const filteredStacks = (StackSummaries ?? []).filter((s) => s.StackStatus !== "DELETE_COMPLETE");
+    stacks.push(...filteredStacks);
+
+    toast.message = `${stacks.length} stacks`;
+    nextToken = cursor;
+  } while (nextToken && stacks.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded stacks";
-  toast.message = `${agg.length} stacks`;
-  return agg;
-};
+  toast.message = `${stacks.length} stacks`;
+  return stacks;
+}
 
 export const useExports = () => {
   const {
@@ -66,24 +69,27 @@ export const useExports = () => {
   return { exports, error, isLoading: (!exports && !error) || isLoading, mutate };
 };
 
-const fetchExports = async (toast: Toast, nextToken?: string, aggregate?: Export[]): Promise<Export[]> => {
-  const { NextToken: cursor, Exports } = await new CloudFormationClient({}).send(
-    new ListExportsCommand({ NextToken: nextToken }),
-  );
+async function fetchExports(toast: Toast, maxResults = 500): Promise<Export[]> {
+  const exports: Export[] = [];
+  let nextToken: string | undefined;
 
-  const exports = (Exports ?? []).filter((e) => e.Name && e.Value);
+  do {
+    const { NextToken: cursor, Exports } = await getCloudFormationClient().send(
+      new ListExportsCommand({ NextToken: nextToken }),
+    );
 
-  const agg = [...(aggregate ?? []), ...exports];
-  toast.message = `${agg.length} exports`;
-  if (cursor) {
-    return await fetchExports(toast, cursor, agg);
-  }
+    const filteredExports = (Exports ?? []).filter((e) => e.Name && e.Value);
+    exports.push(...filteredExports);
+
+    toast.message = `${exports.length} exports`;
+    nextToken = cursor;
+  } while (nextToken && exports.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded exports";
-  toast.message = `${agg.length} exports`;
-  return agg;
-};
+  toast.message = `${exports.length} exports`;
+  return exports;
+}
 
 export const useStackResources = (stackName: string) => {
   const {
@@ -102,26 +108,24 @@ export const useStackResources = (stackName: string) => {
   return { resources, error, isLoading: (!resources && !error) || isLoading };
 };
 
-const fetchStackResources = async (
-  stack: string,
-  toast: Toast,
-  nextToken?: string,
-  aggregate?: StackResourceSummary[],
-): Promise<StackResourceSummary[]> => {
-  const { NextToken: cursor, StackResourceSummaries } = await new CloudFormationClient({}).send(
-    new ListStackResourcesCommand({ NextToken: nextToken, StackName: stack }),
-  );
+async function fetchStackResources(stack: string, toast: Toast, maxResults = 500): Promise<StackResourceSummary[]> {
+  const resources: StackResourceSummary[] = [];
+  let nextToken: string | undefined;
 
-  const resources = (StackResourceSummaries ?? []).filter((r) => r.PhysicalResourceId);
+  do {
+    const { NextToken: cursor, StackResourceSummaries } = await getCloudFormationClient().send(
+      new ListStackResourcesCommand({ NextToken: nextToken, StackName: stack }),
+    );
 
-  const agg = [...(aggregate ?? []), ...resources];
-  toast.message = `${agg.length} resource`;
-  if (cursor) {
-    return await fetchStackResources(stack, toast, cursor, agg);
-  }
+    const filteredResources = (StackResourceSummaries ?? []).filter((r) => r.PhysicalResourceId);
+    resources.push(...filteredResources);
+
+    toast.message = `${resources.length} resources`;
+    nextToken = cursor;
+  } while (nextToken && resources.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded resources";
-  toast.message = `${agg.length} resources`;
-  return agg;
-};
+  toast.message = `${resources.length} resources`;
+  return resources;
+}

--- a/extensions/amazon-aws/src/hooks/use-cloudwatch-dashboards.ts
+++ b/extensions/amazon-aws/src/hooks/use-cloudwatch-dashboards.ts
@@ -1,0 +1,38 @@
+import { useCachedPromise } from "@raycast/utils";
+import { DashboardEntry, ListDashboardsCommand } from "@aws-sdk/client-cloudwatch";
+import { getCloudWatchClient } from "../services/clients/cloudwatch";
+import { isReadyToFetch } from "../util";
+
+async function fetchAllDashboards(maxResults = 500): Promise<DashboardEntry[]> {
+  const dashboards: DashboardEntry[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const { DashboardEntries: entries, NextToken: cursor } = await getCloudWatchClient().send(
+      new ListDashboardsCommand({
+        NextToken: nextToken,
+      }),
+    );
+
+    const validEntries = (entries ?? []).filter((entry) => !!entry.DashboardName && !!entry.DashboardArn);
+
+    dashboards.push(...validEntries);
+    nextToken = cursor;
+  } while (nextToken && dashboards.length < maxResults);
+
+  return dashboards;
+}
+
+export function useDashboards() {
+  const {
+    data: dashboards,
+    mutate,
+    error,
+    isLoading,
+  } = useCachedPromise(fetchAllDashboards, [], {
+    execute: isReadyToFetch(),
+    failureToastOptions: { title: "Failed to load dashboards" },
+  });
+
+  return { dashboards, error, isLoading: (!dashboards && !error) || isLoading, mutate };
+}

--- a/extensions/amazon-aws/src/hooks/use-codepipeline.ts
+++ b/extensions/amazon-aws/src/hooks/use-codepipeline.ts
@@ -1,13 +1,13 @@
 import { useCachedPromise } from "@raycast/utils";
 import { isReadyToFetch } from "../util";
 import {
-  CodePipelineClient,
   GetPipelineStateCommand,
   ListPipelineExecutionsCommand,
   ListPipelinesCommand,
 } from "@aws-sdk/client-codepipeline";
 import { Pipeline, PipelineStage } from "../codepipeline";
 import { showToast, Toast } from "@raycast/api";
+import { getCodePipelineClient } from "../services/clients/codepipeline";
 
 export const usePipelines = () => {
   const {
@@ -35,7 +35,7 @@ export const usePipelineState = (pipelineName: string) => {
     mutate,
   } = useCachedPromise(
     async (name: string) => {
-      const { stageStates } = await new CodePipelineClient({}).send(new GetPipelineStateCommand({ name }));
+      const { stageStates } = await getCodePipelineClient().send(new GetPipelineStateCommand({ name }));
       const definedStages = (stageStates ?? []).filter((s) => !!s.stageName);
       return definedStages.map((s, i) => {
         let nextStage = undefined;
@@ -60,7 +60,7 @@ export const usePipelineExecutions = (pipelineName: string) => {
     mutate,
   } = useCachedPromise(
     async (name: string) => {
-      const { pipelineExecutionSummaries } = await new CodePipelineClient({}).send(
+      const { pipelineExecutionSummaries } = await getCodePipelineClient().send(
         new ListPipelineExecutionsCommand({ pipelineName: name }),
       );
       return (pipelineExecutionSummaries ?? []).filter((e) => !!e.pipelineExecutionId);
@@ -72,32 +72,35 @@ export const usePipelineExecutions = (pipelineName: string) => {
   return { executions, isLoading: (!executions && !error) || isLoading, mutate };
 };
 
-const fetchPipelines = async (toast: Toast, nextToken?: string, aggregate?: Pipeline[]): Promise<Pipeline[]> => {
-  const { pipelines: pipelineSummaries, nextToken: cursor } = await new CodePipelineClient({}).send(
-    new ListPipelinesCommand({ nextToken, maxResults: 5 }),
-  );
+async function fetchPipelines(toast: Toast, maxResults = 100): Promise<Pipeline[]> {
+  const allPipelines: Pipeline[] = [];
+  let nextToken: string | undefined;
 
-  const pipelines = await Promise.all(
-    (pipelineSummaries ?? [])
-      .filter((p) => !!p.name)
-      .map(async (p) => {
-        const { pipelineExecutionSummaries } = await new CodePipelineClient({}).send(
-          new ListPipelineExecutionsCommand({ pipelineName: p.name }),
-        );
+  do {
+    const { pipelines: pipelineSummaries, nextToken: cursor } = await getCodePipelineClient().send(
+      new ListPipelinesCommand({ nextToken, maxResults: Math.min(maxResults - allPipelines.length, 25) }),
+    );
 
-        const executions = (pipelineExecutionSummaries ?? []).filter((e) => !!e.pipelineExecutionId);
-        return { ...p, ...(executions.length > 0 && { latestExecution: executions[0] }) } as Pipeline;
-      }),
-  );
+    const pipelines = await Promise.all(
+      (pipelineSummaries ?? [])
+        .filter((p) => !!p.name)
+        .map(async (p) => {
+          const { pipelineExecutionSummaries } = await getCodePipelineClient().send(
+            new ListPipelineExecutionsCommand({ pipelineName: p.name }),
+          );
 
-  const agg = [...(aggregate ?? []), ...pipelines];
-  toast.message = `${agg.length} pipelines`;
-  if (cursor) {
-    return await fetchPipelines(toast, cursor, agg);
-  }
+          const executions = (pipelineExecutionSummaries ?? []).filter((e) => !!e.pipelineExecutionId);
+          return { ...p, ...(executions.length > 0 && { latestExecution: executions[0] }) } as Pipeline;
+        }),
+    );
+
+    allPipelines.push(...pipelines);
+    toast.message = `${allPipelines.length} pipelines`;
+    nextToken = cursor;
+  } while (nextToken && allPipelines.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded pipelines";
-  toast.message = `${agg.length} pipelines`;
-  return agg;
-};
+  toast.message = `${allPipelines.length} pipelines`;
+  return allPipelines;
+}

--- a/extensions/amazon-aws/src/hooks/use-cognito.ts
+++ b/extensions/amazon-aws/src/hooks/use-cognito.ts
@@ -1,0 +1,581 @@
+import {
+  AdminAddUserToGroupCommand,
+  AdminCreateUserCommand,
+  AdminDeleteUserCommand,
+  AdminDisableUserCommand,
+  AdminEnableUserCommand,
+  AdminGetUserCommand,
+  AdminListGroupsForUserCommand,
+  AdminRemoveUserFromGroupCommand,
+  AdminResetUserPasswordCommand,
+  AttributeType,
+  DescribeUserPoolCommand,
+  GroupType,
+  ListGroupsCommand,
+  ListUserPoolsCommand,
+  ListUsersCommand,
+  SchemaAttributeType,
+  UserPoolDescriptionType,
+  UserPoolType,
+  UserType,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { showToast, Toast } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { getAWSErrorMessage } from "../errors";
+import { getCognitoClient } from "../services/clients/cognito";
+import { isReadyToFetch } from "../util";
+
+/**
+ * Hook to fetch all Cognito user pools in the current AWS account
+ * @returns Object containing userPools array, error state, loading state, and revalidate function
+ */
+export function useCognitoUserPools() {
+  const {
+    data: userPools,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async () => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading user pools" });
+      return await fetchUserPools(toast);
+    },
+    [],
+    { execute: isReadyToFetch(), failureToastOptions: { title: "Failed to load user pools" } },
+  );
+
+  return { userPools, error, isLoading: (!userPools && !error) || isLoading, revalidate };
+}
+
+async function fetchUserPools(toast: Toast, maxResults = 60): Promise<UserPoolDescriptionType[]> {
+  const client = getCognitoClient();
+  const pools: UserPoolDescriptionType[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const { UserPools, NextToken } = await client.send(
+      new ListUserPoolsCommand({ MaxResults: 60, NextToken: nextToken }),
+    );
+
+    if (UserPools) {
+      pools.push(...UserPools);
+    }
+
+    toast.message = `${pools.length} pools`;
+    nextToken = NextToken;
+  } while (nextToken && pools.length < maxResults);
+
+  toast.style = Toast.Style.Success;
+  toast.title = "Loaded user pools";
+  toast.message = `${pools.length} pools`;
+  return pools;
+}
+
+/**
+ * Hook to fetch detailed configuration for a specific user pool
+ * @param userPoolId - The ID of the user pool
+ * @returns Object containing pool details, error state, and loading state
+ */
+export function useCognitoUserPoolDetails(userPoolId: string) {
+  const {
+    data: pool,
+    error,
+    isLoading,
+  } = useCachedPromise(
+    async (poolId: string) => {
+      const client = getCognitoClient();
+      const { UserPool } = await client.send(new DescribeUserPoolCommand({ UserPoolId: poolId }));
+      return UserPool;
+    },
+    [userPoolId],
+    {
+      execute: isReadyToFetch() && !!userPoolId,
+      failureToastOptions: { title: "Failed to load pool details" },
+    },
+  );
+
+  return { pool, error, isLoading: (!pool && !error) || isLoading };
+}
+
+/**
+ * Helper to determine if a user pool uses email as username
+ */
+export function poolUsesEmailAsUsername(pool: UserPoolType | undefined): boolean {
+  return pool?.UsernameAttributes?.includes("email") ?? false;
+}
+
+/**
+ * Helper to determine if a user pool uses phone as username
+ */
+export function poolUsesPhoneAsUsername(pool: UserPoolType | undefined): boolean {
+  return pool?.UsernameAttributes?.includes("phone_number") ?? false;
+}
+
+/**
+ * Custom attribute info for form display
+ */
+export interface CustomAttributeInfo {
+  name: string;
+  displayName: string;
+  required: boolean;
+  mutable: boolean;
+  attributeDataType: string;
+}
+
+/**
+ * Helper to get custom attributes from pool schema
+ * Custom attributes are those starting with "custom:"
+ */
+export function getCustomAttributes(pool: UserPoolType | undefined): CustomAttributeInfo[] {
+  if (!pool?.SchemaAttributes) return [];
+
+  return pool.SchemaAttributes.filter((attr): attr is SchemaAttributeType & { Name: string } =>
+    Boolean(attr.Name?.startsWith("custom:")),
+  ).map((attr) => ({
+    name: attr.Name,
+    displayName: attr.Name.replace("custom:", ""),
+    required: attr.Required ?? false,
+    mutable: attr.Mutable ?? true,
+    attributeDataType: attr.AttributeDataType ?? "String",
+  }));
+}
+
+/**
+ * Hook to fetch users in a specific Cognito user pool
+ * @param userPoolId - The ID of the user pool
+ * @param filter - Optional filter string (e.g., "email ^= \"john\"")
+ * @returns Object containing users array, error state, loading state, and revalidate function
+ */
+export function useCognitoUsers(userPoolId: string, filter?: string) {
+  const {
+    data: users,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async (poolId: string, filterStr?: string) => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading users" });
+      return await fetchUsers(poolId, toast, filterStr);
+    },
+    [userPoolId, filter],
+    {
+      execute: isReadyToFetch() && !!userPoolId,
+      failureToastOptions: { title: "Failed to load users" },
+    },
+  );
+
+  return { users, error, isLoading: (!users && !error) || isLoading, revalidate };
+}
+
+async function fetchUsers(userPoolId: string, toast: Toast, filter?: string, maxResults = 60): Promise<UserType[]> {
+  const client = getCognitoClient();
+  const users: UserType[] = [];
+  let paginationToken: string | undefined;
+
+  do {
+    const { Users, PaginationToken } = await client.send(
+      new ListUsersCommand({
+        UserPoolId: userPoolId,
+        ...(filter && { Filter: filter }),
+        PaginationToken: paginationToken,
+        Limit: 60,
+      }),
+    );
+
+    if (Users) {
+      users.push(...Users);
+    }
+
+    toast.message = `${users.length} users`;
+    paginationToken = PaginationToken;
+  } while (paginationToken && users.length < maxResults);
+
+  toast.style = Toast.Style.Success;
+  toast.title = "Loaded users";
+  toast.message = `${users.length} users`;
+  return users;
+}
+
+/**
+ * Hook to fetch detailed information for a specific user
+ * @param userPoolId - The ID of the user pool
+ * @param username - The username of the user
+ * @returns Object containing user details, error state, and loading state
+ */
+export function useCognitoUserDetails(userPoolId: string, username: string) {
+  const {
+    data: user,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async (poolId: string, name: string) => {
+      const client = getCognitoClient();
+      const response = await client.send(new AdminGetUserCommand({ UserPoolId: poolId, Username: name }));
+      return response;
+    },
+    [userPoolId, username],
+    {
+      execute: isReadyToFetch() && !!userPoolId && !!username,
+      failureToastOptions: { title: "Failed to load user details" },
+    },
+  );
+
+  return { user, error, isLoading: (!user && !error) || isLoading, revalidate };
+}
+
+/**
+ * Hook to fetch all groups in a user pool
+ * @param userPoolId - The ID of the user pool
+ * @returns Object containing groups array, error state, loading state, and revalidate function
+ */
+export function useCognitoGroups(userPoolId: string) {
+  const {
+    data: groups,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async (poolId: string) => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading groups" });
+      return await fetchGroups(poolId, toast);
+    },
+    [userPoolId],
+    {
+      execute: isReadyToFetch() && !!userPoolId,
+      failureToastOptions: { title: "Failed to load groups" },
+    },
+  );
+
+  return { groups, error, isLoading: (!groups && !error) || isLoading, revalidate };
+}
+
+async function fetchGroups(userPoolId: string, toast: Toast, maxResults = 60): Promise<GroupType[]> {
+  const client = getCognitoClient();
+  const groups: GroupType[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const { Groups, NextToken } = await client.send(
+      new ListGroupsCommand({ UserPoolId: userPoolId, NextToken: nextToken, Limit: 60 }),
+    );
+
+    if (Groups) {
+      groups.push(...Groups);
+    }
+
+    toast.message = `${groups.length} groups`;
+    nextToken = NextToken;
+  } while (nextToken && groups.length < maxResults);
+
+  toast.style = Toast.Style.Success;
+  toast.title = "Loaded groups";
+  toast.message = `${groups.length} groups`;
+  return groups;
+}
+
+/**
+ * Hook to fetch groups for a specific user
+ * @param userPoolId - The ID of the user pool
+ * @param username - The username of the user
+ * @returns Object containing groups array, error state, and loading state
+ */
+export function useCognitoUserGroups(userPoolId: string, username: string) {
+  const {
+    data: groups,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async (poolId: string, name: string) => {
+      const client = getCognitoClient();
+      const groups: GroupType[] = [];
+      let nextToken: string | undefined;
+
+      do {
+        const { Groups, NextToken } = await client.send(
+          new AdminListGroupsForUserCommand({
+            UserPoolId: poolId,
+            Username: name,
+            NextToken: nextToken,
+            Limit: 60,
+          }),
+        );
+
+        if (Groups) {
+          groups.push(...Groups);
+        }
+
+        nextToken = NextToken;
+      } while (nextToken);
+
+      return groups;
+    },
+    [userPoolId, username],
+    {
+      execute: isReadyToFetch() && !!userPoolId && !!username,
+      failureToastOptions: { title: "Failed to load user groups" },
+    },
+  );
+
+  return { groups, error, isLoading: (!groups && !error) || isLoading, revalidate };
+}
+
+// Action functions for user management
+
+export interface CreateUserInput {
+  username: string;
+  email?: string;
+  phoneNumber?: string;
+  temporaryPassword?: string;
+  sendInvitation?: boolean;
+  customAttributes?: Record<string, string>;
+}
+
+/**
+ * Creates a new user in a Cognito user pool
+ * @param userPoolId - The ID of the user pool
+ * @param userData - User data including username, email, phone, and optional password
+ * @returns Promise resolving to the created user
+ */
+export async function createCognitoUser(userPoolId: string, userData: CreateUserInput): Promise<UserType | undefined> {
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: "Creating user",
+    message: userData.username,
+  });
+
+  try {
+    const client = getCognitoClient();
+    const userAttributes: AttributeType[] = [];
+
+    if (userData.email) {
+      userAttributes.push({ Name: "email", Value: userData.email });
+      userAttributes.push({ Name: "email_verified", Value: "true" });
+    }
+    if (userData.phoneNumber) {
+      userAttributes.push({ Name: "phone_number", Value: userData.phoneNumber });
+      userAttributes.push({ Name: "phone_number_verified", Value: "true" });
+    }
+
+    // Add custom attributes
+    if (userData.customAttributes) {
+      for (const [name, value] of Object.entries(userData.customAttributes)) {
+        if (value) {
+          userAttributes.push({ Name: name, Value: value });
+        }
+      }
+    }
+
+    const { User } = await client.send(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: userData.username,
+        UserAttributes: userAttributes.length > 0 ? userAttributes : undefined,
+        TemporaryPassword: userData.temporaryPassword,
+        MessageAction: userData.sendInvitation === false ? "SUPPRESS" : undefined,
+        ForceAliasCreation: false,
+      }),
+    );
+
+    toast.style = Toast.Style.Success;
+    toast.title = "User created";
+    toast.message = userData.username;
+    return User;
+  } catch (error) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Failed to create user";
+    toast.message = getAWSErrorMessage(error);
+    throw error;
+  }
+}
+
+/**
+ * Enables a user in a Cognito user pool
+ * @param userPoolId - The ID of the user pool
+ * @param username - The username to enable
+ */
+export async function enableCognitoUser(userPoolId: string, username: string): Promise<void> {
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: "Enabling user",
+    message: username,
+  });
+
+  try {
+    const client = getCognitoClient();
+    await client.send(new AdminEnableUserCommand({ UserPoolId: userPoolId, Username: username }));
+
+    toast.style = Toast.Style.Success;
+    toast.title = "User enabled";
+    toast.message = username;
+  } catch (error) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Failed to enable user";
+    toast.message = getAWSErrorMessage(error);
+    throw error;
+  }
+}
+
+/**
+ * Disables a user in a Cognito user pool
+ * @param userPoolId - The ID of the user pool
+ * @param username - The username to disable
+ */
+export async function disableCognitoUser(userPoolId: string, username: string): Promise<void> {
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: "Disabling user",
+    message: username,
+  });
+
+  try {
+    const client = getCognitoClient();
+    await client.send(new AdminDisableUserCommand({ UserPoolId: userPoolId, Username: username }));
+
+    toast.style = Toast.Style.Success;
+    toast.title = "User disabled";
+    toast.message = username;
+  } catch (error) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Failed to disable user";
+    toast.message = getAWSErrorMessage(error);
+    throw error;
+  }
+}
+
+/**
+ * Resets a user's password, triggering a password reset flow
+ * @param userPoolId - The ID of the user pool
+ * @param username - The username whose password to reset
+ */
+export async function resetCognitoUserPassword(userPoolId: string, username: string): Promise<void> {
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: "Resetting password",
+    message: username,
+  });
+
+  try {
+    const client = getCognitoClient();
+    await client.send(new AdminResetUserPasswordCommand({ UserPoolId: userPoolId, Username: username }));
+
+    toast.style = Toast.Style.Success;
+    toast.title = "Password reset initiated";
+    toast.message = "User will receive a reset code";
+  } catch (error) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Failed to reset password";
+    toast.message = getAWSErrorMessage(error);
+    throw error;
+  }
+}
+
+/**
+ * Deletes a user from a Cognito user pool
+ * @param userPoolId - The ID of the user pool
+ * @param username - The username to delete
+ */
+export async function deleteCognitoUser(userPoolId: string, username: string): Promise<void> {
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: "Deleting user",
+    message: username,
+  });
+
+  try {
+    const client = getCognitoClient();
+    await client.send(new AdminDeleteUserCommand({ UserPoolId: userPoolId, Username: username }));
+
+    toast.style = Toast.Style.Success;
+    toast.title = "User deleted";
+    toast.message = username;
+  } catch (error) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Failed to delete user";
+    toast.message = getAWSErrorMessage(error);
+    throw error;
+  }
+}
+
+/**
+ * Adds a user to a group
+ * @param userPoolId - The ID of the user pool
+ * @param username - The username to add to the group
+ * @param groupName - The name of the group
+ */
+export async function addCognitoUserToGroup(userPoolId: string, username: string, groupName: string): Promise<void> {
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: "Adding to group",
+    message: `${username} -> ${groupName}`,
+  });
+
+  try {
+    const client = getCognitoClient();
+    await client.send(
+      new AdminAddUserToGroupCommand({
+        UserPoolId: userPoolId,
+        Username: username,
+        GroupName: groupName,
+      }),
+    );
+
+    toast.style = Toast.Style.Success;
+    toast.title = "Added to group";
+    toast.message = `${username} -> ${groupName}`;
+  } catch (error) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Failed to add to group";
+    toast.message = getAWSErrorMessage(error);
+    throw error;
+  }
+}
+
+/**
+ * Removes a user from a group
+ * @param userPoolId - The ID of the user pool
+ * @param username - The username to remove from the group
+ * @param groupName - The name of the group
+ */
+export async function removeCognitoUserFromGroup(
+  userPoolId: string,
+  username: string,
+  groupName: string,
+): Promise<void> {
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: "Removing from group",
+    message: `${username} <- ${groupName}`,
+  });
+
+  try {
+    const client = getCognitoClient();
+    await client.send(
+      new AdminRemoveUserFromGroupCommand({
+        UserPoolId: userPoolId,
+        Username: username,
+        GroupName: groupName,
+      }),
+    );
+
+    toast.style = Toast.Style.Success;
+    toast.title = "Removed from group";
+    toast.message = `${username} <- ${groupName}`;
+  } catch (error) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Failed to remove from group";
+    toast.message = getAWSErrorMessage(error);
+    throw error;
+  }
+}
+
+/**
+ * Helper function to get user attribute value
+ * @param attributes - Array of user attributes
+ * @param name - Name of the attribute to find
+ * @returns The attribute value or undefined
+ */
+export function getUserAttribute(attributes: AttributeType[] | undefined, name: string): string | undefined {
+  return attributes?.find((attr) => attr.Name === name)?.Value;
+}

--- a/extensions/amazon-aws/src/hooks/use-ddb.ts
+++ b/extensions/amazon-aws/src/hooks/use-ddb.ts
@@ -1,4 +1,5 @@
-import { DescribeTableCommand, DynamoDBClient, ListTablesCommand, TableDescription } from "@aws-sdk/client-dynamodb";
+import { DescribeTableCommand, ListTablesCommand, TableDescription } from "@aws-sdk/client-dynamodb";
+import { getDynamoDBClient } from "../services/clients/dynamodb";
 import { useCachedPromise } from "@raycast/utils";
 import { PrimaryKey, Table } from "../dynamodb";
 import { isReadyToFetch } from "../util";
@@ -22,29 +23,32 @@ export const useTables = () => {
   return { tables, error, isLoading: (!tables && !error) || isLoading, mutate };
 };
 
-const fetchTables = async (toast: Toast, nextToken?: string, aggregate?: Table[]): Promise<Table[]> => {
-  const { LastEvaluatedTableName: cursor, TableNames } = await new DynamoDBClient({}).send(
-    new ListTablesCommand({ ExclusiveStartTableName: nextToken, Limit: 50 }),
-  );
+async function fetchTables(toast: Toast, maxResults = 200): Promise<Table[]> {
+  const allTables: Table[] = [];
+  let nextToken: string | undefined;
 
-  const tables = await Promise.all(
-    (TableNames || []).map(async (t) => {
-      const { Table } = await new DynamoDBClient({}).send(new DescribeTableCommand({ TableName: t }));
-      return { ...Table, keys: fetchKeys(Table!) } as Table;
-    }),
-  );
+  do {
+    const { LastEvaluatedTableName: cursor, TableNames } = await getDynamoDBClient().send(
+      new ListTablesCommand({ ExclusiveStartTableName: nextToken, Limit: Math.min(maxResults - allTables.length, 50) }),
+    );
 
-  const agg = [...(aggregate ?? []), ...tables];
-  toast.message = `${agg.length} tables`;
-  if (cursor) {
-    return await fetchTables(toast, cursor, agg);
-  }
+    const tables = await Promise.all(
+      (TableNames || []).map(async (t) => {
+        const { Table } = await getDynamoDBClient().send(new DescribeTableCommand({ TableName: t }));
+        return { ...Table, keys: fetchKeys(Table!) } as Table;
+      }),
+    );
+
+    allTables.push(...tables);
+    toast.message = `${allTables.length} tables`;
+    nextToken = cursor;
+  } while (nextToken && allTables.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded tables";
-  toast.message = `${agg.length} tables`;
-  return agg;
-};
+  toast.message = `${allTables.length} tables`;
+  return allTables;
+}
 
 const fetchKeys = (table: TableDescription): Record<string, PrimaryKey> => {
   const keys: Record<string, PrimaryKey> = {};

--- a/extensions/amazon-aws/src/hooks/use-glue.ts
+++ b/extensions/amazon-aws/src/hooks/use-glue.ts
@@ -2,7 +2,8 @@ import { Icon, Color, showToast, Toast } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { isReadyToFetch } from "../util";
 
-import { GlueClient, GetJobRunsCommand, ListJobsCommand } from "@aws-sdk/client-glue";
+import { GetJobRunsCommand, ListJobsCommand } from "@aws-sdk/client-glue";
+import { getGlueClient } from "../services/clients/glue";
 import { GlueJobRun } from "../glue";
 
 export const useGlueJobs = () => {
@@ -31,7 +32,7 @@ export const useGlueJobRuns = (jobName: string) => {
     mutate,
   } = useCachedPromise(
     async (name: string) => {
-      const { JobRuns } = await new GlueClient({}).send(new GetJobRunsCommand({ JobName: name }));
+      const { JobRuns } = await getGlueClient().send(new GetJobRunsCommand({ JobName: name }));
       return (JobRuns ?? []).map((run) => {
         const jobRunResponse = {
           ...run,
@@ -52,35 +53,38 @@ export const useGlueJobRuns = (jobName: string) => {
   return { jobRuns, isLoading: (!jobRuns && !error) || isLoading, mutate };
 };
 
-const fetchGlueJobs = async (toast: Toast, nextToken?: string, aggregate?: GlueJobRun[]): Promise<GlueJobRun[]> => {
-  const { JobNames: jobNames, NextToken: cursor } = await new GlueClient({}).send(
-    new ListJobsCommand({ NextToken: nextToken, MaxResults: 25 }),
-  );
+async function fetchGlueJobs(toast: Toast, maxResults = 100): Promise<GlueJobRun[]> {
+  const allJobs: GlueJobRun[] = [];
+  let nextToken: string | undefined;
 
-  const jobs = await Promise.all(
-    (jobNames ?? []).map(async (jobName) => {
-      const { JobRuns } = await new GlueClient({}).send(new GetJobRunsCommand({ JobName: jobName, MaxResults: 1 }));
+  do {
+    const { JobNames: jobNames, NextToken: cursor } = await getGlueClient().send(
+      new ListJobsCommand({ NextToken: nextToken, MaxResults: Math.min(maxResults - allJobs.length, 25) }),
+    );
 
-      const latestRun = JobRuns && JobRuns.length > 0 ? JobRuns[0] : undefined;
-      const jobRunResponse = latestRun as GlueJobRun;
-      if (jobRunResponse) {
-        setJobRunIcon(jobRunResponse);
-      }
-      return jobRunResponse;
-    }),
-  );
+    const jobs = await Promise.all(
+      (jobNames ?? []).map(async (jobName) => {
+        const { JobRuns } = await getGlueClient().send(new GetJobRunsCommand({ JobName: jobName, MaxResults: 1 }));
 
-  const agg = [...(aggregate ?? []), ...jobs];
-  toast.message = `${agg.length} Glue jobs`;
-  if (cursor) {
-    return await fetchGlueJobs(toast, cursor, agg);
-  }
+        const latestRun = JobRuns && JobRuns.length > 0 ? JobRuns[0] : undefined;
+        const jobRunResponse = latestRun as GlueJobRun;
+        if (jobRunResponse) {
+          setJobRunIcon(jobRunResponse);
+        }
+        return jobRunResponse;
+      }),
+    );
+
+    allJobs.push(...jobs);
+    toast.message = `${allJobs.length} Glue jobs`;
+    nextToken = cursor;
+  } while (nextToken && allJobs.length < maxResults);
 
   toast.style = Toast.Style.Success;
   toast.title = "✅ Loaded Glue jobs";
-  toast.message = `${agg.length} Glue jobs`;
-  return agg;
-};
+  toast.message = `${allJobs.length} Glue jobs`;
+  return allJobs;
+}
 
 const setJobRunIcon = (jobRun: GlueJobRun) => {
   switch (jobRun.JobRunState) {

--- a/extensions/amazon-aws/src/hooks/use-logs.ts
+++ b/extensions/amazon-aws/src/hooks/use-logs.ts
@@ -1,30 +1,41 @@
 import { useCachedPromise } from "@raycast/utils";
-import { CloudWatchLogsClient, DescribeLogGroupsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { DescribeLogGroupsCommand, LogGroup } from "@aws-sdk/client-cloudwatch-logs";
+import { getCloudWatchLogsClient } from "../services/clients/cloudwatch-logs";
 import { isReadyToFetch } from "../util";
 
-export const useLogGroups = (prefixQuery: string) => {
+async function fetchAllLogGroups(maxResults = 500): Promise<LogGroup[]> {
+  const logGroups: LogGroup[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const { logGroups: groups, nextToken: cursor } = await getCloudWatchLogsClient().send(
+      new DescribeLogGroupsCommand({
+        limit: Math.min(maxResults - logGroups.length, 50),
+        nextToken,
+      }),
+    );
+
+    const validGroups = (groups ?? []).filter(
+      (group) => !!group && !!group.logGroupArn && !!group.logGroupName && !!group.creationTime && !!group.storedBytes,
+    );
+
+    logGroups.push(...validGroups);
+    nextToken = cursor;
+  } while (nextToken && logGroups.length < maxResults);
+
+  return logGroups;
+}
+
+export function useLogGroups() {
   const {
     data: logGroups,
     mutate,
     error,
     isLoading,
-  } = useCachedPromise(
-    async (prefix: string) => {
-      const { logGroups: groups } = await new CloudWatchLogsClient({}).send(
-        new DescribeLogGroupsCommand({
-          limit: 50,
-          ...(prefix.trim().length > 2 && { logGroupNamePrefix: prefix }),
-        }),
-      );
-
-      return (groups ?? []).filter(
-        (group) =>
-          !!group && !!group.logGroupArn && !!group.logGroupName && !!group.creationTime && !!group.storedBytes,
-      );
-    },
-    [prefixQuery],
-    { execute: isReadyToFetch(), failureToastOptions: { title: "❌Failed to load log groups" } },
-  );
+  } = useCachedPromise(fetchAllLogGroups, [], {
+    execute: isReadyToFetch(),
+    failureToastOptions: { title: "Failed to load log groups" },
+  });
 
   return { logGroups, error, isLoading: (!logGroups && !error) || isLoading, mutate };
-};
+}

--- a/extensions/amazon-aws/src/hooks/use-quicksight.ts
+++ b/extensions/amazon-aws/src/hooks/use-quicksight.ts
@@ -13,25 +13,21 @@ import { GetCallerIdentityCommand } from "@aws-sdk/client-sts";
 import { getPreferenceValues, showToast, Toast } from "@raycast/api";
 import { getQuickSightClient as getQuickSightClientBase, getSTSClient } from "../services/clients/quicksight";
 
-let cachedAccountId: string | undefined;
+const accountIdCache = new Map<string, string>();
 
 async function getAwsAccountId(): Promise<string> {
-  if (cachedAccountId) return cachedAccountId;
+  const profile = process.env.AWS_PROFILE ?? process.env.AWS_VAULT ?? "default";
+  if (accountIdCache.has(profile)) return accountIdCache.get(profile)!;
 
-  if (process.env.AWS_SSO_ACCOUNT_ID) {
-    cachedAccountId = process.env.AWS_SSO_ACCOUNT_ID;
-    return cachedAccountId;
-  }
-
-  const sts = getSTSClient();
-  const { Account } = await sts.send(new GetCallerIdentityCommand({}));
-  if (!Account) throw new Error("Could not determine AWS account ID");
-  cachedAccountId = Account;
-  return cachedAccountId;
+  const accountId =
+    process.env.AWS_SSO_ACCOUNT_ID ?? (await getSTSClient().send(new GetCallerIdentityCommand({}))).Account;
+  if (!accountId) throw new Error("Could not determine AWS account ID");
+  accountIdCache.set(profile, accountId);
+  return accountId;
 }
 
 function getQuickSightClient(): QuickSightClient {
-  const { quicksightRegion } = getPreferenceValues<{ quicksightRegion?: string }>();
+  const { quicksightRegion } = getPreferenceValues<Preferences.Quicksight>();
   const region = quicksightRegion?.trim() || undefined;
   return getQuickSightClientBase(region);
 }

--- a/extensions/amazon-aws/src/hooks/use-quicksight.ts
+++ b/extensions/amazon-aws/src/hooks/use-quicksight.ts
@@ -1,0 +1,171 @@
+import { useCachedPromise } from "@raycast/utils";
+import { isReadyToFetch } from "../util";
+import {
+  QuickSightClient,
+  DashboardSummary,
+  AnalysisSummary,
+  DataSetSummary,
+  ListDashboardsCommand,
+  ListAnalysesCommand,
+  ListDataSetsCommand,
+} from "@aws-sdk/client-quicksight";
+import { GetCallerIdentityCommand } from "@aws-sdk/client-sts";
+import { getPreferenceValues, showToast, Toast } from "@raycast/api";
+import { getQuickSightClient as getQuickSightClientBase, getSTSClient } from "../services/clients/quicksight";
+
+let cachedAccountId: string | undefined;
+
+async function getAwsAccountId(): Promise<string> {
+  if (cachedAccountId) return cachedAccountId;
+
+  if (process.env.AWS_SSO_ACCOUNT_ID) {
+    cachedAccountId = process.env.AWS_SSO_ACCOUNT_ID;
+    return cachedAccountId;
+  }
+
+  const sts = getSTSClient();
+  const { Account } = await sts.send(new GetCallerIdentityCommand({}));
+  if (!Account) throw new Error("Could not determine AWS account ID");
+  cachedAccountId = Account;
+  return cachedAccountId;
+}
+
+function getQuickSightClient(): QuickSightClient {
+  const { quicksightRegion } = getPreferenceValues<{ quicksightRegion?: string }>();
+  const region = quicksightRegion?.trim() || undefined;
+  return getQuickSightClientBase(region);
+}
+
+export const useQuickSightDashboards = () => {
+  const {
+    data: dashboards,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async () => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading dashboards" });
+      return await fetchDashboards(toast);
+    },
+    [],
+    { execute: isReadyToFetch(), failureToastOptions: { title: "❌Failed to load dashboards" } },
+  );
+
+  return { dashboards, error, isLoading: (!dashboards && !error) || isLoading, revalidate };
+};
+
+export const useQuickSightAnalyses = () => {
+  const {
+    data: analyses,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async () => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading analyses" });
+      return await fetchAnalyses(toast);
+    },
+    [],
+    { execute: isReadyToFetch(), failureToastOptions: { title: "❌Failed to load analyses" } },
+  );
+
+  return { analyses, error, isLoading: (!analyses && !error) || isLoading, revalidate };
+};
+
+export const useQuickSightDataSets = () => {
+  const {
+    data: dataSets,
+    error,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async () => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Loading data sets" });
+      return await fetchDataSets(toast);
+    },
+    [],
+    { execute: isReadyToFetch(), failureToastOptions: { title: "❌Failed to load data sets" } },
+  );
+
+  return { dataSets, error, isLoading: (!dataSets && !error) || isLoading, revalidate };
+};
+
+async function fetchDashboards(toast: Toast, maxResults = 100): Promise<DashboardSummary[]> {
+  const accountId = await getAwsAccountId();
+  const client = getQuickSightClient();
+  const allDashboards: DashboardSummary[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const { DashboardSummaryList, NextToken } = await client.send(
+      new ListDashboardsCommand({
+        AwsAccountId: accountId,
+        NextToken: nextToken,
+        MaxResults: Math.min(maxResults - allDashboards.length, 100),
+      }),
+    );
+
+    allDashboards.push(...(DashboardSummaryList ?? []));
+    toast.message = `${allDashboards.length} dashboards`;
+    nextToken = NextToken;
+  } while (nextToken && allDashboards.length < maxResults);
+
+  toast.style = Toast.Style.Success;
+  toast.title = "✅ Loaded dashboards";
+  toast.message = `${allDashboards.length} dashboards`;
+  return allDashboards;
+}
+
+async function fetchAnalyses(toast: Toast, maxResults = 100): Promise<AnalysisSummary[]> {
+  const accountId = await getAwsAccountId();
+  const client = getQuickSightClient();
+  const allAnalyses: AnalysisSummary[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const { AnalysisSummaryList, NextToken } = await client.send(
+      new ListAnalysesCommand({
+        AwsAccountId: accountId,
+        NextToken: nextToken,
+        MaxResults: Math.min(maxResults - allAnalyses.length, 100),
+      }),
+    );
+
+    allAnalyses.push(...(AnalysisSummaryList ?? []));
+    toast.message = `${allAnalyses.length} analyses`;
+    nextToken = NextToken;
+  } while (nextToken && allAnalyses.length < maxResults);
+
+  toast.style = Toast.Style.Success;
+  toast.title = "✅ Loaded analyses";
+  toast.message = `${allAnalyses.length} analyses`;
+  return allAnalyses;
+}
+
+async function fetchDataSets(toast: Toast, maxResults = 100): Promise<DataSetSummary[]> {
+  const accountId = await getAwsAccountId();
+  const client = getQuickSightClient();
+  const allDataSets: DataSetSummary[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const { DataSetSummaries, NextToken } = await client.send(
+      new ListDataSetsCommand({
+        AwsAccountId: accountId,
+        NextToken: nextToken,
+        MaxResults: Math.min(maxResults - allDataSets.length, 100),
+      }),
+    );
+
+    allDataSets.push(...(DataSetSummaries ?? []));
+    toast.message = `${allDataSets.length} data sets`;
+    nextToken = NextToken;
+  } while (nextToken && allDataSets.length < maxResults);
+
+  toast.style = Toast.Style.Success;
+  toast.title = "✅ Loaded data sets";
+  toast.message = `${allDataSets.length} data sets`;
+  return allDataSets;
+}
+
+export { getAwsAccountId };

--- a/extensions/amazon-aws/src/hooks/use-secrets.ts
+++ b/extensions/amazon-aws/src/hooks/use-secrets.ts
@@ -1,11 +1,7 @@
 import { useCachedPromise } from "@raycast/utils";
 import { isReadyToFetch } from "../util";
-import {
-  GetResourcePolicyCommand,
-  GetSecretValueCommand,
-  ListSecretsCommand,
-  SecretsManagerClient,
-} from "@aws-sdk/client-secrets-manager";
+import { GetResourcePolicyCommand, GetSecretValueCommand, ListSecretsCommand } from "@aws-sdk/client-secrets-manager";
+import { getSecretsManagerClient } from "../services/clients/secrets-manager";
 
 export const useSecrets = (search: string) => {
   const {
@@ -15,7 +11,7 @@ export const useSecrets = (search: string) => {
     mutate,
   } = useCachedPromise(
     async (query: string) => {
-      const { SecretList } = await new SecretsManagerClient({}).send(
+      const { SecretList } = await getSecretsManagerClient().send(
         new ListSecretsCommand({
           MaxResults: 50,
           ...(query.trim().length > 2 && { Filters: [{ Key: "all", Values: [search] }] }),
@@ -37,7 +33,7 @@ export const useSecretValue = (secretId: string) => {
     isLoading,
   } = useCachedPromise(
     async (id: string) => {
-      const { SecretString } = await new SecretsManagerClient({}).send(new GetSecretValueCommand({ SecretId: id }));
+      const { SecretString } = await getSecretsManagerClient().send(new GetSecretValueCommand({ SecretId: id }));
 
       let md = "## Secret Value\n\n```";
       let value = SecretString;
@@ -67,7 +63,7 @@ export const useSecretPolicy = (secretId: string) => {
     isLoading,
   } = useCachedPromise(
     async (id: string) => {
-      const { ResourcePolicy = "❗Not Yet Defined" } = await new SecretsManagerClient({}).send(
+      const { ResourcePolicy = "❗Not Yet Defined" } = await getSecretsManagerClient().send(
         new GetResourcePolicyCommand({ SecretId: id }),
       );
 

--- a/extensions/amazon-aws/src/hooks/use-sqs.ts
+++ b/extensions/amazon-aws/src/hooks/use-sqs.ts
@@ -1,6 +1,7 @@
 import { useCachedPromise } from "@raycast/utils";
 import { isReadyToFetch } from "../util";
-import { GetQueueAttributesCommand, ListQueuesCommand, SQSClient } from "@aws-sdk/client-sqs";
+import { GetQueueAttributesCommand, ListQueuesCommand } from "@aws-sdk/client-sqs";
+import { getSQSClient } from "../services/clients/sqs";
 import { Queue } from "../sqs";
 
 export const useQueues = (prefixQuery: string) => {
@@ -11,7 +12,7 @@ export const useQueues = (prefixQuery: string) => {
     mutate,
   } = useCachedPromise(
     async (prefix: string) => {
-      const { QueueUrls } = await new SQSClient({}).send(
+      const { QueueUrls } = await getSQSClient().send(
         new ListQueuesCommand({
           MaxResults: 25,
           ...(prefix.trim().length > 2 && { QueueNamePrefix: prefix }),
@@ -20,7 +21,7 @@ export const useQueues = (prefixQuery: string) => {
 
       const queues = await Promise.all(
         (QueueUrls ?? []).map(async (queueUrl) => {
-          const { Attributes: attributes } = await new SQSClient({}).send(
+          const { Attributes: attributes } = await getSQSClient().send(
             new GetQueueAttributesCommand({ QueueUrl: queueUrl, AttributeNames: ["All"] }),
           );
 

--- a/extensions/amazon-aws/src/lambda.tsx
+++ b/extensions/amazon-aws/src/lambda.tsx
@@ -1,11 +1,13 @@
-import { FunctionConfiguration, LambdaClient, ListFunctionsCommand } from "@aws-sdk/client-lambda";
-import { Action, ActionPanel, Icon, List } from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
-import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
+import { FunctionConfiguration, ListFunctionsCommand } from "@aws-sdk/client-lambda";
+import { Action, ActionPanel, Icon, List, showToast, Toast } from "@raycast/api";
+import { runAppleScript, useCachedPromise } from "@raycast/utils";
 import CloudwatchLogStreams from "./components/cloudwatch/CloudwatchLogStreams";
-import { isReadyToFetch, resourceToConsoleLink } from "./util";
 import { AwsAction } from "./components/common/action";
 import InvokeLambdaFunction from "./components/lambda/InvokeLambdaFunction";
+import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
+import { getAWSErrorMessage } from "./errors";
+import { getLambdaClient } from "./services/clients/lambda";
+import { isReadyToFetch, resourceToConsoleLink } from "./util";
 
 export default function Lambda() {
   const { data: functions, error, isLoading, revalidate } = useCachedPromise(fetchFunctions);
@@ -26,6 +28,15 @@ export default function Lambda() {
 }
 
 function LambdaFunction({ func }: { func: FunctionConfiguration }) {
+  const AWS_REGION = process.env.AWS_REGION;
+  const logGroupName = func.LoggingConfig?.LogGroup ?? `/aws/lambda/${func.FunctionName}`;
+
+  // CloudWatch Logs Live Tail URL (opens console with live tailing)
+  const liveTailUrl = `https://${AWS_REGION}.console.aws.amazon.com/cloudwatch/home?region=${AWS_REGION}#logsV2:live-tail$3FlogGroupArns$3D${encodeURIComponent(`arn:aws:logs:${AWS_REGION}:*:log-group:${logGroupName}`)}`;
+
+  // AWS CLI command to tail logs in terminal
+  const tailCommand = `aws logs tail "${logGroupName}" --follow`;
+
   return (
     <List.Item
       key={func.FunctionArn}
@@ -37,14 +48,20 @@ function LambdaFunction({ func }: { func: FunctionConfiguration }) {
           <Action.OpenInBrowser
             icon={Icon.Document}
             title="Open CloudWatch Log Group"
-            url={resourceToConsoleLink(`/aws/lambda/${func.FunctionName}`, "AWS::Logs::LogGroup")}
+            url={resourceToConsoleLink(logGroupName, "AWS::Logs::LogGroup")}
             shortcut={{ modifiers: ["cmd"], key: "l" }}
+          />
+          <Action.OpenInBrowser
+            icon={Icon.Livestream}
+            title="Tail Logs in Console"
+            url={liveTailUrl}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
           />
           <Action.Push
             title={"View Log Streams"}
             icon={Icon.Eye}
             shortcut={{ modifiers: ["opt"], key: "l" }}
-            target={<CloudwatchLogStreams logGroupName={`/aws/lambda/${func.FunctionName}`}></CloudwatchLogStreams>}
+            target={<CloudwatchLogStreams logGroupName={logGroupName}></CloudwatchLogStreams>}
           />
           <Action.Push
             title="Invoke Function"
@@ -52,9 +69,40 @@ function LambdaFunction({ func }: { func: FunctionConfiguration }) {
             shortcut={{ modifiers: ["cmd"], key: "i" }}
             target={<InvokeLambdaFunction functionName={func.FunctionName || ""} />}
           />
+          <Action
+            title="Run Tail Command in Terminal"
+            icon={Icon.Terminal}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "t" }}
+            onAction={async () => {
+              const escapedCommand = tailCommand.replace(/"/g, '\\"');
+              const appleScript = `
+                tell application "Terminal"
+                  do script "${escapedCommand}"
+                  activate
+                end tell
+              `;
+              try {
+                await runAppleScript(appleScript);
+                await showToast({ style: Toast.Style.Success, title: "Opened in Terminal" });
+              } catch (error) {
+                await showToast({
+                  style: Toast.Style.Failure,
+                  title: "Failed to open Terminal",
+                  message: getAWSErrorMessage(error),
+                });
+              }
+            }}
+          />
           <ActionPanel.Section title={"Copy"}>
             <Action.CopyToClipboard title="Copy Function ARN" content={func.FunctionArn || ""} />
             <Action.CopyToClipboard title="Copy Function Name" content={func.FunctionName || ""} />
+            <Action.CopyToClipboard
+              title="Copy Tail Command"
+              content={tailCommand}
+              icon={Icon.Terminal}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+            />
+            <AwsAction.ExportResponse response={func} />
           </ActionPanel.Section>
         </ActionPanel>
       }
@@ -68,7 +116,7 @@ async function fetchFunctions(
   functions?: FunctionConfiguration[],
 ): Promise<FunctionConfiguration[]> {
   if (!isReadyToFetch()) return [];
-  const { NextMarker, Functions } = await new LambdaClient({}).send(new ListFunctionsCommand({ Marker: nextMarker }));
+  const { NextMarker, Functions } = await getLambdaClient().send(new ListFunctionsCommand({ Marker: nextMarker }));
 
   const combinedFunctions = [...(functions || []), ...(Functions || [])];
 

--- a/extensions/amazon-aws/src/quicksight.tsx
+++ b/extensions/amazon-aws/src/quicksight.tsx
@@ -1,0 +1,244 @@
+import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
+import { useCachedState, useFrecencySorting } from "@raycast/utils";
+import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
+import { resourceToConsoleLink } from "./util";
+import { AwsAction } from "./components/common/action";
+import { useQuickSightDashboards, useQuickSightAnalyses, useQuickSightDataSets } from "./hooks/use-quicksight";
+
+enum ResourceType {
+  Dashboards = "Dashboards",
+  Analyses = "Analyses",
+  DataSets = "DataSets",
+}
+type SetResourceType = { setResourceType: (value: ResourceType) => void };
+
+export default function QuickSight() {
+  const [resourceType, setResourceType] = useCachedState<ResourceType>("resource-type", ResourceType.Dashboards, {
+    cacheNamespace: "aws-quicksight",
+  });
+
+  if (resourceType === ResourceType.Analyses) {
+    return <QuickSightAnalyses {...{ setResourceType }} />;
+  }
+  if (resourceType === ResourceType.DataSets) {
+    return <QuickSightDataSets {...{ setResourceType }} />;
+  }
+  return <QuickSightDashboards {...{ setResourceType }} />;
+}
+
+const QuickSightDashboards = ({ setResourceType }: SetResourceType) => {
+  const { dashboards, error, isLoading, revalidate } = useQuickSightDashboards();
+
+  const {
+    data: sortedDashboards,
+    visitItem: visit,
+    resetRanking,
+  } = useFrecencySorting(dashboards, {
+    namespace: "aws-quicksight-dashboards",
+    key: (d) => d.DashboardId!,
+    sortUnvisited: (a, b) => (a.Name ?? "").localeCompare(b.Name ?? ""),
+  });
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Filter dashboards by name..."
+      filtering
+      navigationTitle="QuickSight Dashboards"
+      searchBarAccessory={<AWSProfileDropdown onProfileSelected={revalidate} />}
+    >
+      {error && (
+        <List.EmptyView
+          title={error.name}
+          description={error.message}
+          icon={{ source: Icon.Warning, tintColor: Color.Red }}
+        />
+      )}
+      {!error && sortedDashboards.length === 0 && (
+        <List.EmptyView title="No dashboards found!" icon={{ source: Icon.Warning, tintColor: Color.Orange }} />
+      )}
+      {sortedDashboards.map((d) => (
+        <List.Item
+          key={d.DashboardId}
+          icon={"aws-icons/qs.png"}
+          title={d.Name ?? ""}
+          keywords={[d.Name ?? "", d.DashboardId ?? ""]}
+          actions={
+            <ActionPanel>
+              <AwsAction.Console
+                url={resourceToConsoleLink(d.DashboardId, "AWS::QuickSight::Dashboard")}
+                onAction={() => visit(d)}
+              />
+              <ActionPanel.Section title="Dashboard Actions">
+                <Action.CopyToClipboard
+                  title="Copy Dashboard ID"
+                  content={d.DashboardId ?? ""}
+                  onCopy={() => visit(d)}
+                />
+                <Action.CopyToClipboard title="Copy ARN" content={d.Arn ?? ""} onCopy={() => visit(d)} />
+                <AwsAction.ExportResponse response={d} />
+                <Action title="Reset Ranking" icon={Icon.ArrowCounterClockwise} onAction={() => resetRanking(d)} />
+              </ActionPanel.Section>
+              <AwsAction.SwitchResourceType
+                {...{ setResourceType, current: ResourceType.Dashboards, enumType: ResourceType }}
+              />
+            </ActionPanel>
+          }
+          accessories={[
+            { date: d.LastPublishedTime, icon: Icon.Calendar, tooltip: "Last Published" },
+            {
+              icon: statusToIcon(d.LastUpdatedTime ? "AVAILABLE" : "UNKNOWN"),
+              tooltip: d.LastUpdatedTime ? "Available" : "Unknown",
+            },
+          ]}
+        />
+      ))}
+    </List>
+  );
+};
+
+const QuickSightAnalyses = ({ setResourceType }: SetResourceType) => {
+  const { analyses, error, isLoading, revalidate } = useQuickSightAnalyses();
+
+  const {
+    data: sortedAnalyses,
+    visitItem: visit,
+    resetRanking,
+  } = useFrecencySorting(analyses, {
+    namespace: "aws-quicksight-analyses",
+    key: (a) => a.AnalysisId!,
+    sortUnvisited: (a, b) => (a.Name ?? "").localeCompare(b.Name ?? ""),
+  });
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Filter analyses by name..."
+      filtering
+      navigationTitle="QuickSight Analyses"
+      searchBarAccessory={<AWSProfileDropdown onProfileSelected={revalidate} />}
+    >
+      {error && (
+        <List.EmptyView
+          title={error.name}
+          description={error.message}
+          icon={{ source: Icon.Warning, tintColor: Color.Red }}
+        />
+      )}
+      {!error && sortedAnalyses.length === 0 && (
+        <List.EmptyView title="No analyses found!" icon={{ source: Icon.Warning, tintColor: Color.Orange }} />
+      )}
+      {sortedAnalyses.map((a) => (
+        <List.Item
+          key={a.AnalysisId}
+          icon={"aws-icons/qs.png"}
+          title={a.Name ?? ""}
+          keywords={[a.Name ?? "", a.AnalysisId ?? "", a.Status ?? ""]}
+          actions={
+            <ActionPanel>
+              <AwsAction.Console
+                url={resourceToConsoleLink(a.AnalysisId, "AWS::QuickSight::Analysis")}
+                onAction={() => visit(a)}
+              />
+              <ActionPanel.Section title="Analysis Actions">
+                <Action.CopyToClipboard title="Copy Analysis ID" content={a.AnalysisId ?? ""} onCopy={() => visit(a)} />
+                <Action.CopyToClipboard title="Copy ARN" content={a.Arn ?? ""} onCopy={() => visit(a)} />
+                <AwsAction.ExportResponse response={a} />
+                <Action title="Reset Ranking" icon={Icon.ArrowCounterClockwise} onAction={() => resetRanking(a)} />
+              </ActionPanel.Section>
+              <AwsAction.SwitchResourceType
+                {...{ setResourceType, current: ResourceType.Analyses, enumType: ResourceType }}
+              />
+            </ActionPanel>
+          }
+          accessories={[
+            { date: a.LastUpdatedTime, icon: Icon.Calendar, tooltip: "Last Updated" },
+            { icon: statusToIcon(a.Status ?? ""), tooltip: a.Status },
+          ]}
+        />
+      ))}
+    </List>
+  );
+};
+
+const QuickSightDataSets = ({ setResourceType }: SetResourceType) => {
+  const { dataSets, error, isLoading, revalidate } = useQuickSightDataSets();
+
+  const {
+    data: sortedDataSets,
+    visitItem: visit,
+    resetRanking,
+  } = useFrecencySorting(dataSets, {
+    namespace: "aws-quicksight-datasets",
+    key: (ds) => ds.DataSetId!,
+    sortUnvisited: (a, b) => (a.Name ?? "").localeCompare(b.Name ?? ""),
+  });
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Filter data sets by name..."
+      filtering
+      navigationTitle="QuickSight Data Sets"
+      searchBarAccessory={<AWSProfileDropdown onProfileSelected={revalidate} />}
+    >
+      {error && (
+        <List.EmptyView
+          title={error.name}
+          description={error.message}
+          icon={{ source: Icon.Warning, tintColor: Color.Red }}
+        />
+      )}
+      {!error && sortedDataSets.length === 0 && (
+        <List.EmptyView title="No data sets found!" icon={{ source: Icon.Warning, tintColor: Color.Orange }} />
+      )}
+      {sortedDataSets.map((ds) => (
+        <List.Item
+          key={ds.DataSetId}
+          icon={"aws-icons/qs.png"}
+          title={ds.Name ?? ""}
+          keywords={[ds.Name ?? "", ds.DataSetId ?? "", ds.ImportMode ?? ""]}
+          actions={
+            <ActionPanel>
+              <AwsAction.Console
+                url={resourceToConsoleLink(ds.DataSetId, "AWS::QuickSight::DataSet")}
+                onAction={() => visit(ds)}
+              />
+              <ActionPanel.Section title="Data Set Actions">
+                <Action.CopyToClipboard
+                  title="Copy Data Set ID"
+                  content={ds.DataSetId ?? ""}
+                  onCopy={() => visit(ds)}
+                />
+                <Action.CopyToClipboard title="Copy ARN" content={ds.Arn ?? ""} onCopy={() => visit(ds)} />
+                <AwsAction.ExportResponse response={ds} />
+                <Action title="Reset Ranking" icon={Icon.ArrowCounterClockwise} onAction={() => resetRanking(ds)} />
+              </ActionPanel.Section>
+              <AwsAction.SwitchResourceType
+                {...{ setResourceType, current: ResourceType.DataSets, enumType: ResourceType }}
+              />
+            </ActionPanel>
+          }
+          accessories={[
+            { date: ds.LastUpdatedTime, icon: Icon.Calendar, tooltip: "Last Updated" },
+            { tag: ds.ImportMode ?? "", tooltip: `Import mode: ${ds.ImportMode}` },
+          ]}
+        />
+      ))}
+    </List>
+  );
+};
+
+const statusToIcon = (status: string) => {
+  const statusUpper = status.toUpperCase();
+  if (statusUpper === "AVAILABLE" || statusUpper.includes("COMPLETE")) {
+    return { source: Icon.CheckCircle, tintColor: Color.Green };
+  }
+  if (statusUpper.includes("ERROR") || statusUpper.includes("FAILED") || statusUpper === "DELETED") {
+    return { source: Icon.XMarkCircle, tintColor: Color.Red };
+  }
+  if (statusUpper.includes("PROGRESS") || statusUpper === "UPDATING") {
+    return { source: Icon.CircleProgress50, tintColor: Color.Blue };
+  }
+  return { source: Icon.Warning, tintColor: Color.Orange };
+};

--- a/extensions/amazon-aws/src/run-profile-script.tsx
+++ b/extensions/amazon-aws/src/run-profile-script.tsx
@@ -41,7 +41,7 @@ function Profile({ profile }: { profile: Record<string, string | undefined> }) {
           <Action
             title="Run Script"
             onAction={async () => {
-              const { script } = getPreferenceValues<Preferences.RunProfileScript>();
+              const { script } = getPreferenceValues<{ script: string }>();
               const regex = /<profile>/i;
 
               if (script) {

--- a/extensions/amazon-aws/src/s3.tsx
+++ b/extensions/amazon-aws/src/s3.tsx
@@ -17,6 +17,7 @@ import {
 import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
 import { isReadyToFetch, resourceToConsoleLink } from "./util";
 import { AwsAction } from "./components/common/action";
+import { getS3Client } from "./services/clients/s3";
 
 export default function S3() {
   const { data: buckets, error, isLoading, revalidate } = useCachedPromise(fetchBuckets);
@@ -47,8 +48,11 @@ function S3Bucket({ bucket }: { bucket: Bucket }) {
           <Action.Push target={<S3BucketObjects bucket={bucket} />} title="List Objects" icon={Icon.Document} />
           <Action.Push target={<S3BucketPolicy bucket={bucket} />} title="Show Bucket Policy" icon={Icon.Key} />{" "}
           <AwsAction.Console url={resourceToConsoleLink(bucket.Name, "AWS::S3::Bucket")} />
-          <Action.CopyToClipboard title="Copy Name" content={bucket.Name || ""} />
-          <Action.CopyToClipboard title="Copy ARN" content={"arn:aws:s3:::" + bucket.Name || ""} />
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard title="Copy Name" content={bucket.Name || ""} />
+            <Action.CopyToClipboard title="Copy ARN" content={"arn:aws:s3:::" + bucket.Name || ""} />
+            <AwsAction.ExportResponse response={bucket} />
+          </ActionPanel.Section>
         </ActionPanel>
       }
     />
@@ -92,12 +96,15 @@ function S3BucketObjects({ bucket, prefix = "" }: { bucket: Bucket; prefix?: str
                   <AwsAction.Console
                     url={resourceToConsoleLink(`${bucket.Name}/${commonPrefix.Prefix}`, "AWS::S3::Bucket")}
                   />
-                  <Action.CopyToClipboard title="Copy Prefix" content={commonPrefix.Prefix || ""} />
-                  <Action.CopyToClipboard
-                    title="Copy S3 URI"
-                    content={"s3://" + bucket.Name + "/" + (commonPrefix.Prefix || "")}
-                    shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
-                  />
+                  <ActionPanel.Section title="Copy">
+                    <Action.CopyToClipboard title="Copy Prefix" content={commonPrefix.Prefix || ""} />
+                    <Action.CopyToClipboard
+                      title="Copy S3 URI"
+                      content={"s3://" + bucket.Name + "/" + (commonPrefix.Prefix || "")}
+                      shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
+                    />
+                    <AwsAction.ExportResponse response={commonPrefix} />
+                  </ActionPanel.Section>
                 </ActionPanel>
               }
             />
@@ -117,7 +124,7 @@ function S3BucketObjects({ bucket, prefix = "" }: { bucket: Bucket; prefix?: str
                       const toast = await showToast({ style: Toast.Style.Animated, title: "Downloading..." });
 
                       try {
-                        const data = await new S3Client({}).send(
+                        const data = await getS3Client().send(
                           new GetObjectCommand({ Bucket: bucket.Name, Key: object.Key || "" }),
                         );
                         if (data.Body instanceof Readable) {
@@ -135,12 +142,15 @@ function S3BucketObjects({ bucket, prefix = "" }: { bucket: Bucket; prefix?: str
                       }
                     }}
                   />
-                  <Action.CopyToClipboard title="Copy Key" content={object.Key || ""} />
-                  <Action.CopyToClipboard
-                    title="Copy S3 URI"
-                    content={"s3://" + bucket.Name + "/" + (object.Key || "")}
-                    shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
-                  />
+                  <ActionPanel.Section title="Copy">
+                    <Action.CopyToClipboard title="Copy Key" content={object.Key || ""} />
+                    <Action.CopyToClipboard
+                      title="Copy S3 URI"
+                      content={"s3://" + bucket.Name + "/" + (object.Key || "")}
+                      shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
+                    />
+                    <AwsAction.ExportResponse response={object} />
+                  </ActionPanel.Section>
                   <Action
                     title={`${isReversedOrder ? "Standard" : "Reversed"} Order`}
                     onAction={() => setReversedOrder(!isReversedOrder)}
@@ -169,6 +179,9 @@ function S3BucketPolicy({ bucket }: { bucket: Bucket }) {
         <ActionPanel>
           <Action.CopyToClipboard title="Copy Policy" content={policy?.value || ""} />
           <AwsAction.Console url={resourceToConsoleLink(bucket.Name, "AWS::S3::BucketPolicy")} />
+          <ActionPanel.Section title="Copy">
+            <AwsAction.ExportResponse response={policy} />
+          </ActionPanel.Section>
         </ActionPanel>
       }
     />
@@ -176,7 +189,7 @@ function S3BucketPolicy({ bucket }: { bucket: Bucket }) {
 }
 async function fetchBuckets() {
   if (!isReadyToFetch()) return [];
-  const { Buckets } = await new S3Client({}).send(new ListBucketsCommand({}));
+  const { Buckets } = await getS3Client().send(new ListBucketsCommand({}));
 
   return Buckets;
 }
@@ -191,7 +204,7 @@ async function fetchBucketObjects(
   prefixes: CommonPrefix[] = [],
 ): Promise<{ objects: _Object[]; prefixes: CommonPrefix[] }> {
   const region =
-    _region || (await new S3Client({}).send(new GetBucketLocationCommand({ Bucket: bucket }))).LocationConstraint;
+    _region || (await getS3Client().send(new GetBucketLocationCommand({ Bucket: bucket }))).LocationConstraint;
   const { Contents, CommonPrefixes, NextContinuationToken } = await new S3Client({ region }).send(
     new ListObjectsV2Command({ Bucket: bucket, ContinuationToken: continuationToken, Delimiter: "/", Prefix: prefix }),
   );
@@ -237,9 +250,7 @@ export const fetchBucketPolicy = (bucket: string) => {
     isLoading,
   } = useCachedPromise(
     async (bucket: string) => {
-      const { Policy = "❗Not Yet Defined" } = await new S3Client({}).send(
-        new GetBucketPolicyCommand({ Bucket: bucket }),
-      );
+      const { Policy = "❗Not Yet Defined" } = await getS3Client().send(new GetBucketPolicyCommand({ Bucket: bucket }));
       let md = "## Bucket Policy\n\n```";
       let value = Policy;
 

--- a/extensions/amazon-aws/src/secrets.tsx
+++ b/extensions/amazon-aws/src/secrets.tsx
@@ -173,6 +173,7 @@ export default function Secrets() {
                   icon={isDetailsEnabled ? Icon.EyeDisabled : Icon.Eye}
                 />
                 <Action title="Reset Ranking" icon={Icon.ArrowCounterClockwise} onAction={() => resetRanking(secret)} />
+                <AwsAction.ExportResponse response={secret} />
               </ActionPanel.Section>
             </ActionPanel>
           }

--- a/extensions/amazon-aws/src/services/client-cache.ts
+++ b/extensions/amazon-aws/src/services/client-cache.ts
@@ -1,0 +1,55 @@
+type ClientConstructor<T> = new (config: Record<string, unknown>) => T;
+
+/**
+ * Cache key for AWS clients, includes profile and region for proper isolation.
+ */
+export function getClientCacheKey(regionOverride?: string): string {
+  const profile = process.env.AWS_PROFILE ?? process.env.AWS_VAULT ?? "default";
+  const region = regionOverride ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? "us-east-1";
+  return `${profile}:${region}`;
+}
+
+/**
+ * Generic client cache with type safety.
+ */
+class ClientCache {
+  private clients: Map<string, Map<string, unknown>> = new Map();
+
+  /**
+   * Gets or creates a cached client instance.
+   *
+   * @param ClientClass - The AWS SDK client constructor
+   * @param serviceName - Name of the service for cache key
+   * @param regionOverride - Optional region override for region-specific clients
+   */
+  getClient<T>(ClientClass: ClientConstructor<T>, serviceName: string, regionOverride?: string): T {
+    const cacheKey = getClientCacheKey(regionOverride);
+
+    if (!this.clients.has(cacheKey)) {
+      this.clients.set(cacheKey, new Map());
+    }
+
+    const profileClients = this.clients.get(cacheKey);
+
+    if (!profileClients?.has(serviceName)) {
+      const config: Record<string, unknown> = {};
+      if (regionOverride) {
+        config.region = regionOverride;
+      }
+      profileClients?.set(serviceName, new ClientClass(config));
+    }
+
+    return profileClients?.get(serviceName) as T;
+  }
+
+  clearAll(): void {
+    this.clients.clear();
+  }
+
+  clearCurrent(): void {
+    const cacheKey = getClientCacheKey();
+    this.clients.delete(cacheKey);
+  }
+}
+
+export const clientCache = new ClientCache();

--- a/extensions/amazon-aws/src/services/clients/amplify.ts
+++ b/extensions/amazon-aws/src/services/clients/amplify.ts
@@ -1,0 +1,6 @@
+import { AmplifyClient } from "@aws-sdk/client-amplify";
+import { clientCache } from "../client-cache";
+
+export function getAmplifyClient(): AmplifyClient {
+  return clientCache.getClient(AmplifyClient, "amplify");
+}

--- a/extensions/amazon-aws/src/services/clients/api-gateway.ts
+++ b/extensions/amazon-aws/src/services/clients/api-gateway.ts
@@ -1,0 +1,11 @@
+import { APIGatewayClient } from "@aws-sdk/client-api-gateway";
+import { ApiGatewayV2Client } from "@aws-sdk/client-apigatewayv2";
+import { clientCache } from "../client-cache";
+
+export function getApiGatewayClient(): APIGatewayClient {
+  return clientCache.getClient(APIGatewayClient, "apigateway");
+}
+
+export function getApiGatewayV2Client(): ApiGatewayV2Client {
+  return clientCache.getClient(ApiGatewayV2Client, "apigatewayv2");
+}

--- a/extensions/amazon-aws/src/services/clients/appsync.ts
+++ b/extensions/amazon-aws/src/services/clients/appsync.ts
@@ -1,0 +1,6 @@
+import { AppSyncClient } from "@aws-sdk/client-appsync";
+import { clientCache } from "../client-cache";
+
+export function getAppSyncClient(): AppSyncClient {
+  return clientCache.getClient(AppSyncClient, "appsync");
+}

--- a/extensions/amazon-aws/src/services/clients/athena.ts
+++ b/extensions/amazon-aws/src/services/clients/athena.ts
@@ -1,0 +1,6 @@
+import { AthenaClient } from "@aws-sdk/client-athena";
+import { clientCache } from "../client-cache";
+
+export function getAthenaClient(): AthenaClient {
+  return clientCache.getClient(AthenaClient, "athena");
+}

--- a/extensions/amazon-aws/src/services/clients/cloudformation.ts
+++ b/extensions/amazon-aws/src/services/clients/cloudformation.ts
@@ -1,0 +1,6 @@
+import { CloudFormationClient } from "@aws-sdk/client-cloudformation";
+import { clientCache } from "../client-cache";
+
+export function getCloudFormationClient(): CloudFormationClient {
+  return clientCache.getClient(CloudFormationClient, "cloudformation");
+}

--- a/extensions/amazon-aws/src/services/clients/cloudwatch-logs.ts
+++ b/extensions/amazon-aws/src/services/clients/cloudwatch-logs.ts
@@ -1,0 +1,6 @@
+import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
+import { clientCache } from "../client-cache";
+
+export function getCloudWatchLogsClient(): CloudWatchLogsClient {
+  return clientCache.getClient(CloudWatchLogsClient, "cloudwatchlogs");
+}

--- a/extensions/amazon-aws/src/services/clients/cloudwatch.ts
+++ b/extensions/amazon-aws/src/services/clients/cloudwatch.ts
@@ -1,0 +1,6 @@
+import { CloudWatchClient } from "@aws-sdk/client-cloudwatch";
+import { clientCache } from "../client-cache";
+
+export function getCloudWatchClient(): CloudWatchClient {
+  return clientCache.getClient(CloudWatchClient, "cloudwatch");
+}

--- a/extensions/amazon-aws/src/services/clients/codepipeline.ts
+++ b/extensions/amazon-aws/src/services/clients/codepipeline.ts
@@ -1,0 +1,6 @@
+import { CodePipelineClient } from "@aws-sdk/client-codepipeline";
+import { clientCache } from "../client-cache";
+
+export function getCodePipelineClient(): CodePipelineClient {
+  return clientCache.getClient(CodePipelineClient, "codepipeline");
+}

--- a/extensions/amazon-aws/src/services/clients/cognito.ts
+++ b/extensions/amazon-aws/src/services/clients/cognito.ts
@@ -1,0 +1,6 @@
+import { CognitoIdentityProviderClient } from "@aws-sdk/client-cognito-identity-provider";
+import { clientCache } from "../client-cache";
+
+export function getCognitoClient(): CognitoIdentityProviderClient {
+  return clientCache.getClient(CognitoIdentityProviderClient, "cognito");
+}

--- a/extensions/amazon-aws/src/services/clients/dynamodb.ts
+++ b/extensions/amazon-aws/src/services/clients/dynamodb.ts
@@ -1,0 +1,6 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { clientCache } from "../client-cache";
+
+export function getDynamoDBClient(): DynamoDBClient {
+  return clientCache.getClient(DynamoDBClient, "dynamodb");
+}

--- a/extensions/amazon-aws/src/services/clients/ec2.ts
+++ b/extensions/amazon-aws/src/services/clients/ec2.ts
@@ -1,0 +1,6 @@
+import { EC2Client } from "@aws-sdk/client-ec2";
+import { clientCache } from "../client-cache";
+
+export function getEC2Client(): EC2Client {
+  return clientCache.getClient(EC2Client, "ec2");
+}

--- a/extensions/amazon-aws/src/services/clients/ecr.ts
+++ b/extensions/amazon-aws/src/services/clients/ecr.ts
@@ -1,0 +1,6 @@
+import { ECRClient } from "@aws-sdk/client-ecr";
+import { clientCache } from "../client-cache";
+
+export function getECRClient(): ECRClient {
+  return clientCache.getClient(ECRClient, "ecr");
+}

--- a/extensions/amazon-aws/src/services/clients/ecs.ts
+++ b/extensions/amazon-aws/src/services/clients/ecs.ts
@@ -1,0 +1,6 @@
+import { ECSClient } from "@aws-sdk/client-ecs";
+import { clientCache } from "../client-cache";
+
+export function getECSClient(): ECSClient {
+  return clientCache.getClient(ECSClient, "ecs");
+}

--- a/extensions/amazon-aws/src/services/clients/glue.ts
+++ b/extensions/amazon-aws/src/services/clients/glue.ts
@@ -1,0 +1,6 @@
+import { GlueClient } from "@aws-sdk/client-glue";
+import { clientCache } from "../client-cache";
+
+export function getGlueClient(): GlueClient {
+  return clientCache.getClient(GlueClient, "glue");
+}

--- a/extensions/amazon-aws/src/services/clients/lambda.ts
+++ b/extensions/amazon-aws/src/services/clients/lambda.ts
@@ -1,0 +1,6 @@
+import { LambdaClient } from "@aws-sdk/client-lambda";
+import { clientCache } from "../client-cache";
+
+export function getLambdaClient(): LambdaClient {
+  return clientCache.getClient(LambdaClient, "lambda");
+}

--- a/extensions/amazon-aws/src/services/clients/quicksight.ts
+++ b/extensions/amazon-aws/src/services/clients/quicksight.ts
@@ -1,0 +1,11 @@
+import { QuickSightClient } from "@aws-sdk/client-quicksight";
+import { STSClient } from "@aws-sdk/client-sts";
+import { clientCache } from "../client-cache";
+
+export function getQuickSightClient(regionOverride?: string): QuickSightClient {
+  return clientCache.getClient(QuickSightClient, "quicksight", regionOverride);
+}
+
+export function getSTSClient(): STSClient {
+  return clientCache.getClient(STSClient, "sts");
+}

--- a/extensions/amazon-aws/src/services/clients/s3.ts
+++ b/extensions/amazon-aws/src/services/clients/s3.ts
@@ -1,0 +1,6 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import { clientCache } from "../client-cache";
+
+export function getS3Client(): S3Client {
+  return clientCache.getClient(S3Client, "s3");
+}

--- a/extensions/amazon-aws/src/services/clients/secrets-manager.ts
+++ b/extensions/amazon-aws/src/services/clients/secrets-manager.ts
@@ -1,0 +1,6 @@
+import { SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
+import { clientCache } from "../client-cache";
+
+export function getSecretsManagerClient(): SecretsManagerClient {
+  return clientCache.getClient(SecretsManagerClient, "secretsmanager");
+}

--- a/extensions/amazon-aws/src/services/clients/sfn.ts
+++ b/extensions/amazon-aws/src/services/clients/sfn.ts
@@ -1,0 +1,6 @@
+import { SFNClient } from "@aws-sdk/client-sfn";
+import { clientCache } from "../client-cache";
+
+export function getSFNClient(): SFNClient {
+  return clientCache.getClient(SFNClient, "sfn");
+}

--- a/extensions/amazon-aws/src/services/clients/sqs.ts
+++ b/extensions/amazon-aws/src/services/clients/sqs.ts
@@ -1,0 +1,6 @@
+import { SQSClient } from "@aws-sdk/client-sqs";
+import { clientCache } from "../client-cache";
+
+export function getSQSClient(): SQSClient {
+  return clientCache.getClient(SQSClient, "sqs");
+}

--- a/extensions/amazon-aws/src/services/clients/ssm.ts
+++ b/extensions/amazon-aws/src/services/clients/ssm.ts
@@ -1,0 +1,6 @@
+import { SSMClient } from "@aws-sdk/client-ssm";
+import { clientCache } from "../client-cache";
+
+export function getSSMClient(): SSMClient {
+  return clientCache.getClient(SSMClient, "ssm");
+}

--- a/extensions/amazon-aws/src/sqs.tsx
+++ b/extensions/amazon-aws/src/sqs.tsx
@@ -1,4 +1,5 @@
-import { PurgeQueueCommand, QueueAttributeName, SQSClient } from "@aws-sdk/client-sqs";
+import { PurgeQueueCommand, QueueAttributeName } from "@aws-sdk/client-sqs";
+import { getSQSClient } from "./services/clients/sqs";
 import {
   Action,
   ActionPanel,
@@ -182,6 +183,7 @@ export default function SQS() {
                   onAction={() => setDetailsEnabled(!isDetailsEnabled)}
                   icon={isDetailsEnabled ? Icon.EyeDisabled : Icon.Eye}
                 />
+                <AwsAction.ExportResponse response={queue} />
                 <Action title="Reset Ranking" icon={Icon.ArrowCounterClockwise} onAction={() => resetRanking(queue)} />
               </ActionPanel.Section>
             </ActionPanel>
@@ -218,7 +220,7 @@ const purgeQueue = async (queue: Queue, mutate: MutatePromise<Queue[] | undefine
 
 const tryPurgeQueue = async (queue: Queue, mutate: MutatePromise<Queue[] | undefined>) => {
   const toast = await showToast({ style: Toast.Style.Animated, title: "🗑️ Purging queue..." });
-  mutate(new SQSClient({}).send(new PurgeQueueCommand({ QueueUrl: queue.queueUrl })), {
+  mutate(getSQSClient().send(new PurgeQueueCommand({ QueueUrl: queue.queueUrl })), {
     optimisticUpdate: (queues) => {
       if (!queues) {
         return;

--- a/extensions/amazon-aws/src/ssm.tsx
+++ b/extensions/amazon-aws/src/ssm.tsx
@@ -3,7 +3,6 @@ import {
   GetParameterCommand,
   Parameter as SSMParameter,
   ParameterMetadata,
-  SSMClient,
 } from "@aws-sdk/client-ssm";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
@@ -11,6 +10,7 @@ import { useState } from "react";
 import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
 import { isReadyToFetch, resourceToConsoleLink } from "./util";
 import { AwsAction } from "./components/common/action";
+import { getSSMClient } from "./services/clients/ssm";
 
 export default function SSM() {
   const [search, setSearch] = useState<string>("");
@@ -59,7 +59,10 @@ function Parameter({ parameter }: { parameter: ParameterMetadata }) {
           <Action title={showValue ? "Hide Value" : "Show Value"} onAction={() => setShowValue(!showValue)} />
           <Action.CopyToClipboard title="Copy Value" content={parameterDetails?.Value || ""} />
           <AwsAction.Console url={resourceToConsoleLink(parameter.Name, "AWS::SSM::Parameter")} />
-          <Action.CopyToClipboard title="Copy Name" content={parameter.Name || ""} />
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard title="Copy Name" content={parameter.Name || ""} />
+            <AwsAction.ExportResponse response={parameter} />
+          </ActionPanel.Section>
         </ActionPanel>
       }
       accessories={[{ icon: showValue ? Icon.Eye : Icon.EyeDisabled }]}
@@ -76,7 +79,7 @@ async function fetchParameters(
   if (search.length < threshold) return [];
   if (!isReadyToFetch()) return [];
 
-  const { NextToken, Parameters } = await new SSMClient({}).send(
+  const { NextToken, Parameters } = await getSSMClient().send(
     new DescribeParametersCommand({
       NextToken: token,
       ParameterFilters: search ? [{ Key: "Name", Option: "Contains", Values: [search] }] : undefined,
@@ -94,7 +97,7 @@ async function fetchParameters(
 
 async function fetchParameter(name?: string): Promise<SSMParameter | undefined> {
   if (!name) return;
-  const { Parameter } = await new SSMClient({}).send(new GetParameterCommand({ Name: name, WithDecryption: true }));
+  const { Parameter } = await getSSMClient().send(new GetParameterCommand({ Name: name, WithDecryption: true }));
 
   return Parameter;
 }

--- a/extensions/amazon-aws/src/step-functions.tsx
+++ b/extensions/amazon-aws/src/step-functions.tsx
@@ -1,4 +1,5 @@
-import { ListStateMachinesCommand, SFNClient, StateMachineListItem, StateMachineType } from "@aws-sdk/client-sfn"; // ES Modules import
+import { ListStateMachinesCommand, StateMachineListItem, StateMachineType } from "@aws-sdk/client-sfn";
+import { getSFNClient } from "./services/clients/sfn";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import AWSProfileDropdown from "./components/searchbar/aws-profile-dropdown";
@@ -36,6 +37,7 @@ function StateMachine({ item }: { item: StateMachineListItem }) {
           <ActionPanel.Section title={"Copy"}>
             <Action.CopyToClipboard title="Copy State Machine ARN" content={item.stateMachineArn || ""} />
             <Action.CopyToClipboard title="Copy State Machine Name" content={item.name || ""} />
+            <AwsAction.ExportResponse response={item} />
           </ActionPanel.Section>
         </ActionPanel>
       }
@@ -47,7 +49,7 @@ async function fetchStateMachines(
   nextMarker?: string,
   aggregatedStateMachines?: StateMachineListItem[],
 ): Promise<StateMachineListItem[]> {
-  const client = new SFNClient({});
+  const client = getSFNClient();
   const command = new ListStateMachinesCommand({ nextToken: nextMarker });
   const { nextToken, stateMachines } = await client.send(command);
   const combinedStateMachines = [...(aggregatedStateMachines || []), ...(stateMachines || [])];

--- a/extensions/amazon-aws/src/tools/create-amplify-webhook.ts
+++ b/extensions/amazon-aws/src/tools/create-amplify-webhook.ts
@@ -1,4 +1,5 @@
-import { AmplifyClient, CreateWebhookCommand, Webhook } from "@aws-sdk/client-amplify";
+import { CreateWebhookCommand, Webhook } from "@aws-sdk/client-amplify";
+import { getAmplifyClient } from "../services/clients/amplify";
 
 /**
  * Creates a new webhook for an Amplify app
@@ -19,7 +20,7 @@ export default async function createAmplifyWebhook(options: {
     throw new Error("Branch name is required");
   }
 
-  const client = new AmplifyClient({});
+  const client = getAmplifyClient();
 
   const command = new CreateWebhookCommand({
     appId,

--- a/extensions/amazon-aws/src/tools/delete-amplify-webhook.ts
+++ b/extensions/amazon-aws/src/tools/delete-amplify-webhook.ts
@@ -1,4 +1,5 @@
-import { AmplifyClient, DeleteWebhookCommand } from "@aws-sdk/client-amplify";
+import { DeleteWebhookCommand } from "@aws-sdk/client-amplify";
+import { getAmplifyClient } from "../services/clients/amplify";
 
 /**
  * Deletes a webhook for an Amplify app
@@ -12,7 +13,7 @@ export default async function deleteAmplifyWebhook(options: { webhookId: string 
     throw new Error("Webhook ID is required");
   }
 
-  const client = new AmplifyClient({});
+  const client = getAmplifyClient();
 
   const command = new DeleteWebhookCommand({
     webhookId,

--- a/extensions/amazon-aws/src/tools/describe-dynamodb-table.ts
+++ b/extensions/amazon-aws/src/tools/describe-dynamodb-table.ts
@@ -1,0 +1,30 @@
+import { DescribeTableCommand, TableDescription } from "@aws-sdk/client-dynamodb";
+import { getDynamoDBClient } from "../services/clients/dynamodb";
+
+/**
+ * Gets detailed information for a specific DynamoDB table
+ * @param options - Configuration options
+ * @returns Promise<TableDescription | undefined> Table details or undefined if not found
+ */
+export default async function describeDynamoDBTable(options: {
+  tableName: string;
+}): Promise<TableDescription | undefined> {
+  const { tableName } = options;
+
+  if (!tableName) {
+    throw new Error("Table name is required");
+  }
+
+  const client = getDynamoDBClient();
+
+  try {
+    const command = new DescribeTableCommand({ TableName: tableName });
+    const response = await client.send(command);
+    return response.Table;
+  } catch (error) {
+    if (error instanceof Error && error.name === "ResourceNotFoundException") {
+      return undefined;
+    }
+    throw error;
+  }
+}

--- a/extensions/amazon-aws/src/tools/get-amplify-app-details.ts
+++ b/extensions/amazon-aws/src/tools/get-amplify-app-details.ts
@@ -1,4 +1,5 @@
-import { AmplifyClient, GetAppCommand, App } from "@aws-sdk/client-amplify";
+import { GetAppCommand, App } from "@aws-sdk/client-amplify";
+import { getAmplifyClient } from "../services/clients/amplify";
 
 /**
  * Gets detailed information for a specific Amplify app
@@ -12,7 +13,7 @@ export default async function getAmplifyAppDetails(options: { appId: string }): 
     throw new Error("App ID is required");
   }
 
-  const client = new AmplifyClient({});
+  const client = getAmplifyClient();
 
   try {
     const command = new GetAppCommand({ appId });

--- a/extensions/amazon-aws/src/tools/get-amplify-webhook.ts
+++ b/extensions/amazon-aws/src/tools/get-amplify-webhook.ts
@@ -1,4 +1,5 @@
-import { AmplifyClient, GetWebhookCommand, Webhook } from "@aws-sdk/client-amplify";
+import { GetWebhookCommand, Webhook } from "@aws-sdk/client-amplify";
+import { getAmplifyClient } from "../services/clients/amplify";
 
 /**
  * Gets detailed information for a specific Amplify webhook
@@ -12,7 +13,7 @@ export default async function getAmplifyWebhook(options: { webhookId: string }):
     throw new Error("Webhook ID is required");
   }
 
-  const client = new AmplifyClient({});
+  const client = getAmplifyClient();
 
   try {
     const command = new GetWebhookCommand({ webhookId });

--- a/extensions/amazon-aws/src/tools/get-lambda-function-details.ts
+++ b/extensions/amazon-aws/src/tools/get-lambda-function-details.ts
@@ -1,0 +1,30 @@
+import { GetFunctionCommand, GetFunctionResponse } from "@aws-sdk/client-lambda";
+import { getLambdaClient } from "../services/clients/lambda";
+
+/**
+ * Gets detailed information for a specific Lambda function
+ * @param options - Configuration options
+ * @returns Promise<GetFunctionResponse | undefined> Function details or undefined if not found
+ */
+export default async function getLambdaFunctionDetails(options: {
+  functionName: string;
+}): Promise<GetFunctionResponse | undefined> {
+  const { functionName } = options;
+
+  if (!functionName) {
+    throw new Error("Function name is required");
+  }
+
+  const client = getLambdaClient();
+
+  try {
+    const command = new GetFunctionCommand({ FunctionName: functionName });
+    const response = await client.send(command);
+    return response;
+  } catch (error) {
+    if (error instanceof Error && error.name === "ResourceNotFoundException") {
+      return undefined;
+    }
+    throw error;
+  }
+}

--- a/extensions/amazon-aws/src/tools/invoke-lambda-function.ts
+++ b/extensions/amazon-aws/src/tools/invoke-lambda-function.ts
@@ -1,0 +1,35 @@
+import { InvokeCommand, InvokeCommandOutput } from "@aws-sdk/client-lambda";
+import { getLambdaClient } from "../services/clients/lambda";
+
+/**
+ * Invokes a Lambda function with an optional JSON payload
+ * @param options - Configuration options
+ * @returns Promise with status code, response payload, and any function error
+ */
+export default async function invokeLambdaFunction(options: {
+  functionName: string;
+  payload?: string;
+}): Promise<{ statusCode: number | undefined; payload: string; functionError: string | undefined }> {
+  const { functionName, payload } = options;
+
+  if (!functionName) {
+    throw new Error("Function name is required");
+  }
+
+  const client = getLambdaClient();
+
+  const command = new InvokeCommand({
+    FunctionName: functionName,
+    Payload: payload ? new TextEncoder().encode(payload) : undefined,
+  });
+
+  const response: InvokeCommandOutput = await client.send(command);
+
+  const responsePayload = response.Payload ? new TextDecoder().decode(response.Payload) : "";
+
+  return {
+    statusCode: response.StatusCode,
+    payload: responsePayload,
+    functionError: response.FunctionError,
+  };
+}

--- a/extensions/amazon-aws/src/tools/list-amplify-branches.ts
+++ b/extensions/amazon-aws/src/tools/list-amplify-branches.ts
@@ -1,4 +1,5 @@
-import { AmplifyClient, ListBranchesCommand, Branch } from "@aws-sdk/client-amplify";
+import { ListBranchesCommand, Branch } from "@aws-sdk/client-amplify";
+import { getAmplifyClient } from "../services/clients/amplify";
 
 /**
  * Lists all branches for a specific Amplify app
@@ -12,7 +13,7 @@ export default async function listAmplifyBranches(options: { appId: string }): P
     throw new Error("App ID is required");
   }
 
-  const client = new AmplifyClient({});
+  const client = getAmplifyClient();
 
   const branches: Branch[] = [];
   let nextToken: string | undefined;

--- a/extensions/amazon-aws/src/tools/list-amplify-jobs.ts
+++ b/extensions/amazon-aws/src/tools/list-amplify-jobs.ts
@@ -1,4 +1,5 @@
-import { AmplifyClient, ListJobsCommand, JobSummary } from "@aws-sdk/client-amplify";
+import { ListJobsCommand, JobSummary } from "@aws-sdk/client-amplify";
+import { getAmplifyClient } from "../services/clients/amplify";
 
 /**
  * Lists build jobs for a specific Amplify app branch
@@ -19,7 +20,7 @@ export default async function listAmplifyJobs(options: {
     throw new Error("Branch name is required");
   }
 
-  const client = new AmplifyClient({});
+  const client = getAmplifyClient();
 
   const jobs: JobSummary[] = [];
   let nextToken: string | undefined;

--- a/extensions/amazon-aws/src/tools/list-amplify-project.ts
+++ b/extensions/amazon-aws/src/tools/list-amplify-project.ts
@@ -1,11 +1,12 @@
-import { AmplifyClient, App, ListAppsCommand } from "@aws-sdk/client-amplify";
+import { App, ListAppsCommand } from "@aws-sdk/client-amplify";
+import { getAmplifyClient } from "../services/clients/amplify";
 
 /**
  * Lists all Amplify projects (apps) in the current AWS account and region
  * @returns Promise<App[]> Array of Amplify apps
  */
 export default async function listAmplifyProjects(): Promise<App[]> {
-  const client = new AmplifyClient({});
+  const client = getAmplifyClient();
 
   const amplifyApps: App[] = [];
   let nextToken: string | undefined;

--- a/extensions/amazon-aws/src/tools/list-amplify-webhooks.ts
+++ b/extensions/amazon-aws/src/tools/list-amplify-webhooks.ts
@@ -1,4 +1,5 @@
-import { AmplifyClient, ListWebhooksCommand, Webhook } from "@aws-sdk/client-amplify";
+import { ListWebhooksCommand, Webhook } from "@aws-sdk/client-amplify";
+import { getAmplifyClient } from "../services/clients/amplify";
 
 /**
  * Lists all webhooks for a specific Amplify app
@@ -12,7 +13,7 @@ export default async function listAmplifyWebhooks(options: { appId: string }): P
     throw new Error("App ID is required");
   }
 
-  const client = new AmplifyClient({});
+  const client = getAmplifyClient();
 
   const webhooks: Webhook[] = [];
   let nextToken: string | undefined;

--- a/extensions/amazon-aws/src/tools/list-cloudwatch-dashboards.ts
+++ b/extensions/amazon-aws/src/tools/list-cloudwatch-dashboards.ts
@@ -1,0 +1,26 @@
+import { DashboardEntry, ListDashboardsCommand } from "@aws-sdk/client-cloudwatch";
+import { getCloudWatchClient } from "../services/clients/cloudwatch";
+
+/**
+ * Lists CloudWatch dashboards in the current AWS account and region (max 500)
+ * @returns Promise<DashboardEntry[]> Array of CloudWatch dashboards
+ */
+export default async function listCloudWatchDashboards(): Promise<DashboardEntry[]> {
+  const client = getCloudWatchClient();
+
+  const dashboards: DashboardEntry[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const command = new ListDashboardsCommand({ NextToken: nextToken });
+    const response = await client.send(command);
+
+    if (response.DashboardEntries) {
+      dashboards.push(...response.DashboardEntries.filter((d) => d.DashboardName && d.DashboardArn));
+    }
+
+    nextToken = response.NextToken;
+  } while (nextToken && dashboards.length < 500);
+
+  return dashboards;
+}

--- a/extensions/amazon-aws/src/tools/list-cloudwatch-log-groups.ts
+++ b/extensions/amazon-aws/src/tools/list-cloudwatch-log-groups.ts
@@ -1,0 +1,26 @@
+import { LogGroup, DescribeLogGroupsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { getCloudWatchLogsClient } from "../services/clients/cloudwatch-logs";
+
+/**
+ * Lists CloudWatch log groups in the current AWS account and region (max 500)
+ * @returns Promise<LogGroup[]> Array of CloudWatch log groups
+ */
+export default async function listCloudWatchLogGroups(): Promise<LogGroup[]> {
+  const client = getCloudWatchLogsClient();
+
+  const logGroups: LogGroup[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const command = new DescribeLogGroupsCommand({ limit: 50, nextToken });
+    const response = await client.send(command);
+
+    if (response.logGroups) {
+      logGroups.push(...response.logGroups.filter((g) => g.logGroupArn && g.logGroupName && g.creationTime));
+    }
+
+    nextToken = response.nextToken;
+  } while (nextToken && logGroups.length < 500);
+
+  return logGroups;
+}

--- a/extensions/amazon-aws/src/tools/list-codepipeline-pipelines.ts
+++ b/extensions/amazon-aws/src/tools/list-codepipeline-pipelines.ts
@@ -1,0 +1,26 @@
+import { PipelineSummary, ListPipelinesCommand } from "@aws-sdk/client-codepipeline";
+import { getCodePipelineClient } from "../services/clients/codepipeline";
+
+/**
+ * Lists all CodePipeline pipelines in the current AWS account and region
+ * @returns Promise<PipelineSummary[]> Array of pipeline summaries
+ */
+export default async function listCodePipelinePipelines(): Promise<PipelineSummary[]> {
+  const client = getCodePipelineClient();
+
+  const pipelines: PipelineSummary[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const command = new ListPipelinesCommand({ nextToken });
+    const response = await client.send(command);
+
+    if (response.pipelines) {
+      pipelines.push(...response.pipelines.filter((p) => p.name));
+    }
+
+    nextToken = response.nextToken;
+  } while (nextToken);
+
+  return pipelines;
+}

--- a/extensions/amazon-aws/src/tools/list-dynamodb-tables.ts
+++ b/extensions/amazon-aws/src/tools/list-dynamodb-tables.ts
@@ -1,0 +1,26 @@
+import { ListTablesCommand } from "@aws-sdk/client-dynamodb";
+import { getDynamoDBClient } from "../services/clients/dynamodb";
+
+/**
+ * Lists all DynamoDB table names in the current AWS account and region
+ * @returns Promise<string[]> Array of table names
+ */
+export default async function listDynamoDBTables(): Promise<string[]> {
+  const client = getDynamoDBClient();
+
+  const tableNames: string[] = [];
+  let exclusiveStartTableName: string | undefined;
+
+  do {
+    const command = new ListTablesCommand({ ExclusiveStartTableName: exclusiveStartTableName });
+    const response = await client.send(command);
+
+    if (response.TableNames) {
+      tableNames.push(...response.TableNames);
+    }
+
+    exclusiveStartTableName = response.LastEvaluatedTableName;
+  } while (exclusiveStartTableName);
+
+  return tableNames;
+}

--- a/extensions/amazon-aws/src/tools/list-lambda-functions.ts
+++ b/extensions/amazon-aws/src/tools/list-lambda-functions.ts
@@ -1,0 +1,26 @@
+import { FunctionConfiguration, ListFunctionsCommand } from "@aws-sdk/client-lambda";
+import { getLambdaClient } from "../services/clients/lambda";
+
+/**
+ * Lists all Lambda functions in the current AWS account and region
+ * @returns Promise<FunctionConfiguration[]> Array of Lambda function configurations
+ */
+export default async function listLambdaFunctions(): Promise<FunctionConfiguration[]> {
+  const client = getLambdaClient();
+
+  const functions: FunctionConfiguration[] = [];
+  let marker: string | undefined;
+
+  do {
+    const command = new ListFunctionsCommand({ Marker: marker });
+    const response = await client.send(command);
+
+    if (response.Functions) {
+      functions.push(...response.Functions);
+    }
+
+    marker = response.NextMarker;
+  } while (marker);
+
+  return functions;
+}

--- a/extensions/amazon-aws/src/tools/list-quicksight-dashboards.ts
+++ b/extensions/amazon-aws/src/tools/list-quicksight-dashboards.ts
@@ -1,4 +1,5 @@
 import { DashboardSummary, ListDashboardsCommand } from "@aws-sdk/client-quicksight";
+import { getPreferenceValues } from "@raycast/api";
 import { getAwsAccountId } from "../hooks/use-quicksight";
 import { getQuickSightClient } from "../services/clients/quicksight";
 
@@ -8,7 +9,8 @@ import { getQuickSightClient } from "../services/clients/quicksight";
  */
 export default async function listQuickSightDashboards(): Promise<DashboardSummary[]> {
   const accountId = await getAwsAccountId();
-  const client = getQuickSightClient();
+  const { quicksightRegion } = getPreferenceValues<Preferences.Quicksight>();
+  const client = getQuickSightClient(quicksightRegion?.trim() || undefined);
 
   const command = new ListDashboardsCommand({
     AwsAccountId: accountId,

--- a/extensions/amazon-aws/src/tools/list-quicksight-dashboards.ts
+++ b/extensions/amazon-aws/src/tools/list-quicksight-dashboards.ts
@@ -1,0 +1,19 @@
+import { DashboardSummary, ListDashboardsCommand } from "@aws-sdk/client-quicksight";
+import { getAwsAccountId } from "../hooks/use-quicksight";
+import { getQuickSightClient } from "../services/clients/quicksight";
+
+/**
+ * Lists all QuickSight dashboards in the current AWS account
+ * @returns Array of QuickSight dashboard summaries
+ */
+export default async function listQuickSightDashboards(): Promise<DashboardSummary[]> {
+  const accountId = await getAwsAccountId();
+  const client = getQuickSightClient();
+
+  const command = new ListDashboardsCommand({
+    AwsAccountId: accountId,
+  });
+  const response = await client.send(command);
+
+  return response.DashboardSummaryList ?? [];
+}

--- a/extensions/amazon-aws/src/tools/list-s3-buckets.ts
+++ b/extensions/amazon-aws/src/tools/list-s3-buckets.ts
@@ -1,0 +1,15 @@
+import { Bucket, ListBucketsCommand } from "@aws-sdk/client-s3";
+import { getS3Client } from "../services/clients/s3";
+
+/**
+ * Lists all S3 buckets in the current AWS account
+ * @returns Promise<Bucket[]> Array of S3 buckets
+ */
+export default async function listS3Buckets(): Promise<Bucket[]> {
+  const client = getS3Client();
+
+  const command = new ListBucketsCommand({});
+  const response = await client.send(command);
+
+  return response.Buckets ?? [];
+}

--- a/extensions/amazon-aws/src/tools/list-s3-objects.ts
+++ b/extensions/amazon-aws/src/tools/list-s3-objects.ts
@@ -1,0 +1,39 @@
+import { _Object, ListObjectsV2Command } from "@aws-sdk/client-s3";
+import { getS3Client } from "../services/clients/s3";
+
+/**
+ * Lists objects in an S3 bucket with optional prefix filtering
+ * @param options.bucketName - The name of the S3 bucket
+ * @param options.prefix - Optional prefix to filter objects
+ * @param options.maxKeys - Maximum number of objects to return (default: 100)
+ * @returns Promise<_Object[]> Array of S3 objects
+ */
+export default async function listS3Objects(options: {
+  bucketName: string;
+  prefix?: string;
+  maxKeys?: number;
+}): Promise<_Object[]> {
+  const client = getS3Client();
+  const maxKeys = options.maxKeys ?? 100;
+
+  const objects: _Object[] = [];
+  let continuationToken: string | undefined;
+
+  do {
+    const command = new ListObjectsV2Command({
+      Bucket: options.bucketName,
+      Prefix: options.prefix,
+      MaxKeys: maxKeys - objects.length,
+      ContinuationToken: continuationToken,
+    });
+    const response = await client.send(command);
+
+    if (response.Contents) {
+      objects.push(...response.Contents);
+    }
+
+    continuationToken = response.NextContinuationToken;
+  } while (continuationToken && objects.length < maxKeys);
+
+  return objects;
+}

--- a/extensions/amazon-aws/src/tools/list-secrets.ts
+++ b/extensions/amazon-aws/src/tools/list-secrets.ts
@@ -1,0 +1,26 @@
+import { SecretListEntry, ListSecretsCommand } from "@aws-sdk/client-secrets-manager";
+import { getSecretsManagerClient } from "../services/clients/secrets-manager";
+
+/**
+ * Lists all secrets in the current AWS account and region
+ * @returns Promise<SecretListEntry[]> Array of secret list entries
+ */
+export default async function listSecrets(): Promise<SecretListEntry[]> {
+  const client = getSecretsManagerClient();
+
+  const secrets: SecretListEntry[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const command = new ListSecretsCommand({ NextToken: nextToken });
+    const response = await client.send(command);
+
+    if (response.SecretList) {
+      secrets.push(...response.SecretList.filter((s) => s.ARN && s.Name));
+    }
+
+    nextToken = response.NextToken;
+  } while (nextToken);
+
+  return secrets;
+}

--- a/extensions/amazon-aws/src/tools/start-amplify-build.ts
+++ b/extensions/amazon-aws/src/tools/start-amplify-build.ts
@@ -1,4 +1,5 @@
-import { AmplifyClient, StartJobCommand, JobSummary } from "@aws-sdk/client-amplify";
+import { StartJobCommand, JobSummary } from "@aws-sdk/client-amplify";
+import { getAmplifyClient } from "../services/clients/amplify";
 
 /**
  * Starts a new build job for an Amplify app branch
@@ -21,7 +22,7 @@ export default async function startAmplifyBuild(options: {
     throw new Error("Branch name is required");
   }
 
-  const client = new AmplifyClient({});
+  const client = getAmplifyClient();
 
   const command = new StartJobCommand({
     appId,

--- a/extensions/amazon-aws/src/tools/stop-amplify-build.ts
+++ b/extensions/amazon-aws/src/tools/stop-amplify-build.ts
@@ -1,4 +1,5 @@
-import { AmplifyClient, StopJobCommand, JobSummary } from "@aws-sdk/client-amplify";
+import { StopJobCommand, JobSummary } from "@aws-sdk/client-amplify";
+import { getAmplifyClient } from "../services/clients/amplify";
 
 /**
  * Stops a running build job for an Amplify app branch
@@ -22,7 +23,7 @@ export default async function stopAmplifyBuild(options: {
     throw new Error("Job ID is required");
   }
 
-  const client = new AmplifyClient({});
+  const client = getAmplifyClient();
 
   const command = new StopJobCommand({
     appId,

--- a/extensions/amazon-aws/src/util/index.ts
+++ b/extensions/amazon-aws/src/util/index.ts
@@ -38,9 +38,9 @@ export function resourceToConsoleLink(
     case "AWS::Lambda::Function":
       return `${AWS_URL_BASE}/lambda/home?region=${AWS_REGION}#/functions/${resourceId}?tab=monitoring`;
     case "AWS::Glue::JobRun":
-      return `${AWS_URL_BASE}/gluestudio/home?region=eu-central-1#/job/${resourceId}/run/${runId}`;
+      return `${AWS_URL_BASE}/gluestudio/home?region=${AWS_REGION}#/job/${resourceId}/run/${runId}`;
     case "AWS::Glue::JobRuns":
-      return `${AWS_URL_BASE}/gluestudio/home?region=eu-central-1#/editor/job/${resourceId}/runs`;
+      return `${AWS_URL_BASE}/gluestudio/home?region=${AWS_REGION}#/editor/job/${resourceId}/runs`;
     case "AWS::CodePipeline::Pipeline":
       return `${AWS_URL_BASE}/codesuite/codepipeline/pipelines/${resourceId}/view?region=${AWS_REGION}`;
     case "AWS::S3::Bucket":
@@ -120,6 +120,14 @@ export function resourceToConsoleLink(
       const method = parts[parts.length - 1];
       return `https://${AWS_REGION}.console.aws.amazon.com/apigateway/home?region=${AWS_REGION}#/apis/${apiId}/resources/${resourcePath}/methods/${method}`;
     }
+    case "AWS::ApiGateway::Authorizer": {
+      const parts = resourceId.split("/authorizers/");
+      const apiId = parts[0];
+      const authorizerId = parts[1];
+      return `https://${AWS_REGION}.console.aws.amazon.com/apigateway/home?region=${AWS_REGION}#/apis/${apiId}/authorizers/${authorizerId}`;
+    }
+    case "AWS::ApiGateway::DomainName":
+      return `https://${AWS_REGION}.console.aws.amazon.com/apigateway/main/publish/domain-names?region=${AWS_REGION}`;
     case "AWS::ApiGatewayV2::Api":
       return `https://${AWS_REGION}.console.aws.amazon.com/apigateway/main/apis/${resourceId}?region=${AWS_REGION}`;
     case "AWS::ApiGatewayV2::Route": {
@@ -134,14 +142,42 @@ export function resourceToConsoleLink(
       const stageName = parts[1];
       return `https://${AWS_REGION}.console.aws.amazon.com/apigateway/main/apis/${apiId}/stages/${stageName}?region=${AWS_REGION}`;
     }
+    case "AWS::Cognito::UserPool":
+      return `https://${AWS_REGION}.console.aws.amazon.com/cognito/v2/idp/user-pools/${resourceId}/users?region=${AWS_REGION}`;
+    case "AWS::Cognito::User": {
+      const [poolId, username] = resourceId.split("/");
+      return `https://${AWS_REGION}.console.aws.amazon.com/cognito/v2/idp/user-pools/${poolId}/users/${encodeURIComponent(username)}?region=${AWS_REGION}`;
+    }
+    case "AWS::Cognito::UserPoolGroups":
+      return `https://${AWS_REGION}.console.aws.amazon.com/cognito/v2/idp/user-pools/${resourceId}/groups?region=${AWS_REGION}`;
+    case "AWS::Athena::WorkGroup":
+      return `${AWS_URL_BASE}/athena/home?region=${AWS_REGION}#/workgroups/${resourceId}`;
+    case "AWS::Athena::NamedQuery":
+      return `${AWS_URL_BASE}/athena/home?region=${AWS_REGION}#/query-editor/saved-queries/${resourceId}`;
+    case "AWS::Athena::QueryExecution":
+      return `${AWS_URL_BASE}/athena/home?region=${AWS_REGION}#/query-editor/history/${resourceId}`;
+    case "AWS::QuickSight::Dashboard":
+      return `https://${AWS_REGION}.quicksight.aws.amazon.com/sn/dashboards/${resourceId}`;
+    case "AWS::QuickSight::Analysis":
+      return `https://${AWS_REGION}.quicksight.aws.amazon.com/sn/analyses/${resourceId}`;
+    case "AWS::QuickSight::DataSet":
+      return `https://${AWS_REGION}.quicksight.aws.amazon.com/sn/data-sets/${resourceId}`;
     default:
       return "";
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const sortRecord = (record: Record<string, any>): Record<string, any> =>
-  Object.fromEntries(Object.entries(record).sort(([keyA], [keyB]) => keyA.localeCompare(keyB)));
+/**
+ * Sorts a record by its keys alphabetically
+ * @param record - The record to sort
+ * @returns A new record with keys sorted alphabetically
+ */
+export function sortRecord<T>(record: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(Object.entries(record).sort(([keyA], [keyB]) => keyA.localeCompare(keyB))) as Record<
+    string,
+    T
+  >;
+}
 
 export const getErrorMessage = (error: unknown) => {
   if (error instanceof Error) {

--- a/extensions/amazon-aws/src/util/index.ts
+++ b/extensions/amazon-aws/src/util/index.ts
@@ -156,6 +156,8 @@ export function resourceToConsoleLink(
       return `${AWS_URL_BASE}/athena/home?region=${AWS_REGION}#/query-editor/saved-queries/${resourceId}`;
     case "AWS::Athena::QueryExecution":
       return `${AWS_URL_BASE}/athena/home?region=${AWS_REGION}#/query-editor/history/${resourceId}`;
+    case "AWS::CloudWatch::Dashboard":
+      return `https://${AWS_REGION}.console.aws.amazon.com/cloudwatch/home?region=${AWS_REGION}#dashboards/dashboard/${resourceId}`;
     case "AWS::QuickSight::Dashboard":
       return `https://${AWS_REGION}.quicksight.aws.amazon.com/sn/dashboards/${resourceId}`;
     case "AWS::QuickSight::Analysis":


### PR DESCRIPTION
## Description

- Browse and manage Athena work groups, named queries, and query executions
- Browse QuickSight dashboards, analyses, and datasets with region override support
- Search and list Cognito user pool users
- Ask Raycast AI about your Lambda functions, S3 buckets, DynamoDB tables, secrets, pipelines, log groups, and QuickSight dashboards
- Improved Amplify build view with status icons, duration, job type, and one-click log downloads
- Copy and export raw API responses for any Amplify resource
- Fixed large accounts causing out-of-memory errors when loading paginated resources
- Fixed Lambda log groups pointing to wrong CloudWatch group name
- Clearer error messages across all services

### New commands
- **Athena** — manage work groups, named queries, and query executions
- **QuickSight** — browse dashboards, analyses, and datasets (with optional region override preference)
- **Cognito** — user pool management with user listing and search

### New AI tools (11)
Lambda (list, details, invoke), S3 (list buckets, list objects), DynamoDB (list tables, describe table), Secrets Manager, CodePipeline, CloudWatch Log Groups, QuickSight dashboards

### Architecture
- Refactored monolithic `aws-clients.ts` into per-service client modules (`src/services/clients/`) for better tree-shaking
- Shared `ClientCache` handles per-profile/region caching

### Bug fixes
- Fixed out-of-memory errors in all pagination functions for large AWS accounts
- Fixed Lambda using incorrect log group name for custom CloudWatch log groups
- Centralized error handling with `getAWSErrorMessage` for clearer messages

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder