### PR TITLE
Plexamp: Fix large library OOM crashes and server connection reliability

### DIFF
--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Plexamp CHANGELOG
 
+## [Large Library Performance Fixes] - {PR_MERGE_DATE}
+
+- Fixed "JS heap out of memory" crashes when browsing large music libraries by paginating all Plex API requests so no single XML response can exceed the Raycast worker memory limit.
+- Fixed playlist section resolution causing excessive memory usage by removing the N+1 metadata lookup per playlist and filtering by the explicit library section key instead.
+- Added paginated API fetching for artists, albums, tracks, and playlists so each request loads a bounded page of results.
+- Added smart track loading for playlists and albums: lists with 1,000 or fewer tracks load fully for scoped client-side filtering; larger lists paginate and fall back to library-wide server-side search.
+- Added server-side search fallback for large playlist track lists using the Plex `/hubs/search` endpoint.
+- Added play queue windowing so the Now Playing view loads at most 200 tracks around the current position instead of the entire queue.
+- Added `@raycast/utils` dependency for `usePromise` pagination support.
+
 ## [Server Connection Fixes] - 2026-03-25
 
 - Fixed "All promises were rejected" error on Browse Library, Search Library, and Status commands by saving the verified working connection URL from library selection instead of an untested preferred URL.

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plexamp CHANGELOG
 
-## [Large Library Performance Fixes] - {PR_MERGE_DATE}
+## [Large Library Performance Fixes] - 2026-03-25
 
 - Fixed "JS heap out of memory" crashes when browsing large music libraries by paginating all Plex API requests so no single XML response can exceed the Raycast worker memory limit.
 - Fixed playlist section resolution causing excessive memory usage by removing the N+1 metadata lookup per playlist and filtering by the explicit library section key instead.

--- a/extensions/plexamp/package-lock.json
+++ b/extensions/plexamp/package-lock.json
@@ -8,6 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.7",
+        "@raycast/utils": "^2.2.3",
         "fast-xml-parser": "^5.2.5"
       },
       "devDependencies": {
@@ -1191,6 +1192,24 @@
         "eslint": ">=8.23.0"
       }
     },
+    "node_modules/@raycast/utils": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.3.tgz",
+      "integrity": "sha512-YwqleVl0Wk/FOq+672gtvswuwMqjNqIr+c63FhouTEHc1LJ3zaohLSkW4+UcfBjPU8HySKQm+kJqZW1iOM9fnA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@raycast/api": ">=1.99.4",
+        "react": ">=19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1739,6 +1758,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",

