### PR TITLE
[Set Audio Device] Fix window not closing after device selection

### DIFF
--- a/extensions/audio-device/CHANGELOG.md
+++ b/extensions/audio-device/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Audio Device Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fix Raycast window not closing after selecting an audio device
+
 ## [Major Update] - 2026-03-27
 
 ### Default device enforcement

--- a/extensions/audio-device/src/helpers.tsx
+++ b/extensions/audio-device/src/helpers.tsx
@@ -10,6 +10,7 @@ import {
   LaunchType,
   List,
   popToRoot,
+  showHUD,
   showToast,
   Toast,
 } from "@raycast/api";
@@ -354,7 +355,7 @@ function SetAudioDeviceAction({ device, type, onSelection }: SetAudioDeviceActio
           onSelection?.(device.uid);
           await closeMainWindow({ clearRootSearch: true });
           await popToRoot({ clearSearchBar: true });
-          await showToast(Toast.Style.Success, `Set "${device.name}" as ${type} device`);
+          await showHUD(`Set "${device.name}" as ${type} device`);
         } catch (e) {
           console.error(e);
           showToast(Toast.Style.Failure, `Failed setting "${device.name}" as ${type} device`);

--- a/extensions/audio-device/src/helpers.tsx
+++ b/extensions/audio-device/src/helpers.tsx
@@ -2,12 +2,14 @@ import {
   Action,
   ActionPanel,
   Cache,
+  closeMainWindow,
   Color,
   Icon,
   Keyboard,
   launchCommand,
   LaunchType,
   List,
+  popToRoot,
   showToast,
   Toast,
 } from "@raycast/api";
@@ -350,6 +352,8 @@ function SetAudioDeviceAction({ device, type, onSelection }: SetAudioDeviceActio
           await (type === "input" ? setDefaultInputDevice(device.id) : setOutputAndSystemDevice(device.id));
           await setGraceUntil(type, Date.now() + 60_000);
           onSelection?.(device.uid);
+          await closeMainWindow({ clearRootSearch: true });
+          await popToRoot({ clearSearchBar: true });
           await showToast(Toast.Style.Success, `Set "${device.name}" as ${type} device`);
         } catch (e) {
           console.error(e);


### PR DESCRIPTION
`SetAudioDeviceAction` in `helpers.tsx` was missing `closeMainWindow()` and `popToRoot()` calls after setting the audio device. The combo path (`use-combo.tsx:47-48`) already had these calls, so combos closed the window correctly but individual device selection did not.

Added the same two calls (`closeMainWindow({ clearRootSearch: true })` and `popToRoot({ clearSearchBar: true })`) to `SetAudioDeviceAction`, placed after the device is set and before the success toast.

The layout shift mentioned in the issue (hidden devices flashing briefly) is a separate rendering concern and not addressed here to keep the PR focused.

Fixes #26793

This contribution was developed with AI assistance (Claude Code).