### PR TITLE
[AeroSpace] Add "Pull to Current Workspace" action to window switcher

### DIFF
--- a/extensions/aerospace/CHANGELOG.md
+++ b/extensions/aerospace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # aerospace Changelog
 
-## [Feature] - {PR_MERGE_DATE}
+## [Feature] - 2026-03-25
 
 - Add "Pull to Current Workspace" action to window switcher (Shift+Enter)
 

--- a/extensions/aerospace/CHANGELOG.md
+++ b/extensions/aerospace/CHANGELOG.md
@@ -1,5 +1,9 @@
 # aerospace Changelog
 
+## [Feature] - {PR_MERGE_DATE}
+
+- Add "Pull to Current Workspace" action to window switcher (Shift+Enter)
+
 ## [Improvement] - 2026-01-22
 
 - Add LaunchContext support for programmatic integration

--- a/extensions/aerospace/src/switchApps.tsx
+++ b/extensions/aerospace/src/switchApps.tsx
@@ -1,5 +1,5 @@
-import { Action, ActionPanel, LaunchProps, List, getPreferenceValues } from "@raycast/api";
-import { Windows, focusWindow, getWindows } from "./utils/appSwitcher";
+import { Action, ActionPanel, Icon, LaunchProps, List, getPreferenceValues } from "@raycast/api";
+import { Windows, focusWindow, getWindows, pullWindowToCurrentWorkspace } from "./utils/appSwitcher";
 import { useEffect, useMemo, useState } from "react";
 import { useCachedState } from "@raycast/utils";
 
@@ -74,6 +74,14 @@ export default function Command(
                       title="Focus Window"
                       onAction={() => {
                         focusWindow(window["window-id"].toString());
+                      }}
+                    />
+                    <Action
+                      title="Pull to Current Workspace"
+                      icon={Icon.ArrowDown}
+                      shortcut={{ modifiers: ["shift"], key: "enter" }}
+                      onAction={async () => {
+                        await pullWindowToCurrentWorkspace(window["window-id"].toString());
                       }}
                     />
                   </ActionPanel>

--- a/extensions/aerospace/src/utils/appSwitcher.tsx
+++ b/extensions/aerospace/src/utils/appSwitcher.tsx
@@ -1,4 +1,4 @@
-import { popToRoot, closeMainWindow } from "@raycast/api";
+import { popToRoot, closeMainWindow, showToast, Toast } from "@raycast/api";
 import { spawnSync } from "child_process";
 import { shellEnvSync } from "shell-env";
 
@@ -72,6 +72,41 @@ export async function getWindows(workspace: string) {
 
 export function focusWindow(windowId: string) {
   spawnSync("aerospace", ["focus", "--window-id", `${windowId}`], {
+    env: env(),
+    encoding: "utf8",
+    timeout: 15000,
+  });
+
+  popToRoot({ clearSearchBar: true });
+  closeMainWindow({ clearRootSearch: true });
+}
+
+export async function pullWindowToCurrentWorkspace(windowId: string) {
+  const focused = spawnSync("aerospace", ["list-workspaces", "--focused"], {
+    env: env(),
+    encoding: "utf8",
+    timeout: 15000,
+  });
+
+  const focusedWorkspace = focused.stdout.trim();
+
+  if (!focusedWorkspace) {
+    await showToast({ style: Toast.Style.Failure, title: "Could not determine focused workspace" });
+    return;
+  }
+
+  const move = spawnSync("aerospace", ["move-node-to-workspace", "--window-id", windowId, focusedWorkspace], {
+    env: env(),
+    encoding: "utf8",
+    timeout: 15000,
+  });
+
+  if (move.status !== 0) {
+    await showToast({ style: Toast.Style.Failure, title: "Failed to move window", message: move.stderr });
+    return;
+  }
+
+  spawnSync("aerospace", ["focus", "--window-id", windowId], {
     env: env(),
     encoding: "utf8",
     timeout: 15000,


### PR DESCRIPTION
## Description

Add a secondary action (Shift+Enter) that moves the selected window to the currently focused workspace, then focuses it. This mirrors the "pull window" behavior common in tiling WM launchers like rofi/i3.

## Screencast


https://github.com/user-attachments/assets/76a98e46-6236-498c-aea3-723b446a16d9

In the screencast I pull a terminal with Fastfetch from workspace 8 to workspace 5


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
