### PR TITLE
Plexamp: Album grid view, recently played, library cache

### DIFF
--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plexamp CHANGELOG
 
-## [Large Library Performance Fixes] - 2026-03-25
+## [Large Library Performance Fixes] - {PR_MERGE_DATE}
 
 - Fixed "JS heap out of memory" crashes when browsing large music libraries by paginating all Plex API requests so no single XML response can exceed the Raycast worker memory limit.
 - Fixed playlist section resolution causing excessive memory usage by removing the N+1 metadata lookup per playlist and filtering by the explicit library section key instead.

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Plexamp CHANGELOG
 
-## [Recently Played] - {PR_MERGE_DATE}
+## [Recently Played] - 2026-03-26
 
 - Added the `Recently Played` command to browse the 50 most recently played tracks from the selected Plex music library.
 - Recently played data is cached for instant startup on repeat opens.
 
-## [Instant Library Startup Cache] - {PR_MERGE_DATE}
+## [Instant Library Startup Cache] - 2026-03-26
 
 - Added stale-while-revalidate caching for the Browse Library artist and playlist lists using Raycast's Cache API, so repeat opens show content instantly while refreshing in the background.
 - Cached data is preserved on reload and on transient server errors instead of resetting to an empty list.
 
-## [Album Grid View] - {PR_MERGE_DATE}
+## [Album Grid View] - 2026-03-26
 
 - Added a toggleable Grid view for artist album pages showing album art in a square grid with release year subtitles.
 - Added release type grouping in Grid view: albums are organized into sections (Albums, EPs, Singles, Compilations, Live, Demos, Remixes) sorted by release year descending.

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Plexamp CHANGELOG
 
+## [Album Grid View] - 2026-03-26
+
+- Added a toggleable Grid view for artist album pages showing album art in a square grid with release year subtitles.
+- Added release type grouping in Grid view: albums are organized into sections (Albums, EPs, Singles, Compilations, Live, Demos, Remixes) sorted by release year descending.
+- Added Grid/List toggle action (`Cmd+Shift+V`) with the preference persisted across sessions.
+- Added the `Album View Grid Columns` extension preference to configure grid columns (3-6, default 4).
+
 ## [Large Library Performance Fixes] - 2026-03-25
 
 - Fixed "JS heap out of memory" crashes when browsing large music libraries by paginating all Plex API requests so no single XML response can exceed the Raycast worker memory limit.

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plexamp CHANGELOG
 
-## [Album Grid View] - 2026-03-26
+## [Album Grid View] - {PR_MERGE_DATE}
 
 - Added a toggleable Grid view for artist album pages showing album art in a square grid with release year subtitles.
 - Added release type grouping in Grid view: albums are organized into sections (Albums, EPs, Singles, Compilations, Live, Demos, Remixes) sorted by release year descending.

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Plexamp CHANGELOG
 
+## [Instant Library Startup Cache] - {PR_MERGE_DATE}
+
+- Added stale-while-revalidate caching for the Browse Library artist and playlist lists using Raycast's Cache API, so repeat opens show content instantly while refreshing in the background.
+- Cached data is preserved on reload and on transient server errors instead of resetting to an empty list.
+
 ## [Album Grid View] - {PR_MERGE_DATE}
 
 - Added a toggleable Grid view for artist album pages showing album art in a square grid with release year subtitles.

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Plexamp CHANGELOG
 
+## [Recently Played] - {PR_MERGE_DATE}
+
+- Added the `Recently Played` command to browse the 50 most recently played tracks from the selected Plex music library.
+- Recently played data is cached for instant startup on repeat opens.
+
 ## [Instant Library Startup Cache] - {PR_MERGE_DATE}
 
 - Added stale-while-revalidate caching for the Browse Library artist and playlist lists using Raycast's Cache API, so repeat opens show content instantly while refreshing in the background.

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plexamp CHANGELOG
 
-## [Large Library Performance Fixes] - {PR_MERGE_DATE}
+## [Large Library Performance Fixes] - 2026-03-25
 
 - Fixed "JS heap out of memory" crashes when browsing large music libraries by paginating all Plex API requests so no single XML response can exceed the Raycast worker memory limit.
 - Fixed playlist section resolution causing excessive memory usage by removing the N+1 metadata lookup per playlist and filtering by the explicit library section key instead.

