### PR TITLE
Remove drewbabel from google-chrome and chatgpt-quick-actions contributors

### DIFF
--- a/extensions/chatgpt-quick-actions/package.json
+++ b/extensions/chatgpt-quick-actions/package.json
@@ -7,8 +7,7 @@
   "author": "alanzchen",
   "contributors": [
     "kolacek.m",
-    "JonathanAquino",
-    "drewbabel"
+    "JonathanAquino"
   ],
   "categories": [
     "Productivity"

--- a/extensions/google-chrome/package.json
+++ b/extensions/google-chrome/package.json
@@ -17,7 +17,6 @@
     "tleo19",
     "Tarocch1",
     "santiago_perez",
-    "drewbabel",
     "hayden_barnes",
     "pernielsentikaer",
     "j3lte",


### PR DESCRIPTION
I no longer actively maintain these extensions and would like to be removed from the contributors list to stop receiving automated notifications.