### PR TITLE
Update focus extension

### DIFF
--- a/extensions/focus/CHANGELOG.md
+++ b/extensions/focus/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Focus Changelog
+
 ## [Enhancement] - {PR_MERGE_DATE}
 - Added `@Focus` AI extension support — type `@Focus` in Raycast AI Chat to start/stop sessions and take breaks using natural language.
 - Start commands now automatically launch the Focus app if it isn't running, instead of showing an error.

--- a/extensions/focus/CHANGELOG.md
+++ b/extensions/focus/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Focus Changelog
 
 ## [Enhancement] - {PR_MERGE_DATE}
+
 - Added `@Focus` AI extension support — type `@Focus` in Raycast AI Chat to start/stop sessions and take breaks using natural language.
 - Start commands now automatically launch the Focus app if it isn't running, instead of showing an error.
 
 ## [Fix] - 2026-03-18
+
 - Fixed a timeout error when opening Focus preferences from the "No profiles found" state.
 
 ## [Enhancement] - 2026-03-16
+
 - Commands now close the Raycast window automatically on success, showing a brief HUD notification instead of keeping the window open.
 
 ## [Enhancement] - 2026-03-12
+
 - Fixed an issue where Focus app icon would appear in the Dock when running commands.
 - Improved profile list loading to use caching, so profiles appear instantly on repeat opens.
 - Fixed a bug where stopping a break with a profile would send the unbreak command twice.
@@ -22,11 +26,13 @@
 - Updated dependencies.
 
 ## [Fix] - 2024-08-27
+
 - Fixed some bugs where commands would fail on V1 of the Focus app.
 - Updated error handling.
 - Renamed commands.
 
 ## [Enhancement] - 2024-08-27
+
 - Fixed an issue where the extension would fail to start Focus in V2.
 - Added a new "Start Focus with Profile" command.
 - Improved error handling when Focus app is not installed.

--- a/extensions/focus/CHANGELOG.md
+++ b/extensions/focus/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Focus Changelog
+## [Enhancement] - {PR_MERGE_DATE}
+- Added `@Focus` AI extension support — type `@Focus` in Raycast AI Chat to start/stop sessions and take breaks using natural language.
+- Start commands now automatically launch the Focus app if it isn't running, instead of showing an error.
 
 ## [Fix] - 2026-03-18
 - Fixed a timeout error when opening Focus preferences from the "No profiles found" state.

--- a/extensions/focus/CHANGELOG.md
+++ b/extensions/focus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Focus Changelog
 
-## [Enhancement] - {PR_MERGE_DATE}
+## [Enhancement] - 2026-03-30
 
 - Added `@Focus` AI extension support — type `@Focus` in Raycast AI Chat to start/stop sessions and take breaks using natural language.
 - Start commands now automatically launch the Focus app if it isn't running, instead of showing an error.

--- a/extensions/focus/package.json
+++ b/extensions/focus/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "focus",
   "title": "Focus",
-  "description": "Raycast extension for Focus app",
+  "description": "Control Focus App – Website and App Blocker for Mac",
   "icon": "focus-icon.png",
   "author": "ernest",
   "categories": [

--- a/extensions/focus/package.json
+++ b/extensions/focus/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "focus",
-  "title": "Focus - Website Blocker for Mac",
+  "title": "Focus",
   "description": "Raycast extension for Focus app",
   "icon": "focus-icon.png",
   "author": "ernest",
@@ -122,6 +122,75 @@
       "mode": "no-view"
     }
   ],
