### PR TITLE
[Workouts] Improve search command display

### DIFF
--- a/extensions/workouts/CHANGELOG.md
+++ b/extensions/workouts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Workouts Changelog
 
-## [Improved Search Command Display] - {PR_MERGE_DATE}
+## [Improved Search Command Display] - 2026-03-29
 
 - Show activity name as the list item title instead of the sport type (which is already conveyed by the icon)
 - Group activities by month with section headers

--- a/extensions/workouts/CHANGELOG.md
+++ b/extensions/workouts/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Workouts Changelog
 
+## [Improved Search Command Display] - {PR_MERGE_DATE}
+
+- Show activity name as the list item title instead of the sport type (which is already conveyed by the icon)
+- Group activities by month with section headers
+- Use locale-aware relative dates (today, yesterday, weekday name, then short date)
+- Add detail panel fields: description, max speed, weighted average power, average cadence, max heart rate, max/min elevation, start time, kudos, achievements, and PRs
+- Show workout type, commute, and trainer tags in the detail panel
+- Add units to average power (W) and spacing to elevation (ft/m)
+- Fix timezone handling for local activity dates
+- Include sport type name in search keywords
+
 ## [Windows release] - 2025-06-24
 
 - Make available on Windows

--- a/extensions/workouts/package.json
+++ b/extensions/workouts/package.json
@@ -16,7 +16,8 @@
     "yvysunu",
     "pernielsentikaer",
     "dianne_mcewan",
