### PR TITLE
Telegram: fix auth flow, add 2FA support, add Reset Session command

### DIFF
--- a/extensions/telegram/CHANGELOG.md
+++ b/extensions/telegram/CHANGELOG.md
@@ -1,3 +1,12 @@
 # Telegram Changelog
 
+## [Fix Authentication Flow & Add 2FA Support] - {PR_MERGE_DATE}
+
+- Always send a fresh verification code when requested (fixes code not being received on retry)
+- Handle `SESSION_PASSWORD_NEEDED` to support Telegram accounts with Two-Factor Authentication (2FA)
+- Add 2FA password form shown automatically after code verification when 2FA is enabled
+- Clear stale `phoneCodeHash` after a failed sign-in attempt so users can request a fresh code
+- Add "Reset Telegram Session" command to recover from broken authentication states
+- Improve error messages for common Telegram errors (PHONE_CODE_EXPIRED, PHONE_CODE_INVALID, API_ID_INVALID, etc.)
+
 ## [Initial Version] - 2026-02-04

--- a/extensions/telegram/README.md
+++ b/extensions/telegram/README.md
@@ -1,12 +1,15 @@
 # Telegram
 
-A Raycast extension for viewing and sending messages to your Telegram Saved Messages.
+A Raycast extension for browsing chats, reading messages, and sending messages to your Telegram contacts and groups directly from Raycast.
 
 ## Features
 
+- 💬 **Browse Chats**: Browse all your Telegram chats and groups
+- 📨 **Send Messages**: Send messages (and files) to any chat or group
 - 📥 **View Saved Messages**: Browse your Telegram saved messages directly in Raycast
 - 📤 **Send to Saved Messages**: Quickly send notes and messages to yourself
-- 🔐 **Secure Authentication**: Uses official Telegram API with session persistence
+- 🔐 **Secure Authentication**: Uses official Telegram API with session persistence and 2FA support
+- 🔄 **Reset Session**: Recover from broken authentication states with one command
 
 ## Setup
 
@@ -43,7 +46,8 @@ Before using this extension, you need to obtain API credentials from Telegram:
 2. Click "Send Verification Code"
 3. Check your Telegram app for the verification code
 4. Enter the code in Raycast
-5. You're all set! 🎉
+5. **If you have Two-Factor Authentication (2FA) enabled**, you will be prompted to enter your 2FA password after the code step
+6. You're all set! 🎉
 
 The extension will remember your session, so you only need to authenticate once.
 
@@ -51,11 +55,26 @@ The extension will remember your session, so you only need to authenticate once.
 
 ### Authenticate with Telegram
 
-Log in to your Telegram account. You'll need to do this once before using the other commands.
+Log in to your Telegram account. You'll need to do this once before using the other commands. Supports accounts with Two-Factor Authentication (2FA) enabled.
+
+### Browse Chats
+
+Browse all your Telegram private chats and groups in a list view. Features:
+
+- See chat titles, types, and last messages
+- Open a chat to view its message history
+
+### Send Message
+
+Send a message to any Telegram chat or group. Features:
+
+- Search for a chat by name
+- Attach files from your clipboard
 
 ### View Saved Messages
 
 Browse your Telegram saved messages in a list view. Features:
+
 - Search through your messages
 - See message timestamps
 - Copy messages to clipboard
@@ -64,9 +83,20 @@ Browse your Telegram saved messages in a list view. Features:
 ### Send to Saved Messages
 
 Quickly send a message to your Telegram saved messages. Perfect for:
+
 - Saving quick notes
 - Storing links for later
 - Sending reminders to yourself
+
+### Reset Telegram Session
+
+Clear all stored authentication data to recover from a broken or stuck login state. Use this command if:
+
+- Authentication keeps failing after entering a correct code
+- You are stuck in a loop and cannot complete login
+- You want to log in with a different account
+
+After resetting, run "Authenticate with Telegram" to log in again.
 
 ## Privacy & Security
 
@@ -85,18 +115,17 @@ If you see this error, run the "Authenticate with Telegram" command to log in.
 
 Make sure you've entered the correct API ID and API Hash in the extension preferences. The API ID should be a number, not a string.
 
