### PR TITLE
Update mole extension

### DIFF
--- a/extensions/mole/CHANGELOG.md
+++ b/extensions/mole/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mole Changelog
 
-## [Friendly Install Screen] - {PR_MERGE_DATE}
+## [Friendly Install Screen] - 2026-03-23
 
 - Added MoleNotInstalled component with multiple install options when Mole CLI is not found
 - Added install options via Homebrew Raycast extension, Homebrew Terminal, curl script, and GitHub page.

--- a/extensions/mole/CHANGELOG.md
+++ b/extensions/mole/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Friendly Install Screen] - {PR_MERGE_DATE}
 
 - Added MoleNotInstalled component with multiple install options when Mole CLI is not found
-- Install via Homebrew Raycast extension, Homebrew Terminal, curl script, or GitHub page
+- Added install options via Homebrew Raycast extension, Homebrew Terminal, curl script, and GitHub page.
 - Improved Update Mole command to show current version after update check
 - Changed Update Mole from no-view to view mode for better UX
 

--- a/extensions/mole/CHANGELOG.md
+++ b/extensions/mole/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Mole Changelog
 
+## [Friendly Install Screen] - {PR_MERGE_DATE}
+
+- Added MoleNotInstalled component with multiple install options when Mole CLI is not found
+- Install via Homebrew Raycast extension, Homebrew Terminal, curl script, or GitHub page
+- Improved Update Mole command to show current version after update check
+- Changed Update Mole from no-view to view mode for better UX
+
 ## [Uninstall Residual Cleanup] - 2026-03-20
 
 - Added deep residual file scanning when uninstalling apps (searches ~/Library, /Library, containers, and vendor directories)

--- a/extensions/mole/README.md
+++ b/extensions/mole/README.md
@@ -12,12 +12,12 @@
 
 ## Screenshots
 
-| System Status | Clean System |
-|:---:|:---:|
+|           System Status            |           Clean System            |
+| :--------------------------------: | :-------------------------------: |
 | ![System Status](media/mole-1.png) | ![Clean System](media/mole-2.png) |
 
-| Analyze Disk | Optimize System |
-|:---:|:---:|
+|           Analyze Disk            |           Optimize System            |
+| :-------------------------------: | :----------------------------------: |
 | ![Analyze Disk](media/mole-3.png) | ![Optimize System](media/mole-4.png) |
 
 ## Prerequisites
@@ -30,25 +30,25 @@ brew install mole
 
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| **System Status** | Real-time dashboard with health score, CPU, memory, disk, battery, and network |
-| **Clean System** | Preview and remove caches, logs, and temporary files with streaming progress |
-| **Optimize System** | Rebuild databases, refresh services, and optimize system performance |
-| **Uninstall App** | Browse installed applications and move them to the Trash |
-| **Analyze Disk** | Browse folders sorted by size with drill-down navigation |
-| **Purge Dev Artifacts** | Find and remove old node_modules, .next, dist, target, and venv folders |
-| **Clean Installers** | Find and remove .dmg, .pkg, and .iso files from Downloads, Desktop, and Documents |
-| **Touch ID for Sudo** | Check status and toggle Touch ID for sudo authentication |
-| **Update Mole** | Update Mole to the latest version |
+| Command                 | Description                                                                       |
+| ----------------------- | --------------------------------------------------------------------------------- |
+| **System Status**       | Real-time dashboard with health score, CPU, memory, disk, battery, and network    |
+| **Clean System**        | Preview and remove caches, logs, and temporary files with streaming progress      |
+| **Optimize System**     | Rebuild databases, refresh services, and optimize system performance              |
+| **Uninstall App**       | Browse installed applications and move them to the Trash                          |
+| **Analyze Disk**        | Browse folders sorted by size with drill-down navigation                          |
+| **Purge Dev Artifacts** | Find and remove old node_modules, .next, dist, target, and venv folders           |
+| **Clean Installers**    | Find and remove .dmg, .pkg, and .iso files from Downloads, Desktop, and Documents |
+| **Touch ID for Sudo**   | Check status and toggle Touch ID for sudo authentication                          |
+| **Update Mole**         | Update Mole to the latest version                                                 |
 
 ## Configuration
 
