### PR TITLE
Fix potential search error in the Linkwarden Raycast extension

### DIFF
--- a/extensions/linkwarden/CHANGELOG.md
+++ b/extensions/linkwarden/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Linkwarden Changelog
 
-## [Fix Potential Search Errors] - {PR_MERGE_DATE}
+## [Fix Potential Search Errors] - 2026-03-23
 
 - Fixed "Bad Request" error caused by sending empty `collectionId` to the API
 - Fixed search text not being URL-encoded, causing malformed requests with special characters

--- a/extensions/linkwarden/CHANGELOG.md
+++ b/extensions/linkwarden/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Linkwarden Changelog
 
-## [Fix Potential Search Errors] - 2026-03-22
+## [Fix Potential Search Errors] - {PR_MERGE_DATE}
 
 - Fixed "Bad Request" error caused by sending empty `collectionId` to the API
 - Fixed search text not being URL-encoded, causing malformed requests with special characters

--- a/extensions/linkwarden/CHANGELOG.md
+++ b/extensions/linkwarden/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Linkwarden Changelog
 
+## [Fix Potential Search Errors] - 2026-03-22
+
+- Fixed "Bad Request" error caused by sending empty `collectionId` to the API
+- Fixed search text not being URL-encoded, causing malformed requests with special characters
+- Added error toast when link fetching fails (previously silent)
+- Fixed double-slash in API URLs when instance URL has a trailing slash
+
 ## [Add Helium Browser Support] - 2026-01-26
 
 - Added Helium to the list of supported Chromium browsers

--- a/extensions/linkwarden/src/hooks.ts
+++ b/extensions/linkwarden/src/hooks.ts
@@ -3,8 +3,8 @@ import { useFetch } from "@raycast/utils";
 import { ApiResponse, Collection, Tag } from "./interfaces";
 
 const { LinkwardenUrl, LinkwardenApiKey } = getPreferenceValues<Preferences>();
-const baseUrl = `${LinkwardenUrl.replace(/\/+$/, "")}/api/v1/`;
-const headers = {
+export const baseUrl = `${LinkwardenUrl.replace(/\/+$/, "")}/api/v1/`;
+export const headers = {
   Authorization: `Bearer ${LinkwardenApiKey}`,
 };
 

--- a/extensions/linkwarden/src/hooks.ts
+++ b/extensions/linkwarden/src/hooks.ts
@@ -3,7 +3,7 @@ import { useFetch } from "@raycast/utils";
 import { ApiResponse, Collection, Tag } from "./interfaces";
 
 const { LinkwardenUrl, LinkwardenApiKey } = getPreferenceValues<Preferences>();
-const baseUrl = `${LinkwardenUrl}/api/v1/`;
+const baseUrl = `${LinkwardenUrl.replace(/\/+$/, "")}/api/v1/`;
 const headers = {
   Authorization: `Bearer ${LinkwardenApiKey}`,
 };

--- a/extensions/linkwarden/src/search.tsx
+++ b/extensions/linkwarden/src/search.tsx
@@ -12,7 +12,7 @@ import {
 } from "@raycast/api";
 import { getFavicon, useFetch } from "@raycast/utils";
 import axios from "axios";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useCollections } from "./hooks";
 import { ApiResponse, Link } from "./interfaces";
 
