### PR TITLE
Plexamp: Save verified connection URL during library selection

### DIFF
--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plexamp CHANGELOG
 
-## [Server Connection Fixes] - 2026-03-24
+## [Server Connection Fixes] - {PR_MERGE_DATE}
 
 - Fixed "All promises were rejected" error on Browse Library, Search Library, and Status commands by saving the verified working connection URL from library selection instead of an untested preferred URL.
 - Fixed the Now Playing Menubar not showing track information by using the server address from Plexamp's timeline response instead of the saved server URL.

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Server Connection Fixes] - 2026-03-24
 
-- Fixed "All promises were rejected" error on Browse Library, Search Library, and Status commands when the saved server connection URL is unreachable by automatically re-discovering the server via plex.tv and trying all available connections.
+- Fixed "All promises were rejected" error on Browse Library, Search Library, and Status commands by saving the verified working connection URL from library selection instead of an untested preferred URL.
 - Fixed the Now Playing Menubar not showing track information by using the server address from Plexamp's timeline response instead of the saved server URL.
 
 ## [Library Selection Fixes] - 2026-03-24

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plexamp CHANGELOG
 
-## [Server Connection Fixes] - {PR_MERGE_DATE}
+## [Server Connection Fixes] - 2026-03-25
 
 - Fixed "All promises were rejected" error on Browse Library, Search Library, and Status commands by saving the verified working connection URL from library selection instead of an untested preferred URL.
 - Fixed the Now Playing Menubar not showing track information by using the server address from Plexamp's timeline response instead of the saved server URL.

--- a/extensions/plexamp/src/plex-config.ts
+++ b/extensions/plexamp/src/plex-config.ts
@@ -173,15 +173,15 @@ export async function clearManagedConfiguration(): Promise<void> {
   invalidateCachedConfig();
 }
 
