### PR TITLE
Add Copy Wikilink and Paste Wikilink actions to Obsidian extension

### DIFF
--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Obsidian Changelog
 
+## [Wikilink Actions] - 2026-04-01
+
+- New: Copy Wikilink — copies `[[Note Title]]` to clipboard (⌥W)
+- New: Paste Wikilink — pastes `[[Note Title]]` into the focused app (⌥⇧W)
+
 ## [Silent Mode No Longer Activates Obsidian] - 2026-03-31
 
 - Fix: Append to Daily Note, Append Task, and custom actions with silent mode enabled no longer bring Obsidian to the foreground

--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Obsidian Changelog
 
-## [Wikilink Actions] - 2026-04-01
+## [Wikilink Actions] - {PR_MERGE_DATE}
 
 - New: Copy Wikilink — copies `[[Note Title]]` to clipboard (⌥W)
 - New: Paste Wikilink — pastes `[[Note Title]]` into the focused app (⌥⇧W)

--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Obsidian Changelog
 
-## [Wikilink Actions] - {PR_MERGE_DATE}
+## [Wikilink Actions] - 2026-04-07
 
 - New: Copy Wikilink — copies `[[Note Title]]` to clipboard (⌥W)
 - New: Paste Wikilink — pastes `[[Note Title]]` into the focused app (⌥⇧W)

--- a/extensions/obsidian/src/utils/actions.tsx
+++ b/extensions/obsidian/src/utils/actions.tsx
@@ -429,13 +429,13 @@ export function NoteActions(props: {
       <CopyNoteAction note={note} />
       <CopyNoteTitleAction note={note} />
       <CopyNotePathAction note={note} />
-      <CopyWikilinkAction note={note} />
-      <PasteWikilinkAction note={note} />
       <PasteNoteAction note={note} />
       <CopyMarkdownLinkAction note={note} />
       <CopyObsidianURIAction note={note} />
       <DeleteNoteAction note={note} vault={vault} onDelete={onDelete} />
       <AppendTaskAction note={note} vault={vault} onNoteUpdated={onNoteUpdated} />
+      <CopyWikilinkAction note={note} />
+      <PasteWikilinkAction note={note} />
     </>
   );
 }

--- a/extensions/obsidian/src/utils/actions.tsx
+++ b/extensions/obsidian/src/utils/actions.tsx
@@ -6,6 +6,7 @@ import {
   getDefaultApplication,
   getPreferenceValues,
   Icon,
+  Keyboard,
   List,
 } from "@raycast/api";
 import React, { useEffect, useState } from "react";
@@ -146,7 +147,7 @@ export function CopyWikilinkAction(props: { note: Note }) {
       title="Copy Wikilink"
       icon={Icon.Link}
       content={`[[${note.title}]]`}
-      shortcut={{ modifiers: ["opt"], key: "w" }}
+      shortcut={Keyboard.Shortcut.Common.CopyDeeplink}
     />
   );
 }
@@ -158,7 +159,7 @@ export function PasteWikilinkAction(props: { note: Note }) {
       title="Paste Wikilink"
       icon={Icon.Link}
       content={`[[${note.title}]]`}
-      shortcut={{ modifiers: ["opt", "shift"], key: "w" }}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "v" }}
     />
   );
 }

--- a/extensions/obsidian/src/utils/actions.tsx
+++ b/extensions/obsidian/src/utils/actions.tsx
@@ -6,7 +6,6 @@ import {
   getDefaultApplication,
   getPreferenceValues,
   Icon,
-  Keyboard,
   List,
 } from "@raycast/api";
 import React, { useEffect, useState } from "react";
@@ -147,7 +146,10 @@ export function CopyWikilinkAction(props: { note: Note }) {
       title="Copy Wikilink"
       icon={Icon.Link}
       content={`[[${note.title}]]`}
-      shortcut={{ modifiers: ["opt"], key: "w" }}
+      shortcut={{
+        macOS: { modifiers: ["opt"], key: "w" },
+        Windows: { modifiers: ["alt"], key: "w" },
+      }}
     />
   );
 }