-| Preference | Scope | Description |
-|-----------|-------|-------------|
-| Mole Binary Path | Extension | Custom path to the `mo` binary (auto-detected by default) |
+| Preference       | Scope         | Description                                                |
+| ---------------- | ------------- | ---------------------------------------------------------- |
+| Mole Binary Path | Extension     | Custom path to the `mo` binary (auto-detected by default)  |
 | Refresh Interval | System Status | How often to refresh status data (3, 5, 10, or 30 seconds) |
-| Default Path | Analyze Disk | Starting directory for disk analysis |
+| Default Path     | Analyze Disk  | Starting directory for disk analysis                       |
 
 ## Credits
 

--- a/extensions/mole/package.json
+++ b/extensions/mole/package.json
@@ -29,7 +29,14 @@
       "subtitle": "Mole",
       "description": "View real-time system health, CPU, memory, disk, battery, and network status",
       "mode": "view",
-      "keywords": ["health", "cpu", "memory", "disk", "battery", "monitor"],
+      "keywords": [
+        "health",
+        "cpu",
+        "memory",
+        "disk",
+        "battery",
+        "monitor"
+      ],
       "preferences": [
         {
           "name": "statusRefreshInterval",
@@ -39,10 +46,22 @@
           "required": false,
           "default": "5",
           "data": [
-            { "title": "3 Seconds", "value": "3" },
-            { "title": "5 Seconds", "value": "5" },
-            { "title": "10 Seconds", "value": "10" },
-            { "title": "30 Seconds", "value": "30" }
+            {
+              "title": "3 Seconds",
+              "value": "3"
+            },
+            {
+              "title": "5 Seconds",
+              "value": "5"
+            },
+            {
+              "title": "10 Seconds",
+              "value": "10"
+            },
+            {
+              "title": "30 Seconds",
+              "value": "30"
+            }
           ]
         }
       ]
@@ -53,7 +72,14 @@
       "subtitle": "Mole",
       "description": "Preview and remove caches, logs, and temporary files to free up disk space",
       "mode": "view",
