### PR TITLE
Update font-awesome extension

### DIFF
--- a/extensions/fontawesome/CHANGELOG.md
+++ b/extensions/fontawesome/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Font Awesome Changelog
 
-## [Improve API token error handling] - {PR_MERGE_DATE}
+## [Improve API token error handling] - 2026-04-06
 
 - Added a clearer error state for misconfigured custom API tokens while keeping the default no-token free-icon flow working normally.
 

--- a/extensions/fontawesome/CHANGELOG.md
+++ b/extensions/fontawesome/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Font Awesome Changelog
 
+## [Improve API token error handling] - {PR_MERGE_DATE}
+
+- Added a clearer error state for misconfigured custom API tokens while keeping the default no-token free-icon flow working normally.
+
 ## [Fix pro token refresh and kit loading] - 2026-03-27
 
 - Fixed pro icon searches after changing the API token by scoping cached access tokens and expiry timestamps to the selected API token, which prevents the extension from continuing to use the default free token after a pro token is added (ref: [Issue #26096](https://github.com/raycast/extensions/issues/26096#issuecomment-4013620785)).

--- a/extensions/fontawesome/src/hooks/useAccessToken.ts
+++ b/extensions/fontawesome/src/hooks/useAccessToken.ts
@@ -1,10 +1,16 @@
 import { useCachedState, useFetch, useLocalStorage } from "@raycast/utils";
 import { TokenData } from "@/types";
-import { getAccessTokenStorageKeys, shouldRefreshAccessToken } from "@/utils/access-token";
+import {
+  buildScopedCacheKey,
+  getAccessTokenStorageKeys,
+  getApiTokenConfigurationError,
+  shouldRefreshAccessToken,
+} from "@/utils/access-token";
 
-export const useAccessToken = (API_TOKEN: string) => {
+export const useAccessToken = (API_TOKEN: string, validateApiToken: boolean) => {
   const { tokenFingerprint, accessTokenKey, expiryKey } = getAccessTokenStorageKeys(API_TOKEN);
   const [accessToken, setAccessToken] = useCachedState<string>(accessTokenKey, "");
+  const [scopes, setScopes] = useCachedState<string[]>(buildScopedCacheKey("tokenScopes", tokenFingerprint), []);
 
   const {
     value: tokenTimeStart,
@@ -20,11 +26,16 @@ export const useAccessToken = (API_TOKEN: string) => {
     });
 
   // Fetch access token, store expiry info in local storage and state and store access token
-  const { isLoading: isTokenLoading } = useFetch<TokenData>("https://api.fontawesome.com/token", {
+  const { isLoading: isTokenLoading, error } = useFetch<TokenData>("https://api.fontawesome.com/token", {
     execute: executeTokenFetch,
     onData: (data) => {
       setTokenTimerStart(Date.now());
       setAccessToken(data.access_token);
+      setScopes(data.scopes);
+    },
+    onError: () => {
+      setAccessToken("");
+      setScopes([]);
     },
     method: "POST",
     headers: {
@@ -32,8 +43,21 @@ export const useAccessToken = (API_TOKEN: string) => {
     },
   });
 
-  const isLoading = isTokenTimerLoading || isTokenLoading;
-  const executeDataLoading = !!(accessToken && !isLoading);
+  const configurationError = getApiTokenConfigurationError(scopes, validateApiToken);
+  const tokenError = error
+    ? {
+        title: "Font Awesome API token is invalid",
+        description: "Open Extension Preferences and replace the API token with a valid Font Awesome token.",
+      }
+    : configurationError
+      ? {
+          title: "Font Awesome API token is missing permissions",
+          description: configurationError,
+        }
+      : undefined;
 
-  return { accessToken, cacheScope: tokenFingerprint, isLoading, executeDataLoading };
+  const isLoading = isTokenTimerLoading || isTokenLoading;
+  const executeDataLoading = !!(accessToken && !isLoading && !tokenError);
+
+  return { accessToken, cacheScope: tokenFingerprint, isLoading, executeDataLoading, tokenError };
 };

--- a/extensions/fontawesome/src/hooks/useAccessToken.ts
+++ b/extensions/fontawesome/src/hooks/useAccessToken.ts
@@ -10,7 +10,10 @@ import {
 export const useAccessToken = (API_TOKEN: string, validateApiToken: boolean) => {
   const { tokenFingerprint, accessTokenKey, expiryKey } = getAccessTokenStorageKeys(API_TOKEN);
   const [accessToken, setAccessToken] = useCachedState<string>(accessTokenKey, "");
-  const [scopes, setScopes] = useCachedState<string[]>(buildScopedCacheKey("tokenScopes", tokenFingerprint), []);
+  const [scopes, setScopes] = useCachedState<string[] | undefined>(
+    buildScopedCacheKey("tokenScopes", tokenFingerprint),
+    undefined,
+  );
 
   const {
     value: tokenTimeStart,
@@ -35,7 +38,7 @@ export const useAccessToken = (API_TOKEN: string, validateApiToken: boolean) => 
     },
     onError: () => {
       setAccessToken("");
-      setScopes([]);
+      setScopes(undefined);
     },
     method: "POST",
     headers: {

--- a/extensions/fontawesome/src/hooks/usePreferences.ts
+++ b/extensions/fontawesome/src/hooks/usePreferences.ts
@@ -5,6 +5,7 @@ export const usePreferences = () => {
   let { API_TOKEN, STYLE_PREFERENCE } = preferences;
   const { KIT_FILTER, REMEMBER_LAST_KIT } = preferences;
   let account = "pro";
+  const hasCustomToken = !!API_TOKEN;
 
   //if pro API Token not provided, use free API Token
   if (!API_TOKEN) {
@@ -13,5 +14,12 @@ export const usePreferences = () => {
     STYLE_PREFERENCE = "fas";
   }
 
-  return { API_TOKEN, STYLE_PREFERENCE, account, kitFilter: KIT_FILTER, rememberLastKit: REMEMBER_LAST_KIT };
+  return {
+    API_TOKEN,
+    STYLE_PREFERENCE,
+    account,
+    hasCustomToken,
+    kitFilter: KIT_FILTER,
+    rememberLastKit: REMEMBER_LAST_KIT,
+  };
 };

--- a/extensions/fontawesome/src/index.tsx
+++ b/extensions/fontawesome/src/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Color, Grid } from "@raycast/api";
+import { Action, ActionPanel, Color, Grid, Icon, openExtensionPreferences } from "@raycast/api";
 import { useCachedState } from "@raycast/utils";
 import { useAccessToken } from "@/hooks/useAccessToken";
 import { useData } from "@/hooks/useData";
@@ -9,14 +9,20 @@ import { IconActions } from "@/components/IconActions";
 import { StyleSelector } from "@/components/StyleSelector";
 
 export default function Command() {
-  const { API_TOKEN, STYLE_PREFERENCE, account, kitFilter, rememberLastKit } = usePreferences();
+  const { API_TOKEN, STYLE_PREFERENCE, account, hasCustomToken, kitFilter, rememberLastKit } = usePreferences();
 
   const [lastType, setLastType] = useCachedState<string | undefined>("lastType", undefined);
   const initialType = rememberLastKit && lastType ? lastType : STYLE_PREFERENCE;
   const [type, setType] = useState<string>(initialType);
   const [query, setQuery] = useState<string>("");
 
-  const { accessToken, cacheScope, isLoading: isAccessTokenLoading, executeDataLoading } = useAccessToken(API_TOKEN);
+  const {
+    accessToken,
+    cacheScope,
+    isLoading: isAccessTokenLoading,
+    executeDataLoading,
+    tokenError,
+  } = useAccessToken(API_TOKEN, hasCustomToken);
   const { isLoading: isDataLoading, data } = useData(accessToken, cacheScope, executeDataLoading, query, type);
   const { kits, isLoading: isKitsLoading } = useKits(
     accessToken,
@@ -50,20 +56,33 @@ export default function Command() {
         />
       }
     >
-      {data.map((searchItem) => (
-        <Grid.Item
-          title={searchItem.id}
-          key={searchItem.id}
-          actions={<IconActions searchItem={searchItem} />}
-          content={{
-            value: {
-              source: `data:image/svg+xml;base64,${Buffer.from(searchItem.svgs[0].html).toString("base64")}`,
-              tintColor: Color.PrimaryText,
-            },
-            tooltip: searchItem.id,
-          }}
+      {tokenError ? (
+        <Grid.EmptyView
+          icon={Icon.ExclamationMark}
+          title={tokenError.title}
+          description={tokenError.description}
+          actions={
+            <ActionPanel>
+              <Action title="Open Extension Preferences" onAction={openExtensionPreferences} />
+            </ActionPanel>
+          }
         />
-      ))}
+      ) : (
+        data.map((searchItem) => (
+          <Grid.Item
+            title={searchItem.id}
+            key={searchItem.id}
+            actions={<IconActions searchItem={searchItem} />}
+            content={{
+              value: {
+                source: `data:image/svg+xml;base64,${Buffer.from(searchItem.svgs[0].html).toString("base64")}`,
+                tintColor: Color.PrimaryText,
+              },
+              tooltip: searchItem.id,
+            }}
+          />
+        ))
+      )}
     </Grid>
   );
 }

--- a/extensions/fontawesome/src/utils/access-token.ts
+++ b/extensions/fontawesome/src/utils/access-token.ts
@@ -15,6 +15,8 @@ export function buildScopedCacheKey(baseKey: string, scope: string, suffix?: str
   return [baseKey, scope, suffix].filter(Boolean).join(":");
 }
 
+const REQUIRED_PRO_TOKEN_SCOPES = ["kits_read", "domains_read", "svg_icons_pro"];
+
 export function getAccessTokenStorageKeys(apiToken: string) {
   const tokenFingerprint = getApiTokenFingerprint(apiToken);
   return {
@@ -31,4 +33,18 @@ export function shouldRefreshAccessToken({
   ttlMs = 3_600_000,
 }: RefreshAccessTokenOptions) {
   return !accessToken || !tokenTimeStart || now - tokenTimeStart >= ttlMs;
+}
+
+export function getApiTokenConfigurationError(scopes: string[], shouldValidate = true) {
+  if (!shouldValidate) {
+    return undefined;
+  }
+
+  const hasRequiredScopes = REQUIRED_PRO_TOKEN_SCOPES.every((scope) => scopes.includes(scope));
+
+  if (hasRequiredScopes) {
+    return undefined;
+  }
+
+  return 'Your Font Awesome API token is missing the required permissions. Recreate it with "Read kits data", "Allowed domains", and "Pro icons and metadata" enabled.';
 }

--- a/extensions/fontawesome/src/utils/access-token.ts
+++ b/extensions/fontawesome/src/utils/access-token.ts
@@ -35,8 +35,8 @@ export function shouldRefreshAccessToken({
   return !accessToken || !tokenTimeStart || now - tokenTimeStart >= ttlMs;
 }
 
-export function getApiTokenConfigurationError(scopes: string[], shouldValidate = true) {
-  if (!shouldValidate) {
+export function getApiTokenConfigurationError(scopes: string[] | undefined, shouldValidate = true) {
+  if (!shouldValidate || scopes === undefined) {
     return undefined;
   }
 

--- a/extensions/fontawesome/tests/access-token.test.ts
+++ b/extensions/fontawesome/tests/access-token.test.ts
@@ -62,3 +62,7 @@ test("accepts a correctly configured pro token", () => {
 test("does not report missing permissions when token validation is disabled", () => {
   assert.equal(getApiTokenConfigurationError(["public", "kits_read"], false), undefined);
 });
+
+test("does not report missing permissions before scopes are loaded", () => {
+  assert.equal(getApiTokenConfigurationError(undefined), undefined);
+});

--- a/extensions/fontawesome/tests/access-token.test.ts
+++ b/extensions/fontawesome/tests/access-token.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   buildScopedCacheKey,
+  getApiTokenConfigurationError,
   getAccessTokenStorageKeys,
   shouldRefreshAccessToken,
 } from "../src/utils/access-token.ts";
@@ -42,4 +43,22 @@ test("refreshes when there is no cached access token for the selected API token"
 test("buildScopedCacheKey keeps scopes stable and readable", () => {
   assert.equal(buildScopedCacheKey("iconData", "token-a"), "iconData:token-a");
   assert.equal(buildScopedCacheKey("iconData", "token-a", "far"), "iconData:token-a:far");
+});
+
+test("reports a helpful configuration error when required scopes are missing", () => {
+  assert.equal(
+    getApiTokenConfigurationError(["public", "kits_read"]),
+    'Your Font Awesome API token is missing the required permissions. Recreate it with "Read kits data", "Allowed domains", and "Pro icons and metadata" enabled.',
+  );
+});
+
+test("accepts a correctly configured pro token", () => {
+  assert.equal(
+    getApiTokenConfigurationError(["public", "kits_read", "domains_read", "svg_icons_pro"]),
+    undefined,
+  );
+});
+
+test("does not report missing permissions when token validation is disabled", () => {
+  assert.equal(getApiTokenConfigurationError(["public", "kits_read"], false), undefined);
 });


### PR DESCRIPTION
## Description

This PR improves API token error handling in the Font Awesome extension so users get a clear, actionable message when a custom token is misconfigured, without breaking the default free-token experience.

## Screencast

<img width="1920" height="1320" alt="CleanShot 2026-03-27 at 09 26 52@2x" src="https://github.com/user-attachments/assets/f46cf0db-4646-41b2-b69b-0e9da07c0037" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
