### PR TITLE
Fix Dust extension: SSE streaming and workspace picker

### DIFF
--- a/extensions/dust-tt/CHANGELOG.md
+++ b/extensions/dust-tt/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dust.tt Changelog
 
+## [Fixes] - 2026-03-31
+
+- Fix SSE streaming: replace client library streaming with direct undici fetch to fix incompatibility with Raycast's Node.js environment.
+- Fix AbortController lifecycle causing the stream to abort mid-flight on React re-renders.
+- Fix workspace picker to fall back to user.workspaces when organizations list is empty, using the region from the JWT token.
+
 ## [Fixes] - 2025-11-27
 
 - Tighten auth flow for people with multiple accounts

--- a/extensions/dust-tt/CHANGELOG.md
+++ b/extensions/dust-tt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dust.tt Changelog
 
-## [Fixes] - 2026-03-31
+## [Fixes] - {PR_MERGE_DATE}
 
 - Fix SSE streaming: replace client library streaming with direct undici fetch to fix incompatibility with Raycast's Node.js environment.
 - Fix AbortController lifecycle causing the stream to abort mid-flight on React re-renders.

--- a/extensions/dust-tt/CHANGELOG.md
+++ b/extensions/dust-tt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dust.tt Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-04-02
 
 - Fix SSE streaming: replace client library streaming with direct undici fetch to fix incompatibility with Raycast's Node.js environment.
 - Fix AbortController lifecycle causing the stream to abort mid-flight on React re-renders.

--- a/extensions/dust-tt/src/answerQuestion.tsx
+++ b/extensions/dust-tt/src/answerQuestion.tsx
@@ -214,6 +214,7 @@ async function answerQuestion({
           title: "Thinking...",
         });
 
