### PR TITLE
Add Windows platform support to 1Password

### DIFF
--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1Password Changelog
 
-## [Added Windows Support] - {PR_MERGE_DATE}
+## [Added Windows Support] - 2026-04-06
 
 - Added Windows platform support
 - Added Windows-compatible 1Password CLI path detection

--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 1Password Changelog
 
+## [Added Windows Support] - {PR_MERGE_DATE}
+
+- Added Windows platform support
+- Added Windows-compatible 1Password CLI path detection
+- Updated keyboard shortcuts for cross-platform compatibility
+- Updated setup guide for Windows (Windows Hello instead of Touch ID)
+
 ## [Chore] - 2025-11-15
 
 - Add stricter, opinionated eslint rules for clarity

--- a/extensions/1password/package-lock.json
+++ b/extensions/1password/package-lock.json
@@ -7,7 +7,7 @@
       "name": "1password",
       "license": "MIT",
       "dependencies": {
-        "@1password/sdk": "^0.4.0-beta.1",
+        "@1password/sdk": "^0.4.0",
         "@raycast/api": "^1.103.6",
         "@raycast/utils": "^2.2.2",
         "fast-glob": "^3.3.3"
@@ -22,18 +22,18 @@
       }
     },
     "node_modules/@1password/sdk": {
-      "version": "0.4.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@1password/sdk/-/sdk-0.4.0-beta.1.tgz",
-      "integrity": "sha512-oLZUV/PaZcKu+5qRnqyZXStnAXzj76ZFmSHCKb4ykM75iQ6WFmWrKX9WVad3s5GL9sPATo+OGbZ8OGTXrE7rnA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@1password/sdk/-/sdk-0.4.0.tgz",
+      "integrity": "sha512-RIypujc9R/UeUaobjyClTYokqRFpcaIkHq+EO/X9XoHId98Vg+SbjwGV+yygRC4MyHwYNo1KP1iEbZcqJ4ZTdw==",
       "license": "MIT",
       "dependencies": {
-        "@1password/sdk-core": "0.4.0-beta.1"
+        "@1password/sdk-core": "0.4.0"
       }
     },
     "node_modules/@1password/sdk-core": {
-      "version": "0.4.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@1password/sdk-core/-/sdk-core-0.4.0-beta.1.tgz",
-      "integrity": "sha512-YXblRzkcGPj6W/T5WJ++Ndr3bbu/+9sf14PLUeV73HcydTbjnD4HJeCpvxzc4O5iLqBquQ76EkSsAGmS0t2L8g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@1password/sdk-core/-/sdk-core-0.4.0.tgz",
+      "integrity": "sha512-vjeI1o4wiONY+t1naA4dtUp6HktdLH1D2S+tN1Lh4l41S9XIUHxrljov9B5u6G+VHr7f2MUoxmzXA9zT3aokQQ==",
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/extensions/1password/package.json
+++ b/extensions/1password/package.json
@@ -15,7 +15,8 @@
     "lukah",
     "litomore",
     "vimtor",
-    "pavelas"
+    "pavelas",
+    "Logan-8f"
   ],
   "past_contributors": [
     "Davidwalser",
@@ -196,17 +197,17 @@
       "type": "textfield"
     },
     {
-      "description": "Enter your ZSH binary path",
+      "description": "Enter your shell binary path (macOS only, e.g., /bin/zsh)",
       "name": "zshPath",
       "placeholder": "e.g., /bin/zsh",
       "required": false,
-      "title": "1Password SHELL path",
+      "title": "1Password SHELL path (macOS)",
       "type": "textfield",
       "default": "/bin/zsh"
     }
   ],
   "dependencies": {
-    "@1password/sdk": "^0.4.0-beta.1",
+    "@1password/sdk": "^0.4.0",
     "@raycast/api": "^1.103.6",
     "@raycast/utils": "^2.2.2",
     "fast-glob": "^3.3.3"
@@ -228,6 +229,7 @@
     "publish": "npx @raycast/api@latest publish"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ]
 }

--- a/extensions/1password/src/v8/components/ActionCopyToClipboard.tsx
+++ b/extensions/1password/src/v8/components/ActionCopyToClipboard.tsx
@@ -2,7 +2,7 @@ import { Action, Clipboard, Icon, Keyboard, showHUD, showToast, Toast } from "@r
 import { execFileSync } from "node:child_process";
 
 import { useFrontmostApp } from "../hooks/useFrontmostApp";
