### PR TITLE
[GitHub Copilot] Improve repository picker

### DIFF
--- a/extensions/github-copilot/CHANGELOG.md
+++ b/extensions/github-copilot/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Changelog
 
-## [Improve repository picker] - {PR_MERGE_DATE}
+## [Improve repository picker] - 2026-03-26
 
 - Remember "Recently used" repositories in the repository picker
 - Show a more relevant list of repositories in the repository picker by default

--- a/extensions/github-copilot/CHANGELOG.md
+++ b/extensions/github-copilot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GitHub Copilot Changelog
 
+## [Improve repository picker] - {PR_MERGE_DATE}
+
+- Remember "Recently used" repositories in the repository picker
+- Show a more relevant list of repositories in the repository picker by default
+- Fix repository picker search filtering to only show matching repositories, hiding the previously selected repository if it doesn't match
+
 ## [Fix "Create Task" command error on successful creation] - 2026-03-20
 
 - Fix error when a task is created successfully with the "Create Task" command

--- a/extensions/github-copilot/src/assign-issue.tsx
+++ b/extensions/github-copilot/src/assign-issue.tsx
@@ -2,7 +2,7 @@ import { Action, ActionPanel, Form, Icon, popToRoot, showToast, Toast } from "@r
 import { FormValidation, showFailureToast, useForm, withAccessToken } from "@raycast/utils";
 import { useState } from "react";
 
-import { BranchDropdown, CustomAgentsDropdown, IssueDropdown, RepositoryDropdown } from "./components";
+import { BranchDropdown, CustomAgentsDropdown, IssueDropdown, RepositoryDropdown, cacheRepository } from "./components";
 import { ModelDropdown } from "./components/ModelDropdown";
 import { useRepositoryMetadata } from "./hooks/useRepositoryMetadata";
 import { useViewer } from "./hooks/useViewer";
@@ -69,6 +69,7 @@ function Command() {
           title: "Issue assigned to Copilot",
         });
 
