### PR TITLE
[wrap-text] Fix clipboard race condition after paste

### DIFF
--- a/extensions/wrap-text/CHANGELOG.md
+++ b/extensions/wrap-text/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Wrap Text Changelog
 
+## [Fix] - 2026-03-30
+
+- Fix clipboard race condition: add delay before restoring previous clipboard content
 ## [Initial Version] - 2026-03-23
 
 - Added 6 individual wrap commands: Brackets, Single Quotes, Double Quotes, Curly Brackets, Parentheses, and Wrap with Custom Characters

--- a/extensions/wrap-text/src/utils.ts
+++ b/extensions/wrap-text/src/utils.ts
@@ -15,6 +15,7 @@ export async function wrapSelectedText(left: string, right: string = left) {
     const previousClipboard = await Clipboard.read();
 
     await Clipboard.paste(wrapped);
+    await new Promise((resolve) => setTimeout(resolve, 200));
 
     // Restore the previous clipboard content.
     if (previousClipboard.text !== undefined) {


### PR DESCRIPTION
## Description

Fixes the wrap-text extension pasting wrong clipboard content. After wrapping text, the extension pastes the original (unwrapped) content instead of the wrapped version.

## Root Cause

Race condition in `utils.ts`: `Clipboard.paste()` sends a simulated Cmd+V keystroke asynchronously. The code immediately restores the previous clipboard content before the target app processes the paste. The target app then reads the restored (original) clipboard instead of the wrapped text.

Regression from #25993 which added clipboard save/restore.

## Fix

Added a 200ms delay between `Clipboard.paste(wrapped)` and restoring previous clipboard content (`utils.ts:18`). This gives the target app time to process the Cmd+V before the clipboard changes back.

This contribution was developed with AI assistance (Claude Code).

Fixes #26579