### PR TITLE
Improve AI Chat UX and auto-titling for raycast-gemini

### DIFF
--- a/extensions/raycast-gemini/CHANGELOG.md
+++ b/extensions/raycast-gemini/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Gemini Changelog
 
-## [AI Chat UX & Naming Improvements] - 2026-03-27
+## [AI Chat UX & Naming Improvements] - {PR_MERGE_DATE}
 
 - 💬 Make `Enter` send messages in AI Chat instead of copying the current answer.
 - ⚙️ Add shared `System Prompt`, default `Model`, and `Title Model` preferences for the `AI Chat` command.

--- a/extensions/raycast-gemini/CHANGELOG.md
+++ b/extensions/raycast-gemini/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Google Gemini Changelog
 
+## [AI Chat UX & Naming Improvements] - 2026-03-27
+
+- 💬 Make `Enter` send messages in AI Chat instead of copying the current answer.
+- ⚙️ Add shared `System Prompt`, default `Model`, and `Title Model` preferences for the `AI Chat` command.
+- 🆕 Remove the chat creation form and start new chats immediately from the main AI Chat view.
+- 🏷️ Automatically generate a chat title from the first user prompt with a lightweight model.
+- 🧭 Reuse the existing empty draft chat instead of creating multiple blank conversations.
+
 ## [TypeScript Migration & Model Updates] - 2026-03-16
 
 - 🛠️ Migrated entire codebase from JSX to TypeScript (TSX/TS) for improved type safety.

--- a/extensions/raycast-gemini/CHANGELOG.md
+++ b/extensions/raycast-gemini/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Gemini Changelog
 
-## [AI Chat UX & Naming Improvements] - {PR_MERGE_DATE}
+## [AI Chat UX & Naming Improvements] - 2026-04-03
 
 - 💬 Make `Enter` send messages in AI Chat instead of copying the current answer.
 - ⚙️ Add shared `System Prompt`, default `Model`, and `Title Model` preferences for the `AI Chat` command.

--- a/extensions/raycast-gemini/package.json
+++ b/extensions/raycast-gemini/package.json
@@ -131,20 +131,6 @@
           ]
         },
         {
-          "description": "Model used to generate chat titles after the first reply.",
-          "name": "titleModel",
-          "title": "Title Model",
-          "type": "dropdown",
-          "required": false,
-          "default": "gemini-2.5-flash-lite",
-          "data": [
-            {
-              "title": "Gemini 2.5 Flash-Lite",
-              "value": "gemini-2.5-flash-lite"
-            }
-          ]
-        },
-        {
           "name": "prompt",
           "title": "System Prompt",
           "description": "The shared system prompt to use for AI Chat.",
@@ -968,6 +954,5 @@
   "platforms": [
     "macOS",
     "Windows"
-  ],
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+  ]
 }

--- a/extensions/raycast-gemini/package.json
+++ b/extensions/raycast-gemini/package.json
@@ -11,7 +11,8 @@
     "ViGeng",
     "anwarulislam",
     "DanielPFitzsimmons",
