### PR TITLE
Dia: Fix escaping in sql query

### DIFF
--- a/extensions/dia/CHANGELOG.md
+++ b/extensions/dia/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Dia Changelog
 
+## [Fixed SQL query escaping] - 2026-03-27
+
+- Fixed single quote escaping in SQL queries to use proper SQL string literals instead of double quotes
+
 ## [Fix tab fetching and JSON parsing] - 2026-03-12
 
 - Fix unescaped quotes in JSON from AppleScript so tab data parses correctly

--- a/extensions/dia/src/dia.ts
+++ b/extensions/dia/src/dia.ts
@@ -114,7 +114,7 @@ function getHistoryQuery(searchText?: string, limit = 100) {
         .filter((word) => word.length > 0)
         .map((term) => {
           const escapedTerm = escapeSQLLikePattern(term);
-          return `(url LIKE "%${escapedTerm}%" ESCAPE '\\' OR title LIKE "%${escapedTerm}%" ESCAPE '\\')`;
+          return `(url LIKE '%${escapedTerm}%' ESCAPE '\\' OR title LIKE '%${escapedTerm}%' ESCAPE '\\')`;
         })
         .join(" AND ")
     : undefined;

--- a/extensions/dia/src/utils.ts
+++ b/extensions/dia/src/utils.ts
@@ -12,11 +12,11 @@ export function escapeAppleScriptString(str: string): string {
 
 /**
  * Escapes special characters in SQL LIKE patterns to prevent SQL injection.
- * Escapes: %, _, \, and quotes
+ * Escapes: %, _, \, and single quotes
  * Note: Backslashes are doubled for SQL string literals, then special chars are escaped
  */
 export function escapeSQLLikePattern(pattern: string): string {
-  return pattern.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_").replace(/"/g, '""');
+  return pattern.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_").replace(/'/g, "''");
 }
 
 export function getSafeFavicon(url: string): List.Item.Props["icon"] {


### PR DESCRIPTION
The issue was that SQL uses single quotes (') for string literals, not double quotes ("). Double quotes in SQL are interpreted as identifiers (column names), which is why SQLite complained about "no such column".