### PR TITLE
Update singularityapp extension

### DIFF
--- a/extensions/singularityapp/CHANGELOG.md
+++ b/extensions/singularityapp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # SingularityApp Changelog
 
-## [0.3.0] - {PR_MERGE_DATE}
+## [0.3.0] - 2026-03-30
 
 - Added hierarchical project ordering with visual indentation
 

--- a/extensions/singularityapp/CHANGELOG.md
+++ b/extensions/singularityapp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SingularityApp Changelog
 
+## [0.3.0] - {PR_MERGE_DATE}
+
+- Added hierarchical project ordering with visual indentation
+
 ## [0.2.0] - 2026-03-01
 
 ### Added

--- a/extensions/singularityapp/src/add-task.tsx
+++ b/extensions/singularityapp/src/add-task.tsx
@@ -1,6 +1,6 @@
 import { Form, ActionPanel, Action, showToast, Toast, popToRoot, Icon } from "@raycast/api";
 import { useState, useEffect } from "react";
-import { createTask, getProjects, Project, withErrorHandling, getProjectIcon } from "./api";
+import { createTask, getProjects, Project, withErrorHandling, getProjectIcon, getProjectIndent } from "./api";
 
 function Command() {
   const [title, setTitle] = useState("");
@@ -87,7 +87,7 @@ function Command() {
             <Form.Dropdown.Item
               key={project.id}
               value={project.id}
-              title={`${getProjectIcon(project, true).source}  ${project.title}`}
+              title={`${getProjectIndent(project)}${getProjectIcon(project, true).source}  ${project.title}`}
             />
           ))}
         </Form.Dropdown>

--- a/extensions/singularityapp/src/api.ts
+++ b/extensions/singularityapp/src/api.ts
@@ -375,6 +375,13 @@ function sortProjectsHierarchically(projects: Project[]): Project[] {
     addProjectWithChildren(project, 0);
   }
 
+  // Fallback: include any unvisited projects at root level
+  for (const project of projects) {
+    if (!visited.has(project.id)) {
+      result.push({ ...project, depth: 0 });
+    }
+  }
+
   return result;
 }
 