-import { ExtensionError, getCliPath, handleErrors, titleCaseWord } from "../utils";
+import { ExtensionError, getCliPath, handleErrors, titleCaseWord, windowsEnv } from "../utils";
 
 export function CopyToClipboard({
   attribute,
@@ -37,12 +37,12 @@ export function CopyToClipboard({
           let stdout;
           if (attribute === "otp") {
             // based on OTP-type not field name
-            stdout = execFileSync(cliPath, ["item", "get", id, "--otp"]);
+            stdout = execFileSync(cliPath, ["item", "get", id, "--otp"], windowsEnv ? { env: windowsEnv } : {});
           } else {
             const attributeQueryParam = attribute ? `?attribute=${attribute}` : "";
             const uri = `op://${vault_id}/${id}/${field}${attributeQueryParam}`;
 
-            stdout = execFileSync(cliPath, ["read", uri]);
+            stdout = execFileSync(cliPath, ["read", uri], windowsEnv ? { env: windowsEnv } : {});
           }
 
           const value = stdout.toString().trim();

--- a/extensions/1password/src/v8/components/ActionShareItem.tsx
+++ b/extensions/1password/src/v8/components/ActionShareItem.tsx
@@ -1,7 +1,7 @@
 import { Action, Clipboard, Icon, Keyboard, showHUD, showToast, Toast } from "@raycast/api";
 import { execFileSync } from "node:child_process";
 
-import { ExtensionError, getCliPath, handleErrors } from "../utils";
+import { ExtensionError, getCliPath, handleErrors, windowsEnv } from "../utils";
 
 export function ShareItem({ id, shortcut, title }: { id: string; shortcut: Keyboard.Shortcut; title: string }) {
   return (
@@ -14,7 +14,7 @@ export function ShareItem({ id, shortcut, title }: { id: string; shortcut: Keybo
         });
 
         try {
-          const stdout = execFileSync(getCliPath(), ["item", "share", id]);
+          const stdout = execFileSync(getCliPath(), ["item", "share", id], windowsEnv ? { env: windowsEnv } : {});
 
           await Clipboard.copy(stdout.toString().trim(), { concealed: true });
 

--- a/extensions/1password/src/v8/components/AuthContext.tsx
+++ b/extensions/1password/src/v8/components/AuthContext.tsx
@@ -20,6 +20,7 @@ import {
   errorRegex,
   getCliPath,
   getSignInStatus,
+  isWindows,
   signIn,
   useAccounts,
   ZSH_PATH,
@@ -80,14 +81,16 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   };
   const authenticate = async () => {
-    await closeMainWindow({ popToRootType: PopToRootType.Suspended });
+    if (!isWindows) {
+      await closeMainWindow({ popToRootType: PopToRootType.Suspended });
+    }
     const toast = await showToast({
       style: Toast.Style.Animated,
       title: "Authenticating...",
     });
 
     try {
-      if (!ZSH_PATH) {
+      if (!isWindows && !ZSH_PATH) {
         throw new ZshMissingError("Zsh Binary Path Missing!");
       }
 

--- a/extensions/1password/src/v8/components/Error.tsx
+++ b/extensions/1password/src/v8/components/Error.tsx
@@ -1,7 +1,7 @@
 import { Action, ActionPanel, Detail, Icon, openExtensionPreferences } from "@raycast/api";
 
 import resetCache from "../../reset-cache";
-import { getCliPath, ZSH_PATH } from "../utils";
+import { getCliPath, isWindows, ZSH_PATH } from "../utils";
 
 export function Error() {
   const cliPath = getCliPath();
@@ -21,7 +21,7 @@ ${
 
 
 ${
-  ZSH_PATH
+  ZSH_PATH || isWindows
     ? ""
     : `
 -  Make sure that Zsh is installed by running \`zsh --version\` in your terminal.

--- a/extensions/1password/src/v8/components/Guide.tsx
+++ b/extensions/1password/src/v8/components/Guide.tsx
@@ -2,6 +2,7 @@ import { Action, ActionPanel, Detail, environment, Icon, openExtensionPreference
 import { join } from "node:path";
 
 import resetCache from "../../reset-cache";
+import { isWindows } from "../utils";
 
 const binary = join(environment.assetsPath, "binary-instruction.png");
 const settings = join(environment.assetsPath, "1password-settings.png");
@@ -22,11 +23,15 @@ const INSTRUCTION = `
 
 1. Open [1Password](onepassword://settings).
 2. Select the account or collection at the top of the sidebar and choose Preferences > Security.
-3. Check [Touch ID](https://support.1password.com/touch-id-mac/).
+3. Check [${isWindows ? "Windows Hello" : "Touch ID"}](${isWindows ? "https://support.1password.com/windows-hello/" : "https://support.1password.com/touch-id-mac/"}).
 4. Select Developer in the sidebar.
 5. Check "Connect with 1Password CLI".
-
-You can also unlock 1Password CLI with your [Apple Watch](https://support.1password.com/apple-watch-mac/).
+${
+  isWindows
+    ? ""
+    : `
+You can also unlock 1Password CLI with your [Apple Watch](https://support.1password.com/apple-watch-mac/).`
+}
 `;
 
 export function Guide() {

--- a/extensions/1password/src/v8/components/ItemActionPanel.tsx
+++ b/extensions/1password/src/v8/components/ItemActionPanel.tsx
@@ -55,7 +55,10 @@ function CopyOneTimePassword(item: Item) {
       field="one-time password"
       id={item.id}
       key="copy-one-time-password"
-      shortcut={{ key: "c", modifiers: ["cmd", "ctrl"] }}
+      shortcut={{
+        macOS: { key: "c", modifiers: ["cmd", "ctrl"] },
+        windows: { key: "c", modifiers: ["ctrl", "shift", "opt"] },
+      }}
       vault_id={item.vault.id}
     />
   );
@@ -67,7 +70,7 @@ function CopyPassword(item: Item) {
       field="password"
       id={item.id}
       key="copy-password"
-      shortcut={{ key: "c", modifiers: ["cmd", "opt"] }}
+      shortcut={{ macOS: { key: "c", modifiers: ["cmd", "opt"] }, windows: { key: "c", modifiers: ["ctrl", "opt"] } }}
       vault_id={item.vault.id}
     />
   );
@@ -75,7 +78,15 @@ function CopyPassword(item: Item) {
 
 function CopyShareItem(item: Item) {
   return (
-    <ShareItem id={item.id} key="share-item" shortcut={{ key: "s", modifiers: ["cmd", "shift"] }} title={item.title} />
+    <ShareItem
+      id={item.id}
+      key="share-item"
+      shortcut={{
+        macOS: { key: "s", modifiers: ["cmd", "shift"] },
+        windows: { key: "s", modifiers: ["ctrl", "shift"] },
+      }}
+      title={item.title}
+    />
   );
 }
 
@@ -85,7 +96,10 @@ function CopyUsername(item: Item) {
       field="username"
       id={item.id}
       key="copy-username"
-      shortcut={{ key: "c", modifiers: ["cmd", "shift"] }}
+      shortcut={{
+        macOS: { key: "c", modifiers: ["cmd", "shift"] },
+        windows: { key: "c", modifiers: ["ctrl", "shift"] },
+      }}
       vault_id={item.vault.id}
     />
   );
@@ -95,9 +109,11 @@ function OpenIn1Password(account: undefined | User, item: Item) {
   if (account) {
     return (
       <Action.Open
-        application="com.1password.1password"
         key="open-in-1password"
-        shortcut={{ key: "o", modifiers: ["cmd", "shift"] }}
+        shortcut={{
+          macOS: { key: "o", modifiers: ["cmd", "shift"] },
+          windows: { key: "o", modifiers: ["ctrl", "shift"] },
+        }}
         target={`onepassword://view-item/?a=${account.account_uuid}&v=${item.vault.id}&i=${item.id}`}
         title="Open in 1Password"
       />
@@ -132,7 +148,10 @@ function PasteOneTimePassword(item: Item) {
       id={item.id}
       isPasteAction
       key="paste-one-time-password"
-      shortcut={{ key: "v", modifiers: ["cmd", "ctrl"] }}
+      shortcut={{
+        macOS: { key: "v", modifiers: ["cmd", "ctrl"] },
+        windows: { key: "v", modifiers: ["ctrl", "shift", "opt"] },
+      }}
       vault_id={item.vault.id}
     />
   );
@@ -145,7 +164,7 @@ function PastePassword(item: Item) {
       id={item.id}
       isPasteAction
       key="paste-password"
-      shortcut={{ key: "v", modifiers: ["cmd", "opt"] }}
+      shortcut={{ macOS: { key: "v", modifiers: ["cmd", "opt"] }, windows: { key: "v", modifiers: ["ctrl", "opt"] } }}
       vault_id={item.vault.id}
     />
   );
@@ -158,7 +177,10 @@ function PasteUsername(item: Item) {
       id={item.id}
       isPasteAction
       key="paste-username"
-      shortcut={{ key: "v", modifiers: ["cmd", "shift"] }}
+      shortcut={{
+        macOS: { key: "v", modifiers: ["cmd", "shift"] },
+        windows: { key: "v", modifiers: ["ctrl", "shift"] },
+      }}
       vault_id={item.vault.id}
     />
   );

--- a/extensions/1password/src/v8/components/ItemActionPanel.tsx
+++ b/extensions/1password/src/v8/components/ItemActionPanel.tsx
@@ -57,7 +57,7 @@ function CopyOneTimePassword(item: Item) {
       key="copy-one-time-password"
       shortcut={{
         macOS: { key: "c", modifiers: ["cmd", "ctrl"] },
-        windows: { key: "c", modifiers: ["ctrl", "shift", "opt"] },
+        Windows: { key: "c", modifiers: ["ctrl", "shift", "opt"] },
       }}
       vault_id={item.vault.id}
     />
@@ -70,7 +70,7 @@ function CopyPassword(item: Item) {
       field="password"
       id={item.id}
       key="copy-password"
-      shortcut={{ macOS: { key: "c", modifiers: ["cmd", "opt"] }, windows: { key: "c", modifiers: ["ctrl", "opt"] } }}
+      shortcut={{ macOS: { key: "c", modifiers: ["cmd", "opt"] }, Windows: { key: "c", modifiers: ["ctrl", "opt"] } }}
       vault_id={item.vault.id}
     />
   );
@@ -83,7 +83,7 @@ function CopyShareItem(item: Item) {
       key="share-item"
       shortcut={{
         macOS: { key: "s", modifiers: ["cmd", "shift"] },
-        windows: { key: "s", modifiers: ["ctrl", "shift"] },
+        Windows: { key: "s", modifiers: ["ctrl", "shift"] },
       }}
       title={item.title}
     />
@@ -98,7 +98,7 @@ function CopyUsername(item: Item) {
       key="copy-username"
       shortcut={{
         macOS: { key: "c", modifiers: ["cmd", "shift"] },
-        windows: { key: "c", modifiers: ["ctrl", "shift"] },
+        Windows: { key: "c", modifiers: ["ctrl", "shift"] },
       }}
       vault_id={item.vault.id}
     />
@@ -112,7 +112,7 @@ function OpenIn1Password(account: undefined | User, item: Item) {
         key="open-in-1password"
         shortcut={{
           macOS: { key: "o", modifiers: ["cmd", "shift"] },
-          windows: { key: "o", modifiers: ["ctrl", "shift"] },
+          Windows: { key: "o", modifiers: ["ctrl", "shift"] },
         }}
         target={`onepassword://view-item/?a=${account.account_uuid}&v=${item.vault.id}&i=${item.id}`}
         title="Open in 1Password"
@@ -150,7 +150,7 @@ function PasteOneTimePassword(item: Item) {
       key="paste-one-time-password"
       shortcut={{
         macOS: { key: "v", modifiers: ["cmd", "ctrl"] },
-        windows: { key: "v", modifiers: ["ctrl", "shift", "opt"] },
+        Windows: { key: "v", modifiers: ["ctrl", "shift", "opt"] },
       }}
       vault_id={item.vault.id}
     />
@@ -164,7 +164,7 @@ function PastePassword(item: Item) {
       id={item.id}
       isPasteAction
       key="paste-password"
-      shortcut={{ macOS: { key: "v", modifiers: ["cmd", "opt"] }, windows: { key: "v", modifiers: ["ctrl", "opt"] } }}
+      shortcut={{ macOS: { key: "v", modifiers: ["cmd", "opt"] }, Windows: { key: "v", modifiers: ["ctrl", "opt"] } }}
       vault_id={item.vault.id}
     />
   );
@@ -179,7 +179,7 @@ function PasteUsername(item: Item) {
       key="paste-username"
       shortcut={{
         macOS: { key: "v", modifiers: ["cmd", "shift"] },
-        windows: { key: "v", modifiers: ["ctrl", "shift"] },
+        Windows: { key: "v", modifiers: ["ctrl", "shift"] },
       }}
       vault_id={item.vault.id}
     />

--- a/extensions/1password/src/v8/components/RandomPassword.tsx
+++ b/extensions/1password/src/v8/components/RandomPassword.tsx
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { useEffect, useState } from "react";
 
 import { Item } from "../types";
-import { getCliPath } from "../utils";
+import { getCliPath, isWindows, windowsEnv } from "../utils";
 
 import Shortcut = Keyboard.Shortcut;
 import Style = Toast.Style;
@@ -35,16 +35,20 @@ export function RandomPassword() {
 
       try {
         // https://1password.community/discussion/139189/feature-request-generate-random-passwords-with-cli-via-dedicated-command-e-g-op-generate
-        const stdout = execFileSync(getCliPath(), [
-          "item",
-          "create",
-          "--dry-run",
-          "--category",
-          "Password",
-          `--generate-password=${args.join(",")}`,
-          "--format",
-          "json",
-        ]);
+        const stdout = execFileSync(
+          getCliPath(),
+          [
+            "item",
+            "create",
+            "--dry-run",
+            "--category",
+            "Password",
+            `--generate-password=${args.join(",")}`,
+            "--format",
+            "json",
+          ],
+          { ...(windowsEnv ? { env: windowsEnv } : {}), stdio: ["ignore", "pipe", "pipe"] },
+        );
         const item: Item = JSON.parse(stdout.toString());
         const password = item.fields
           ?.filter((field) => field.id === "password")
@@ -53,9 +57,12 @@ export function RandomPassword() {
           .at(0);
 
         setGeneratedPassword(password || "ERROR");
-        await Clipboard.copy(password || "", { concealed: true });
+        // Clipboard.copy closes main window on Windows: https://github.com/raycast/extensions/issues/26731
+        if (!isWindows) {
+          await Clipboard.copy(password || "", { concealed: true });
+        }
         toast.style = Style.Success;
-        toast.title = "Copied to clipboard!";
+        toast.title = isWindows ? "Password generated!" : "Copied to clipboard!";
         toast.message = "";
       } catch (e) {
         toast.style = Style.Failure;

--- a/extensions/1password/src/v8/utils.ts
+++ b/extensions/1password/src/v8/utils.ts
@@ -2,8 +2,21 @@ import { getPreferenceValues, Icon, showToast, Toast } from "@raycast/api";
 import { useExec } from "@raycast/utils";
 import { execFileSync, execSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { Category, CategoryName, Item, User, Vault } from "./types";
+
+export const isWindows = process.platform === "win32";
+
+// Raycast on Windows may not set LOCALAPPDATA/USERPROFILE, which 1Password CLI needs to find the desktop app
+export const windowsEnv = isWindows
+  ? {
+      ...process.env,
+      LOCALAPPDATA: process.env.LOCALAPPDATA || join(homedir(), "AppData", "Local"),
+      USERPROFILE: process.env.USERPROFILE || homedir(),
+    }
+  : undefined;
 
 export type ActionID = string;
 
@@ -22,7 +35,14 @@ export class ConnectionError extends ExtensionError {}
 export class NotFoundError extends ExtensionError {}
 export class ZshMissingError extends ExtensionError {}
 export const getCliPath = () => {
-  const cliPath = [preferences.cliPath, "/usr/local/bin/op", "/opt/homebrew/bin/op"]
+  const defaultPaths = isWindows
+    ? [
+        "C:\\Program Files\\1Password CLI\\op.exe",
+        join(homedir(), "AppData", "Local", "Microsoft", "WinGet", "Links", "op.exe"),
+      ]
+    : ["/usr/local/bin/op", "/opt/homebrew/bin/op"];
+
+  const cliPath = [preferences.cliPath, ...defaultPaths]
     .filter(Boolean)
     .find((path) => (path ? existsSync(path) : false));
 
@@ -32,7 +52,7 @@ export const getCliPath = () => {
 
   return cliPath;
 };
-export const ZSH_PATH = [preferences.zshPath, "/bin/zsh"].find((path) => existsSync(path));
+export const ZSH_PATH = isWindows ? undefined : [preferences.zshPath, "/bin/zsh"].find((path) => existsSync(path));
 export const errorRegex = new RegExp(/\[\w+\]\s+\d{4}\/\d{2}\/\d{2}\s+\d{2}:\d{2}:\d{2}\s+(.*)$/m);
 export function actionsForItem(item: Item): ActionID[] {
   // all actions in the default order
@@ -77,7 +97,7 @@ export function op(args: string[]) {
   const cliPath = getCliPath();
 
   if (cliPath) {
-    const stdout = execFileSync(cliPath, args, { maxBuffer: 4096 * 1024 });
+    const stdout = execFileSync(cliPath, args, { maxBuffer: 4096 * 1024, ...(windowsEnv ? { env: windowsEnv } : {}) });
 
     return stdout.toString();
   }
@@ -98,17 +118,30 @@ export const handleErrors = (stderr: string) => {
   }
 };
 export const checkZsh = () => {
+  if (isWindows) return true;
   if (!ZSH_PATH) {
     return false;
   }
-
   return true;
 };
-export const signIn = (account?: string) =>
-  execSync(`${getCliPath()} signin ${account ? account : ""}`, { shell: ZSH_PATH });
+export const signIn = (account?: string) => {
+  if (isWindows) {
+    execFileSync(getCliPath(), ["signin", ...(account ? [account] : [])], {
+      stdio: "inherit",
+      timeout: 30000,
+      env: windowsEnv,
+    });
+  } else {
+    execSync(`${getCliPath()} signin ${account ? account : ""}`, { shell: ZSH_PATH });
+  }
+};
 export const getSignInStatus = () => {
   try {
-    execSync(`${getCliPath()} whoami`);
+    if (isWindows) {
+      execFileSync(getCliPath(), ["whoami"], { env: windowsEnv });
+    } else {
+      execSync(`${getCliPath()} whoami`);
+    }
     return true;
   } catch {
     return false;
@@ -116,6 +149,7 @@ export const getSignInStatus = () => {
 };
 export const useOp = <T = Buffer, U = undefined>(args: string[], callback?: (data: T) => T) => {
   return useExec<T, U>(getCliPath(), [...args, "--format=json"], {
+    env: windowsEnv,
     onError: async (e) => {
       await showToast({
         style: Toast.Style.Failure,
@@ -144,6 +178,7 @@ export const usePasswords2 = ({
     getCliPath(),
     ["--account", account, "items", "list", "--long", "--format=json", ...flags],
     {
+      env: windowsEnv,
       execute,
       onError: async (e) => {
         await showToast({
@@ -182,6 +217,7 @@ export const useCategories = () =>
 export const useAccount = () => useOp<User, ExtensionError>(["whoami"]);
 export const useAccounts = <T = User[], U = ExtensionError>(execute = true) =>
   useExec<T, U>(getCliPath(), ["account", "list", "--format=json"], {
+    env: windowsEnv,
     execute: execute,
     onError: async (e) => {
       await showToast({

--- a/extensions/1password/src/v8/utils.ts
+++ b/extensions/1password/src/v8/utils.ts
@@ -126,7 +126,7 @@ export const checkZsh = () => {
 };
 export const signIn = (account?: string) => {
   if (isWindows) {
-    execFileSync(getCliPath(), ["signin", ...(account ? [account] : [])], {
+    execFileSync(getCliPath(), ["signin", ...(account ? account.split(" ") : [])], {
       stdio: "inherit",
       timeout: 30000,
       env: windowsEnv,


### PR DESCRIPTION
## Description

Add Windows platform support to the 1Password extension.

### Key changes:
- **Environment fix**: Raycast on Windows doesn't set `LOCALAPPDATA`/`USERPROFILE` env vars, which 1Password CLI needs to discover the desktop app's named pipe. Added fallback values for these.
- **CLI path detection**: Added Windows paths (Program Files, WinGet) for `op.exe`
- **Authentication**: Use `execFileSync` with `stdio: "inherit"` on Windows to allow Windows Hello biometric prompt
- **Cross-platform shortcuts**: All keyboard shortcuts now use `{ macOS: ..., windows: ... }` format
- **Setup guide**: Touch ID → Windows Hello, removed Apple Watch reference on Windows
- **Zsh**: Skipped Zsh requirement on Windows (not needed)
- **Known limitation**: `Clipboard.copy()` closes the Raycast main window on Windows (tracked in #26731). Auto-copy is disabled for Generate Password as a workaround.

### Tested on Windows:
- ✅ Windows Hello authentication
- ✅ Session persistence (no re-auth on subsequent opens)
- ✅ My Passwords (list, copy username, copy password)
- ✅ Open in 1Password (via onepassword:// URI)
- ✅ Open in Browser
- ✅ Generate Password
- ✅ My Vaults

Closes #22310

## Screencast

<img width="1301" height="436" alt="Snipaste_2026-03-29_15-25-07" src="https://github.com/user-attachments/assets/1385aac5-801d-4231-9b09-de2e3d9e5b40" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)