### PR TITLE
Update kaneo-for-raycast extension

### DIFF
--- a/extensions/kaneo-for-raycast/CHANGELOG.md
+++ b/extensions/kaneo-for-raycast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kaneo Changelog
 
-## [Add subtasks support] - 2026-03-27
+## [Add Subtasks Support] - 2026-03-27
 
 - Added support for sub tasks in task details
 - Added keyboard shortcuts to move to parent task

--- a/extensions/kaneo-for-raycast/CHANGELOG.md
+++ b/extensions/kaneo-for-raycast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kaneo Changelog
 
-## [Add Keyboard Shortcuts] - 2026-03-27
+## [Add subtasks support] - 2026-03-27
 
 - Added support for sub tasks in task details
 - Added keyboard shortcuts to move to parent task


### PR DESCRIPTION
## Description
Change the name of the latest version, as it is incorrect and may mislead the user about the actual purpose of the update.
I was planning to fix it in the next update but probably gonna confuse user.

## Screencast
<img width="330" height="66" alt="image" src="https://github.com/user-attachments/assets/e91ea4ba-98ff-4160-a173-7aa16df435cb" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
