### PR TITLE
Changelog Alignment

### DIFF
--- a/extensions/abstract-api/CHANGELOG.md
+++ b/extensions/abstract-api/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Abstract API Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`.
 

--- a/extensions/abstract-api/package.json
+++ b/extensions/abstract-api/package.json
@@ -145,5 +145,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Progress Bars & Zero-Config Auth] - {PR_MERGE_DATE}
+## [Progress Bars & Zero-Config Auth] - 2026-03-16
 
 ### New Features
 

--- a/extensions/ai-gen/CHANGELOG.md
+++ b/extensions/ai-gen/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OpenAI Generator Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/ai-gen/package.json
+++ b/extensions/ai-gen/package.json
@@ -96,5 +96,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/aleph/CHANGELOG.md
+++ b/extensions/aleph/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Aleph Changelog
 
- ## [Update] - 2023-06-16
+## [Update] - 2023-06-16
 
  - First push

--- a/extensions/aleph/package.json
+++ b/extensions/aleph/package.json
@@ -51,5 +51,8 @@
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/anki/CHANGELOG.md
+++ b/extensions/anki/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Anki Changelog
 
-## [Security Maintenance] - {PR_MERGE_DATE}
+## [Security Maintenance] - 2026-02-13
 
 - Removed unused `npm-check-updates` dependency.
 - Reduced transitive dependency surface (including removal of transitive `tar` usage) to address security advisories.

--- a/extensions/anki/package.json
+++ b/extensions/anki/package.json
@@ -117,5 +117,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/ansible-documentation/CHANGELOG.md
+++ b/extensions/ansible-documentation/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Search Ansible Documentation Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/ansible-documentation/package.json
+++ b/extensions/ansible-documentation/package.json
@@ -36,5 +36,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/appcleaner/CHANGELOG.md
+++ b/extensions/appcleaner/CHANGELOG.md
@@ -1,6 +1,6 @@
 # App Cleaner Changelog
 
-## [Allow any app to be an uninstaller] - {PR_MERGE_DATE}
+## [Allow any app to be an uninstaller] - 2026-03-16
 - Replaced a hardcoded list of supported uninstallers with an app picker dropdown that allows any app to be used as an uninstaller.
 
 ## [New uninstaller] - 2025-05-23

--- a/extensions/bazinga-tools/CHANGELOG.md
+++ b/extensions/bazinga-tools/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Bazinga Tools Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/bazinga-tools/package.json
+++ b/extensions/bazinga-tools/package.json
@@ -34,5 +34,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/bttv-emote/CHANGELOG.md
+++ b/extensions/bttv-emote/CHANGELOG.md
@@ -1,6 +1,6 @@
 # BTTV Emote Changelog
 
- ## [Introducing GRID View] - 2022-06-09
+## [Introducing GRID View] - 2022-06-09
 
  - Added new grid layout for emotes.
  - UI / UX improvement.

--- a/extensions/bttv-emote/package.json
+++ b/extensions/bttv-emote/package.json
@@ -33,5 +33,8 @@
     "build": "ray build -e dist",
     "dev": "ray develop",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/bundlephobia-search/CHANGELOG.md
+++ b/extensions/bundlephobia-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Bundlephobia Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/bundlephobia-search/package.json
+++ b/extensions/bundlephobia-search/package.json
@@ -39,5 +39,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/calendly/CHANGELOG.md
+++ b/extensions/calendly/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Calendly Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 - Update TypeScript to ^5.8.3 to fix build errors with modern @types/node

--- a/extensions/calendly/package.json
+++ b/extensions/calendly/package.json
@@ -53,5 +53,8 @@
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/cilium-docs/changelog.md
+++ b/extensions/cilium-docs/changelog.md
@@ -1,3 +1,3 @@
 # Cilium Changelog
 
- ## [Initial Release] - 2023-11-06
+## [Initial Release] - 2023-11-06

--- a/extensions/cilium-docs/package.json
+++ b/extensions/cilium-docs/package.json
@@ -39,5 +39,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/citation-generator/CHANGELOG.md
+++ b/extensions/citation-generator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Generate Citation Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/citation-generator/package.json
+++ b/extensions/citation-generator/package.json
@@ -37,5 +37,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/clash/CHANGELOG.md
+++ b/extensions/clash/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clash Changelog
 
- ## [Update] - 2022-12-05
+## [Update] - 2022-12-05
 
 - Fix traffic unit in Dashboard/Conns
 - Improve: Pin Conns title in list

--- a/extensions/clash/package.json
+++ b/extensions/clash/package.json
@@ -39,5 +39,8 @@
     "build": "ray build -e dist",
     "dev": "ray develop",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/coda-bookmarks-search/CHANGELOG.md
+++ b/extensions/coda-bookmarks-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/coda-bookmarks-search/package.json
+++ b/extensions/coda-bookmarks-search/package.json
@@ -62,5 +62,8 @@
     "eslint-plugin-react-hooks": "4.5.0",
     "prettier": "2.6.2",
     "typescript": "4.7.3"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/code-execution/CHANGELOG.md
+++ b/extensions/code-execution/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Code Execution Changelog
 
-## [Python Modules & AppleScript] - December 7, 2024
+## [Python Modules & AppleScript] - 2024-12-07
 
 With this update, Code Execution now has the full powers of Python Modules, the Command Line, and also AppleScript. Anything you can dream, Code Execution can do.
 

--- a/extensions/code-execution/CHANGELOG.md
+++ b/extensions/code-execution/CHANGELOG.md
@@ -16,7 +16,7 @@ With this update, Code Execution now has the full powers of Python Modules, the 
 * There are new, clearer icons for Bash, Python, and AppleScript tools so that the language you are running is clear on a glance
 
 
-## [Initial Version] - December 5, 2024
+## [Initial Version] - 2024-12-05
 
 The powers of Python and Bash, in the comfort of Raycast!
 

--- a/extensions/code-execution/package.json
+++ b/extensions/code-execution/package.json
@@ -161,5 +161,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/coinbase-pro/CHANGELOG.md
+++ b/extensions/coinbase-pro/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Coinbase PRO Changelog
 
- ## [Update] - 2022-07-31
+## [Update] - 2022-07-31
 
  - Updated icon host

--- a/extensions/coinbase-pro/package.json
+++ b/extensions/coinbase-pro/package.json
@@ -58,5 +58,8 @@
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/coinmarketcap-crypto-crawler/CHANGELOG.md
+++ b/extensions/coinmarketcap-crypto-crawler/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CoinMarketCap Crypto Crawler Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 - Update TypeScript to ^5.8.3 and @types/react to ^19.1.8 to fix build errors

--- a/extensions/coinmarketcap-crypto-crawler/package.json
+++ b/extensions/coinmarketcap-crypto-crawler/package.json
@@ -55,5 +55,8 @@
     "build": "ray build -e dist",
     "dev": "ray develop",
     "lint": "ray lint --fix"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/coinpaprika/CHANGELOG.md
+++ b/extensions/coinpaprika/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coinpaprika Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/coinpaprika/package.json
+++ b/extensions/coinpaprika/package.json
@@ -38,5 +38,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/cpanel/CHANGELOG.md
+++ b/extensions/cpanel/CHANGELOG.md
@@ -1,6 +1,6 @@
 # cPanel Changelog
 
-## [Security: Refresh Lockfile to Remove Unused Transitive Dependencies] - {PR_MERGE_DATE}
+## [Security: Refresh Lockfile to Remove Unused Transitive Dependencies] - 2026-02-13
 
 - Refreshed `package-lock.json` to remove stale transitive entries (including `got`/`electron`) that were no longer part of the installed dependency graph.
 

--- a/extensions/curl/CHANGELOG.md
+++ b/extensions/curl/CHANGELOG.md
@@ -1,10 +1,10 @@
 # cURL Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 
-## [Security: Refresh Lockfile to Remove Unused Transitive Dependencies] - {PR_MERGE_DATE}
+## [Security: Refresh Lockfile to Remove Unused Transitive Dependencies] - 2026-02-13
 
 - Refreshed `package-lock.json` to remove stale transitive entries (including `got`/`electron`) that were no longer part of the installed dependency graph.
 

--- a/extensions/debank/CHANGELOG.md
+++ b/extensions/debank/CHANGELOG.md
@@ -1,5 +1,5 @@
 # debank Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`

--- a/extensions/debank/package.json
+++ b/extensions/debank/package.json
@@ -33,5 +33,8 @@
     "build": "ray build -e dist",
     "dev": "ray develop",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/defichain-dobby/CHANGELOG.md
+++ b/extensions/defichain-dobby/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Defichain Dobby Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/defichain-dobby/package.json
+++ b/extensions/defichain-dobby/package.json
@@ -48,5 +48,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/dex-screener/CHANGELOG.md
+++ b/extensions/dex-screener/CHANGELOG.md
@@ -1,5 +1,5 @@
 # dex-screener Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`