+  "tools": [
+    {
+      "name": "get-status",
+      "title": "Get Focus Status",
+      "description": "Returns whether a focus session or break is currently active, the active profile, and all available profiles"
+    },
+    {
+      "name": "start-focus",
+      "title": "Start Focus Session",
+      "description": "Starts a focus session. Optionally specify a profile name and/or duration in hours and minutes"
+    },
+    {
+      "name": "stop-focus",
+      "title": "Stop Focus Session",
+      "description": "Stops the currently active focus session"
+    },
+    {
+      "name": "take-break",
+      "title": "Take a Break",
+      "description": "Takes a break from the current focus session. Defaults to 5 minutes, or specify a custom duration"
+    }
+  ],
+  "ai": {
+    "instructions": "Use this extension to control the Focus app on macOS, which blocks distracting websites and apps. Always call get-status first to check the current state before starting or stopping sessions. Use the available profiles from get-status when the user mentions a profile by name.",
+    "evals": [
+      {
+        "input": "@focus Am I currently focusing?",
+        "mocks": {
+          "get-status": { "isFocusing": true, "isOnBreak": false, "activeProfile": "Work", "availableProfiles": ["Work", "Study"] }
+        },
+        "expected": [
+          { "callsTool": "get-status" },
+          { "meetsCriteria": "Confirms a focus session is active with the Work profile" }
+        ]
+      },
+      {
+        "input": "@focus Start a 25-minute focus session",
+        "mocks": {
+          "get-status": { "isFocusing": false, "isOnBreak": false, "activeProfile": null, "availableProfiles": ["Work"] },
+          "start-focus": "Focus session started (25m)."
+        },
+        "expected": [
+          { "callsTool": "get-status" },
+          { "callsTool": { "name": "start-focus", "arguments": { "minutes": 25 } } }
+        ]
+      },
+      {
+        "input": "@focus Stop my focus session",
+        "mocks": {
+          "get-status": { "isFocusing": true, "isOnBreak": false, "activeProfile": "Work", "availableProfiles": ["Work"] },
+          "stop-focus": "Focus session stopped."
+        },
+        "expected": [
+          { "callsTool": "get-status" },
+          { "callsTool": "stop-focus" }
+        ]
+      },
+      {
+        "input": "@focus Take a 10 minute break",
+        "mocks": {
+          "get-status": { "isFocusing": true, "isOnBreak": false, "activeProfile": "Work", "availableProfiles": ["Work"] },
+          "take-break": "10-minute break started."
+        },
+        "expected": [
+          { "callsTool": { "name": "take-break", "arguments": { "minutes": 10 } } }
+        ]
+      }
+    ]
+  },
   "dependencies": {
     "@raycast/api": "^1.83.1",
     "@raycast/utils": "^1.17.0",

--- a/extensions/focus/src/helpers.tsx
+++ b/extensions/focus/src/helpers.tsx
@@ -1,7 +1,7 @@
 import { Toast, showToast } from "@raycast/api";
 import { getInstallStatus, isFocusRunning } from "./utils";
 
-export async function ensureFocusIsRunning() {
+export async function ensureFocusIsInstalled() {
   if (!(await getInstallStatus())) {
     await showToast({
       style: Toast.Style.Failure,
@@ -10,6 +10,11 @@ export async function ensureFocusIsRunning() {
     });
     return false;
   }
+  return true;
+}
+
+export async function ensureFocusIsRunning() {
+  if (!(await ensureFocusIsInstalled())) return false;
 
   if (!(await isFocusRunning())) {
     await showToast({

--- a/extensions/focus/src/start-focus-25.tsx
+++ b/extensions/focus/src/start-focus-25.tsx
@@ -1,6 +1,6 @@
 import { Toast, showToast, showHUD } from "@raycast/api";
 import { getProfileNames, startFocusWithProfile25, startFocus25, getActiveProfileName } from "./utils";
-import { ensureFocusIsRunning } from "./helpers";
+import { ensureFocusIsInstalled } from "./helpers";
 
 export default async function Command() {
   const toast = await showToast({
@@ -8,7 +8,7 @@ export default async function Command() {
     title: "Starting Focus (25 minutes)...",
   });
 
-  if (!(await ensureFocusIsRunning())) {
+  if (!(await ensureFocusIsInstalled())) {
     return;
   }
 

--- a/extensions/focus/src/start-focus-custom.tsx
+++ b/extensions/focus/src/start-focus-custom.tsx
@@ -1,6 +1,6 @@
 import { Toast, showToast, showHUD, LaunchProps } from "@raycast/api";
 import { getProfileNames, startFocusCustom, getActiveProfileName } from "./utils";
-import { ensureFocusIsRunning } from "./helpers";
+import { ensureFocusIsInstalled } from "./helpers";
 
 interface FocusArguments {
   hours?: number;
@@ -24,7 +24,7 @@ export default async function Command(props: LaunchProps<{ arguments: FocusArgum
     title: "Starting Focus (Custom Duration)...",
   });
 
-  if (!(await ensureFocusIsRunning())) {
+  if (!(await ensureFocusIsInstalled())) {
     return;
   }
 

--- a/extensions/focus/src/start-focus-with-profile.tsx
+++ b/extensions/focus/src/start-focus-with-profile.tsx
@@ -1,13 +1,13 @@
 import { Toast, showToast, showHUD, List, ActionPanel, Action, Icon, closeMainWindow } from "@raycast/api";
 import { getProfileNames, startFocusWithProfile, getActiveProfileName, openPreferences } from "./utils";
 import { useCachedPromise } from "@raycast/utils";
-import { ensureFocusIsRunning } from "./helpers";
+import { ensureFocusIsInstalled } from "./helpers";
 
 export default function Command() {
   const { data: profiles = [], isLoading } = useCachedPromise(getProfileNames);
 
   async function handleProfileSelection(profileName: string) {
-    if (!(await ensureFocusIsRunning())) {
+    if (!(await ensureFocusIsInstalled())) {
       return;
     }
 

--- a/extensions/focus/src/start-focus.tsx
+++ b/extensions/focus/src/start-focus.tsx
@@ -1,6 +1,6 @@
 import { Toast, showToast, showHUD } from "@raycast/api";
 import { getProfileNames, startFocusWithProfile, startFocus, getActiveProfileName } from "./utils";
-import { ensureFocusIsRunning } from "./helpers";
+import { ensureFocusIsInstalled } from "./helpers";
 
 export default async function Command() {
   const toast = await showToast({
@@ -8,7 +8,7 @@ export default async function Command() {
     title: "Starting Focus...",
   });
 
-  if (!(await ensureFocusIsRunning())) {
+  if (!(await ensureFocusIsInstalled())) {
     return;
   }
 

--- a/extensions/focus/src/tools/get-status.ts
+++ b/extensions/focus/src/tools/get-status.ts
@@ -1,0 +1,21 @@
+import { getActiveProfileName, isBreakRunning, isFocusRunning, getProfileNames } from "../utils";
+
+/**
+ * Returns the current status of the Focus app: whether a focus session or break is active,
+ * the active profile name, and all available profiles.
+ */
+export default async function tool() {
+  const [focusing, onBreak, activeProfile, profiles] = await Promise.all([
+    isFocusRunning(),
+    isBreakRunning(),
+    getActiveProfileName(),
+    getProfileNames(),
+  ]);
+
+  return {
+    isFocusing: focusing,
+    isOnBreak: onBreak,
+    activeProfile: activeProfile || null,
+    availableProfiles: profiles,
+  };
+}

--- a/extensions/focus/src/tools/get-status.ts
+++ b/extensions/focus/src/tools/get-status.ts
@@ -1,10 +1,14 @@
-import { getActiveProfileName, isBreakRunning, isFocusRunning, getProfileNames } from "../utils";
+import { getActiveProfileName, getInstallStatus, isBreakRunning, isFocusRunning, getProfileNames } from "../utils";
 
 /**
  * Returns the current status of the Focus app: whether a focus session or break is active,
  * the active profile name, and all available profiles.
  */
 export default async function tool() {
+  if (!(await getInstallStatus())) {
+    throw new Error("Focus is not installed. Install it from: https://heyfocus.com");
+  }
+
   const [focusing, onBreak, activeProfile, profiles] = await Promise.all([
     isFocusRunning(),
     isBreakRunning(),

--- a/extensions/focus/src/tools/start-focus.ts
+++ b/extensions/focus/src/tools/start-focus.ts
@@ -1,4 +1,4 @@
-import { startFocus, startFocusCustom, startFocusWithProfile } from "../utils";
+import { getInstallStatus, startFocus, startFocusCustom, startFocusWithProfile } from "../utils";
 
 type Input = {
   /**
@@ -22,6 +22,10 @@ type Input = {
  * If a session is already running, starting a new one will replace it.
  */
 export default async function tool(input: Input) {
+  if (!(await getInstallStatus())) {
+    throw new Error("Focus is not installed. Install it from: https://heyfocus.com");
+  }
+
   const hasProfile = !!input.profile;
   const hasDuration = (input.hours ?? 0) > 0 || (input.minutes ?? 0) > 0;
 

--- a/extensions/focus/src/tools/start-focus.ts
+++ b/extensions/focus/src/tools/start-focus.ts
@@ -1,0 +1,42 @@
+import { startFocus, startFocusCustom, startFocusWithProfile } from "../utils";
+
+type Input = {
+  /**
+   * The name of the Focus profile to use. Leave empty to use the default profile.
+   * Use the get-status tool first to see available profiles.
+   */
+  profile?: string;
+  /**
+   * Duration in minutes. Leave empty for an unlimited session.
+   */
+  minutes?: number;
+  /**
+   * Duration in hours. Can be combined with minutes.
+   */
+  hours?: number;
+};
+
+/**
+ * Starts a focus session using the Focus app on macOS.
+ * Optionally specify a profile name and/or duration in hours and minutes.
+ * If a session is already running, starting a new one will replace it.
+ */
+export default async function tool(input: Input) {
+  const hasProfile = !!input.profile;
+  const hasDuration = (input.hours ?? 0) > 0 || (input.minutes ?? 0) > 0;
+
+  if (hasDuration) {
+    await startFocusCustom(input.hours, input.minutes, input.profile);
+  } else if (hasProfile && input.profile) {
+    await startFocusWithProfile(input.profile);
+  } else {
+    await startFocus();
+  }
+
+  const parts = [];
+  if (input.profile) parts.push(`profile "${input.profile}"`);
+  if (input.hours) parts.push(`${input.hours}h`);
+  if (input.minutes) parts.push(`${input.minutes}m`);
+
+  return `Focus session started${parts.length ? ` (${parts.join(", ")})` : ""}.`;
+}

--- a/extensions/focus/src/tools/stop-focus.ts
+++ b/extensions/focus/src/tools/stop-focus.ts
@@ -1,0 +1,14 @@
+import { Tool } from "@raycast/api";
+import { stopFocus } from "../utils";
+
+/**
+ * Stops the currently active focus session in the Focus app.
+ */
+export default async function tool() {
+  await stopFocus();
+  return "Focus session stopped.";
+}
+
+export const confirmation: Tool.Confirmation<Record<string, never>> = async () => ({
+  message: "Are you sure you want to stop the current focus session?",
+});

--- a/extensions/focus/src/tools/stop-focus.ts
+++ b/extensions/focus/src/tools/stop-focus.ts
@@ -1,10 +1,14 @@
 import { Tool } from "@raycast/api";
-import { stopFocus } from "../utils";
+import { isFocusRunning, stopFocus } from "../utils";
 
 /**
  * Stops the currently active focus session in the Focus app.
  */
 export default async function tool() {
+  const isRunning = await isFocusRunning();
+  if (!isRunning) {
+    return "No active focus session to stop.";
+  }
   await stopFocus();
   return "Focus session stopped.";
 }

--- a/extensions/focus/src/tools/take-break.ts
+++ b/extensions/focus/src/tools/take-break.ts
@@ -1,0 +1,22 @@
+import { takeBreak5, takeBreakCustom } from "../utils";
+
+type Input = {
+  /**
+   * Duration of the break in minutes. Defaults to 5 minutes if not specified.
+   */
+  minutes?: number;
+};
+
+/**
+ * Takes a break from the current focus session. Defaults to 5 minutes.
+ * Specify a duration in minutes for a custom break length.
+ */
+export default async function tool(input: Input) {
+  if (input.minutes && input.minutes > 0) {
+    await takeBreakCustom(input.minutes);
+    return `${input.minutes}-minute break started.`;
+  } else {
+    await takeBreak5();
+    return "5-minute break started.";
+  }
+}

--- a/extensions/focus/src/tools/take-break.ts
+++ b/extensions/focus/src/tools/take-break.ts
@@ -1,4 +1,4 @@
-import { takeBreak5, takeBreakCustom } from "../utils";
+import { isFocusRunning, takeBreak5, takeBreakCustom } from "../utils";
 
 type Input = {
   /**
@@ -12,6 +12,10 @@ type Input = {
  * Specify a duration in minutes for a custom break length.
  */
 export default async function tool(input: Input) {
+  const isRunning = await isFocusRunning();
+  if (!isRunning) {
+    return "No active focus session found — cannot start a break.";
+  }
   if (input.minutes && input.minutes > 0) {
     await takeBreakCustom(input.minutes);
     return `${input.minutes}-minute break started.`;

--- a/extensions/focus/src/utils.tsx
+++ b/extensions/focus/src/utils.tsx
@@ -32,23 +32,18 @@ export async function getActiveProfileName() {
 }
 
 export async function startFocus() {
-  if (!(await isFocusRunning())) return;
   await runAppleScript('do shell script "open -g focus://focus"');
 }
 
 export async function startFocus25(): Promise<void> {
-  if (!(await isFocusRunning())) return;
   await runAppleScript('do shell script "open -g focus://focus?minutes=25"');
 }
 
 export async function startFocusWithProfile25(profile: string): Promise<void> {
-  if (!(await isFocusRunning())) return;
   await runAppleScript(`do shell script "open -g 'focus://focus?profile=${encodeURIComponent(profile)}&minutes=25'"`);
 }
 
 export async function startFocusCustom(hours?: number, minutes?: number, profile?: string): Promise<boolean> {
-  if (!(await isFocusRunning())) return false;
-
   let totalSeconds = 0;
   if (hours !== undefined) {
     totalSeconds += hours * 60 * 60;
@@ -148,7 +143,6 @@ export async function getProfileNames() {
 }
 
 export async function startFocusWithProfile(profileName: string) {
-  if (!(await isFocusRunning())) return;
   await runAppleScript(`do shell script "open -g 'focus://focus?profile=${encodeURIComponent(profileName)}'"`);
 }
 


### PR DESCRIPTION
## Description

- Added AI extension support
- Commands now automatically launch the Focus app if it isn't running, instead of showing an error.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
