### PR TITLE
Update linkinize extension

### DIFF
--- a/extensions/linkinize/CHANGELOG.md
+++ b/extensions/linkinize/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Linkinize Changelog
 
+## [Favicon Fallback] - {PR_MERGE_DATE}
+
+- Added initial letter avatars as fallback for bookmarks with broken or missing favicons
+- Favicon validation results are cached for faster subsequent loads
+
 ## [Update Contributors] - 2026-01-20
 
 - Updated extension metadata (author, contributors, owner)

--- a/extensions/linkinize/CHANGELOG.md
+++ b/extensions/linkinize/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Linkinize Changelog
 
-## [Favicon Fallback] - {PR_MERGE_DATE}
+## [Favicon Fallback] - 2026-07-31
 
 - Added initial letter avatars as fallback for bookmarks with broken or missing favicons
 - Favicon validation results are cached for faster subsequent loads

--- a/extensions/linkinize/package-lock.json
+++ b/extensions/linkinize/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkinize",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkinize",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.1",

--- a/extensions/linkinize/package.json
+++ b/extensions/linkinize/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "linkinize",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "title": "Linkinize",
   "description": "AI Bookmark Manager For Teams",
   "icon": "icon.png",

--- a/extensions/linkinize/src/SearchComponent.tsx
+++ b/extensions/linkinize/src/SearchComponent.tsx
@@ -1,14 +1,147 @@
-import { Action, ActionPanel, List, LaunchType, launchCommand } from "@raycast/api";
+import { Action, ActionPanel, Image, List, LaunchType, launchCommand } from "@raycast/api";
+import axios from "axios";
 import { useEffect, useState } from "react";
 import { Bookmark } from "./interfaces";