-### "Failed to Load Messages" Error
+### "Verification code has expired" Error
 
-This usually means your session has expired. Try running the "Authenticate with Telegram" command again.
+Verification codes expire quickly. Click "Send Verification Code" again to request a fresh code and enter it promptly.
 
-## Future Features
+### Stuck or broken authentication state
 
-Coming soon:
-- View all chats
-- Send messages to other users and groups
-- Media support (photos, files)
-- Message search
-- Notifications
+Run the "Reset Telegram Session" command to clear all stored state, then run "Authenticate with Telegram" again.
+
+### 2FA / Two-Factor Authentication
+
+If your Telegram account has 2FA enabled, you will see a password prompt automatically after entering your verification code. Enter your Telegram cloud password to complete authentication.
 
 ## License
 

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -5,6 +5,9 @@
   "description": "Browse chats, view messages, and send messages to your Telegram contacts and groups",
   "icon": "telegram.png",
   "author": "ikupenov",
+  "contributors": [
+    "JediRhymeTrix"
+  ],
   "platforms": [
     "macOS",
     "Windows"
@@ -79,6 +82,12 @@
       "name": "send-saved-message",
       "title": "Send to Saved Messages",
       "description": "Send a message to your Telegram saved messages",
+      "mode": "view"
+    },
+    {
+      "name": "reset-session",
+      "title": "Reset Telegram Session",
+      "description": "Clear stored authentication data to recover from a broken login state",
       "mode": "view"
     }
   ],

--- a/extensions/telegram/src/authenticate.tsx
+++ b/extensions/telegram/src/authenticate.tsx
@@ -1,35 +1,32 @@
 import { useState } from "react";
-import { Form, ActionPanel, Action, showToast, Toast, popToRoot, Icon } from "@raycast/api";
+import { Form, ActionPanel, Action, popToRoot, Icon } from "@raycast/api";
 import { useForm, FormValidation } from "@raycast/utils";
 import dedent from "dedent";
-import { handleAuthFlow } from "./utils/auth";
+import { handleAuthFlow, handlePasswordFlow } from "./utils/auth";
 
 interface AuthCodeFormValues {
   code: string;
 }
 
