### PR TITLE
Fix {date} template variable using UTC instead of local timezone

### DIFF
--- a/extensions/slack-templated-message/CHANGELOG.md
+++ b/extensions/slack-templated-message/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Templated Message Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+Fixed `{date}` template variable using UTC instead of local timezone
+
 ## [Fixes] - 2025-03-06
 
 Fixed performance issue with Create Slack Template command when handling a large number of Slack channels

--- a/extensions/slack-templated-message/CHANGELOG.md
+++ b/extensions/slack-templated-message/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Templated Message Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-04-01
 
 Fixed `{date}` template variable using UTC instead of local timezone
 

--- a/extensions/slack-templated-message/package.json
+++ b/extensions/slack-templated-message/package.json
@@ -55,5 +55,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/slack-templated-message/src/lib/slack.ts
+++ b/extensions/slack-templated-message/src/lib/slack.ts
@@ -61,8 +61,12 @@ export async function replaceTemplateVariables(message: string, client: WebClien
     console.error("Failed to get user info:", error);
   }
 
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+
   const variables: { [key: string]: string } = {
-    date: now.toISOString().split("T")[0],
+    date: `${year}-${month}-${day}`,
     time: now.toTimeString().slice(0, 5),
     user: userName,
   };


### PR DESCRIPTION
## Summary
- The `{date}` template variable in Slack Templated Message uses `toISOString().split("T")[0]`, which returns a UTC-based date
- This causes the date to be off by one day for users in positive UTC offset timezones (e.g., JST/UTC+9) between midnight and 09:00 local time
- Changed to use `getFullYear()`/`getMonth()`/`getDate()` which respect the local timezone, consistent with how `{time}` already uses `toTimeString()`

