### PR TITLE
ext/plexamp Critical library selection fix

### DIFF
--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [Library Selection Fixes] - {PR_MERGE_DATE}
+
+- Fixed music library detection failing silently when the preferred server connection is unreachable by trying all connections concurrently.
+- Fixed the library selection screen hanging for minutes when remote server connections timeout.
+- Fixed the "Sign in to Plex" screen flashing briefly on the Plexamp Status command while the initial load completes.
+- Added progressive loading to the library selection screen so libraries appear as each server responds instead of waiting for all servers.
+- Added local server prioritization so nearby servers appear first during library selection.
+- Removed servers without music libraries from the library selection screen.
+- Removed the LAN badge and "Shared By" accessories from library selection items.
+
 ## [Plex Sign-In, Now Playing, and Search Improvements] - 2026-03-22
 
 - Added managed Plex sign-in, server selection, and music library selection inside Raycast.

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plexamp CHANGELOG
 
-## [Library Selection Fixes] - {PR_MERGE_DATE}
+## [Library Selection Fixes] - 2026-03-24
 
 - Fixed music library detection failing silently when the preferred server connection is unreachable by trying all connections concurrently.
 - Fixed the library selection screen hanging for minutes when remote server connections timeout.

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Plexamp CHANGELOG
+
 ## [Library Selection Fixes] - {PR_MERGE_DATE}
 
 - Fixed music library detection failing silently when the preferred server connection is unreachable by trying all connections concurrently.

--- a/extensions/plexamp/src/plex-library.ts
+++ b/extensions/plexamp/src/plex-library.ts
@@ -86,15 +86,7 @@ function parsePlexampClientInfo(container: XmlNode): PlexampClientInfo {
   };
 }
 
-export async function getMusicSectionsForServer(server: PlexServerResource): Promise<LibrarySection[]> {
-  const preferredConnection = server.preferredConnection ?? server.connections[0];
-
-  if (!preferredConnection) {
-    throw new Error(`No usable connection was found for ${server.name}.`);
-  }
-
-  const container = await requestXml(preferredConnection.uri, "/library/sections", undefined, true, server.accessToken);
-
+function parseMusicSections(container: XmlNode): LibrarySection[] {
   return arrayify(container.Directory)
     .filter((node): node is XmlNode => typeof node === "object")
     .filter((node) => asString(node.type) === "artist")
@@ -104,6 +96,29 @@ export async function getMusicSectionsForServer(server: PlexServerResource): Pro
       type: "artist" as const,
       totalSize: asNumber(node.totalSize),
     }));