+interface AuthPasswordFormValues {
+  password: string;
+}
+
 export default function Authenticate() {
   const [needsCode, setNeedsCode] = useState(false);
+  const [needsPassword, setNeedsPassword] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { handleSubmit, itemProps } = useForm<AuthCodeFormValues>({
+  const { handleSubmit: handleCodeSubmit, itemProps: codeItemProps } = useForm<AuthCodeFormValues>({
     onSubmit: async (values) => {
       setIsSubmitting(true);
       try {
         const result = await handleAuthFlow(values.code);
         if (result.success) {
-          await showToast({
-            style: Toast.Style.Success,
-            title: "Successfully authenticated with Telegram",
-          });
           await popToRoot();
+        } else if (result.needsPassword) {
+          setNeedsPassword(true);
         }
-      } catch (error) {
-        await showToast({
-          style: Toast.Style.Failure,
-          title: "Authentication Failed",
-          message: error instanceof Error ? error.message : "Unknown error occurred",
-        });
       } finally {
         setIsSubmitting(false);
       }
@@ -39,56 +36,67 @@ export default function Authenticate() {
     },
   });
 
-  const handleInitialAuth = async () => {
-    try {
-      const result = await handleAuthFlow();
-      if (result.needsCode) {
-        setNeedsCode(true);
-      } else if (result.success) {
-        await showToast({
-          style: Toast.Style.Success,
-          title: "Successfully authenticated with Telegram",
-        });
-        await popToRoot();
+  const { handleSubmit: handlePasswordSubmit, itemProps: passwordItemProps } = useForm<AuthPasswordFormValues>({
+    onSubmit: async (values) => {
+      setIsSubmitting(true);
+      try {
+        const result = await handlePasswordFlow(values.password);
+        if (result.success) {
+          await popToRoot();
+        }
+      } finally {
+        setIsSubmitting(false);
       }
-    } catch (error) {
-      await showToast({
-        style: Toast.Style.Failure,
-        title: "Authentication Failed",
-        message: error instanceof Error ? error.message : "Unknown error occurred",
-      });
+    },
+    validation: {
+      password: FormValidation.Required,
+    },
+  });
+
+  const handleInitialAuth = async () => {
+    const result = await handleAuthFlow();
+    if (result.needsCode) {
+      setNeedsCode(true);
+    } else if (result.success) {
+      await popToRoot();
     }
   };
 
-  if (!needsCode) {
+  if (needsPassword) {
     return (
       <Form
+        isLoading={isSubmitting}
         actions={
           <ActionPanel>
-            <Action icon={Icon.ArrowRight} title="Send Verification Code" onAction={handleInitialAuth} />
-            <Action.OpenInBrowser
-              title="Get API Credentials"
-              url="https://my.telegram.org/apps"
-              shortcut={{ modifiers: ["cmd"], key: "o" }}
-            />
+            <Action.SubmitForm icon={Icon.Lock} title="Verify Password" onSubmit={handlePasswordSubmit} />
           </ActionPanel>
         }
       >
-        <Form.Description
-          title="Setup Required"
-          text="Before authenticating, you need to configure your Telegram API credentials in the extension preferences (⌘+,)."
+        <Form.PasswordField
+          title="Two-Factor Authentication Password"
+          info="Your Telegram two-factor authentication password"
+          placeholder="Enter your 2FA password"
+          {...passwordItemProps.password}
         />
-        <Form.Separator />
-        <Form.Description
-          title="How to Get API Credentials"
-          text={dedent`
-            1. Visit https://my.telegram.org/apps (⌘+O to open)
-            2. Log in with your phone number
-            3. Click "API development tools"
-            4. Create an application to get your API ID and API Hash
-            5. Enter these credentials in Raycast preferences
-            6. Return here and click "Send Verification Code"
-          `}
+      </Form>
+    );
+  }
+
+  if (needsCode) {
+    return (
+      <Form
+        isLoading={isSubmitting}
+        actions={
+          <ActionPanel>
+            <Action.SubmitForm icon={Icon.ArrowRight} title="Verify Code" onSubmit={handleCodeSubmit} />
+          </ActionPanel>
+        }
+      >
+        <Form.TextField
+          title="Verification Code"
+          info="Enter the verification code sent to your Telegram app"
+          placeholder="12345"
+          {...codeItemProps.code}
         />
       </Form>
     );
@@ -96,18 +104,32 @@ export default function Authenticate() {
 
   return (
     <Form
-      isLoading={isSubmitting}
       actions={
         <ActionPanel>
-          <Action.SubmitForm icon={Icon.ArrowRight} title="Verify Code" onSubmit={handleSubmit} />
+          <Action icon={Icon.ArrowRight} title="Send Verification Code" onAction={handleInitialAuth} />
+          <Action.OpenInBrowser
+            title="Get API Credentials"
+            url="https://my.telegram.org/apps"
+            shortcut={{ modifiers: ["cmd"], key: "o" }}
+          />
         </ActionPanel>
       }
     >
-      <Form.TextField
-        title="Verification Code"
-        info="Enter the verification code sent to your Telegram app"
-        placeholder="12345"
-        {...itemProps.code}
+      <Form.Description
+        title="Setup Required"
+        text="Before authenticating, you need to configure your Telegram API credentials in the extension preferences (⌘+,)."
+      />
+      <Form.Separator />
+      <Form.Description
+        title="How to Get API Credentials"
+        text={dedent`
+          1. Visit https://my.telegram.org/apps (⌘+O to open)
+          2. Log in with your phone number
+          3. Click "API development tools"
+          4. Create an application to get your API ID and API Hash
+          5. Enter these credentials in Raycast preferences
+          6. Return here and click "Send Verification Code"
+        `}
       />
     </Form>
   );

--- a/extensions/telegram/src/reset-session.tsx
+++ b/extensions/telegram/src/reset-session.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+import { Icon, List, showToast, Toast, popToRoot, confirmAlert, Alert } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { resetSession } from "./services/telegram-client";
+
+export default function ResetSession() {
+  useEffect(() => {
+    async function run() {
+      const confirmed = await confirmAlert({
+        title: "Reset Telegram Session",
+        message: "This will clear all stored authentication data. You will need to re-authenticate.",
+        icon: Icon.Trash,
+        primaryAction: {
+          title: "Reset Session",
+          style: Alert.ActionStyle.Destructive,
+        },
+      });
+
+      if (!confirmed) {
+        await popToRoot();
+        return;
+      }
+
+      try {
+        await resetSession();
+        await showToast({
+          style: Toast.Style.Success,
+          title: "Session Reset",
+          message: "Your Telegram session has been cleared. Run the authentication command to log in again.",
+        });
+      } catch (error) {
+        await showFailureToast(error, { title: "Reset Failed" });
+      } finally {
+        await popToRoot();
+      }
+    }
+    run();
+  }, []);
+
+  return <List isLoading />;
+}

--- a/extensions/telegram/src/services/telegram-client.ts
+++ b/extensions/telegram/src/services/telegram-client.ts
@@ -123,7 +123,10 @@ export async function isAuthenticated(): Promise<boolean> {
   return !!sessionString;
 }
 
-export async function authenticate(config: TelegramConfig, code?: string): Promise<{ needsCode: boolean }> {
+export async function authenticate(
+  config: TelegramConfig,
+  code?: string,
+): Promise<{ needsCode: boolean; needsPassword?: boolean }> {
   const client = await getClient(config);
 
   if (!client.connected) {
@@ -135,18 +138,15 @@ export async function authenticate(config: TelegramConfig, code?: string): Promi
   }
 
   if (!code) {
-    const phoneCodeHash = await LocalStorage.getItem<string>(PHONE_CODE_HASH_KEY);
-    if (!phoneCodeHash) {
-      const result = await client.sendCode(
-        {
-          apiId: config.apiId,
-          apiHash: config.apiHash,
-        },
-        config.phoneNumber,
-      );
-      await LocalStorage.setItem(PHONE_CODE_HASH_KEY, result.phoneCodeHash);
-      return { needsCode: true };
-    }
+    // Always send a fresh code when requested so the user reliably receives it.
+    const result = await client.sendCode(
+      {
+        apiId: config.apiId,
+        apiHash: config.apiHash,
+      },
+      config.phoneNumber,
+    );
+    await LocalStorage.setItem(PHONE_CODE_HASH_KEY, result.phoneCodeHash);
     return { needsCode: true };
   }
 
@@ -155,13 +155,23 @@ export async function authenticate(config: TelegramConfig, code?: string): Promi
     throw new Error("Phone code hash not found. Please restart authentication.");
   }
 
-  await client.invoke(
-    new Api.auth.SignIn({
-      phoneNumber: config.phoneNumber,
-      phoneCodeHash: phoneCodeHash,
-      phoneCode: code,
-    }),
-  );
+  try {
+    await client.invoke(
+      new Api.auth.SignIn({
+        phoneNumber: config.phoneNumber,
+        phoneCodeHash: phoneCodeHash,
+        phoneCode: code,
+      }),
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("SESSION_PASSWORD_NEEDED")) {
+      // The code was accepted; only the 2FA password step remains.
+      return { needsCode: false, needsPassword: true };
+    }
+    // Clear the stale hash so the user can request a fresh code next time.
+    await LocalStorage.removeItem(PHONE_CODE_HASH_KEY);
+    throw error;
+  }
 
   const session = client.session.save() as unknown as string;
   await LocalStorage.setItem(SESSION_KEY, session);
@@ -172,6 +182,33 @@ export async function authenticate(config: TelegramConfig, code?: string): Promi
   await LocalStorage.removeItem(PHONE_CODE_HASH_KEY);
 
   return { needsCode: false };
+}
+
+export async function verifyPassword(config: TelegramConfig, password: string): Promise<void> {
+  const client = await getClient(config);
+
+  if (!client.connected) {
+    await client.connect();
+  }
+
+  const { computeCheck } = await import("telegram/Password");
+  const passwordInfo = await client.invoke(new Api.account.GetPassword());
+  const srpCheck = await computeCheck(passwordInfo, password);
+
+  await client.invoke(new Api.auth.CheckPassword({ password: srpCheck }));
+
+  const session = client.session.save() as unknown as string;
+  await LocalStorage.setItem(SESSION_KEY, session);
+
+  const me = await client.getMe();
+  await LocalStorage.setItem(USER_ID_KEY, me.id.toString());
+}
+
+export async function resetSession(): Promise<void> {
+  await LocalStorage.removeItem(SESSION_KEY);
+  await LocalStorage.removeItem(USER_ID_KEY);
+  await LocalStorage.removeItem(PHONE_CODE_HASH_KEY);
+  clientInstance = null;
 }
 
 function ensureMediaCacheDir(): void {

--- a/extensions/telegram/src/services/telegram-client.ts
+++ b/extensions/telegram/src/services/telegram-client.ts
@@ -202,6 +202,8 @@ export async function verifyPassword(config: TelegramConfig, password: string): 
 
   const me = await client.getMe();
   await LocalStorage.setItem(USER_ID_KEY, me.id.toString());
+
+  await LocalStorage.removeItem(PHONE_CODE_HASH_KEY);
 }
 
 export async function resetSession(): Promise<void> {

--- a/extensions/telegram/src/utils/auth.ts
+++ b/extensions/telegram/src/utils/auth.ts
@@ -1,5 +1,7 @@
 import { getPreferenceValues, showToast, Toast } from "@raycast/api";
-import { isAuthenticated, authenticate, TelegramConfig } from "../services/telegram-client";
+import { showFailureToast } from "@raycast/utils";
+import { isAuthenticated, authenticate, verifyPassword, TelegramConfig } from "../services/telegram-client";
+import { handleTelegramError } from "./errors";
 
 export interface Preferences {
   apiId: string;
@@ -37,7 +39,9 @@ export async function ensureAuthenticated(): Promise<boolean> {
   return true;
 }
 
-export async function handleAuthFlow(code?: string): Promise<{ success: boolean; needsCode: boolean }> {
+export async function handleAuthFlow(
+  code?: string,
+): Promise<{ success: boolean; needsCode: boolean; needsPassword?: boolean }> {
   try {
     const config = getConfig();
     const result = await authenticate(config, code);
@@ -51,6 +55,10 @@ export async function handleAuthFlow(code?: string): Promise<{ success: boolean;
       return { success: false, needsCode: true };
     }
 
+    if (result.needsPassword) {
+      return { success: false, needsCode: false, needsPassword: true };
+    }
+
     if (!result.needsCode) {
       await showToast({
         style: Toast.Style.Success,
@@ -61,12 +69,36 @@ export async function handleAuthFlow(code?: string): Promise<{ success: boolean;
     }
 
     return { success: false, needsCode: result.needsCode };
-  } catch (error) {
-    await showToast({
-      style: Toast.Style.Failure,
-      title: "Authentication Failed",
-      message: error instanceof Error ? error.message : "Unknown error occurred",
-    });
+  } catch (rawError) {
+    let friendlyError = rawError;
+    try {
+      handleTelegramError(rawError);
+    } catch (e) {
+      friendlyError = e;
+    }
+    await showFailureToast(friendlyError, { title: "Authentication Failed" });
     return { success: false, needsCode: false };
+  }
+}
+
+export async function handlePasswordFlow(password: string): Promise<{ success: boolean }> {
+  try {
+    const config = getConfig();
+    await verifyPassword(config, password);
+    await showToast({
+      style: Toast.Style.Success,
+      title: "Authenticated",
+      message: "Successfully authenticated with Telegram!",
+    });
+    return { success: true };
+  } catch (rawError) {
+    let friendlyError = rawError;
+    try {
+      handleTelegramError(rawError);
+    } catch (e) {
+      friendlyError = e;
+    }
+    await showFailureToast(friendlyError, { title: "Authentication Failed" });
+    return { success: false };
   }
 }

--- a/extensions/telegram/src/utils/errors.ts
+++ b/extensions/telegram/src/utils/errors.ts
@@ -1,8 +1,36 @@
 export function handleTelegramError(error: unknown): never {
-  if (error instanceof Error && error.message.includes("FloodWaitError")) {
-    const match = error.message.match(/(\d+) seconds/);
-    const seconds = match ? match[1] : "unknown";
-    throw new Error(`Rate limited by Telegram. Please wait ${seconds} seconds before trying again.`);
+  if (error instanceof Error) {
+    const msg = error.message;
+
+    if (msg.includes("FloodWaitError") || msg.includes("FLOOD_WAIT")) {
+      const match = msg.match(/(\d+) seconds/);
+      const seconds = match ? match[1] : "unknown";
+      throw new Error(`Rate limited by Telegram. Please wait ${seconds} seconds before trying again.`);
+    }
+
+    if (msg.includes("PHONE_CODE_EXPIRED")) {
+      throw new Error("Verification code has expired. Please request a new code.");
+    }
+
+    if (msg.includes("PHONE_CODE_INVALID")) {
+      throw new Error("Invalid verification code. Please check the code and try again.");
+    }
+
+    if (msg.includes("SESSION_PASSWORD_NEEDED")) {
+      throw new Error("Two-factor authentication is required. Please enter your 2FA password.");
+    }
+
+    if (msg.includes("PASSWORD_HASH_INVALID")) {
+      throw new Error("Invalid 2FA password. Please check your Telegram two-factor authentication password.");
+    }
+
+    if (msg.includes("API_ID_INVALID")) {
+      throw new Error("Invalid API ID. Please check your credentials in the extension preferences.");
+    }
+
+    if (msg.includes("PHONE_NUMBER_INVALID")) {
+      throw new Error("Invalid phone number format. Please use the international format (e.g., +1234567890).");
+    }
   }
 
   throw error instanceof Error ? error : new Error("Unknown error occurred");


### PR DESCRIPTION
Fixes authentication reliability issues and adds 2FA support. Introduces a Reset Session command to recover from broken auth states.

## Description

**Auth fixes (`telegram-client.ts`, `auth.ts`)**
- Always send a fresh code on request — drops the stale `phoneCodeHash` re-use path that caused users not to receive a code on retry
- Clear `phoneCodeHash` from LocalStorage on failed sign-in so the next attempt starts clean
- Remove dead catch blocks; pipe all raw Telegram errors through `handleTelegramError` before surfacing via `showFailureToast`

**2FA support (`telegram-client.ts`, `auth.ts`, `authenticate.tsx`)**
- `authenticate()` catches `SESSION_PASSWORD_NEEDED` and returns `{ needsPassword: true }` instead of throwing
- New `verifyPassword()` — SRP exchange via `telegram/Password.computeCheck` + `auth.CheckPassword`, saves session on success
- New `handlePasswordFlow()` in `auth.ts` — calls `verifyPassword`, shows success toast, routes errors through `handleTelegramError`
- `authenticate.tsx` adds a `needsPassword` state that auto-renders a `Form.PasswordField` step after code verification

**Reset Session command (`reset-session.tsx`, `telegram-client.ts`, `package.json`)**
- New `resetSession()` — clears `SESSION_KEY`, `USER_ID_KEY`, `PHONE_CODE_HASH_KEY`, nulls client cache
- `reset-session.tsx` fires `confirmAlert` immediately via `useEffect`; renders `<List isLoading />` as backdrop to avoid empty-state flash; cancels to root, confirms then resets with `showFailureToast` on error

**Error translations (`errors.ts`)**

Expanded `handleTelegramError` to cover: `PHONE_CODE_EXPIRED`, `PHONE_CODE_INVALID`, `SESSION_PASSWORD_NEEDED`, `PASSWORD_HASH_INVALID`, `API_ID_INVALID`, `PHONE_NUMBER_INVALID`

**Docs (`README.md`, `CHANGELOG.md`)**
- README: 2FA setup instructions, Reset Session command entry, updated troubleshooting, removed stale "Future Features" section
- CHANGELOG: new "Fix Authentication Flow & Add 2FA Support" entry

## Screencast

No new views introduced. The Reset Session command presents a confirmation dialog immediately on launch rather than requiring an intermediate list interaction.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

Fixes #26479 Fixes #25850 Fixes #25566