### PR TITLE
brew: Add cask id to metadata

### DIFF
--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Brew Changelog
 
-## [Cask Id] - {PR_MERGE_DATE}
+## [Cask Id] - 2026-03-24
 
 - Add cask id to the cask metadata
 

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Brew Changelog
 
+## [Cask Id] - {PR_MERGE_DATE}
+
+- Add cask id to the cask metadata
+
 ## [Improvements] - 2026-02-24
 
 - Remove updating homebrew index toast from outdated command

--- a/extensions/brew/src/components/actionPanels.tsx
+++ b/extensions/brew/src/components/actionPanels.tsx
@@ -83,7 +83,7 @@ export function CaskActionPanel(props: {
 
         <ActionPanel.Section>
           <Action.CopyToClipboard
-            title="Copy Cask Name"
+            title="Copy Cask ID"
             content={cask.token}
             shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
           />
@@ -109,13 +109,12 @@ export function CaskActionPanel(props: {
           <Actions.FormulaInstallAction formula={cask} onAction={props.onAction} />
         </ActionPanel.Section>
         <ActionPanel.Section>
-          <Action.CopyToClipboard title="Copy Tap Name" content={cask.tap} />
-
           <Action.CopyToClipboard
-            title="Copy Cask Name"
+            title="Copy Cask ID"
             content={cask.token}
             shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
           />
+          <Action.CopyToClipboard title="Copy Tap Name" content={cask.tap} />
           <Action.CopyToClipboard
             title="Copy Install Command"
             content={brewInstallCommand(cask)}

--- a/extensions/brew/src/components/caskInfo.tsx
+++ b/extensions/brew/src/components/caskInfo.tsx
@@ -97,6 +97,7 @@ export function CaskInfo({
       navigationTitle={`Cask Info: ${brewName(cask)}`}
       metadata={
         <Detail.Metadata>
+          <Detail.Metadata.Label title="Id" text={cask.token || "Loading..."} />
           {cask.homepage ? (
             <Detail.Metadata.Link title="Homepage" text={cask.homepage} target={cask.homepage} />
           ) : (

--- a/extensions/brew/src/components/listItemDetail.tsx
+++ b/extensions/brew/src/components/listItemDetail.tsx
@@ -88,6 +88,8 @@ export function CaskListItemDetail({ cask, isInstalled }: CaskListItemDetailProp
       markdown={formatCaskMarkdown(cask)}
       metadata={
         <List.Item.Detail.Metadata>
+          <List.Item.Detail.Metadata.Label title="Id" text={cask.token || "—"} />
+          <List.Item.Detail.Metadata.Separator />
           {cask.homepage ? (
             <List.Item.Detail.Metadata.Link title="Homepage" text={cask.homepage} target={cask.homepage} />
           ) : (


### PR DESCRIPTION
## Description

Adds Cask id to metadata

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