--- a/extensions/singularityapp/src/api.ts
+++ b/extensions/singularityapp/src/api.ts
@@ -329,11 +329,15 @@ export async function getProjects(): Promise<Project[]> {
 
 /** Sorts projects hierarchically: parent followed by its children (recursively), then next sibling */
 function sortProjectsHierarchically(projects: Project[]): Project[] {
+  // Build a set of valid project IDs for orphan detection
+  const projectIds = new Set(projects.map((p) => p.id));
+
   // Build a map of parent -> children
   const childrenMap = new Map<string | undefined, Project[]>();
 
   for (const project of projects) {
-    const parentId = project.parent || undefined;
+    // Treat as root if no parent, or if parent ID doesn't exist (orphan)
+    const parentId = project.parent && projectIds.has(project.parent) ? project.parent : undefined;
     if (!childrenMap.has(parentId)) {
       childrenMap.set(parentId, []);
     }
@@ -351,8 +355,13 @@ function sortProjectsHierarchically(projects: Project[]): Project[] {
 
   // Recursively flatten the tree: parent, then all its children (depth-first)
   const result: Project[] = [];
+  const visited = new Set<string>(); // Cycle detection
 
   function addProjectWithChildren(project: Project, depth: number) {
+    // Guard against cycles
+    if (visited.has(project.id)) return;
+    visited.add(project.id);
+
     result.push({ ...project, depth });
     const children = childrenMap.get(project.id) || [];
     for (const child of children) {

--- a/extensions/singularityapp/src/api.ts
+++ b/extensions/singularityapp/src/api.ts
@@ -145,6 +145,9 @@ export interface Project {
   title: string;
   emoji?: string;
   color?: string;
+  parent?: string;
+  parentOrder?: number;
+  depth?: number;
 }
 
 export interface ProjectListResponse {
@@ -320,7 +323,56 @@ export async function getNote(noteId: string): Promise<Note | null> {
 }
 
 export async function getProjects(): Promise<Project[]> {
-  return await fetchAllPages<Project>(`${API_BASE_URL}/v2/project`, "projects", new URLSearchParams());
+  const projects = await fetchAllPages<Project>(`${API_BASE_URL}/v2/project`, "projects", new URLSearchParams());
+  return sortProjectsHierarchically(projects);
+}
+
+/** Sorts projects hierarchically: parent followed by its children (recursively), then next sibling */
+function sortProjectsHierarchically(projects: Project[]): Project[] {
+  // Build a map of parent -> children
+  const childrenMap = new Map<string | undefined, Project[]>();
+
+  for (const project of projects) {
+    const parentId = project.parent || undefined;
+    if (!childrenMap.has(parentId)) {
+      childrenMap.set(parentId, []);
+    }
+    childrenMap.get(parentId)!.push(project);
+  }
+
+  // Sort children within each parent by parentOrder
+  for (const children of childrenMap.values()) {
+    children.sort((a, b) => {
+      const orderA = a.parentOrder ?? Number.MAX_SAFE_INTEGER;
+      const orderB = b.parentOrder ?? Number.MAX_SAFE_INTEGER;
+      return orderA - orderB;
+    });
+  }
+
+  // Recursively flatten the tree: parent, then all its children (depth-first)
+  const result: Project[] = [];
+
+  function addProjectWithChildren(project: Project, depth: number) {
+    result.push({ ...project, depth });
+    const children = childrenMap.get(project.id) || [];
+    for (const child of children) {
+      addProjectWithChildren(child, depth + 1);
+    }
+  }
+
+  // Start with root projects (no parent)
+  const rootProjects = childrenMap.get(undefined) || [];
+  for (const project of rootProjects) {
+    addProjectWithChildren(project, 0);
+  }
+
+  return result;
+}
+
+/** Returns indentation prefix for nested projects */
+export function getProjectIndent(project: Project): string {
+  const depth = project.depth ?? 0;
+  return "      ".repeat(depth); // 6 spaces per level
 }
 
 export async function withErrorHandling<T>(

--- a/extensions/singularityapp/src/components/TaskActions.tsx
+++ b/extensions/singularityapp/src/components/TaskActions.tsx
@@ -8,6 +8,7 @@ import {
   completeTask,
   uncompleteTask,
   getProjectIcon,
+  getProjectIndent,
   getAPIDateString,
 } from "../api";
 import TaskUpdater from "./TaskUpdater";
@@ -170,8 +171,7 @@ export default function TaskActions({ task, projects, onTaskUpdated }: TaskActio
             {projects.map((project) => (
               <Action
                 key={project.id}
-                title={project.title}
-                icon={getProjectIcon(project)}
+                title={`${getProjectIndent(project)}${getProjectIcon(project, true).source}  ${project.title}`}
                 onAction={() => handleMoveToProject(project.id)}
               />
             ))}

--- a/extensions/singularityapp/src/components/TaskUpdater.tsx
+++ b/extensions/singularityapp/src/components/TaskUpdater.tsx
@@ -8,6 +8,7 @@ import {
   getNote,
   withErrorHandling,
   getProjectIcon,
+  getProjectIndent,
   getAPIDateString,
 } from "../api";
 import { parseNoteContent } from "../utils/delta-to-markdown";
@@ -121,7 +122,7 @@ export default function TaskUpdater({ task, projects: initialProjects, onTaskUpd
             <Form.Dropdown.Item
               key={project.id}
               value={project.id}
-              title={`${getProjectIcon(project, true).source}  ${project.title}`}
+              title={`${getProjectIndent(project)}${getProjectIcon(project, true).source}  ${project.title}`}
             />
           ))}
         </Form.Dropdown>

--- a/extensions/singularityapp/src/home.tsx
+++ b/extensions/singularityapp/src/home.tsx
@@ -10,6 +10,7 @@ import {
   getProjectTasks,
   getProjects,
   getProjectIcon,
+  getProjectIndent,
   withErrorHandling,
   ApiError,
 } from "./api";
@@ -257,9 +258,8 @@ function Home({ launchContext }: LaunchProps<{ launchContext?: { view: ViewType 
               {projects.map((project) => (
                 <List.Dropdown.Item
                   key={project.id}
-                  title={project.title}
+                  title={`${getProjectIndent(project)}${getProjectIcon(project, true).source}  ${project.title}`}
                   value={`project_${project.id}`}
-                  icon={getProjectIcon(project)}
                 />
               ))}
             </List.Dropdown.Section>


### PR DESCRIPTION
## Description

Added hierarchical project ordering with visual indentation

Projects now display in their correct order matching the SingularityApp desktop client, with nested projects appearing directly after their parent. Child projects are visually indented in all dropdowns and menus for clearer hierarchy.
## Screencast

Before:
<img width="294" height="312" alt="imagen" src="https://github.com/user-attachments/assets/5c05725b-76ed-4652-b80c-d0a83079ec43" />


After:
<img width="293" height="306" alt="imagen" src="https://github.com/user-attachments/assets/abb61e6a-59dc-4d27-a868-98a7fc82fa44" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