-    "aleksishere"
+    "aleksishere",
+    "sayaka"
   ],
   "categories": [
     "Productivity",
@@ -93,7 +94,65 @@
       "subtitle": "Google Gemini",
       "description": "Chat with Google's Gemini Pro",
       "icon": "chat-icon.png",
-      "mode": "view"
+      "mode": "view",
+      "preferences": [
+        {
+          "description": "Which model this command uses by default for new chats.",
+          "name": "model",
+          "title": "Model",
+          "type": "dropdown",
+          "required": false,
+          "default": "default",
+          "data": [
+            {
+              "title": "Default",
+              "value": "default"
+            },
+            {
+              "title": "Gemini 2.5 Flash-Lite",
+              "value": "gemini-2.5-flash-lite"
+            },
+            {
+              "title": "Gemini 2.5 Flash",
+              "value": "gemini-2.5-flash"
+            },
+            {
+              "title": "Gemini 2.5 Pro",
+              "value": "gemini-2.5-pro"
+            },
+            {
+              "title": "Gemini 3.0 Flash",
+              "value": "gemini-3-flash-preview"
+            },
+            {
+              "title": "Gemini 3.1 Pro",
+              "value": "gemini-3.1-pro-preview"
+            }
+          ]
+        },
+        {
+          "description": "Model used to generate chat titles after the first reply.",
+          "name": "titleModel",
+          "title": "Title Model",
+          "type": "dropdown",
+          "required": false,
+          "default": "gemini-2.5-flash-lite",
+          "data": [
+            {
+              "title": "Gemini 2.5 Flash-Lite",
+              "value": "gemini-2.5-flash-lite"
+            }
+          ]
+        },
+        {
+          "name": "prompt",
+          "title": "System Prompt",
+          "description": "The shared system prompt to use for AI Chat.",
+          "type": "textfield",
+          "required": false,
+          "default": "You are a helpful assistant. Provide clear, accurate, and concise responses."
+        }
+      ]
     },
     {
       "name": "askAboutScreen",
@@ -909,5 +968,6 @@
   "platforms": [
     "macOS",
     "Windows"
-  ]
+  ],
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/extensions/raycast-gemini/src/aiChat.tsx
+++ b/extensions/raycast-gemini/src/aiChat.tsx
@@ -2,7 +2,6 @@ import {
   Action,
   ActionPanel,
   confirmAlert,
-  Form,
   getPreferenceValues,
   getSelectedText,
   Icon,
@@ -11,11 +10,11 @@ import {
   LocalStorage,
   showToast,
   Toast,
-  useNavigation,
   Alert,
 } from "@raycast/api";
 import { GoogleGenAI } from "@google/genai";
 import { useEffect, useState } from "react";
+import { ensureUniqueChatName, generateChatTitle, isGeneratedChatName } from "./api/chatTitles";
 import { getSafetySettings } from "./api/safetySettings";
 
 interface ChatMessage {
@@ -52,19 +51,11 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
     });
   };
 
-  function showFailureToast(error: unknown, options: { title?: string; primaryAction?: Toast.ActionOptions } = {}) {
-    return showToast({
-      style: Toast.Style.Failure,
-      title: options.title || "Error",
-      message: error instanceof Error ? error.message : String(error),
-      primaryAction: options.primaryAction,
-    });
-  }
-
-  const { apiKey, defaultModel } = getPreferenceValues<Preferences.AiChat>();
+  const { apiKey, defaultModel, model, prompt, titleModel } = getPreferenceValues<Preferences.AiChat>();
+  const aiChatModel = model === "default" ? defaultModel : model;
   const genAI = new GoogleGenAI({ apiKey });
