### PR TITLE
Kitty: Resolve kitten path dynamically

### DIFF
--- a/extensions/kitty/CHANGELOG.md
+++ b/extensions/kitty/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kitty Raycast Extension Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-03-30
 
 ### Fixed
 

--- a/extensions/kitty/CHANGELOG.md
+++ b/extensions/kitty/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Kitty Raycast Extension Changelog
 
-## [Initial Version] - 2026-02-27
+## [1.1.0] - 2026-03-26
+
+### Fixed
+
+- Kitten binary path is no longer hardcoded to `/Applications/kitty.app/Contents/MacOS/kitten`. The extension now auto-detects the binary from PATH, standard macOS locations, and Homebrew paths.
+- Process detection (`pgrep`) now works for Kitty installations outside `/Applications`.
+
+### Added
+
+- New **Kitten Path** preference to manually override the path to the `kitten` binary.
+
+## [Initial Version] - 2026-02-24
 
 - New Kitty Window command
 - New Kitty Tab command

--- a/extensions/kitty/CHANGELOG.md
+++ b/extensions/kitty/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kitty Raycast Extension Changelog
 
-## [1.1.0] - 2026-03-26
+## [1.1.0] - {PR_MERGE_DATE}
 
 ### Fixed
 

--- a/extensions/kitty/CHANGELOG.md
+++ b/extensions/kitty/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kitty Raycast Extension Changelog
 
-## [1.1.0] - {PR_MERGE_DATE}
+## [Update] - {PR_MERGE_DATE}
 
 ### Fixed
 

--- a/extensions/kitty/README.md
+++ b/extensions/kitty/README.md
@@ -61,16 +61,30 @@ Opens the folder currently shown in Finder in a new Kitty window, with its worki
 
 ## Setup
 
-Most commands rely on Kitty's remote control socket. Add the following line to your `kitty.conf`:
+Most commands rely on Kitty's remote control socket. Add the following lines to your `kitty.conf`:
 
 ```
-listen_on unix:/tmp/kitty-socket
+allow_remote_control socket-only
+listen_on unix:/tmp/kitty-socket-{kitty_pid}
 ```
 
 Then restart Kitty. The extension will auto-detect the socket, or you can set a custom path in the extension preferences.
+
+### Kitty installed in a non-standard location
+
+The extension automatically detects the `kitten` binary by searching:
+
+1. Your `PATH` (`which kitten`)
+2. `/Applications/kitty.app/Contents/MacOS/kitten`
+3. `~/Applications/kitty.app/Contents/MacOS/kitten`
+4. `/opt/homebrew/bin/kitten` (Homebrew on Apple Silicon)
+5. `/usr/local/bin/kitten` (Homebrew on Intel)
+
+If none of these match, you can set the path manually in the **Kitten Path** preference.
 
 ## Preferences
 
 | Preference | Description |
 |------------|-------------|
 | **Socket Path** | Path to the Kitty remote control socket. Leave empty to auto-detect `/tmp/kitty-socket-{pid}`. |
+| **Kitten Path** | Path to the `kitten` binary. Leave empty to auto-detect from PATH and standard locations. |

--- a/extensions/kitty/package.json
+++ b/extensions/kitty/package.json
@@ -18,6 +18,14 @@
       "type": "textfield",
       "required": false,
       "default": ""
