### PR TITLE
GitHub: Fix PR list accessories alignment

### DIFF
--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Fix PR List Accessories Alignment] - {PR_MERGE_DATE}
 
-- Pull Requests: Move PR number from subtitle to accessories for consistent column alignment
+- Pull Requests: Always show comment count (zero shown as dimmed) to prevent accessories from shifting
 - Pull Requests: Always show comment count (zero shown as dimmed) to prevent accessories from shifting
 - Pull Requests: Replace variable-length relative date with fixed `MMM dd` format (e.g. "Mar 30")
 - Pull Requests: Replace review decision text badges with compact icons to prevent truncation on long titles

--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Changelog
 
-## [Fix PR List Accessories Alignment] - {PR_MERGE_DATE}
+## [Fix PR List Accessories Alignment] - 2026-04-13
 
 - Pull Requests: Always show comment count (zero shown as dimmed) to prevent accessories from shifting
 - Pull Requests: Replace variable-length relative date with fixed `MMM dd` format (e.g. "Mar 30")

--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,5 +1,14 @@
 # GitHub Changelog
 
+## [Fix PR List Accessories Alignment] - {PR_MERGE_DATE}
+
+- Pull Requests: Move PR number from subtitle to accessories for consistent column alignment
+- Pull Requests: Always show comment count (zero shown as dimmed) to prevent accessories from shifting
+- Pull Requests: Replace variable-length relative date with fixed `MMM dd` format (e.g. "Mar 30")
+- Pull Requests: Replace review decision text badges with compact icons to prevent truncation on long titles
+- Pull Requests: Add placeholder icon for rows without a review decision to keep CI check column aligned
+- Pull Requests: Add `showAuthor` prop to show author icon in Search and Repository views
+
 ## [Security Fix] - 2026-03-17
 
 - Bump lodash/lodash-es to fix prototype pollution vulnerability (CVE-2025-13465)

--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## [Fix PR List Accessories Alignment] - {PR_MERGE_DATE}
 
 - Pull Requests: Always show comment count (zero shown as dimmed) to prevent accessories from shifting
-- Pull Requests: Always show comment count (zero shown as dimmed) to prevent accessories from shifting
 - Pull Requests: Replace variable-length relative date with fixed `MMM dd` format (e.g. "Mar 30")
 - Pull Requests: Replace review decision text badges with compact icons to prevent truncation on long titles
 - Pull Requests: Add placeholder icon for rows without a review decision to keep CI check column aligned

--- a/extensions/github/src/components/PullRequestListItem.tsx
+++ b/extensions/github/src/components/PullRequestListItem.tsx
@@ -71,12 +71,6 @@ export default function PullRequestListItem({
     }
   }
 