@@ -23,29 +23,54 @@ export default function Command() {
 
   const { isLoading: isLoadingCollections, data: collections } = useCollections();
 
+  // NOTE: GET /api/v1/links is deprecated per Linkwarden API docs.
+  // Migrate to GET /api/v1/search when feasible.
+  // See: https://docs.linkwarden.app/api/retrieve-a-list-of-links
+  const baseUrl = preferences.LinkwardenUrl.replace(/\/+$/, "");
+  const searchParams = new URLSearchParams({
+    sort: "0",
+    searchQueryString: searchText,
+    searchByName: "true",
+    searchByUrl: "true",
+    searchByDescription: "true",
+    searchByTags: "true",
+    searchByTextContent: "true",
+  });
+  if (collectionId) {
+    searchParams.set("collectionId", collectionId);
+  }
+
   const {
     isLoading: isLoadingLinks,
     data,
+    error: linksError,
     revalidate,
-  } = useFetch(
-    `${preferences.LinkwardenUrl}/api/v1/links?sort=0&searchQueryString=${searchText}&searchByName=true&searchByUrl=true&searchByDescription=true&searchByTags=true&searchByTextContent=true&collectionId=${collectionId}`,
-    {
-      headers: {
-        Authorization: `Bearer ${preferences.LinkwardenApiKey}`,
-      },
-      mapResult(result: ApiResponse<Link[]>) {
-        return {
-          data: result.response,
-        };
-      },
-      initialData: [],
-      keepPreviousData: true,
+  } = useFetch(`${baseUrl}/api/v1/links?${searchParams.toString()}`, {
+    headers: {
+      Authorization: `Bearer ${preferences.LinkwardenApiKey}`,
     },
-  );
+    mapResult(result: ApiResponse<Link[]>) {
+      return {
+        data: result.response,
+      };
+    },
+    initialData: [],
+    keepPreviousData: true,
+  });
+
+  useEffect(() => {
+    if (linksError) {
+      showToast({
+        style: Toast.Style.Failure,
+        title: "Failed to fetch links",
+        message: linksError.message,
+      });
+    }
+  }, [linksError]);
 
   const deleteLink = async (id: number) => {
     try {
-      await axios.delete(`${preferences.LinkwardenUrl}/api/v1/links/${id}`, {
+      await axios.delete(`${baseUrl}/api/v1/links/${id}`, {
         headers: {
           Authorization: `Bearer ${preferences.LinkwardenApiKey}`,
         },

--- a/extensions/linkwarden/src/search.tsx
+++ b/extensions/linkwarden/src/search.tsx
@@ -1,23 +1,11 @@
-import {
-  Action,
-  ActionPanel,
-  getPreferenceValues,
-  Icon,
-  Keyboard,
-  launchCommand,
-  LaunchType,
-  List,
-  showToast,
-  Toast,
-} from "@raycast/api";
+import { Action, ActionPanel, Icon, Keyboard, launchCommand, LaunchType, List, showToast, Toast } from "@raycast/api";
 import { getFavicon, useFetch } from "@raycast/utils";
 import axios from "axios";
 import { useEffect, useState } from "react";
-import { useCollections } from "./hooks";
+import { baseUrl, headers, useCollections } from "./hooks";
 import { ApiResponse, Link } from "./interfaces";
 
 export default function Command() {
-  const preferences = getPreferenceValues<Preferences>();
   const [searchText, setSearchText] = useState("");
   const [collectionId, setCollectionId] = useState("");
 
@@ -26,7 +14,6 @@ export default function Command() {
   // NOTE: GET /api/v1/links is deprecated per Linkwarden API docs.
   // Migrate to GET /api/v1/search when feasible.
   // See: https://docs.linkwarden.app/api/retrieve-a-list-of-links
-  const baseUrl = preferences.LinkwardenUrl.replace(/\/+$/, "");
   const searchParams = new URLSearchParams({
     sort: "0",
     searchQueryString: searchText,
@@ -45,10 +32,8 @@ export default function Command() {
     data,
     error: linksError,
     revalidate,
-  } = useFetch(`${baseUrl}/api/v1/links?${searchParams.toString()}`, {
-    headers: {
-      Authorization: `Bearer ${preferences.LinkwardenApiKey}`,
-    },
+  } = useFetch(`${baseUrl}links?${searchParams.toString()}`, {
+    headers,
     mapResult(result: ApiResponse<Link[]>) {
       return {
         data: result.response,
@@ -70,10 +55,8 @@ export default function Command() {
 
   const deleteLink = async (id: number) => {
     try {
-      await axios.delete(`${baseUrl}/api/v1/links/${id}`, {
-        headers: {
-          Authorization: `Bearer ${preferences.LinkwardenApiKey}`,
-        },
+      await axios.delete(`${baseUrl}links/${id}`, {
+        headers,
       });
 
       showToast({


### PR DESCRIPTION
## Description

### Fix potential search error in the Linkwarden Raycast extension

When no collection is selected, the search command was sending an empty collectionId= to the API — which expects an integer, so it responds with a 400 Bad Request. On top of that, search text wasn't being URL-encoded, so typing characters like &, #, or = would break the query string and cause similar errors.

Changes:
- Only include collectionId param when a collection is actually selected
- Use URLSearchParams to properly encode all query parameters
- Surface fetch errors to the user via toast (previously silently swallowed)
- Strip trailing slashes from the instance URL to avoid double-slash API paths

Note: GET /api/v1/links is marked as deprecated in the Linkwarden API docs (https://docs.linkwarden.app/api/retrieve-a-list-of-links) in favor of GET /api/v1/search.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