+}
+
+export async function getMusicSectionsForServer(server: PlexServerResource): Promise<LibrarySection[]> {
+  const preferred = server.preferredConnection ?? server.connections[0];
+  const fallbacks = server.connections.filter((c) => c !== preferred);
+  const candidates = preferred ? [preferred, ...fallbacks] : fallbacks;
+
+  if (candidates.length === 0) {
+    throw new Error(`No usable connection was found for ${server.name}.`);
+  }
+
+  let lastError: unknown;
+
+  for (const connection of candidates) {
+    try {
+      const container = await requestXml(connection.uri, "/library/sections", undefined, true, server.accessToken);
+      return parseMusicSections(container);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
 export async function getMusicSections(): Promise<LibrarySection[]> {

--- a/extensions/plexamp/src/plex-library.ts
+++ b/extensions/plexamp/src/plex-library.ts
@@ -99,26 +99,17 @@ function parseMusicSections(container: XmlNode): LibrarySection[] {
 }
 
 export async function getMusicSectionsForServer(server: PlexServerResource): Promise<LibrarySection[]> {
-  const preferred = server.preferredConnection ?? server.connections[0];
-  const fallbacks = server.connections.filter((c) => c !== preferred);
-  const candidates = preferred ? [preferred, ...fallbacks] : fallbacks;
+  const candidates = server.connections.length > 0 ? server.connections : server.preferredConnection ? [server.preferredConnection] : [];
 
   if (candidates.length === 0) {
     throw new Error(`No usable connection was found for ${server.name}.`);
   }
 
-  let lastError: unknown;
+  const container = await Promise.any(
+    candidates.map((connection) => requestXml(connection.uri, "/library/sections", undefined, true, server.accessToken)),
+  );
 
-  for (const connection of candidates) {
-    try {
-      const container = await requestXml(connection.uri, "/library/sections", undefined, true, server.accessToken);
-      return parseMusicSections(container);
-    } catch (error) {
-      lastError = error;
-    }
-  }
-
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  return parseMusicSections(container);
 }
 
 export async function getMusicSections(): Promise<LibrarySection[]> {

--- a/extensions/plexamp/src/plex-library.ts
+++ b/extensions/plexamp/src/plex-library.ts
@@ -99,14 +99,17 @@ function parseMusicSections(container: XmlNode): LibrarySection[] {
 }
 
 export async function getMusicSectionsForServer(server: PlexServerResource): Promise<LibrarySection[]> {
-  const candidates = server.connections.length > 0 ? server.connections : server.preferredConnection ? [server.preferredConnection] : [];
+  const candidates =
+    server.connections.length > 0 ? server.connections : server.preferredConnection ? [server.preferredConnection] : [];
 
   if (candidates.length === 0) {
     throw new Error(`No usable connection was found for ${server.name}.`);
   }
 
   const container = await Promise.any(
-    candidates.map((connection) => requestXml(connection.uri, "/library/sections", undefined, true, server.accessToken)),
+    candidates.map((connection) =>
+      requestXml(connection.uri, "/library/sections", undefined, true, server.accessToken),
+    ),
   );
 
   return parseMusicSections(container);

--- a/extensions/plexamp/src/plex-setup-view.tsx
+++ b/extensions/plexamp/src/plex-setup-view.tsx
@@ -64,13 +64,6 @@ function setupDescription(status?: PlexSetupStatus, problem?: string): string {
   return [problem, ...details].filter(Boolean).join("\n\n");
 }
 
-function serverAccessories(server: PlexServerResource): List.Item.Accessory[] {
-  return [
-    ...(server.preferredConnection?.localNetwork ? [{ tag: { value: "LAN", color: Color.Blue } }] : []),
-    ...(server.sourceTitle ? [{ text: server.sourceTitle, tooltip: "Shared By" }] : []),
-  ];
-}
-
 export function PlexSetupView(props: PlexSetupViewProps) {
   const [authPin, setAuthPin] = useState<PlexAuthPin>();
   const [state, setState] = useState<SetupState>({
@@ -401,7 +394,6 @@ export function PlexSetupView(props: PlexSetupViewProps) {
                         },
                       ]
                     : []),
-                  ...serverAccessories(server),
                   ...(library.totalSize !== undefined ? [{ text: `${library.totalSize} artists` }] : []),
                 ]}
                 actions={

--- a/extensions/plexamp/src/plex-setup-view.tsx
+++ b/extensions/plexamp/src/plex-setup-view.tsx
@@ -104,22 +104,39 @@ export function PlexSetupView(props: PlexSetupViewProps) {
         });
 
         const servers = await discoverPlexServers();
-        const serverLibraries = (
-          await Promise.all(
-            servers.map(async (server) => {
-              try {
-                return {
-                  server,
-                  libraries: await getMusicSectionsForServer(server),
-                };
-              } catch {
-                return undefined;
-              }
-            }),
-          )
-        ).filter((entry): entry is ServerLibraries => entry !== undefined && entry.libraries.length > 0);
 
-        const selectableLibraries = serverLibraries.flatMap((entry) =>
+        // Sort local servers first so they appear sooner
+        const sortedServers = [...servers].sort((a, b) => {
+          const aLocal = a.preferredConnection?.localNetwork ? 0 : 1;
+          const bLocal = b.preferredConnection?.localNetwork ? 0 : 1;
+          return aLocal - bLocal;
+        });
+
+        // Stream results in as each server resolves
+        const results: ServerLibraries[] = [];
+        let remaining = sortedServers.length;
+
+        await Promise.all(
+          sortedServers.map(async (server) => {
+            try {
+              const libraries = await getMusicSectionsForServer(server);
+              if (libraries.length > 0) {
+                results.push({ server, libraries });
+                setState((current) => ({
+                  ...current,
+                  isLoading: remaining > 1,
+                  serverLibraries: [...results],
+                }));
+              }
+            } catch {
+              // Server unreachable or has no music — skip
+            } finally {
+              remaining--;
+            }
+          }),
+        );
+
+        const selectableLibraries = results.flatMap((entry) =>
           entry.libraries.map((library) => ({ server: entry.server, library })),
         );
 
@@ -141,7 +158,7 @@ export function PlexSetupView(props: PlexSetupViewProps) {
           isLoading: false,
           stage: "library-selection",
           status,
-          serverLibraries,
+          serverLibraries: results,
           problem: props.problem,
         });
         return;
@@ -356,7 +373,7 @@ export function PlexSetupView(props: PlexSetupViewProps) {
   if (state.stage === "library-selection") {
     return (
       <List
-        isLoading={state.isLoading && state.serverLibraries.length > 0}
+        isLoading={state.isLoading}
         navigationTitle={props.navigationTitle}
         searchBarPlaceholder="Choose a Plex music library"
       >

--- a/extensions/plexamp/src/plex-setup-view.tsx
+++ b/extensions/plexamp/src/plex-setup-view.tsx
@@ -34,7 +34,6 @@ type SetupStage = "loading" | "auth" | "waiting-auth" | "library-selection" | "p
 interface ServerLibraries {
   server: PlexServerResource;
   libraries: LibrarySection[];
-  problem?: string;
 }
 
 interface PlexSetupViewProps {
@@ -112,22 +111,20 @@ export function PlexSetupView(props: PlexSetupViewProps) {
         });
 
         const servers = await discoverPlexServers();
-        const serverLibraries = await Promise.all(
-          servers.map(async (server) => {
-            try {
-              return {
-                server,
-                libraries: await getMusicSectionsForServer(server),
-              };
-            } catch (error) {
-              return {
-                server,
-                libraries: [],
-                problem: error instanceof Error ? error.message : String(error),
-              };
-            }
-          }),
-        );
+        const serverLibraries = (
+          await Promise.all(
+            servers.map(async (server) => {
+              try {
+                return {
+                  server,
+                  libraries: await getMusicSectionsForServer(server),
+                };
+              } catch {
+                return undefined;
+              }
+            }),
+          )
+        ).filter((entry): entry is ServerLibraries => entry !== undefined && entry.libraries.length > 0);
 
         const selectableLibraries = serverLibraries.flatMap((entry) =>
           entry.libraries.map((library) => ({ server: entry.server, library })),
@@ -388,55 +385,39 @@ export function PlexSetupView(props: PlexSetupViewProps) {
         ) : null}
         {state.serverLibraries.map(({ server, libraries }) => (
           <List.Section key={server.clientIdentifier} title={server.name} subtitle={server.preferredConnection?.uri}>
-            {libraries.length > 0 ? (
-              libraries.map((library) => (
-                <List.Item
-                  key={`${server.clientIdentifier}:${library.key}`}
-                  icon={Icon.Music}
-                  title={library.title}
-                  accessories={[
-                    ...(state.status?.selectedLibrary === library.key
-                      ? [
-                          {
-                            icon: {
-                              source: Icon.CheckCircle,
-                              tintColor: Color.Green,
-                            },
-                          },
-                        ]
-                      : []),
-                    ...serverAccessories(server),
-                    ...(library.totalSize !== undefined ? [{ text: `${library.totalSize} artists` }] : []),
-                  ]}
-                  actions={
-                    <ActionPanel>
-                      <Action
-                        title="Use This Library"
-                        icon={Icon.CheckCircle}
-                        onAction={() => void chooseLibrary(library, server)}
-                      />
-                      <Action title="Refresh Libraries" icon={Icon.ArrowClockwise} onAction={() => void reload()} />
-                      <Action title="Reset Setup" icon={Icon.Trash} onAction={() => void resetSetup()} />
-                      <PreferencesAction />
-                    </ActionPanel>
-                  }
-                />
-              ))
-            ) : (
+            {libraries.map((library) => (
               <List.Item
-                key={`${server.clientIdentifier}:empty`}
-                icon={Icon.Warning}
-                title="No Music Libraries Available"
-                accessories={serverAccessories(server)}
+                key={`${server.clientIdentifier}:${library.key}`}
+                icon={Icon.Music}
+                title={library.title}
+                accessories={[
+                  ...(state.status?.selectedLibrary === library.key
+                    ? [
+                        {
+                          icon: {
+                            source: Icon.CheckCircle,
+                            tintColor: Color.Green,
+                          },
+                        },
+                      ]
+                    : []),
+                  ...serverAccessories(server),
+                  ...(library.totalSize !== undefined ? [{ text: `${library.totalSize} artists` }] : []),
+                ]}
                 actions={
                   <ActionPanel>
+                    <Action
+                      title="Use This Library"
+                      icon={Icon.CheckCircle}
+                      onAction={() => void chooseLibrary(library, server)}
+                    />
                     <Action title="Refresh Libraries" icon={Icon.ArrowClockwise} onAction={() => void reload()} />
                     <Action title="Reset Setup" icon={Icon.Trash} onAction={() => void resetSetup()} />
                     <PreferencesAction />
                   </ActionPanel>
                 }
               />
-            )}
+            ))}
           </List.Section>
         ))}
       </List>

--- a/extensions/plexamp/src/plex-setup-view.tsx
+++ b/extensions/plexamp/src/plex-setup-view.tsx
@@ -112,20 +112,20 @@ export function PlexSetupView(props: PlexSetupViewProps) {
           return aLocal - bLocal;
         });
 
-        // Stream results in as each server resolves
-        const results: ServerLibraries[] = [];
+        // Stream results in as each server resolves, preserving sort order
+        const results: (ServerLibraries | null)[] = new Array(sortedServers.length).fill(null);
         let remaining = sortedServers.length;
 
         await Promise.all(
-          sortedServers.map(async (server) => {
+          sortedServers.map(async (server, index) => {
             try {
               const libraries = await getMusicSectionsForServer(server);
               if (libraries.length > 0) {
-                results.push({ server, libraries });
+                results[index] = { server, libraries };
                 setState((current) => ({
                   ...current,
                   isLoading: remaining > 1,
-                  serverLibraries: [...results],
+                  serverLibraries: results.filter((r): r is ServerLibraries => r !== null),
                 }));
               }
             } catch {
@@ -136,7 +136,8 @@ export function PlexSetupView(props: PlexSetupViewProps) {
           }),
         );
 
-        const selectableLibraries = results.flatMap((entry) =>
+        const serverLibraries = results.filter((r): r is ServerLibraries => r !== null);
+        const selectableLibraries = serverLibraries.flatMap((entry) =>
           entry.libraries.map((library) => ({ server: entry.server, library })),
         );
 
@@ -158,7 +159,7 @@ export function PlexSetupView(props: PlexSetupViewProps) {
           isLoading: false,
           stage: "library-selection",
           status,
-          serverLibraries: results,
+          serverLibraries,
           problem: props.problem,
         });
         return;

--- a/extensions/plexamp/src/plexamp-status.tsx
+++ b/extensions/plexamp/src/plexamp-status.tsx
@@ -187,7 +187,7 @@ export default function Command() {
     ].join("\n");
   }, [state]);
 
-  if (error || !state.selectedLibrary) {
+  if (!isLoading && (error || !state.selectedLibrary)) {
     return <PlexSetupView navigationTitle="Plexamp Status" problem={error} onConfigured={() => void reload()} />;
   }
 


### PR DESCRIPTION
## Summary
- **Fix music library detection**: Try all available server connections concurrently (`Promise.any`) instead of only the preferred one, so unreachable local connections no longer silently fail
- **Hide servers without music**: Filter out servers that have no music libraries (or where all connections fail) from the selection list
- **Fix search hang**: Replace sequential connection fallback with concurrent racing so the UI no longer hangs for minutes when connections timeout
- **Progressive loading**: Stream library results into the UI as each server resolves instead of waiting for all servers, with local servers prioritized first
- **Remove UI noise**: Remove LAN badge and "Shared By" accessories from library selection items
- **Fix status screen flash**: Prevent the "Sign in to Plex" screen from flashing on the status command while the initial async load is in progress

## Testing
- Manual testing of library selection flow with local and remote servers
- Type checking passes (`tsc --noEmit`)
- ESLint passes on all changed files

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: client-side Raycast extension with no server-side components.