--- a/extensions/dex-screener/package.json
+++ b/extensions/dex-screener/package.json
@@ -38,5 +38,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/dlmoji/CHANGELOG.md
+++ b/extensions/dlmoji/CHANGELOG.md
@@ -1,6 +1,6 @@
 # DLmoji Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 ## [Added DLmoji] - 2022-08-24

--- a/extensions/dlmoji/package.json
+++ b/extensions/dlmoji/package.json
@@ -1,110 +1,113 @@
 {
-    "$schema": "https://www.raycast.com/schemas/extension.json",
-    "name": "dlmoji",
-    "title": "DLmoji",
-    "description": "Semantic search for Emojis, powered by Deep Learning and intelligent APIs",
-    "icon": "dlmoji-icon.png",
-    "author": "Hydrapse",
-    "license": "MIT",
-    "commands": [
-        {
-            "name": "dlmoji",
-            "title": "Get Emoji",
-            "subtitle": "DLmoji",
-            "description": "Semantic search for Emojis, powered by Deep Learning and intelligent APIs",
-            "mode": "view"
-        }
-    ],
-    "categories": [
-        "Fun",
-        "Documentation",
-        "Web"
-    ],
-    "preferences": [
-        {
-            "title": "API Selection",
-            "name": "useEmojiTranslate",
-            "type": "checkbox",
-            "label": "Emoji Translate",
-            "required": false,
-            "default": true,
-            "description": "Translate Human Language to Emoji"
-        },
-        {
-            "name": "useBidirectTranslate",
-            "type": "checkbox",
-            "label": "EMOJIALL Bidirectional Translate",
-            "required": false,
-            "default": true,
-            "description": "Translate Emoji to Human Language"
-        },
-        {
-            "name": "useEmojiAll",
-            "type": "checkbox",
-            "label": "EMOJIALL Emoji Dictionary",
-            "required": false,
-            "default": true,
-            "description": "Emoji search, meaning, examples and usage"
-        },
-        {
-            "title": "Others",
-            "name": "isAutomaticPaste",
-            "type": "checkbox",
-            "label": "Automatic Paste",
-            "required": false,
-            "default": true,
-            "description": "When you copy automatic paste to focus"
-        },
-        {
-            "title": "Deepmoji Service URL",
-            "name": "deepmojiURL",
-            "type": "textfield",
-            "required": false,
-            "description": "Your Deepmoji web service URL",
-            "default": ""
-        },
-        {
-            "title": "Baidu App ID",
-            "name": "baiduAppId",
-            "type": "textfield",
-            "required": false,
-            "description": "Your Baidu App ID",
-            "default": ""
-        },
-        {
-            "title": "Baidu App Secret",
-            "name": "baiduAppSecret",
-            "type": "textfield",
-            "required": false,
-            "description": "Your Baidu App Secret",
-            "default": ""
-        }
-    ],
-    "dependencies": {
-        "@raycast/api": "^1.31.0",
-        "axios": "^0.30.3",
-        "cheerio": "^1.0.0-rc.12",
-        "crypto-js": "^4.1.1",
-        "form-data": "^4.0.0",
-        "html-entities": "^2.3.3",
-        "lodash": "^4.17.21",
-        "prettier": "^2.7.1"
-    },
-    "devDependencies": {
-        "@types/crypto-js": "^4.1.1",
-        "@types/lodash": "^4.14.182",
-        "@types/node": "~16.10.0",
-        "@types/react": "^17.0.28",
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^7.32.0",
-        "eslint-config-prettier": "^8.3.0",
-        "typescript": "^4.4.3"
-    },
-    "scripts": {
-        "build": "ray build -e dist",
-        "dev": "ray develop",
-        "lint": "ray lint",
-        "fix": "prettier --write ."
+  "$schema": "https://www.raycast.com/schemas/extension.json",
+  "name": "dlmoji",
+  "title": "DLmoji",
+  "description": "Semantic search for Emojis, powered by Deep Learning and intelligent APIs",
+  "icon": "dlmoji-icon.png",
+  "author": "Hydrapse",
+  "license": "MIT",
+  "commands": [
+    {
+      "name": "dlmoji",
+      "title": "Get Emoji",
+      "subtitle": "DLmoji",
+      "description": "Semantic search for Emojis, powered by Deep Learning and intelligent APIs",
+      "mode": "view"
     }
+  ],
+  "categories": [
+    "Fun",
+    "Documentation",
+    "Web"
+  ],
+  "preferences": [
+    {
+      "title": "API Selection",
+      "name": "useEmojiTranslate",
+      "type": "checkbox",
+      "label": "Emoji Translate",
+      "required": false,
+      "default": true,
+      "description": "Translate Human Language to Emoji"
+    },
+    {
+      "name": "useBidirectTranslate",
+      "type": "checkbox",
+      "label": "EMOJIALL Bidirectional Translate",
+      "required": false,
+      "default": true,
+      "description": "Translate Emoji to Human Language"
+    },
+    {
+      "name": "useEmojiAll",
+      "type": "checkbox",
+      "label": "EMOJIALL Emoji Dictionary",
+      "required": false,
+      "default": true,
+      "description": "Emoji search, meaning, examples and usage"
+    },
+    {
+      "title": "Others",
+      "name": "isAutomaticPaste",
+      "type": "checkbox",
+      "label": "Automatic Paste",
+      "required": false,
+      "default": true,
+      "description": "When you copy automatic paste to focus"
+    },
+    {
+      "title": "Deepmoji Service URL",
+      "name": "deepmojiURL",
+      "type": "textfield",
+      "required": false,
+      "description": "Your Deepmoji web service URL",
+      "default": ""
+    },
+    {
+      "title": "Baidu App ID",
+      "name": "baiduAppId",
+      "type": "textfield",
+      "required": false,
+      "description": "Your Baidu App ID",
+      "default": ""
+    },
+    {
+      "title": "Baidu App Secret",
+      "name": "baiduAppSecret",
+      "type": "textfield",
+      "required": false,
+      "description": "Your Baidu App Secret",
+      "default": ""
+    }
+  ],
+  "dependencies": {
+    "@raycast/api": "^1.31.0",
+    "axios": "^0.30.3",
+    "cheerio": "^1.0.0-rc.12",
+    "crypto-js": "^4.1.1",
+    "form-data": "^4.0.0",
+    "html-entities": "^2.3.3",
+    "lodash": "^4.17.21",
+    "prettier": "^2.7.1"
+  },
+  "devDependencies": {
+    "@types/crypto-js": "^4.1.1",
+    "@types/lodash": "^4.14.182",
+    "@types/node": "~16.10.0",
+    "@types/react": "^17.0.28",
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/parser": "^5.0.0",
+    "eslint": "^7.32.0",
+    "eslint-config-prettier": "^8.3.0",
+    "typescript": "^4.4.3"
+  },
+  "scripts": {
+    "build": "ray build -e dist",
+    "dev": "ray develop",
+    "lint": "ray lint",
+    "fix": "prettier --write ."
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/dota-2/CHANGELOG.md
+++ b/extensions/dota-2/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dota 2
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/dota-2/package.json
+++ b/extensions/dota-2/package.json
@@ -1,51 +1,54 @@
 {
-	"$schema": "https://www.raycast.com/schemas/extension.json",
-	"author": "FlorianWendelborn",
-	"categories": [
-		"Data",
-		"Fun"
-	],
-	"commands": [
-		{
-			"description": "View a list of Dota 2 heroes.",
-			"mode": "view",
-			"name": "command-heroes",
-			"subtitle": "Dota 2",
-			"title": "View Heroes"
-		},
-		{
-			"description": "View a list of Dota 2 items.",
-			"mode": "view",
-			"name": "command-items",
-			"subtitle": "Dota 2",
-			"title": "View Items"
-		}
-	],
-	"dependencies": {
-		"@metatypes/typography": "^0.5.0",
-		"@raycast/api": "^1.39.3",
-		"axios": "^0.30.3",
-		"lodash.startcase": "^4.4.0",
-		"zod": "^3.19.0"
-	},
-	"description": "View various data about Dota 2, like heroes and their stats.",
-	"devDependencies": {
-		"@types/lodash.startcase": "^4.4.7",
-		"@types/node": "~18.7.16",
-		"@types/react": "^18.0.19",
-		"@typescript-eslint/eslint-plugin": "^5.36.2",
-		"@typescript-eslint/parser": "^5.36.2",
-		"eslint": "^8.23.0",
-		"eslint-config-prettier": "^8.5.0",
-		"typescript": "^4.8.3"
-	},
-	"icon": "icon.png",
-	"license": "MIT",
-	"name": "dota-2",
-	"preferences": [],
-	"scripts": {
-		"build": "ray build -e dist",
-		"dev": "ray develop"
-	},
-	"title": "Dota 2"
+  "$schema": "https://www.raycast.com/schemas/extension.json",
+  "author": "FlorianWendelborn",
+  "categories": [
+    "Data",
+    "Fun"
+  ],
+  "commands": [
+    {
+      "description": "View a list of Dota 2 heroes.",
+      "mode": "view",
+      "name": "command-heroes",
+      "subtitle": "Dota 2",
+      "title": "View Heroes"
+    },
+    {
+      "description": "View a list of Dota 2 items.",
+      "mode": "view",
+      "name": "command-items",
+      "subtitle": "Dota 2",
+      "title": "View Items"
+    }
+  ],
+  "dependencies": {
+    "@metatypes/typography": "^0.5.0",
+    "@raycast/api": "^1.39.3",
+    "axios": "^0.30.3",
+    "lodash.startcase": "^4.4.0",
+    "zod": "^3.19.0"
+  },
+  "description": "View various data about Dota 2, like heroes and their stats.",
+  "devDependencies": {
+    "@types/lodash.startcase": "^4.4.7",
+    "@types/node": "~18.7.16",
+    "@types/react": "^18.0.19",
+    "@typescript-eslint/eslint-plugin": "^5.36.2",
+    "@typescript-eslint/parser": "^5.36.2",
+    "eslint": "^8.23.0",
+    "eslint-config-prettier": "^8.5.0",
+    "typescript": "^4.8.3"
+  },
+  "icon": "icon.png",
+  "license": "MIT",
+  "name": "dota-2",
+  "preferences": [],
+  "scripts": {
+    "build": "ray build -e dist",
+    "dev": "ray develop"
+  },
+  "title": "Dota 2",
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/dotnet-docs-search/CHANGELOG.md
+++ b/extensions/dotnet-docs-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # .NET Documentation Search Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/dotnet-docs-search/package.json
+++ b/extensions/dotnet-docs-search/package.json
@@ -39,5 +39,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/drafts/CHANGELOG.md
+++ b/extensions/drafts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Drafts Changelog
 
-## [Security Maintenance] - {PR_MERGE_DATE}
+## [Security Maintenance] - 2026-02-13
 
 - Update transitive `tar` dependency to 7.5.11 to address hardlink path traversal CVE
 

--- a/extensions/dutch-article/CHANGELOG.md
+++ b/extensions/dutch-article/CHANGELOG.md
@@ -1,3 +1,3 @@
-## Dutch Article
+## [Initial Version] - 2026-02-05
 
 - Initial release

--- a/extensions/eagle/CHANGELOG.md
+++ b/extensions/eagle/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Eagle Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/fantasy-premier-league-rankings/CHANGELOG.md
+++ b/extensions/fantasy-premier-league-rankings/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fantasy Premier League Rankings Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/fantasy-premier-league-rankings/package.json
+++ b/extensions/fantasy-premier-league-rankings/package.json
@@ -50,5 +50,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/fhir/CHANGELOG.md
+++ b/extensions/fhir/CHANGELOG.md
@@ -1,6 +1,6 @@
 # FHIR Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Remove unused `fast-xml-parser` dependency (not imported anywhere; all data flows use JSON)
 

--- a/extensions/fhir/package.json
+++ b/extensions/fhir/package.json
@@ -44,5 +44,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/file-info/CHANGELOG.md
+++ b/extensions/file-info/CHANGELOG.md
@@ -1,6 +1,6 @@
 # File Info Changelog
 
-## [PR_MERGE_DATE]
+## [Clear File Metadata] - 2026-02-16
 - Added `Clear File Metadata` command to remove EXIF, GPS, IPTC, and XMP data
 - Added cross-platform support (Windows)
 - Implemented secure file handling and installation checks

--- a/extensions/file-manager/CHANGELOG.md
+++ b/extensions/file-manager/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Added a preferences to enable search by file permissions
 
-## [Fixes] - 2025-02-29
+## [Fixes] - 2025-01-30
 
 - Fixed shell command errors caused by filenames containing single quotes.
 

--- a/extensions/flutter-pub-dev-search/CHANGELOG.md
+++ b/extensions/flutter-pub-dev-search/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Flutter Changelog
 
- ## [Update] - 2023-03-23
+## [Update] - 2023-03-23
 
  - Added a preference to change the Primary Action in Search Dart or Flutter Package.

--- a/extensions/flutter-pub-dev-search/package.json
+++ b/extensions/flutter-pub-dev-search/package.json
@@ -56,5 +56,8 @@
     "build": "ray build -e dist",
     "dev": "ray develop",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/fork-repositories/CHANGELOG.md
+++ b/extensions/fork-repositories/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Added Windows support with platform-specific Fork data paths and app detection
 
-## [Bug Fix] - {PR_MERGE_DATE}
+## [Bug Fix] - 2026-01-26
 
 - Added support for Fork's `repositories.toml` file with fallback to `repositories.json`.
 

--- a/extensions/fvm/CHANGELOG.md
+++ b/extensions/fvm/CHANGELOG.md
@@ -1,6 +1,6 @@
 # FVM Changelog
 
-## [Security Fixes] - {PR_MERGE_DATE}
+## [Security Fixes] - 2026-02-13
 
 - Update `tar` to ^7.5.11 to address hardlink path traversal CVE
 

--- a/extensions/fvm/package.json
+++ b/extensions/fvm/package.json
@@ -70,5 +70,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/gitee/CHANGELOG.md
+++ b/extensions/gitee/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Gitee Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/gitee/package.json
+++ b/extensions/gitee/package.json
@@ -69,5 +69,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/google-trends/CHANGELOG.md
+++ b/extensions/google-trends/CHANGELOG.md
@@ -1,5 +1,5 @@
 # google-trends Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`

--- a/extensions/google-trends/package.json
+++ b/extensions/google-trends/package.json
@@ -815,5 +815,8 @@
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/hellonext-changelogs/CHANGELOG.md
+++ b/extensions/hellonext-changelogs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Hellonext Changelogs Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/hellonext-changelogs/package.json
+++ b/extensions/hellonext-changelogs/package.json
@@ -50,5 +50,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/heroku/CHANGELOG.md
+++ b/extensions/heroku/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Heroku extension for Raycast Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/heroku/package.json
+++ b/extensions/heroku/package.json
@@ -52,5 +52,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/itranslate/CHANGELOG.md
+++ b/extensions/itranslate/CHANGELOG.md
@@ -1,6 +1,6 @@
 # iTranslate Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/itranslate/package.json
+++ b/extensions/itranslate/package.json
@@ -1372,5 +1372,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/jsrepo/CHANGELOG.md
+++ b/extensions/jsrepo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # jsrepo Changelog
 
-## [Dependency Maintenance] - {PR_MERGE_DATE}
+## [Dependency Maintenance] - 2026-02-13
 
 - Refreshed `package-lock.json` and updated transitive dependencies (including `devalue` to `5.6.2`).
 

--- a/extensions/jsrepo/package.json
+++ b/extensions/jsrepo/package.json
@@ -1,158 +1,161 @@
 {
-	"$schema": "https://www.raycast.com/schemas/extension.json",
-	"name": "jsrepo",
-	"title": "jsrepo",
-	"description": "Interact with jsrepo registries all without leaving Raycast.",
-	"icon": "jsrepo.png",
-	"author": "ieedan",
-	"categories": [
-		"Developer Tools"
-	],
-	"license": "MIT",
-	"commands": [
-		{
-			"name": "search-registries",
-			"title": "Search Registries",
-			"description": "Search registries and view their blocks.",
-			"mode": "view"
-		}
-	],
-	"preferences": [
-		{
-			"name": "orderBy",
-			"title": "Sort Registries By",
-			"type": "dropdown",
-			"description": "How should registries be sorted",
-			"data": [
-				{
-					"title": "Alphabetical",
-					"value": "alphabetical"
-				},
-				{
-					"title": "Most Popular",
-					"value": "views"
-				}
-			],
-			"required": false,
-			"default": "alphabetical"
-		},
-		{
-			"name": "github_token",
-			"title": "GitHub Token",
-			"label": "GitHub Token",
-			"type": "password",
-			"description": "Your personal access token used to access registries hosted on GitHub.",
-			"required": false,
-			"placeholder": "Enter your personal access token"
-		},
-		{
-			"name": "gitlab_token",
-			"title": "GitLab Token",
-			"label": "GitLab Token",
-			"type": "password",
-			"description": "Your personal access token used to access registries hosted on GitLab.",
-			"required": false,
-			"placeholder": "Enter your personal access token"
-		},
-		{
-			"name": "bitbucket_token",
-			"title": "BitBucket Token",
-			"label": "BitBucket Token",
-			"type": "password",
-			"description": "Your personal access token used to access registries hosted on BitBucket.",
-			"required": false,
-			"placeholder": "Enter your personal access token"
-		},
-		{
-			"name": "azure_token",
-			"title": "AzureDevops Token",
-			"label": "AzureDevops Token",
-			"type": "password",
-			"description": "Your personal access token used to access registries hosted on AzureDevops.",
-			"required": false,
-			"placeholder": "Enter your personal access token"
-		},
-		{
-			"name": "limitPreviewLOC",
-			"title": "Limit Preview LOC",
-			"label": "Limit Preview LOC",
-			"type": "checkbox",
-			"description": "Should we limit code previews to a specified maximum amount of lines",
-			"default": true,
-			"required": false
-		},
-		{
-			"name": "maximumPreviewLOC",
-			"title": "Maximum Preview LOC",
-			"label": "Maximum Preview LOC",
-			"type": "dropdown",
-			"description": "The maximum lines of code that will be previewed when viewing blocks. (For performance reasons)",
-			"data": [
-				{
-					"title": "100",
-					"value": "100"
-				},
-				{
-					"title": "200",
-					"value": "200"
-				},
-				{
-					"title": "300",
-					"value": "300"
-				},
-				{
-					"title": "400",
-					"value": "400"
-				},
-				{
-					"title": "500",
-					"value": "500"
-				},
-				{
-					"title": "600",
-					"value": "600"
-				},
-				{
-					"title": "700",
-					"value": "700"
-				},
-				{
-					"title": "800",
-					"value": "800"
-				},
-				{
-					"title": "900",
-					"value": "900"
-				},
-				{
-					"title": "1000",
-					"value": "1000"
-				}
-			],
-			"required": false,
-			"default": "400"
-		}
-	],
-	"dependencies": {
-		"@raycast/api": "^1.94.3",
-		"@raycast/utils": "^1.17.0",
-		"jsrepo": "^1.45.3"
-	},
-	"devDependencies": {
-		"@raycast/eslint-config": "^2.0.4",
-		"@types/node": "22.13.10",
-		"@types/react": "19.0.10",
-		"eslint": "^9.22.0",
-		"prettier": "^3.5.3",
-		"typescript": "^5.8.2"
-	},
-	"scripts": {
-		"build": "ray build",
-		"dev": "ray develop",
-		"fix-lint": "ray lint --fix",
-		"lint": "ray lint",
-		"format": "npx prettier . --write",
-		"prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
-		"publish": "npx @raycast/api@latest publish"
-	}
+  "$schema": "https://www.raycast.com/schemas/extension.json",
+  "name": "jsrepo",
+  "title": "jsrepo",
+  "description": "Interact with jsrepo registries all without leaving Raycast.",
+  "icon": "jsrepo.png",
+  "author": "ieedan",
+  "categories": [
+    "Developer Tools"
+  ],
+  "license": "MIT",
+  "commands": [
+    {
+      "name": "search-registries",
+      "title": "Search Registries",
+      "description": "Search registries and view their blocks.",
+      "mode": "view"
+    }
+  ],
+  "preferences": [
+    {
+      "name": "orderBy",
+      "title": "Sort Registries By",
+      "type": "dropdown",
+      "description": "How should registries be sorted",
+      "data": [
+        {
+          "title": "Alphabetical",
+          "value": "alphabetical"
+        },
+        {
+          "title": "Most Popular",
+          "value": "views"
+        }
+      ],
+      "required": false,
+      "default": "alphabetical"
+    },
+    {
+      "name": "github_token",
+      "title": "GitHub Token",
+      "label": "GitHub Token",
+      "type": "password",
+      "description": "Your personal access token used to access registries hosted on GitHub.",
+      "required": false,
+      "placeholder": "Enter your personal access token"
+    },
+    {
+      "name": "gitlab_token",
+      "title": "GitLab Token",
+      "label": "GitLab Token",
+      "type": "password",
+      "description": "Your personal access token used to access registries hosted on GitLab.",
+      "required": false,
+      "placeholder": "Enter your personal access token"
+    },
+    {
+      "name": "bitbucket_token",
+      "title": "BitBucket Token",
+      "label": "BitBucket Token",
+      "type": "password",
+      "description": "Your personal access token used to access registries hosted on BitBucket.",
+      "required": false,
+      "placeholder": "Enter your personal access token"
+    },
+    {
+      "name": "azure_token",
+      "title": "AzureDevops Token",
+      "label": "AzureDevops Token",
+      "type": "password",
+      "description": "Your personal access token used to access registries hosted on AzureDevops.",
+      "required": false,
+      "placeholder": "Enter your personal access token"
+    },
+    {
+      "name": "limitPreviewLOC",
+      "title": "Limit Preview LOC",
+      "label": "Limit Preview LOC",
+      "type": "checkbox",
+      "description": "Should we limit code previews to a specified maximum amount of lines",
+      "default": true,
+      "required": false
+    },
+    {
+      "name": "maximumPreviewLOC",
+      "title": "Maximum Preview LOC",
+      "label": "Maximum Preview LOC",
+      "type": "dropdown",
+      "description": "The maximum lines of code that will be previewed when viewing blocks. (For performance reasons)",
+      "data": [
+        {
+          "title": "100",
+          "value": "100"
+        },
+        {
+          "title": "200",
+          "value": "200"
+        },
+        {
+          "title": "300",
+          "value": "300"
+        },
+        {
+          "title": "400",
+          "value": "400"
+        },
+        {
+          "title": "500",
+          "value": "500"
+        },
+        {
+          "title": "600",
+          "value": "600"
+        },
+        {
+          "title": "700",
+          "value": "700"
+        },
+        {
+          "title": "800",
+          "value": "800"
+        },
+        {
+          "title": "900",
+          "value": "900"
+        },
+        {
+          "title": "1000",
+          "value": "1000"
+        }
+      ],
+      "required": false,
+      "default": "400"
+    }
+  ],
+  "dependencies": {
+    "@raycast/api": "^1.94.3",
+    "@raycast/utils": "^1.17.0",
+    "jsrepo": "^1.45.3"
+  },
+  "devDependencies": {
+    "@raycast/eslint-config": "^2.0.4",
+    "@types/node": "22.13.10",
+    "@types/react": "19.0.10",
+    "eslint": "^9.22.0",
+    "prettier": "^3.5.3",
+    "typescript": "^5.8.2"
+  },
+  "scripts": {
+    "build": "ray build",
+    "dev": "ray develop",
+    "fix-lint": "ray lint --fix",
+    "lint": "ray lint",
+    "format": "npx prettier . --write",
+    "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
+    "publish": "npx @raycast/api@latest publish"
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/kaleidoscope/CHANGELOG.md
+++ b/extensions/kaleidoscope/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Kaleidoscope Changelog
 
-## [New Commands] - 03-07-2025
+## [New Commands] - 2025-07-03
 
 - Rename command `Open With Kaleidoscope` to `Compare Files` to avoid redundancy
 - Add command `Compare Clipboards` to compare the two latest entries in the Raycast Clipboard History in Kaleidoscope
 - Add command `Open Changeset` showing the changeset for a Git Commit in Kaleidoscope
 - Add command `Open Git History` to show the history of Git commits for a file in Kaleidoscope
 
-## [Initial Version] - 31-12-2023
+## [Initial Version] - 2023-12-31

--- a/extensions/korean-add-calendar/CHANGELOG.md
+++ b/extensions/korean-add-calendar/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Extension Changelog
 
-## [2026-03-16]
+## [Initial Version] - 2026-03-16
 
 ### Added
 

--- a/extensions/kubectx/CHANGELOG.md
+++ b/extensions/kubectx/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Kubectx Changelog
 
- ## [Update] - 2023-03-17
+## [Update] - 2023-03-17
 
  - Support KUBECONFIG enviroment variable in preferences

--- a/extensions/kubectx/package.json
+++ b/extensions/kubectx/package.json
@@ -47,5 +47,8 @@
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/laby-net/CHANGELOG.md
+++ b/extensions/laby-net/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Laby.net Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/laby-net/package.json
+++ b/extensions/laby-net/package.json
@@ -46,5 +46,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/laliga/CHANGELOG.md
+++ b/extensions/laliga/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LaLiga Changelog
 
-## [Maintenance & Stability] - {PR_MERGED_DATE}
+## [Maintenance & Stability] - 2025-10-27
 
 - Fixed an issue on the club details page where some information was missing.
 - Upgraded to the latest dependencies for improved security and stability.

--- a/extensions/laravel-herd/CHANGELOG.md
+++ b/extensions/laravel-herd/CHANGELOG.md
@@ -15,4 +15,4 @@
 - Polished README
 
 
-## [Initial Version] - April 8, 2025
+## [Initial Version] - 2025-04-08

--- a/extensions/laravel-herd/package.json
+++ b/extensions/laravel-herd/package.json
@@ -157,5 +157,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/latest-news/CHANGELOG.md
+++ b/extensions/latest-news/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Latest News Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/latest-news/package.json
+++ b/extensions/latest-news/package.json
@@ -1,42 +1,45 @@
 {
-    "$schema": "https://www.raycast.com/schemas/extension.json",
-    "name": "latest-news",
-    "title": "Latest Local News",
-    "description": "Latest local news served by Microsoft Bing",
-    "icon": "command-icon.png",
-    "author": "FilipeCerejo",
-    "categories": [
-        "News"
-    ],
-    "license": "MIT",
-    "commands": [
-        {
-            "name": "index",
-            "title": "Latest Local News",
-            "subtitle": "Microsoft Bing",
-            "description": "Get the latest local news updates by Microsoft Bing",
-            "mode": "view"
-        }
-    ],
-    "dependencies": {
-        "@raycast/api": "^1.35.2",
-        "axios": "^0.30.3",
-        "cheerio": "^1.0.0-rc.11"
-    },
-    "devDependencies": {
-        "@types/node": "~16.10.0",
-        "@types/react": "^17.0.28",
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^7.32.0",
-        "eslint-config-prettier": "^8.3.0",
-        "prettier": "^2.5.1",
-        "typescript": "^4.4.3"
-    },
-    "scripts": {
-        "build": "ray build -e dist",
-        "dev": "ray develop",
-        "fix-lint": "ray lint --fix",
-        "lint": "ray lint"
+  "$schema": "https://www.raycast.com/schemas/extension.json",
+  "name": "latest-news",
+  "title": "Latest Local News",
+  "description": "Latest local news served by Microsoft Bing",
+  "icon": "command-icon.png",
+  "author": "FilipeCerejo",
+  "categories": [
+    "News"
+  ],
+  "license": "MIT",
+  "commands": [
+    {
+      "name": "index",
+      "title": "Latest Local News",
+      "subtitle": "Microsoft Bing",
+      "description": "Get the latest local news updates by Microsoft Bing",
+      "mode": "view"
     }
+  ],
+  "dependencies": {
+    "@raycast/api": "^1.35.2",
+    "axios": "^0.30.3",
+    "cheerio": "^1.0.0-rc.11"
+  },
+  "devDependencies": {
+    "@types/node": "~16.10.0",
+    "@types/react": "^17.0.28",
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/parser": "^5.0.0",
+    "eslint": "^7.32.0",
+    "eslint-config-prettier": "^8.3.0",
+    "prettier": "^2.5.1",
+    "typescript": "^4.4.3"
+  },
+  "scripts": {
+    "build": "ray build -e dist",
+    "dev": "ray develop",
+    "fix-lint": "ray lint --fix",
+    "lint": "ray lint"
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/lega-serie-a/CHANGELOG.md
+++ b/extensions/lega-serie-a/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Lega Serie A Changelog
 
-## API Modernization - {PR_MERGED_DATE}
+## API Modernization - 2025-10-28
 
 - Migrated standings data fetching to API v3.
 - Maintained support for the older standings API for historical data spanning the 2022-23 season and backward, ensuring no disruption for older data retrieval.

--- a/extensions/lifx/CHANGELOG.md
+++ b/extensions/lifx/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LIFX Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/lifx/package.json
+++ b/extensions/lifx/package.json
@@ -89,5 +89,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/m3o/CHANGELOG.md
+++ b/extensions/m3o/CHANGELOG.md
@@ -1,6 +1,6 @@
 # M3O Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/m3o/package.json
+++ b/extensions/m3o/package.json
@@ -54,5 +54,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/mail/CHANGELOG.md
+++ b/extensions/mail/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bump lodash/lodash-es to fix prototype pollution vulnerability (CVE-2025-13465)
 
-## [Security] - {PR_MERGE_DATE}
+## [Security] - 2026-03-16
 
 - Upgrade `mailparser` to 3.9.4 to fix DoS via uncontrolled recursion in nodemailer's addressparser (CVE-2025-14874)
 

--- a/extensions/mattermost/CHANGELOG.md
+++ b/extensions/mattermost/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mattermost Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/midas/CHANGELOG.md
+++ b/extensions/midas/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Midas Changelog
 
-## [0.1.0] - 18.02.2025
+## [0.1.0] - 2025-02-18
 
 - Added two main commands:
   - Call Agent - Make general calls to Midas AI

--- a/extensions/midas/package.json
+++ b/extensions/midas/package.json
@@ -62,5 +62,8 @@
       "description": "Your wallet private key for transactions",
       "default": ""
     }
+  ],
+  "platforms": [
+    "macOS"
   ]
 }

--- a/extensions/monse/CHANGELOG.md
+++ b/extensions/monse/CHANGELOG.md
@@ -1,6 +1,6 @@
 # monse Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/monse/package.json
+++ b/extensions/monse/package.json
@@ -75,5 +75,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/musicthread/CHANGELOG.md
+++ b/extensions/musicthread/CHANGELOG.md
@@ -1,6 +1,6 @@
 # MusicThread Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/musicthread/package.json
+++ b/extensions/musicthread/package.json
@@ -52,5 +52,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/nano-games/CHANGELOG.md
+++ b/extensions/nano-games/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nano Games Changelog
 
-## [Initial Version] - {PR_MERGE_DATE}
+## [Initial Version] - 2026-03-16
 
 ### Added Games
 

--- a/extensions/netlify/CHANGELOG.md
+++ b/extensions/netlify/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/netlify/package.json
+++ b/extensions/netlify/package.json
@@ -316,14 +316,14 @@
           ],
           "get-environment-variables": [
             {
-              "is_secret" : false,
-              "key" : "KEY",
-              "values" : [
+              "is_secret": false,
+              "key": "KEY",
+              "values": [
                 {
-                  "context" : "all",
-                  "id" : "xxxxxx-xxxx-xxxx-xxxx-xxxxxx",
-                  "role" : "",
-                  "value" : "VALUE"
+                  "context": "all",
+                  "id": "xxxxxx-xxxx-xxxx-xxxx-xxxxxx",
+                  "role": "",
+                  "value": "VALUE"
                 }
               ]
             }
@@ -429,5 +429,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/novu/CHANGELOG.md
+++ b/extensions/novu/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Novu Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/obs-clippings/CHANGELOG.md
+++ b/extensions/obs-clippings/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Obsidian Clippings
 
-### [Initial Release] - 2023-06-01
+## [Initial Release] - 2023-06-01
 
 See README.md

--- a/extensions/obs-clippings/package.json
+++ b/extensions/obs-clippings/package.json
@@ -5,7 +5,11 @@
   "description": "Creates a new (opionated) clipping in Obsidian. Optionally includes the page content with an AI summary",
   "icon": "command-icon.png",
   "author": "trevware",
-  "categories": ["Productivity", "Applications", "Web"],
+  "categories": [
+    "Productivity",
+    "Applications",
+    "Web"
+  ],
   "license": "MIT",
   "commands": [
     {
@@ -60,5 +64,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/oci/CHANGELOG.md
+++ b/extensions/oci/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bump lodash/lodash-es to fix prototype pollution vulnerability (CVE-2025-13465)
 
-## [Security: Refresh Lockfile to Remove Unused Transitive Dependencies] - {PR_MERGE_DATE}
+## [Security: Refresh Lockfile to Remove Unused Transitive Dependencies] - 2026-02-13
 
 - Refreshed `package-lock.json` to remove stale transitive entries (including `got`/`electron`) that were no longer part of the installed dependency graph.
 

--- a/extensions/odin/CHANGELOG.md
+++ b/extensions/odin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ODIN Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/odin/package.json
+++ b/extensions/odin/package.json
@@ -38,5 +38,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/ohmyzsh-plugins/CHANGELOG.md
+++ b/extensions/ohmyzsh-plugins/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ohmyzsh-plugins Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/ohmyzsh-plugins/package.json
+++ b/extensions/ohmyzsh-plugins/package.json
@@ -41,5 +41,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/omnivore/CHANGELOG.md
+++ b/extensions/omnivore/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Omnivore Changelog
 
-## Empty label bug fixed - 2024-23-06
+## Empty label bug fixed - 2024-06-23
 
 - Saving URL without a label no longer creates an empty label in Omnivore
 - Saving URL with a label separated with spaces will create a single label (only commas can be used as separator)
 
-## Tags/Labels support - 2024-29-04
+## Tags/Labels support - 2024-04-29
 
 - From now you can quickly capture URL with labels
 

--- a/extensions/omnivore/package.json
+++ b/extensions/omnivore/package.json
@@ -73,5 +73,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/ones/CHANGELOG.md
+++ b/extensions/ones/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ones Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/ones/package.json
+++ b/extensions/ones/package.json
@@ -166,5 +166,8 @@
     "pc": "prettier --check .",
     "pw": "prettier --write .",
     "fix-lint": "ray lint --fix"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/parcel-tracker/CHANGELOG.md
+++ b/extensions/parcel-tracker/CHANGELOG.md
@@ -1,5 +1,5 @@
 # parcel-tracker Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`

--- a/extensions/parcel-tracker/package.json
+++ b/extensions/parcel-tracker/package.json
@@ -43,5 +43,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/parrot-translate/CHANGELOG.md
+++ b/extensions/parrot-translate/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Parrot Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/parrot-translate/package.json
+++ b/extensions/parrot-translate/package.json
@@ -1,327 +1,330 @@
 {
-    "$schema": "https://www.raycast.com/schemas/extension.json",
-    "name": "parrot-translate",
-    "title": "Parrot Translate",
-    "description": "Powerful and Easy to use translation, Support TTS and lowerCamelCase/ALL_UPPERCASE Copy mode, and more",
-    "icon": "parrot-icon.png",
-    "author": "Haojen",
-    "license": "MIT",
-    "commands": [
-        {
-            "name": "parrot",
-            "title": "Translate",
-            "subtitle": "Parrot",
-            "description": "Powerful and Easy to use translation, Support TTS and lowerCamelCase/ALL_UPPERCASE Copy mode, and more",
-            "mode": "view"
-        }
-    ],
-    "categories": [
-        "Documentation",
-        "Web",
-        "Developer Tools"
-    ],
-    "preferences": [
-        {
-            "name": "lang1",
-            "type": "dropdown",
-            "required": true,
-            "title": "First Language",
-            "description": "Select you first language",
-            "data": [
-                {
-                    "title": "English",
-                    "value": "en"
-                },
-                {
-                    "title": "Chinese-Simplified",
-                    "value": "zh-CHS"
-                },
-                {
-                    "title": "Japan",
-                    "value": "ja"
-                },
-                {
-                    "title": "Korea",
-                    "value": "ko"
-                },
-                {
-                    "title": "French",
-                    "value": "fr"
-                },
-                {
-                    "title": "Spanish",
-                    "value": "es"
-                },
-                {
-                    "title": "Portuguese",
-                    "value": "pt"
-                },
-                {
-                    "title": "Italian",
-                    "value": "it"
-                },
-                {
-                    "title": "Russian",
-                    "value": "ru"
-                },
-                {
-                    "title": "German",
-                    "value": "de"
-                },
-                {
-                    "title": "Arabic",
-                    "value": "ar"
-                },
-                {
-                    "title": "Swedish",
-                    "value": "sv"
-                },
-                {
-                    "title": "Hebrew",
-                    "value": "he"
-                },
-                {
-                    "title": "Indonesia",
-                    "value": "id"
-                },
-                {
-                    "title": "Dutch",
-                    "value": "nl"
-                },
-                {
-                    "title": "Romanian",
-                    "value": "ro"
-                },
-                {
-                    "title": "Thai",
-                    "value": "th"
-                },
-                {
-                    "title": "Slovak",
-                    "value": "sk"
-                },
-                {
-                    "title": "Hindi",
-                    "value": "hi"
-                },
-                {
-                    "title": "Hungarian",
-                    "value": "hu"
-                },
-                {
-                    "title": "Greek",
-                    "value": "el"
-                },
-                {
-                    "title": "Danish",
-                    "value": "da"
-                },
-                {
-                    "title": "Finnish",
-                    "value": "fi"
-                },
-                {
-                    "title": "Turkish",
-                    "value": "tr"
-                },
-                {
-                    "title": "Polish",
-                    "value": "pl"
-                },
-                {
-                    "title": "Czech",
-                    "value": "cs"
-                }
-            ]
-        },
-        {
-            "name": "lang2",
-            "type": "dropdown",
-            "required": true,
-            "title": "Second Language",
-            "description": "Select you second language",
-            "data": [
-                {
-                    "title": "Chinese-Simplified",
-                    "value": "zh-CHS"
-                },
-                {
-                    "title": "English",
-                    "value": "en"
-                },
-                {
-                    "title": "Japan",
-                    "value": "ja"
-                },
-                {
-                    "title": "Korea",
-                    "value": "ko"
-                },
-                {
-                    "title": "French",
-                    "value": "fr"
-                },
-                {
-                    "title": "Spanish",
-                    "value": "es"
-                },
-                {
-                    "title": "Portuguese",
-                    "value": "pt"
-                },
-                {
-                    "title": "Italian",
-                    "value": "it"
-                },
-                {
-                    "title": "Russian",
-                    "value": "ru"
-                },
-                {
-                    "title": "German",
-                    "value": "de"
-                },
-                {
-                    "title": "Arabic",
-                    "value": "ar"
-                },
-                {
-                    "title": "Swedish",
-                    "value": "sv"
-                },
-                {
-                    "title": "Hebrew",
-                    "value": "he"
-                },
-                {
-                    "title": "Indonesia",
-                    "value": "id"
-                },
-                {
-                    "title": "Dutch",
-                    "value": "nl"
-                },
-                {
-                    "title": "Romanian",
-                    "value": "ro"
-                },
-                {
-                    "title": "Thai",
-                    "value": "th"
-                },
-                {
-                    "title": "Slovak",
-                    "value": "sk"
-                },
-                {
-                    "title": "Hindi",
-                    "value": "hi"
-                },
-                {
-                    "title": "Hungarian",
-                    "value": "hu"
-                },
-                {
-                    "title": "Greek",
-                    "value": "el"
-                },
-                {
-                    "title": "Danish",
-                    "value": "da"
-                },
-                {
-                    "title": "Finnish",
-                    "value": "fi"
-                },
-                {
-                    "title": "Turkish",
-                    "value": "tr"
-                },
-                {
-                    "title": "Polish",
-                    "value": "pl"
-                },
-                {
-                    "title": "Czech",
-                    "value": "cs"
-                }
-            ]
-        },
-        {
-            "name": "appId",
-            "type": "textfield",
-            "required": false,
-            "title": "App ID",
-            "description": "Your App ID",
-            "default": "0d68776be7e9be0b"
-        },
-        {
-            "name": "appKey",
-            "type": "textfield",
-            "required": false,
-            "title": "App Key",
-            "description": "Your App Key",
-            "default": "MIbu7DGsOPdbatL9KmgycGx0qDOzQWCM"
-        },
-        {
-            "title": "Open third-party dict apps",
-            "name": "openThirdPartyDict",
-            "type": "appPicker",
-            "description": "Open third-party we support dict apps",
-            "required": false
-        },
-        {
-            "title": "Others",
-            "name": "isAutomaticPaste",
-            "type": "checkbox",
-            "label": "Automatic Paste",
-            "required": false,
-            "default": true,
-            "description": "When you copy automatic paste to focus"
-        },
-        {
-            "name": "isQuickSwitchLanguage",
-            "type": "checkbox",
-            "label": "Quick Switch Language",
-            "required": false,
-            "default": true,
-            "description": "Show quick switch Language in ActionPanel"
-        },
-        {
-            "name": "isPlayTTS",
-            "type": "checkbox",
-            "label": "Play TTS",
-            "required": false,
-            "default": true,
-            "description": "Show Play Text to Speech button in ActionPanel"
-        },
-        {
-            "title": "Delay Fetch Translate API Time",
-            "name": "delayFetchTranslateAPITime",
-            "type": "textfield",
-            "required": false,
-            "default": "400",
-            "description": "Delay fetch translate API",
-            "placeholder": "Range 50-600ms, default 400ms"
-        }
-    ],
-    "dependencies": {
-        "@raycast/api": "^1.31.0",
-        "axios": "^0.30.3"
-    },
-    "devDependencies": {
-        "@types/node": "~16.10.0",
-        "@types/react": "^17.0.28",
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^7.32.0",
-        "eslint-config-prettier": "^8.3.0",
-        "typescript": "^4.4.3"
-    },
-    "scripts": {
-        "build": "ray build -e dist",
-        "dev": "ray develop",
-        "lint": "ray lint",
-        "fix": "prettier --write ."
+  "$schema": "https://www.raycast.com/schemas/extension.json",
+  "name": "parrot-translate",
+  "title": "Parrot Translate",
+  "description": "Powerful and Easy to use translation, Support TTS and lowerCamelCase/ALL_UPPERCASE Copy mode, and more",
+  "icon": "parrot-icon.png",
+  "author": "Haojen",
+  "license": "MIT",
+  "commands": [
+    {
+      "name": "parrot",
+      "title": "Translate",
+      "subtitle": "Parrot",
+      "description": "Powerful and Easy to use translation, Support TTS and lowerCamelCase/ALL_UPPERCASE Copy mode, and more",
+      "mode": "view"
     }
+  ],
+  "categories": [
+    "Documentation",
+    "Web",
+    "Developer Tools"
+  ],
+  "preferences": [
+    {
+      "name": "lang1",
+      "type": "dropdown",
+      "required": true,
+      "title": "First Language",
+      "description": "Select you first language",
+      "data": [
+        {
+          "title": "English",
+          "value": "en"
+        },
+        {
+          "title": "Chinese-Simplified",
+          "value": "zh-CHS"
+        },
+        {
+          "title": "Japan",
+          "value": "ja"
+        },
+        {
+          "title": "Korea",
+          "value": "ko"
+        },
+        {
+          "title": "French",
+          "value": "fr"
+        },
+        {
+          "title": "Spanish",
+          "value": "es"
+        },
+        {
+          "title": "Portuguese",
+          "value": "pt"
+        },
+        {
+          "title": "Italian",
+          "value": "it"
+        },
+        {
+          "title": "Russian",
+          "value": "ru"
+        },
+        {
+          "title": "German",
+          "value": "de"
+        },
+        {
+          "title": "Arabic",
+          "value": "ar"
+        },
+        {
+          "title": "Swedish",
+          "value": "sv"
+        },
+        {
+          "title": "Hebrew",
+          "value": "he"
+        },
+        {
+          "title": "Indonesia",
+          "value": "id"
+        },
+        {
+          "title": "Dutch",
+          "value": "nl"
+        },
+        {
+          "title": "Romanian",
+          "value": "ro"
+        },
+        {
+          "title": "Thai",
+          "value": "th"
+        },
+        {
+          "title": "Slovak",
+          "value": "sk"
+        },
+        {
+          "title": "Hindi",
+          "value": "hi"
+        },
+        {
+          "title": "Hungarian",
+          "value": "hu"
+        },
+        {
+          "title": "Greek",
+          "value": "el"
+        },
+        {
+          "title": "Danish",
+          "value": "da"
+        },
+        {
+          "title": "Finnish",
+          "value": "fi"
+        },
+        {
+          "title": "Turkish",
+          "value": "tr"
+        },
+        {
+          "title": "Polish",
+          "value": "pl"
+        },
+        {
+          "title": "Czech",
+          "value": "cs"
+        }
+      ]
+    },
+    {
+      "name": "lang2",
+      "type": "dropdown",
+      "required": true,
+      "title": "Second Language",
+      "description": "Select you second language",
+      "data": [
+        {
+          "title": "Chinese-Simplified",
+          "value": "zh-CHS"
+        },
+        {
+          "title": "English",
+          "value": "en"
+        },
+        {
+          "title": "Japan",
+          "value": "ja"
+        },
+        {
+          "title": "Korea",
+          "value": "ko"
+        },
+        {
+          "title": "French",
+          "value": "fr"
+        },
+        {
+          "title": "Spanish",
+          "value": "es"
+        },
+        {
+          "title": "Portuguese",
+          "value": "pt"
+        },
+        {
+          "title": "Italian",
+          "value": "it"
+        },
+        {
+          "title": "Russian",
+          "value": "ru"
+        },
+        {
+          "title": "German",
+          "value": "de"
+        },
+        {
+          "title": "Arabic",
+          "value": "ar"
+        },
+        {
+          "title": "Swedish",
+          "value": "sv"
+        },
+        {
+          "title": "Hebrew",
+          "value": "he"
+        },
+        {
+          "title": "Indonesia",
+          "value": "id"
+        },
+        {
+          "title": "Dutch",
+          "value": "nl"
+        },
+        {
+          "title": "Romanian",
+          "value": "ro"
+        },
+        {
+          "title": "Thai",
+          "value": "th"
+        },
+        {
+          "title": "Slovak",
+          "value": "sk"
+        },
+        {
+          "title": "Hindi",
+          "value": "hi"
+        },
+        {
+          "title": "Hungarian",
+          "value": "hu"
+        },
+        {
+          "title": "Greek",
+          "value": "el"
+        },
+        {
+          "title": "Danish",
+          "value": "da"
+        },
+        {
+          "title": "Finnish",
+          "value": "fi"
+        },
+        {
+          "title": "Turkish",
+          "value": "tr"
+        },
+        {
+          "title": "Polish",
+          "value": "pl"
+        },
+        {
+          "title": "Czech",
+          "value": "cs"
+        }
+      ]
+    },
+    {
+      "name": "appId",
+      "type": "textfield",
+      "required": false,
+      "title": "App ID",
+      "description": "Your App ID",
+      "default": "0d68776be7e9be0b"
+    },
+    {
+      "name": "appKey",
+      "type": "textfield",
+      "required": false,
+      "title": "App Key",
+      "description": "Your App Key",
+      "default": "MIbu7DGsOPdbatL9KmgycGx0qDOzQWCM"
+    },
+    {
+      "title": "Open third-party dict apps",
+      "name": "openThirdPartyDict",
+      "type": "appPicker",
+      "description": "Open third-party we support dict apps",
+      "required": false
+    },
+    {
+      "title": "Others",
+      "name": "isAutomaticPaste",
+      "type": "checkbox",
+      "label": "Automatic Paste",
+      "required": false,
+      "default": true,
+      "description": "When you copy automatic paste to focus"
+    },
+    {
+      "name": "isQuickSwitchLanguage",
+      "type": "checkbox",
+      "label": "Quick Switch Language",
+      "required": false,
+      "default": true,
+      "description": "Show quick switch Language in ActionPanel"
+    },
+    {
+      "name": "isPlayTTS",
+      "type": "checkbox",
+      "label": "Play TTS",
+      "required": false,
+      "default": true,
+      "description": "Show Play Text to Speech button in ActionPanel"
+    },
+    {
+      "title": "Delay Fetch Translate API Time",
+      "name": "delayFetchTranslateAPITime",
+      "type": "textfield",
+      "required": false,
+      "default": "400",
+      "description": "Delay fetch translate API",
+      "placeholder": "Range 50-600ms, default 400ms"
+    }
+  ],
+  "dependencies": {
+    "@raycast/api": "^1.31.0",
+    "axios": "^0.30.3"
+  },
+  "devDependencies": {
+    "@types/node": "~16.10.0",
+    "@types/react": "^17.0.28",
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/parser": "^5.0.0",
+    "eslint": "^7.32.0",
+    "eslint-config-prettier": "^8.3.0",
+    "typescript": "^4.4.3"
+  },
+  "scripts": {
+    "build": "ray build -e dist",
+    "dev": "ray develop",
+    "lint": "ray lint",
+    "fix": "prettier --write ."
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/ploi/CHANGELOG.md
+++ b/extensions/ploi/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ploi Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/ploi/package.json
+++ b/extensions/ploi/package.json
@@ -65,5 +65,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/pm2/CHANGELOG.md
+++ b/extensions/pm2/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Raycast PM2
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update transitive `systeminformation` dependency to 5.31.4 to address command injection CVEs
 

--- a/extensions/polar/CHANGELOG.md
+++ b/extensions/polar/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Polar Changelog
 
-## [Security: Refresh Lockfile to Remove Unused Transitive Dependencies] - {PR_MERGE_DATE}
+## [Security: Refresh Lockfile to Remove Unused Transitive Dependencies] - 2026-02-13
 
 - Refreshed `package-lock.json` to remove stale transitive entries (including `got`/`electron`) that were no longer part of the installed dependency graph.
 

--- a/extensions/polar/package.json
+++ b/extensions/polar/package.json
@@ -68,5 +68,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/proxyman/CHANGELOG.md
+++ b/extensions/proxyman/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Proxyman Changelog
 
-## [Initial Release 📣] - {PR_MERGE_DAGE}
+## [Initial Release 📣] - 2024-10-24
 Introduce some common actions in Proxyman:
 
 - Toggle System Proxy

--- a/extensions/proxyman/package.json
+++ b/extensions/proxyman/package.json
@@ -136,5 +136,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/rain-radars/CHANGELOG.md
+++ b/extensions/rain-radars/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Rain Radars Changelog
 
- ## [Update] - 2022-08-18
+## [Update] - 2022-08-18
 
  - Adde better caching of images

--- a/extensions/rain-radars/package.json
+++ b/extensions/rain-radars/package.json
@@ -42,5 +42,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/readymetrics/CHANGELOG.md
+++ b/extensions/readymetrics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Readymetrics Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/readymetrics/package.json
+++ b/extensions/readymetrics/package.json
@@ -48,5 +48,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/redis/CHANGELOG.md
+++ b/extensions/redis/CHANGELOG.md
@@ -1,6 +1,6 @@
 # redis Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/redis/package.json
+++ b/extensions/redis/package.json
@@ -89,5 +89,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/render/CHANGELOG.md
+++ b/extensions/render/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Render Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/send-to-flomo/CHANGELOG.md
+++ b/extensions/send-to-flomo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Send to Flomo Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/send-to-flomo/package.json
+++ b/extensions/send-to-flomo/package.json
@@ -52,5 +52,8 @@
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/sensible/CHANGELOG.md
+++ b/extensions/sensible/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Sensible Changelog
 
- ## [Initial Release] - 2023-11-22
+## [Initial Release] - 2023-11-22

--- a/extensions/sensible/package.json
+++ b/extensions/sensible/package.json
@@ -49,5 +49,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/sesh/CHANGELOG.md
+++ b/extensions/sesh/CHANGELOG.md
@@ -32,6 +32,6 @@
 
 - Add error message if tmux is not running
 
-## [Initial Version] - 2024-01-10
+## [Initial Version] - 2024-01-23
 
 - Add `Connect to Session` command

--- a/extensions/sesh/CHANGELOG.md
+++ b/extensions/sesh/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Add [nix-darwin](https://github.com/LnL7/nix-darwin) support by adding `/run/current-system/sw/bin/` to the PATH
 
-## Add config source - 03-28-24
+## Add config source - 2024-03-28
 
 - Add config section between tmux and zoxide in list items
 - Combine to one sessions state object
@@ -20,7 +20,7 @@
 - Use session name for connecting instead of path
 - Wrap connect command argument in quotes
 
-## Visual improvements - 02-22-24
+## Visual improvements - 2024-02-22
 
 - List sessions with `--json` flag for metadata
 - Group sessions by tmux and zoxide
@@ -28,10 +28,10 @@
 - Show window count for tmux sessions
 - Show score for zoxide results
 
-## [Require tmux running] - 01-31-24
+## [Require tmux running] - 2024-01-31
 
 - Add error message if tmux is not running
 
-## [Initial Version] - 10-01-2024
+## [Initial Version] - 2024-01-10
 
 - Add `Connect to Session` command

--- a/extensions/simctl/CHANGELOG.md
+++ b/extensions/simctl/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Merge boot and open actions into a single action
 
-## [Update Icons + Rename "Show" Actions for clarity] - {PR_MERGE_DAET}
+## [Update Icons + Rename "Show" Actions for clarity] - 2024-09-11
 
 - different icons for devices
 - actions renamed from "Show..." to "Open..."

--- a/extensions/specify/CHANGELOG.md
+++ b/extensions/specify/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Specify Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/specify/package.json
+++ b/extensions/specify/package.json
@@ -77,5 +77,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/stock-lookup/CHANGELOG.md
+++ b/extensions/stock-lookup/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Stock Lookup Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/stock-lookup/package.json
+++ b/extensions/stock-lookup/package.json
@@ -47,5 +47,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/supabase-cron-monitor/CHANGELOG.md
+++ b/extensions/supabase-cron-monitor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Initial Release - 2026-01-26]
+## [Initial Release] - 2026-01-26
 - Added cron job list with status and per-job run history.
 - Added recent run history command.
 - Added Supabase setup SQL and configuration preferences.

--- a/extensions/svgr/CHANGELOG.md
+++ b/extensions/svgr/CHANGELOG.md
@@ -1,5 +1,5 @@
 # SVGR Changelog
 
-## [Initial Version] - 2022-16-03
+## [Initial Version] - 2022-03-16
 
 Initial version code

--- a/extensions/svgr/package.json
+++ b/extensions/svgr/package.json
@@ -40,5 +40,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/taskplane/CHANGELOG.md
+++ b/extensions/taskplane/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Taskplane Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/taskplane/package.json
+++ b/extensions/taskplane/package.json
@@ -50,5 +50,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/tim/CHANGELOG.md
+++ b/extensions/tim/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tim Changelog
 
-## [Update] - 24-10-27
+## [Update] - 2024-10-30
 
 - Update dependencies
 - Mute expected errors

--- a/extensions/tim/package.json
+++ b/extensions/tim/package.json
@@ -807,5 +807,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/typescript-documentation-search/CHANGELOG.md
+++ b/extensions/typescript-documentation-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Typescript Documentation Search Changelog
 
- ## [Fix] - 2022-09-06
+## [Fix] - 2022-09-06
 
  - Corrected a typo in searchBarPlaceholder
  - Added metadata image

--- a/extensions/typescript-documentation-search/package.json
+++ b/extensions/typescript-documentation-search/package.json
@@ -40,5 +40,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/umami/CHANGELOG.md
+++ b/extensions/umami/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Umami Changelog
 
-## [Security: Pin Transitive Next.js Version] - {PR_MERGE_DATE}
+## [Security: Pin Transitive Next.js Version] - 2026-02-13
 
 - Added an `overrides.next` pin to `15.5.10` to address transitive Next.js advisories pulled via `@umami/api-client`/`next-basics`.
 - Refreshed `package-lock.json` accordingly.

--- a/extensions/unogs/CHANGELOG.md
+++ b/extensions/unogs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unogs Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`
 

--- a/extensions/unogs/package.json
+++ b/extensions/unogs/package.json
@@ -48,5 +48,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/upset-dev/CHANGELOG.md
+++ b/extensions/upset-dev/CHANGELOG.md
@@ -1,1 +1,3 @@
 # upset.dev Changelog
+
+## [Initial Release] - 2026-02-16

--- a/extensions/video-call-reactions/CHANGELOG.md
+++ b/extensions/video-call-reactions/CHANGELOG.md
@@ -1,47 +1,47 @@
-    # Video Call Reactions Changelog
+# Video Call Reactions Changelog
 
-    # [1.2.4] - 2024-12-18
-    ## Changed
-    - Updated compatibility for macOS Sequoia 15.0.
+## [1.2.4] - 2024-12-18
+### Changed
+- Updated compatibility for macOS Sequoia 15.0.
 
-    # [1.2.3] - 2024-06-15
-    ## Changed
-    - Improved photos in Readme to local media folder
-    - Changing my Raycast account to correct one
+## [1.2.3] - 2024-06-15
+### Changed
+- Improved photos in Readme to local media folder
+- Changing my Raycast account to correct one
 
-    ## [1.2.2] - 2024-06-13
-    ### Changed
-    - Updated the README with an example
+## [1.2.2] - 2024-06-13
+### Changed
+- Updated the README with an example
 
-    ## [1.2.1] - 2024-06-12
-    ### Changed
-    - Simplified the command structure to a single dropdown with a preset default argument.
+## [1.2.1] - 2024-06-12
+### Changed
+- Simplified the command structure to a single dropdown with a preset default argument.
 
-    ## [1.2.0] - 2024-06-11
-    ### Added
-    - Added a new dropdown argument command to trigger video call reactions based on the chosen option.
+## [1.2.0] - 2024-06-11
+### Added
+- Added a new dropdown argument command to trigger video call reactions based on the chosen option.
 
-    ### Changed
-    - Refactored the code to support the new feature, improve debugging and error handling, and renamed files to accommodate the added functionalities.
-    - Renamed the favorite/preset command.
+### Changed
+- Refactored the code to support the new feature, improve debugging and error handling, and renamed files to accommodate the added functionalities.
+- Renamed the favorite/preset command.
 
-    ### Improved
-    - Enhanced error handling for additional errors and edge cases, resulting in a better user experience.
+### Improved
+- Enhanced error handling for additional errors and edge cases, resulting in a better user experience.
 
-    ## [1.1.0] - 2024-06-07
-    ### Changed
-    - Resolved an AppleScript execution issue in Full Screen Mode.
-    - Changed Confetti messages to handle different cases: confetti only without a video call and different when with a video call.
-    - Added the option to play sound when confetti is triggered.
+## [1.1.0] - 2024-06-07
+### Changed
+- Resolved an AppleScript execution issue in Full Screen Mode.
+- Changed Confetti messages to handle different cases: confetti only without a video call and different when with a video call.
+- Added the option to play sound when confetti is triggered.
 
-    ### Improved
-    - Aligned the extension with Raycast guidelines.
-    - Enhanced debug information and user messages.
-    - Added a loading animation.
+### Improved
+- Aligned the extension with Raycast guidelines.
+- Enhanced debug information and user messages.
+- Added a loading animation.
 
-    ## [1.0.0] - 2024-05-31
-    ### Added
-    - Initial release of the "Video Call Reactions" extension.
-    - Support for triggering video call reactions such as hearts, thumbs up/down, balloons, rain, confetti, fireworks, and lasers.
-    - Preferences to set default reaction and toggle confetti and sound effects.
-    - Sound effect integration for confetti reaction.
+## [1.0.0] - 2024-05-31
+### Added
+- Initial release of the "Video Call Reactions" extension.
+- Support for triggering video call reactions such as hearts, thumbs up/down, balloons, rain, confetti, fireworks, and lasers.
+- Preferences to set default reaction and toggle confetti and sound effects.
+- Sound effect integration for confetti reaction.

--- a/extensions/yasb/CHANGELOG.md
+++ b/extensions/yasb/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-# [Release] - 2025-10-31
+## [Release] - 2025-10-31
 
 Add YASBC extension

--- a/extensions/yr-weather-forecast/CHANGELOG.md
+++ b/extensions/yr-weather-forecast/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Yr Weather Forecast Changelog
 
-## Initial release [1.0.0] - [PR_MERGE_DATE]
+## Initial release [1.0.0] - 2025-09-10

--- a/extensions/yr-weather-forecast/package.json
+++ b/extensions/yr-weather-forecast/package.json
@@ -116,5 +116,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }


### PR DESCRIPTION
## Description

This is a bit of a different PR. My project [awesome-raycast](https://github.com/j3lte/awesome-raycast) partially relies on well-formatted changelogs for interpreting updates. I noticed two big PRs (67 packages) did NOT update the `{PR_MERGE_DATE}` in `CHANGELOG.md`. 

These are the PRs:
- #26287 
- #25421 

Besides that, there are quite a few number of extensions that didn't have a properly formatted changelog. I have updated those with a better formatting, so all changelogs adhere to the same format.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)