### PR TITLE
Update cron-description extension

### DIFF
--- a/extensions/cron-description/.gitignore
+++ b/extensions/cron-description/.gitignore
@@ -5,3 +5,10 @@
 
 # misc
 .DS_Store
+
+# Raycast build / env artifacts
+raycast-env.d.ts
+.raycast-swift-build
+.swiftpm
+compiled_raycast_swift
+compiled_raycast_rust

--- a/extensions/cron-description/CHANGELOG.md
+++ b/extensions/cron-description/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Cron Expression Description Changelog
 
+## [Add Default Timezone Configuration] - {PR_MERGE_DATE}
+
+- Added a user preference to set a default timezone for cron expressions instead of always using the local timezone
+- Added validation to ensure the configured timezone is valid, with fallback to local timezone and a warning toast if invalid
+
 ## [Set Timezone + Modernize] - 2026-01-19
 
 - Set a timezone to use for Cron calculation and see when the next run will be (ref: [Issue #24588](https://github.com/raycast/extensions/issues/24588))

--- a/extensions/cron-description/CHANGELOG.md
+++ b/extensions/cron-description/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Cron Description Changelog
 
-## [Add Default Timezone Configuration] - {PR_MERGE_DATE}
+## [Add Default Timezone Configuration] - 2026-03-23
 
 - Added a user preference to set a default timezone for cron expressions instead of always using the local timezone
 - Added validation to ensure the configured timezone is valid, with fallback to local timezone and a warning toast if invalid

--- a/extensions/cron-description/CHANGELOG.md
+++ b/extensions/cron-description/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Cron Expression Description Changelog
+# Cron Description Changelog
 
 ## [Add Default Timezone Configuration] - {PR_MERGE_DATE}
 

--- a/extensions/cron-description/README.md
+++ b/extensions/cron-description/README.md
@@ -3,3 +3,9 @@
 _Converts cron expressions into a human readable description._
 
 Additionally, set the cron timezone to see when the next run will be.
+
+**Default Timezone Preference:**
+
+- **Preference name:** `defaultTimezone`
+- **Format:** an IANA timezone string (for example, `UTC`, `America/New_York`, `Europe/London`).
+- **Behavior:** If set to a valid timezone the extension will use it as the default for cron calculations. Leave empty to use your local timezone. Invalid values fall back to the local timezone and show a warning.

--- a/extensions/cron-description/package.json
+++ b/extensions/cron-description/package.json
@@ -20,6 +20,16 @@
       "mode": "view"
     }
   ],
