### PR TITLE
Update search npm extension

### DIFF
--- a/extensions/search-npm/CHANGELOG.md
+++ b/extensions/search-npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Search npm Changelog
 
+## [Improvements] - {PR_MERGE_DATE}
+
+- Moved the package version to the subtitle to prevent truncation in the accessories
+
 ## [API usage optimization] - 2026-03-25
 
 - Debounce search API calls to avoid unnecessary requests while the user is typing.

--- a/extensions/search-npm/CHANGELOG.md
+++ b/extensions/search-npm/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Search npm Changelog
 
-## [Improvements] - {PR_MERGE_DATE}
+## [Improvements] - 2026-03-30
 
 - Moved the package version to the subtitle to prevent truncation in the accessories
 

--- a/extensions/search-npm/src/components/PackagListItem.tsx
+++ b/extensions/search-npm/src/components/PackagListItem.tsx
@@ -113,6 +113,11 @@ export const PackageListItem = ({
 
   const keywords = Array.isArray(pkg.keywords) ? pkg.keywords : typeof pkg.keywords === "string" ? [pkg.keywords] : [];
 
+  const subtitle =
+    pkg.description != null && String(pkg.description).length > 0
+      ? `v${pkg.version} · ${pkg.description}`
+      : `v${pkg.version}`;
+
   const accessories: List.Item.Accessory[] = [
     keywords?.length
       ? {
@@ -122,16 +127,10 @@ export const PackageListItem = ({
       : {},
   ];
   if (!isViewingFavorites) {
-    accessories.push(
-      {
-        text: `v${pkg.version}`,
-        tooltip: `Latest version`,
-      },
-      {
-        icon: Icon.Calendar,
-        tooltip: `Last updated: ${tinyRelativeDate(new Date(pkg.date))}`,
-      },
-    );
+    accessories.push({
+      icon: Icon.Calendar,
+      tooltip: `Last updated: ${tinyRelativeDate(new Date(pkg.date))}`,
+    });
     if (isFavorited) {
       accessories.push({
         icon: Icon.Star,
@@ -144,7 +143,7 @@ export const PackageListItem = ({
       id={pkg.name}
       key={pkg.name}
       title={pkg.name}
-      subtitle={pkg.description}
+      subtitle={subtitle}
       icon={Icon.Box}
       accessories={accessories}
       keywords={keywords}


### PR DESCRIPTION
## Description
Moved the package version to the subtitle to prevent truncation in the accessories. Close #26626.
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1000" height="625" alt="search-npm 2026-03-27 at 23 25 21" src="https://github.com/user-attachments/assets/34dd5c95-19b4-4389-be0d-4e6c2d06daef" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
