### PR TITLE
Add Windows platform support to IsDown

### DIFF
--- a/extensions/isdown/CHANGELOG.md
+++ b/extensions/isdown/CHANGELOG.md
@@ -1,6 +1,6 @@
 # IsDown
 
-## [Added Windows Support] - {PR_MERGE_DATE}
+## [Added Windows Support] - 2026-03-31
 
 - Added Windows to supported platforms
 

--- a/extensions/isdown/CHANGELOG.md
+++ b/extensions/isdown/CHANGELOG.md
@@ -1,3 +1,7 @@
 # IsDown
 
+## [Added Windows Support] - {PR_MERGE_DATE}
+
+- Added Windows to supported platforms
+
 ## [Initial Version] - 2026-03-18

--- a/extensions/isdown/package.json
+++ b/extensions/isdown/package.json
@@ -5,6 +5,7 @@
   "description": "Search and check the status of services and cloud providers",
   "icon": "isdown.png",
   "author": "nunotomas",
+  "contributors": ["Logan-8f"],
   "categories": [
     "Developer Tools"
   ],

--- a/extensions/isdown/package.json
+++ b/extensions/isdown/package.json
@@ -38,6 +38,7 @@
     "publish": "npx @raycast/api@latest publish"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ]
 }


### PR DESCRIPTION
## Description

Add Windows to the supported platforms for the IsDown extension. The extension only uses cross-platform Raycast APIs and HTTP calls to the isdown.app API — no macOS-specific code exists.

Closes #26575

## Screencast

<img width="1291" height="819" alt="image" src="https://github.com/user-attachments/assets/bbe47193-6f90-452b-8124-d40a3340db31" />

No UI changes — only a platform support addition. Tested on Windows and confirmed the extension works correctly.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)