### PR TITLE
fix(coffee): restore exit listener to prevent zombie caffeinate processes

### DIFF
--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## [Fix] - 2026-03-24
 
-- Fixed zombie process accumulation by properly detaching the caffeinate process with spawn/unref
+- Attempted to mitigate zombie process accumulation by detaching the caffeinate process with `spawn({ detached: true })` and `unref()` (incomplete without `exit` listener; final fix landed in {PR_MERGE_DATE})
 - Folded the `-u` flag into the main caffeinate process, eliminating periodic `caffeinate -u -t 1` spawning
 - Removed stale process filter in menu bar status
 

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Coffee Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed zombie process accumulation: restored `exit` listener on spawned caffeinate process so libuv reaps it when killed. The listener introduced in [#26523](https://github.com/raycast/extensions/pull/26523) was inadvertently removed by [#26577](https://github.com/raycast/extensions/pull/26577).
+
 ## [Fix] - 2026-03-24
 
 - Fixed zombie process accumulation by properly detaching the caffeinate process with spawn/unref

--- a/extensions/coffee/package.json
+++ b/extensions/coffee/package.json
@@ -14,7 +14,8 @@
     "ridemountainpig",
     "zakj",
     "Visual-Studio-Coder",
-    "Katsuba"
+    "Katsuba",
+    "Mearman"
   ],
   "platforms": [
     "macOS"

--- a/extensions/coffee/src/utils.ts
+++ b/extensions/coffee/src/utils.ts
@@ -17,6 +17,7 @@ export async function startCaffeinate(updates: Updates, hudMessage?: string, add
 
   const args = ["-u", ...generateArgs(additionalArgs).split(/\s+/).filter(Boolean)];
   const child = spawn("/usr/bin/caffeinate", args, { detached: true, stdio: "ignore" });
+  child.on("exit", () => {});
   child.unref();
 
   await update(updates, true);

--- a/extensions/coffee/src/utils.ts
+++ b/extensions/coffee/src/utils.ts
@@ -17,6 +17,8 @@ export async function startCaffeinate(updates: Updates, hudMessage?: string, add
 
   const args = ["-u", ...generateArgs(additionalArgs).split(/\s+/).filter(Boolean)];
   const child = spawn("/usr/bin/caffeinate", args, { detached: true, stdio: "ignore" });
+  // Intentionally empty: keeps libuv's SIGCHLD/waitpid reaping for the detached child
+  // (preventing zombies) while still allowing `unref()` to let the event loop exit.
   child.on("exit", () => {});
   child.unref();
 


### PR DESCRIPTION
## Summary

The `exit` listener introduced in #26523 (to fix #26512) was inadvertently removed by #26577, reintroducing zombie process accumulation.

### Root cause

`spawn()` with `detached: true` + `child.unref()` alone is insufficient. Without an `exit` listener, libuv drops its SIGCHLD interest for the child and never calls `waitpid()`. When `caffeinate` is subsequently killed (via `killall` in `stopCaffeinate`), via `-t` timeout, or via `-w` watched-app exit, the process becomes a zombie.

Adding `child.on("exit", () => {})` before `child.unref()` registers a SIGCHLD-backed `waitpid()` call in libuv, ensuring the process is reaped while still allowing the Node event loop to exit freely (unref'd).

### Changes

- `src/utils.ts`: restored `child.on("exit", () => {})` on the spawned caffeinate process
- `CHANGELOG.md`: added entry referencing this fix and the relevant PRs

## Related

- Fixes #26512
- Reverts regression introduced by #26577
- Restores fix from #26523