### PR TITLE
fix(clipboard-type): disable AppleScript timeout for long text typing

### DIFF
--- a/extensions/clipboard-type/CHANGELOG.md
+++ b/extensions/clipboard-type/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clipboard Type Changelog
 
-## [Fixed timeout for long text] - {PR_MERGE_DATE}
+## [Fixed timeout for long text] - 2026-03-25
 
 - Disabled the default 10s AppleScript timeout which caused typing to fail for long clipboard content with human cadence enabled.
 

--- a/extensions/clipboard-type/CHANGELOG.md
+++ b/extensions/clipboard-type/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Clipboard Type Changelog
 
+## [Fixed timeout for long text] {PR_MERGE_DATE}
+
+- Disabled the default 10s AppleScript timeout which caused typing to fail for long clipboard content with human cadence enabled.
+
 ## [Added soft newlines preference] 2026-03-23
 
 - Added a new preference to use Shift+Enter for newlines instead of Enter. Useful for apps and websites that treat Enter as submit.

--- a/extensions/clipboard-type/CHANGELOG.md
+++ b/extensions/clipboard-type/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Clipboard Type Changelog
 
-## [Fixed timeout for long text] {PR_MERGE_DATE}
+## [Fixed timeout for long text] - {PR_MERGE_DATE}
 
 - Disabled the default 10s AppleScript timeout which caused typing to fail for long clipboard content with human cadence enabled.
 
-## [Added soft newlines preference] 2026-03-23
+## [Added soft newlines preference] - 2026-03-23
 
 - Added a new preference to use Shift+Enter for newlines instead of Enter. Useful for apps and websites that treat Enter as submit.
 
-## [Added human cadence typing] 2026-02-10
+## [Added human cadence typing] - 2026-02-10
 
 - Added a new preference to enable human cadence typing, which simulates more natural typing by introducing random delays between keystrokes.
 

--- a/extensions/clipboard-type/src/type-clipboard.ts
+++ b/extensions/clipboard-type/src/type-clipboard.ts
@@ -45,7 +45,9 @@ end tell
 
   // Execute the AppleScript using osascript directly
   try {
-    await runAppleScript(appleScriptContent);
+    await runAppleScript(appleScriptContent, {
+      timeout: 0, // runAppleScript defaults to 10s: typing long text + human cadence can exceed that
+    });
   } catch (error) {
     await showFailureToast(error);
   }


### PR DESCRIPTION
## Summary

- Disables the default 10s `runAppleScript` timeout which caused typing to fail for long clipboard content, especially with human cadence enabled.

## Why?

When using the human cadence typing preference, long clipboard text easily exceeds the default 10-second AppleScript timeout, causing the command to silently fail mid-typing. Setting the timeout to `0` (unlimited) fixes this.

## Changes

- `src/type-clipboard.ts`: Pass `timeout: 0` to `runAppleScript` to prevent timeout on long text
- `CHANGELOG.md`: Added changelog entry for the fix