-  const createNewChatName = (prefix = "New Chat ") => {
-    const existingChatNames = chatData!.chats.map((x) => x.name);
+  const createNewChatName = (chats: ChatEntry[], prefix = "New Chat ") => {
+    const existingChatNames = chats.map((x) => x.name);
     const newChatNumbers = existingChatNames
       .filter((x) => x.match(/^New Chat \d+$/))
       .map((x) => parseInt(x.replace(prefix, "")));
@@ -75,58 +66,59 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
     return prefix + lowestAvailableNumber;
   };
 
-  const CreateChat = () => {
-    const { pop } = useNavigation();
+  const findDraftChat = (chats: ChatEntry[]) => {
+    return chats.find((chat) => chat.messages.length === 0 && isGeneratedChatName(chat.name)) ?? null;
+  };
 
-    return (
-      <Form
-        actions={
-          <ActionPanel>
-            <Action.SubmitForm
-              title="Create Chat"
-              onSubmit={(values: { chatName: string; model: string }) => {
-                const newName = values.chatName.trim() || createNewChatName();
-                if (chatData!.chats.map((x) => x.name).includes(newName)) {
-                  showFailureToast("Chat with that name already exists.");
-                } else {
-                  pop();
-                  setChatData((oldData) => {
-                    const newChatData = structuredClone(oldData!);
-                    newChatData.chats.push({
-                      name: newName,
-                      creationDate: new Date(),
-                      messages: [],
-                      model: values.model === "default" ? defaultModel : values.model,
-                    });
-                    newChatData.currentChat = newName;
+  const createChat = () => {
+    setSearchText("");
+    setChatData((oldData) => {
+      const newChatData = structuredClone(oldData!);
+      const existingDraft = findDraftChat(newChatData.chats);
+      if (existingDraft) {
+        newChatData.currentChat = existingDraft.name;
+        return newChatData;
+      }
 
-                    return newChatData;
-                  });
-                }
-              }}
-            />
-          </ActionPanel>
-        }
-      >
-        <Form.Description
-          title="Chat Name"
-          text="In each chat, Gemini will remember the previous messages you send in it."
-        />
-        <Form.TextField id="chatName" />
-        <Form.Description
-          title="Chat Model"
-          text="The model used for this chat. Setting this to Default will use the model you set as Default for the extension in Preferences."
-        />
-        <Form.Dropdown id="model" defaultValue="default">
-          <Form.Dropdown.Item title="Default" value="default" />
-          <Form.Dropdown.Item title="Gemini 2.5 Flash-Lite" value="gemini-2.5-flash-lite" />
-          <Form.Dropdown.Item title="Gemini 2.5 Flash" value="gemini-2.5-flash" />
-          <Form.Dropdown.Item title="Gemini 2.5 Pro" value="gemini-2.5-pro" />
-          <Form.Dropdown.Item title="Gemini 3.0 Flash" value="gemini-3-flash-preview" />
-          <Form.Dropdown.Item title="Gemini 3.1 Pro" value="gemini-3.1-pro-preview" />
-        </Form.Dropdown>
-      </Form>
-    );
+      const newName = createNewChatName(newChatData.chats);
+      newChatData.chats.push({
+        name: newName,
+        creationDate: new Date(),
+        messages: [],
+        model: aiChatModel,
+      });
+      newChatData.currentChat = newName;
+      return newChatData;
+    });
+  };
+
+  const applyGeneratedChatTitle = (chatName: string, nextTitle: string) => {
+    setChatData((oldData) => {
+      if (!oldData) {
+        return oldData;
+      }
+
+      const newChatData = structuredClone(oldData);
+      const chat = getChat(chatName, newChatData.chats);
+      if (!chat || !isGeneratedChatName(chat.name) || chat.messages.length !== 1 || !chat.messages[0].finished) {
+        return oldData;
+      }
+
+      const uniqueTitle = ensureUniqueChatName(
+        nextTitle,
+        newChatData.chats.map((existingChat) => existingChat.name),
+        chat.name,
+      );
+      if (uniqueTitle === chat.name) {
+        return oldData;
+      }
+
+      chat.name = uniqueTitle;
+      if (newChatData.currentChat === chatName) {
+        newChatData.currentChat = uniqueTitle;
+      }
+      return newChatData;
+    });
   };
 
   const GeminiActionPanel = ({ idx }: { idx?: number } = {}) => {
@@ -151,26 +143,6 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
 
     return (
       <ActionPanel>
-        {message && (
-          <ActionPanel.Section title="Copy">
-            <Action.CopyToClipboard title="Copy Answer" content={message.answer ?? ""} />
-            <Action.CopyToClipboard
-              title="Copy Prompt"
-              content={message.prompt ?? ""}
-              shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
-            />
-          </ActionPanel.Section>
-        )}
-
-        {fullChatText && (
-          <ActionPanel.Section title="Export">
-            <Action.CopyToClipboard
-              title="Copy Entire Chat (Transcript)"
-              content={fullChatText}
-              shortcut={{ modifiers: ["cmd", "shift"], key: "e" }}
-            />
-          </ActionPanel.Section>
-        )}
         <Action
           icon={Icon.Message}
           title="Send to Gemini"
@@ -183,11 +155,13 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
             const query = searchText;
             setSearchText("");
             const currentChatObj = getChat(chatData!.currentChat)!;
+            const currentChatName = chatData!.currentChat;
+            const shouldGenerateTitle = currentChatObj.messages.length === 0;
             if (currentChatObj.messages.length == 0 || currentChatObj.messages[0].finished) {
               toast(Toast.Style.Animated, "Response Loading", "Please Wait");
               setChatData((x) => {
                 const newChatData = structuredClone(x!);
-                const currentChat = getChat(chatData!.currentChat, newChatData.chats)!;
+                const currentChat = getChat(currentChatName, newChatData.chats)!;
 
                 currentChat.messages.unshift({
                   prompt: query,
@@ -210,14 +184,21 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
                     ])
                     .flat();
 
-                  const modelName = currentChatObj.model ?? defaultModel;
+                  const modelName = currentChatObj.model ?? aiChatModel;
                   const chatSession = genAI.chats.create({
                     model: modelName,
                     config: {
                       safetySettings: getSafetySettings(),
+                      ...(prompt?.trim() ? { systemInstruction: prompt.trim() } : {}),
                     },
                     history: historyMessages,
                   });
+                  const titlePromise = shouldGenerateTitle
+                    ? generateChatTitle(genAI, titleModel, query).catch((error) => {
+                        console.error("Failed to generate chat title", error);
+                        return null;
+                      })
+                    : null;
 
                   const result = await chatSession.sendMessageStream({
                     message: query,
@@ -228,7 +209,7 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
                     if (chunkText) {
                       setChatData((oldData) => {
                         const newChatData = structuredClone(oldData!);
-                        const chatToUpdate = getChat(chatData!.currentChat, newChatData.chats);
+                        const chatToUpdate = getChat(currentChatName, newChatData.chats);
                         if (chatToUpdate && chatToUpdate.messages[0]) {
                           chatToUpdate.messages[0].answer += chunkText;
                         }
@@ -239,15 +220,22 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
 
                   setChatData((oldData) => {
                     const newChatData = structuredClone(oldData!);
-                    getChat(chatData!.currentChat, newChatData.chats)!.messages[0].finished = true;
+                    getChat(currentChatName, newChatData.chats)!.messages[0].finished = true;
                     return newChatData;
                   });
+
+                  if (titlePromise) {
+                    const nextTitle = await titlePromise;
+                    if (nextTitle) {
+                      applyGeneratedChatTitle(currentChatName, nextTitle);
+                    }
+                  }
 
                   toast(Toast.Style.Success, "Response Loaded");
                 } catch (e: unknown) {
                   setChatData((oldData) => {
                     const newChatData = structuredClone(oldData!);
-                    getChat(chatData!.currentChat, newChatData.chats)!.messages.shift();
+                    getChat(currentChatName, newChatData.chats)!.messages.shift();
                     return newChatData;
                   });
                   console.error(e);
@@ -264,11 +252,35 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
             }
           }}
         />
+        {message && (
+          <ActionPanel.Section title="Copy">
+            <Action.CopyToClipboard
+              title="Copy Answer"
+              content={message.answer ?? ""}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "x" }}
+            />
+            <Action.CopyToClipboard
+              title="Copy Prompt"
+              content={message.prompt ?? ""}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+            />
+          </ActionPanel.Section>
+        )}
+
+        {fullChatText && (
+          <ActionPanel.Section title="Export">
+            <Action.CopyToClipboard
+              title="Copy Entire Chat (Transcript)"
+              content={fullChatText}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "e" }}
+            />
+          </ActionPanel.Section>
+        )}
         <ActionPanel.Section title="Manage Chats">
-          <Action.Push
+          <Action
             icon={Icon.PlusCircle}
             title="Create Chat"
-            target={<CreateChat />}
+            onAction={createChat}
             shortcut={{ modifiers: ["cmd"], key: "n" }}
           />
           <Action
@@ -397,6 +409,7 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
 
         if (getChat(newData.currentChat, newData.chats)?.messages[0]?.finished === false) {
           const currentChat = getChat(newData.currentChat, newData.chats)!;
+          const shouldGenerateTitle = currentChat.messages.length === 1;
           const historyMessages = currentChat.messages
             .slice(1)
             .reverse()
@@ -408,9 +421,10 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
             .flat();
 
           const chatSession = genAI.chats.create({
-            model: currentChat.model ?? defaultModel,
+            model: currentChat.model ?? aiChatModel,
             config: {
               safetySettings: getSafetySettings(),
+              ...(prompt?.trim() ? { systemInstruction: prompt.trim() } : {}),
             },
             history: historyMessages,
           });
@@ -419,6 +433,13 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
           toast(Toast.Style.Animated, "Regenerating Last Message");
           (async () => {
             try {
+              const titlePromise = shouldGenerateTitle
+                ? generateChatTitle(genAI, titleModel, promptToRegen).catch((error) => {
+                    console.error("Failed to generate chat title", error);
+                    return null;
+                  })
+                : null;
+
               const result = await chatSession.sendMessageStream({
                 message: promptToRegen,
               });
@@ -443,6 +464,13 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
                 return newChatData;
               });
 
+              if (titlePromise) {
+                const nextTitle = await titlePromise;
+                if (nextTitle) {
+                  applyGeneratedChatTitle(newData.currentChat, nextTitle);
+                }
+              }
+
               toast(Toast.Style.Success, "Response Loaded");
             } catch (e: unknown) {
               setChatData((oldData) => {
@@ -465,7 +493,7 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
               name: "New Chat 1",
               creationDate: new Date(),
               messages: [],
-              model: defaultModel,
+              model: aiChatModel,
             },
           ],
         };
@@ -493,6 +521,7 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
                 finished: true,
               },
             ],
+            model: aiChatModel,
           });
           newChatData.currentChat = `Quick AI at ${new Date().toLocaleString("en-US", {
             month: "2-digit",

--- a/extensions/raycast-gemini/src/aiChat.tsx
+++ b/extensions/raycast-gemini/src/aiChat.tsx
@@ -51,8 +51,11 @@ export default function Chat({ launchContext }: LaunchProps<{ launchContext: Cha
     });
   };
 
-  const { apiKey, defaultModel, model, prompt, titleModel } = getPreferenceValues<Preferences.AiChat>();
+  const { apiKey, defaultModel, model, prompt } = getPreferenceValues<Preferences.AiChat>();
   const aiChatModel = model === "default" ? defaultModel : model;
+  // Temporary hardcoded title model. Google marks gemini-2.5-flash-lite as
+  // "July 22, 2026" for shutdown, and recommend to switch to "gemini-3.1-flash-lite-preview"
+  const titleModel = "gemini-2.5-flash-lite";
   const genAI = new GoogleGenAI({ apiKey });
   const createNewChatName = (chats: ChatEntry[], prefix = "New Chat ") => {
     const existingChatNames = chats.map((x) => x.name);

--- a/extensions/raycast-gemini/src/api/chatTitles.ts
+++ b/extensions/raycast-gemini/src/api/chatTitles.ts
@@ -1,0 +1,52 @@
+import { GoogleGenAI } from "@google/genai";
+
+function normalizeGeneratedTitle(title: string) {
+  return title
+    .replace(/^title:\s*/i, "")
+    .replace(/[\r\n]+/g, " ")
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 60);
+}
+
+export function isGeneratedChatName(name: string) {
+  return /^New Chat \d+$/.test(name);
+}
+
+export function ensureUniqueChatName(candidate: string, existingNames: string[], currentName: string) {
+  const trimmedCandidate = candidate.trim();
+  if (!trimmedCandidate) {
+    return currentName;
+  }
+
+  const existingNameSet = new Set(existingNames.filter((name) => name !== currentName));
+  let uniqueName = trimmedCandidate;
+  let suffix = 2;
+  while (existingNameSet.has(uniqueName)) {
+    uniqueName = `${trimmedCandidate} ${suffix}`;
+    suffix++;
+  }
+  return uniqueName;
+}
+
+export async function generateChatTitle(genAI: GoogleGenAI, titleModel: string, firstPrompt: string) {
+  const response = await genAI.models.generateContent({
+    model: titleModel,
+    contents: [
+      "Your only task is to generate a short session title based on the user message below.",
+      "Do NOT answer or respond to the user message.",
+      "Do NOT act as an assistant.",
+      "ONLY output the title, nothing else.",
+      "Requirements:",
+      "- no quotes",
+      "- Be specific, not generic (avoid titles like Chat or Question)",
+      "- Use the same language as the user's message",
+      "- Focus on the core topic or intent",
+      `User message: ${firstPrompt}`,
+    ].join("\n"),
+  });
+
+  const nextTitle = normalizeGeneratedTitle(response.text ?? "");
+  return nextTitle || null;
+}


### PR DESCRIPTION
## Description


This PR improves the AI Chat experience in `raycast-gemini` by simplifying chat creation and adding automatic chat titles.

### What changed
- make `Enter` send messages in AI Chat
- add per-command AI Chat preferences for `Model` and `System Prompt`
- reuse an existing empty draft chat instead of creating multiple blank chats
- automatically generate a chat title from the first user prompt using a lightweight model

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
