### PR TITLE
[Skills] Add support for removing skills from specific agents

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Agent-Specific Skill Removal] - {PR_MERGE_DATE}
+
+- Support removing skills from specific agents instead of all agents at once
+- Show an agent picker form with checkboxes when a skill is installed in multiple agents
+
 ## [Lock File Metadata] - 2026-03-23
 
 - Show skill source, install date, and update date from the global lock file in the detail panel

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Agent-Specific Skill Removal] - {PR_MERGE_DATE}
+## [Agent-Specific Skill Removal] - 2026-03-27
 
 - Support removing skills from specific agents instead of all agents at once
 - Show an agent picker form with checkboxes when a skill is installed in multiple agents

--- a/extensions/skills/src/components/InstalledSkillListItem.tsx
+++ b/extensions/skills/src/components/InstalledSkillListItem.tsx
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { useCachedPromise } from "@raycast/utils";
 import { type InstalledSkill, parseFrontmatter } from "../shared";
+import type { MutateSkills } from "../hooks/useInstalledSkills";
 import { RemoveSkillAction } from "./actions/RemoveSkillAction";
 import { UpdateSkillAction } from "./actions/UpdateSkillAction";
 
@@ -79,6 +80,7 @@ interface InstalledSkillListItemProps {
   skill: InstalledSkill;
   isSelected: boolean;
   isShowingDetail: boolean;
+  mutate: MutateSkills;
   onToggleDetail: () => void;
   onUpdate: () => void;
 }
