### PR TITLE
password-store: Fix insert hanging due to execFile stdin

### DIFF
--- a/extensions/password-store/CHANGELOG.md
+++ b/extensions/password-store/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Password Store Changelog
 
+## [Fix] - 2026-03-25
+
+- Fixed insert password hanging indefinitely due to stdin not closing properly
+
 ## [Improvements] - 2026-03-23
 
 - Able to insert password via `pass insert`

--- a/extensions/password-store/CHANGELOG.md
+++ b/extensions/password-store/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Password Store Changelog
 
-## [Fix] - 2026-03-25
+## [Fix] - {PR_MERGE_DATE}
 
 - Fixed insert password hanging indefinitely due to stdin not closing properly
 

--- a/extensions/password-store/CHANGELOG.md
+++ b/extensions/password-store/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Password Store Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-03-25
 
 - Fixed insert password hanging indefinitely due to stdin not closing properly
 

--- a/extensions/password-store/src/utils/cmd.util.ts
+++ b/extensions/password-store/src/utils/cmd.util.ts
@@ -2,7 +2,7 @@ import { getPreferenceValues } from "@raycast/api";
 import { exec, execFile, spawn } from "child_process";
 import { promisify } from "node:util";
 
-/** Executes `pass` executable directly without spawning a shell. */
+/** Executes `pass` executable directly. Uses `spawn` when stdin input is needed, `execFile` otherwise. */
 export const runPassCmd = async (args: string[], input?: string): Promise<string> => {
   const preferences = getPreferenceValues();
   const paths = [...(preferences.ADDITIONAL_PATH?.split(":") || []), "/opt/homebrew/bin"].filter(Boolean).join(":");

--- a/extensions/password-store/src/utils/cmd.util.ts
+++ b/extensions/password-store/src/utils/cmd.util.ts
@@ -1,29 +1,38 @@
 import { getPreferenceValues } from "@raycast/api";
-import { exec, execFile } from "child_process";
+import { exec, execFile, spawn } from "child_process";
 import { promisify } from "node:util";
 
-/** Executes `pass` executable directly without spawing a shell.  */
+/** Executes `pass` executable directly without spawning a shell. */
 export const runPassCmd = async (args: string[], input?: string): Promise<string> => {
+  const preferences = getPreferenceValues();
+  const paths = [...(preferences.ADDITIONAL_PATH?.split(":") || []), "/opt/homebrew/bin"].filter(Boolean).join(":");
+  const env = {
+    ...process.env,
+    PATH: `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${process.env.PATH}:${paths}`,
+  };
+
+  if (input !== undefined) {
+    return new Promise((resolve, reject) => {
+      const child = spawn("pass", args, { env });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (data: Buffer) => (stdout += data.toString()));
+      child.stderr.on("data", (data: Buffer) => (stderr += data.toString()));
+      child.on("error", reject);
+      child.on("close", (code) => {
+        if (code === 0) resolve(stdout);
+        else reject(new Error(`pass exited with code ${code}: ${stderr}`));
+      });
+      child.stdin.write(input);
+      child.stdin.end();
+    });
+  }
+
   try {
     const execFileAsync = promisify(execFile);
-    const preferences = getPreferenceValues();
-
-    // Needed for the 'pass' command to work on M1 Mac
-    const paths = [...(preferences.ADDITIONAL_PATH?.split(":") || []), "/opt/homebrew/bin"].filter(Boolean).join(":");
-
-    const env = {
-      ...process.env,
-      PATH: `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${process.env.PATH}:${paths}`,
-    };
-
-    const { stdout } = await execFileAsync("pass", args, {
-      env,
-      ...(input ? { input } : {}),
-    });
-
+    const { stdout } = await execFileAsync("pass", args, { env });
     return stdout;
   } catch (error) {
-    // Log the error and rethrow it
     console.error("Error executing command:", error);
     throw error;
   }


### PR DESCRIPTION
## Summary

- Fix `pass insert` command hanging indefinitely when called with stdin input via `execFile`'s `input` option
- Use `spawn` with explicit `stdin.write()`/`stdin.end()` when input is provided, which properly signals EOF to the `pass` bash script's GPG encryption pipeline

## Problem

When inserting a new password, `runPassCmd` calls `execFile("pass", ["insert", "-m", ...], { input })`. The `execFile` `input` option does not properly close stdin in a way that the `pass → gpg` pipeline recognizes as EOF. The child process never exits, causing the `await` to hang forever — the success toast never shows and `pop()` (navigate back) never runs.

Passwords are written to disk successfully, but the UI remains stuck on the insert form.

This is the same class of bug identified in #25809 for `pass rm` (where the fix was to use `--force` to skip stdin). The `insert -m` case has no equivalent flag, so it requires proper stdin handling.

## Fix

When `input` is provided, use `spawn` instead of `execFile` with manual stdin handling:
- `child.stdin.write(input)` sends the data
- `child.stdin.end()` explicitly closes the stream, sending a proper EOF
- Listen for the `close` event to resolve the promise

When no `input` is provided, the original `execFile` path is unchanged.

## Test plan

- [ ] Insert a new password via the extension — form should close and show success toast
- [ ] Insert a password with metadata — both password and metadata should be saved
- [ ] Existing commands (decrypt, generate, rename, delete) continue working