-import { authenticationCheck, getCachedBookmarks, performSync, recordInteraction } from "./support";
+import { INVALID_FAVICONS } from "./constants";
+import { authenticationCheck, cache, getCachedBookmarks, performSync, recordInteraction } from "./support";
+
+const AVATAR_COLORS = [
+  "#e54d2e",
+  "#e5484d",
+  "#e93d82",
+  "#d6409f",
+  "#8e4ec6",
+  "#6e56cf",
+  "#3e63dd",
+  "#0090ff",
+  "#00a2c7",
+  "#12a594",
+  "#30a46c",
+  "#978365",
+  "#f76b15",
+  "#e54666",
+  "#5b5bd6",
+];
+
+const FAVICON_TIMEOUT = 3000;
+const FAVICON_MAX_BYTES = 512 * 1024;
+const FAVICON_CONCURRENCY = 8;
+
+const XML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&apos;",
+};
+
+function escapeXml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => XML_ESCAPES[character]);
+}
+
+// Cached failures expire so that an endpoint which later recovers is picked up again.
+// No status is treated as permanent, only as "not worth re-checking for a while".
+const INVALID_FAVICON_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Maps a favicon URL to the time its failure was recorded.
+function getInvalidFavicons(): Map<string, number> {
+  const cached = cache.get(INVALID_FAVICONS);
+  if (!cached) {
+    return new Map();
+  }
+  try {
+    const parsed: unknown = JSON.parse(cached);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return new Map();
+    }
+    const now = Date.now();
+    const entries = Object.entries(parsed as Record<string, unknown>).filter(
+      ([, recordedAt]) => typeof recordedAt === "number" && now - recordedAt < INVALID_FAVICON_TTL_MS,
+    );
+    return new Map(entries as [string, number][]);
+  } catch {
+    return new Map();
+  }
+}
+
+// `invalid` is the already-pruned map from getInvalidFavicons, so expired entries
+// are dropped from the cache on every write.
+function saveInvalidFavicons(invalid: Map<string, number>, faviconUrls: string[]) {
+  if (faviconUrls.length === 0) {
+    return;
+  }
+  const now = Date.now();
+  for (const faviconUrl of faviconUrls) {
+    invalid.set(faviconUrl, now);
+  }
+  cache.set(INVALID_FAVICONS, JSON.stringify(Object.fromEntries(invalid)));
+}
+
+// 4xx statuses that describe a temporary condition rather than a missing favicon.
+const TRANSIENT_STATUSES = new Set([408, 425, 429]);
+
+// "invalid" means the favicon is known to be unusable and worth remembering,
+// "unavailable" means we could not tell this time and should retry on a later launch.
+type FaviconCheck = "valid" | "invalid" | "unavailable";
+
+async function checkFavicon(faviconUrl: string, signal: AbortSignal): Promise<FaviconCheck> {
+  try {
+    const response = await axios.get(faviconUrl, {
+      timeout: FAVICON_TIMEOUT,
+      maxRedirects: 5,
+      maxContentLength: FAVICON_MAX_BYTES,
+      responseType: "arraybuffer",
+      signal,
+    });
+    // Hosts often answer a missing favicon with an HTML error page and a 200 status.
+    const contentType = String(response.headers["content-type"] ?? "");
+    return contentType.startsWith("image/") ? "valid" : "invalid";
+  } catch (error) {
+    const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+    // A 4xx suggests the favicon is genuinely missing, so it is worth remembering
+    // for a while. Timeouts, rate limits, aborts, network errors and 5xx say nothing
+    // about the favicon itself, so they are retried on the next launch.
+    const isMissing = status !== undefined && status >= 400 && status < 500 && !TRANSIENT_STATUSES.has(status);
+    return isMissing ? "invalid" : "unavailable";
+  }
+}
+
+async function mapWithConcurrency<T>(items: T[], limit: number, worker: (item: T) => Promise<void>) {
+  let cursor = 0;
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (cursor < items.length) {
+      await worker(items[cursor++]);
+    }
+  });
+  await Promise.all(runners);
+}
+
+function getRoundedAvatarIcon(name: string): Image.ImageLike {
+  const trimmed = name.trim();
+  // Split by code point so names starting with an emoji keep a valid character.
+  const initial = trimmed.length > 0 ? ([...trimmed][0] as string).toUpperCase() : "?";
+  let charSum = 0;
+  for (let i = 0; i < name.length; i++) charSum += name.charCodeAt(i);
+  const color = AVATAR_COLORS[charSum % AVATAR_COLORS.length];
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100"><rect width="100" height="100" rx="20" fill="${color}"/><text x="50" y="72" text-anchor="middle" font-size="46" font-family="-apple-system,system-ui,sans-serif" font-weight="600" fill="white">${escapeXml(initial)}</text></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+function getBookmarkIcon(bookmark: Bookmark): Image.ImageLike {
+  if (bookmark.favicon) {
+    return { source: bookmark.favicon, mask: Image.Mask.RoundedRectangle };
+  }
+  return getRoundedAvatarIcon(bookmark.name || "?");
+}
 
 export function Search() {
   const [items, setItems] = useState<Bookmark[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    const controller = new AbortController();
     let canceled = false;
+
     const load = async () => {
       const authenticated = await authenticationCheck();
       if (!authenticated) {
@@ -22,14 +155,41 @@ export function Search() {
         await performSync();
         bookmarks = getCachedBookmarks();
       }
-      if (!canceled) {
-        setItems(bookmarks);
-        setIsLoading(false);
+      if (canceled) {
+        return;
       }
+
+      const invalidFavicons = getInvalidFavicons();
+      setItems(bookmarks.map((b) => (b.favicon && invalidFavicons.has(b.favicon) ? { ...b, favicon: "" } : b)));
+      setIsLoading(false);
+
+      // Bookmarks frequently share a host, so validate each distinct favicon once.
+      const pending = [
+        ...new Set(bookmarks.map((b) => b.favicon).filter((favicon) => favicon && !invalidFavicons.has(favicon))),
+      ];
+      const confirmedInvalid: string[] = [];
+
+      await mapWithConcurrency(pending, FAVICON_CONCURRENCY, async (favicon) => {
+        if (canceled) {
+          return;
+        }
+        const result = await checkFavicon(favicon, controller.signal);
+        if (result === "valid" || canceled) {
+          return;
+        }
+        if (result === "invalid") {
+          confirmedInvalid.push(favicon);
+        }
+        setItems((prev) => prev.map((b) => (b.favicon === favicon ? { ...b, favicon: "" } : b)));
+      });
+
+      saveInvalidFavicons(invalidFavicons, confirmedInvalid);
     };
+
     load();
     return () => {
       canceled = true;
+      controller.abort();
     };
   }, []);
 
@@ -58,7 +218,7 @@ export function Search() {
                 <Action.CopyToClipboard title="Copy Link" content={item.url} />
               </ActionPanel>
             }
-            icon={item.favicon}
+            icon={getBookmarkIcon(item)}
             subtitle={item.description}
             title={item.name}
           />

--- a/extensions/linkinize/src/constants.tsx
+++ b/extensions/linkinize/src/constants.tsx
@@ -9,4 +9,5 @@ export const INTERACTIONS = "interactions";
 export const ACTIVE_ORGANIZATION = "active_organization";
 export const ACTIVE_WORKSPACE = "active_workspace";
 export const LINKINIZE_DOMAIN = "https://app.linkinize.com";
+export const INVALID_FAVICONS = "invalid_favicons";
 export const EXTENSION_VERSION = packageJson.version;


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->
Fixes broken or missing bookmark icons in the Linkinize extension.

Previously, bookmarks with an invalid or unavailable favicon URL could display a broken image. This update:

- Validates bookmark favicon URLs in the background
- Displays a generated avatar using the bookmark’s first letter when its favicon is missing or invalid
- Uses a consistent avatar color based on the bookmark name
- Caches invalid favicon URLs to avoid repeating failed requests on subsequent loads
- Bumps the extension version to 0.1.2 and updates the changelog

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
