### PR TITLE
Update font-awesome extension

### DIFF
--- a/extensions/fontawesome/CHANGELOG.md
+++ b/extensions/fontawesome/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Font Awesome Changelog
 
+## [Fix pro token refresh and kit loading] - {PR_MERGE_DATE}
+
+- Fixed pro icon searches after changing the API token by scoping cached access tokens and expiry timestamps to the selected API token, which prevents the extension from continuing to use the default free token after a pro token is added (ref: [Issue #26096](https://github.com/raycast/extensions/issues/26096#issuecomment-4013620785)).
+- Scoped cached icon and kit data to the active token/style selection so custom kit results and pro search results no longer bleed across token changes.
+- Updated custom kit handling to rely on Font Awesome kit tokens instead of a nonexistent `Kit.id` field when filtering, selecting, and loading kit uploads.
+
 ## [Added Custom Kits Support for Pro accounts] - 2025-11-25
 
 - Added support for browsing and searching custom kit icons

--- a/extensions/fontawesome/CHANGELOG.md
+++ b/extensions/fontawesome/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Font Awesome Changelog
 
-## [Fix pro token refresh and kit loading] - {PR_MERGE_DATE}
+## [Fix pro token refresh and kit loading] - 2026-03-27
 
 - Fixed pro icon searches after changing the API token by scoping cached access tokens and expiry timestamps to the selected API token, which prevents the extension from continuing to use the default free token after a pro token is added (ref: [Issue #26096](https://github.com/raycast/extensions/issues/26096#issuecomment-4013620785)).
 - Scoped cached icon and kit data to the active token/style selection so custom kit results and pro search results no longer bleed across token changes.

--- a/extensions/fontawesome/src/components/StyleSelector.tsx
+++ b/extensions/fontawesome/src/components/StyleSelector.tsx
@@ -71,9 +71,9 @@ export const StyleSelector = ({ setType, STYLE_PREFERENCE, account, kits }: Styl
             <Grid.Dropdown.Section title="Custom Kits">
               {kits.map((kit) => (
                 <Grid.Dropdown.Item
-                  key={`kit:${kit.id ?? kit.token}`}
+                  key={`kit:${kit.token}`}
                   title={kit.name}
-                  value={`kit:${kit.id ?? kit.token}`}
+                  value={`kit:${kit.token}`}
                   icon={{ source: iconForStyle("fas"), tintColor: Color.SecondaryText }}
                 />
               ))}

--- a/extensions/fontawesome/src/hooks/useAccessToken.ts
+++ b/extensions/fontawesome/src/hooks/useAccessToken.ts
@@ -1,16 +1,23 @@
 import { useCachedState, useFetch, useLocalStorage } from "@raycast/utils";
 import { TokenData } from "@/types";
+import { getAccessTokenStorageKeys, shouldRefreshAccessToken } from "@/utils/access-token";
 
 export const useAccessToken = (API_TOKEN: string) => {
-  const [accessToken, setAccessToken] = useCachedState<string>("accessToken", "");
+  const { tokenFingerprint, accessTokenKey, expiryKey } = getAccessTokenStorageKeys(API_TOKEN);
+  const [accessToken, setAccessToken] = useCachedState<string>(accessTokenKey, "");
 
   const {
     value: tokenTimeStart,
     setValue: setTokenTimerStart,
     isLoading: isTokenTimerLoading,
-  } = useLocalStorage<number>("token-expiry-start");
+  } = useLocalStorage<number>(expiryKey);
 
-  const executeTokenFetch = !isTokenTimerLoading && (!tokenTimeStart || Date.now() - (tokenTimeStart || 0) >= 3600000);
+  const executeTokenFetch =
+    !isTokenTimerLoading &&
+    shouldRefreshAccessToken({
+      accessToken,
+      tokenTimeStart,
+    });
 
   // Fetch access token, store expiry info in local storage and state and store access token
   const { isLoading: isTokenLoading } = useFetch<TokenData>("https://api.fontawesome.com/token", {
@@ -28,5 +35,5 @@ export const useAccessToken = (API_TOKEN: string) => {
   const isLoading = isTokenTimerLoading || isTokenLoading;
   const executeDataLoading = !!(accessToken && !isLoading);
 
-  return { accessToken, isLoading, executeDataLoading };
+  return { accessToken, cacheScope: tokenFingerprint, isLoading, executeDataLoading };
 };

--- a/extensions/fontawesome/src/hooks/useData.ts
+++ b/extensions/fontawesome/src/hooks/useData.ts
@@ -1,12 +1,14 @@
 import { useCachedState, useFetch } from "@raycast/utils";
 import type { KitIconsResult, SearchItem, SearchResult } from "@/types";
+import { buildScopedCacheKey } from "@/utils/access-token";
 import { familyStylesByPrefix } from "@/utils/data";
+import { findKitByToken } from "@/utils/kits";
 import { iconQuery, kitIconsQuery } from "@/utils/query";
 
 type ApiResult = SearchResult | KitIconsResult | undefined;
 
-export const useData = (accessToken: string, execute: boolean, query: string, type: string) => {
-  const [iconData, setIconData] = useCachedState<ApiResult>("iconData");
+export const useData = (accessToken: string, cacheScope: string, execute: boolean, query: string, type: string) => {
+  const [iconData, setIconData] = useCachedState<ApiResult>(buildScopedCacheKey("iconData", cacheScope, type));
 
   const isKitSelection = type.startsWith("kit:");
   const kitToken = isKitSelection ? type.replace("kit:", "") : "";
@@ -36,7 +38,7 @@ export const useData = (accessToken: string, execute: boolean, query: string, ty
     if (isKitSelection) {
       const kitResult = raw as KitIconsResult;
       const kits = kitResult?.data?.me?.kits ?? [];
-      const kit = kits.find((k: { token: string; id: string }) => k.token === kitToken || k.id === kitToken) ?? kits[0];
+      const kit = findKitByToken(kits, kitToken) ?? kits[0];
       const uploads = kit?.iconUploads ?? [];
 
       const trimmedQuery = query.trim().toLowerCase();

--- a/extensions/fontawesome/src/hooks/useData.ts
+++ b/extensions/fontawesome/src/hooks/useData.ts
@@ -1,5 +1,5 @@
 import { useCachedState, useFetch } from "@raycast/utils";
-import type { KitIconsResult, SearchItem, SearchResult } from "@/types";
+import type { KitIconUpload, KitIconsResult, SearchItem, SearchResult } from "@/types";
 import { buildScopedCacheKey } from "@/utils/access-token";
 import { familyStylesByPrefix } from "@/utils/data";
 import { findKitByToken } from "@/utils/kits";
@@ -44,7 +44,7 @@ export const useData = (accessToken: string, cacheScope: string, execute: boolea
       const trimmedQuery = query.trim().toLowerCase();
 
       normalized = uploads
-        .filter((upload) => {
+        .filter((upload: KitIconUpload) => {
           if (!trimmedQuery) {
             return true;
           }
@@ -58,7 +58,7 @@ export const useData = (accessToken: string, cacheScope: string, execute: boolea
 
           return nameMatch || unicodeMatch;
         })
-        .map((upload) => {
+        .map((upload: KitIconUpload) => {
           const rawPathData = upload.pathData;
           const paths = Array.isArray(rawPathData) ? rawPathData : [rawPathData];
 

--- a/extensions/fontawesome/src/hooks/useKits.ts
+++ b/extensions/fontawesome/src/hooks/useKits.ts
@@ -1,9 +1,11 @@
 import { useCachedState, useFetch } from "@raycast/utils";
 import type { Kit, KitsResult } from "@/types";
+import { buildScopedCacheKey } from "@/utils/access-token";
+import { filterKits } from "@/utils/kits";
 import { kitsQuery } from "@/utils/query";
 
-export const useKits = (accessToken: string, execute: boolean, kitFilter?: string) => {
-  const [cachedKits, setCachedKits] = useCachedState<Kit[]>("kits", []);
+export const useKits = (accessToken: string, cacheScope: string, execute: boolean, kitFilter?: string) => {
+  const [cachedKits, setCachedKits] = useCachedState<Kit[]>(buildScopedCacheKey("kits", cacheScope), []);
 
   const { isLoading, data, revalidate } = useFetch<KitsResult>("https://api.fontawesome.com", {
     execute: !!(accessToken && execute),
@@ -21,26 +23,5 @@ export const useKits = (accessToken: string, execute: boolean, kitFilter?: strin
   });
 
   const allKits = (cachedKits && cachedKits.length > 0 ? cachedKits : data?.data?.me?.kits) ?? [];
-
-  const trimmedFilter = kitFilter?.trim();
-  let filteredKits: Kit[] = allKits;
-
-  if (trimmedFilter && allKits.length > 0) {
-    const tokensOrNames = trimmedFilter
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .map((s) => s.toLowerCase());
-
-    if (tokensOrNames.length > 0) {
-      filteredKits = allKits.filter((kit) => {
-        const nameLower = kit.name?.toLowerCase() ?? "";
-        const tokenLower = kit.token?.toLowerCase() ?? "";
-        const idLower = kit.id?.toLowerCase() ?? "";
-        return tokensOrNames.some((value) => value === tokenLower || value === idLower || value === nameLower);
-      });
-    }
-  }
-
-  return { kits: filteredKits, isLoading, revalidate };
+  return { kits: filterKits(allKits, kitFilter), isLoading, revalidate };
 };

--- a/extensions/fontawesome/src/index.tsx
+++ b/extensions/fontawesome/src/index.tsx
@@ -16,9 +16,14 @@ export default function Command() {
   const [type, setType] = useState<string>(initialType);
   const [query, setQuery] = useState<string>("");
 
-  const { accessToken, isLoading: isAccessTokenLoading, executeDataLoading } = useAccessToken(API_TOKEN);
-  const { isLoading: isDataLoading, data } = useData(accessToken, executeDataLoading, query, type);
-  const { kits, isLoading: isKitsLoading } = useKits(accessToken, executeDataLoading && account === "pro", kitFilter);
+  const { accessToken, cacheScope, isLoading: isAccessTokenLoading, executeDataLoading } = useAccessToken(API_TOKEN);
+  const { isLoading: isDataLoading, data } = useData(accessToken, cacheScope, executeDataLoading, query, type);
+  const { kits, isLoading: isKitsLoading } = useKits(
+    accessToken,
+    cacheScope,
+    executeDataLoading && account === "pro",
+    kitFilter,
+  );
 
   return (
     <Grid

--- a/extensions/fontawesome/src/types/index.ts
+++ b/extensions/fontawesome/src/types/index.ts
@@ -52,14 +52,14 @@ export interface KitIconUpload {
   pathData: string | string[];
 }
 
+export interface KitWithIconUploads extends Kit {
+  iconUploads: KitIconUpload[];
+}
+
 export interface KitIconsResult {
   data: {
     me: {
-      kits: {
-        name: string;
-        token: string;
-        iconUploads: KitIconUpload[];
-      }[];
+      kits: KitWithIconUploads[];
     };
   };
 }

--- a/extensions/fontawesome/src/types/index.ts
+++ b/extensions/fontawesome/src/types/index.ts
@@ -28,7 +28,6 @@ export interface TokenData {
 
 // Kits metadata returned from the Font Awesome GraphQL API
 export interface Kit {
-  id: string;
   name: string;
   token: string;
 }
@@ -57,7 +56,6 @@ export interface KitIconsResult {
   data: {
     me: {
       kits: {
-        id: string;
         name: string;
         token: string;
         iconUploads: KitIconUpload[];

--- a/extensions/fontawesome/src/utils/access-token.ts
+++ b/extensions/fontawesome/src/utils/access-token.ts
@@ -1,0 +1,34 @@
+import { createHash } from "node:crypto";
+
+type RefreshAccessTokenOptions = {
+  accessToken: string;
+  tokenTimeStart?: number;
+  now?: number;
+  ttlMs?: number;
+};
+
+export function getApiTokenFingerprint(apiToken: string) {
+  return createHash("sha256").update(apiToken).digest("hex");
+}
+
+export function buildScopedCacheKey(baseKey: string, scope: string, suffix?: string) {
+  return [baseKey, scope, suffix].filter(Boolean).join(":");
+}
+
+export function getAccessTokenStorageKeys(apiToken: string) {
+  const tokenFingerprint = getApiTokenFingerprint(apiToken);
+  return {
+    tokenFingerprint,
+    accessTokenKey: buildScopedCacheKey("accessToken", tokenFingerprint),
+    expiryKey: buildScopedCacheKey("token-expiry-start", tokenFingerprint),
+  };
+}
+
+export function shouldRefreshAccessToken({
+  accessToken,
+  tokenTimeStart,
+  now = Date.now(),
+  ttlMs = 3_600_000,
+}: RefreshAccessTokenOptions) {
+  return !accessToken || !tokenTimeStart || now - tokenTimeStart >= ttlMs;
+}

--- a/extensions/fontawesome/src/utils/kits.ts
+++ b/extensions/fontawesome/src/utils/kits.ts
@@ -1,0 +1,29 @@
+import type { Kit } from "@/types";
+
+export function filterKits(kits: Kit[], kitFilter?: string) {
+  const trimmedFilter = kitFilter?.trim();
+
+  if (!trimmedFilter || kits.length === 0) {
+    return kits;
+  }
+
+  const tokensOrNames = trimmedFilter
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => value.toLowerCase());
+
+  if (tokensOrNames.length === 0) {
+    return kits;
+  }
+
+  return kits.filter((kit) => {
+    const nameLower = kit.name.toLowerCase();
+    const tokenLower = kit.token.toLowerCase();
+    return tokensOrNames.some((value) => value === tokenLower || value === nameLower);
+  });
+}
+
+export function findKitByToken(kits: Kit[], kitToken: string) {
+  return kits.find((kit) => kit.token === kitToken);
+}

--- a/extensions/fontawesome/src/utils/kits.ts
+++ b/extensions/fontawesome/src/utils/kits.ts
@@ -24,6 +24,6 @@ export function filterKits(kits: Kit[], kitFilter?: string) {
   });
 }
 
-export function findKitByToken(kits: Kit[], kitToken: string) {
+export function findKitByToken<T extends Kit>(kits: T[], kitToken: string) {
   return kits.find((kit) => kit.token === kitToken);
 }

--- a/extensions/fontawesome/tests/access-token.test.ts
+++ b/extensions/fontawesome/tests/access-token.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildScopedCacheKey,
+  getAccessTokenStorageKeys,
+  shouldRefreshAccessToken,
+} from "../src/utils/access-token.ts";
+
+test("creates distinct storage keys for different API tokens", () => {
+  const freeKeys = getAccessTokenStorageKeys("free-token");
+  const proKeys = getAccessTokenStorageKeys("pro-token");
+
+  assert.notEqual(freeKeys.accessTokenKey, proKeys.accessTokenKey);
+  assert.notEqual(freeKeys.expiryKey, proKeys.expiryKey);
+});
+
+test("does not refresh an unexpired cached access token", () => {
+  assert.equal(
+    shouldRefreshAccessToken({
+      accessToken: "cached-access-token",
+      tokenTimeStart: 1_700_000_000_000,
+      now: 1_700_000_100_000,
+      ttlMs: 3_600_000,
+    }),
+    false,
+  );
+});
+
+test("refreshes when there is no cached access token for the selected API token", () => {
+  assert.equal(
+    shouldRefreshAccessToken({
+      accessToken: "",
+      tokenTimeStart: undefined,
+      now: 1_700_000_100_000,
+      ttlMs: 3_600_000,
+    }),
+    true,
+  );
+});
+
+test("buildScopedCacheKey keeps scopes stable and readable", () => {
+  assert.equal(buildScopedCacheKey("iconData", "token-a"), "iconData:token-a");
+  assert.equal(buildScopedCacheKey("iconData", "token-a", "far"), "iconData:token-a:far");
+});

--- a/extensions/fontawesome/tests/kits.test.ts
+++ b/extensions/fontawesome/tests/kits.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { filterKits, findKitByToken } from "../src/utils/kits.ts";
+
+test("filters kits by token or exact name without relying on an id field", () => {
+  const kits = [
+    { name: "Combined Kit", token: "combined-kit" },
+    { name: "Breville Sage Icons", token: "breville-icons" },
+  ];
+
+  assert.deepEqual(filterKits(kits, "combined-kit"), [{ name: "Combined Kit", token: "combined-kit" }]);
+  assert.deepEqual(filterKits(kits, "Breville Sage Icons"), [{ name: "Breville Sage Icons", token: "breville-icons" }]);
+});
+
+test("findKitByToken resolves kits using the schema-backed token field", () => {
+  const kits = [
+    { name: "Combined Kit", token: "combined-kit" },
+    { name: "Breville Sage Icons", token: "breville-icons" },
+  ];
+
+  assert.deepEqual(findKitByToken(kits, "breville-icons"), { name: "Breville Sage Icons", token: "breville-icons" });
+  assert.equal(findKitByToken(kits, "missing-kit"), undefined);
+});


### PR DESCRIPTION
## Description

This PR fixes two related issues in the Font Awesome Raycast extension:

- Pro-only icons were not being searched correctly after adding a Pro API token. https://github.com/raycast/extensions/issues/26096#issuecomment-4013620785
- Custom kits were not loading reliably.

The main cause was stale cached auth/data from a previously used token, combined with kit handling that relied on a field the Font Awesome API does not actually return.

### What Changed
- Scoped cached access tokens and expiry timestamps to the active API token.
- Scoped cached icon results and kit results to the active token and selection.
- Updated custom kit handling to use the kit token consistently instead of a nonexistent id.
- Added focused tests for token cache invalidation and kit lookup/filtering.

## Screencast

https://github.com/user-attachments/assets/bd03feef-0817-4109-acf4-1e11f1d5646e

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