@@ -87,6 +89,7 @@ export function InstalledSkillListItem({
   skill,
   isSelected,
   isShowingDetail,
+  mutate,
   onToggleDetail,
   onUpdate,
 }: InstalledSkillListItemProps) {
@@ -144,7 +147,7 @@ export function InstalledSkillListItem({
           </ActionPanel.Section>
           <ActionPanel.Section>
             {skill.hasUpdate && <UpdateSkillAction onUpdate={onUpdate} />}
-            <RemoveSkillAction skill={skill} onRemove={onUpdate} />
+            <RemoveSkillAction skill={skill} mutate={mutate} />
           </ActionPanel.Section>
           <Action
             title={isShowingDetail ? "Hide Detail Panel" : "Show Detail Panel"}

--- a/extensions/skills/src/components/actions/RemoveSkillAction.tsx
+++ b/extensions/skills/src/components/actions/RemoveSkillAction.tsx
@@ -1,14 +1,124 @@
-import { Action, Icon, confirmAlert, Alert, showToast, Toast } from "@raycast/api";
+import {
+  Action,
+  ActionPanel,
+  Form,
+  Icon,
+  Color,
+  useNavigation,
+  confirmAlert,
+  Alert,
+  showToast,
+  Toast,
+} from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
+import { useState } from "react";
 import type { InstalledSkill } from "../../shared";
 import { removeSkill } from "../../utils/skills-cli";
+import type { MutateSkills } from "../../hooks/useInstalledSkills";
 
 interface RemoveSkillActionProps {
   skill: InstalledSkill;
-  onRemove: () => void;
+  mutate: MutateSkills;
 }
 
-export function RemoveSkillAction({ skill, onRemove }: RemoveSkillActionProps) {
+function AgentPickerForm({ skill, mutate }: RemoveSkillActionProps) {
+  const { pop } = useNavigation();
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const allSelected = selected.size === skill.agents.length;
+
+  function toggleAll() {
+    setSelected(allSelected ? new Set() : new Set(skill.agents));
+  }
+
+  function toggleAgent(agent: string, checked: boolean) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(agent);
+      } else {
+        next.delete(agent);
+      }
+      return next;
+    });
+  }
+
+  async function handleSubmit() {
+    if (selected.size === 0) return;
+
+    const agents = [...selected];
+    const isAll = agents.length === skill.agents.length;
+    const label = isAll ? "all agents" : agents.join(", ");
+    const confirmed = await confirmAlert({
+      title: isAll ? `Remove "${skill.name}"?` : `Remove "${skill.name}" from ${label}?`,
+      message: isAll
+        ? "This will remove the skill from all agents."
+        : `This will remove the skill from ${agents.length} agent${agents.length > 1 ? "s" : ""}.`,
+      primaryAction: { title: "Remove", style: Alert.ActionStyle.Destructive },
+    });
+    if (!confirmed) return;
+
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Removing skill..." });
+    try {
+      const removedSet = new Set(agents);
+      pop();
+      await mutate(removeSkill(skill.name, isAll ? undefined : agents), {
+        optimisticUpdate: (skills) => {
+          if (!skills) return [];
+          if (isAll) return skills.filter((s) => s.name !== skill.name);
+          return skills
+            .map((s) =>
+              s.name === skill.name
+                ? { ...s, agents: s.agents.filter((a) => !removedSet.has(a)), agentCount: s.agentCount - agents.length }
+                : s,
+            )
+            .filter((s) => s.agents.length > 0);
+        },
+      });
+      toast.style = Toast.Style.Success;
+      toast.title = isAll ? "Skill removed" : `Skill removed from ${label}`;
+    } catch (error) {
+      await toast.hide();
+      await showFailureToast(error, { title: "Failed to remove skill" });
+    }
+  }
+
+  return (
+    <Form
+      navigationTitle={`Remove "${skill.name}"`}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Remove" icon={Icon.Trash} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.Description text={`Select agents to remove "${skill.name}" from:`} />
+      <Form.Checkbox id="select-all" label="Select All" value={allSelected} onChange={toggleAll} />
+      <Form.Separator />
+      {skill.agents.map((agent) => (
+        <Form.Checkbox
+          key={agent}
+          id={agent}
+          label={agent}
+          value={selected.has(agent)}
+          onChange={(checked) => toggleAgent(agent, checked)}
+        />
+      ))}
+    </Form>
+  );
+}
+
+export function RemoveSkillAction({ skill, mutate }: RemoveSkillActionProps) {
+  if (skill.agents.length > 1) {
+    return (
+      <Action.Push
+        title="Remove Skill…"
+        icon={{ source: Icon.Trash, tintColor: Color.Red }}
+        shortcut={{ modifiers: ["ctrl"], key: "x" }}
+        target={<AgentPickerForm skill={skill} mutate={mutate} />}
+      />
+    );
+  }
+
   return (
     <Action
       title="Remove Skill"
@@ -25,10 +135,11 @@ export function RemoveSkillAction({ skill, onRemove }: RemoveSkillActionProps) {
 
         const toast = await showToast({ style: Toast.Style.Animated, title: "Removing skill..." });
         try {
-          await removeSkill(skill.name);
+          await mutate(removeSkill(skill.name), {
+            optimisticUpdate: (skills) => (skills ? skills.filter((s) => s.name !== skill.name) : []),
+          });
           toast.style = Toast.Style.Success;
           toast.title = "Skill removed";
-          onRemove();
         } catch (error) {
           await toast.hide();
           await showFailureToast(error, { title: "Failed to remove skill" });

--- a/extensions/skills/src/components/actions/RemoveSkillAction.tsx
+++ b/extensions/skills/src/components/actions/RemoveSkillAction.tsx
@@ -43,7 +43,10 @@ function AgentPickerForm({ skill, mutate }: RemoveSkillActionProps) {
   }
 
   async function handleSubmit() {
-    if (selected.size === 0) return;
+    if (selected.size === 0) {
+      await showToast({ style: Toast.Style.Failure, title: "Select at least one agent" });
+      return;
+    }
 
     const agents = [...selected];
     const isAll = agents.length === skill.agents.length;

--- a/extensions/skills/src/hooks/useInstalledSkills.ts
+++ b/extensions/skills/src/hooks/useInstalledSkills.ts
@@ -1,8 +1,10 @@
-import { useCachedPromise } from "@raycast/utils";
+import { useCachedPromise, type MutatePromise } from "@raycast/utils";
 import { listInstalledSkills, checkForUpdates, readSkillLock } from "../utils/skills-cli";
-import { stripGitSuffix } from "../shared";
+import { type InstalledSkill, stripGitSuffix } from "../shared";
 
-async function fetchSkillsWithUpdateStatus() {
+export type MutateSkills = MutatePromise<InstalledSkill[] | undefined>;
+
+async function fetchSkillsWithUpdateStatus(): Promise<InstalledSkill[]> {
   const [skills, updatable, lockEntries] = await Promise.all([
     listInstalledSkills(),
     checkForUpdates().catch(() => [] as string[]),
@@ -25,7 +27,7 @@ async function fetchSkillsWithUpdateStatus() {
 }
 
 export function useInstalledSkills() {
-  const { data, isLoading, error, revalidate } = useCachedPromise(fetchSkillsWithUpdateStatus, [], {
+  const { data, isLoading, error, revalidate, mutate } = useCachedPromise(fetchSkillsWithUpdateStatus, [], {
     keepPreviousData: true,
   });
 
@@ -34,5 +36,6 @@ export function useInstalledSkills() {
     isLoading,
     error,
     revalidate,
+    mutate,
   };
 }

--- a/extensions/skills/src/manage-skills.tsx
+++ b/extensions/skills/src/manage-skills.tsx
@@ -6,7 +6,7 @@ import { InstalledSkillListItem } from "./components/InstalledSkillListItem";
 import { UpdateSkillAction } from "./components/actions/UpdateSkillAction";
 
 export default function Command() {
-  const { skills, isLoading, error, revalidate } = useInstalledSkills();
+  const { skills, isLoading, error, revalidate, mutate } = useInstalledSkills();
   const [selectedAgent, setSelectedAgent] = useState<string>("all");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [isShowingDetail, setIsShowingDetail] = useState(true);
@@ -124,6 +124,7 @@ This is an npx resolution issue in the local CLI runtime.
                 skill={skill}
                 isSelected={selectedId === skill.name}
                 isShowingDetail={isShowingDetail}
+                mutate={mutate}
                 onToggleDetail={toggleDetail}
                 onUpdate={revalidate}
               />

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -134,8 +134,31 @@ export async function installSkill(skill: Skill): Promise<void> {
   await runSkillsCli(["add", `${skill.source}@${skill.skillId}`, "-g", "-y"]);
 }
 
-export async function removeSkill(skillName: string): Promise<void> {
-  await runSkillsCli(["remove", skillName, "-g", "-y"]);
+/**
+ * Map of display names (from `skills list --json`) to CLI agent IDs
+ * (expected by `skills remove -a`).
+ * Only entries that differ from the default transform (lowercase + space→hyphen)
+ * need to be listed here.
+ */
+const AGENT_DISPLAY_TO_ID: Record<string, string> = {
+  "Cortex Code": "cortex",
+  "Deep Agents": "deepagents",
+  "Kilo Code": "kilo",
+  "Kimi Code CLI": "kimi-cli",
+  "Roo Code": "roo",
+};
+
+function agentDisplayNameToId(displayName: string): string {
+  return AGENT_DISPLAY_TO_ID[displayName] ?? displayName.toLowerCase().replace(/\s+/g, "-");
+}
+
+export async function removeSkill(skillName: string, agentDisplayNames?: string[]): Promise<void> {
+  const args = ["remove", skillName, "-g"];
+  if (agentDisplayNames && agentDisplayNames.length > 0) {
+    args.push("-a", ...agentDisplayNames.map(agentDisplayNameToId));
+  }
+  args.push("-y");
+  await runSkillsCli(args);
 }
 
 /**


### PR DESCRIPTION
## Description

Previously, removing a skill always removed it from all agents at once. This PR adds an agent picker form so users can choose exactly which agents to remove a skill from. When a skill is installed in multiple agents, pressing `Ctrl+X` pushes a form with checkboxes for each agent and a "Select All" toggle.

## Screencast

<img width="1500" height="942" alt="2026-03-26 at 14 29 43" src="https://github.com/user-attachments/assets/c5786b12-fcde-4282-ab55-5e363c8e993d" />

<img width="1498" height="940" alt="2026-03-26 at 14 31 15" src="https://github.com/user-attachments/assets/df400052-97af-4dc2-9d24-fce3c5d53fc5" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
