### PR TITLE
Update one-time-secret extension

### DIFF
--- a/extensions/one-time-secret/.eslintrc.json
+++ b/extensions/one-time-secret/.eslintrc.json
@@ -1,4 +1,0 @@
-{
-  "root": true,
-  "extends": ["@raycast"]
-}

--- a/extensions/one-time-secret/.eslintrc.json
+++ b/extensions/one-time-secret/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": ["@raycast"]
+}

--- a/extensions/one-time-secret/CHANGELOG.md
+++ b/extensions/one-time-secret/CHANGELOG.md
@@ -1,5 +1,17 @@
 # One-Time Secret Changelog
 
+## [Recent Secrets, region choice, and receipt access] - 2026-03-25
+
+- Choose your **region** (Canada, EU, New Zealand, UK, or US) so you can decide where your data is stored.
+- The extension now uses **Onetime Secret API v2**, the latest version of their service.
+- Optionally add your **username** and **API token** to unlock **Recent Secrets**: see what you have shared, copy links, open them in the browser, jump to the full receipt page on the website, or **burn** a link so it stops working. Secrets you create from Raycast while signed in appear in this list.
+- Optional **passphrases** must be at least **8 characters** when you use one.
+
+## [Clipboard command and cleaner send flow] - 2026-03-24
+
+- Adds **Send from Clipboard**: a no-view command that creates a one-time secret from the clipboard with a **3 hour** lifetime and **no passphrase**, then copies the share link (empty clipboard shows an error toast).
+- **Send One-Time Secret**: after a successful share, Raycast **closes** and draft state is cleared so the form does not stay open with the previous secret, and reopening the command does not restore that secret.
+
 ## [AI Ready + Windows Support] - 2025-12-15
 - Adds **Windows** support
 - Adds support to use as an **AI** extension

--- a/extensions/one-time-secret/CHANGELOG.md
+++ b/extensions/one-time-secret/CHANGELOG.md
@@ -1,6 +1,6 @@
 # One-Time Secret Changelog
 
-## [Recent Secrets, region choice, and receipt access] - {PR_MERGE_DATE}
+## [Recent Secrets, region choice, and receipt access] - 2026-03-25
 
 - Choose your **region** (Canada, EU, New Zealand, UK, or US) so you can decide where your data is stored.
 - The extension now uses **Onetime Secret API v2**, the latest version of their service.

--- a/extensions/one-time-secret/CHANGELOG.md
+++ b/extensions/one-time-secret/CHANGELOG.md
@@ -1,6 +1,6 @@
 # One-Time Secret Changelog
 
-## [Recent Secrets, region choice, and receipt access] - 2026-03-25
+## [Recent Secrets, region choice, and receipt access] - {PR_MERGE_DATE}
 
 - Choose your **region** (Canada, EU, New Zealand, UK, or US) so you can decide where your data is stored.
 - The extension now uses **Onetime Secret API v2**, the latest version of their service.

--- a/extensions/one-time-secret/package.json
+++ b/extensions/one-time-secret/package.json
@@ -17,11 +17,71 @@
     "Security"
   ],
   "license": "MIT",
+  "preferences": [
+    {
+      "name": "region",
+      "type": "dropdown",
+      "title": "Data centre region",
+      "description": "Secrets are stored only in the region you select. Accounts and API tokens are separate per region — use the same region here as on onetimesecret.com when you create your account and API token.",
+      "required": false,
+      "default": "uk",
+      "data": [
+        {
+          "title": "Canada (Toronto)",
+          "value": "ca"
+        },
+        {
+          "title": "European Union (Nuremberg)",
+          "value": "eu"
+        },
+        {
+          "title": "Aotearoa New Zealand (Porirua)",
+          "value": "nz"
+        },
+        {
+          "title": "United Kingdom (London)",
+          "value": "uk"
+        },
+        {
+          "title": "United States (Oregon)",
+          "value": "us"
+        }
+      ]
+    },
+    {
+      "name": "username",
+      "type": "textfield",
+      "title": "Username",
+      "description": "Your Onetime Secret login name for this region. Optional — leave blank to create secrets anonymously. Required (with API token) for Recent Secrets.",
+      "required": false,
+      "placeholder": "Account username"
+    },
+    {
+      "name": "apiToken",
+      "type": "password",
+      "title": "API token",
+      "description": "Create an API token in your account on the regional site (e.g. uk.onetimesecret.com) and paste it here. Must match the selected region. Username and token are sent as HTTP Basic Auth — not stored by the extension beyond Raycast preferences.",
+      "required": false,
+      "placeholder": "API token from account settings"
+    }
+  ],
   "commands": [
     {
       "name": "index",
       "title": "Send One-Time Secret",
       "description": "Stores a secret on One-Time Secret and gives back the shareable URL.",
+      "mode": "view"
+    },
+    {
+      "name": "send-from-clipboard",
+      "title": "Send from Clipboard",
+      "description": "Creates a one-time secret from the clipboard (3h lifetime, no passphrase) and copies the link.",
+      "mode": "no-view"
+    },
+    {
+      "name": "recent-secrets",
+      "title": "Recent Secrets",
+      "description": "Lists recent secrets for your account (requires username and API token in preferences).",
       "mode": "view"
     }
   ],