-      "keywords": ["cache", "clean", "free", "space", "trash", "logs"]
+      "keywords": [
+        "cache",
+        "clean",
+        "free",
+        "space",
+        "trash",
+        "logs"
+      ]
     },
     {
       "name": "optimize",
@@ -61,7 +87,14 @@
       "subtitle": "Mole",
       "description": "Rebuild databases, refresh services, and optimize system performance",
       "mode": "view",
-      "keywords": ["optimize", "repair", "rebuild", "dns", "spotlight", "performance"]
+      "keywords": [
+        "optimize",
+        "repair",
+        "rebuild",
+        "dns",
+        "spotlight",
+        "performance"
+      ]
     },
     {
       "name": "uninstall",
@@ -69,7 +102,13 @@
       "subtitle": "Mole",
       "description": "Uninstall apps and clean residual files from Library, Caches, and Preferences",
       "mode": "view",
-      "keywords": ["uninstall", "remove", "delete", "app", "application"]
+      "keywords": [
+        "uninstall",
+        "remove",
+        "delete",
+        "app",
+        "application"
+      ]
     },
     {
       "name": "purge",
@@ -77,7 +116,14 @@
       "subtitle": "Mole",
       "description": "Find and remove old build artifacts like node_modules, .next, dist, and target folders",
       "mode": "view",
-      "keywords": ["purge", "node_modules", "build", "artifacts", "dev", "clean"]
+      "keywords": [
+        "purge",
+        "node_modules",
+        "build",
+        "artifacts",
+        "dev",
+        "clean"
+      ]
     },
     {
       "name": "analyze",
@@ -85,7 +131,14 @@
       "subtitle": "Mole",
       "description": "Browse folders sorted by size to find what's using your disk space",
       "mode": "view",
-      "keywords": ["disk", "space", "size", "analyze", "storage", "usage"],
+      "keywords": [
+        "disk",
+        "space",
+        "size",
+        "analyze",
+        "storage",
+        "usage"
+      ],
       "preferences": [
         {
           "name": "analyzePath",
@@ -102,7 +155,13 @@
       "subtitle": "Mole",
       "description": "Find and remove installer files (.dmg, .pkg, .iso) from Downloads, Desktop, and Documents",
       "mode": "view",
-      "keywords": ["installer", "dmg", "pkg", "downloads", "cleanup"]
+      "keywords": [
+        "installer",
+        "dmg",
+        "pkg",
+        "downloads",
+        "cleanup"
+      ]
     },
     {
       "name": "touchid",
@@ -110,15 +169,24 @@
       "subtitle": "Mole",
       "description": "Configure Touch ID for sudo authentication",
       "mode": "view",
-      "keywords": ["touchid", "sudo", "fingerprint", "auth"]
+      "keywords": [
+        "touchid",
+        "sudo",
+        "fingerprint",
+        "auth"
+      ]
     },
     {
       "name": "update-mole",
       "title": "Update Mole",
       "subtitle": "Mole",
       "description": "Update Mole to the latest version",
-      "mode": "no-view",
-      "keywords": ["update", "upgrade", "version"]
+      "mode": "view",
+      "keywords": [
+        "update",
+        "upgrade",
+        "version"
+      ]
     }
   ],
   "dependencies": {

--- a/extensions/mole/src/analyze.tsx
+++ b/extensions/mole/src/analyze.tsx
@@ -4,6 +4,7 @@ import { execFile } from "child_process";
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { getMolePathSafe, MOLE_ENV } from "./utils/mole";
 import { formatBytes } from "./utils/parsers";
+import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
 interface AnalyzeEntry {
   name: string;
@@ -52,15 +53,7 @@ export default function AnalyzeDisk() {
   const molePath = useMemo(() => getMolePathSafe(), []);
 
   if (!molePath) {
-    return (
-      <List>
-        <List.EmptyView
-          title="Mole Not Installed"
-          description="Install Mole to use this extension: brew install mole"
-          icon={Icon.ExclamationMark}
-        />
-      </List>
-    );
+    return <MoleNotInstalled />;
   }
 
   const { analyzePath } = getPreferenceValues<Preferences.Analyze>();

--- a/extensions/mole/src/analyze.tsx
+++ b/extensions/mole/src/analyze.tsx
@@ -50,7 +50,7 @@ function useAnalyze(molePath: string, dirPath: string) {
 }
 
 export default function AnalyzeDisk() {
-  const molePath = useMemo(() => getMolePathSafe(), []);
+  const molePath = getMolePathSafe();
 
   if (!molePath) {
     return <MoleNotInstalled />;
@@ -65,12 +65,12 @@ export default function AnalyzeDisk() {
 function AnalyzeList({ molePath, dirPath }: { molePath: string; dirPath: string }) {
   const { data, isLoading, revalidate } = useAnalyze(molePath, dirPath);
 
-  const sorted = useMemo(() => {
+  const sorted = useMemo<AnalyzeEntry[]>(() => {
     if (!data?.entries) return [];
     return [...data.entries].sort((a, b) => b.size - a.size);
   }, [data]);
 
-  const totalSize = useMemo(() => sorted.reduce((sum, e) => sum + e.size, 0), [sorted]);
+  const totalSize = useMemo<number>(() => sorted.reduce((sum: number, e: AnalyzeEntry) => sum + e.size, 0), [sorted]);
 
   const sizeColor = (size: number): Color => {
     const ratio = totalSize > 0 ? size / totalSize : 0;
@@ -83,7 +83,7 @@ function AnalyzeList({ molePath, dirPath }: { molePath: string; dirPath: string 
   return (
     <List isLoading={isLoading} searchBarPlaceholder={`Browsing ${dirPath}`} navigationTitle={dirPath.split("/").pop()}>
       {isLoading && !data && <List.Item title="Analyzing..." subtitle={dirPath} icon={Icon.MagnifyingGlass} />}
-      {sorted.map((entry) => (
+      {sorted.map((entry: AnalyzeEntry) => (
         <List.Item
           key={entry.path}
           title={entry.name}

--- a/extensions/mole/src/clean.tsx
+++ b/extensions/mole/src/clean.tsx
@@ -4,6 +4,7 @@ import { spawn, type ChildProcess } from "child_process";
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { getMolePathSafe, runMole, MOLE_ENV } from "./utils/mole";
 import { parseCleanDryRun, type CleanDryRunResult } from "./utils/parsers";
+import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
 function useStreamingClean(molePath: string) {
   const [data, setData] = useState<CleanDryRunResult>({ sections: [], totalSpace: "Scanning...", totalItems: 0 });
@@ -75,15 +76,7 @@ export default function CleanSystem() {
   const molePath = useMemo(() => getMolePathSafe(), []);
 
   if (!molePath) {
-    return (
-      <List>
-        <List.EmptyView
-          title="Mole Not Installed"
-          description="Install Mole to use this extension: brew install mole"
-          icon={Icon.ExclamationMark}
-        />
-      </List>
-    );
+    return <MoleNotInstalled />;
   }
 
   return <CleanView molePath={molePath} />;

--- a/extensions/mole/src/clean.tsx
+++ b/extensions/mole/src/clean.tsx
@@ -1,7 +1,7 @@
 import { List, Icon, Color, ActionPanel, Action, Toast, showToast, confirmAlert } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { spawn, type ChildProcess } from "child_process";
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { getMolePathSafe, runMole, MOLE_ENV } from "./utils/mole";
 import { parseCleanDryRun, type CleanDryRunResult } from "./utils/parsers";
 import { MoleNotInstalled } from "./components/MoleNotInstalled";
@@ -73,7 +73,7 @@ function useStreamingClean(molePath: string) {
 }
 
 export default function CleanSystem() {
-  const molePath = useMemo(() => getMolePathSafe(), []);
+  const molePath = getMolePathSafe();
 
   if (!molePath) {
     return <MoleNotInstalled />;

--- a/extensions/mole/src/components/MoleNotInstalled.tsx
+++ b/extensions/mole/src/components/MoleNotInstalled.tsx
@@ -1,0 +1,55 @@
+import { List, Icon, ActionPanel, Action, LaunchType, launchCommand, open } from "@raycast/api";
+import { execFile } from "child_process";
+
+const MOLE_GITHUB = "https://github.com/tw93/Mole";
+const BREW_COMMAND = "brew install mole";
+const SCRIPT_COMMAND = "curl -fsSL https://raw.githubusercontent.com/tw93/mole/main/install.sh | bash";
+
+function openInBrewExtension() {
+  launchCommand({
+    name: "search",
+    type: LaunchType.UserInitiated,
+    extensionName: "brew",
+    ownerOrAuthorName: "nhojb",
+    fallbackText: "mole",
+  }).catch(() => {
+    open("raycast://extensions/nhojb/brew/search?fallbackText=mole");
+  });
+}
+
+function runInTerminal(command: string) {
+  execFile("/usr/bin/osascript", [
+    "-e",
+    `tell application "Terminal" to do script "${command}"`,
+    "-e",
+    'tell application "Terminal" to activate',
+  ]);
+}
+
+export function MoleNotInstalled() {
+  return (
+    <List>
+      <List.EmptyView
+        title="Mole Not Installed"
+        description="Mole CLI is required to use this extension. Choose an install method below."
+        icon={Icon.Download}
+        actions={
+          <ActionPanel>
+            <Action title="Install with Homebrew (Raycast)" icon={Icon.RaycastLogoNeg} onAction={openInBrewExtension} />
+            <Action
+              title="Install with Homebrew (Terminal)"
+              icon={Icon.Terminal}
+              onAction={() => runInTerminal(BREW_COMMAND)}
+            />
+            <Action
+              title="Install with Script (Terminal)"
+              icon={Icon.Terminal}
+              onAction={() => runInTerminal(SCRIPT_COMMAND)}
+            />
+            <Action.OpenInBrowser title="Open Mole on GitHub" icon={Icon.Globe} url={MOLE_GITHUB} />
+          </ActionPanel>
+        }
+      />
+    </List>
+  );
+}

--- a/extensions/mole/src/components/MoleNotInstalled.tsx
+++ b/extensions/mole/src/components/MoleNotInstalled.tsx
@@ -1,4 +1,4 @@
-import { List, Icon, ActionPanel, Action, LaunchType, launchCommand, open } from "@raycast/api";
+import { List, Icon, ActionPanel, Action, LaunchType, launchCommand, open, showToast, Toast } from "@raycast/api";
 import { execFile } from "child_process";
 
 const MOLE_GITHUB = "https://github.com/tw93/Mole";
@@ -18,12 +18,15 @@ function openInBrewExtension() {
 }
 
 function runInTerminal(command: string) {
-  execFile("/usr/bin/osascript", [
-    "-e",
-    `tell application "Terminal" to do script "${command}"`,
-    "-e",
-    'tell application "Terminal" to activate',
-  ]);
+  execFile(
+    "/usr/bin/osascript",
+    ["-e", `tell application "Terminal" to do script "${command}"`, "-e", 'tell application "Terminal" to activate'],
+    (err) => {
+      if (err) {
+        showToast({ style: Toast.Style.Failure, title: "Failed to open Terminal", message: err.message });
+      }
+    },
+  );
 }
 
 export function MoleNotInstalled() {

--- a/extensions/mole/src/components/MoleNotInstalled.tsx
+++ b/extensions/mole/src/components/MoleNotInstalled.tsx
@@ -17,10 +17,13 @@ function openInBrewExtension() {
   });
 }
 
-function runInTerminal(command: string) {
+type KnownInstallCommand = typeof BREW_COMMAND | typeof SCRIPT_COMMAND;
+
+function runInTerminal(command: KnownInstallCommand) {
+  const escaped = command.replace(/"/g, '\\"');
   execFile(
     "/usr/bin/osascript",
-    ["-e", `tell application "Terminal" to do script "${command}"`, "-e", 'tell application "Terminal" to activate'],
+    ["-e", `tell application "Terminal" to do script "${escaped}"`, "-e", 'tell application "Terminal" to activate'],
     (err) => {
       if (err) {
         showToast({ style: Toast.Style.Failure, title: "Failed to open Terminal", message: err.message });

--- a/extensions/mole/src/installer.tsx
+++ b/extensions/mole/src/installer.tsx
@@ -2,7 +2,7 @@ import { List, Icon, Color, ActionPanel, Action, Toast, showToast, confirmAlert,
 import { showFailureToast } from "@raycast/utils";
 import { readdirSync, statSync } from "fs";
 import { join } from "path";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { getMolePathSafe } from "./utils/mole";
 import { formatBytes } from "./utils/parsers";
 import { MoleNotInstalled } from "./components/MoleNotInstalled";
@@ -69,7 +69,7 @@ function useInstallerFiles() {
 }
 
 export default function CleanInstallers() {
-  const molePath = useMemo(() => getMolePathSafe(), []);
+  const molePath = getMolePathSafe();
 
   if (!molePath) {
     return <MoleNotInstalled />;

--- a/extensions/mole/src/installer.tsx
+++ b/extensions/mole/src/installer.tsx
@@ -5,6 +5,7 @@ import { join } from "path";
 import { useState, useEffect, useMemo } from "react";
 import { getMolePathSafe } from "./utils/mole";
 import { formatBytes } from "./utils/parsers";
+import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
 interface InstallerFile {
   name: string;
@@ -71,15 +72,7 @@ export default function CleanInstallers() {
   const molePath = useMemo(() => getMolePathSafe(), []);
 
   if (!molePath) {
-    return (
-      <List>
-        <List.EmptyView
-          title="Mole Not Installed"
-          description="Install Mole to use this extension: brew install mole"
-          icon={Icon.ExclamationMark}
-        />
-      </List>
-    );
+    return <MoleNotInstalled />;
   }
 
   return <InstallerView />;

--- a/extensions/mole/src/optimize.tsx
+++ b/extensions/mole/src/optimize.tsx
@@ -3,20 +3,13 @@ import { useCachedPromise, showFailureToast } from "@raycast/utils";
 import { useMemo } from "react";
 import { getMolePathSafe, runMole } from "./utils/mole";
 import { parseOptimizeDryRun } from "./utils/parsers";
+import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
 export default function OptimizeSystem() {
   const molePath = useMemo(() => getMolePathSafe(), []);
 
   if (!molePath) {
-    return (
-      <List>
-        <List.EmptyView
-          title="Mole Not Installed"
-          description="Install Mole to use this extension: brew install mole"
-          icon={Icon.ExclamationMark}
-        />
-      </List>
-    );
+    return <MoleNotInstalled />;
   }
 
   return <OptimizeView />;

--- a/extensions/mole/src/optimize.tsx
+++ b/extensions/mole/src/optimize.tsx
@@ -1,12 +1,11 @@
 import { List, Icon, Color, ActionPanel, Action, Toast, showToast, confirmAlert } from "@raycast/api";
 import { useCachedPromise, showFailureToast } from "@raycast/utils";
-import { useMemo } from "react";
 import { getMolePathSafe, runMole } from "./utils/mole";
 import { parseOptimizeDryRun } from "./utils/parsers";
 import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
 export default function OptimizeSystem() {
-  const molePath = useMemo(() => getMolePathSafe(), []);
+  const molePath = getMolePathSafe();
 
   if (!molePath) {
     return <MoleNotInstalled />;

--- a/extensions/mole/src/purge.tsx
+++ b/extensions/mole/src/purge.tsx
@@ -4,6 +4,7 @@ import { execFile } from "child_process";
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { getMolePathSafe, getMolePath, runMole, MOLE_ENV } from "./utils/mole";
 import { parsePurgeDryRun, type PurgeDryRunResult } from "./utils/parsers";
+import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
 function usePurgeScan(molePath: string) {
   const [data, setData] = useState<PurgeDryRunResult | null>(null);
@@ -44,15 +45,7 @@ export default function PurgeArtifacts() {
   const molePath = useMemo(() => getMolePathSafe(), []);
 
   if (!molePath) {
-    return (
-      <List>
-        <List.EmptyView
-          title="Mole Not Installed"
-          description="Install Mole to use this extension: brew install mole"
-          icon={Icon.ExclamationMark}
-        />
-      </List>
-    );
+    return <MoleNotInstalled />;
   }
 
   return <PurgeView />;

--- a/extensions/mole/src/purge.tsx
+++ b/extensions/mole/src/purge.tsx
@@ -1,7 +1,7 @@
 import { List, Icon, Color, ActionPanel, Action, Toast, showToast, confirmAlert, trash } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { execFile } from "child_process";
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { getMolePathSafe, getMolePath, runMole, MOLE_ENV } from "./utils/mole";
 import { parsePurgeDryRun, type PurgeDryRunResult } from "./utils/parsers";
 import { MoleNotInstalled } from "./components/MoleNotInstalled";
@@ -42,7 +42,7 @@ function usePurgeScan(molePath: string) {
 }
 
 export default function PurgeArtifacts() {
-  const molePath = useMemo(() => getMolePathSafe(), []);
+  const molePath = getMolePathSafe();
 
   if (!molePath) {
     return <MoleNotInstalled />;

--- a/extensions/mole/src/system-status.tsx
+++ b/extensions/mole/src/system-status.tsx
@@ -1,13 +1,13 @@
 import { List, Icon, Color, ActionPanel, Action, getPreferenceValues } from "@raycast/api";
 import { useExec } from "@raycast/utils";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { getMolePathSafe } from "./utils/mole";
 import { type MoleStatus, formatBytes, formatPercent, formatRate } from "./utils/parsers";
 import { getHealthIcon, getUsageColor, getBatteryIcon } from "./utils/icons";
 import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
 export default function SystemStatus() {
-  const molePath = useMemo(() => getMolePathSafe(), []);
+  const molePath = getMolePathSafe();
 
   if (!molePath) {
     return <MoleNotInstalled />;

--- a/extensions/mole/src/system-status.tsx
+++ b/extensions/mole/src/system-status.tsx
@@ -4,20 +4,13 @@ import { useEffect, useMemo } from "react";
 import { getMolePathSafe } from "./utils/mole";
 import { type MoleStatus, formatBytes, formatPercent, formatRate } from "./utils/parsers";
 import { getHealthIcon, getUsageColor, getBatteryIcon } from "./utils/icons";
+import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
 export default function SystemStatus() {
   const molePath = useMemo(() => getMolePathSafe(), []);
 
   if (!molePath) {
-    return (
-      <List>
-        <List.EmptyView
-          title="Mole Not Installed"
-          description="Install Mole to use this extension: brew install mole"
-          icon={Icon.ExclamationMark}
-        />
-      </List>
-    );
+    return <MoleNotInstalled />;
   }
 
   return <StatusView molePath={molePath} />;

--- a/extensions/mole/src/touchid.tsx
+++ b/extensions/mole/src/touchid.tsx
@@ -3,6 +3,7 @@ import { execFile } from "child_process";
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { getMolePathSafe, MOLE_ENV } from "./utils/mole";
 import { stripAnsi } from "./utils/parsers";
+import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
 function useTouchIdStatus(molePath: string) {
   const [enabled, setEnabled] = useState<boolean | null>(null);
@@ -32,15 +33,7 @@ export default function TouchIdForSudo() {
   const molePath = useMemo(() => getMolePathSafe(), []);
 
   if (!molePath) {
-    return (
-      <List>
-        <List.EmptyView
-          title="Mole Not Installed"
-          description="Install Mole to use this extension: brew install mole"
-          icon={Icon.ExclamationMark}
-        />
-      </List>
-    );
+    return <MoleNotInstalled />;
   }
 
   return <TouchIdView molePath={molePath} />;

--- a/extensions/mole/src/touchid.tsx
+++ b/extensions/mole/src/touchid.tsx
@@ -1,6 +1,6 @@
 import { List, Icon, Color, ActionPanel, Action, Clipboard, showHUD } from "@raycast/api";
 import { execFile } from "child_process";
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { getMolePathSafe, MOLE_ENV } from "./utils/mole";
 import { stripAnsi } from "./utils/parsers";
 import { MoleNotInstalled } from "./components/MoleNotInstalled";
@@ -30,7 +30,7 @@ function useTouchIdStatus(molePath: string) {
 }
 
 export default function TouchIdForSudo() {
-  const molePath = useMemo(() => getMolePathSafe(), []);
+  const molePath = getMolePathSafe();
 
   if (!molePath) {
     return <MoleNotInstalled />;
@@ -91,11 +91,12 @@ function TouchIdView({ molePath }: { molePath: string }) {
                 title="Run in Terminal"
                 icon={Icon.Terminal}
                 onAction={async () => {
+                  const escaped = command.replace(/"/g, '\\"');
                   execFile(
                     "/usr/bin/osascript",
                     [
                       "-e",
-                      `tell application "Terminal" to do script "${command}"`,
+                      `tell application "Terminal" to do script "${escaped}"`,
                       "-e",
                       `tell application "Terminal" to activate`,
                     ],

--- a/extensions/mole/src/uninstall.tsx
+++ b/extensions/mole/src/uninstall.tsx
@@ -5,6 +5,7 @@ import { showFailureToast } from "@raycast/utils";
 import { useState, useEffect, useMemo } from "react";
 import { getMolePathSafe } from "./utils/mole";
 import { formatBytes } from "./utils/parsers";
+import { MoleNotInstalled } from "./components/MoleNotInstalled";
 import { execFile } from "child_process";
 
 interface AppInfo {
@@ -414,15 +415,7 @@ export default function UninstallApp() {
   const molePath = useMemo(() => getMolePathSafe(), []);
 
   if (!molePath) {
-    return (
-      <List>
-        <List.EmptyView
-          title="Mole Not Installed"
-          description="Install Mole to use this extension: brew install mole"
-          icon={Icon.ExclamationMark}
-        />
-      </List>
-    );
+    return <MoleNotInstalled />;
   }
 
   return <UninstallView />;

--- a/extensions/mole/src/uninstall.tsx
+++ b/extensions/mole/src/uninstall.tsx
@@ -2,7 +2,7 @@ import { List, Icon, ActionPanel, Action, Alert, showToast, Toast, confirmAlert,
 import { readdirSync, statSync, existsSync } from "fs";
 import { join, basename } from "path";
 import { showFailureToast } from "@raycast/utils";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { getMolePathSafe } from "./utils/mole";
 import { formatBytes } from "./utils/parsers";
 import { MoleNotInstalled } from "./components/MoleNotInstalled";
@@ -412,7 +412,7 @@ function useInstalledApps() {
 }
 
 export default function UninstallApp() {
-  const molePath = useMemo(() => getMolePathSafe(), []);
+  const molePath = getMolePathSafe();
 
   if (!molePath) {
     return <MoleNotInstalled />;

--- a/extensions/mole/src/update-mole.tsx
+++ b/extensions/mole/src/update-mole.tsx
@@ -1,14 +1,67 @@
-import { showToast, Toast } from "@raycast/api";
+import { Detail, showToast, Toast } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
-import { runMole } from "./utils/mole";
+import { useState, useEffect, useMemo } from "react";
+import { runMole, getMolePathSafe } from "./utils/mole";
+import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
-export default async function UpdateMole() {
-  const toast = await showToast({ style: Toast.Style.Animated, title: "Updating Mole..." });
-  try {
-    const output = await runMole(["update"], { timeout: 60000 });
-    toast.style = Toast.Style.Success;
-    toast.title = output.includes("already") ? "Already up to date" : "Mole updated successfully";
-  } catch (err) {
-    await showFailureToast(err, { title: "Update failed" });
+function parseVersion(output: string): string {
+  const match = output.match(/Mole version ([\d.]+)/);
+  return match ? match[1] : "unknown";
+}
+
+function UpdateView() {
+  const [result, setResult] = useState<{ status: "loading" | "success" | "error"; message: string; version: string }>({
+    status: "loading",
+    message: "Checking for updates...",
+    version: "",
+  });
+
+  useEffect(() => {
+    async function update() {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Updating Mole..." });
+      try {
+        const output = await runMole(["update"], { timeout: 60000 });
+        const alreadyUpToDate = output.toLowerCase().includes("already");
+
+        const versionOutput = await runMole(["--version"], { timeout: 10000 });
+        const version = parseVersion(versionOutput);
+
+        toast.style = Toast.Style.Success;
+        toast.title = alreadyUpToDate ? "No updates available" : "Mole updated successfully";
+
+        setResult({
+          status: "success",
+          message: alreadyUpToDate ? "You're on the latest version." : "Mole has been updated.",
+          version,
+        });
+      } catch (err) {
+        await showFailureToast(err, { title: "Update failed" });
+        setResult({
+          status: "error",
+          message: err instanceof Error ? err.message : "Unknown error",
+          version: "",
+        });
+      }
+    }
+    update();
+  }, []);
+
+  const markdown =
+    result.status === "loading"
+      ? "Checking for updates..."
+      : result.status === "error"
+        ? `## Update Failed\n\n\`${result.message}\``
+        : `## ${result.message}\n\n**Version:** ${result.version}`;
+
+  return <Detail isLoading={result.status === "loading"} markdown={markdown} />;
+}
+
+export default function UpdateMole() {
+  const molePath = useMemo(() => getMolePathSafe(), []);
+
+  if (!molePath) {
+    return <MoleNotInstalled />;
   }
+
+  return <UpdateView />;
 }

--- a/extensions/mole/src/update-mole.tsx
+++ b/extensions/mole/src/update-mole.tsx
@@ -1,6 +1,6 @@
 import { Detail, showToast, Toast } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { runMole, getMolePathSafe } from "./utils/mole";
 import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
@@ -17,6 +17,8 @@ function UpdateView() {
   });
 
   useEffect(() => {
+    let mounted = true;
+
     async function update() {
       const toast = await showToast({ style: Toast.Style.Animated, title: "Updating Mole..." });
       try {
@@ -29,6 +31,8 @@ function UpdateView() {
         toast.style = Toast.Style.Success;
         toast.title = alreadyUpToDate ? "No updates available" : "Mole updated successfully";
 
+        if (!mounted) return;
+
         setResult({
           status: "success",
           message: alreadyUpToDate ? "You're on the latest version." : "Mole has been updated.",
@@ -36,6 +40,7 @@ function UpdateView() {
         });
       } catch (err) {
         await showFailureToast(err, { title: "Update failed" });
+        if (!mounted) return;
         setResult({
           status: "error",
           message: err instanceof Error ? err.message : "Unknown error",
@@ -43,7 +48,12 @@ function UpdateView() {
         });
       }
     }
+
     update();
+
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   const markdown =
@@ -57,7 +67,7 @@ function UpdateView() {
 }
 
 export default function UpdateMole() {
-  const molePath = useMemo(() => getMolePathSafe(), []);
+  const molePath = getMolePathSafe();
 
   if (!molePath) {
     return <MoleNotInstalled />;


### PR DESCRIPTION
## Description

Adds a friendly install screen when Mole CLI (`mo`) is not found, replacing the plain "Mole Not Installed" empty view across all commands.

**New `MoleNotInstalled` component** with 4 install options:
- **Install with Homebrew (Raycast)** — Opens the Brew extension's search with "mole" pre-filled via `launchCommand` with `fallbackText`
- **Install with Homebrew (Terminal)** — Runs `brew install mole` in Terminal
- **Install with Script (Terminal)** — Runs the official curl install script in Terminal
- **Open Mole on GitHub** — Opens the repo in browser

**Improved Update Mole command:**
- Changed from `no-view` to `view` mode to show the install screen when CLI is missing
- Shows current version number after checking for updates
- Correctly distinguishes between "already on latest version" vs "updated successfully"

Addresses #26543

## Screencast

<img width="2000" height="1250" alt="mole 2026-03-22 at 20 27 49" src="https://github.com/user-attachments/assets/f14ef75b-d29a-4fe5-bf57-bdf7447433dc" />
<img width="2000" height="1250" alt="mole 2026-03-22 at 20 26 10" src="https://github.com/user-attachments/assets/1e1b9f0e-c015-42d4-a86f-e198c2941db8" />
<img width="2000" height="1250" alt="mole 2026-03-22 at 20 25 42" src="https://github.com/user-attachments/assets/ad19c4c8-e567-45a9-9369-c0f1c9d19798" />

## Checklist
- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside of the `metadata` folder