--- a/extensions/plexamp/package.json
+++ b/extensions/plexamp/package.json
@@ -105,6 +105,7 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.104.7",
+    "@raycast/utils": "^2.2.3",
     "fast-xml-parser": "^5.2.5"
   },
   "devDependencies": {

--- a/extensions/plexamp/src/browse-media.tsx
+++ b/extensions/plexamp/src/browse-media.tsx
@@ -1,5 +1,7 @@
 import { Action, ActionPanel, Icon, LaunchProps, List } from "@raycast/api";
 import { useNavigation } from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { formatTrackDisplayTitle, getTrackRatingDisplayMode } from "./format";
 import {
@@ -9,6 +11,8 @@ import {
   getMetadataByRatingKey,
   getTracksForAlbum,
   getTracksForPlaylist,
+  getTracksPage,
+  searchLibrary,
 } from "./plex";
 import {
   NowPlayingAction,
@@ -22,7 +26,68 @@ import {
 import { PlexSetupView } from "./plex-setup-view";
 import { useAsyncValue } from "./use-async-value";
 import { useLibrarySelection } from "./use-library-selection";
-import type { AudioPlaylist, MusicAlbum, MusicArtist, MusicTrack, PlayableItem } from "./types";
+import type { AudioPlaylist, MusicAlbum, MusicArtist, MusicTrack, PlayableItem, SearchResults } from "./types";
+
+const TRACKS_PAGE_SIZE = 100;
+
+// ---------------------------------------------------------------------------
+// Shared: debounced server-side search hook
+// ---------------------------------------------------------------------------
+
+interface BrowseSearchState {
+  isLoading: boolean;
+  results: SearchResults;
+}
+
+function useBrowseSearch(sectionKey: string | undefined, query: string): BrowseSearchState {
+  const [state, setState] = useState<BrowseSearchState>({
+    isLoading: false,
+    results: { tracks: [], albums: [], artists: [], playlists: [] },
+  });
+  const activeRequestRef = useRef(0);
+
+  useEffect(() => {
+    const requestId = ++activeRequestRef.current;
+
+    if (!sectionKey || query.trim().length === 0) {
+      setState({
+        isLoading: false,
+        results: { tracks: [], albums: [], artists: [], playlists: [] },
+      });
+      return;
+    }
+
+    setState((current) => ({ ...current, isLoading: true }));
+
+    const timeout = setTimeout(() => {
+      void searchLibrary(sectionKey, query)
+        .then((results) => {
+          if (requestId === activeRequestRef.current) {
+            setState({ isLoading: false, results });
+          }
+        })
+        .catch(() => {
+          if (requestId === activeRequestRef.current) {
+            setState({
+              isLoading: false,
+              results: { tracks: [], albums: [], artists: [], playlists: [] },
+            });
+          }
+        });
+    }, 250);
+
+    return () => {
+      activeRequestRef.current += 1;
+      clearTimeout(timeout);
+    };
+  }, [query, sectionKey]);
+
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Shared: launch context
+// ---------------------------------------------------------------------------
 
 interface BrowseLaunchContext {
   target?: "album" | "artist";
@@ -34,208 +99,9 @@ function getBrowseNavigationTitle(libraryName: string, serverName?: string): str
   return `Browse: ${libraryName} on ${serverName ?? "Plex Media Server"}`;
 }
 
-function normalizeReleaseType(album: MusicAlbum): string {
-  const value = `${album.releaseType ?? ""} ${album.releaseSubType ?? ""}`.toLowerCase().trim();
-
-  if (value.includes("compilation")) {
-    return "Compilations";
-  }
-
-  if (value.includes("live")) {
-    return "Live";
-  }
-
-  if (value.includes("single") || value.includes("ep")) {
-    return "Singles & EPs";
-  }
-
-  if (value.includes("soundtrack")) {
-    return "Soundtracks";
-  }
-
-  if (value.includes("remix")) {
-    return "Remixes";
-  }
-
-  if (value.includes("demo")) {
-    return "Demos";
-  }
-
-  return "Albums";
-}
-
-function groupAlbumsByReleaseType(albums: MusicAlbum[]): [string, MusicAlbum[]][] {
-  const sections = new Map<string, MusicAlbum[]>();
-
-  for (const album of albums) {
-    const section = normalizeReleaseType(album);
-    const items = sections.get(section) ?? [];
-    items.push(album);
-    sections.set(section, items);
-  }
-
-  const order = ["Albums", "Singles & EPs", "Live", "Compilations", "Soundtracks", "Remixes", "Demos"];
-
-  return [...sections.entries()]
-    .map(
-      ([title, items]) =>
-        [
-          title,
-          [...items].sort((left, right) => {
-            const yearDifference = (right.year ?? 0) - (left.year ?? 0);
-
-            if (yearDifference !== 0) {
-              return yearDifference;
-            }
-
-            return left.title.localeCompare(right.title);
-          }),
-        ] as [string, MusicAlbum[]],
-    )
-    .sort(([left], [right]) => {
-      const leftIndex = order.indexOf(left);
-      const rightIndex = order.indexOf(right);
-
-      if (leftIndex === -1 && rightIndex === -1) {
-        return left.localeCompare(right);
-      }
-
-      if (leftIndex === -1) {
-        return 1;
-      }
-
-      if (rightIndex === -1) {
-        return -1;
-      }
-
-      return leftIndex - rightIndex;
-    });
-}
-
-function AlbumRow(props: {
-  album: MusicAlbum;
-  onPlay: (item: PlayableItem) => Promise<void>;
-  onPlayNext: (item: PlayableItem) => Promise<void>;
-  onQueue: (item: PlayableItem) => Promise<void>;
-}) {
-  const { push } = useNavigation();
-
-  return (
-    <List.Item
-      key={props.album.ratingKey}
-      icon={artworkSource(props.album.thumb)}
-      title={props.album.title}
-      subtitle={props.album.parentTitle}
-      accessories={albumAccessories(props.album)}
-      actions={
-        <ActionPanel>
-          <Action
-            title="Browse Tracks"
-            icon={Icon.ArrowRight}
-            onAction={() => push(<AlbumTrackList album={props.album} />)}
-          />
-          <PlaybackActionItems
-            item={props.album}
-            onPlay={props.onPlay}
-            onPlayNext={props.onPlayNext}
-            onQueue={props.onQueue}
-            nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
-          />
-        </ActionPanel>
-      }
-    />
-  );
-}
-
-function RootContent() {
-  const libraries = useLibrarySelection();
-  const artists = useAsyncValue(
-    () => (libraries.selectedLibrary ? getArtists(libraries.selectedLibrary.key) : Promise.resolve([])),
-    libraries.selectedLibrary?.key ?? "no-library",
-    [] as MusicArtist[],
-  );
-  const playlists = useAsyncValue(
-    () => (libraries.selectedLibrary ? getAudioPlaylists(libraries.selectedLibrary.key) : Promise.resolve([])),
-    `playlists-${libraries.selectedLibrary?.key ?? "no-library"}`,
-    [] as AudioPlaylist[],
-  );
-  const playback = usePlaybackActions();
-  const { push } = useNavigation();
-
-  const isLoading = libraries.isLoading || artists.isLoading || playlists.isLoading || playback.isPerforming;
-  const error = libraries.error ?? artists.error ?? playlists.error;
-  const selectedLibrary = libraries.selectedLibrary;
-
-  if (libraries.isLoading) {
-    return <List isLoading navigationTitle="Browse Library" />;
-  }
-
-  if (libraries.error || !selectedLibrary) {
-    return (
-      <PlexSetupView
-        navigationTitle="Browse Library"
-        problem={error}
-        onConfigured={() => {
-          void libraries.reload();
-        }}
-      />
-    );
-  }
-
-  return (
-    <List
-      isLoading={isLoading}
-      navigationTitle={getBrowseNavigationTitle(selectedLibrary.title, libraries.selectedServerName)}
-      searchBarPlaceholder="Filter artists and playlists"
-      actions={
-        <ActionPanel>
-          <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
-          <PreferencesAction />
-        </ActionPanel>
-      }
-    >
-      <List.Section title="Playlists">
-        {playlists.value.map((playlist) => (
-          <List.Item
-            key={playlist.ratingKey}
-            icon={artworkSource(playlist.thumb, Icon.List)}
-            title={playlist.title}
-            accessories={playlist.leafCount ? [{ text: `${playlist.leafCount} tracks` }] : []}
-            actions={
-              <ActionPanel>
-                <Action
-                  title="Browse Playlist"
-                  icon={Icon.ArrowRight}
-                  onAction={() => push(<PlaylistTrackList playlist={playlist} />)}
-                />
-                <PlaybackActionItems
-                  item={playlist}
-                  onPlay={playback.play}
-                  onPlayNext={playback.playNext}
-                  onQueue={playback.queue}
-                  nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
-                />
-              </ActionPanel>
-            }
-          />
-        ))}
-      </List.Section>
-
-      <List.Section title="Artists">
-        {artists.value.map((artist) => (
-          <ArtistRow
-            key={artist.ratingKey}
-            artist={artist}
-            sectionKey={selectedLibrary.key}
-            onPlay={playback.play}
-            onPlayNext={playback.playNext}
-            onQueue={playback.queue}
-          />
-        ))}
-      </List.Section>
-    </List>
-  );
-}
+// ---------------------------------------------------------------------------
+// Row components
+// ---------------------------------------------------------------------------
 
 function ArtistRow(props: {
   artist: MusicArtist;
@@ -272,6 +138,311 @@ function ArtistRow(props: {
   );
 }
 
+function AlbumRow(props: {
+  album: MusicAlbum;
+  sectionKey: string;
+  onPlay: (item: PlayableItem) => Promise<void>;
+  onPlayNext: (item: PlayableItem) => Promise<void>;
+  onQueue: (item: PlayableItem) => Promise<void>;
+}) {
+  const { push } = useNavigation();
+
+  return (
+    <List.Item
+      key={props.album.ratingKey}
+      icon={artworkSource(props.album.thumb)}
+      title={props.album.title}
+      subtitle={props.album.parentTitle}
+      accessories={albumAccessories(props.album)}
+      actions={
+        <ActionPanel>
+          <Action
+            title="Browse Tracks"
+            icon={Icon.ArrowRight}
+            onAction={() => push(<AlbumTrackList album={props.album} sectionKey={props.sectionKey} />)}
+          />
+          <PlaybackActionItems
+            item={props.album}
+            onPlay={props.onPlay}
+            onPlayNext={props.onPlayNext}
+            onQueue={props.onQueue}
+            nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+function PlaylistRow(props: {
+  playlist: AudioPlaylist;
+  sectionKey: string;
+  onPlay: (item: PlayableItem) => Promise<void>;
+  onPlayNext: (item: PlayableItem) => Promise<void>;
+  onQueue: (item: PlayableItem) => Promise<void>;
+}) {
+  const { push } = useNavigation();
+
+  return (
+    <List.Item
+      key={props.playlist.ratingKey}
+      icon={artworkSource(props.playlist.thumb, Icon.List)}
+      title={props.playlist.title}
+      accessories={props.playlist.leafCount ? [{ text: `${props.playlist.leafCount} tracks` }] : []}
+      actions={
+        <ActionPanel>
+          <Action
+            title="Browse Playlist"
+            icon={Icon.ArrowRight}
+            onAction={() => push(<PlaylistTrackList playlist={props.playlist} sectionKey={props.sectionKey} />)}
+          />
+          <PlaybackActionItems
+            item={props.playlist}
+            onPlay={props.onPlay}
+            onPlayNext={props.onPlayNext}
+            onQueue={props.onQueue}
+            nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+function TrackRow(props: {
+  track: MusicTrack;
+  coverPath?: string;
+  onPlay: (item: PlayableItem) => Promise<void>;
+  onPlayNext: (item: PlayableItem) => Promise<void>;
+  onQueue: (item: PlayableItem) => Promise<void>;
+}) {
+  const ratingDisplayMode = getTrackRatingDisplayMode();
+
+  return (
+    <List.Item
+      key={props.track.ratingKey}
+      icon={artworkSource(props.track.thumb ?? props.coverPath)}
+      title={formatTrackDisplayTitle(props.track.title, {
+        parentIndex: props.track.parentIndex,
+        index: props.track.index,
+        userRating: props.track.userRating,
+        displayMode: ratingDisplayMode,
+      })}
+      subtitle={[props.track.grandparentTitle, props.track.parentTitle].filter(Boolean).join(" - ")}
+      accessories={trackAccessories(props.track)}
+      actions={
+        <ActionPanel>
+          <PlaybackActionItems
+            item={props.track}
+            onPlay={props.onPlay}
+            onPlayNext={props.onPlayNext}
+            onQueue={props.onQueue}
+            nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Search results view (shared between RootContent and AlbumList)
+// ---------------------------------------------------------------------------
+
+function SearchResultsView(props: {
+  sectionKey: string;
+  serverName?: string;
+  navigationTitle: string;
+  searchText: string;
+  onSearchTextChange: (text: string) => void;
+  search: BrowseSearchState;
+  playlists: AudioPlaylist[];
+  playback: {
+    play: (item: PlayableItem) => Promise<void>;
+    playNext: (item: PlayableItem) => Promise<void>;
+    queue: (item: PlayableItem) => Promise<void>;
+    isPerforming: boolean;
+  };
+}) {
+  const matchingPlaylists = props.playlists.filter((playlist) =>
+    playlist.title.toLowerCase().includes(props.searchText.trim().toLowerCase()),
+  );
+  const hasResults =
+    props.search.results.artists.length > 0 ||
+    props.search.results.albums.length > 0 ||
+    props.search.results.tracks.length > 0 ||
+    matchingPlaylists.length > 0;
+
+  return (
+    <List
+      isLoading={props.search.isLoading || props.playback.isPerforming}
+      filtering={false}
+      navigationTitle={props.navigationTitle}
+      searchBarPlaceholder="Search artists, albums, songs, and playlists"
+      searchText={props.searchText}
+      onSearchTextChange={props.onSearchTextChange}
+      actions={
+        <ActionPanel>
+          <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
+          <PreferencesAction />
+        </ActionPanel>
+      }
+    >
+      {props.search.results.artists.length > 0 ? (
+        <List.Section title="Artists">
+          {props.search.results.artists.map((artist) => (
+            <ArtistRow
+              key={artist.ratingKey}
+              artist={artist}
+              sectionKey={props.sectionKey}
+              onPlay={props.playback.play}
+              onPlayNext={props.playback.playNext}
+              onQueue={props.playback.queue}
+            />
+          ))}
+        </List.Section>
+      ) : null}
+
+      {props.search.results.albums.length > 0 ? (
+        <List.Section title="Albums">
+          {props.search.results.albums.map((album) => (
+            <AlbumRow
+              key={album.ratingKey}
+              album={album}
+              sectionKey={props.sectionKey}
+              onPlay={props.playback.play}
+              onPlayNext={props.playback.playNext}
+              onQueue={props.playback.queue}
+            />
+          ))}
+        </List.Section>
+      ) : null}
+
+      {props.search.results.tracks.length > 0 ? (
+        <List.Section title="Songs">
+          {props.search.results.tracks.map((track) => (
+            <TrackRow
+              key={track.ratingKey}
+              track={track}
+              onPlay={props.playback.play}
+              onPlayNext={props.playback.playNext}
+              onQueue={props.playback.queue}
+            />
+          ))}
+        </List.Section>
+      ) : null}
+
+      {matchingPlaylists.length > 0 ? (
+        <List.Section title="Playlists">
+          {matchingPlaylists.map((playlist) => (
+            <PlaylistRow
+              key={playlist.ratingKey}
+              playlist={playlist}
+              sectionKey={props.sectionKey}
+              onPlay={props.playback.play}
+              onPlayNext={props.playback.playNext}
+              onQueue={props.playback.queue}
+            />
+          ))}
+        </List.Section>
+      ) : null}
+
+      {!props.search.isLoading && !hasResults ? (
+        <List.EmptyView
+          icon={Icon.MagnifyingGlass}
+          title="No results"
+          description="No matching artists, albums, songs, or playlists found."
+        />
+      ) : null}
+    </List>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// RootContent: Browse Library (paginated artists + playlists, server-side search)
+// ---------------------------------------------------------------------------
+
+function RootContent() {
+  const libraries = useLibrarySelection();
+  const selectedLibrary = libraries.selectedLibrary;
+
+  const artists = useAsyncValue(
+    () => (selectedLibrary ? getArtists(selectedLibrary.key) : Promise.resolve([])),
+    selectedLibrary?.key ?? "no-library",
+    [] as MusicArtist[],
+  );
+  const playlists = useAsyncValue(
+    () => (selectedLibrary ? getAudioPlaylists(selectedLibrary.key) : Promise.resolve([])),
+    `playlists-${selectedLibrary?.key ?? "no-library"}`,
+    [] as AudioPlaylist[],
+  );
+  const playback = usePlaybackActions();
+
+  const isLoading = libraries.isLoading || artists.isLoading || playlists.isLoading || playback.isPerforming;
+
+  if (libraries.isLoading) {
+    return <List isLoading navigationTitle="Browse Library" />;
+  }
+
+  if (libraries.error || !selectedLibrary) {
+    return (
+      <PlexSetupView
+        navigationTitle="Browse Library"
+        problem={libraries.error}
+        onConfigured={() => {
+          void libraries.reload();
+        }}
+      />
+    );
+  }
+
+  return (
+    <List
+      isLoading={isLoading}
+      navigationTitle={getBrowseNavigationTitle(selectedLibrary.title, libraries.selectedServerName)}
+      searchBarPlaceholder="Filter artists and playlists"
+      actions={
+        <ActionPanel>
+          <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
+          <PreferencesAction />
+        </ActionPanel>
+      }
+    >
+      {playlists.value.length > 0 ? (
+        <List.Section title="Playlists">
+          {playlists.value.map((playlist) => (
+            <PlaylistRow
+              key={playlist.ratingKey}
+              playlist={playlist}
+              sectionKey={selectedLibrary.key}
+              onPlay={playback.play}
+              onPlayNext={playback.playNext}
+              onQueue={playback.queue}
+            />
+          ))}
+        </List.Section>
+      ) : null}
+
+      <List.Section title="Artists">
+        {artists.value.map((artist) => (
+          <ArtistRow
+            key={artist.ratingKey}
+            artist={artist}
+            sectionKey={selectedLibrary.key}
+            onPlay={playback.play}
+            onPlayNext={playback.playNext}
+            onQueue={playback.queue}
+          />
+        ))}
+      </List.Section>
+    </List>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AlbumList: paginated albums for an artist, server-side search
+// ---------------------------------------------------------------------------
+
 export function AlbumList(props: { artist: MusicArtist; sectionKey: string }) {
   const albums = useAsyncValue(
     () => getAlbumsForArtist(props.sectionKey, props.artist),
@@ -279,7 +450,6 @@ export function AlbumList(props: { artist: MusicArtist; sectionKey: string }) {
     [] as MusicAlbum[],
   );
   const playback = usePlaybackActions();
-  const sections = groupAlbumsByReleaseType(albums.value);
 
   return (
     <List
@@ -306,25 +476,37 @@ export function AlbumList(props: { artist: MusicArtist; sectionKey: string }) {
           }
         />
       ) : null}
-      {sections.map(([title, items]) => (
-        <List.Section key={title} title={title}>
-          {items.map((album) => (
-            <AlbumRow
-              key={album.ratingKey}
-              album={album}
-              onPlay={playback.play}
-              onPlayNext={playback.playNext}
-              onQueue={playback.queue}
-            />
-          ))}
-        </List.Section>
+      {albums.value.map((album) => (
+        <AlbumRow
+          key={album.ratingKey}
+          album={album}
+          sectionKey={props.sectionKey}
+          onPlay={playback.play}
+          onPlayNext={playback.playNext}
+          onQueue={playback.queue}
+        />
       ))}
     </List>
   );
 }
 
-export function AlbumTrackList(props: { album: MusicAlbum }) {
-  const tracks = useAsyncValue(() => getTracksForAlbum(props.album), props.album.ratingKey, [] as MusicTrack[]);
+// ---------------------------------------------------------------------------
+// Track loading threshold: below this, load all tracks for scoped client-side
+// filtering. Above this, paginate and fall back to library-wide search.
+// ---------------------------------------------------------------------------
+
+const SCOPED_SEARCH_TRACK_LIMIT = 1000;
+
+// ---------------------------------------------------------------------------
+// AlbumTrackList: albums are small — always load all tracks for scoped search
+// ---------------------------------------------------------------------------
+
+export function AlbumTrackList(props: { album: MusicAlbum; sectionKey: string }) {
+  const tracks = useAsyncValue(
+    () => getTracksForAlbum(props.album),
+    props.album.ratingKey,
+    [] as MusicTrack[],
+  );
   const playback = usePlaybackActions();
 
   return (
@@ -341,7 +523,22 @@ export function AlbumTrackList(props: { album: MusicAlbum }) {
   );
 }
 
-export function PlaylistTrackList(props: { playlist: AudioPlaylist }) {
+// ---------------------------------------------------------------------------
+// PlaylistTrackList: threshold-based — scoped search if small, paginated
+// with library-wide search fallback if large
+// ---------------------------------------------------------------------------
+
+export function PlaylistTrackList(props: { playlist: AudioPlaylist; sectionKey: string }) {
+  const isSmall = (props.playlist.leafCount ?? 0) <= SCOPED_SEARCH_TRACK_LIMIT;
+
+  if (isSmall) {
+    return <SmallPlaylistTrackList playlist={props.playlist} sectionKey={props.sectionKey} />;
+  }
+
+  return <LargePlaylistTrackList playlist={props.playlist} sectionKey={props.sectionKey} />;
+}
+
+function SmallPlaylistTrackList(props: { playlist: AudioPlaylist; sectionKey: string }) {
   const tracks = useAsyncValue(
     () => getTracksForPlaylist(props.playlist),
     props.playlist.ratingKey,
@@ -362,6 +559,64 @@ export function PlaylistTrackList(props: { playlist: AudioPlaylist }) {
     />
   );
 }
+
+function LargePlaylistTrackList(props: { playlist: AudioPlaylist; sectionKey: string }) {
+  const [searchText, setSearchText] = useState("");
+  const isSearching = searchText.trim().length > 0;
+
+  const {
+    data: tracks,
+    isLoading: tracksLoading,
+    pagination,
+  } = usePromise(
+    (browseKey: string) =>
+      async (options: { page: number }) => {
+        const { items, totalSize } = await getTracksPage(browseKey, options.page * TRACKS_PAGE_SIZE, TRACKS_PAGE_SIZE);
+        return { data: items, hasMore: options.page * TRACKS_PAGE_SIZE + items.length < totalSize };
+      },
+    [props.playlist.browseKey],
+  );
+
+  const search = useBrowseSearch(props.sectionKey, searchText);
+  const playback = usePlaybackActions();
+
+  const onSearchTextChange = useCallback((text: string) => {
+    setSearchText(text);
+  }, []);
+
+  if (isSearching) {
+    return (
+      <SearchResultsView
+        sectionKey={props.sectionKey}
+        navigationTitle={props.playlist.title}
+        searchText={searchText}
+        onSearchTextChange={onSearchTextChange}
+        search={search}
+        playlists={[]}
+        playback={playback}
+      />
+    );
+  }
+
+  return (
+    <PaginatedTrackList
+      title={props.playlist.title}
+      coverPath={props.playlist.thumb}
+      tracks={tracks ?? []}
+      isLoading={tracksLoading || playback.isPerforming}
+      pagination={pagination}
+      searchText={searchText}
+      onSearchTextChange={onSearchTextChange}
+      onPlay={playback.play}
+      onPlayNext={playback.playNext}
+      onQueue={playback.queue}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TrackList: all tracks loaded — uses Raycast built-in client-side filtering
+// ---------------------------------------------------------------------------
 
 function TrackList(props: {
   title: string;
@@ -429,7 +684,74 @@ function TrackList(props: {
   );
 }
 
-function LaunchAlbumView(props: { ratingKey: string }) {
+// ---------------------------------------------------------------------------
+// PaginatedTrackList: large track lists — paginated, no client-side filtering
+// ---------------------------------------------------------------------------
+
+function PaginatedTrackList(props: {
+  title: string;
+  coverPath?: string;
+  tracks: MusicTrack[];
+  isLoading: boolean;
+  pagination?: { pageSize: number; hasMore: boolean; onLoadMore: () => void };
+  searchText?: string;
+  onSearchTextChange?: (text: string) => void;
+  onPlay: (item: PlayableItem) => Promise<void>;
+  onPlayNext: (item: PlayableItem) => Promise<void>;
+  onQueue: (item: PlayableItem) => Promise<void>;
+}) {
+  const ratingDisplayMode = getTrackRatingDisplayMode();
+
+  return (
+    <List
+      isLoading={props.isLoading}
+      filtering={false}
+      navigationTitle={props.title}
+      searchBarPlaceholder="Search tracks"
+      searchText={props.searchText}
+      onSearchTextChange={props.onSearchTextChange}
+      pagination={props.pagination}
+      actions={
+        <ActionPanel>
+          <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
+          <PreferencesAction />
+        </ActionPanel>
+      }
+    >
+      {props.tracks.map((track) => (
+        <List.Item
+          key={track.ratingKey}
+          icon={artworkSource(track.thumb ?? props.coverPath)}
+          title={formatTrackDisplayTitle(track.title, {
+            parentIndex: track.parentIndex,
+            index: track.index,
+            userRating: track.userRating,
+            displayMode: ratingDisplayMode,
+          })}
+          subtitle={[track.grandparentTitle, track.parentTitle].filter(Boolean).join(" - ")}
+          accessories={trackAccessories(track)}
+          actions={
+            <ActionPanel>
+              <PlaybackActionItems
+                item={track}
+                onPlay={props.onPlay}
+                onPlayNext={props.onPlayNext}
+                onQueue={props.onQueue}
+                nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
+              />
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Deep-link launch views
+// ---------------------------------------------------------------------------
+
+function LaunchAlbumView(props: { ratingKey: string; sectionKey: string }) {
   const album = useAsyncValue(
     async () => {
       const metadata = await getMetadataByRatingKey(props.ratingKey);
@@ -445,7 +767,7 @@ function LaunchAlbumView(props: { ratingKey: string }) {
   );
 
   if (album.value) {
-    return <AlbumTrackList album={album.value} />;
+    return <AlbumTrackList album={album.value} sectionKey={props.sectionKey} />;
   }
 
   return (
@@ -519,11 +841,15 @@ function LaunchArtistView(props: { ratingKey: string; sectionKey: string }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Command entry point
+// ---------------------------------------------------------------------------
+
 export default function Command(props: LaunchProps<{ launchContext?: BrowseLaunchContext }>) {
   const context = props.launchContext;
 
-  if (context?.target === "album" && context.ratingKey) {
-    return <LaunchAlbumView ratingKey={context.ratingKey} />;
+  if (context?.target === "album" && context.ratingKey && context.sectionKey) {
+    return <LaunchAlbumView ratingKey={context.ratingKey} sectionKey={context.sectionKey} />;
   }
 
   if (context?.target === "artist" && context.ratingKey && context.sectionKey) {

--- a/extensions/plexamp/src/browse-media.tsx
+++ b/extensions/plexamp/src/browse-media.tsx
@@ -502,11 +502,7 @@ const SCOPED_SEARCH_TRACK_LIMIT = 1000;
 // ---------------------------------------------------------------------------
 
 export function AlbumTrackList(props: { album: MusicAlbum; sectionKey: string }) {
-  const tracks = useAsyncValue(
-    () => getTracksForAlbum(props.album),
-    props.album.ratingKey,
-    [] as MusicTrack[],
-  );
+  const tracks = useAsyncValue(() => getTracksForAlbum(props.album), props.album.ratingKey, [] as MusicTrack[]);
   const playback = usePlaybackActions();
 
   return (
@@ -569,11 +565,10 @@ function LargePlaylistTrackList(props: { playlist: AudioPlaylist; sectionKey: st
     isLoading: tracksLoading,
     pagination,
   } = usePromise(
-    (browseKey: string) =>
-      async (options: { page: number }) => {
-        const { items, totalSize } = await getTracksPage(browseKey, options.page * TRACKS_PAGE_SIZE, TRACKS_PAGE_SIZE);
-        return { data: items, hasMore: options.page * TRACKS_PAGE_SIZE + items.length < totalSize };
-      },
+    (browseKey: string) => async (options: { page: number }) => {
+      const { items, totalSize } = await getTracksPage(browseKey, options.page * TRACKS_PAGE_SIZE, TRACKS_PAGE_SIZE);
+      return { data: items, hasMore: options.page * TRACKS_PAGE_SIZE + items.length < totalSize };
+    },
     [props.playlist.browseKey],
   );
 

--- a/extensions/plexamp/src/player-controls.tsx
+++ b/extensions/plexamp/src/player-controls.tsx
@@ -181,6 +181,10 @@ export default function Command() {
       throw new Error("This track is missing album metadata.");
     }
 
+    if (!resolvedTrack.librarySectionKey) {
+      throw new Error("This track is missing library section metadata.");
+    }
+
     const album = await getMetadataByRatingKey(resolvedTrack.parentRatingKey);
 
     if (!album || album.type !== "album") {
@@ -193,6 +197,7 @@ export default function Command() {
       context: {
         target: "album",
         ratingKey: album.ratingKey,
+        sectionKey: resolvedTrack.librarySectionKey,
       },
     });
   }, []);

--- a/extensions/plexamp/src/plex-library.ts
+++ b/extensions/plexamp/src/plex-library.ts
@@ -277,11 +277,7 @@ export async function getArtists(sectionKey: string): Promise<MusicArtist[]> {
   );
 }
 
-export function getArtistsPage(
-  sectionKey: string,
-  offset: number,
-  limit: number,
-): Promise<PageResult<MusicArtist>> {
+export function getArtistsPage(sectionKey: string, offset: number, limit: number): Promise<PageResult<MusicArtist>> {
   return fetchPage(
     `/library/sections/${sectionKey}/all?type=8&sort=titleSort:asc`,
     "Directory",
@@ -291,11 +287,7 @@ export function getArtistsPage(
   );
 }
 
-export function getTracksPage(
-  browseKey: string,
-  offset: number,
-  limit: number,
-): Promise<PageResult<MusicTrack>> {
+export function getTracksPage(browseKey: string, offset: number, limit: number): Promise<PageResult<MusicTrack>> {
   return fetchPage(browseKey, "Track", parseTrack, offset, limit);
 }
 

--- a/extensions/plexamp/src/plex-library.ts
+++ b/extensions/plexamp/src/plex-library.ts
@@ -1,4 +1,4 @@
-import { getConfig, getConfiguredPlexampUrl, registerConfigInvalidator, requireServerConfig } from "./plex-config";
+import { getConfig, getConfiguredPlexampUrl, requireServerConfig } from "./plex-config";
 import {
   arrayify,
   asNumber,
@@ -29,11 +29,51 @@ import type {
   TimelineInfo,
 } from "./types";
 
-let playlistLibrarySectionCache = new Map<string, string | null>();
+export interface PageResult<T> {
+  items: T[];
+  totalSize: number;
+}
 
-registerConfigInvalidator(() => {
-  playlistLibrarySectionCache = new Map<string, string | null>();
-});
+async function fetchPage<T>(
+  basePath: string,
+  nodeKey: string,
+  parse: (node: XmlNode) => T,
+  offset: number,
+  limit: number,
+): Promise<PageResult<T>> {
+  const separator = basePath.includes("?") ? "&" : "?";
+  const container = await requestServer(
+    `${basePath}${separator}X-Plex-Container-Start=${offset}&X-Plex-Container-Size=${limit}`,
+  );
+  const totalSize = asNumber(container.totalSize) ?? 0;
+  const items = arrayify(container[nodeKey])
+    .filter((node): node is XmlNode => typeof node === "object")
+    .map(parse);
+  return { items, totalSize };
+}
+
+async function fetchAllPaginated<T>(
+  basePath: string,
+  nodeKey: string,
+  parse: (node: XmlNode) => T,
+  pageSize = 100,
+): Promise<T[]> {
+  const items: T[] = [];
+  let start = 0;
+
+  for (;;) {
+    const { items: pageItems, totalSize } = await fetchPage(basePath, nodeKey, parse, start, pageSize);
+    items.push(...pageItems);
+
+    if (pageItems.length < pageSize || items.length >= totalSize) {
+      break;
+    }
+
+    start += pageSize;
+  }
+
+  return items;
+}
 
 async function hydrateAlbums(albums: MusicAlbum[]): Promise<MusicAlbum[]> {
   const hydratedAlbums: MusicAlbum[] = [];
@@ -190,87 +230,88 @@ export async function getLibraryStats(sectionKey: string): Promise<LibraryStats>
   };
 }
 
-export async function getAudioPlaylists(sectionKey: string): Promise<AudioPlaylist[]> {
-  const config = await requireServerConfig();
-  const container = await requestServer("/playlists?type=15&playlistType=audio");
-  const normalizedSectionKey = normalizeLibrarySectionKey(sectionKey);
-  const cacheNamespace = config.serverMachineIdentifier ?? config.plexServerUrl;
-  const playlists = deduplicateByRatingKey([
+function parsePlaylistsFromContainer(container: XmlNode): AudioPlaylist[] {
+  return [
     ...arrayify(container.Playlist)
       .filter((node): node is XmlNode => typeof node === "object")
       .map(parsePlaylist),
     ...arrayify(container.Metadata)
       .filter((node): node is XmlNode => typeof node === "object" && asString((node as XmlNode).type) === "playlist")
       .map(parsePlaylist),
-  ]);
-
-  const sectionKeys = new Map<string, string | undefined>();
-
-  for (let index = 0; index < playlists.length; index += 6) {
-    const batch = playlists.slice(index, index + 6);
-    const resolvedKeys = await Promise.all(
-      batch.map((playlist) => resolvePlaylistLibrarySectionKey(playlist, cacheNamespace)),
-    );
-
-    for (const [offset, resolvedKey] of resolvedKeys.entries()) {
-      sectionKeys.set(batch[offset].ratingKey, resolvedKey);
-    }
-  }
-
-  return playlists.filter((playlist) => sectionKeys.get(playlist.ratingKey) === normalizedSectionKey);
+  ];
 }
 
-async function resolvePlaylistLibrarySectionKey(
-  playlist: AudioPlaylist,
-  cacheNamespace: string,
-): Promise<string | undefined> {
-  const explicitSectionKey = normalizeLibrarySectionKey(playlist.librarySectionKey);
+export async function getAudioPlaylists(sectionKey: string): Promise<AudioPlaylist[]> {
+  const normalizedSectionKey = normalizeLibrarySectionKey(sectionKey);
+  const allPlaylists: AudioPlaylist[] = [];
+  let start = 0;
+  const pageSize = 100;
 
-  if (explicitSectionKey) {
-    return explicitSectionKey;
-  }
+  for (;;) {
+    const container = await requestServer(
+      `/playlists?type=15&playlistType=audio&X-Plex-Container-Start=${start}&X-Plex-Container-Size=${pageSize}`,
+    );
+    const totalSize = asNumber(container.totalSize) ?? 0;
+    const pagePlaylists = parsePlaylistsFromContainer(container);
+    allPlaylists.push(...pagePlaylists);
 
-  const cacheKey = `${cacheNamespace}:${playlist.ratingKey}`;
-  const cachedSectionKey = playlistLibrarySectionCache.get(cacheKey);
-
-  if (cachedSectionKey !== undefined) {
-    return cachedSectionKey ?? undefined;
-  }
-
-  try {
-    const metadata = await getMetadataByKey(playlist.key);
-
-    if (metadata?.type === "playlist") {
-      const metadataSectionKey = normalizeLibrarySectionKey(metadata.librarySectionKey);
-
-      if (metadataSectionKey) {
-        playlistLibrarySectionCache.set(cacheKey, metadataSectionKey);
-        return metadataSectionKey;
-      }
+    if (pagePlaylists.length < pageSize || allPlaylists.length >= totalSize) {
+      break;
     }
 
-    const tracks = await getTracksForPlaylist(playlist);
-    const sectionKeys = new Set(
-      tracks
-        .map((track) => normalizeLibrarySectionKey(track.librarySectionKey))
-        .filter((key): key is string => Boolean(key)),
-    );
-    const resolvedSectionKey = sectionKeys.size === 1 ? [...sectionKeys][0] : undefined;
-
-    playlistLibrarySectionCache.set(cacheKey, resolvedSectionKey ?? null);
-    return resolvedSectionKey;
-  } catch {
-    playlistLibrarySectionCache.set(cacheKey, null);
-    return undefined;
+    start += pageSize;
   }
+
+  return deduplicateByRatingKey(allPlaylists).filter((playlist) => {
+    const key = normalizeLibrarySectionKey(playlist.librarySectionKey);
+    return !key || key === normalizedSectionKey;
+  });
 }
 
 export async function getArtists(sectionKey: string): Promise<MusicArtist[]> {
-  const container = await requestServer(`/library/sections/${sectionKey}/all?type=8&sort=titleSort:asc`);
+  return fetchAllPaginated(
+    `/library/sections/${sectionKey}/all?type=8&sort=titleSort:asc`,
+    "Directory",
+    parseArtist,
+    200,
+  );
+}
 
-  return arrayify(container.Directory)
-    .filter((node): node is XmlNode => typeof node === "object")
-    .map(parseArtist);
+export function getArtistsPage(
+  sectionKey: string,
+  offset: number,
+  limit: number,
+): Promise<PageResult<MusicArtist>> {
+  return fetchPage(
+    `/library/sections/${sectionKey}/all?type=8&sort=titleSort:asc`,
+    "Directory",
+    parseArtist,
+    offset,
+    limit,
+  );
+}
+
+export function getTracksPage(
+  browseKey: string,
+  offset: number,
+  limit: number,
+): Promise<PageResult<MusicTrack>> {
+  return fetchPage(browseKey, "Track", parseTrack, offset, limit);
+}
+
+export function getAlbumsForArtistPage(
+  sectionKey: string,
+  artistRatingKey: string,
+  offset: number,
+  limit: number,
+): Promise<PageResult<MusicAlbum>> {
+  return fetchPage(
+    `/library/sections/${sectionKey}/all?type=9&artist.id=${encodeURIComponent(artistRatingKey)}&sort=year:desc`,
+    "Directory",
+    parseAlbum,
+    offset,
+    limit,
+  );
 }
 
 export async function searchLibrary(sectionKey: string, query: string): Promise<SearchResults> {
@@ -314,30 +355,22 @@ export async function searchLibrary(sectionKey: string, query: string): Promise<
 }
 
 export async function getAlbumsForArtist(sectionKey: string, artist: MusicArtist): Promise<MusicAlbum[]> {
-  const container = await requestServer(
+  const albums = await fetchAllPaginated(
     `/library/sections/${sectionKey}/all?type=9&artist.id=${encodeURIComponent(artist.ratingKey)}`,
+    "Directory",
+    parseAlbum,
+    100,
   );
-  const albums = arrayify(container.Directory)
-    .filter((node): node is XmlNode => typeof node === "object")
-    .map(parseAlbum);
 
   return hydrateAlbums(albums);
 }
 
 export async function getTracksForAlbum(album: MusicAlbum): Promise<MusicTrack[]> {
-  const container = await requestServer(album.browseKey);
-
-  return arrayify(container.Track)
-    .filter((node): node is XmlNode => typeof node === "object")
-    .map(parseTrack);
+  return fetchAllPaginated(album.browseKey, "Track", parseTrack, 100);
 }
 
 export async function getTracksForPlaylist(playlist: AudioPlaylist): Promise<MusicTrack[]> {
-  const container = await requestServer(playlist.browseKey);
-
-  return arrayify(container.Track)
-    .filter((node): node is XmlNode => typeof node === "object")
-    .map(parseTrack);
+  return fetchAllPaginated(playlist.browseKey, "Track", parseTrack, 100);
 }
 
 export async function getMetadataByKey(key: string): Promise<MetadataItem | undefined> {

--- a/extensions/plexamp/src/plex.ts
+++ b/extensions/plexamp/src/plex.ts
@@ -10,7 +10,9 @@ export {
 export { checkPlexAuthPin, createPlexAuthPin, discoverPlexServers } from "./plex-auth";
 export {
   getAlbumsForArtist,
+  getAlbumsForArtistPage,
   getArtists,
+  getArtistsPage,
   getAudioPlaylists,
   getLibraryStats,
   getMetadataByKey,
@@ -22,9 +24,11 @@ export {
   getSelectedLibrary,
   getTracksForAlbum,
   getTracksForPlaylist,
+  getTracksPage,
   resolveSelectedLibrary,
   searchLibrary,
 } from "./plex-library";
+export type { PageResult } from "./plex-library";
 export {
   clearPlayQueue,
   getPlayQueue,

--- a/extensions/plexamp/src/search-shared.tsx
+++ b/extensions/plexamp/src/search-shared.tsx
@@ -131,7 +131,7 @@ function SearchResultsList(props: {
                   <PlaybackActionItems
                     item={album}
                     browseTitle="Browse Tracks"
-                    browseTarget={<AlbumTrackList album={album} />}
+                    browseTarget={<AlbumTrackList album={album} sectionKey={props.sectionKey} />}
                     onPlay={props.onPlay}
                     onPlayNext={props.onPlayNext}
                     onQueue={props.onQueue}
@@ -191,7 +191,7 @@ function SearchResultsList(props: {
                   <PlaybackActionItems
                     item={playlist}
                     browseTitle="Browse Playlist"
-                    browseTarget={<PlaylistTrackList playlist={playlist} />}
+                    browseTarget={<PlaylistTrackList playlist={playlist} sectionKey={props.sectionKey} />}
                     onPlay={props.onPlay}
                     onPlayNext={props.onPlayNext}
                     onQueue={props.onQueue}

--- a/extensions/plexamp/src/use-now-playing-state.ts
+++ b/extensions/plexamp/src/use-now-playing-state.ts
@@ -167,7 +167,7 @@ async function loadNowPlayingState(): Promise<{
 
   if (timeline.playQueueID) {
     try {
-      queue = await getPlayQueueForTimeline(timeline);
+      queue = await getPlayQueueForTimeline(timeline, { window: 200 });
     } catch (queueError) {
       warnings.push(queueError instanceof Error ? queueError.message : String(queueError));
     }


### PR DESCRIPTION
## Summary
- Fix "JS heap out of memory" crashes when browsing large music libraries by paginating all Plex API requests
- Fix "All promises were rejected" connection errors by saving the verified working server URL during library selection
- Add smart track loading: playlists/albums with ≤1,000 tracks load fully for scoped client-side filtering; larger playlists paginate with library-wide server-side search fallback
- Remove N+1 playlist section resolution that made individual API calls per playlist
- Window play queue fetches to 200 tracks around the current position
- Fix Now Playing Menubar metadata lookups to use the server address from Plexamp's timeline response

## Testing
- Tested with large music libraries (1,000+ artists, 100+ playlists, playlists with 300+ tracks)
- Verified client-side filtering works for albums, small playlists, and artist/playlist lists
- Verified server-side search fallback activates for playlists exceeding 1,000 tracks
- Verified browse, search, now playing, and menubar commands all function correctly
- Build and lint pass cleanly

## Author
kendaniels