### PR TITLE
Update zotero extension

### DIFF
--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zotero Changelog
 
-## [Features] - {PR_MERGE_DATE}
+## [Features] - 2026-03-23
 
 - Add Pandoc Citation Key copy and paste actions
 - Support Zotero 7/8 native Citation Key from `zotero.sqlite` (no `better-bibtex.sqlite` required)

--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Zotero Changelog
 
+## [Features] - {PR_MERGE_DATE}
+
+- Add Pandoc Citation Key copy and paste actions
+- Support Zotero 7/8 native Citation Key from `zotero.sqlite` (no `better-bibtex.sqlite` required)
+
 ## [Fixes] - 2026-03-02
 
 - Fix "No data found" error with Zotero 7+ when Better BibTeX is enabled: `better-bibtex.migrated` (renamed from `better-bibtex.sqlite` by Zotero 7's migration) is now recognised as a valid citation key source

--- a/extensions/zotero/package.json
+++ b/extensions/zotero/package.json
@@ -11,7 +11,8 @@
   "contributors": [
     "lazarjov",
     "joshuahhh",
-    "faridrashidi"
+    "faridrashidi",
+    "ridemountainpig"
   ],
   "version": "1.0.0",
   "license": "MIT",

--- a/extensions/zotero/src/commandSearchZotero.tsx
+++ b/extensions/zotero/src/commandSearchZotero.tsx
@@ -4,21 +4,18 @@ import { useStore } from "./common/store";
 import { View } from "./common/View";
 
 export default function MyView() {
-  const store = useStore(["results"], (_, q) => searchResources(q as string));
+  const store = useStore(["results"], (_, q) => searchResources(q as string), true);
   const [collections, setCollections] = useState<string[]>([]);
   const sectionNames = ["Search Results"];
 
   useEffect(() => {
-    const getCols = async () => {
+    const init = async () => {
       const cols = await getCollections();
       setCollections(cols);
+      await store.runQuery("");
     };
 
-    getCols(); // run it, run it
-
-    return () => {
-      // this now gets called when the component unmounts
-    };
+    init();
   }, []);
 
   return (
@@ -28,11 +25,7 @@ export default function MyView() {
       isLoading={store.queryIsLoading}
       collections={collections}
       onSearchTextChange={(text) => {
-        if (text) {
-          store.runQuery(text);
-        } else {
-          store.clearResults();
-        }
+        store.runQuery(text);
       }}
       throttle
     />

--- a/extensions/zotero/src/common/View.tsx
+++ b/extensions/zotero/src/common/View.tsx
@@ -11,7 +11,14 @@ import {
 } from "@raycast/api";
 import { RefData, Preferences } from "./zoteroApi";
 import { useVisitedUrls } from "./useVisitedUrls";
-import { exportRef, exportRefPaste, exportBibtexRef, exportBibtexRefPaste } from "./clipboard";
+import {
+  exportRef,
+  exportRefPaste,
+  exportBibtexRef,
+  exportBibtexRefPaste,
+  exportPandocKey,
+  exportPandocKeyPaste,
+} from "./clipboard";
 import { useState } from "react";
 import CollectionDropdown from "./CollectionDropdown";
 
@@ -45,6 +52,8 @@ const copyRefShortcut: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "
 const copyBibShortcut: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "4" };
 const pasteRefShortcut: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "5" };
 const pasteBibShortcut: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "6" };
+const copyPandocShortcut: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "7" };
+const pastePandocShortcut: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "8" };
 
 const copyURLShortcut: Keyboard.Shortcut = { modifiers: ["cmd"], key: "." };
 const copyPDFURLShortcut: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "p" };