@@ -35,19 +95,19 @@
   "ai": {
     "evals": [
       {
-        "input" : "@one-time-secret store \"santa is real\" for 1 week. passcode: \"christmas\"",
-        "mocks" : {
-          "send-one-time-secret" : "https://onetimesecret.com/secret/2uim0qy8e88vxm3saw4hceg3v0boaa6"
+        "input": "@one-time-secret store \"santa is real\" for 1 week. passcode: \"christmas\"",
+        "mocks": {
+          "send-one-time-secret": "https://uk.onetimesecret.com/secret/2uim0qy8e88vxm3saw4hceg3v0boaa6"
         },
-        "expected" : [
+        "expected": [
           {
-            "callsTool" : {
-              "arguments" : {
-                "lifetime" : "604800",
-                "passphrase" : "christmas",
-                "secret" : "santa is real"
+            "callsTool": {
+              "arguments": {
+                "lifetime": "604800",
+                "passphrase": "christmas",
+                "secret": "santa is real"
               },
-              "name" : "send-one-time-secret"
+              "name": "send-one-time-secret"
             }
           }
         ]
@@ -70,7 +130,7 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
+    "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
   }
 }

--- a/extensions/one-time-secret/src/create-client.ts
+++ b/extensions/one-time-secret/src/create-client.ts
@@ -1,0 +1,12 @@
+import { getPreferenceValues } from "@raycast/api";
+import { OneTimeSecretClient, type OneTimeSecretCredentials, type RegionCode } from "./one-time-secret-client";
+
+export function createClientFromPreferences(): OneTimeSecretClient {
+  const prefs = getPreferenceValues<Preferences>();
+  const region = (prefs.region ?? "uk") as RegionCode;
+  const username = prefs.username?.trim() ?? "";
+  const apiToken = prefs.apiToken?.trim() ?? "";
+  const credentials: OneTimeSecretCredentials | null =
+    username.length > 0 && apiToken.length > 0 ? { username, apiToken } : null;
+  return OneTimeSecretClient.fromRegion(region, credentials);
+}

--- a/extensions/one-time-secret/src/index.tsx
+++ b/extensions/one-time-secret/src/index.tsx
@@ -1,6 +1,16 @@
-import { Form, ActionPanel, Action, Clipboard, showToast, Toast, LaunchProps } from "@raycast/api";
+import {
+  Form,
+  ActionPanel,
+  Action,
+  Clipboard,
+  showToast,
+  Toast,
+  LaunchProps,
+  popToRoot,
+  closeMainWindow,
+} from "@raycast/api";
 import { useState } from "react";
-import { OneTimeSecretClient } from "./one-time-secret-client";
+import { createClientFromPreferences } from "./create-client";
 
 type Values = {
   lifetime: string;
@@ -9,10 +19,13 @@ type Values = {
   secret: string;
 };
 
+const MIN_PASSPHRASE_LENGTH = 8;
+
 export default function Command(props: LaunchProps<{ draftValues: Values }>) {
   const { draftValues } = props;
 
   const [secretError, setSecretError] = useState<string | undefined>();
+  const [passphraseError, setPassphraseError] = useState<string | undefined>();
 
   function dropSecretErrorIfNeeded() {
     if (secretError && secretError.length > 0) {
@@ -20,8 +33,18 @@ export default function Command(props: LaunchProps<{ draftValues: Values }>) {
     }
   }
 
+  function dropPassphraseErrorIfNeeded() {
+    if (passphraseError && passphraseError.length > 0) {
+      setPassphraseError(undefined);
+    }
+  }
+
   async function handleSubmit(values: Values) {
-    console.log(values);
+    const trimmedPass = values.passphrase?.trim() ?? "";
+    if (trimmedPass.length > 0 && trimmedPass.length < MIN_PASSPHRASE_LENGTH) {
+      setPassphraseError(`Passphrase must be at least ${MIN_PASSPHRASE_LENGTH} characters (API requirement).`);
+      return;
+    }
 
     const toast = await showToast({
       style: Toast.Style.Animated,
@@ -29,19 +52,22 @@ export default function Command(props: LaunchProps<{ draftValues: Values }>) {
     });
 
     try {
-      const oneTimeSecretClient = new OneTimeSecretClient();
-
-      const response = await oneTimeSecretClient.storeAnonymousSecret(
+      const client = createClientFromPreferences();
+      const ttl = Number.parseInt(values.lifetime, 10);
+      const response = await client.concealSecret(
         values.secret,
-        values.lifetime,
-        values.passphrase,
+        Number.isNaN(ttl) ? 3600 : ttl,
+        trimmedPass.length > 0 ? trimmedPass : null,
       );
 
-      await Clipboard.copy(oneTimeSecretClient.getShareableUrl(response.secret_key));
+      await Clipboard.copy(client.getShareableUrl(response.secretIdentifier));
 
       toast.style = Toast.Style.Success;
       toast.title = "Shared secret";
       toast.message = "Copied link to clipboard";
+
+      await popToRoot({ clearSearchBar: false });
+      await closeMainWindow();
     } catch (error) {
       toast.style = Toast.Style.Failure;
       toast.title = "Failed sharing secret";
@@ -79,8 +105,10 @@ export default function Command(props: LaunchProps<{ draftValues: Values }>) {
         id="passphrase"
         title="Passphrase"
         placeholder="Something top sneaky"
-        info="Optional. Encrypt the secret with this value."
+        info={`Optional. Minimum ${MIN_PASSPHRASE_LENGTH} characters if set.`}
         defaultValue={draftValues?.passphrase}
+        error={passphraseError}
+        onChange={dropPassphraseErrorIfNeeded}
       />
       <Form.Dropdown
         id="lifetime"

--- a/extensions/one-time-secret/src/one-time-secret-client.ts
+++ b/extensions/one-time-secret/src/one-time-secret-client.ts
@@ -233,6 +233,17 @@ export class OneTimeSecretClient {
 
 export function parseRecentResponse(data: unknown): RecentReceiptRow[] {
   const root = asRecord(data);
+
+  const fromRecords: RecentReceiptRow[] = [];
+  if (Array.isArray(root?.records)) {
+    for (const item of root.records as unknown[]) {
+      const row = normaliseReceiptItem(item);
+      if (row) {
+        fromRecords.push(row);
+      }
+    }
+  }
+
   const record = asRecord(root?.record);
   const details =
     asRecord(record?.details) ??
@@ -242,12 +253,22 @@ export function parseRecentResponse(data: unknown): RecentReceiptRow[] {
   const received = Array.isArray(details?.received) ? (details.received as unknown[]) : [];
   const notreceived = Array.isArray(details?.notreceived) ? (details.notreceived as unknown[]) : [];
 
-  const rows: RecentReceiptRow[] = [];
+  const fromDetails: RecentReceiptRow[] = [];
   for (const item of [...notreceived, ...received]) {
     const row = normaliseReceiptItem(item);
     if (row) {
-      rows.push(row);
+      fromDetails.push(row);
     }
+  }
+
+  const seen = new Set<string>();
+  const rows: RecentReceiptRow[] = [];
+  for (const row of [...fromRecords, ...fromDetails]) {
+    if (seen.has(row.metadataKey)) {
+      continue;
+    }
+    seen.add(row.metadataKey);
+    rows.push(row);
   }
 
   return rows;
@@ -268,18 +289,20 @@ function normaliseReceiptItem(item: unknown): RecentReceiptRow | null {
   if (!rec) {
     return null;
   }
-  return normaliseReceiptObject(rec);
+  const nested = asRecord(rec.receipt);
+  return normaliseReceiptObject(nested ?? rec);
 }
 
 function normaliseReceiptObject(rec: Record<string, unknown>): RecentReceiptRow | null {
-  const metadataKey = readString(rec.key) ?? readString(rec.identifier);
+  const metadataKey = readString(rec.key) ?? readString(rec.identifier) ?? readString(rec.metadata_key);
   if (!metadataKey) {
     return null;
   }
 
-  const isBurned = readBool(rec.is_burned);
-  const isReceived = readBool(rec.is_received);
-  const isViewed = readBool(rec.is_viewed);
+  const stateStr = readString(rec.state);
+  const isBurned = readBool(rec.is_burned) || stateStr === "burned";
+  const isReceived = readBool(rec.is_received) || readBool(rec.is_revealed) || stateStr === "revealed";
+  const isViewed = readBool(rec.is_viewed) || readBool(rec.is_previewed) || stateStr === "previewed";
   const lifecycle: RecentReceiptLifecycle = isBurned
     ? "burned"
     : isReceived
@@ -288,15 +311,18 @@ function normaliseReceiptObject(rec: Record<string, unknown>): RecentReceiptRow 
         ? "viewed"
         : "none";
 
+  const metadataTtl = readNumber(rec.metadata_ttl);
+  const receiptTtl = readNumber(rec.receipt_ttl);
+
   return {
     metadataKey,
     secretIdentifier: readString(rec.secret_identifier),
-    secretShortid: readString(rec.secret_shortid),
+    secretShortid: readString(rec.secret_shortid) ?? readString(rec.shortid),
     secretTtlSeconds: readNumber(rec.secret_ttl),
-    metadataTtlSeconds: readNumber(rec.metadata_ttl),
+    metadataTtlSeconds: metadataTtl > 0 ? metadataTtl : receiptTtl,
     hasPassphrase: readBool(rec.has_passphrase),
     createdUnix: readNumber(rec.created),
     lifecycle,
-    state: readString(rec.state),
+    state: stateStr,
   };
 }

--- a/extensions/one-time-secret/src/one-time-secret-client.ts
+++ b/extensions/one-time-secret/src/one-time-secret-client.ts
@@ -1,56 +1,302 @@
+export type RegionCode = "ca" | "eu" | "nz" | "uk" | "us";
+
+export type OneTimeSecretCredentials = {
+  username: string;
+  apiToken: string;
+};
+
+export type ConcealResult = {
+  /** Public path segment for `/secret/{id}` */
+  secretIdentifier: string;
+};
+
+/**
+ * Derived from API `is_burned` / `is_received` / `is_viewed` with fixed precedence
+ * (burned → received → viewed). When `"none"`, use `state` for display if present.
+ */
+export type RecentReceiptLifecycle = "burned" | "received" | "viewed" | "none";
+
+/** Normalised receipt row for Recent Secrets UI */
+export type RecentReceiptRow = {
+  /** Key used in `/private/:key` (metadata / receipt identifier) */
+  metadataKey: string;
+  secretIdentifier: string | null;
+  secretShortid: string | null;
+  secretTtlSeconds: number;
+  metadataTtlSeconds: number;
+  hasPassphrase: boolean;
+  createdUnix: number;
+  lifecycle: RecentReceiptLifecycle;
+  state: string | null;
+};
+
+function regionHost(region: RegionCode): string {
+  return `${region}.onetimesecret.com`;
+}
+
+export function getRegionBaseUrl(region: RegionCode): string {
+  return `https://${regionHost(region)}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function readBool(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (value === "true" || value === "1") {
+    return true;
+  }
+  if (value === "false" || value === "0") {
+    return false;
+  }
+  return Boolean(value);
+}
+
+function readNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && !Number.isNaN(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const n = Number(value);
+    return Number.isNaN(n) ? fallback : n;
+  }
+  return fallback;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
 export class OneTimeSecretClient {
-  baseUrl: string;
+  constructor(
+    readonly baseUrl: string,
+    private readonly credentials: OneTimeSecretCredentials | null = null,
+  ) {}
 
-  constructor() {
-    this.baseUrl = "https://onetimesecret.com";
+  public static fromRegion(
+    region: RegionCode,
+    credentials: OneTimeSecretCredentials | null = null,
+  ): OneTimeSecretClient {
+    return new OneTimeSecretClient(getRegionBaseUrl(region), credentials);
   }
 
-  public getShareableUrl(secret_key: string): string {
-    return `${this.baseUrl}/secret/${secret_key}`;
+  public getShareableUrl(secretIdentifier: string): string {
+    return `${this.baseUrl}/secret/${secretIdentifier}`;
   }
 
-  public async storeAnonymousSecret(
-    secret: string,
-    ttl: string,
-    passphrase: string | null = null,
-  ): Promise<OneTimeSecretResponse> {
-    const body = new URLSearchParams();
-    body.append("secret", secret);
-    body.append("ttl", ttl);
+  /** Web receipt / history page for this metadata key (regional site). */
+  public getReceiptHistoryUrl(metadataKey: string): string {
+    const base = this.baseUrl.replace(/\/$/, "");
+    return `${base}/receipt/${encodeURIComponent(metadataKey)}`;
+  }
 
-    if (passphrase) {
-      body.append("passphrase", passphrase);
+  public hasCredentials(): boolean {
+    return this.credentials !== null;
+  }
+
+  private authHeader(): Record<string, string> {
+    if (!this.credentials) {
+      return {};
+    }
+    const raw = `${this.credentials.username}:${this.credentials.apiToken}`;
+    const encoded = Buffer.from(raw, "utf8").toString("base64");
+    return { Authorization: `Basic ${encoded}` };
+  }
+
+  private apiUrl(path: string): string {
+    const base = this.baseUrl.replace(/\/$/, "");
+    const p = path.startsWith("/") ? path : `/${path}`;
+    return `${base}/api/v2${p}`;
+  }
+
+  private async parseJsonResponse(response: Response): Promise<unknown> {
+    const text = await response.text();
+    if (!text) {
+      return null;
+    }
+    try {
+      return JSON.parse(text) as unknown;
+    } catch {
+      throw new Error(`Invalid JSON response (${response.status}): ${text.slice(0, 200)}`);
+    }
+  }
+
+  private formatApiError(status: number, body: unknown): string {
+    const rec = asRecord(body);
+    const message = readString(rec?.message) ?? readString(rec?.error);
+    if (message) {
+      return `${message} (${status})`;
+    }
+    return `Request failed (${status})`;
+  }
+
+  private async requestJson(
+    method: string,
+    path: string,
+    options: { body?: unknown; auth?: "optional" | "required" } = {},
+  ): Promise<unknown> {
+    const { body, auth = "optional" } = options;
+    if (auth === "required" && !this.credentials) {
+      throw new Error("Authentication required. Set username and API token in extension preferences.");
     }
 
-    return await this.post(body);
+    const headers = new Headers([["Accept", "application/json"]]);
+    if (body !== undefined) {
+      headers.set("Content-Type", "application/json");
+    }
+
+    const shouldSendAuth = auth === "required" || (auth === "optional" && this.credentials !== null);
+    if (shouldSendAuth && this.credentials) {
+      const authHeaders = new Headers(this.authHeader());
+      const authorization = authHeaders.get("Authorization");
+      if (authorization) {
+        headers.set("Authorization", authorization);
+      }
+    }
+
+    const response = await fetch(this.apiUrl(path), {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    const parsed = await this.parseJsonResponse(response);
+
+    if (!response.ok) {
+      throw new Error(this.formatApiError(response.status, parsed));
+    }
+
+    return parsed;
   }
 
-  private async post(body: URLSearchParams): Promise<OneTimeSecretResponse> {
-    const init: RequestInit = {
-      method: "POST",
-      headers: new Headers([["content-type", "application/x-www-form-urlencoded"]]),
-      body: body.toString(),
+  /**
+   * Create a secret. Uses authenticated Basic auth when credentials are set so the secret appears in Recent.
+   */
+  public async concealSecret(
+    secret: string,
+    ttlSeconds: number,
+    passphrase: string | null = null,
+  ): Promise<ConcealResult> {
+    const secretPayload: Record<string, unknown> = {
+      secret,
+      ttl: ttlSeconds,
     };
+    if (passphrase && passphrase.length > 0) {
+      secretPayload.passphrase = passphrase;
+    }
 
-    const url = new URL(`${this.baseUrl}/api/v1/share`);
-    const response: Response = await fetch(url.href, init);
-    const data: OneTimeSecretResponse = (await response.json()) as OneTimeSecretResponse;
-    console.log(data);
+    const body = { secret: secretPayload };
+    const data = await this.requestJson("POST", "/secret/conceal", { body, auth: "optional" });
 
-    return data;
+    const root = asRecord(data);
+    if (!root || root.success !== true) {
+      throw new Error("Unexpected response when creating secret");
+    }
+
+    const record = asRecord(root.record);
+    const receipt = asRecord(record?.receipt);
+    const secretRec = asRecord(record?.secret);
+
+    const secretIdentifier =
+      readString(receipt?.secret_identifier) ?? readString(secretRec?.key) ?? readString(secretRec?.identifier) ?? null;
+
+    if (!secretIdentifier) {
+      throw new Error("Could not read secret identifier from API response");
+    }
+
+    return { secretIdentifier };
+  }
+
+  public async getRecentReceipts(): Promise<RecentReceiptRow[]> {
+    const data = await this.requestJson("GET", "/private/recent", { auth: "required" });
+    return parseRecentResponse(data);
+  }
+
+  public async getPrivateMetadata(metadataKey: string): Promise<RecentReceiptRow | null> {
+    const encoded = encodeURIComponent(metadataKey);
+    const data = await this.requestJson("GET", `/private/${encoded}`, { auth: "required" });
+    const row = parseSingleReceiptRecord(data);
+    return row;
+  }
+
+  public async burn(metadataKey: string): Promise<void> {
+    const encoded = encodeURIComponent(metadataKey);
+    await this.requestJson("POST", `/private/${encoded}/burn`, {
+      auth: "required",
+      body: { continue: "true" },
+    });
   }
 }
 
-export type OneTimeSecretResponse = {
-  custid: string;
-  metadata_key: string;
-  secret_key: string;
-  ttl: number;
-  metadata_ttl: number;
-  secret_ttl: number;
-  state: string;
-  updated: number;
-  created: number;
-  recipient: Array<string>;
-  passphrase_required: string;
-};
+export function parseRecentResponse(data: unknown): RecentReceiptRow[] {
+  const root = asRecord(data);
+  const record = asRecord(root?.record);
+  const details =
+    asRecord(record?.details) ??
+    (Array.isArray(record?.received) || Array.isArray(record?.notreceived) ? record : null) ??
+    asRecord(root?.details);
+
+  const received = Array.isArray(details?.received) ? (details.received as unknown[]) : [];
+  const notreceived = Array.isArray(details?.notreceived) ? (details.notreceived as unknown[]) : [];
+
+  const rows: RecentReceiptRow[] = [];
+  for (const item of [...notreceived, ...received]) {
+    const row = normaliseReceiptItem(item);
+    if (row) {
+      rows.push(row);
+    }
+  }
+
+  return rows;
+}
+
+function parseSingleReceiptRecord(data: unknown): RecentReceiptRow | null {
+  const root = asRecord(data);
+  const record = asRecord(root?.record);
+  const receipt = asRecord(record?.receipt) ?? asRecord(root?.receipt);
+  if (receipt) {
+    return normaliseReceiptObject(receipt);
+  }
+  return normaliseReceiptItem(data);
+}
+
+function normaliseReceiptItem(item: unknown): RecentReceiptRow | null {
+  const rec = asRecord(item);
+  if (!rec) {
+    return null;
+  }
+  return normaliseReceiptObject(rec);
+}
+
+function normaliseReceiptObject(rec: Record<string, unknown>): RecentReceiptRow | null {
+  const metadataKey = readString(rec.key) ?? readString(rec.identifier);
+  if (!metadataKey) {
+    return null;
+  }
+
+  const isBurned = readBool(rec.is_burned);
+  const isReceived = readBool(rec.is_received);
+  const isViewed = readBool(rec.is_viewed);
+  const lifecycle: RecentReceiptLifecycle = isBurned
+    ? "burned"
+    : isReceived
+      ? "received"
+      : isViewed
+        ? "viewed"
+        : "none";
+
+  return {
+    metadataKey,
+    secretIdentifier: readString(rec.secret_identifier),
+    secretShortid: readString(rec.secret_shortid),
+    secretTtlSeconds: readNumber(rec.secret_ttl),
+    metadataTtlSeconds: readNumber(rec.metadata_ttl),
+    hasPassphrase: readBool(rec.has_passphrase),
+    createdUnix: readNumber(rec.created),
+    lifecycle,
+    state: readString(rec.state),
+  };
+}

--- a/extensions/one-time-secret/src/recent-secrets.tsx
+++ b/extensions/one-time-secret/src/recent-secrets.tsx
@@ -1,0 +1,229 @@
+import {
+  Action,
+  ActionPanel,
+  Alert,
+  Clipboard,
+  Icon,
+  List,
+  openExtensionPreferences,
+  showToast,
+  Toast,
+  open,
+  confirmAlert,
+} from "@raycast/api";
+import { useCallback, useEffect, useState } from "react";
+import { createClientFromPreferences } from "./create-client";
+import type { RecentReceiptRow } from "./one-time-secret-client";
+
+function formatTtl(seconds: number): string {
+  if (seconds <= 0) {
+    return "expired";
+  }
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 48) {
+    return `${Math.round(seconds / 86400)}d left`;
+  }
+  if (h > 0) {
+    return `${h}h ${m}m left`;
+  }
+  return `${m}m left`;
+}
+
+function formatTime(unix: number): string {
+  if (!unix) {
+    return "";
+  }
+  return new Date(unix * 1000).toLocaleString();
+}
+
+function statusLabel(row: RecentReceiptRow): string {
+  switch (row.lifecycle) {
+    case "burned":
+      return "Burned";
+    case "received":
+      return "Revealed";
+    case "viewed":
+      return "Viewed";
+    default:
+      return row.state ?? "New";
+  }
+}
+
+/** Burn is only allowed before the secret has been revealed or destroyed. */
+function canBurnSecret(row: RecentReceiptRow): boolean {
+  return row.lifecycle !== "received" && row.lifecycle !== "viewed" && row.lifecycle !== "burned";
+}
+
+export default function RecentSecretsCommand() {
+  const [rows, setRows] = useState<RecentReceiptRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const client = createClientFromPreferences();
+      if (!client.hasCredentials()) {
+        setRows([]);
+        setError("Add your username and API token in extension preferences to list recent secrets.");
+        return;
+      }
+      const list = await client.getRecentReceipts();
+      setRows(list);
+    } catch (e) {
+      setError(String(e));
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (error && rows.length === 0 && !loading) {
+    return (
+      <List isLoading={loading}>
+        <List.EmptyView
+          title="Cannot load recent secrets"
+          description={error}
+          actions={
+            <ActionPanel>
+              <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={() => openExtensionPreferences()} />
+              <Action title="Try Again" icon={Icon.ArrowClockwise} onAction={() => void load()} />
+            </ActionPanel>
+          }
+        />
+      </List>
+    );
+  }
+
+  return (
+    <List isLoading={loading} searchBarPlaceholder="Search recent secrets">
+      {rows.map((row) => {
+        const title = row.secretShortid ?? row.metadataKey.slice(0, 12);
+        const subtitle = `${statusLabel(row)} · ${formatTtl(row.metadataTtlSeconds)} · ${formatTime(row.createdUnix)}`;
+        const receiptHistoryUrl = createClientFromPreferences().getReceiptHistoryUrl(row.metadataKey);
+        return (
+          <List.Item
+            key={row.metadataKey}
+            title={title}
+            subtitle={subtitle}
+            accessories={[{ text: row.hasPassphrase ? "Passphrase" : "" }].filter((a) => a.text.length > 0)}
+            actions={
+              <ActionPanel>
+                <Action
+                  title="Copy Share Link"
+                  icon={Icon.Clipboard}
+                  onAction={async () => {
+                    try {
+                      const client = createClientFromPreferences();
+                      let secretId = row.secretIdentifier;
+                      if (!secretId) {
+                        const detail = await client.getPrivateMetadata(row.metadataKey);
+                        secretId = detail?.secretIdentifier ?? null;
+                      }
+                      if (!secretId) {
+                        await showToast({
+                          style: Toast.Style.Failure,
+                          title: "No share link",
+                          message: "Could not resolve secret identifier for this item.",
+                        });
+                        return;
+                      }
+                      await Clipboard.copy(client.getShareableUrl(secretId));
+                      await showToast({ style: Toast.Style.Success, title: "Copied link" });
+                    } catch (e) {
+                      await showToast({ style: Toast.Style.Failure, title: "Failed", message: String(e) });
+                    }
+                  }}
+                />
+                <Action
+                  title="Open in Browser"
+                  icon={Icon.Globe}
+                  onAction={async () => {
+                    try {
+                      const client = createClientFromPreferences();
+                      let secretId = row.secretIdentifier;
+                      if (!secretId) {
+                        const detail = await client.getPrivateMetadata(row.metadataKey);
+                        secretId = detail?.secretIdentifier ?? null;
+                      }
+                      if (!secretId) {
+                        await showToast({
+                          style: Toast.Style.Failure,
+                          title: "Cannot open",
+                          message: "Could not resolve secret identifier.",
+                        });
+                        return;
+                      }
+                      await open(client.getShareableUrl(secretId));
+                    } catch (e) {
+                      await showToast({ style: Toast.Style.Failure, title: "Failed", message: String(e) });
+                    }
+                  }}
+                />
+                <Action.OpenInBrowser
+                  title="View Receipt History"
+                  url={receiptHistoryUrl}
+                  icon={Icon.Receipt}
+                  shortcut={{
+                    macOS: { modifiers: ["cmd", "shift"], key: "h" },
+                    Windows: { modifiers: ["ctrl", "shift"], key: "h" },
+                  }}
+                />
+                {canBurnSecret(row) ? (
+                  <Action
+                    title="Burn Secret"
+                    icon={Icon.Trash}
+                    style={Action.Style.Destructive}
+                    onAction={async () => {
+                      const confirmed = await confirmAlert({
+                        title: "Burn this secret?",
+                        message: "The share link will stop working. This cannot be undone.",
+                        primaryAction: { title: "Burn", style: Alert.ActionStyle.Destructive },
+                        dismissAction: { title: "Cancel", style: Alert.ActionStyle.Cancel },
+                      });
+                      if (!confirmed) {
+                        return;
+                      }
+                      try {
+                        const client = createClientFromPreferences();
+                        await client.burn(row.metadataKey);
+                        await showToast({ style: Toast.Style.Success, title: "Burned" });
+                        await load();
+                      } catch (e) {
+                        await showToast({ style: Toast.Style.Failure, title: "Burn failed", message: String(e) });
+                      }
+                    }}
+                  />
+                ) : null}
+                <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={() => void load()} />
+                <Action
+                  title="Open Extension Preferences"
+                  icon={Icon.Gear}
+                  onAction={() => openExtensionPreferences()}
+                />
+              </ActionPanel>
+            }
+          />
+        );
+      })}
+      <List.EmptyView
+        title={loading ? "Loading…" : "No recent secrets"}
+        description={
+          loading ? undefined : "Create secrets while signed in (username + API token in preferences) to see them here."
+        }
+        actions={
+          <ActionPanel>
+            <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={() => void load()} />
+            <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={() => openExtensionPreferences()} />
+          </ActionPanel>
+        }
+      />
+    </List>
+  );
+}

--- a/extensions/one-time-secret/src/send-from-clipboard.tsx
+++ b/extensions/one-time-secret/src/send-from-clipboard.tsx
@@ -1,0 +1,37 @@
+import { Clipboard, showToast, Toast } from "@raycast/api";
+import { createClientFromPreferences } from "./create-client";
+
+const THREE_HOURS_TTL_SECONDS = 10800;
+
+export default async function Command() {
+  const raw = await Clipboard.readText();
+  const secret = raw?.trim() ?? "";
+
+  if (secret.length === 0) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Nothing to send",
+      message: "Clipboard is empty or whitespace only.",
+    });
+    return;
+  }
+
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: "Storing secret",
+  });
+
+  try {
+    const client = createClientFromPreferences();
+    const response = await client.concealSecret(secret, THREE_HOURS_TTL_SECONDS, null);
+    await Clipboard.copy(client.getShareableUrl(response.secretIdentifier));
+
+    toast.style = Toast.Style.Success;
+    toast.title = "Shared secret";
+    toast.message = "Copied link to clipboard";
+  } catch (error) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Failed sharing secret";
+    toast.message = String(error);
+  }
+}

--- a/extensions/one-time-secret/src/tools/send-one-time-secret.ts
+++ b/extensions/one-time-secret/src/tools/send-one-time-secret.ts
@@ -1,4 +1,4 @@
-import { OneTimeSecretClient } from "../one-time-secret-client";
+import { createClientFromPreferences } from "../create-client";
 
 type Input = {
   /** The secret to be sent */
@@ -16,12 +16,18 @@ type Input = {
    *  value="1209600" title="14 days"
    */
   lifetime: string;
-  /** Optional. Encrypt the secret with this value. */
+  /** Optional. Encrypt the secret with this value (minimum 8 characters if provided). */
   passphrase?: string;
 };
 
 export default async function (input: Input) {
-  const oneTimeSecretClient = new OneTimeSecretClient();
-  const response = await oneTimeSecretClient.storeAnonymousSecret(input.secret, input.lifetime, input.passphrase);
-  return oneTimeSecretClient.getShareableUrl(response.secret_key);
+  const client = createClientFromPreferences();
+  const ttl = Number.parseInt(input.lifetime, 10);
+  const trimmed = input.passphrase?.trim() ?? "";
+  const passphrase = trimmed.length > 0 ? trimmed : null;
+  if (passphrase && passphrase.length < 8) {
+    throw new Error("Passphrase must be at least 8 characters.");
+  }
+  const response = await client.concealSecret(input.secret, Number.isNaN(ttl) ? 3600 : ttl, passphrase);
+  return client.getShareableUrl(response.secretIdentifier);
 }


### PR DESCRIPTION
## Description

## [Recent Secrets, region choice, and receipt access] - 2026-03-25

- Choose your **region** (Canada, EU, New Zealand, UK, or US) so you can decide where your data is stored.
- The extension now uses **Onetime Secret API v2**, the latest version of their service.
- Optionally add your **username** and **API token** to unlock **Recent Secrets**: see what you have shared, copy links, open them in the browser, jump to the full receipt page on the website, or **burn** a link so it stops working. Secrets you create from Raycast while signed in appear in this list.
- Optional **passphrases** must be at least **8 characters** when you use one.

## [Clipboard command and cleaner send flow] - 2026-03-24

- Adds **Send from Clipboard**: a no-view command that creates a one-time secret from the clipboard with a **3 hour** lifetime and **no passphrase**, then copies the share link (empty clipboard shows an error toast).
- **Send One-Time Secret**: after a successful share, Raycast **closes** and draft state is cleared so the form does not stay open with the previous secret, and reopening the command does not restore that secret.

## Screencast


Showing new send from clipboard action

https://github.com/user-attachments/assets/52b251db-346b-4908-867b-eebd3f7078f5

Showing new recent secrets action

https://github.com/user-attachments/assets/11bb7390-6a35-4696-ab20-39f0b425aedf


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