+        let streamError = false;
         const processEvent = (eventData: Record<string, unknown>) => {
           const event = eventData.data as Record<string, unknown> | undefined;
           if (!event || !event.type) return;
@@ -223,12 +224,14 @@ async function answerQuestion({
               const error = event.error as { code: string; message: string };
               console.error(`User message error: code: ${error.code} message: ${error.message}`);
               setDustAnswer(`**User message error** ${error.message}`);
+              streamError = true;
               break;
             }
             case "agent_error": {
               const error = event.error as { code: string; message: string };
               console.error(`Agent message error: code: ${error.code} message: ${error.message}`);
               setDustAnswer(`**Dust API error** ${error.message}`);
+              streamError = true;
               break;
             }
             case "agent_action_success": {
@@ -291,6 +294,7 @@ async function answerQuestion({
 
         const decoder = new TextDecoder();
         for await (const chunk of res.body) {
+          if (streamError) break;
           parser.feed(decoder.decode(chunk as Buffer, { stream: true }));
         }
       } catch (error) {

--- a/extensions/dust-tt/src/answerQuestion.tsx
+++ b/extensions/dust-tt/src/answerQuestion.tsx
@@ -1,7 +1,9 @@
 import { AgentActionPublicType, DataSourceViewType, DustAPI } from "@dust-tt/client";
 import { Action, ActionPanel, Color, Detail, Icon, List, showToast, Toast } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
+import { createParser } from "eventsource-parser";
 import { useEffect, useState } from "react";
+import { fetch as undiciFetch } from "undici";
 import { AskAgentQuestionForm } from "./askAgent";
 import { getDustClient, withPickedWorkspace } from "./dust_api/oauth";
 import { addDustHistory } from "./history";
@@ -168,92 +170,135 @@ async function answerQuestion({
       setDustAnswer("**Dust API error** (conversation or message is missing)");
     } else {
       setConversationId(conversation.sId);
+
+      // Find the agent message sId from conversation content
+      const agentMessage = conversation.content
+        .map((versions) => versions[versions.length - 1])
+        .find((m) => m && m.type === "agent_message" && m.parentMessageId === message.sId);
+
+      if (!agentMessage) {
+        showToast({ style: Toast.Style.Failure, title: "Failed to retrieve agent message" });
+        setDustAnswer("**Dust API error** (no agent message found)");
+        return;
+      }
+
       try {
-        const r = await dustApi.streamAgentAnswerEvents({ conversation, userMessageId: message.sId, signal });
-        if (r.isErr()) {
-          throw new Error(r.error.message);
-        } else {
-          const { eventStream } = r.value;
+        // Stream SSE events directly using undici fetch + Node.js async iterable,
+        // bypassing the Dust client's streamAgentAnswerEvents which uses
+        // ReadableStream.getReader() — incompatible with undici in Raycast's environment.
+        const headers = await dustApi.baseHeaders();
+        headers["Content-Type"] = "application/json";
+        headers["Accept"] = "text/event-stream";
 
-          let answer = "";
-          let action: AgentActionPublicType | undefined = undefined;
-          const chainOfThought: {
-            tokens: string;
-            timestamp: number;
-          }[] = [];
+        const eventsUrl = `${dustApi.apiUrl()}/api/v1/w/${dustApi.workspaceId()}/assistant/conversations/${conversation.sId}/messages/${agentMessage.sId}/events`;
 
-          showToast({
-            style: Toast.Style.Animated,
-            title: "Thinking...",
-          });
+        const res = await undiciFetch(eventsUrl, {
+          method: "GET",
+          headers,
+          signal,
+        });
 
-          for await (const event of eventStream) {
-            if (!event) {
-              continue;
+        if (!res.ok || !res.body) {
+          throw new Error(`Events request failed: status=${res.status}`);
+        }
+
+        let answer = "";
+        let action: AgentActionPublicType | undefined = undefined;
+        const chainOfThought: {
+          tokens: string;
+          timestamp: number;
+        }[] = [];
+
+        showToast({
+          style: Toast.Style.Animated,
+          title: "Thinking...",
+        });
+
+        const processEvent = (eventData: Record<string, unknown>) => {
+          const event = eventData.data as Record<string, unknown> | undefined;
+          if (!event || !event.type) return;
+
+          switch (event.type) {
+            case "user_message_error": {
+              const error = event.error as { code: string; message: string };
+              console.error(`User message error: code: ${error.code} message: ${error.message}`);
+              setDustAnswer(`**User message error** ${error.message}`);
+              break;
             }
-            switch (event.type) {
-              case "user_message_error": {
-                console.error(`User message error: code: ${event.error.code} message: ${event.error.message}`);
-                setDustAnswer(`**User message error** ${event.error.message}`);
-                return;
-              }
-              case "agent_error": {
-                console.error(`Agent message error: code: ${event.error.code} message: ${event.error.message}`);
-                setDustAnswer(`**Dust API error** ${event.error.message}`);
-                return;
-              }
-              case "agent_action_success": {
-                action = event.action;
-                break;
-              }
-
-              case "generation_tokens": {
-                if (event.classification === "tokens") {
-                  answer = (answer + event.text).trim();
-                  const dustAnswer = processAction({ content: answer, action, setDustDocuments });
-                  setDustAnswer(dustAnswer + "...");
-                } else if (event.classification === "chain_of_thought") {
-                  chainOfThought.push({ tokens: event.text, timestamp: event.created });
-
-                  const thinking = chainOfThought.map((c) => c.tokens).join("");
-                  const recent = thinking.slice(-60);
-
-                  showToast({
-                    style: Toast.Style.Animated,
-                    title: `@${agent.name} is thinking...`,
-                    message: recent,
-                  });
-                }
-                break;
-              }
-              case "agent_message_success": {
-                answer = processAction({ content: event.message.content ?? "", action, setDustDocuments });
+            case "agent_error": {
+              const error = event.error as { code: string; message: string };
+              console.error(`Agent message error: code: ${error.code} message: ${error.message}`);
+              setDustAnswer(`**Dust API error** ${error.message}`);
+              break;
+            }
+            case "agent_action_success": {
+              action = event.action as AgentActionPublicType;
+              break;
+            }
+            case "generation_tokens": {
+              if (event.classification === "tokens") {
+                answer = (answer + (event.text as string)).trim();
+                const dustAnswer = processAction({ content: answer, action, setDustDocuments });
+                setDustAnswer(dustAnswer + "...");
+              } else if (event.classification === "chain_of_thought") {
+                chainOfThought.push({
+                  tokens: event.text as string,
+                  timestamp: event.created as number,
+                });
+                const thinking = chainOfThought.map((c) => c.tokens).join("");
+                const recent = thinking.slice(-60);
                 showToast({
-                  style: Toast.Style.Success,
-                  title: `@${agent.name} answered your question`,
-                  message: question,
+                  style: Toast.Style.Animated,
+                  title: `@${agent.name} is thinking...`,
+                  message: recent,
                 });
-                setDustAnswer(answer);
-                await addDustHistory({
-                  conversationId: conversation.sId,
-                  question: question,
-                  answer: answer,
-                  date: new Date(),
-                  agent: agent.name,
-                });
-                return;
               }
-              default:
-              // Nothing to do on unsupported events
+              break;
+            }
+            case "agent_message_success": {
+              const msg = event.message as { content?: string };
+              answer = processAction({ content: msg.content ?? "", action, setDustDocuments });
+              showToast({
+                style: Toast.Style.Success,
+                title: `@${agent.name} answered your question`,
+                message: question,
+              });
+              setDustAnswer(answer);
+              addDustHistory({
+                conversationId: conversation.sId,
+                question: question,
+                answer: answer,
+                date: new Date(),
+                agent: agent.name,
+              });
+              break;
+            }
+            default:
+            // Nothing to do on unsupported events
+          }
+        };
+
+        const parser = createParser((sseEvent) => {
+          if (sseEvent.type === "event" && sseEvent.data) {
+            try {
+              const parsed = JSON.parse(sseEvent.data);
+              processEvent(parsed);
+            } catch (err) {
+              console.error("Failed parsing SSE event data:", err);
             }
           }
+        });
+
+        const decoder = new TextDecoder();
+        for await (const chunk of res.body) {
+          parser.feed(decoder.decode(chunk as Buffer, { stream: true }));
         }
       } catch (error) {
-        if (error instanceof Error && error.message.includes("AbortError")) {
-          showToast({
-            style: Toast.Style.Failure,
-            title: "Request was aborted",
-          });
+        const isAbort =
+          (error instanceof DOMException && error.name === "AbortError") ||
+          (error instanceof Error && (error.name === "AbortError" || error.message.includes("AbortError")));
+        if (isAbort) {
+          // Silently ignore — user navigated away or component unmounted
         } else {
           showToast({
             style: Toast.Style.Failure,
@@ -273,40 +318,32 @@ export const AskDustQuestion = withPickedWorkspace(
     const [conversationTitle, setConversationTitle] = useState<string | undefined>(undefined);
     const [dustAnswer, setDustAnswer] = useState<string | undefined>(undefined);
     const [dustDocuments, setDustDocuments] = useState<DustDocument[]>([]);
-    const [abortController] = useState(new AbortController());
     const { context, isLoading: isLoadingContext } = useConversationContext();
 
     const dustApi = getDustClient();
 
     useEffect(() => {
-      if (question && !conversationId && !isLoadingContext && context && dustApi) {
-        const asyncAnswer = async () => {
-          await answerQuestion({
-            question,
-            context,
-            dustApi,
-            agent,
-            setDustAnswer,
-            setConversationId,
-            setConversationTitle,
-            setDustDocuments,
-            signal: abortController.signal,
-          });
-        };
-
-        asyncAnswer();
-      }
-    }, [question, conversationId, isLoadingContext]);
-
-    useEffect(() => {
-      return () => {
-        try {
+      if (question && !conversationId && !isLoadingContext && context) {
+        const abortController = new AbortController();
+        answerQuestion({
+          question,
+          context,
+          dustApi,
+          agent,
+          setDustAnswer,
+          setConversationId,
+          setConversationTitle,
+          setDustDocuments,
+          signal: abortController.signal,
+        });
+        return () => {
           abortController.abort();
-        } catch (e) {
-          /* empty */
-        }
-      };
-    }, []);
+        };
+      }
+      // Note: context is intentionally omitted — it's a new object reference on every render
+      // and is guaranteed to be non-null when isLoadingContext is false.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [question, isLoadingContext]);
 
     const dustAssistantUrl = `${dustApi.apiUrl()}/w/${dustApi.workspaceId()}/assistant`;
 

--- a/extensions/dust-tt/src/answerQuestion.tsx
+++ b/extensions/dust-tt/src/answerQuestion.tsx
@@ -346,7 +346,6 @@ export const AskDustQuestion = withPickedWorkspace(
       }
       // Note: context is intentionally omitted — it's a new object reference on every render
       // and is guaranteed to be non-null when isLoadingContext is false.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [question, isLoadingContext]);
 
     const dustAssistantUrl = `${dustApi.apiUrl()}/w/${dustApi.workspaceId()}/assistant`;

--- a/extensions/dust-tt/src/pickWorkspace.tsx
+++ b/extensions/dust-tt/src/pickWorkspace.tsx
@@ -51,6 +51,13 @@ export default withDustClient(function PickWorkspaceCommand() {
         workspaces.push({ sId: org.externalId!, name: org.name, region: region });
       });
 
+      if (workspaces.length === 0) {
+        const jwtRegion = await LocalStorage.getItem<string>("selectedRegion");
+        user.workspaces?.forEach((ws) => {
+          workspaces.push({ sId: ws.sId, name: ws.name, region: jwtRegion || "us-central1" });
+        });
+      }
+
       if (user.selectedWorkspace) {
         const selectedOrg = workspaces.find((org) => org.sId === user?.selectedWorkspace);
         // Use the helper function to save both workspace ID and region


### PR DESCRIPTION
## Summary
- **Fix SSE streaming hang**: The Dust client's `streamAgentAnswerEvents()` uses `ReadableStream.getReader()` which is incompatible with undici's fetch polyfill in Raycast's Node.js environment, causing the stream to hang indefinitely. Replaced with direct undici fetch + Node.js async iterable (`for await...of`) which properly delivers SSE chunks.
- **Fix AbortController lifecycle**: The previous `useEffect` had `conversationId` in its dependency array, causing the effect cleanup to abort the stream mid-flight when `setConversationId` triggered a re-render. Moved `AbortController` creation inside the effect and removed `conversationId` from deps.
- **Fix workspace picker fallback**: When `user.organizations` is empty, fall back to `user.workspaces` from the `/me` endpoint, using the region from the JWT token claim (`https://dust.tt/region`) instead of a hardcoded value.

## Test plan
- [x] Ask Dust a question → streaming response appears incrementally
- [x] Chain of thought / thinking toast updates during generation
- [x] Final answer displays correctly with success toast
- [x] Workspace picker shows workspaces when organizations list is empty
- [x] Region is correctly detected from JWT token