### PR TITLE
[Quit Applications] Fix error when process has no file property

### DIFF
--- a/extensions/quit-applications/CHANGELOG.md
+++ b/extensions/quit-applications/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quit Applications Changelog
 
-## [Bug fix] - {PR_MERGE_DATE}
+## [Bug fix] - 2026-04-04
 
 - Fixed error when a foreground process has no file property (error -1728)
 

--- a/extensions/quit-applications/CHANGELOG.md
+++ b/extensions/quit-applications/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Quit Applications Changelog
 
+## [Bug fix] - {PR_MERGE_DATE}
+
+- Fixed error when a foreground process has no file property (error -1728)
+
 ## [Bug fix] - 2025-10-09
 
 - Fixed Apple Events authorization error (-1743) by adding fallback to `ps` command when System Events permission is not granted

--- a/extensions/quit-applications/src/index.tsx
+++ b/extensions/quit-applications/src/index.tsx
@@ -31,9 +31,11 @@ async function getRunningAppsPaths(): Promise<string[]> {
     const result = await runAppleScript(`
       set appPaths to {}
       tell application "System Events"
-        repeat with aProcess in (get file of every process whose background only is false)
-          set processPath to POSIX path of aProcess
-          set end of appPaths to processPath
+        repeat with aProcess in (every process whose background only is false)
+          try
+            set processPath to POSIX path of (file of aProcess)
+            set end of appPaths to processPath
+          end try
         end repeat
       end tell
 


### PR DESCRIPTION
The AppleScript in `getRunningAppsPaths()` (`index.tsx:34`) calls `get file of every process whose background only is false`, which fetches all file properties in a single operation. If any foreground process lacks a `file` property (system helper agents, background-promoted processes), the entire call fails with error -1728: "Can't get POSIX path of missing value."

Changed to iterate `every process` individually and wrap `file of aProcess` in a per-process `try` block. Processes without a valid file path are silently skipped. The existing fallback path (lines 46-63, using `ps` when AppleScript auth fails) is unchanged.

Fixes #26786

This contribution was developed with AI assistance (Claude Code).