--- a/extensions/plexamp/README.md
+++ b/extensions/plexamp/README.md
@@ -24,7 +24,6 @@ Raycast extension for browsing Plex music libraries and controlling a Plexamp pl
 - Sign in with Plex from Raycast using a managed Plex auth flow.
 - Browse artists, grouped artist releases, library-scoped playlists, and album track lists from the selected Plex music library.
 - Toggle between list and grid view for artist albums (`Cmd+Shift+V`), with albums grouped by release type (Albums, EPs, Singles, Compilations, etc.) and sorted by release year in grid view. Grid column count is configurable in extension preferences.
-- Browse recently played tracks sorted by last played time, with cached startup for instant repeat opens.
 - Search the library the way Plex does, with grouped results for artists, albums, and songs.
 - Play immediately in Plexamp, add to queue, or insert as play next from browse and search results.
 - Inspect the active Plexamp queue and use transport controls from Raycast in `Now Playing`.

--- a/extensions/plexamp/README.md
+++ b/extensions/plexamp/README.md
@@ -6,6 +6,7 @@ Raycast extension for browsing Plex music libraries and controlling a Plexamp pl
 
 - `Browse Library`: browse the selected Plex music library, artists, albums, playlists, and queue tracks or entire albums in Plexamp
 - `Search Library`: quickly search artists, albums, and tracks and play/queue them in Plexamp
+- `Recently Played`: browse the most recently played tracks from the selected Plex music library
 - `Now Playing`: see what's playing, control the transport and adjust the queue
 - `Now Playing Menubar`: show the current album art and a customizable now playing label in the macOS menu bar
 - `Plexamp Status`: inspect the connected Plexamp client and selected Plex music library
@@ -22,6 +23,8 @@ Raycast extension for browsing Plex music libraries and controlling a Plexamp pl
 
 - Sign in with Plex from Raycast using a managed Plex auth flow.
 - Browse artists, grouped artist releases, library-scoped playlists, and album track lists from the selected Plex music library.
+- Toggle between list and grid view for artist albums (`Cmd+Shift+V`), with albums grouped by release type (Albums, EPs, Singles, Compilations, etc.) and sorted by release year in grid view. Grid column count is configurable in extension preferences.
+- Browse recently played tracks sorted by last played time, with cached startup for instant repeat opens.
 - Search the library the way Plex does, with grouped results for artists, albums, and songs.
 - Play immediately in Plexamp, add to queue, or insert as play next from browse and search results.
 - Inspect the active Plexamp queue and use transport controls from Raycast in `Now Playing`.

--- a/extensions/plexamp/package.json
+++ b/extensions/plexamp/package.json
@@ -59,6 +59,13 @@
       "subtitle": "Plexamp",
       "description": "Search songs, albums, and artists in the selected Plex music library.",
       "mode": "view"