+        cacheRepository(formValues.repository);
         await popToRoot();
       } catch (error) {
         await showFailureToast(error, { title: "Failed to assign issue" });

--- a/extensions/github-copilot/src/components/RepositoryDropdown.tsx
+++ b/extensions/github-copilot/src/components/RepositoryDropdown.tsx
@@ -1,7 +1,45 @@
-import { Form } from "@raycast/api";
-import { useCachedState } from "@raycast/utils";
+import { Cache, Form } from "@raycast/api";
 import { useState, useEffect } from "react";
 import { Repository, useSearchRepositories } from "../hooks/useRepositorySearch";
+
+const PREVIOUS_REPOSITORIES_CACHE_KEY = "previousRepositories";
+const MAX_PREVIOUS_REPOSITORIES = 15;
+const cache = new Cache();
+
+function readCachedRepositories(): Repository[] {
+  const raw = cache.get(PREVIOUS_REPOSITORIES_CACHE_KEY);
+  return raw ? JSON.parse(raw) : [];
+}
+
+function writeCachedRepositories(repos: Repository[]) {
+  cache.set(PREVIOUS_REPOSITORIES_CACHE_KEY, JSON.stringify(repos.slice(0, MAX_PREVIOUS_REPOSITORIES)));
+}
+
+/**
+ * Cache a repository as "recently used". Call this on successful form
+ * submission rather than on dropdown selection to avoid caching auto-selected repos.
+ */
+export function cacheRepository(nameWithOwner: string) {
+  const previous = readCachedRepositories();
+
+  const existing = previous.find((r) => r.nameWithOwner === nameWithOwner);
+
+  let updated: Repository[];
+  if (existing) {
+    updated = [existing, ...previous.filter((r) => r.nameWithOwner !== nameWithOwner)];
+  } else {
+    const [owner, name] = nameWithOwner.split("/");
+    const newRepo: Repository = {
+      id: nameWithOwner,
+      name,
+      nameWithOwner,
+      owner: { login: owner, avatarUrl: "" },
+    };
+    updated = [newRepo, ...previous];
+  }
+
+  writeCachedRepositories(updated);
+}
 
 export function RepositoryDropdown(
   props: Readonly<{
@@ -11,7 +49,7 @@ export function RepositoryDropdown(
   }>,
 ) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [previousRepositories, setPreviousRepositories] = useCachedState<Repository[]>("previousRepositories", []);
+  const [previousRepositories] = useState<Repository[]>(readCachedRepositories);
   const { data, isLoading } = useSearchRepositories({
     searchQuery,
     organizations: props.organizations,
@@ -39,21 +77,18 @@ export function RepositoryDropdown(
       onSearchTextChange={setSearchQuery}
       onChange={(value) => {
         onChange?.(value);
-
-        const repository = data?.nodes?.find((repository) => repository.nameWithOwner === value);
-        if (repository) {
-          setPreviousRepositories([
-            repository,
-            ...previousRepositories.filter((prevRepo) => prevRepo.id !== repository.id),
-          ]);
-        }
       }}
       value={value}
       {...restItemProps}
       throttle
     >
       <Form.Dropdown.Section title="Recently Used">
-        {previousRepositories.map((repository) => (
+        {(searchQuery
+          ? previousRepositories.filter((repository) =>
+              repository.nameWithOwner.toLowerCase().includes(searchQuery.toLowerCase()),
+            )
+          : previousRepositories
+        ).map((repository) => (
           <Form.Dropdown.Item
             key={`${repository.id}-recent`}
             value={repository.nameWithOwner}
@@ -63,7 +98,10 @@ export function RepositoryDropdown(
       </Form.Dropdown.Section>
       <Form.Dropdown.Section title="All">
         {data?.nodes
-          ?.filter((repository) => !previousRepositories.some((prevRepo) => prevRepo.id === repository.id))
+          ?.filter(
+            (repository) =>
+              !previousRepositories.some((prevRepo) => prevRepo.nameWithOwner === repository.nameWithOwner),
+          )
           .map((repository) => (
             <Form.Dropdown.Item key={repository.id} value={repository.nameWithOwner} title={repository.nameWithOwner} />
           ))}

--- a/extensions/github-copilot/src/create-task.tsx
+++ b/extensions/github-copilot/src/create-task.tsx
@@ -14,7 +14,7 @@ import {
 import { FormValidation, showFailureToast, useForm, withAccessToken } from "@raycast/utils";
 import { useState } from "react";
 
-import { BranchDropdown, RepositoryDropdown, CustomAgentsDropdown } from "./components";
+import { BranchDropdown, RepositoryDropdown, CustomAgentsDropdown, cacheRepository } from "./components";
 import { useViewer } from "./hooks/useViewer";
 import { provider, reauthorize } from "./lib/oauth";
 import { createTask } from "./services/copilot";
@@ -87,6 +87,7 @@ function Command() {
           },
         });
 
+        cacheRepository(values.repository);
         await popToRoot();
       } catch (error) {
         await showFailureToast(error, { title: "Failed creating task" });

--- a/extensions/github-copilot/src/hooks/useRepositorySearch.ts
+++ b/extensions/github-copilot/src/hooks/useRepositorySearch.ts
@@ -1,4 +1,5 @@
 import { useCachedPromise } from "@raycast/utils";
+import { GraphqlResponseError } from "@octokit/graphql";
 import { getOctokit } from "../lib/oauth";
 
 const SEARCH_REPOSITORIES_QUERY = `
@@ -20,50 +21,93 @@ const SEARCH_REPOSITORIES_QUERY = `
   }
 `;
 
+const CONTRIBUTED_REPOSITORIES_QUERY = `
+  query ContributedRepositories {
+    viewer {
+      repositoriesContributedTo(
+        first: 100
+        contributionTypes: [COMMIT, PULL_REQUEST]
+        includeUserRepositories: true
+      ) {
+        nodes {
+          id
+          name
+          nameWithOwner
+          owner {
+            login
+            avatarUrl(size: 64)
+          }
+        }
+      }
+    }
+  }
+`;
+
+type RepositoryNode = {
+  id: string;
+  name: string;
+  nameWithOwner: string;
+  owner: { login: string; avatarUrl: string };
+};
+
 type SearchRepositoriesQueryResponse = {
   search: {
     repositoryCount: number;
-    nodes: {
-      id: string;
-      name: string;
-      nameWithOwner: string;
-      owner: { login: string; avatarUrl: string };
-    }[];
+    nodes: RepositoryNode[];
   };
 };
 
-export type Repository = Pick<
-  SearchRepositoriesQueryResponse["search"]["nodes"][number],
-  "id" | "name" | "nameWithOwner" | "owner"
->;
+type ContributedRepositoriesQueryResponse = {
+  viewer: {
+    repositoriesContributedTo: {
+      nodes: RepositoryNode[];
+    };
+  };
+};
+
+export type Repository = Pick<RepositoryNode, "id" | "name" | "nameWithOwner" | "owner">;
 
 export function useSearchRepositories(opts: { searchQuery?: string; organizations?: string[] }) {
   return useCachedPromise(
     async (searchQuery?: string, organizations?: string[]) => {
-      let searchText = `sort:pushed_at:desc sort:updated-desc`;
-      if (searchQuery) {
-        const [owner, repo] = searchQuery.includes("/") ? searchQuery.split("/") : [undefined, undefined];
-        if (owner) {
-          searchText += ` user:${owner} ${repo}`;
-        } else {
-          searchText += ` user:@me ${searchQuery}`;
-          if (organizations) {
-            searchText += ` org:${organizations.join(" org:")}`;
+      const octokit = getOctokit();
+
+      // When there's no search query, show repos the user has actually contributed to
+      if (!searchQuery) {
+        try {
+          const response = await octokit.graphql<ContributedRepositoriesQueryResponse>(CONTRIBUTED_REPOSITORIES_QUERY);
+          const nodes = response.viewer.repositoriesContributedTo.nodes.filter((n) => n != null);
+          return { nodes };
+        } catch (error) {
+          // If some orgs require SAML, the query may return partial data alongside errors.
+          if (error instanceof GraphqlResponseError) {
+            const nodes =
+              (error.data?.viewer?.repositoriesContributedTo?.nodes ?? []).filter(
+                (node: RepositoryNode | null) => node != null,
+              );
+            return { nodes: nodes as RepositoryNode[] };
           }
-        }
-      } else {
-        searchText += ` user:@me`;
-        if (organizations) {
-          searchText += ` org:${organizations.join(" org:")}`;
+          throw error;
         }
       }
 
-      const octokit = getOctokit();
+      // When searching, use the search API
+      let searchText = `sort:updated-desc`;
+      const [owner, repo] = searchQuery.includes("/") ? searchQuery.split("/") : [undefined, undefined];
+      if (owner) {
+        searchText += ` user:${owner} ${repo}`;
+      } else {
+        searchText += ` ${searchQuery}`;
+        if (organizations) {
+          searchText += organizations.map((org) => ` org:${org}`).join("");
+        }
+      }
+
       const response = await octokit.graphql<SearchRepositoriesQueryResponse>(SEARCH_REPOSITORIES_QUERY, {
         searchText,
       });
 
-      return response.search;
+      return { nodes: response.search.nodes };
     },
     [opts.searchQuery, opts.organizations],
     { keepPreviousData: true },

--- a/extensions/github-copilot/src/hooks/useRepositorySearch.ts
+++ b/extensions/github-copilot/src/hooks/useRepositorySearch.ts
@@ -81,10 +81,9 @@ export function useSearchRepositories(opts: { searchQuery?: string; organization
         } catch (error) {
           // If some orgs require SAML, the query may return partial data alongside errors.
           if (error instanceof GraphqlResponseError) {
-            const nodes =
-              (error.data?.viewer?.repositoriesContributedTo?.nodes ?? []).filter(
-                (node: RepositoryNode | null) => node != null,
-              );
+            const nodes = (error.data?.viewer?.repositoriesContributedTo?.nodes ?? []).filter(
+              (node: RepositoryNode | null) => node != null,
+            );
             return { nodes: nodes as RepositoryNode[] };
           }
           throw error;

--- a/extensions/github-copilot/src/hooks/useRepositorySearch.ts
+++ b/extensions/github-copilot/src/hooks/useRepositorySearch.ts
@@ -97,7 +97,7 @@ export function useSearchRepositories(opts: { searchQuery?: string; organization
       if (owner) {
         searchText += ` user:${owner} ${repo}`;
       } else {
-        searchText += ` ${searchQuery}`;
+        searchText += ` user:@me ${searchQuery}`;
         if (organizations) {
           searchText += organizations.map((org) => ` org:${org}`).join("");
         }

--- a/extensions/github-copilot/src/lib/oauth.ts
+++ b/extensions/github-copilot/src/lib/oauth.ts
@@ -26,8 +26,6 @@ export const provider = new OAuthService({
   tokenUrl: TOKEN_URL,
   scope: SCOPES,
   onAuthorize: ({ token }) => {
-    cache.remove("previousRepositories");
-
     octokitInstance = new Octokit({ auth: token });
   },
   extraParameters: {
@@ -36,6 +34,7 @@ export const provider = new OAuthService({
 });
 
 export const reauthorize = async (): Promise<string> => {
+  cache.remove("previousRepositories");
   await client.removeTokens();
   return provider.authorize();
 };


### PR DESCRIPTION
## Description

This improves the repository picker used in the GitHub Copilot extension to:

- Remember "Recently used" repositories in the repository picker
- Show a more relevant list of repositories in the repository picker by default
- Fix repository picker search filtering to only show matching repositories, hiding the previously selected repository if it doesn't match

## Screencast

N/A

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
