### PR TITLE
fix(year-in-progress): prevent LocalStorage overwrite during initial …

### DIFF
--- a/extensions/year-in-progress/CHANGELOG.md
+++ b/extensions/year-in-progress/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Year in Progress Changelog
 
-## [Bugfix] - {PR_MERGE_DATE}
+## [Bugfix] - 2026-03-24
 
 - Fixed user preferences (pinned items, menubar selections) resetting on extension restart
 

--- a/extensions/year-in-progress/CHANGELOG.md
+++ b/extensions/year-in-progress/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Year in Progress Changelog
 
-## [Bugfix] - 2026-03-20
+## [Bugfix] - {PR_MERGE_DATE}
 
 - Fixed user preferences (pinned items, menubar selections) resetting on extension restart
 

--- a/extensions/year-in-progress/CHANGELOG.md
+++ b/extensions/year-in-progress/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Year in Progress Changelog
 
+## [Bugfix] - 2026-03-20
+
+- Fixed user preferences (pinned items, menubar selections) resetting on extension restart
+
 ## [Bugfix] - 2025-01-02
 
 - Fix typos in "Week starts date" settings dropdown

--- a/extensions/year-in-progress/package.json
+++ b/extensions/year-in-progress/package.json
@@ -101,5 +101,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/year-in-progress/src/hooks/use-local-storage-progress.ts
+++ b/extensions/year-in-progress/src/hooks/use-local-storage-progress.ts
@@ -98,6 +98,7 @@ export function useLocalStorageProgress(): [
   }, []);
 
   useEffect(() => {
+    if (state.isLoading) return;
     LocalStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({ allProgress: state.allProgress, currMenubarProgressTitle: state.currMenubarProgressTitle })


### PR DESCRIPTION
**Fix: User preferences (pins, menubar) reset on extension restart**

The save useEffect fires with default state before the async load from LocalStorage completes, overwriting user preferences (pinned items, menubar selections) on every extension 
restart (lock/unlock, sleep/wake).

Adds an isLoading guard to skip persisting until stored state has loaded.