+    },
+    {
+      "name": "recently-played",
+      "title": "Recently Played",
+      "subtitle": "Plexamp",
+      "description": "Browse recently played tracks from the selected Plex music library.",
+      "mode": "view"
     }
   ],
   "preferences": [

--- a/extensions/plexamp/package.json
+++ b/extensions/plexamp/package.json
@@ -94,6 +94,20 @@
       ]
     },
     {
+      "name": "gridColumns",
+      "type": "dropdown",
+      "required": false,
+      "title": "Album View Grid Columns",
+      "default": "4",
+      "description": "Number of columns in album grid view.",
+      "data": [
+        { "title": "3", "value": "3" },
+        { "title": "4", "value": "4" },
+        { "title": "5", "value": "5" },
+        { "title": "6", "value": "6" }
+      ]
+    },
+    {
       "name": "menuBarFormat",
       "type": "textfield",
       "required": false,

--- a/extensions/plexamp/src/browse-media.tsx
+++ b/extensions/plexamp/src/browse-media.tsx
@@ -502,7 +502,11 @@ const SCOPED_SEARCH_TRACK_LIMIT = 1000;
 // ---------------------------------------------------------------------------
 
 export function AlbumTrackList(props: { album: MusicAlbum; sectionKey: string }) {
-  const tracks = useAsyncValue(() => getTracksForAlbum(props.album), props.album.ratingKey, [] as MusicTrack[]);
+  const tracks = useAsyncValue(
+    () => getTracksForAlbum(props.album),
+    props.album.ratingKey,
+    [] as MusicTrack[],
+  );
   const playback = usePlaybackActions();
 
   return (
@@ -565,10 +569,11 @@ function LargePlaylistTrackList(props: { playlist: AudioPlaylist; sectionKey: st
     isLoading: tracksLoading,
     pagination,
   } = usePromise(
-    (browseKey: string) => async (options: { page: number }) => {
-      const { items, totalSize } = await getTracksPage(browseKey, options.page * TRACKS_PAGE_SIZE, TRACKS_PAGE_SIZE);
-      return { data: items, hasMore: options.page * TRACKS_PAGE_SIZE + items.length < totalSize };
-    },
+    (browseKey: string) =>
+      async (options: { page: number }) => {
+        const { items, totalSize } = await getTracksPage(browseKey, options.page * TRACKS_PAGE_SIZE, TRACKS_PAGE_SIZE);
+        return { data: items, hasMore: options.page * TRACKS_PAGE_SIZE + items.length < totalSize };
+      },
     [props.playlist.browseKey],
   );
 

--- a/extensions/plexamp/src/browse-media.tsx
+++ b/extensions/plexamp/src/browse-media.tsx
@@ -375,11 +375,13 @@ function RootContent() {
     () => (selectedLibrary ? getArtists(selectedLibrary.key) : Promise.resolve([])),
     selectedLibrary?.key ?? "no-library",
     [] as MusicArtist[],
+    selectedLibrary ? `artists-${selectedLibrary.key}` : undefined,
   );
   const playlists = useAsyncValue(
     () => (selectedLibrary ? getAudioPlaylists(selectedLibrary.key) : Promise.resolve([])),
     `playlists-${selectedLibrary?.key ?? "no-library"}`,
     [] as AudioPlaylist[],
+    selectedLibrary ? `playlists-${selectedLibrary.key}` : undefined,
   );
   const playback = usePlaybackActions();
 

--- a/extensions/plexamp/src/browse-media.tsx
+++ b/extensions/plexamp/src/browse-media.tsx
@@ -502,11 +502,7 @@ const SCOPED_SEARCH_TRACK_LIMIT = 1000;
 // ---------------------------------------------------------------------------
 
 export function AlbumTrackList(props: { album: MusicAlbum; sectionKey: string }) {
-  const tracks = useAsyncValue(
-    () => getTracksForAlbum(props.album),
-    props.album.ratingKey,
-    [] as MusicTrack[],
-  );
+  const tracks = useAsyncValue(() => getTracksForAlbum(props.album), props.album.ratingKey, [] as MusicTrack[]);
   const playback = usePlaybackActions();
 
   return (
@@ -569,11 +565,10 @@ function LargePlaylistTrackList(props: { playlist: AudioPlaylist; sectionKey: st
     isLoading: tracksLoading,
     pagination,
   } = usePromise(
-    (browseKey: string) =>
-      async (options: { page: number }) => {
-        const { items, totalSize } = await getTracksPage(browseKey, options.page * TRACKS_PAGE_SIZE, TRACKS_PAGE_SIZE);
-        return { data: items, hasMore: options.page * TRACKS_PAGE_SIZE + items.length < totalSize };
-      },
+    (browseKey: string) => async (options: { page: number }) => {
+      const { items, totalSize } = await getTracksPage(browseKey, options.page * TRACKS_PAGE_SIZE, TRACKS_PAGE_SIZE);
+      return { data: items, hasMore: options.page * TRACKS_PAGE_SIZE + items.length < totalSize };
+    },
     [props.playlist.browseKey],
   );
 

--- a/extensions/plexamp/src/browse-media.tsx
+++ b/extensions/plexamp/src/browse-media.tsx
@@ -612,7 +612,7 @@ export function AlbumList(props: { artist: MusicArtist; sectionKey: string }) {
 
   if (viewMode === "grid") {
     const groups = groupAlbumsByReleaseType(albums.value);
-    const gridColumns = Number(getPreferenceValues<{ gridColumns?: string }>().gridColumns) || 4;
+    const gridColumns = Number(getPreferenceValues<Preferences>().gridColumns) || 4;
 
     return (
       <Grid

--- a/extensions/plexamp/src/browse-media.tsx
+++ b/extensions/plexamp/src/browse-media.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Icon, LaunchProps, List } from "@raycast/api";
+import { Action, ActionPanel, getPreferenceValues, Grid, Icon, LaunchProps, List, LocalStorage } from "@raycast/api";
 import { useNavigation } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -141,6 +141,8 @@ function ArtistRow(props: {
 function AlbumRow(props: {
   album: MusicAlbum;
   sectionKey: string;
+  viewMode?: "list" | "grid";
+  onToggleView?: () => void;
   onPlay: (item: PlayableItem) => Promise<void>;
   onPlayNext: (item: PlayableItem) => Promise<void>;
   onQueue: (item: PlayableItem) => Promise<void>;
@@ -161,6 +163,9 @@ function AlbumRow(props: {
             icon={Icon.ArrowRight}
             onAction={() => push(<AlbumTrackList album={props.album} sectionKey={props.sectionKey} />)}
           />
+          {props.viewMode && props.onToggleView && (
+            <ToggleViewAction viewMode={props.viewMode} onToggle={props.onToggleView} />
+          )}
           <PlaybackActionItems
             item={props.album}
             onPlay={props.onPlay}
@@ -440,8 +445,121 @@ function RootContent() {
 }
 
 // ---------------------------------------------------------------------------
-// AlbumList: paginated albums for an artist, server-side search
+// AlbumList: albums for an artist, toggleable between list and grid view
 // ---------------------------------------------------------------------------
+
+const ALBUM_VIEW_MODE_KEY = "albumViewMode";
+
+const RELEASE_TYPE_ORDER: Record<string, number> = {
+  album: 0,
+  ep: 1,
+  single: 2,
+  compilation: 3,
+  live: 4,
+  demo: 5,
+  remix: 6,
+};
+
+const RELEASE_TYPE_LABELS: Record<string, string> = {
+  album: "Albums",
+  ep: "EPs",
+  single: "Singles",
+  compilation: "Compilations",
+  live: "Live Albums",
+  demo: "Demos",
+  remix: "Remixes",
+};
+
+function groupAlbumsByReleaseType(albums: MusicAlbum[]): { type: string; label: string; albums: MusicAlbum[] }[] {
+  const groups = new Map<string, MusicAlbum[]>();
+  for (const album of albums) {
+    const type = (album.releaseType ?? "album").toLowerCase();
+    const existing = groups.get(type);
+    if (existing) {
+      existing.push(album);
+    } else {
+      groups.set(type, [album]);
+    }
+  }
+
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => (RELEASE_TYPE_ORDER[a] ?? 99) - (RELEASE_TYPE_ORDER[b] ?? 99))
+    .map(([type, items]) => ({
+      type,
+      label: RELEASE_TYPE_LABELS[type] ?? type.charAt(0).toUpperCase() + type.slice(1) + "s",
+      albums: items.sort((a, b) => (b.year ?? 0) - (a.year ?? 0)),
+    }));
+}
+
+function useAlbumViewMode() {
+  const [viewMode, setViewMode] = useState<"list" | "grid">("list");
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    LocalStorage.getItem<string>(ALBUM_VIEW_MODE_KEY).then((stored) => {
+      if (stored === "grid" || stored === "list") setViewMode(stored);
+      setIsLoaded(true);
+    });
+  }, []);
+
+  const toggleViewMode = useCallback(() => {
+    const next = viewMode === "list" ? "grid" : "list";
+    setViewMode(next);
+    LocalStorage.setItem(ALBUM_VIEW_MODE_KEY, next);
+  }, [viewMode]);
+
+  return { viewMode, toggleViewMode, isLoaded };
+}
+
+function ToggleViewAction(props: { viewMode: "list" | "grid"; onToggle: () => void }) {
+  return (
+    <Action
+      title={props.viewMode === "list" ? "Switch to Grid View" : "Switch to List View"}
+      icon={props.viewMode === "list" ? Icon.AppWindowGrid3x3 : Icon.AppWindowList}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "v" }}
+      onAction={props.onToggle}
+    />
+  );
+}
+
+function AlbumGridItem(props: {
+  album: MusicAlbum;
+  sectionKey: string;
+  viewMode: "list" | "grid";
+  onToggleView: () => void;
+  onPlay: (item: PlayableItem) => Promise<void>;
+  onPlayNext: (item: PlayableItem) => Promise<void>;
+  onQueue: (item: PlayableItem) => Promise<void>;
+}) {
+  const { push } = useNavigation();
+
+  return (
+    <Grid.Item
+      key={props.album.ratingKey}
+      content={artworkSource(props.album.thumb)}
+      title={props.album.title}
+      subtitle={props.album.year?.toString()}
+      keywords={[props.album.parentTitle, props.album.year?.toString()].filter(Boolean) as string[]}
+      actions={
+        <ActionPanel>
+          <Action
+            title="Browse Tracks"
+            icon={Icon.ArrowRight}
+            onAction={() => push(<AlbumTrackList album={props.album} sectionKey={props.sectionKey} />)}
+          />
+          <ToggleViewAction viewMode={props.viewMode} onToggle={props.onToggleView} />
+          <PlaybackActionItems
+            item={props.album}
+            onPlay={props.onPlay}
+            onPlayNext={props.onPlayNext}
+            onQueue={props.onQueue}
+            nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
 
 export function AlbumList(props: { artist: MusicArtist; sectionKey: string }) {
   const albums = useAsyncValue(
@@ -450,37 +568,95 @@ export function AlbumList(props: { artist: MusicArtist; sectionKey: string }) {
     [] as MusicAlbum[],
   );
   const playback = usePlaybackActions();
+  const { viewMode, toggleViewMode, isLoaded } = useAlbumViewMode();
+
+  const isLoading = !isLoaded || albums.isLoading || playback.isPerforming;
+
+  const errorView = albums.error ? (
+    viewMode === "list" ? (
+      <List.EmptyView
+        icon={Icon.ExclamationMark}
+        title="Unable to load albums"
+        description={albums.error}
+        actions={
+          <ActionPanel>
+            <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
+            <PreferencesAction />
+          </ActionPanel>
+        }
+      />
+    ) : (
+      <Grid.EmptyView
+        icon={Icon.ExclamationMark}
+        title="Unable to load albums"
+        description={albums.error}
+        actions={
+          <ActionPanel>
+            <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
+            <PreferencesAction />
+          </ActionPanel>
+        }
+      />
+    )
+  ) : null;
+
+  const defaultActions = (
+    <ActionPanel>
+      <ToggleViewAction viewMode={viewMode} onToggle={toggleViewMode} />
+      <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
+      <PreferencesAction />
+    </ActionPanel>
+  );
+
+  if (viewMode === "grid") {
+    const groups = groupAlbumsByReleaseType(albums.value);
+    const gridColumns = Number(getPreferenceValues<{ gridColumns?: string }>().gridColumns) || 4;
+
+    return (
+      <Grid
+        columns={gridColumns}
+        aspectRatio="1"
+        isLoading={isLoading}
+        navigationTitle={props.artist.title}
+        searchBarPlaceholder="Filter albums"
+        actions={defaultActions}
+      >
+        {errorView}
+        {groups.map((group) => (
+          <Grid.Section key={group.type} title={group.label}>
+            {group.albums.map((album) => (
+              <AlbumGridItem
+                key={album.ratingKey}
+                album={album}
+                sectionKey={props.sectionKey}
+                viewMode={viewMode}
+                onToggleView={toggleViewMode}
+                onPlay={playback.play}
+                onPlayNext={playback.playNext}
+                onQueue={playback.queue}
+              />
+            ))}
+          </Grid.Section>
+        ))}
+      </Grid>
+    );
+  }
 
   return (
     <List
-      isLoading={albums.isLoading || playback.isPerforming}
+      isLoading={isLoading}
       navigationTitle={props.artist.title}
       searchBarPlaceholder="Filter albums"
-      actions={
-        <ActionPanel>
-          <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
-          <PreferencesAction />
-        </ActionPanel>
-      }
+      actions={defaultActions}
     >
-      {albums.error ? (
-        <List.EmptyView
-          icon={Icon.ExclamationMark}
-          title="Unable to load albums"
-          description={albums.error}
-          actions={
-            <ActionPanel>
-              <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
-              <PreferencesAction />
-            </ActionPanel>
-          }
-        />
-      ) : null}
+      {errorView}
       {albums.value.map((album) => (
         <AlbumRow
           key={album.ratingKey}
           album={album}
           sectionKey={props.sectionKey}
+          viewMode={viewMode}
+          onToggleView={toggleViewMode}
           onPlay={playback.play}
           onPlayNext={playback.playNext}
           onQueue={playback.queue}

--- a/extensions/plexamp/src/plex-library.ts
+++ b/extensions/plexamp/src/plex-library.ts
@@ -357,6 +357,17 @@ export async function getAlbumsForArtist(sectionKey: string, artist: MusicArtist
   return hydrateAlbums(albums);
 }
 
+export async function getRecentlyPlayed(sectionKey: string, limit = 50): Promise<MusicTrack[]> {
+  const result = await fetchPage(
+    `/library/sections/${sectionKey}/all?type=10&sort=lastViewedAt:desc`,
+    "Track",
+    parseTrack,
+    0,
+    limit,
+  );
+  return result.items;
+}
+
 export async function getTracksForAlbum(album: MusicAlbum): Promise<MusicTrack[]> {
   return fetchAllPaginated(album.browseKey, "Track", parseTrack, 100);
 }

--- a/extensions/plexamp/src/plex-library.ts
+++ b/extensions/plexamp/src/plex-library.ts
@@ -277,7 +277,11 @@ export async function getArtists(sectionKey: string): Promise<MusicArtist[]> {
   );
 }
 
-export function getArtistsPage(sectionKey: string, offset: number, limit: number): Promise<PageResult<MusicArtist>> {
+export function getArtistsPage(
+  sectionKey: string,
+  offset: number,
+  limit: number,
+): Promise<PageResult<MusicArtist>> {
   return fetchPage(
     `/library/sections/${sectionKey}/all?type=8&sort=titleSort:asc`,
     "Directory",
@@ -287,7 +291,11 @@ export function getArtistsPage(sectionKey: string, offset: number, limit: number
   );
 }
 
-export function getTracksPage(browseKey: string, offset: number, limit: number): Promise<PageResult<MusicTrack>> {
+export function getTracksPage(
+  browseKey: string,
+  offset: number,
+  limit: number,
+): Promise<PageResult<MusicTrack>> {
   return fetchPage(browseKey, "Track", parseTrack, offset, limit);
 }
 

--- a/extensions/plexamp/src/plex-library.ts
+++ b/extensions/plexamp/src/plex-library.ts
@@ -277,11 +277,7 @@ export async function getArtists(sectionKey: string): Promise<MusicArtist[]> {
   );
 }
 
-export function getArtistsPage(
-  sectionKey: string,
-  offset: number,
-  limit: number,
-): Promise<PageResult<MusicArtist>> {
+export function getArtistsPage(sectionKey: string, offset: number, limit: number): Promise<PageResult<MusicArtist>> {
   return fetchPage(
     `/library/sections/${sectionKey}/all?type=8&sort=titleSort:asc`,
     "Directory",
@@ -291,11 +287,7 @@ export function getArtistsPage(
   );
 }
 
-export function getTracksPage(
-  browseKey: string,
-  offset: number,
-  limit: number,
-): Promise<PageResult<MusicTrack>> {
+export function getTracksPage(browseKey: string, offset: number, limit: number): Promise<PageResult<MusicTrack>> {
   return fetchPage(browseKey, "Track", parseTrack, offset, limit);
 }
 

--- a/extensions/plexamp/src/plex.ts
+++ b/extensions/plexamp/src/plex.ts
@@ -12,6 +12,7 @@ export {
   getAlbumsForArtist,
   getAlbumsForArtistPage,
   getArtists,
+  getRecentlyPlayed,
   getArtistsPage,
   getAudioPlaylists,
   getLibraryStats,

--- a/extensions/plexamp/src/recently-played.tsx
+++ b/extensions/plexamp/src/recently-played.tsx
@@ -1,0 +1,120 @@
+import { ActionPanel, Icon, List } from "@raycast/api";
+
+import { formatTrackDisplayTitle, getTrackRatingDisplayMode } from "./format";
+import { getRecentlyPlayed } from "./plex";
+import {
+  NowPlayingAction,
+  PlaybackActionItems,
+  PreferencesAction,
+  artworkSource,
+  trackAccessories,
+  usePlaybackActions,
+} from "./shared-ui";
+import { PlexSetupView } from "./plex-setup-view";
+import { useAsyncValue } from "./use-async-value";
+import { useLibrarySelection } from "./use-library-selection";
+import type { MusicTrack, PlayableItem } from "./types";
+
+function RecentTrackRow(props: {
+  track: MusicTrack;
+  onPlay: (item: PlayableItem) => Promise<void>;
+  onPlayNext: (item: PlayableItem) => Promise<void>;
+  onQueue: (item: PlayableItem) => Promise<void>;
+}) {
+  const ratingDisplayMode = getTrackRatingDisplayMode();
+
+  return (
+    <List.Item
+      key={props.track.ratingKey}
+      icon={artworkSource(props.track.thumb)}
+      title={formatTrackDisplayTitle(props.track.title, {
+        userRating: props.track.userRating,
+        displayMode: ratingDisplayMode,
+      })}
+      subtitle={[props.track.grandparentTitle, props.track.parentTitle].filter(Boolean).join(" — ")}
+      accessories={trackAccessories(props.track)}
+      actions={
+        <ActionPanel>
+          <PlaybackActionItems
+            item={props.track}
+            onPlay={props.onPlay}
+            onPlayNext={props.onPlayNext}
+            onQueue={props.onQueue}
+            nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+export default function Command() {
+  const libraries = useLibrarySelection();
+  const selectedLibrary = libraries.selectedLibrary;
+
+  const tracks = useAsyncValue(
+    () => (selectedLibrary ? getRecentlyPlayed(selectedLibrary.key) : Promise.resolve([])),
+    selectedLibrary?.key ?? "no-library",
+    [] as MusicTrack[],
+    selectedLibrary ? `recently-played-${selectedLibrary.key}` : undefined,
+  );
+  const playback = usePlaybackActions();
+
+  const isLoading = libraries.isLoading || tracks.isLoading || playback.isPerforming;
+
+  if (libraries.isLoading) {
+    return <List isLoading navigationTitle="Recently Played" />;
+  }
+
+  if (libraries.error || !selectedLibrary) {
+    return (
+      <PlexSetupView
+        navigationTitle="Recently Played"
+        problem={libraries.error}
+        onConfigured={() => {
+          void libraries.reload();
+        }}
+      />
+    );
+  }
+
+  return (
+    <List
+      isLoading={isLoading}
+      navigationTitle="Recently Played"
+      searchBarPlaceholder="Filter recently played"
+      actions={
+        <ActionPanel>
+          <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
+          <PreferencesAction />
+        </ActionPanel>
+      }
+    >
+      {tracks.error ? (
+        <List.EmptyView
+          icon={Icon.ExclamationMark}
+          title="Unable to load recently played"
+          description={tracks.error}
+          actions={
+            <ActionPanel>
+              <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
+              <PreferencesAction />
+            </ActionPanel>
+          }
+        />
+      ) : null}
+      {!tracks.isLoading && tracks.value.length === 0 && !tracks.error ? (
+        <List.EmptyView icon={Icon.Clock} title="No recently played tracks" description="Play some music to see your history here." />
+      ) : null}
+      {tracks.value.map((track) => (
+        <RecentTrackRow
+          key={track.ratingKey}
+          track={track}
+          onPlay={playback.play}
+          onPlayNext={playback.playNext}
+          onQueue={playback.queue}
+        />
+      ))}
+    </List>
+  );
+}

--- a/extensions/plexamp/src/recently-played.tsx
+++ b/extensions/plexamp/src/recently-played.tsx
@@ -104,7 +104,11 @@ export default function Command() {
         />
       ) : null}
       {!tracks.isLoading && tracks.value.length === 0 && !tracks.error ? (
-        <List.EmptyView icon={Icon.Clock} title="No recently played tracks" description="Play some music to see your history here." />
+        <List.EmptyView
+          icon={Icon.Clock}
+          title="No recently played tracks"
+          description="Play some music to see your history here."
+        />
       ) : null}
       {tracks.value.map((track) => (
         <RecentTrackRow

--- a/extensions/plexamp/src/use-async-value.ts
+++ b/extensions/plexamp/src/use-async-value.ts
@@ -1,4 +1,25 @@
+import { Cache } from "@raycast/api";
 import { useCallback, useEffect, useRef, useState } from "react";
+
+const cache = new Cache();
+
+function readCache<T>(key: string): T | undefined {
+  const raw = cache.get(key);
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeCache<T>(key: string, value: T): void {
+  try {
+    cache.set(key, JSON.stringify(value));
+  } catch {
+    // Cache write failures are non-critical
+  }
+}
 
 interface AsyncValueState<T> {
   isLoading: boolean;
@@ -6,32 +27,47 @@ interface AsyncValueState<T> {
   error?: string;
 }
 
-export function useAsyncValue<T>(loader: () => Promise<T>, dependencyKey: string, initialValue: T) {
+export function useAsyncValue<T>(
+  loader: () => Promise<T>,
+  dependencyKey: string,
+  initialValue: T,
+  cacheKey?: string,
+) {
+  const cached = cacheKey ? readCache<T>(cacheKey) : undefined;
+
   const [state, setState] = useState<AsyncValueState<T>>({
     isLoading: true,
-    value: initialValue,
+    value: cached ?? initialValue,
   });
   const loaderRef = useRef(loader);
   const initialValueRef = useRef(initialValue);
+  const cacheKeyRef = useRef(cacheKey);
   const requestIdRef = useRef(0);
 
   loaderRef.current = loader;
   initialValueRef.current = initialValue;
+  cacheKeyRef.current = cacheKey;
 
   const reload = useCallback(async () => {
     const requestId = ++requestIdRef.current;
+    const currentCacheKey = cacheKeyRef.current;
 
-    setState({
+    // When we have cached data, keep showing it (don't reset to initialValue)
+    setState((prev) => ({
       isLoading: true,
-      value: initialValueRef.current,
+      value: prev.value === initialValueRef.current && currentCacheKey ? (readCache<T>(currentCacheKey) ?? prev.value) : prev.value,
       error: undefined,
-    });
+    }));
 
     try {
       const value = await loaderRef.current();
 
       if (requestId !== requestIdRef.current) {
         return;
+      }
+
+      if (currentCacheKey) {
+        writeCache(currentCacheKey, value);
       }
 
       setState({
@@ -43,9 +79,12 @@ export function useAsyncValue<T>(loader: () => Promise<T>, dependencyKey: string
         return;
       }
 
+      // On error, keep cached data if available instead of falling back to empty
+      const fallback = currentCacheKey ? (readCache<T>(currentCacheKey) ?? initialValueRef.current) : initialValueRef.current;
+
       setState({
         isLoading: false,
-        value: initialValueRef.current,
+        value: fallback,
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/extensions/plexamp/src/use-async-value.ts
+++ b/extensions/plexamp/src/use-async-value.ts
@@ -27,12 +27,7 @@ interface AsyncValueState<T> {
   error?: string;
 }
 
-export function useAsyncValue<T>(
-  loader: () => Promise<T>,
-  dependencyKey: string,
-  initialValue: T,
-  cacheKey?: string,
-) {
+export function useAsyncValue<T>(loader: () => Promise<T>, dependencyKey: string, initialValue: T, cacheKey?: string) {
   const cached = cacheKey ? readCache<T>(cacheKey) : undefined;
 
   const [state, setState] = useState<AsyncValueState<T>>({
@@ -55,7 +50,10 @@ export function useAsyncValue<T>(
     // When we have cached data, keep showing it (don't reset to initialValue)
     setState((prev) => ({
       isLoading: true,
-      value: prev.value === initialValueRef.current && currentCacheKey ? (readCache<T>(currentCacheKey) ?? prev.value) : prev.value,
+      value:
+        prev.value === initialValueRef.current && currentCacheKey
+          ? (readCache<T>(currentCacheKey) ?? prev.value)
+          : prev.value,
       error: undefined,
     }));
 
@@ -80,7 +78,9 @@ export function useAsyncValue<T>(
       }
 
       // On error, keep cached data if available instead of falling back to empty
-      const fallback = currentCacheKey ? (readCache<T>(currentCacheKey) ?? initialValueRef.current) : initialValueRef.current;
+      const fallback = currentCacheKey
+        ? (readCache<T>(currentCacheKey) ?? initialValueRef.current)
+        : initialValueRef.current;
 
       setState({
         isLoading: false,


### PR DESCRIPTION
## Summary

- **Album grid view**: Added a toggleable Grid/List view (`Cmd+Shift+V`) for artist album pages with album art displayed in a configurable column layout (3-6, default 4). Grid view groups albums by release type (Albums, EPs, Singles, Compilations, etc.) sorted by release year. View preference is persisted across sessions. Added `Album View Grid Columns` extension preference.
- **Recently Played command**: New command showing the 50 most recently played tracks from the selected Plex music library, sorted by last played time.
- **Library cache**: Added stale-while-revalidate caching to Browse Library so artist and playlist lists show instantly from cache on repeat opens while refreshing in the background. Cached data is preserved during reloads and transient server errors.
- **Bug fix**: Pass `sectionKey` in `navigateToAlbum` launch context.

## Test plan

- [ ] Open Browse Library → select an artist → verify albums load in list view
- [ ] Press `Cmd+Shift+V` to toggle to grid view → verify album art grid with release type sections
- [ ] Close and reopen the artist → verify grid preference is remembered
- [ ] Change `Album View Grid Columns` in preferences → verify column count updates
- [ ] Open Browse Library → close → reopen → verify artists load instantly from cache
- [ ] Open Recently Played → verify tracks appear sorted by last played
- [ ] Navigate to an album from Now Playing → verify `sectionKey` is passed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)