### PR TITLE
fix(coffee): keep caffeinate child referenced until exit

### DIFF
--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Coffee Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Prevent zombie caffeinate child processes by keeping the spawned process referenced until exit.
 ## [Fix] - 2026-03-19
 
 - Fixed zombie process accumulation caused by unreaped `caffeinate -u` child processes in the status command.

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coffee Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-03-22
 
 - Prevent zombie caffeinate child processes by keeping the spawned process referenced until exit.
 

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Fix] - {PR_MERGE_DATE}
 
 - Prevent zombie caffeinate child processes by keeping the spawned process referenced until exit.
+
 ## [Fix] - 2026-03-19
 
 - Fixed zombie process accumulation caused by unreaped `caffeinate -u` child processes in the status command.

--- a/extensions/coffee/src/status.ts
+++ b/extensions/coffee/src/status.ts
@@ -69,7 +69,6 @@ export default async function Command() {
       stdio: "ignore",
     });
     child.on("exit", () => {});
-    child.unref();
   }
 
   updateCommandMetadata({ subtitle });


### PR DESCRIPTION
## Bug
https://github.com/raycast/extensions/issues/26512 — the Coffee status command spawns `caffeinate -u -t 1`, but `child.unref()` can drop the handle before process exit, which can leave unreaped zombie processes.

## Fix
Removed `child.unref()` in `extensions/coffee/src/status.ts` so the child process stays referenced long enough for Node to observe process exit and reap it.

## Testing
- Verified the Coffee command still compiles with the change (single-line lifecycle update only).
- Tried to run extension lint (`pnpm -C extensions/coffee lint`), but local tooling requires the Ray CLI (`ray`) which is not available in this environment.

Happy to address any feedback.

Greetings, saschabuehrle
