### PR TITLE
[Prompts.chat] Fix crash from API field rename (content -> contentPreview)

### DIFF
--- a/extensions/prompts-chat/CHANGELOG.md
+++ b/extensions/prompts-chat/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Fix] - 2026-03-30
+
+- Fix crash from upstream API field rename (content -> contentPreview)
 ## [Initial Version] - 2026-01-26
 
 - Added Search Prompts command for searching AI prompts

--- a/extensions/prompts-chat/CHANGELOG.md
+++ b/extensions/prompts-chat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-03-30
 
 - Fix crash from upstream API field rename (content -> contentPreview)
 

--- a/extensions/prompts-chat/CHANGELOG.md
+++ b/extensions/prompts-chat/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Fix] - {PR_MERGE_DATE}
 
 - Fix crash from upstream API field rename (content -> contentPreview)
+
 ## [Initial Version] - 2026-01-26
 
 - Added Search Prompts command for searching AI prompts

--- a/extensions/prompts-chat/CHANGELOG.md
+++ b/extensions/prompts-chat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix] - 2026-03-30
+## [Fix] - {PR_MERGE_DATE}
 
 - Fix crash from upstream API field rename (content -> contentPreview)
 ## [Initial Version] - 2026-01-26

--- a/extensions/prompts-chat/src/cache.ts
+++ b/extensions/prompts-chat/src/cache.ts
@@ -56,7 +56,8 @@ interface PromptsJsonResponse {
     title: string;
     slug: string;
     description: string | null;
-    content: string;
+    content?: string | null;
+    contentPreview?: string | null;
     type: string;
     voteCount: number;
     category: {
@@ -89,7 +90,7 @@ export async function downloadAllPrompts(): Promise<CachedPrompt[]> {
   const prompts: CachedPrompt[] = data.prompts.map((item) => ({
     id: item.id,
     title: item.title,
-    content: item.content,
+    content: item.contentPreview ?? item.content ?? "",
     description: item.description || undefined,
     type: item.type,
     author: {
@@ -118,7 +119,7 @@ export function searchPrompts(
   return prompts.filter(
     (p) =>
       p.title.toLowerCase().includes(lowerQuery) ||
-      p.content.toLowerCase().includes(lowerQuery) ||
+      (p.content ?? "").toLowerCase().includes(lowerQuery) ||
       (p.description && p.description.toLowerCase().includes(lowerQuery)) ||
       p.author.username.toLowerCase().includes(lowerQuery) ||
       (p.author.name && p.author.name.toLowerCase().includes(lowerQuery)) ||


### PR DESCRIPTION
## Description

Fixes the prompts.chat extension crashing when searching or loading prompts.

## Root Cause

The prompts.chat API renamed the `content` field to `contentPreview`. In `cache.ts`, `downloadAllPrompts()` maps `item.content` which is now `undefined`. When `searchPrompts()` calls `.toLowerCase()` on this undefined value, the extension crashes.

Verified by calling the API directly: all 1595 prompts have `contentPreview`, none have `content`.

## Fix

In `cache.ts`:
- `downloadAllPrompts()`: map `item.contentPreview ?? item.content ?? ""` (handles both new and cached data)
- `searchPrompts()`: null-safe `(p.content ?? "").toLowerCase()` in the filter

This contribution was developed with AI assistance (Claude Code).

Fixes #26607