-export async function saveSelectedServer(server: PlexServerResource): Promise<void> {
-  const preferredConnection = server.preferredConnection ?? server.connections[0];
+export async function saveSelectedServer(server: PlexServerResource, connectionUri?: string): Promise<void> {
+  const uri = connectionUri ?? server.preferredConnection?.uri ?? server.connections[0]?.uri;
 
-  if (!preferredConnection) {
+  if (!uri) {
     throw new Error(`No usable connection was found for ${server.name}.`);
   }
 
   await Promise.all([
-    LocalStorage.setItem(MANAGED_SERVER_URL_KEY, preferredConnection.uri),
+    LocalStorage.setItem(MANAGED_SERVER_URL_KEY, uri),
     server.accessToken
       ? LocalStorage.setItem(MANAGED_SERVER_TOKEN_KEY, server.accessToken)
       : LocalStorage.removeItem(MANAGED_SERVER_TOKEN_KEY),
@@ -189,17 +189,6 @@ export async function saveSelectedServer(server: PlexServerResource): Promise<vo
     LocalStorage.setItem(MANAGED_SERVER_NAME_KEY, server.name),
     LocalStorage.removeItem(MANAGED_LIBRARY_KEY),
   ]);
-  invalidateCachedConfig();
-}
-
-export async function updateSavedServerConnection(uri: string, accessToken?: string): Promise<void> {
-  const updates: Promise<void>[] = [LocalStorage.setItem(MANAGED_SERVER_URL_KEY, uri)];
-
-  if (accessToken) {
-    updates.push(LocalStorage.setItem(MANAGED_SERVER_TOKEN_KEY, accessToken));
-  }
-
-  await Promise.all(updates);
   invalidateCachedConfig();
 }
 

--- a/extensions/plexamp/src/plex-library.ts
+++ b/extensions/plexamp/src/plex-library.ts
@@ -1,10 +1,4 @@
-import {
-  getConfig,
-  getConfiguredPlexampUrl,
-  registerConfigInvalidator,
-  requireServerConfig,
-  updateSavedServerConnection,
-} from "./plex-config";
+import { getConfig, getConfiguredPlexampUrl, registerConfigInvalidator, requireServerConfig } from "./plex-config";
 import {
   arrayify,
   asNumber,
@@ -20,7 +14,6 @@ import {
   requiredString,
   type XmlNode,
 } from "./plex-parsing";
-import { discoverPlexServers } from "./plex-auth";
 import { getTimelineServerBaseUrl, requestServer, requestServerWithConnection, requestXml } from "./plex-request";
 import type {
   AudioPlaylist,
@@ -105,7 +98,12 @@ function parseMusicSections(container: XmlNode): LibrarySection[] {
     }));
 }
 
-export async function getMusicSectionsForServer(server: PlexServerResource): Promise<LibrarySection[]> {
+export interface ServerSectionsResult {
+  libraries: LibrarySection[];
+  connectionUri: string;
+}
+
+export async function getMusicSectionsForServer(server: PlexServerResource): Promise<ServerSectionsResult> {
   const candidates =
     server.connections.length > 0 ? server.connections : server.preferredConnection ? [server.preferredConnection] : [];
 
@@ -113,75 +111,29 @@ export async function getMusicSectionsForServer(server: PlexServerResource): Pro
     throw new Error(`No usable connection was found for ${server.name}.`);
   }
 
-  const container = await Promise.any(
-    candidates.map((connection) =>
-      requestXml(connection.uri, "/library/sections", undefined, true, server.accessToken),
-    ),
+  const { container, uri } = await Promise.any(
+    candidates.map(async (connection) => {
+      const result = await requestXml(connection.uri, "/library/sections", undefined, true, server.accessToken);
+      return { container: result, uri: connection.uri };
+    }),
   );
 
-  return parseMusicSections(container);
+  return { libraries: parseMusicSections(container), connectionUri: uri };
 }
 
 export async function getMusicSections(): Promise<LibrarySection[]> {
   const config = await requireServerConfig();
 
-  const savedServer: PlexServerResource = {
+  const result = await getMusicSectionsForServer({
     name: config.serverName ?? "Plex Media Server",
     clientIdentifier: config.serverMachineIdentifier ?? config.plexServerUrl,
     accessToken: config.plexServerToken ?? config.plexToken,
     owned: true,
     connections: [{ uri: config.plexServerUrl }],
     preferredConnection: { uri: config.plexServerUrl },
-  };
+  });
 
-  try {
-    return await getMusicSectionsForServer(savedServer);
-  } catch (savedError) {
-    // Saved connection failed — attempt re-discovery via plex.tv
-    if (!config.serverMachineIdentifier) {
-      throw savedError;
-    }
-
-    let servers: PlexServerResource[];
-
-    try {
-      servers = await discoverPlexServers();
-    } catch {
-      throw savedError;
-    }
-
-    const server = servers.find((s) => s.clientIdentifier === config.serverMachineIdentifier);
-
-    if (!server || server.connections.length === 0) {
-      throw savedError;
-    }
-
-    // Try all discovered connections, tracking which one succeeds
-    const { sections, uri, accessToken } = await Promise.any(
-      server.connections.map(async (connection) => {
-        const container = await requestXml(
-          connection.uri,
-          "/library/sections",
-          undefined,
-          true,
-          server.accessToken ?? config.plexToken,
-        );
-
-        return {
-          sections: parseMusicSections(container),
-          uri: connection.uri,
-          accessToken: server.accessToken,
-        };
-      }),
-    );
-
-    // Update saved connection so subsequent requestServer calls use the working URL
-    if (uri !== config.plexServerUrl) {
-      await updateSavedServerConnection(uri, accessToken);
-    }
-
-    return sections;
-  }
+  return result.libraries;
 }
 
 export async function resolveSelectedLibrary(libraries: LibrarySection[]): Promise<LibrarySection | undefined> {

--- a/extensions/plexamp/src/plex-setup-view.tsx
+++ b/extensions/plexamp/src/plex-setup-view.tsx
@@ -34,6 +34,7 @@ type SetupStage = "loading" | "auth" | "waiting-auth" | "library-selection" | "p
 interface ServerLibraries {
   server: PlexServerResource;
   libraries: LibrarySection[];
+  connectionUri: string;
 }
 
 interface PlexSetupViewProps {
@@ -119,9 +120,9 @@ export function PlexSetupView(props: PlexSetupViewProps) {
         await Promise.all(
           sortedServers.map(async (server, index) => {
             try {
-              const libraries = await getMusicSectionsForServer(server);
+              const { libraries, connectionUri } = await getMusicSectionsForServer(server);
               if (libraries.length > 0) {
-                results[index] = { server, libraries };
+                results[index] = { server, libraries, connectionUri };
                 setState((current) => ({
                   ...current,
                   isLoading: remaining > 1,
@@ -138,11 +139,11 @@ export function PlexSetupView(props: PlexSetupViewProps) {
 
         const serverLibraries = results.filter((r): r is ServerLibraries => r !== null);
         const selectableLibraries = serverLibraries.flatMap((entry) =>
-          entry.libraries.map((library) => ({ server: entry.server, library })),
+          entry.libraries.map((library) => ({ server: entry.server, library, connectionUri: entry.connectionUri })),
         );
 
         if (!props.forceLibrarySelection && selectableLibraries.length === 1) {
-          await saveSelectedServer(selectableLibraries[0].server);
+          await saveSelectedServer(selectableLibraries[0].server, selectableLibraries[0].connectionUri);
           await saveSelectedLibrary(selectableLibraries[0].library);
           await props.onConfigured?.();
           setState({
@@ -204,6 +205,7 @@ export function PlexSetupView(props: PlexSetupViewProps) {
                     connections: [],
                   },
                   libraries,
+                  connectionUri: "",
                 },
               ]
             : [],
@@ -343,7 +345,7 @@ export function PlexSetupView(props: PlexSetupViewProps) {
   }, [reload]);
 
   const chooseLibrary = useCallback(
-    async (library: LibrarySection, server?: PlexServerResource) => {
+    async (library: LibrarySection, server?: PlexServerResource, connectionUri?: string) => {
       const toast = await showToast({
         style: Toast.Style.Animated,
         title: `Saving ${library.title}...`,
@@ -351,7 +353,7 @@ export function PlexSetupView(props: PlexSetupViewProps) {
 
       try {
         if (server?.connections.length) {
-          await saveSelectedServer(server);
+          await saveSelectedServer(server, connectionUri);
         }
         await saveSelectedLibrary(library);
         toast.style = Toast.Style.Success;
@@ -394,8 +396,8 @@ export function PlexSetupView(props: PlexSetupViewProps) {
             }
           />
         ) : null}
-        {state.serverLibraries.map(({ server, libraries }) => (
-          <List.Section key={server.clientIdentifier} title={server.name} subtitle={server.preferredConnection?.uri}>
+        {state.serverLibraries.map(({ server, libraries, connectionUri }) => (
+          <List.Section key={server.clientIdentifier} title={server.name} subtitle={connectionUri}>
             {libraries.map((library) => (
               <List.Item
                 key={`${server.clientIdentifier}:${library.key}`}
@@ -419,7 +421,7 @@ export function PlexSetupView(props: PlexSetupViewProps) {
                     <Action
                       title="Use This Library"
                       icon={Icon.CheckCircle}
-                      onAction={() => void chooseLibrary(library, server)}
+                      onAction={() => void chooseLibrary(library, server, connectionUri)}
                     />
                     <Action title="Refresh Libraries" icon={Icon.ArrowClockwise} onAction={() => void reload()} />
                     <Action title="Reset Setup" icon={Icon.Trash} onAction={() => void resetSetup()} />

--- a/extensions/plexamp/src/plex.ts
+++ b/extensions/plexamp/src/plex.ts
@@ -6,7 +6,6 @@ export {
   saveManagedAuthToken,
   saveSelectedLibrary,
   saveSelectedServer,
-  updateSavedServerConnection,
 } from "./plex-config";
 export { checkPlexAuthPin, createPlexAuthPin, discoverPlexServers } from "./plex-auth";
 export {


### PR DESCRIPTION
## Summary
- Fixed "All promises were rejected" error on Browse Library, Search Library, and Status commands by saving the connection URL that actually loaded the user's chosen library, instead of an untested ranked-preferred URL that may be unreachable.
- Fixed the Now Playing Menubar not showing track information by using the server address from Plexamp's timeline response.

## What changed
During setup, Plex servers expose multiple connection URLs (local IP, remote domain, relay). Previously `saveSelectedServer` saved the ranked-preferred URL (local > remote > relay) regardless of which one actually worked. Now `getMusicSectionsForServer` returns the URI of the connection that successfully loaded libraries, and that URI is passed through to `saveSelectedServer` when the user selects their library.

## Test plan
- [ ] Sign in and select a music library from library selection
- [ ] Verify Browse Library and Search Library work without "All promises were rejected" errors
- [ ] Verify Now Playing Menubar displays current track info
- [ ] Verify choosing a different library via Change Library command updates the saved connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)