+  "preferences": [
+    {
+      "name": "defaultTimezone",
+      "type": "textfield",
+      "required": false,
+      "title": "Default Timezone",
+      "description": "The default timezone for cron expressions (e.g., UTC, America/New_York). Leave empty to use your local timezone.",
+      "default": ""
+    }
+  ],
   "dependencies": {
     "@raycast/api": "^1.104.1",
     "cron-parser": "^5.5.0",

--- a/extensions/cron-description/src/index.tsx
+++ b/extensions/cron-description/src/index.tsx
@@ -4,19 +4,20 @@ import { CronExpressionParser } from "cron-parser";
 import { useEffect, useState } from "react";
 
 const TIMEZONES = ["UTC", ...Intl.supportedValuesOf("timeZone")];
+const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 export default function main() {
-  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const preferences = getPreferenceValues<Preferences>();
+  const defaultTz =
+    preferences.defaultTimezone && TIMEZONES.includes(preferences.defaultTimezone)
+      ? preferences.defaultTimezone
+      : localTimezone;
 
-  const preferences = getPreferenceValues<{ defaultTimezone: string }>();
-  let defaultTz = localTimezone;
-  if (preferences.defaultTimezone) {
-    if (TIMEZONES.includes(preferences.defaultTimezone)) {
-      defaultTz = preferences.defaultTimezone;
-    } else {
+  useEffect(() => {
+    if (preferences.defaultTimezone && !TIMEZONES.includes(preferences.defaultTimezone)) {
       showToast(Toast.Style.Failure, "Invalid default timezone", `Using local timezone: ${localTimezone}`);
     }
-  }
+  }, []);
 
   const [cron, setCron] = useState("* * * * *");
   const [cronTimezone, setCronTimezone] = useState(defaultTz);

--- a/extensions/cron-description/src/index.tsx
+++ b/extensions/cron-description/src/index.tsx
@@ -5,14 +5,13 @@ import { useEffect, useState } from "react";
 
 const TIMEZONES = ["UTC", ...Intl.supportedValuesOf("timeZone")];
 const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const preferences = getPreferenceValues<Preferences>();
+const defaultTz =
+  preferences.defaultTimezone && TIMEZONES.includes(preferences.defaultTimezone)
+    ? preferences.defaultTimezone
+    : localTimezone;
 
 export default function main() {
-  const preferences = getPreferenceValues<Preferences>();
-  const defaultTz =
-    preferences.defaultTimezone && TIMEZONES.includes(preferences.defaultTimezone)
-      ? preferences.defaultTimezone
-      : localTimezone;
-
   useEffect(() => {
     if (preferences.defaultTimezone && !TIMEZONES.includes(preferences.defaultTimezone)) {
       showToast(Toast.Style.Failure, "Invalid default timezone", `Using local timezone: ${localTimezone}`);

--- a/extensions/cron-description/src/index.tsx
+++ b/extensions/cron-description/src/index.tsx
@@ -66,7 +66,7 @@ export default function main() {
       setNextRunCronTz("Unable to calculate");
       setNextRunLocalTz("");
     }
-  }, [cron, cronTimezone, localTimezone]);
+  }, [cron, cronTimezone]);
 
   return (
     <Form

--- a/extensions/cron-description/src/index.tsx
+++ b/extensions/cron-description/src/index.tsx
@@ -1,4 +1,4 @@
-import { Form, ActionPanel, Action, Keyboard } from "@raycast/api";
+import { Form, ActionPanel, Action, Keyboard, getPreferenceValues, showToast, Toast } from "@raycast/api";
 import cronstrue from "cronstrue";
 import { CronExpressionParser } from "cron-parser";
 import { useEffect, useState } from "react";
@@ -8,8 +8,18 @@ const TIMEZONES = ["UTC", ...Intl.supportedValuesOf("timeZone")];
 export default function main() {
   const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
+  const preferences = getPreferenceValues<{ defaultTimezone: string }>();
+  let defaultTz = localTimezone;
+  if (preferences.defaultTimezone) {
+    if (TIMEZONES.includes(preferences.defaultTimezone)) {
+      defaultTz = preferences.defaultTimezone;
+    } else {
+      showToast(Toast.Style.Failure, "Invalid default timezone", `Using local timezone: ${localTimezone}`);
+    }
+  }
+
   const [cron, setCron] = useState("* * * * *");
-  const [cronTimezone, setCronTimezone] = useState(localTimezone);
+  const [cronTimezone, setCronTimezone] = useState(defaultTz);
   const [cronError, setCronError] = useState("");
   const [description, setDescription] = useState("");
   const [nextRunCronTz, setNextRunCronTz] = useState("");


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

- Added a user preference to set a default timezone for cron expressions instead of always using the local timezone. (close #26533)
- Added validation to ensure the configured timezone is valid, with fallback to local timezone and a warning toast if invalid.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

<img width="1112" height="762" alt="Screenshot 2026-03-22 at 18 39 32" src="https://github.com/user-attachments/assets/19c7330e-ac8f-4ce1-aa27-07ec65f18924" />

<img width="862" height="586" alt="Screenshot 2026-03-22 at 18 40 08" src="https://github.com/user-attachments/assets/b2553f89-84a4-4f7e-9b4d-f50d1f01f322" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