-    "stphstph"
+    "stphstph",
+    "bendrucker"
   ],
   "platforms": [
     "macOS",

--- a/extensions/workouts/src/api/types.ts
+++ b/extensions/workouts/src/api/types.ts
@@ -137,6 +137,10 @@ export type StravaActivitySummary = {
   trainer: boolean;
   commute: boolean;
   photo_count: number;
+  workout_type?: number;
+  kudos_count?: number;
+  achievement_count?: number;
+  pr_count?: number;
 };
 
 export type StravaActivity = StravaActivitySummary & {

--- a/extensions/workouts/src/api/types.ts
+++ b/extensions/workouts/src/api/types.ts
@@ -121,19 +121,19 @@ export type StravaActivitySummary = {
   map: {
     summary_polyline: string;
   };
-  average_speed: number;
-  max_speed: number;
-  average_cadence: number;
-  has_heartrate: boolean;
-  average_heartrate: number;
-  max_heartrate: number;
-  suffer_score: number;
-  average_watts: number;
-  max_watts: number;
-  weighted_average_watts: number;
-  kilojoules: number;
-  elev_high: number;
-  elev_low: number;
+  average_speed?: number;
+  max_speed?: number;
+  average_cadence?: number;
+  has_heartrate?: boolean;
+  average_heartrate?: number;
+  max_heartrate?: number;
+  suffer_score?: number;
+  average_watts?: number;
+  max_watts?: number;
+  weighted_average_watts?: number;
+  kilojoules?: number;
+  elev_high?: number;
+  elev_low?: number;
   trainer: boolean;
   commute: boolean;
   photo_count: number;
@@ -227,7 +227,7 @@ export type StravaClubActivity = {
   elapsed_time: number;
   total_elevation_gain: number;
   sport_type: SportType;
-  workout_type: number;
+  workout_type?: number;
 };
 
 export type StravaManualActivity = {

--- a/extensions/workouts/src/constants.ts
+++ b/extensions/workouts/src/constants.ts
@@ -53,7 +53,7 @@ export const sportIcons: { [key: string]: string } = {
   Yoga: "yoga.svg",
 };
 
-export const workoutTypeLabels: Record<string, Record<number, string>> = {
+export const workoutTypeLabels = {
   run: {
     1: "Race",
     2: "Long Run",
@@ -63,7 +63,7 @@ export const workoutTypeLabels: Record<string, Record<number, string>> = {
     11: "Race",
     12: "Workout",
   },
-};
+} as const satisfies Record<string, Record<number, string>>;
 
 export const distancePresets = {
   Marathon: { km: "42.195", mi: "26.219" },

--- a/extensions/workouts/src/constants.ts
+++ b/extensions/workouts/src/constants.ts
@@ -53,6 +53,18 @@ export const sportIcons: { [key: string]: string } = {
   Yoga: "yoga.svg",
 };
 
+export const workoutTypeLabels: Record<string, Record<number, string>> = {
+  run: {
+    1: "Race",
+    2: "Long Run",
+    3: "Workout",
+  },
+  ride: {
+    11: "Race",
+    12: "Workout",
+  },
+};
+
 export const distancePresets = {
   Marathon: { km: "42.195", mi: "26.219" },
   "Half-Marathon": { km: "21.0975", mi: "13.1095" },

--- a/extensions/workouts/src/utils.ts
+++ b/extensions/workouts/src/utils.ts
@@ -131,12 +131,12 @@ export function formatAccessoryDate(date: Date): string {
   const startOfDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
   const diffDays = Math.round((startOfToday.getTime() - startOfDate.getTime()) / (1000 * 60 * 60 * 24));
 
-  if (diffDays <= 1) {
+  if (diffDays >= 0 && diffDays <= 1) {
     const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
     const label = rtf.format(-diffDays, "day");
     return label.charAt(0).toUpperCase() + label.slice(1);
   }
-  if (diffDays < 7) return date.toLocaleDateString(undefined, { weekday: "long" });
+  if (diffDays >= 2 && diffDays < 7) return date.toLocaleDateString(undefined, { weekday: "long" });
   return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
@@ -152,7 +152,8 @@ export function getWorkoutTypeLabel(sportType: SportType, workoutType?: number):
   }
 
   if (!family) return undefined;
-  return workoutTypeLabels[family]?.[workoutType];
+  const familyLabels = workoutTypeLabels[family as keyof typeof workoutTypeLabels];
+  return familyLabels?.[workoutType as keyof typeof familyLabels];
 }
 
 export function getWorkoutTypeColor(label: string): Color {

--- a/extensions/workouts/src/utils.ts
+++ b/extensions/workouts/src/utils.ts
@@ -8,9 +8,9 @@ import { homedir } from "os";
 const METERS_PER_MILE = 1609.344;
 const FEET_PER_METER = 3.28084;
 const KM_PER_MILE = 1.60934;
-const MS_TO_KMH = 3.6; // (1000 m/km) / (3600 s/hr)
+const MS_TO_KMH = 3.6; // (3600 s/hr) / (1000 m/km)
 const MS_TO_MPH = 2.23694;
-const MS_TO_MIN_PER_KM = 0.06; // (1/1000) * 60
+const MS_TO_KM_PER_MIN = 0.06; // (1/1000) * 60
 
 export const formatDuration = (duration: number) => {
   return new Date(duration * 1000).toISOString().substring(11, 19);
@@ -40,7 +40,7 @@ export const formatSpeedForSportType = (sportType: ActivityType, speed: number) 
 
   switch (sportType) {
     case "Run": {
-      const pace = 1 / (speed * MS_TO_MIN_PER_KM);
+      const pace = 1 / (speed * MS_TO_KM_PER_MIN);
       if (preferences.distance_unit === "km") {
         return `${Math.floor(pace)}:${Math.floor((pace % 1) * 60)
           .toString()
@@ -115,6 +115,8 @@ export function getSportTypesFromActivityTypes(activityTypes: SportType[], local
   return sportTypes;
 }
 
+// Strava's start_date_local includes a trailing Z despite representing local time.
+// Strip it so JS constructs the Date in the system timezone.
 export function parseLocalDate(dateString: string): Date {
   const [datePart, timePart] = dateString.split("T");
   const [year, month, day] = datePart.split("-").map(Number);
@@ -138,10 +140,10 @@ export function formatAccessoryDate(date: Date): string {
   return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
-export function getWorkoutTypeLabel(activityType: ActivityType, workoutType?: number): string | undefined {
+export function getWorkoutTypeLabel(sportType: SportType, workoutType?: number): string | undefined {
   if (workoutType == null) return undefined;
 
-  const typeName = activityType.toString().toLowerCase();
+  const typeName = sportType.toLowerCase();
   let family: string | undefined;
   if (typeName.includes("run")) {
     family = "run";

--- a/extensions/workouts/src/utils.ts
+++ b/extensions/workouts/src/utils.ts
@@ -1,8 +1,16 @@
-import { getPreferenceValues, environment, showToast, Toast } from "@raycast/api";
+import { getPreferenceValues, environment, showToast, Toast, Color } from "@raycast/api";
 import { ActivityType, SportType } from "./api/types";
+import { workoutTypeLabels } from "./constants";
 import { createWriteStream } from "fs";
 import path, { resolve } from "path";
 import { homedir } from "os";
+
+const METERS_PER_MILE = 1609.344;
+const FEET_PER_METER = 3.28084;
+const KM_PER_MILE = 1.60934;
+const MS_TO_KMH = 3.6; // (1000 m/km) / (3600 s/hr)
+const MS_TO_MPH = 2.23694;
+const MS_TO_MIN_PER_KM = 0.06; // (1/1000) * 60
 
 export const formatDuration = (duration: number) => {
   return new Date(duration * 1000).toISOString().substring(11, 19);
@@ -11,19 +19,17 @@ export const formatDuration = (duration: number) => {
 export const formatElevationGain = (elevationGain: number) => {
   const preferences = getPreferenceValues<Preferences>();
   if (preferences.distance_unit === "mi") {
-    return `${(elevationGain * 3.28084).toFixed(0)}ft`;
+    return `${(elevationGain * FEET_PER_METER).toFixed(0)} ft`;
   }
-  return `${Math.round(elevationGain)}m`;
+  return `${Math.round(elevationGain)} m`;
 };
 
 export const formatDistance = (distance: number) => {
-  const preferences = getPreferenceValues<Preferences>();
-
-  if (preferences.distance_unit === "km") {
+  const { distance_unit } = getPreferenceValues<Preferences>();
+  if (distance_unit === "km") {
     return `${(distance / 1000).toFixed(1)} km`;
-  } else {
-    return `${(distance / 1609.34).toFixed(2)} mi`;
   }
+  return `${(distance / METERS_PER_MILE).toFixed(2)} mi`;
 };
 export const formatSpeedForSportType = (sportType: ActivityType, speed: number) => {
   const preferences = getPreferenceValues<Preferences>();
@@ -34,13 +40,13 @@ export const formatSpeedForSportType = (sportType: ActivityType, speed: number) 
 
   switch (sportType) {
     case "Run": {
-      const pace = 1 / (speed * 0.06);
+      const pace = 1 / (speed * MS_TO_MIN_PER_KM);
       if (preferences.distance_unit === "km") {
         return `${Math.floor(pace)}:${Math.floor((pace % 1) * 60)
           .toString()
           .padStart(2, "0")}min/km`;
       } else {
-        const paceMiles = pace * 1.60934;
+        const paceMiles = pace * KM_PER_MILE;
         return `${Math.floor(paceMiles)}’${Math.floor((paceMiles % 1) * 60)
           .toString()
           .padStart(2, "0")}” min/mile`;
@@ -48,9 +54,9 @@ export const formatSpeedForSportType = (sportType: ActivityType, speed: number) 
     }
     default:
       if (preferences.distance_unit === "km") {
-        return `${(speed * 3.6).toFixed(1)} km/h`;
+        return `${(speed * MS_TO_KMH).toFixed(1)} km/h`;
       } else {
-        return `${(speed * 2.23694).toFixed(1)} mph`;
+        return `${(speed * MS_TO_MPH).toFixed(1)} mph`;
       }
   }
 };
@@ -109,6 +115,57 @@ export function getSportTypesFromActivityTypes(activityTypes: SportType[], local
   return sportTypes;
 }
 
+export function parseLocalDate(dateString: string): Date {
+  const [datePart, timePart] = dateString.split("T");
+  const [year, month, day] = datePart.split("-").map(Number);
+  if (!timePart) return new Date(year, month - 1, day);
+  const [hours, minutes, seconds] = timePart.replace("Z", "").split(":").map(Number);
+  return new Date(year, month - 1, day, hours, minutes, seconds);
+}
+
+export function formatAccessoryDate(date: Date): string {
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const diffDays = Math.round((startOfToday.getTime() - startOfDate.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (diffDays <= 1) {
+    const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+    const label = rtf.format(-diffDays, "day");
+    return label.charAt(0).toUpperCase() + label.slice(1);
+  }
+  if (diffDays < 7) return date.toLocaleDateString(undefined, { weekday: "long" });
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export function getWorkoutTypeLabel(activityType: ActivityType, workoutType?: number): string | undefined {
+  if (workoutType == null) return undefined;
+
+  const typeName = activityType.toString().toLowerCase();
+  let family: string | undefined;
+  if (typeName.includes("run")) {
+    family = "run";
+  } else if (typeName.includes("ride") || typeName === "velomobile" || typeName === "handcycle") {
+    family = "ride";
+  }
+
+  if (!family) return undefined;
+  return workoutTypeLabels[family]?.[workoutType];
+}
+
+export function getWorkoutTypeColor(label: string): Color {
+  switch (label) {
+    case "Race":
+      return Color.Red;
+    case "Long Run":
+      return Color.Blue;
+    case "Workout":
+      return Color.Orange;
+    default:
+      return Color.SecondaryText;
+  }
+}
+
 export function formatSportTypesText(input: string): string {
   input = input.replace(/(^E)([A-Z])/g, "E-$2");
   return input.replace(/([a-z0-9])([A-Z])/g, "$1 $2");
@@ -149,7 +206,7 @@ export function convertDistanceToMeters(distance: string, unit: string) {
     case "km":
       return value * 1000;
     case "mi":
-      return value * 1609.344;
+      return value * METERS_PER_MILE;
     default:
       throw new Error("Unsupported unit");
   }

--- a/extensions/workouts/src/utils.ts
+++ b/extensions/workouts/src/utils.ts
@@ -132,12 +132,12 @@ export function formatAccessoryDate(date: Date): string {
   const diffDays = Math.round((startOfToday.getTime() - startOfDate.getTime()) / (1000 * 60 * 60 * 24));
 
   if (diffDays >= 0 && diffDays <= 1) {
-    const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+    const rtf = new Intl.RelativeTimeFormat("en-US", { numeric: "auto" });
     const label = rtf.format(-diffDays, "day");
     return label.charAt(0).toUpperCase() + label.slice(1);
   }
-  if (diffDays >= 2 && diffDays < 7) return date.toLocaleDateString(undefined, { weekday: "long" });
-  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  if (diffDays >= 2 && diffDays < 7) return date.toLocaleDateString("en-US", { weekday: "long" });
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
 export function getWorkoutTypeLabel(sportType: SportType, workoutType?: number): string | undefined {

--- a/extensions/workouts/src/workouts.tsx
+++ b/extensions/workouts/src/workouts.tsx
@@ -166,7 +166,7 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
 
               <List.Item.Detail.Metadata.Label
                 title="Start Time"
-                text={activityDate.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
+                text={activityDate.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })}
               />
               {activity.moving_time && activity.moving_time !== activity.elapsed_time ? (
                 <List.Item.Detail.Metadata.Label title="Moving Time" text={formattedMovingTime} />
@@ -246,7 +246,7 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
 function groupActivitiesByMonth(activities: StravaActivitySummary[]): [string, StravaActivitySummary[]][] {
   const groups = new Map<string, StravaActivitySummary[]>();
   for (const activity of activities) {
-    const key = parseLocalDate(activity.start_date_local).toLocaleDateString(undefined, {
+    const key = parseLocalDate(activity.start_date_local).toLocaleDateString("en-US", {
       month: "long",
       year: "numeric",
     });

--- a/extensions/workouts/src/workouts.tsx
+++ b/extensions/workouts/src/workouts.tsx
@@ -1,10 +1,20 @@
 import { ActionPanel, List, Action, getPreferenceValues, Toast, showToast, Color, Detail, Icon } from "@raycast/api";
 import { useCachedPromise, usePromise, withAccessToken } from "@raycast/utils";
 import { PAGE_SIZE, getActivities, getActivity, provider } from "./api/client";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { StravaActivitySummary } from "./api/types";
 import { sportIcons, sportNames } from "./constants";
-import { formatDistance, formatElevationGain, formatSpeedForSportType, generateMapboxImage } from "./utils";
+import {
+  formatAccessoryDate,
+  formatDistance,
+  formatDuration,
+  formatElevationGain,
+  formatSpeedForSportType,
+  generateMapboxImage,
+  getWorkoutTypeLabel,
+  getWorkoutTypeColor,
+  parseLocalDate,
+} from "./utils";
 
 export function Splits({ activityId }: { activityId: StravaActivitySummary["id"] }) {
   const { data: activity, isLoading } = usePromise(() => getActivity(activityId), []);
@@ -50,26 +60,26 @@ ${
 
 export function Activity({ activity, isLoading }: { activity: StravaActivitySummary; isLoading: boolean }) {
   const sportType = sportNames[activity.sport_type] ?? "Workout";
-  const date = new Date(activity.start_date_local).toLocaleDateString("en-US", { month: "long", day: "numeric" });
-  const formattedDuration = new Date(activity.elapsed_time * 1000).toISOString().substring(11, 19);
-  const formattedMovingTime = new Date(activity.moving_time * 1000).toISOString().substring(11, 19);
-  const formattedHeartRate = `${Math.floor(activity.average_heartrate || 0)} bpm`;
+  const activityDate = parseLocalDate(activity.start_date_local);
+  const formattedDuration = formatDuration(activity.elapsed_time);
+  const formattedMovingTime = formatDuration(activity.moving_time);
+  const formattedHeartRate = `${Math.floor(activity.average_heartrate)} bpm`;
   const formattedKilojoules = `${activity.kilojoules} kJ`;
   const speedTitle = `Average ${["run", "swim"].includes(activity.type.toLowerCase()) ? "Pace" : "Speed"}`;
   const formattedSpeed = formatSpeedForSportType(activity.type, activity.average_speed);
   const formattedDistance = formatDistance(activity.distance);
   const mapboxImage = generateMapboxImage(activity.map.summary_polyline);
   const elevationGain = formatElevationGain(activity.total_elevation_gain);
+  const workoutLabel = getWorkoutTypeLabel(activity.type, activity.workout_type);
 
   const stravaLink = `https://www.strava.com/activities/${activity.id}/`;
 
+  const hasTags = !!(workoutLabel || activity.commute || activity.trainer);
+
   return (
     <List.Item
-      title={{
-        value: sportType,
-        tooltip: activity.name,
-      }}
-      accessories={[{ text: date }]}
+      title={activity.name}
+      accessories={[{ text: formatAccessoryDate(activityDate) }]}
       icon={{
         source: sportIcons[activity.type] ?? sportIcons["Workout"],
         tintColor: Color.PrimaryText,
@@ -81,6 +91,22 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
           metadata={
             <List.Item.Detail.Metadata>
               <List.Item.Detail.Metadata.Label title="Name" text={activity.name} />
+              {activity.description ? (
+                <List.Item.Detail.Metadata.Label title="Description" text={activity.description} />
+              ) : null}
+              {hasTags ? (
+                <List.Item.Detail.Metadata.TagList title="Tags">
+                  {workoutLabel ? (
+                    <List.Item.Detail.Metadata.TagList.Item text={workoutLabel} color={getWorkoutTypeColor(workoutLabel)} />
+                  ) : null}
+                  {activity.commute ? (
+                    <List.Item.Detail.Metadata.TagList.Item text="Commute" color={Color.Green} />
+                  ) : null}
+                  {activity.trainer ? (
+                    <List.Item.Detail.Metadata.TagList.Item text="Trainer" color={Color.Purple} />
+                  ) : null}
+                </List.Item.Detail.Metadata.TagList>
+              ) : null}
               <List.Item.Detail.Metadata.Separator />
 
               {activity.average_speed ||
@@ -94,16 +120,35 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
                   {activity.average_speed ? (
                     <List.Item.Detail.Metadata.Label title={speedTitle} text={formattedSpeed} />
                   ) : null}
+                  {activity.max_speed ? (
+                    <List.Item.Detail.Metadata.Label title="Max Speed" text={formatSpeedForSportType(activity.type, activity.max_speed)} />
+                  ) : null}
                   {activity.average_watts ? (
-                    <List.Item.Detail.Metadata.Label title="Average Power" text={activity.average_watts.toString()} />
+                    <List.Item.Detail.Metadata.Label title="Average Power" text={`${activity.average_watts} W`} />
+                  ) : null}
+                  {activity.weighted_average_watts ? (
+                    <List.Item.Detail.Metadata.Label title="Weighted Average Power" text={`${activity.weighted_average_watts} W`} />
+                  ) : null}
+                  {activity.average_cadence ? (
+                    <List.Item.Detail.Metadata.Label title="Average Cadence" text={`${Math.round(activity.average_cadence)} rpm`} />
                   ) : null}
                   {activity.total_elevation_gain ? (
                     <List.Item.Detail.Metadata.Label title="Elevation Gain" text={elevationGain} />
+                  ) : null}
+                  {activity.elev_high ? (
+                    <List.Item.Detail.Metadata.Label title="Max Elevation" text={formatElevationGain(activity.elev_high)} />
+                  ) : null}
+                  {activity.elev_low ? (
+                    <List.Item.Detail.Metadata.Label title="Min Elevation" text={formatElevationGain(activity.elev_low)} />
                   ) : null}
                   <List.Item.Detail.Metadata.Separator />
                 </>
               ) : null}
 
+              <List.Item.Detail.Metadata.Label
+                title="Start Time"
+                text={activityDate.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
+              />
               {activity.moving_time && activity.moving_time !== activity.elapsed_time ? (
                 <List.Item.Detail.Metadata.Label title="Moving Time" text={formattedMovingTime} />
               ) : null}
@@ -114,6 +159,9 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
               <List.Item.Detail.Metadata.Separator />
               {activity.average_heartrate ? (
                 <List.Item.Detail.Metadata.Label title="Average Heart Rate" text={formattedHeartRate} />
+              ) : null}
+              {activity.max_heartrate ? (
+                <List.Item.Detail.Metadata.Label title="Max Heart Rate" text={`${Math.round(activity.max_heartrate)} bpm`} />
               ) : null}
               {activity.suffer_score ? (
                 <List.Item.Detail.Metadata.Label
@@ -126,6 +174,23 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
               ) : null}
               {activity.kilojoules ? (
                 <List.Item.Detail.Metadata.Label title="Energy Output" text={formattedKilojoules} />
+              ) : null}
+
+              {activity.kudos_count || activity.achievement_count || activity.pr_count ? (
+                <>
+                  <List.Item.Detail.Metadata.Separator />
+                  <List.Item.Detail.Metadata.TagList title="Stats">
+                    {activity.kudos_count ? (
+                      <List.Item.Detail.Metadata.TagList.Item text={`${activity.kudos_count} kudos`} color={Color.Orange} />
+                    ) : null}
+                    {activity.achievement_count ? (
+                      <List.Item.Detail.Metadata.TagList.Item text={`${activity.achievement_count} achievements`} color={Color.Yellow} />
+                    ) : null}
+                    {activity.pr_count ? (
+                      <List.Item.Detail.Metadata.TagList.Item text={`${activity.pr_count} PRs`} color={Color.Purple} />
+                    ) : null}
+                  </List.Item.Detail.Metadata.TagList>
+                </>
               ) : null}
             </List.Item.Detail.Metadata>
           }
@@ -145,9 +210,23 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
           ) : null}
         </ActionPanel>
       }
-      keywords={[activity.name]}
+      keywords={[activity.name, sportType]}
     />
   );
+}
+
+function groupActivitiesByMonth(activities: StravaActivitySummary[]): [string, StravaActivitySummary[]][] {
+  const groups = new Map<string, StravaActivitySummary[]>();
+  for (const activity of activities) {
+    const key = parseLocalDate(activity.start_date_local).toLocaleDateString(undefined, { month: "long", year: "numeric" });
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(activity);
+    } else {
+      groups.set(key, [activity]);
+    }
+  }
+  return Array.from(groups.entries());
 }
 
 function Workouts() {
@@ -174,9 +253,20 @@ function Workouts() {
     }
   }, [error]);
 
+  const groupedActivities = useMemo(() => {
+    if (!activities) return [];
+    return groupActivitiesByMonth(activities);
+  }, [activities]);
+
   return (
     <List searchBarPlaceholder="Search workouts" isLoading={isLoading} pagination={pagination} throttle isShowingDetail>
-      {activities?.map((activity) => <Activity key={activity.id} activity={activity} isLoading={isLoading} />)}
+      {groupedActivities.map(([monthTitle, monthActivities]) => (
+        <List.Section key={monthTitle} title={monthTitle}>
+          {monthActivities.map((activity) => (
+            <Activity key={activity.id} activity={activity} isLoading={isLoading} />
+          ))}
+        </List.Section>
+      ))}
     </List>
   );
 }

--- a/extensions/workouts/src/workouts.tsx
+++ b/extensions/workouts/src/workouts.tsx
@@ -66,7 +66,7 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
   const formattedHeartRate = activity.average_heartrate ? `${Math.floor(activity.average_heartrate)} bpm` : undefined;
   const formattedKilojoules = activity.kilojoules ? `${activity.kilojoules} kJ` : undefined;
   const speedTitle = `Average ${["run", "swim"].includes(activity.type.toLowerCase()) ? "Pace" : "Speed"}`;
-  const formattedSpeed = formatSpeedForSportType(activity.type, activity.average_speed);
+  const formattedSpeed = activity.average_speed ? formatSpeedForSportType(activity.type, activity.average_speed) : undefined;
   const formattedDistance = formatDistance(activity.distance);
   const mapboxImage = generateMapboxImage(activity.map.summary_polyline);
   const elevationGain = formatElevationGain(activity.total_elevation_gain);

--- a/extensions/workouts/src/workouts.tsx
+++ b/extensions/workouts/src/workouts.tsx
@@ -3,7 +3,7 @@ import { useCachedPromise, usePromise, withAccessToken } from "@raycast/utils";
 import { PAGE_SIZE, getActivities, getActivity, provider } from "./api/client";
 import { useEffect, useMemo } from "react";
 import { StravaActivitySummary } from "./api/types";
-import { sportIcons, sportNames } from "./constants";
+import { sportIcons } from "./constants";
 import {
   formatAccessoryDate,
   formatDistance,
@@ -59,14 +59,15 @@ ${
 }
 
 export function Activity({ activity, isLoading }: { activity: StravaActivitySummary; isLoading: boolean }) {
-  const sportType = sportNames[activity.sport_type] ?? "Workout";
   const activityDate = parseLocalDate(activity.start_date_local);
   const formattedDuration = formatDuration(activity.elapsed_time);
   const formattedMovingTime = formatDuration(activity.moving_time);
   const formattedHeartRate = activity.average_heartrate ? `${Math.floor(activity.average_heartrate)} bpm` : undefined;
   const formattedKilojoules = activity.kilojoules ? `${activity.kilojoules} kJ` : undefined;
   const speedTitle = `Average ${["run", "swim"].includes(activity.type.toLowerCase()) ? "Pace" : "Speed"}`;
-  const formattedSpeed = activity.average_speed ? formatSpeedForSportType(activity.type, activity.average_speed) : undefined;
+  const formattedSpeed = activity.average_speed
+    ? formatSpeedForSportType(activity.type, activity.average_speed)
+    : undefined;
   const formattedDistance = formatDistance(activity.distance);
   const mapboxImage = generateMapboxImage(activity.map.summary_polyline);
   const elevationGain = formatElevationGain(activity.total_elevation_gain);

--- a/extensions/workouts/src/workouts.tsx
+++ b/extensions/workouts/src/workouts.tsx
@@ -97,7 +97,10 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
               {hasTags ? (
                 <List.Item.Detail.Metadata.TagList title="Tags">
                   {workoutLabel ? (
-                    <List.Item.Detail.Metadata.TagList.Item text={workoutLabel} color={getWorkoutTypeColor(workoutLabel)} />
+                    <List.Item.Detail.Metadata.TagList.Item
+                      text={workoutLabel}
+                      color={getWorkoutTypeColor(workoutLabel)}
+                    />
                   ) : null}
                   {activity.commute ? (
                     <List.Item.Detail.Metadata.TagList.Item text="Commute" color={Color.Green} />
@@ -121,25 +124,40 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
                     <List.Item.Detail.Metadata.Label title={speedTitle} text={formattedSpeed} />
                   ) : null}
                   {activity.max_speed ? (
-                    <List.Item.Detail.Metadata.Label title="Max Speed" text={formatSpeedForSportType(activity.type, activity.max_speed)} />
+                    <List.Item.Detail.Metadata.Label
+                      title="Max Speed"
+                      text={formatSpeedForSportType(activity.type, activity.max_speed)}
+                    />
                   ) : null}
                   {activity.average_watts ? (
                     <List.Item.Detail.Metadata.Label title="Average Power" text={`${activity.average_watts} W`} />
                   ) : null}
                   {activity.weighted_average_watts ? (
-                    <List.Item.Detail.Metadata.Label title="Weighted Average Power" text={`${activity.weighted_average_watts} W`} />
+                    <List.Item.Detail.Metadata.Label
+                      title="Weighted Average Power"
+                      text={`${activity.weighted_average_watts} W`}
+                    />
                   ) : null}
                   {activity.average_cadence ? (
-                    <List.Item.Detail.Metadata.Label title="Average Cadence" text={`${Math.round(activity.average_cadence)} rpm`} />
+                    <List.Item.Detail.Metadata.Label
+                      title="Average Cadence"
+                      text={`${Math.round(activity.average_cadence)} rpm`}
+                    />
                   ) : null}
                   {activity.total_elevation_gain ? (
                     <List.Item.Detail.Metadata.Label title="Elevation Gain" text={elevationGain} />
                   ) : null}
                   {activity.elev_high != null ? (
-                    <List.Item.Detail.Metadata.Label title="Max Elevation" text={formatElevationGain(activity.elev_high)} />
+                    <List.Item.Detail.Metadata.Label
+                      title="Max Elevation"
+                      text={formatElevationGain(activity.elev_high)}
+                    />
                   ) : null}
                   {activity.elev_low != null ? (
-                    <List.Item.Detail.Metadata.Label title="Min Elevation" text={formatElevationGain(activity.elev_low)} />
+                    <List.Item.Detail.Metadata.Label
+                      title="Min Elevation"
+                      text={formatElevationGain(activity.elev_low)}
+                    />
                   ) : null}
                   <List.Item.Detail.Metadata.Separator />
                 </>
@@ -161,7 +179,10 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
                 <List.Item.Detail.Metadata.Label title="Average Heart Rate" text={formattedHeartRate} />
               ) : null}
               {activity.max_heartrate ? (
-                <List.Item.Detail.Metadata.Label title="Max Heart Rate" text={`${Math.round(activity.max_heartrate)} bpm`} />
+                <List.Item.Detail.Metadata.Label
+                  title="Max Heart Rate"
+                  text={`${Math.round(activity.max_heartrate)} bpm`}
+                />
               ) : null}
               {activity.suffer_score ? (
                 <List.Item.Detail.Metadata.Label
@@ -181,10 +202,16 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
                   <List.Item.Detail.Metadata.Separator />
                   <List.Item.Detail.Metadata.TagList title="Stats">
                     {activity.kudos_count ? (
-                      <List.Item.Detail.Metadata.TagList.Item text={`${activity.kudos_count} kudos`} color={Color.Orange} />
+                      <List.Item.Detail.Metadata.TagList.Item
+                        text={`${activity.kudos_count} kudos`}
+                        color={Color.Orange}
+                      />
                     ) : null}
                     {activity.achievement_count ? (
-                      <List.Item.Detail.Metadata.TagList.Item text={`${activity.achievement_count} achievements`} color={Color.Yellow} />
+                      <List.Item.Detail.Metadata.TagList.Item
+                        text={`${activity.achievement_count} achievements`}
+                        color={Color.Yellow}
+                      />
                     ) : null}
                     {activity.pr_count ? (
                       <List.Item.Detail.Metadata.TagList.Item text={`${activity.pr_count} PRs`} color={Color.Purple} />
@@ -218,7 +245,10 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
 function groupActivitiesByMonth(activities: StravaActivitySummary[]): [string, StravaActivitySummary[]][] {
   const groups = new Map<string, StravaActivitySummary[]>();
   for (const activity of activities) {
-    const key = parseLocalDate(activity.start_date_local).toLocaleDateString(undefined, { month: "long", year: "numeric" });
+    const key = parseLocalDate(activity.start_date_local).toLocaleDateString(undefined, {
+      month: "long",
+      year: "numeric",
+    });
     const existing = groups.get(key);
     if (existing) {
       existing.push(activity);

--- a/extensions/workouts/src/workouts.tsx
+++ b/extensions/workouts/src/workouts.tsx
@@ -237,7 +237,7 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
           ) : null}
         </ActionPanel>
       }
-      keywords={[activity.name, sportType]}
+      keywords={[activity.name]}
     />
   );
 }

--- a/extensions/workouts/src/workouts.tsx
+++ b/extensions/workouts/src/workouts.tsx
@@ -63,14 +63,14 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
   const activityDate = parseLocalDate(activity.start_date_local);
   const formattedDuration = formatDuration(activity.elapsed_time);
   const formattedMovingTime = formatDuration(activity.moving_time);
-  const formattedHeartRate = `${Math.floor(activity.average_heartrate)} bpm`;
-  const formattedKilojoules = `${activity.kilojoules} kJ`;
+  const formattedHeartRate = activity.average_heartrate ? `${Math.floor(activity.average_heartrate)} bpm` : undefined;
+  const formattedKilojoules = activity.kilojoules ? `${activity.kilojoules} kJ` : undefined;
   const speedTitle = `Average ${["run", "swim"].includes(activity.type.toLowerCase()) ? "Pace" : "Speed"}`;
   const formattedSpeed = formatSpeedForSportType(activity.type, activity.average_speed);
   const formattedDistance = formatDistance(activity.distance);
   const mapboxImage = generateMapboxImage(activity.map.summary_polyline);
   const elevationGain = formatElevationGain(activity.total_elevation_gain);
-  const workoutLabel = getWorkoutTypeLabel(activity.type, activity.workout_type);
+  const workoutLabel = getWorkoutTypeLabel(activity.sport_type, activity.workout_type);
 
   const stravaLink = `https://www.strava.com/activities/${activity.id}/`;
 
@@ -135,10 +135,10 @@ export function Activity({ activity, isLoading }: { activity: StravaActivitySumm
                   {activity.total_elevation_gain ? (
                     <List.Item.Detail.Metadata.Label title="Elevation Gain" text={elevationGain} />
                   ) : null}
-                  {activity.elev_high ? (
+                  {activity.elev_high != null ? (
                     <List.Item.Detail.Metadata.Label title="Max Elevation" text={formatElevationGain(activity.elev_high)} />
                   ) : null}
-                  {activity.elev_low ? (
+                  {activity.elev_low != null ? (
                     <List.Item.Detail.Metadata.Label title="Min Elevation" text={formatElevationGain(activity.elev_low)} />
                   ) : null}
                   <List.Item.Detail.Metadata.Separator />


### PR DESCRIPTION
## Description

Improves the search command list and detail view:

- Show activity name as the list item title instead of the redundant sport type (already conveyed by the icon)
- Group activities by month with section headers
- Use locale-aware relative dates (today, yesterday, weekday, then short date)
- Fix timezone handling for local activity dates (Strava's start_date_local uses a Z suffix despite representing local time)
- Add detail panel fields: description, max speed, weighted average power, average cadence, max heart rate, max/min elevation, start time, kudos, achievements, PRs
- Show workout type, commute, and trainer as tags in the detail panel
- Add units to average power (W) and spacing to elevation values
- Extract unit conversion magic numbers into named constants
- Mark API fields that can be absent as optional on StravaActivitySummary (average_heartrate, average_watts, etc.)

## Screencast

<img width="862" height="586" alt="screenshot" src="https://github.com/user-attachments/assets/6c62d45f-34a9-4806-a573-58b4e5273167" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)