### PR TITLE
Remove drewbabel from google-chrome contributors

### DIFF
--- a/extensions/google-chrome/package.json
+++ b/extensions/google-chrome/package.json
@@ -17,7 +17,6 @@
     "tleo19",
     "Tarocch1",
     "santiago_perez",
-    "drewbabel",
     "hayden_barnes",
     "pernielsentikaer",
     "j3lte",


### PR DESCRIPTION
I no longer actively maintain this extension and would like to be removed from the contributors list to stop receiving automated notifications.