+    },
+    {
+      "name": "kittenPath",
+      "title": "Kitten Path",
+      "description": "Path to the kitten binary. Leave empty to auto-detect from PATH and standard locations",
+      "type": "textfield",
+      "required": false,
+      "default": ""
     }
   ],
   "commands": [

--- a/extensions/kitty/raycast-env.d.ts
+++ b/extensions/kitty/raycast-env.d.ts
@@ -1,0 +1,45 @@
+/// <reference types="@raycast/api">
+
+/* 🚧 🚧 🚧
+ * This file is auto-generated from the extension's manifest.
+ * Do not modify manually. Instead, update the `package.json` file.
+ * 🚧 🚧 🚧 */
+
+/* eslint-disable @typescript-eslint/ban-types */
+
+type ExtensionPreferences = {
+  /** Socket Path - Path to the Kitty remote control socket. Leave empty to auto-detect /tmp/kitty-socket-{pid} */
+  "socketPath": string,
+  /** Kitten Path - Path to the kitten binary. Leave empty to auto-detect from PATH and standard locations */
+  "kittenPath": string
+}
+
+/** Preferences accessible in all the extension's commands */
+declare type Preferences = ExtensionPreferences
+
+declare namespace Preferences {
+  /** Preferences accessible in the `new-kitty-window` command */
+  export type NewKittyWindow = ExtensionPreferences & {}
+  /** Preferences accessible in the `new-kitty-tab` command */
+  export type NewKittyTab = ExtensionPreferences & {}
+  /** Preferences accessible in the `search-kitty-tabs` command */
+  export type SearchKittyTabs = ExtensionPreferences & {}
+  /** Preferences accessible in the `open-kitty-launch-config` command */
+  export type OpenKittyLaunchConfig = ExtensionPreferences & {}
+  /** Preferences accessible in the `open-with-kitty` command */
+  export type OpenWithKitty = ExtensionPreferences & {}
+}
+
+declare namespace Arguments {
+  /** Arguments passed to the `new-kitty-window` command */
+  export type NewKittyWindow = {}
+  /** Arguments passed to the `new-kitty-tab` command */
+  export type NewKittyTab = {}
+  /** Arguments passed to the `search-kitty-tabs` command */
+  export type SearchKittyTabs = {}
+  /** Arguments passed to the `open-kitty-launch-config` command */
+  export type OpenKittyLaunchConfig = {}
+  /** Arguments passed to the `open-with-kitty` command */
+  export type OpenWithKitty = {}
+}
+

--- a/extensions/kitty/src/utils/components.tsx
+++ b/extensions/kitty/src/utils/components.tsx
@@ -27,7 +27,7 @@ ls -la /tmp/kitty-socket-*
 And test remote control:
 
 \`\`\`bash
-kitten @ --to unix:/tmp/kitty-socket-$(pgrep -x kitty) ls
+kitten @ --to unix:/tmp/kitty-socket-$(pgrep -f kitty.app) ls
 \`\`\`
 
 ## Custom Socket Path

--- a/extensions/kitty/src/utils/components.tsx
+++ b/extensions/kitty/src/utils/components.tsx
@@ -27,7 +27,7 @@ ls -la /tmp/kitty-socket-*
 And test remote control:
 
 \`\`\`bash
-kitten @ --to unix:/tmp/kitty-socket-$(pgrep -f kitty.app) ls
+kitten @ --to unix:/tmp/kitty-socket-$(pgrep -f kitty.app/Contents/MacOS/kitty) ls
 \`\`\`
 
 ## Custom Socket Path

--- a/extensions/kitty/src/utils/kitty-remote.ts
+++ b/extensions/kitty/src/utils/kitty-remote.ts
@@ -4,11 +4,6 @@ import { homedir } from "os";
 import { getPreferenceValues } from "@raycast/api";
 import type { KittyOSWindow } from "./types";
 
-interface Preferences {
-  socketPath: string;
-  kittenPath: string;
-}
-
 const TIMEOUT = 5000;
 
 const KITTEN_CANDIDATES = [
@@ -18,22 +13,21 @@ const KITTEN_CANDIDATES = [
   "/usr/local/bin/kitten",
 ];
 
-let resolvedKittenPath: string | undefined;
+let detectedKittenPath: string | undefined;
 
 function resolveKittenPath(): string {
-  if (resolvedKittenPath) return resolvedKittenPath;
-
   const { kittenPath } = getPreferenceValues<Preferences>();
   if (kittenPath && existsSync(kittenPath)) {
-    resolvedKittenPath = kittenPath;
-    return resolvedKittenPath;
+    return kittenPath;
   }
+
+  if (detectedKittenPath) return detectedKittenPath;
 
   try {
     const p = execSync("which kitten", { encoding: "utf-8", timeout: 2000 }).trim();
     if (p && existsSync(p)) {
-      resolvedKittenPath = p;
-      return resolvedKittenPath;
+      detectedKittenPath = p;
+      return detectedKittenPath;
     }
   } catch {
     // not in PATH, try known locations
@@ -41,8 +35,8 @@ function resolveKittenPath(): string {
 
   for (const candidate of KITTEN_CANDIDATES) {
     if (existsSync(candidate)) {
-      resolvedKittenPath = candidate;
-      return resolvedKittenPath;
+      detectedKittenPath = candidate;
+      return detectedKittenPath;
     }
   }
 

--- a/extensions/kitty/src/utils/kitty-remote.ts
+++ b/extensions/kitty/src/utils/kitty-remote.ts
@@ -1,14 +1,53 @@
 import { execSync } from "child_process";
 import { existsSync, readdirSync, statSync } from "fs";
+import { homedir } from "os";
 import { getPreferenceValues } from "@raycast/api";
 import type { KittyOSWindow } from "./types";
 
 interface Preferences {
   socketPath: string;
+  kittenPath: string;
 }
 
-const KITTEN_PATH = "/Applications/kitty.app/Contents/MacOS/kitten";
 const TIMEOUT = 5000;
+
+const KITTEN_CANDIDATES = [
+  "/Applications/kitty.app/Contents/MacOS/kitten",
+  `${homedir()}/Applications/kitty.app/Contents/MacOS/kitten`,
+  "/opt/homebrew/bin/kitten",
+  "/usr/local/bin/kitten",
+];
+
+let resolvedKittenPath: string | undefined;
+
+function resolveKittenPath(): string {
+  if (resolvedKittenPath) return resolvedKittenPath;
+
+  const { kittenPath } = getPreferenceValues<Preferences>();
+  if (kittenPath && existsSync(kittenPath)) {
+    resolvedKittenPath = kittenPath;
+    return resolvedKittenPath;
+  }
+
+  try {
+    const p = execSync("which kitten", { encoding: "utf-8", timeout: 2000 }).trim();
+    if (p && existsSync(p)) {
+      resolvedKittenPath = p;
+      return resolvedKittenPath;
+    }
+  } catch {
+    // not in PATH, try known locations
+  }
+
+  for (const candidate of KITTEN_CANDIDATES) {
+    if (existsSync(candidate)) {
+      resolvedKittenPath = candidate;
+      return resolvedKittenPath;
+    }
+  }
+
+  throw new Error("kitten not found — set the path in the Kitten Path extension preference");
+}
 
 function findKittySocket(): string | undefined {
   try {
@@ -29,13 +68,13 @@ export function getSocketPath(): string {
 
 export function runKittenCommand(args: string[]): string {
   const socket = getSocketPath();
-  const cmd = `${KITTEN_PATH} @ --to unix:${socket} ${args.join(" ")}`;
+  const cmd = `${resolveKittenPath()} @ --to unix:${socket} ${args.join(" ")}`;
   return execSync(cmd, { encoding: "utf-8", timeout: TIMEOUT }).trim();
 }
 
 export function isKittyRunning(): boolean {
   try {
-    execSync("pgrep -x kitty", { encoding: "utf-8", timeout: 3000 });
+    execSync("pgrep -f kitty.app", { encoding: "utf-8", timeout: 3000 });
     return true;
   } catch {
     return false;

--- a/extensions/kitty/src/utils/kitty-remote.ts
+++ b/extensions/kitty/src/utils/kitty-remote.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { existsSync, readdirSync, statSync } from "fs";
 import { homedir } from "os";
 import { getPreferenceValues } from "@raycast/api";
@@ -24,7 +24,7 @@ function resolveKittenPath(): string {
   if (detectedKittenPath) return detectedKittenPath;
 
   try {
-    const p = execSync("which kitten", { encoding: "utf-8", timeout: 2000 }).trim();
+    const p = execFileSync("which", ["kitten"], { encoding: "utf-8", timeout: 2000 }).trim();
     if (p && existsSync(p)) {
       detectedKittenPath = p;
       return detectedKittenPath;
@@ -62,13 +62,18 @@ export function getSocketPath(): string {
 
 export function runKittenCommand(args: string[]): string {
   const socket = getSocketPath();
-  const cmd = `${resolveKittenPath()} @ --to unix:${socket} ${args.join(" ")}`;
-  return execSync(cmd, { encoding: "utf-8", timeout: TIMEOUT }).trim();
+  return execFileSync(resolveKittenPath(), ["@", "--to", `unix:${socket}`, ...args], {
+    encoding: "utf-8",
+    timeout: TIMEOUT,
+  }).trim();
 }
 
 export function isKittyRunning(): boolean {
   try {
-    execSync("pgrep -f kitty.app", { encoding: "utf-8", timeout: 3000 });
+    execFileSync("pgrep", ["-f", "kitty.app/Contents/MacOS/kitty"], {
+      encoding: "utf-8",
+      timeout: 3000,
+    });
     return true;
   } catch {
     return false;
@@ -80,12 +85,13 @@ export function isSocketAvailable(): boolean {
 }
 
 export function activateKitty(): void {
-  execSync(`osascript -e 'tell application "kitty" to activate'`, { timeout: 3000 });
+  execFileSync("osascript", ["-e", 'tell application "kitty" to activate'], { timeout: 3000 });
 }
 
 export function launchKittyApp(args?: string[]): void {
-  const extra = args?.length ? ` --args ${args.join(" ")}` : "";
-  execSync(`open -a kitty${extra}`, { timeout: 5000 });
+  const cmd = ["-a", "kitty"];
+  if (args?.length) cmd.push("--args", ...args);
+  execFileSync("open", cmd, { timeout: 5000 });
 }
 
 export async function ensureKittyRunning(): Promise<void> {
@@ -145,8 +151,7 @@ export function focusWindow(windowId: number): void {
 }
 
 export function sendText(windowId: number, text: string): void {
-  const escaped = text.replace(/'/g, "'\\''");
-  runKittenCommand(["send-text", `--match=id:${windowId}`, `'${escaped}\n'`]);
+  runKittenCommand(["send-text", `--match=id:${windowId}`, `${text}\n`]);
 }
 
 export function closeTab(tabId: number): void {

--- a/extensions/kitty/tsconfig.json
+++ b/extensions/kitty/tsconfig.json
@@ -18,5 +18,5 @@
     "strict": true,
     "target": "ES2022"
   },
-  "include": ["src/**/*", "env.d.ts"]
+  "include": ["src/**/*", "raycast-env.d.ts"]
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded `/Applications/kitty.app/Contents/MacOS/kitten` path with dynamic resolution: user preference > `which kitten` > standard locations (`/Applications`, `~/Applications`, Homebrew paths)
- Add new **Kitten Path** preference for manual override when auto-detection fails
- Improve process detection by replacing `pgrep -x kitty` with `pgrep -f kitty.app` to handle non-standard installations

Closes #26668

## Test plan

- [ ] Install Kitty in `/Applications` and verify auto-detection works
- [ ] Install Kitty in `~/Applications` and verify auto-detection works
- [ ] Install Kitty via Homebrew and verify auto-detection works
- [ ] Set a custom path in Kitten Path preference and verify it is used
- [ ] Leave Kitten Path empty and verify `which kitten` fallback works
- [ ] Verify `isKittyRunning()` detects the process for non-standard installs
- [ ] Verify all commands (New Window, New Tab, Search Tabs, Open with Kitty) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)