### PR TITLE
Update linear extension

### DIFF
--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Linear Changelog
 
+## [OAuth Client Unification] - {PR_MERGE_DATE}
+
+- Unified OAuth usage in all commands by switching remaining direct token paths to the shared `getLinearClient()` flow.
+- Ensures all command auth runs through the same `withAccessToken` / `OAuthService.linear` lifecycle, including refresh-token handling.
+
 ## [Security Fix] - 2026-03-17
 
 - Bump lodash/lodash-es to fix prototype pollution vulnerability (CVE-2025-13465)

--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Unified OAuth usage in all commands by switching remaining direct token paths to the shared `getLinearClient()` flow.
 - Ensures all command auth runs through the same `withAccessToken` / `OAuthService.linear` lifecycle, including refresh-token handling.
+- Fix `quick-add-comment-to-issue`: validate API result before treating the operation as successful (check `newComment` instead of the input `comment`).
 
 ## [Security Fix] - 2026-03-17
 

--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Linear Changelog
 
-## [OAuth Client Unification] - {PR_MERGE_DATE}
+## [OAuth Client Unification] - 2026-04-04
 
 - Unified OAuth usage in all commands by switching remaining direct token paths to the shared `getLinearClient()` flow.
 - Ensures all command auth runs through the same `withAccessToken` / `OAuthService.linear` lifecycle, including refresh-token handling.

--- a/extensions/linear/src/create-issue-for-myself.ts
+++ b/extensions/linear/src/create-issue-for-myself.ts
@@ -1,16 +1,14 @@
-import { LinearClient } from "@linear/sdk";
 import { Clipboard, closeMainWindow, getPreferenceValues, open, Toast, showToast, Keyboard } from "@raycast/api";
-import { getAccessToken, withAccessToken } from "@raycast/utils";
+import { withAccessToken } from "@raycast/utils";
 
 import { getTeams } from "./api/getTeams";
-import { linear } from "./api/linearClient";
+import { getLinearClient, linear } from "./api/linearClient";
 
 const command = async (props: { arguments: Arguments.CreateIssueForMyself }) => {
   const toast = await showToast({ style: Toast.Style.Animated, title: "Creating issue" });
 
   try {
-    const { token } = getAccessToken();
-    const linearClient = new LinearClient({ accessToken: token });
+    const { linearClient } = getLinearClient();
 
     const preferences = getPreferenceValues<Preferences.CreateIssueForMyself>();
 

--- a/extensions/linear/src/quick-add-comment-to-issue.ts
+++ b/extensions/linear/src/quick-add-comment-to-issue.ts
@@ -36,7 +36,7 @@ const command = async (props: { arguments: Arguments.QuickAddCommentToIssue }) =
 
     const newComment = await payload.comment;
 
-    if (!payload.success || !comment) {
+    if (!payload.success || !newComment) {
       throw Error("Something went wrong");
     }
 

--- a/extensions/linear/src/quick-add-comment-to-issue.ts
+++ b/extensions/linear/src/quick-add-comment-to-issue.ts
@@ -1,4 +1,3 @@
-import { LinearClient } from "@linear/sdk";
 import {
   Clipboard,
   closeMainWindow,
@@ -9,9 +8,9 @@ import {
   showHUD,
   Keyboard,
 } from "@raycast/api";
-import { getAccessToken, withAccessToken } from "@raycast/utils";
+import { withAccessToken } from "@raycast/utils";
 
-import { linear } from "./api/linearClient";
+import { getLinearClient, linear } from "./api/linearClient";
 
 const command = async (props: { arguments: Arguments.QuickAddCommentToIssue }) => {
   const { issueId, comment } = props.arguments;
@@ -24,8 +23,7 @@ const command = async (props: { arguments: Arguments.QuickAddCommentToIssue }) =
   const preferences = getPreferenceValues<Preferences.QuickAddCommentToIssue>();
 
   try {
-    const { token } = getAccessToken();
-    const linearClient = new LinearClient({ accessToken: token });
+    const { linearClient } = getLinearClient();
 
     if (preferences.shouldCloseMainWindow) {
       await closeMainWindow();


### PR DESCRIPTION
## Description

This pull request unifies the OAuth authentication flow across all Linear extension commands by ensuring that all commands use the shared `getLinearClient()` approach instead of directly accessing tokens. This standardization improves maintainability and ensures consistent handling of authentication, including token refresh logic.

**OAuth Client Unification:**

* All commands now use the shared `getLinearClient()` function for OAuth, replacing direct token access and manual `LinearClient` instantiation. This ensures that authentication and token refreshes are handled consistently throughout the extension.

**Documentation:**

* Updated `CHANGELOG.md` to document the OAuth client unification and highlight that all command authentication now runs through the same lifecycle, including refresh-token handling.d, explain what it does. 

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