-  // Insert #number and optional author before the date (rightmost)
-  accessories.splice(accessories.length - 1, 0, {
-    text: { value: `#${pullRequest.number}`, color: Color.SecondaryText },
-    tooltip: `Repository: ${pullRequest.repository.nameWithOwner}`,
-  });
-
   if (author) {
     accessories.splice(accessories.length - 1, 0, {
       icon: author.icon,
@@ -94,6 +88,7 @@ export default function PullRequestListItem({
     <List.Item
       key={pullRequest.id}
       title={pullRequest.title}
+      subtitle={{ value: `#${pullRequest.number}`, tooltip: `Repository: ${pullRequest.repository.nameWithOwner}` }}
       icon={{ value: status.icon, tooltip: `Status: ${status.text}` }}
       keywords={keywords}
       accessories={accessories}

--- a/extensions/github/src/components/PullRequestListItem.tsx
+++ b/extensions/github/src/components/PullRequestListItem.tsx
@@ -21,6 +21,7 @@ type PullRequestListItemProps = {
   pullRequest: PullRequestFieldsFragment;
   viewer?: UserFieldsFragment;
   mutateList?: MutatePromise<PullRequestFieldsFragment[] | undefined> | ReturnType<typeof useMyPullRequests>["mutate"];
+  showAuthor?: boolean;
 };
 
 export default function PullRequestListItem({
@@ -29,35 +30,33 @@ export default function PullRequestListItem({
   mutateList,
   sortQuery,
   setSortQuery,
+  showAuthor = false,
 }: PullRequestListItemProps & SortActionProps) {
   const updatedAt = new Date(pullRequest.updatedAt);
 
-  const numberOfComments = useMemo(() => getNumberOfComments(pullRequest), []);
-  const author = getPullRequestAuthor(pullRequest);
+  const numberOfComments = useMemo(() => getNumberOfComments(pullRequest), [pullRequest]);
+  const author = showAuthor ? getPullRequestAuthor(pullRequest) : null;
   const status = getPullRequestStatus(pullRequest);
   const reviewDecision = getReviewDecision(pullRequest.reviewDecision);
 
   const accessories: List.Item.Accessory[] = [
     {
-      date: updatedAt,
+      text: format(updatedAt, "MMM dd"),
       tooltip: `Updated: ${format(updatedAt, "EEEE d MMMM yyyy 'at' HH:mm")}`,
-    },
-    {
-      icon: author.icon,
-      tooltip: `Author: ${author.text}`,
     },
   ];
 
-  if (reviewDecision) {
-    accessories.unshift(reviewDecision);
-  }
+  accessories.unshift({
+    text: {
+      value: `${numberOfComments}`,
+      color: numberOfComments > 0 ? Color.PrimaryText : Color.SecondaryText,
+    },
+    icon: Icon.Bubble,
+  });
 
-  if (numberOfComments > 0) {
-    accessories.unshift({
-      text: `${numberOfComments}`,
-      icon: Icon.Bubble,
-    });
-  }
+  accessories.unshift(
+    reviewDecision ?? { icon: { source: Icon.Circle, tintColor: Color.SecondaryText }, tooltip: "No review requested" },
+  );
 
   if (pullRequest.repository.autoMergeAllowed && pullRequest.autoMergeRequest) {
     accessories.unshift({ tag: { value: "Auto-merge", color: Color.Yellow } });
@@ -72,6 +71,19 @@ export default function PullRequestListItem({
     }
   }
 
+  // Insert #number and optional author before the date (rightmost)
+  accessories.splice(accessories.length - 1, 0, {
+    text: { value: `#${pullRequest.number}`, color: Color.SecondaryText },
+    tooltip: `Repository: ${pullRequest.repository.nameWithOwner}`,
+  });
+
+  if (author) {
+    accessories.splice(accessories.length - 1, 0, {
+      icon: author.icon,
+      tooltip: `Author: ${author.text}`,
+    });
+  }
+
   const keywords = [`${pullRequest.number}`];
 
   if (pullRequest.author?.login) {
@@ -82,7 +94,6 @@ export default function PullRequestListItem({
     <List.Item
       key={pullRequest.id}
       title={pullRequest.title}
-      subtitle={{ value: `#${pullRequest.number}`, tooltip: `Repository: ${pullRequest.repository.nameWithOwner}` }}
       icon={{ value: status.icon, tooltip: `Status: ${status.text}` }}
       keywords={keywords}
       accessories={accessories}

--- a/extensions/github/src/components/RepositoryPullRequest.tsx
+++ b/extensions/github/src/components/RepositoryPullRequest.tsx
@@ -35,7 +35,7 @@ export function RepositoryPullRequestList(props: { repo: string }): JSX.Element 
     <List isLoading={isLoading} onSearchTextChange={setSearchText} navigationTitle={props.repo} throttle>
       <List.Section title="Pull Requests" subtitle={`${data?.length}`}>
         {data?.map((d) => (
-          <PullRequestListItem key={d.id} pullRequest={d} {...{ mutateList, sortQuery, setSortQuery }} />
+          <PullRequestListItem key={d.id} showAuthor pullRequest={d} {...{ mutateList, sortQuery, setSortQuery }} />
         ))}
       </List.Section>
     </List>

--- a/extensions/github/src/helpers/pull-request.ts
+++ b/extensions/github/src/helpers/pull-request.ts
@@ -144,13 +144,11 @@ export function getCheckStateAccessory(commitStatusCheckRollupState: StatusState
 export function getReviewDecision(reviewDecision?: PullRequestReviewDecision | null): List.Item.Accessory | null {
   switch (reviewDecision) {
     case "REVIEW_REQUIRED":
-      return { tag: { value: "Review required" } };
+      return { icon: { source: Icon.Eye, tintColor: Color.Yellow }, tooltip: "Review required" };
     case "CHANGES_REQUESTED":
-      return { tag: { value: "Changes requested" } };
+      return { icon: { source: Icon.Pencil, tintColor: Color.Orange }, tooltip: "Changes requested" };
     case "APPROVED":
-      return {
-        tag: { value: "Approved" },
-      };
+      return { icon: { source: Icon.CheckCircle, tintColor: Color.Green }, tooltip: "Approved" };
     default:
       return null;
   }

--- a/extensions/github/src/hooks/useMyPullRequests.ts
+++ b/extensions/github/src/hooks/useMyPullRequests.ts
@@ -8,7 +8,7 @@ import { PullRequestFieldsFragment } from "../generated/graphql";
 import { pluralize } from "../helpers";
 import { getRepositoryFilter } from "../helpers/repository";
 
-enum SectionType {
+export enum SectionType {
   Open = "Open",
   Assigned = "Assigned",
   Mentioned = "Mentioned",

--- a/extensions/github/src/my-pull-requests.tsx
+++ b/extensions/github/src/my-pull-requests.tsx
@@ -7,7 +7,7 @@ import PullRequestListItem from "./components/PullRequestListItem";
 import RepositoriesDropdown from "./components/RepositoryDropdown";
 import { PR_DEFAULT_SORT_QUERY } from "./helpers/pull-request";
 import { withGitHubClient } from "./helpers/withGithubClient";
-import { useMyPullRequests } from "./hooks/useMyPullRequests";
+import { SectionType, useMyPullRequests } from "./hooks/useMyPullRequests";
 import { useViewer } from "./hooks/useViewer";
 
 function MyPullRequests() {
@@ -56,6 +56,7 @@ function MyPullRequests() {
               return (
                 <PullRequestListItem
                   key={pullRequest.id}
+                  showAuthor={section.type !== SectionType.Open}
                   {...{ pullRequest, viewer, mutateList, sortQuery, setSortQuery }}
                 />
               );

--- a/extensions/github/src/search-pull-requests.tsx
+++ b/extensions/github/src/search-pull-requests.tsx
@@ -61,6 +61,7 @@ function SearchPullRequests() {
             return (
               <PullRequestListItem
                 key={pullRequest.id}
+                showAuthor
                 {...{ pullRequest, viewer, mutateList, sortQuery, setSortQuery }}
               />
             );


### PR DESCRIPTION
## Description

### Before
<img width="862" height="586" alt="스크린샷 2026-03-30 03 57 34" src="https://github.com/user-attachments/assets/8e73ab18-4658-4640-8acf-4d684903d518" />

### After
<img width="862" height="586" alt="스크린샷 2026-03-30 10 14 51" src="https://github.com/user-attachments/assets/c004364e-21ca-4e08-85ae-9f021db97201" />

### Problem

The PR list had three independent issues causing accessories (PR number, comment count, review status, date) to appear at inconsistent horizontal positions across rows:

1. **`#number` position varied with title length** — rendered as `subtitle`, which positions it immediately after the title text. Moved to the accessories area so it always appears in a fixed column.

2. **Optional accessories shifted remaining items** — comment count was hidden when zero, and review decision was hidden when absent. Each omission caused other accessories to shift. Now the comment count is always shown (zero is dimmed), and a placeholder circle icon always occupies the review decision slot.

3. **Relative date had variable width** — Raycast's `date:` field renders strings like `"5h ago"`, `"yesterday"`, `"Mar 24"` with inconsistent widths. Replaced with a fixed `MMM dd` format (e.g. `"Mar 30"`) — 6 characters, consistent, and locale-neutral.

### Changes

**`PullRequestListItem.tsx`**
- Remove `#number` from `subtitle`; insert as a fixed accessory before the date
- Always render comment count accessory (dimmed at zero)
- Replace `date:` field with `text: format(updatedAt, "MMM dd")`
- Always render review decision slot (placeholder `Icon.Circle` when absent) so the CI check column stays aligned
- Add `showAuthor` prop (default `false`) to optionally show the PR author icon
- Fix `useMemo` stale closure: add `pullRequest` to the dependency array

**`helpers/pull-request.ts`**
- Replace text-based review decision tags (`"Review required"` etc.) with compact icons + tooltips. The original text badges consumed enough width to truncate `#number` on rows with long titles — the icon approach preserves alignment without losing the information (available on hover).

**`search-pull-requests.tsx` / `RepositoryPullRequest.tsx`**
- Pass `showAuthor` — author icon shown where multiple authors appear

**`my-pull-requests.tsx`**
- Pass `showAuthor={section.type !== SectionType.Open}` — author shown for Assigned / Mentioned / Review Requests / Reviewed / Recently Closed sections; omitted for Open where the author is always the current user

**`hooks/useMyPullRequests.ts`**
- Export `SectionType` enum for use in `my-pull-requests.tsx`

### Result

All rows share a consistent column order:
`[CI?] [auto-merge?] [review] [💬] [#number] [author?] [MMM dd]`

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)