### PR TITLE
Update git-repos extension

### DIFF
--- a/extensions/git-repos/CHANGELOG.md
+++ b/extensions/git-repos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Git Repos Changelog
 
+## [Added Command] - {PR_MERGE_DATE}
+
+- Added a new `Clone Repo` command to clone a repository into one of the scanned directories from preferences.
+
 ## [Added Command] - 2026-03-22
 
 - Added a new `Remove Repo` command to move a local repository to the Trash. The default action prevents removal if there are uncommitted changes or unpushed commits. A force remove option is available to bypass these checks.

--- a/extensions/git-repos/CHANGELOG.md
+++ b/extensions/git-repos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Git Repos Changelog
 
-## [Added Command] - {PR_MERGE_DATE}
+## [Added Command] - 2026-03-26
 
 - Added a new `Clone Repo` command to clone a repository into one of the scanned directories from preferences.
 

--- a/extensions/git-repos/package.json
+++ b/extensions/git-repos/package.json
@@ -32,6 +32,12 @@
       "title": "Remove Repo",
       "description": "Safely remove a local git repository from your filesystem",
       "mode": "view"
+    },
+    {
+      "name": "clone-repo",
+      "title": "Clone Repo",
+      "description": "Clone a git repository into one of your configured scan directories",
+      "mode": "view"
     }
   ],
   "preferences": [

--- a/extensions/git-repos/src/clone-repo.tsx
+++ b/extensions/git-repos/src/clone-repo.tsx
@@ -1,0 +1,59 @@
+import { Form, ActionPanel, Action, showToast, Toast, popToRoot, List } from "@raycast/api";
+import { execFile } from "child_process";
+import { Preferences, parsePath, tildifyPath } from "./utils";
+import { getPreferenceValues } from "@raycast/api";
+
+function updateToast(toast: Toast, style: Toast.Style, title: string, message?: string) {
+  toast.style = style;
+  toast.title = title;
+  toast.message = message;
+}
+
+export default function CloneRepo() {
+  const preferences = getPreferenceValues<Preferences>();
+  const [dirs] = parsePath(preferences.repoScanPath);
+
+  if (dirs.length === 0) {
+    return (
+      <List>
+        <List.EmptyView
+          title="No Directories Configured"
+          description="Make sure the scan path is configured in preferences and the directories exist."
+        />
+      </List>
+    );
+  }
+
+  async function handleSubmit(values: { url: string; directory: string }) {
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Cloning…" });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        execFile("git", ["clone", values.url], { cwd: values.directory }, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      updateToast(toast, Toast.Style.Success, "Cloned successfully");
+      await popToRoot();
+    } catch (err) {
+      updateToast(toast, Toast.Style.Failure, "Clone failed", err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Clone Repository" onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField id="url" title="Repository URL" placeholder="https://github.com/owner/repo.git" />
+      <Form.Dropdown id="directory" title="Clone Into">
+        {dirs.map((dir) => (
+          <Form.Dropdown.Item key={dir} value={dir} title={tildifyPath(dir)} />
+        ))}
+      </Form.Dropdown>
+    </Form>
+  );
+}

--- a/extensions/git-repos/src/clone-repo.tsx
+++ b/extensions/git-repos/src/clone-repo.tsx
@@ -1,4 +1,5 @@
 import { Form, ActionPanel, Action, showToast, Toast, popToRoot, List, getPreferenceValues } from "@raycast/api";
+import { useForm, FormValidation } from "@raycast/utils";
 import { execFile } from "child_process";
 import { parsePath, tildifyPath } from "./utils";
 
@@ -8,9 +9,35 @@ function updateToast(toast: Toast, style: Toast.Style, title: string, message?: 
   toast.message = message;
 }
 
+interface CloneFormValues {
+  url: string;
+  directory: string;
+}
+
 export default function CloneRepo() {
   const preferences = getPreferenceValues<ExtensionPreferences>();
   const [dirs] = parsePath(preferences.repoScanPath);
+
+  const { handleSubmit, itemProps } = useForm<CloneFormValues>({
+    async onSubmit(values) {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Cloning…" });
+      try {
+        await new Promise<void>((resolve, reject) => {
+          execFile("git", ["clone", values.url], { cwd: values.directory }, (err) => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+        updateToast(toast, Toast.Style.Success, "Cloned successfully");
+        await popToRoot();
+      } catch (err) {
+        updateToast(toast, Toast.Style.Failure, "Clone failed", err instanceof Error ? err.message : String(err));
+      }
+    },
+    validation: {
+      url: FormValidation.Required,
+    },
+  });
 
   if (dirs.length === 0) {
     return (
@@ -23,22 +50,6 @@ export default function CloneRepo() {
     );
   }
 
-  async function handleSubmit(values: { url: string; directory: string }) {
-    const toast = await showToast({ style: Toast.Style.Animated, title: "Cloning…" });
-    try {
-      await new Promise<void>((resolve, reject) => {
-        execFile("git", ["clone", values.url], { cwd: values.directory }, (err) => {
-          if (err) reject(err);
-          else resolve();
-        });
-      });
-      updateToast(toast, Toast.Style.Success, "Cloned successfully");
-      await popToRoot();
-    } catch (err) {
-      updateToast(toast, Toast.Style.Failure, "Clone failed", err instanceof Error ? err.message : String(err));
-    }
-  }
-
   return (
     <Form
       actions={
@@ -47,8 +58,8 @@ export default function CloneRepo() {
         </ActionPanel>
       }
     >
-      <Form.TextField id="url" title="Repository URL" placeholder="https://github.com/owner/repo.git" />
-      <Form.Dropdown id="directory" title="Clone Into">
+      <Form.TextField title="Repository URL" placeholder="https://github.com/owner/repo.git" {...itemProps.url} />
+      <Form.Dropdown title="Clone Into" {...itemProps.directory}>
         {dirs.map((dir) => (
           <Form.Dropdown.Item key={dir} value={dir} title={tildifyPath(dir)} />
         ))}

--- a/extensions/git-repos/src/clone-repo.tsx
+++ b/extensions/git-repos/src/clone-repo.tsx
@@ -1,7 +1,6 @@
-import { Form, ActionPanel, Action, showToast, Toast, popToRoot, List } from "@raycast/api";
+import { Form, ActionPanel, Action, showToast, Toast, popToRoot, List, getPreferenceValues } from "@raycast/api";
 import { execFile } from "child_process";
-import { Preferences, parsePath, tildifyPath } from "./utils";
-import { getPreferenceValues } from "@raycast/api";
+import { parsePath, tildifyPath } from "./utils";
 
 function updateToast(toast: Toast, style: Toast.Style, title: string, message?: string) {
   toast.style = style;
@@ -10,7 +9,7 @@ function updateToast(toast: Toast, style: Toast.Style, title: string, message?: 
 }
 
 export default function CloneRepo() {
-  const preferences = getPreferenceValues<Preferences>();
+  const preferences = getPreferenceValues<ExtensionPreferences>();
   const [dirs] = parsePath(preferences.repoScanPath);
 
   if (dirs.length === 0) {

--- a/extensions/git-repos/src/list.tsx
+++ b/extensions/git-repos/src/list.tsx
@@ -15,7 +15,7 @@ import path from "path";
 import { useState } from "react";
 import { useCachedPromise } from "@raycast/utils";
 import { GetInstalledBrowsers } from "get-installed-browsers";
-import { GitRepo, Preferences, tildifyPath, GitRepoService, GitRepoType, OpenWith } from "./utils";
+import { GitRepo, tildifyPath, GitRepoService, GitRepoType } from "./utils";
 import { useUsageBasedSort } from "./hooks/useUsageBasedSort";
 
 const installedBrowsers = GetInstalledBrowsers().map(
@@ -26,7 +26,7 @@ const installedBrowsers = GetInstalledBrowsers().map(
 );
 
 export default function Command() {
-  const preferences = getPreferenceValues<Preferences>();
+  const preferences = getPreferenceValues<ExtensionPreferences>();
   const gitReposState = useCachedPromise(GitRepoService.gitRepos);
   const favoriteGitReposState = useCachedPromise(GitRepoService.favorites);
 
@@ -80,7 +80,7 @@ export default function Command() {
 }
 
 function GitRepoListItem(props: {
-  preferences: Preferences;
+  preferences: ExtensionPreferences;
   repo: GitRepo;
   isFavorite: boolean;
   revalidate: () => void;
@@ -306,7 +306,7 @@ function GitRepoPropertyDropdown(props: {
 
 function GitRepoOpenAction(props: {
   repo: GitRepo;
-  openWith: OpenWith;
+  openWith: Application;
   shortcut?: Keyboard.Shortcut;
   recordUsageHook?: (id: string | number) => void;
 }) {

--- a/extensions/git-repos/src/utils.tsx
+++ b/extensions/git-repos/src/utils.tsx
@@ -55,7 +55,7 @@ export class GitRepoService {
     }
     const repos = await findRepos(
       repoPaths,
-      parseInt(preferences.repoScanDepth) ?? 3,
+      parseInt(preferences.repoScanDepth, 10) || 3,
       preferences.includeSubmodules ?? false,
     );
 

--- a/extensions/git-repos/src/utils.tsx
+++ b/extensions/git-repos/src/utils.tsx
@@ -10,24 +10,6 @@ import parseGitConfig from "parse-git-config";
 import parseGithubURL from "parse-github-url";
 import getDefaultBrowser from "default-browser";
 
-export interface OpenWith {
-  name: string;
-  path: string;
-  bundleId: string;
-}
-
-export interface Preferences {
-  repoScanPath: string;
-  repoScanDepth?: number;
-  includeSubmodules?: boolean;
-  searchKeys?: string;
-  openWith1?: OpenWith;
-  openWith2?: OpenWith;
-  openWith3?: OpenWith;
-  openWith4?: OpenWith;
-  openWith5?: OpenWith;
-}
-
 export enum GitRepoType {
   All = "All",
   Repo = "Repo",
@@ -54,15 +36,11 @@ interface GitRemote {
   url: string;
 }
 
-function getPreferences(): Preferences {
-  return getPreferenceValues<Preferences>();
-}
-
 export class GitRepoService {
   private static favoritesStorageKey = "git-repos-favorites";
 
   static async gitRepos(): Promise<GitRepo[]> {
-    const preferences = getPreferences();
+    const preferences = getPreferenceValues<ExtensionPreferences>();
     if (preferences.repoScanPath.length == 0) {
       showToast(Toast.Style.Failure, "", "Directories to scan has not been defined in settings");
       return [];
@@ -75,7 +53,11 @@ export class GitRepoService {
         `Director${unresolvedPaths.length === 1 ? "y" : "ies"} not found: ${unresolvedPaths}`,
       );
     }
-    const repos = await findRepos(repoPaths, preferences.repoScanDepth ?? 3, preferences.includeSubmodules ?? false);
+    const repos = await findRepos(
+      repoPaths,
+      parseInt(preferences.repoScanDepth) ?? 3,
+      preferences.includeSubmodules ?? false,
+    );
 
     return repos;
   }


### PR DESCRIPTION
## Description

Add a new Clone Repo command that lets you clone repos into any of the directories provided in preferences.

## Screencast

<img width="1000" height="625" alt="git-repos 2026-03-22 at 21 16 05" src="https://github.com/user-attachments/assets/f8396359-4fa9-4151-9b99-66a420ed9fa7" />
<img width="1000" height="625" alt="git-repos 2026-03-22 at 21 16 41" src="https://github.com/user-attachments/assets/04295155-b409-4fb0-8c03-849a285edcb1" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
