### PR TITLE
[skills] Fix fnm base directory resolution on macOS

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Fix `fnm` macOS Path Resolution] - {PR_MERGE_DATE}
+
+- Detect additional macOS `fnm` install locations, including `~/Library/Application Support/fnm`
+- Match the official `fnm` directory resolution preference order when resolving `fnm` paths.
+
 ## [Agent-Specific Skill Removal] - 2026-03-27
 
 - Support removing skills from specific agents instead of all agents at once

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix `fnm` macOS Path Resolution] - {PR_MERGE_DATE}
+## [Fix `fnm` macOS Path Resolution] - 2026-03-28
 
 - Detect additional macOS `fnm` install locations, including `~/Library/Application Support/fnm`
 - Match the official `fnm` directory resolution preference order when resolving `fnm` paths.

--- a/extensions/skills/src/utils/exec-options.ts
+++ b/extensions/skills/src/utils/exec-options.ts
@@ -26,7 +26,7 @@ export const getExecOptions = async () => {
 
     if (!process.env.FNM_DIR) {
       const fnmBaseDir = await resolveFnmBaseDir(home);
-      if (fnmBaseDir && (await pathExists(fnmBaseDir))) {
+      if (fnmBaseDir) {
         env.FNM_DIR = fnmBaseDir;
       }
     }

--- a/extensions/skills/src/utils/node-path-resolver.ts
+++ b/extensions/skills/src/utils/node-path-resolver.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import semver from "semver";
 
 const isWindows = process.platform === "win32";
+const isMacOS = process.platform === "darwin";
 
 let cachedPaths: string | null = null;
 let cachedPathsPromise: Promise<string> | null = null;
@@ -65,14 +66,23 @@ const scanVersionedNodePaths = async (
 export const resolveFnmBaseDir = async (home = process.env.HOME): Promise<string | null> => {
   if (!home) return null;
 
-  const legacyFnmPath = join(home, ".fnm");
-  if (await pathExists(legacyFnmPath)) {
-    // Older fnm installs keep everything under ~/.fnm instead of XDG data directories
-    return legacyFnmPath;
+  const fnmBaseDirCandidates = process.env.FNM_DIR ? [process.env.FNM_DIR] : [];
+  fnmBaseDirCandidates.push(join(home, ".fnm"));
+  if (process.env.XDG_DATA_HOME) {
+    fnmBaseDirCandidates.push(join(process.env.XDG_DATA_HOME, "fnm"));
+  }
+  if (isMacOS) {
+    fnmBaseDirCandidates.push(join(home, "Library", "Application Support", "fnm"));
+  }
+  fnmBaseDirCandidates.push(join(home, ".local", "share", "fnm"));
+
+  for (const dir of fnmBaseDirCandidates) {
+    if (await pathExists(dir)) {
+      return dir;
+    }
   }
 
-  const xdgDataHome = process.env.XDG_DATA_HOME || join(home, ".local", "share");
-  return join(xdgDataHome, "fnm");
+  return null;
 };
 
 export const resolveVersionManagerPaths = async (): Promise<string[]> => {

--- a/extensions/skills/src/utils/node-path-resolver.ts
+++ b/extensions/skills/src/utils/node-path-resolver.ts
@@ -66,15 +66,12 @@ const scanVersionedNodePaths = async (
 export const resolveFnmBaseDir = async (home = process.env.HOME): Promise<string | null> => {
   if (!home) return null;
 
-  const fnmBaseDirCandidates = process.env.FNM_DIR ? [process.env.FNM_DIR] : [];
-  fnmBaseDirCandidates.push(join(home, ".fnm"));
-  if (process.env.XDG_DATA_HOME) {
-    fnmBaseDirCandidates.push(join(process.env.XDG_DATA_HOME, "fnm"));
-  }
+  const xdgBaseDir = join(process.env.XDG_DATA_HOME || join(home, ".local", "share"), "fnm");
+  const fnmBaseDirCandidates = [xdgBaseDir, join(home, ".fnm")];
+
   if (isMacOS) {
     fnmBaseDirCandidates.push(join(home, "Library", "Application Support", "fnm"));
   }
-  fnmBaseDirCandidates.push(join(home, ".local", "share", "fnm"));
 
   for (const dir of fnmBaseDirCandidates) {
     if (await pathExists(dir)) {
@@ -82,7 +79,8 @@ export const resolveFnmBaseDir = async (home = process.env.HOME): Promise<string
     }
   }
 
-  return null;
+  // Default to the XDG data dir even if it does not exist yet
+  return xdgBaseDir;
 };
 
 export const resolveVersionManagerPaths = async (): Promise<string[]> => {


### PR DESCRIPTION
## Description

This change improves `fnm` path resolution when building the environment for running the Skills CLI through `npx`.
 
On macOS, `fnm` may be installed under `~/Library/Application Support/fnm`, which the previous logic did not detect. That could leave `FNM_DIR` pointing to the wrong location.

The fix updates `resolveFnmBaseDir()` to look for `fnm` in the same locations and preference order used by the [official install script](https://github.com/Schniz/fnm/blob/master/.ci/install.sh).

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [X] I checked that files in the `assets` folder are used by the extension itself
- [X] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