@@ -206,89 +215,85 @@ export const View = ({
   const [urls, onOpen] = useVisitedUrls();
   const [collection, setCollection] = useState<string>("All");
   const preferences: Preferences = getPreferenceValues();
-  const [searchText, setSearchText] = useState<string>("");
   return (
     <List
       isShowingDetail={queryResults[0].length > 0}
       isLoading={isLoading}
       onSearchTextChange={(text) => {
-        setSearchText(text);
         onSearchTextChange?.(text);
       }}
       throttle={throttle}
       searchBarPlaceholder="Search Zotero..."
       searchBarAccessory={<CollectionDropdown onSelection={setCollection} collections={collections} />}
     >
-      {searchText.length === 0 ? (
-        <List.EmptyView icon={{ source: "no-view.png" }} title="Type something to search Zotero Database!" />
-      ) : (
-        sectionNames.map((sectionName, sectionIndex) => (
-          <List.Section key={sectionIndex} title={sectionName} subtitle={`${queryResults[sectionIndex].length}`}>
-            {queryResults[sectionIndex]
-              .filter((item) => item.collection?.includes(collection) || collection == "All")
-              .map((item) => (
-                <List.Item
-                  key={item.key}
-                  id={`${item.id}`}
-                  title={item.title + (urls.includes(item.url) ? " (visited)" : "")}
-                  icon={getItemIcon(item)}
-                  detail={<List.Item.Detail markdown={getItemDetail(item)} />}
-                  actions={
-                    <ActionPanel>
-                      {item.attachment && item.attachment.key && item.attachment.key !== `` && (
-                        <Action.OpenInBrowser
-                          icon={Icon.ArrowRightCircleFilled}
-                          title="Open PDF"
-                          url={`zotero://open-pdf/library/items/${item.attachment.key}`}
-                          onOpen={onOpen}
-                        />
-                      )}
+      {sectionNames.map((sectionName, sectionIndex) => (
+        <List.Section key={sectionIndex} title={sectionName} subtitle={`${queryResults[sectionIndex].length}`}>
+          {queryResults[sectionIndex]
+            .filter((item) => item.collection?.includes(collection) || collection == "All")
+            .map((item) => (
+              <List.Item
+                key={item.key}
+                id={`${item.id}`}
+                title={item.title + (urls.includes(item.url) ? " (visited)" : "")}
+                icon={getItemIcon(item)}
+                detail={<List.Item.Detail markdown={getItemDetail(item)} />}
+                actions={
+                  <ActionPanel>
+                    {item.attachment && item.attachment.key && item.attachment.key !== `` && (
                       <Action.OpenInBrowser
-                        icon={Icon.Link}
-                        title="Open in Zotero"
-                        url={`zotero://select/items/${item.library ? item.library : 0}_${item.key}`}
+                        icon={Icon.ArrowRightCircleFilled}
+                        title="Open PDF"
+                        url={`zotero://open-pdf/library/items/${item.attachment.key}`}
                         onOpen={onOpen}
                       />
-                      {getURL(item) !== "" && (
-                        <Action.OpenInBrowser
-                          title="Open Original Link"
-                          url={getURL(item)}
-                          shortcut={openExtLinkCommandShortcut}
-                          onOpen={onOpen}
+                    )}
+                    <Action.OpenInBrowser
+                      icon={Icon.Link}
+                      title="Open in Zotero"
+                      url={`zotero://select/items/${item.library ? item.library : 0}_${item.key}`}
+                      onOpen={onOpen}
+                    />
+                    {getURL(item) !== "" && (
+                      <Action.OpenInBrowser
+                        title="Open Original Link"
+                        url={getURL(item)}
+                        shortcut={openExtLinkCommandShortcut}
+                        onOpen={onOpen}
+                      />
+                    )}
+
+                    {preferences.use_bibtex && item.citekey && (
+                      <Action.CopyToClipboard
+                        title="Copy Bibtex Citation Key"
+                        content={item.citekey}
+                        shortcut={copyRefCommandShortcut}
+                      />
+                    )}
+                    {preferences.use_bibtex && item.citekey && <RefCopyToClipboardAction selected={item.citekey} />}
+                    {preferences.use_bibtex && item.citekey && <BibCopyToClipboardAction selected={item.citekey} />}
+                    {preferences.use_bibtex && item.citekey && <PandocCopyAction selected={item.citekey} />}
+                    {preferences.use_bibtex && item.citekey && <RefPasteAction selected={item.citekey} />}
+                    {preferences.use_bibtex && item.citekey && <BibPasteAction selected={item.citekey} />}
+                    {preferences.use_bibtex && item.citekey && <PandocPasteAction selected={item.citekey} />}
+
+                    <ActionPanel.Section>
+                      {item.attachment && item.attachment.key && item.attachment.key !== `` && (
+                        <PDFURLCopyToClipboardAction
+                          itemURL={`zotero://open-pdf/library/items/${item.attachment.key}`}
                         />
                       )}
-
-                      {preferences.use_bibtex && (
-                        <Action.CopyToClipboard
-                          title="Copy Bibtex Citation Key"
-                          content={item.citekey}
-                          shortcut={copyRefCommandShortcut}
-                        />
-                      )}
-                      {preferences.use_bibtex && <RefCopyToClipboardAction selected={item.citekey} />}
-                      {preferences.use_bibtex && <BibCopyToClipboardAction selected={item.citekey} />}
-                      {preferences.use_bibtex && <RefPasteAction selected={item.citekey} />}
-                      {preferences.use_bibtex && <BibPasteAction selected={item.citekey} />}
-
-                      <ActionPanel.Section>
-                        {item.attachment && item.attachment.key && item.attachment.key !== `` && (
-                          <PDFURLCopyToClipboardAction
-                            itemURL={`zotero://open-pdf/library/items/${item.attachment.key}`}
-                          />
-                        )}
-                        {getURL(item) !== "" && <URLCopyToClipboardAction itemURL={getURL(item)} />}
-                        {getItemTitle(item) !== "" && <TitleCopyToClipboardAction itemTitle={getItemTitle(item)} />}
-                        {getItemAuthors(item) !== "" && <AuthorsCopyToClipboardAction authors={getItemAuthors(item)} />}
-                        {getItemZotUrl(item) && <ZoteroUrlCopyToClipboard zotUrl={getItemZotUrl(item)} />}
-                        {getItemDoi(item) !== "" && <DoiCopyToClipboardAction itemDoi={getItemDoi(item)} />}
-                      </ActionPanel.Section>
-                    </ActionPanel>
-                  }
-                />
-              ))}
-          </List.Section>
-        ))
-      )}
+                      {getURL(item) !== "" && <URLCopyToClipboardAction itemURL={getURL(item)} />}
+                      {getItemTitle(item) !== "" && <TitleCopyToClipboardAction itemTitle={getItemTitle(item)} />}
+                      {getItemAuthors(item) !== "" && <AuthorsCopyToClipboardAction authors={getItemAuthors(item)} />}
+                      {getItemZotUrl(item) && <ZoteroUrlCopyToClipboard zotUrl={getItemZotUrl(item)} />}
+                      {getItemDoi(item) !== "" && <DoiCopyToClipboardAction itemDoi={getItemDoi(item)} />}
+                    </ActionPanel.Section>
+                  </ActionPanel>
+                }
+              />
+            ))}
+        </List.Section>
+      ))}
     </List>
   );
 };
@@ -404,6 +409,28 @@ function BibCopyToClipboardAction({ selected }: { selected: string }) {
       icon={Icon.Clipboard}
       shortcut={copyBibShortcut}
       onAction={() => exportBibtexRef(selected)}
+    />
+  );
+}
+
+function PandocCopyAction({ selected }: { selected: string }) {
+  return (
+    <Action
+      title="Copy Pandoc Citation Key"
+      icon={Icon.Clipboard}
+      shortcut={copyPandocShortcut}
+      onAction={() => exportPandocKey(selected)}
+    />
+  );
+}
+
+function PandocPasteAction({ selected }: { selected: string }) {
+  return (
+    <Action
+      title="Paste Pandoc Citation Key to App"
+      icon={Icon.Document}
+      shortcut={pastePandocShortcut}
+      onAction={() => exportPandocKeyPaste(selected)}
     />
   );
 }

--- a/extensions/zotero/src/common/clipboard.ts
+++ b/extensions/zotero/src/common/clipboard.ts
@@ -22,3 +22,14 @@ export async function exportBibtexRefPaste(bibtexKey: string) {
   await Clipboard.paste(await generateBibtexReference(bibtexKey));
   await popToRoot();
 }
+
+export async function exportPandocKey(bibtexKey: string) {
+  await showHUD("Copied to Clipboard");
+  await Clipboard.copy(`[@${bibtexKey}]`);
+}
+
+export async function exportPandocKeyPaste(bibtexKey: string) {
+  await showHUD("Pasted to App");
+  await Clipboard.paste(`[@${bibtexKey}]`);
+  await popToRoot();
+}

--- a/extensions/zotero/src/common/zoteroApi.ts
+++ b/extensions/zotero/src/common/zoteroApi.ts
@@ -387,7 +387,7 @@ async function getData(): Promise<RefData[]> {
     }
 
     if (preferences.use_bibtex) {
-      row.citekey = await getBibtexKey(row.key, row.library);
+      row.citekey = row.citationKey || (await getBibtexKey(row.key, row.library));
     }
 
     rows.push(row);


### PR DESCRIPTION
## Description
- Add Pandoc Citation Key copy and paste actions. Close #25973.
- Support Zotero 7/8 native Citation Key from `zotero.sqlite` (no `better-bibtex.sqlite` required). Close #26380.
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1000" height="625" alt="zotero 2026-03-20 at 16 25 09" src="https://github.com/user-attachments/assets/81f00f4c-85a9-4078-b46e-1157fa078d47" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
