### PR TITLE
[Google Tasks] Fix due date timezone shift

### DIFF
--- a/extensions/google-tasks/CHANGELOG.md
+++ b/extensions/google-tasks/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Google Tasks Changelog
 
+## [Fix] - 2026-03-30
+
+- Fix due date timezone shift for UTC+ users
 ## [Update] - 2025-12-07
 
 - Add "Create Task" command for quick task creation

--- a/extensions/google-tasks/CHANGELOG.md
+++ b/extensions/google-tasks/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Google Tasks Changelog
 
-## [Fix] - 2026-03-30
+## [Fix] - {PR_MERGE_DATE}
 
 - Fix due date timezone shift for UTC+ users
+
 ## [Update] - 2025-12-07
 
 - Add "Create Task" command for quick task creation

--- a/extensions/google-tasks/CHANGELOG.md
+++ b/extensions/google-tasks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Tasks Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-03-31
 
 - Fix due date timezone shift for UTC+ users
 

--- a/extensions/google-tasks/src/api/endpoints.tsx
+++ b/extensions/google-tasks/src/api/endpoints.tsx
@@ -94,10 +94,26 @@ export async function deleteTask(tasklist: string, id: string): Promise<void> {
   }
 }
 
+function serializeTaskDueDate<T extends { due?: string | Date }>(task: T): T {
+  if (!(task.due instanceof Date)) {
+    return task;
+  }
+
+  const year = task.due.getFullYear();
+  const month = String(task.due.getMonth() + 1).padStart(2, "0");
+  const day = String(task.due.getDate()).padStart(2, "0");
+
+  return {
+    ...task,
+    due: `${year}-${month}-${day}T00:00:00.000Z`,
+  };
+}
+
 export async function createTask(tasklist: string, task: TaskForm): Promise<void> {
+  const payload = serializeTaskDueDate(task);
   const response = await fetch(`https://tasks.googleapis.com/tasks/v1/lists/${tasklist}/tasks`, {
     method: "POST",
-    body: JSON.stringify(task),
+    body: JSON.stringify(payload),
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${(await client.getTokens())?.accessToken}`,
@@ -109,9 +125,10 @@ export async function createTask(tasklist: string, task: TaskForm): Promise<void
   }
 }
 export async function editTask(tasklist: string, task: Task): Promise<void> {
+  const payload = serializeTaskDueDate(task);
   const response = await fetch(`https://tasks.googleapis.com/tasks/v1/lists/${tasklist}/tasks/${task.id}`, {
     method: "PATCH",
-    body: JSON.stringify(task),
+    body: JSON.stringify(payload),
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${(await client.getTokens())?.accessToken}`,

--- a/extensions/google-tasks/src/api/endpoints.tsx
+++ b/extensions/google-tasks/src/api/endpoints.tsx
@@ -106,7 +106,7 @@ function serializeTaskDueDate<T extends { due?: string | Date | null }>(task: T)
   return {
     ...task,
     due: `${year}-${month}-${day}T00:00:00.000Z`,
-  };
+  } as T;
 }
 
 export async function createTask(tasklist: string, task: TaskForm): Promise<void> {

--- a/extensions/google-tasks/src/api/endpoints.tsx
+++ b/extensions/google-tasks/src/api/endpoints.tsx
@@ -94,7 +94,7 @@ export async function deleteTask(tasklist: string, id: string): Promise<void> {
   }
 }
 
-function serializeTaskDueDate<T extends { due?: string | Date }>(task: T): T {
+function serializeTaskDueDate<T extends { due?: string | Date | null }>(task: T): T {
   if (!(task.due instanceof Date)) {
     return task;
   }


### PR DESCRIPTION
## Description

Fixes the due date being shifted back by 1 day for users in UTC+ timezones when creating or editing tasks.

## Root Cause

`createTask()` and `editTask()` in `endpoints.tsx` pass task objects to `JSON.stringify()`, which calls `Date.toJSON()` on the `due` field. This converts the local-midnight Date to a UTC string, shifting the date back for anyone east of UTC.

For example, a user in UTC+1 selecting March 29:
- Local: `2026-03-29T00:00:00+01:00`
- After `JSON.stringify`: `"2026-03-28T23:00:00.000Z"` (March 28)

## Fix

Added a `serializeTaskDueDate()` helper that formats the due date using local date parts (`getFullYear`, `getMonth`, `getDate`) to construct `YYYY-MM-DDT00:00:00.000Z`. Applied to both `createTask()` and `editTask()`.

This contribution was developed with AI assistance (Claude Code).

Fixes #26524