### PR TITLE
[HomeAssistant] Fix "Show Entity IDs" preference being completely non-functional

### DIFF
--- a/extensions/homeassistant/CHANGELOG.md
+++ b/extensions/homeassistant/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Home Assistant Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+- Fix "Show Entity IDs" preference
+
 ## [Fix] - 2026-03-15
 - use translations for services if available
   - fallback to service slug when no translation is available

--- a/extensions/homeassistant/CHANGELOG.md
+++ b/extensions/homeassistant/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Home Assistant Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-03-24
 - Fix "Show Entity IDs" preference
 
 ## [Fix] - 2026-03-15

--- a/extensions/homeassistant/src/components/state/list.tsx
+++ b/extensions/homeassistant/src/components/state/list.tsx
@@ -89,7 +89,7 @@ export function StateListItem(props: { state: State }): React.ReactElement {
         icon = ha.urlJoin(ep);
       }
     }
-    if (shouldDisplayEntityID()) {
+    if (!shouldDisplayEntityID()) {
       return extra;
     }
     if (extra) {

--- a/extensions/homeassistant/src/lib/common.ts
+++ b/extensions/homeassistant/src/lib/common.ts
@@ -48,6 +48,5 @@ export async function getHAWSConnection(): Promise<Connection> {
 
 export function shouldDisplayEntityID(): boolean {
   const preferences = getPreferenceValues();
-  const result = (preferences.instance as boolean) || false;
-  return result;
+  return (preferences.showEntityId as boolean) || false;
 }


### PR DESCRIPTION
## Description

Two bugs combined to make the "Show Entity IDs" checkbox do nothing:

1. `shouldDisplayEntityID()` read `preferences.instance` (the HA URL textfield, always truthy) instead of `preferences.showEntityId` (the actual checkbox).

2. The subtitle logic was inverted: `if (shouldDisplayEntityID())` suppressed the entity ID instead of showing it.

These cancelled out in practice — the always-true result meant entity IDs were always hidden, which matched the default unchecked state. But toggling the checkbox had no effect either way.

> [!NOTE]
> Might conflict with https://github.com/raycast/extensions/pull/26561. This one should probably be merged first.

## Screencast

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)