@@ -159,7 +161,10 @@ export function PasteWikilinkAction(props: { note: Note }) {
       title="Paste Wikilink"
       icon={Icon.Link}
       content={`[[${note.title}]]`}
-      shortcut={{ modifiers: ["opt", "shift"], key: "w" }}
+      shortcut={{
+        macOS: { modifiers: ["opt", "shift"], key: "w" },
+        Windows: { modifiers: ["alt", "shift"], key: "w" },
+      }}
     />
   );
 }

--- a/extensions/obsidian/src/utils/actions.tsx
+++ b/extensions/obsidian/src/utils/actions.tsx
@@ -139,6 +139,30 @@ export function CopyNotePathAction(props: { note: Note }) {
   );
 }
 
+export function CopyWikilinkAction(props: { note: Note }) {
+  const { note } = props;
+  return (
+    <Action.CopyToClipboard
+      title="Copy Wikilink"
+      icon={Icon.Link}
+      content={`[[${note.title}]]`}
+      shortcut={{ modifiers: ["opt"], key: "w" }}
+    />
+  );
+}
+
+export function PasteWikilinkAction(props: { note: Note }) {
+  const { note } = props;
+  return (
+    <Action.Paste
+      title="Paste Wikilink"
+      icon={Icon.Link}
+      content={`[[${note.title}]]`}
+      shortcut={{ modifiers: ["opt", "shift"], key: "w" }}
+    />
+  );
+}
+
 export function PasteNoteAction(props: { note: NoteWithContent }) {
   const { note } = props;
   return <Action.Paste title="Paste Note Content" content={note.content} shortcut={{ modifiers: ["opt"], key: "v" }} />;
@@ -405,6 +429,8 @@ export function NoteActions(props: {
       <CopyNoteAction note={note} />
       <CopyNoteTitleAction note={note} />
       <CopyNotePathAction note={note} />
+      <CopyWikilinkAction note={note} />
+      <PasteWikilinkAction note={note} />
       <PasteNoteAction note={note} />
       <CopyMarkdownLinkAction note={note} />
       <CopyObsidianURIAction note={note} />

--- a/extensions/obsidian/src/utils/actions.tsx
+++ b/extensions/obsidian/src/utils/actions.tsx
@@ -147,7 +147,7 @@ export function CopyWikilinkAction(props: { note: Note }) {
       title="Copy Wikilink"
       icon={Icon.Link}
       content={`[[${note.title}]]`}
-      shortcut={Keyboard.Shortcut.Common.CopyDeeplink}
+      shortcut={{ modifiers: ["opt"], key: "w" }}
     />
   );
 }
@@ -159,7 +159,7 @@ export function PasteWikilinkAction(props: { note: Note }) {
       title="Paste Wikilink"
       icon={Icon.Link}
       content={`[[${note.title}]]`}
-      shortcut={{ modifiers: ["cmd", "shift"], key: "v" }}
+      shortcut={{ modifiers: ["opt", "shift"], key: "w" }}
     />
   );
 }


### PR DESCRIPTION
## Description

Adds two wikilink actions to the Search Notes command, appearing after **Copy File Path** in the action panel (⌘K):

- **Copy Wikilink** (⌥W) — copies `[[Note Title]]` to clipboard
- **Paste Wikilink** (⌥⇧W) — pastes `[[Note Title]]` directly into the focused app

## Motivation

Wikilinks are the primary way Obsidian users create internal connections between notes. When referencing a note from another app or within Obsidian itself, users want to paste `[[Note Title]]` without manually typing brackets or copying the title separately.

## Changes

- `src/utils/actions.tsx` — added `CopyWikilinkAction` and `PasteWikilinkAction`, inserted after `CopyNotePathAction` in `NoteActions`
- `CHANGELOG.md` — entry added

## Checklist

- [x] Shortcuts don't conflict with existing actions (⌥W and ⌥⇧W are unused)
- [x] Follows existing action patterns (`Action.CopyToClipboard` / `Action.Paste`)
- [x] CHANGELOG updated