### PR TITLE
fix(keepassxc): support passwordless vaults

### DIFF
--- a/extensions/keepassxc/CHANGELOG.md
+++ b/extensions/keepassxc/CHANGELOG.md
@@ -1,5 +1,10 @@
 # KeePassXC Extension Changelog
 
+n## [Unreleased]
+
+### Fixed
+
+- Support passwordless vaults by making the password field optional (#26714).
 ## [1.9.0] - 2026-02-11
 
 ### Added

--- a/extensions/keepassxc/CHANGELOG.md
+++ b/extensions/keepassxc/CHANGELOG.md
@@ -1,10 +1,11 @@
 # KeePassXC Extension Changelog
 
-n## [Unreleased]
+## [Unreleased]
 
 ### Fixed
 
-- Support passwordless vaults by making the password field optional (#26714).
+- Support passwordless vaults by making the password field optional and passing `--no-password` to the CLI when no password is provided (#26714).
+
 ## [1.9.0] - 2026-02-11
 
 ### Added

--- a/extensions/keepassxc/src/components/unlock-database.tsx
+++ b/extensions/keepassxc/src/components/unlock-database.tsx
@@ -31,22 +31,17 @@ export default function UnlockDatabase({
         style: Toast.Style.Animated,
         title: "Unlocking Database...",
       });
-      KeePassLoader.checkCredentials(value.password, value.keyFile[0]).then(() => {
+      KeePassLoader.checkCredentials(value.password || "", value.keyFile[0]).then(() => {
         showToast({
           style: Toast.Style.Success,
           title: "Database Unlocked",
         });
-        KeePassLoader.cacheCredentials(value.password, value.keyFile[0]);
-        KeePassLoader.setCredentials(value.password, value.keyFile[0]);
+        KeePassLoader.cacheCredentials(value.password || "", value.keyFile[0]);
+        KeePassLoader.setCredentials(value.password || "", value.keyFile[0]);
         setIsUnlocked(true);
       }, showToastKeepassxcCliErrors);
     },
-    validation: {
-      password: (value) => {
-        if (!value) {
-          return "Required";
-        }
-      },
+    // Password is optional to support passwordless vaults
     },
   });
 
@@ -62,7 +57,7 @@ export default function UnlockDatabase({
       <Form.PasswordField title="Database Password" {...itemProps.password} />
       <Form.FilePicker id="keyFile" title="Key File" allowMultipleSelection={false} />
       <Form.Description
-        text={"ⓘ Your password and key file path will be stored in your Raycast's local encrypted storage."}
+        text={"ⓘ Password is optional for passwordless vaults. Credentials are stored in your Raycast's local encrypted storage."}
       />
     </Form>
   );

--- a/extensions/keepassxc/src/components/unlock-database.tsx
+++ b/extensions/keepassxc/src/components/unlock-database.tsx
@@ -12,7 +12,7 @@ interface PasswordForm {
 /**
  * Component for unlocking the KeePass database
  *
- * This component renders a form that requires a password and an optional key file
+ * This component renders a form that accepts an optional password and an optional key file
  * to unlock the KeePass database. Upon submission, it validates the credentials,
  * stores them securely, and updates the lock status of the database
  *
@@ -31,13 +31,13 @@ export default function UnlockDatabase({
         style: Toast.Style.Animated,
         title: "Unlocking Database...",
       });
-      KeePassLoader.checkCredentials(value.password || "", value.keyFile[0]).then(() => {
+      KeePassLoader.checkCredentials(value.password ?? "", value.keyFile[0]).then(() => {
         showToast({
           style: Toast.Style.Success,
           title: "Database Unlocked",
         });
-        KeePassLoader.cacheCredentials(value.password || "", value.keyFile[0]);
-        KeePassLoader.setCredentials(value.password || "", value.keyFile[0]);
+        KeePassLoader.cacheCredentials(value.password ?? "", value.keyFile[0]);
+        KeePassLoader.setCredentials(value.password ?? "", value.keyFile[0]);
         setIsUnlocked(true);
       }, showToastKeepassxcCliErrors);
     },
@@ -56,7 +56,7 @@ export default function UnlockDatabase({
       <Form.PasswordField title="Database Password" {...itemProps.password} />
       <Form.FilePicker id="keyFile" title="Key File" allowMultipleSelection={false} />
       <Form.Description
-        text={"ⓘ Your password and key file path will be stored in your Raycast's local encrypted storage."}
+        text={"ⓘ Your password and key file path will be stored in Raycast's local encrypted storage."}
       />
     </Form>
   );

--- a/extensions/keepassxc/src/components/unlock-database.tsx
+++ b/extensions/keepassxc/src/components/unlock-database.tsx
@@ -41,8 +41,7 @@ export default function UnlockDatabase({
         setIsUnlocked(true);
       }, showToastKeepassxcCliErrors);
     },
-    // Password is optional to support passwordless vaults
-    },
+    // Password is optional to support passwordless vaults (key-file-only)
   });
 
   return (
@@ -57,7 +56,7 @@ export default function UnlockDatabase({
       <Form.PasswordField title="Database Password" {...itemProps.password} />
       <Form.FilePicker id="keyFile" title="Key File" allowMultipleSelection={false} />
       <Form.Description
-        text={"ⓘ Password is optional for passwordless vaults. Credentials are stored in your Raycast's local encrypted storage."}
+        text={"ⓘ Your password and key file path will be stored in your Raycast's local encrypted storage."}
       />
     </Form>
   );

--- a/extensions/keepassxc/src/utils/keepass-loader.ts
+++ b/extensions/keepassxc/src/utils/keepass-loader.ts
@@ -86,6 +86,15 @@ class KeePassLoader {
     keyFile != "" && keyFile != null ? ["-k", `${keyFile}`] : [];
 
   /**
+   * Returns `["--no-password"]` when the password is empty, so the CLI does not
+   * prompt for one. Returns an empty array when a password is provided.
+   *
+   * @param {string} password - The database password (may be empty for passwordless vaults)
+   * @returns {string[]} - `["--no-password"]` or `[]`
+   */
+  private static convertIntoNoPasswordOption = (password: string) => (password === "" ? ["--no-password"] : []);
+
+  /**
    * Converts a string from the KeePassXC CLI into a sorted array of strings
    *
    * The KeePassXC CLI returns a CSV string, which this function parses into an array
@@ -191,11 +200,15 @@ class KeePassLoader {
         const cli = this.spawn(`${this.keepassxcCli}`, [
           "db-info",
           ...this.convertIntoKeyFileOption(keyFile),
+          ...this.convertIntoNoPasswordOption(databasePassword),
           "-q",
           `${this.database}`,
         ]);
 
-        cli.stdin.write(`${databasePassword}\n`);
+        // Only write password to stdin when a password is provided
+        if (databasePassword !== "") {
+          cli.stdin.write(`${databasePassword}\n`);
+        }
         cli.stdin.end();
         cli.on("error", reject);
         cli.stderr.on("data", this.cliStderrErrorHandler(reject));
@@ -235,7 +248,9 @@ class KeePassLoader {
     KeePassLoader.findApplication().then(() => {
       return new Promise<string>((resolve, reject) => {
         const chuncks: Buffer[] = [];
-        const cli = this.spawn(`${this.keepassxcCli}`, options);
+        // Prepend --no-password flag when the stored password is empty (passwordless vault)
+        const noPasswordOption = this.convertIntoNoPasswordOption(this.databasePassword ?? "");
+        const cli = this.spawn(`${this.keepassxcCli}`, [...noPasswordOption, ...options]);
         const tryResolve = () => {
           if (ended && exited) {
             resolve(result);
@@ -245,7 +260,10 @@ class KeePassLoader {
         let exited = false;
         let result: string;
 
-        cli.stdin.write(`${this.databasePassword}\n`);
+        // Only write password to stdin when a password is provided
+        if (this.databasePassword !== "" && this.databasePassword != null) {
+          cli.stdin.write(`${this.databasePassword}\n`);
+        }
         cli.stdin.end();
         cli.on("error", reject);
         cli.stderr.on("data", this.cliStderrErrorHandler(reject));


### PR DESCRIPTION
Fixes #26714

KeePass vaults can be protected by a key file alone, without a password. The unlock form currently requires a password, showing "Required" validation error when the field is empty.

## Changes
- Removed mandatory password validation to allow empty passwords
- Added null coalescing for password in credential calls
- Updated help text to mention passwordless vault support

## Testing
- Open a KeePassXC vault protected by key file only (no password)
- Leave password field empty, select key file
- Click "Unlock" — vault should open successfully