### PR TITLE
Mole: Add health menu bar command

### DIFF
--- a/extensions/mole/CHANGELOG.md
+++ b/extensions/mole/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Mole Changelog
 
+## [Health Menu Bar] - {PR_MERGE_DATE}
+
+- Added Health Monitor menu bar command showing health score with color-coded heart icon (green ≥90, yellow ≥70, orange ≥50, red <50)
+- Added dropdown summary with CPU, RAM, disk, and battery metrics on click
+- Added "Open System Status" action in dropdown for quick access to the full dashboard
+- Added configurable refresh interval preference (30s, 1m, 5m, 10m, 30m; default 1m)
+- Menu bar item hides automatically when Mole CLI is unavailable
+
 ## [Friendly Install Screen] - 2026-03-23
 
 - Added MoleNotInstalled component with multiple install options when Mole CLI is not found

--- a/extensions/mole/CHANGELOG.md
+++ b/extensions/mole/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mole Changelog
 
-## [Health Menu Bar] - {PR_MERGE_DATE}
+## [Health Menu Bar] - 2026-04-12
 
 - Added Health Monitor menu bar command showing health score with color-coded heart icon (green ≥90, yellow ≥70, orange ≥50, red <50)
 - Added dropdown summary with CPU, RAM, disk, and battery metrics on click

--- a/extensions/mole/README.md
+++ b/extensions/mole/README.md
@@ -41,6 +41,7 @@ brew install mole
 | **Clean Installers**    | Find and remove .dmg, .pkg, and .iso files from Downloads, Desktop, and Documents |
 | **Touch ID for Sudo**   | Check status and toggle Touch ID for sudo authentication                          |
 | **Update Mole**         | Update Mole to the latest version                                                 |
+| **Health Menu Bar**     | Show system health score in the menu bar with CPU, RAM, disk, and battery summary  |
 
 ## Configuration
 
@@ -49,6 +50,7 @@ brew install mole
 | Mole Binary Path | Extension     | Custom path to the `mo` binary (auto-detected by default)  |
 | Refresh Interval | System Status | How often to refresh status data (3, 5, 10, or 30 seconds) |
 | Default Path     | Analyze Disk  | Starting directory for disk analysis                       |
+| Refresh Interval | Health Menu Bar | How often to refresh the health score in the menu bar    |
 
 ## Credits
 

--- a/extensions/mole/package.json
+++ b/extensions/mole/package.json
@@ -190,6 +190,52 @@
         "upgrade",
         "version"
       ]
+    },
+    {
+      "name": "health-menu-bar",
+      "title": "Health Menu Bar",
+      "subtitle": "Mole",
+      "description": "Show system health score in the menu bar",
+      "mode": "menu-bar",
+      "interval": "30s",
+      "keywords": [
+        "health",
+        "status",
+        "monitor",
+        "menu bar"
+      ],
+      "preferences": [
+        {
+          "name": "refreshInterval",
+          "title": "Refresh Interval",
+          "description": "How often to refresh the health score in the menu bar",
+          "type": "dropdown",
+          "required": false,
+          "default": "60",
+          "data": [
+            {
+              "title": "30 Seconds",
+              "value": "30"
+            },
+            {
+              "title": "1 Minute",
+              "value": "60"
+            },
+            {
+              "title": "5 Minutes",
+              "value": "300"
+            },
+            {
+              "title": "10 Minutes",
+              "value": "600"
+            },
+            {
+              "title": "30 Minutes",
+              "value": "1800"
+            }
+          ]
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/extensions/mole/package.json
+++ b/extensions/mole/package.json
@@ -5,6 +5,9 @@
   "description": "Deep clean and optimize your Mac",
   "icon": "extension-icon.png",
   "author": "jlrochin",
+  "contributors": [
+    "adria_navarrete"
+  ],
   "platforms": [
     "macOS"
   ],

--- a/extensions/mole/src/health-menu-bar.tsx
+++ b/extensions/mole/src/health-menu-bar.tsx
@@ -1,0 +1,75 @@
+import { Icon, MenuBarExtra, open } from "@raycast/api";
+import { useExec } from "@raycast/utils";
+import { getMolePathSafe } from "./utils/mole";
+import { formatPercent, type MoleStatus } from "./utils/parsers";
+import { getBatteryIcon, getHealthIcon, getUsageColor } from "./utils/icons";
+
+export default function HealthMenuBar() {
+  const molePath = getMolePathSafe();
+
+  if (!molePath) {
+    return null;
+  }
+
+  return <HealthMenuBarView molePath={molePath} />;
+}
+
+function HealthMenuBarView({ molePath }: { molePath: string }) {
+  const { data, isLoading } = useExec(molePath, ["status", "--json"], {
+    parseOutput: ({ stdout }) => JSON.parse(stdout) as MoleStatus,
+    keepPreviousData: true,
+  });
+
+  if (!data && !isLoading) {
+    return null;
+  }
+
+  const icon = data ? getHealthIcon(data.health_score) : { source: "extension-icon.png" };
+  const title = data ? `${data.health_score}` : undefined;
+  const primaryDisk = data?.disks?.[0];
+  const battery = data?.batteries?.[0];
+
+  return (
+    <MenuBarExtra icon={icon} title={title} isLoading={isLoading}>
+      {data && (
+        <>
+          <MenuBarExtra.Section title="Health">
+            <MenuBarExtra.Item
+              icon={icon}
+              title={`${data.health_score}/100 — ${data.health_score_msg}`}
+            />
+          </MenuBarExtra.Section>
+          <MenuBarExtra.Section title="System">
+            <MenuBarExtra.Item
+              icon={{ source: Icon.ComputerChip, tintColor: getUsageColor(data.cpu.usage) }}
+              title={`CPU: ${formatPercent(data.cpu.usage)}`}
+            />
+            <MenuBarExtra.Item
+              icon={{ source: Icon.MemoryChip, tintColor: getUsageColor(data.memory.used_percent) }}
+              title={`RAM: ${formatPercent(data.memory.used_percent)}`}
+            />
+            {primaryDisk && (
+              <MenuBarExtra.Item
+                icon={{ source: Icon.HardDrive, tintColor: getUsageColor(primaryDisk.used_percent) }}
+                title={`Disk: ${formatPercent(primaryDisk.used_percent)}`}
+              />
+            )}
+            {battery && (
+              <MenuBarExtra.Item
+                icon={getBatteryIcon(battery.percent, battery.status)}
+                title={`Battery: ${battery.percent}% (${battery.status})`}
+              />
+            )}
+          </MenuBarExtra.Section>
+          <MenuBarExtra.Section>
+            <MenuBarExtra.Item
+              icon={Icon.Monitor}
+              title="Open System Status"
+              onAction={() => open("raycast://extensions/jlrochin/mole/system-status")}
+            />
+          </MenuBarExtra.Section>
+        </>
+      )}
+    </MenuBarExtra>
+  );
+}

--- a/extensions/mole/src/health-menu-bar.tsx
+++ b/extensions/mole/src/health-menu-bar.tsx
@@ -1,8 +1,12 @@
-import { Icon, MenuBarExtra, open } from "@raycast/api";
+import { Cache, Icon, MenuBarExtra, getPreferenceValues, open } from "@raycast/api";
 import { useExec } from "@raycast/utils";
 import { getMolePathSafe } from "./utils/mole";
 import { formatPercent, type MoleStatus } from "./utils/parsers";
 import { getBatteryIcon, getHealthIcon, getUsageColor } from "./utils/icons";
+
+const cache = new Cache();
+const CACHE_KEY_TIMESTAMP = "health-menu-bar:last-fetch";
+const CACHE_KEY_DATA = "health-menu-bar:data";
 
 export default function HealthMenuBar() {
   const molePath = getMolePathSafe();
@@ -15,10 +19,27 @@ export default function HealthMenuBar() {
 }
 
 function HealthMenuBarView({ molePath }: { molePath: string }) {
-  const { data, isLoading } = useExec(molePath, ["status", "--json"], {
-    parseOutput: ({ stdout }) => JSON.parse(stdout) as MoleStatus,
+  const { refreshInterval } = getPreferenceValues<Preferences.HealthMenuBar>();
+  const intervalMs = (parseInt(refreshInterval ?? "60", 10) || 60) * 1000;
+
+  const lastFetch = parseInt(cache.get(CACHE_KEY_TIMESTAMP) ?? "0", 10);
+  const shouldFetch = Date.now() - lastFetch >= intervalMs;
+
+  const { data: freshData, isLoading } = useExec(molePath, ["status", "--json"], {
+    parseOutput: ({ stdout }) => {
+      cache.set(CACHE_KEY_TIMESTAMP, String(Date.now()));
+      cache.set(CACHE_KEY_DATA, stdout);
+      return JSON.parse(stdout) as MoleStatus;
+    },
     keepPreviousData: true,
+    execute: shouldFetch,
   });
+
+  let data = freshData;
+  if (!data) {
+    const raw = cache.get(CACHE_KEY_DATA);
+    if (raw) data = JSON.parse(raw) as MoleStatus;
+  }
 
   if (!data && !isLoading) {
     return null;
@@ -34,10 +55,7 @@ function HealthMenuBarView({ molePath }: { molePath: string }) {
       {data && (
         <>
           <MenuBarExtra.Section title="Health">
-            <MenuBarExtra.Item
-              icon={icon}
-              title={`${data.health_score}/100 — ${data.health_score_msg}`}
-            />
+            <MenuBarExtra.Item icon={icon} title={`${data.health_score}/100 — ${data.health_score_msg}`} />
           </MenuBarExtra.Section>
           <MenuBarExtra.Section title="System">
             <MenuBarExtra.Item

--- a/extensions/mole/src/health-menu-bar.tsx
+++ b/extensions/mole/src/health-menu-bar.tsx
@@ -22,6 +22,9 @@ function HealthMenuBarView({ molePath }: { molePath: string }) {
   const { refreshInterval } = getPreferenceValues<Preferences.HealthMenuBar>();
   const intervalMs = (parseInt(refreshInterval ?? "60", 10) || 60) * 1000;
 
+  // The command's interval (package.json) is set to 30s to match the smallest
+  // refreshInterval preference. Raycast wakes us every 30s regardless of the
+  // user's choice, but skipped intervals are cheap — just a timestamp comparison.
   const lastFetch = parseInt(cache.get(CACHE_KEY_TIMESTAMP) ?? "0", 10);
   const shouldFetch = Date.now() - lastFetch >= intervalMs;
 

--- a/extensions/mole/src/health-menu-bar.tsx
+++ b/extensions/mole/src/health-menu-bar.tsx
@@ -27,6 +27,7 @@ function HealthMenuBarView({ molePath }: { molePath: string }) {
 
   const { data: freshData, isLoading } = useExec(molePath, ["status", "--json"], {
     parseOutput: ({ stdout }) => {
+      if (!stdout.trim()) return undefined as unknown as MoleStatus;
       cache.set(CACHE_KEY_TIMESTAMP, String(Date.now()));
       cache.set(CACHE_KEY_DATA, stdout);
       return JSON.parse(stdout) as MoleStatus;
@@ -46,7 +47,7 @@ function HealthMenuBarView({ molePath }: { molePath: string }) {
   }
 
   const icon = data ? getHealthIcon(data.health_score) : { source: "extension-icon.png" };
-  const title = data ? `${data.health_score}` : undefined;
+  const title = data ? `${data.health_score}` : "—";
   const primaryDisk = data?.disks?.[0];
   const battery = data?.batteries?.[0];
 

--- a/extensions/mole/src/health-menu-bar.tsx
+++ b/extensions/mole/src/health-menu-bar.tsx
@@ -28,9 +28,14 @@ function HealthMenuBarView({ molePath }: { molePath: string }) {
   const { data: freshData, isLoading } = useExec(molePath, ["status", "--json"], {
     parseOutput: ({ stdout }) => {
       if (!stdout.trim()) return undefined as unknown as MoleStatus;
-      cache.set(CACHE_KEY_TIMESTAMP, String(Date.now()));
-      cache.set(CACHE_KEY_DATA, stdout);
-      return JSON.parse(stdout) as MoleStatus;
+      try {
+        const parsed = JSON.parse(stdout) as MoleStatus;
+        cache.set(CACHE_KEY_TIMESTAMP, String(Date.now()));
+        cache.set(CACHE_KEY_DATA, stdout);
+        return parsed;
+      } catch {
+        return undefined as unknown as MoleStatus;
+      }
     },
     keepPreviousData: true,
     execute: shouldFetch,
@@ -39,7 +44,14 @@ function HealthMenuBarView({ molePath }: { molePath: string }) {
   let data = freshData;
   if (!data) {
     const raw = cache.get(CACHE_KEY_DATA);
-    if (raw) data = JSON.parse(raw) as MoleStatus;
+    if (raw) {
+      try {
+        data = JSON.parse(raw) as MoleStatus;
+      } catch {
+        cache.remove(CACHE_KEY_DATA);
+        cache.remove(CACHE_KEY_TIMESTAMP);
+      }
+    }
   }
 
   if (!data && !isLoading) {


### PR DESCRIPTION
## Description

Adds a **Health Monitor menu bar command** to the Mole extension, providing at-a-glance system health monitoring directly from the macOS menu bar.

### New command: `health-menu-bar`

- Displays the system health score (0–100) in the menu bar with a color-coded heart icon:
  - 🟢 Green (≥90) · 🟡 Yellow (≥70) · 🟠 Orange (≥50) · 🔴 Red (<50)
- **Dropdown summary on click** showing key metrics: CPU usage, RAM usage, disk usage, and battery percentage with charging status
- **"Open System Status" action** in the dropdown for quick navigation to the full System Status dashboard
- **Configurable refresh interval** via command preferences: 30s, 1m (default), 5m, 10m, or 30m
- Automatically hides when the Mole CLI binary is not installed or unavailable
- Uses Raycast's `Cache` API to preserve the last known data between refreshes, avoiding unnecessary CLI calls

### Implementation details

- New file: `src/health-menu-bar.tsx`
- Registered in `package.json` as `mode: "menu-bar"` with `interval: "1m"`
- Reuses existing utilities: `getMolePathSafe()`, `getHealthIcon()`, `getBatteryIcon()`,`getUsageColor()`,`formatPercent()`, and `MoleStatus` type — no new abstractions introduced
- Data sourced from `mo status --json` via `useExec` from `@raycast/utils`

## Test plan

- [ ] Verify menu bar icon and score appear after enabling the command
- [ ] Verify dropdown shows CPU, RAM, disk, and battery metrics
- [ ] Verify "Open System Status" opens the full dashboard
- [ ] Verify changing refresh interval in preferences takes effect
- [ ] Verify menu bar item is hidden when Mole CLI is not installed
- [ ] Verify cached data displays while a fresh fetch is in progress

## Screencast

<img width="307" height="119" alt="image" src="https://github.com/user-attachments/assets/cfed79b0-cd04-4ed5-bf61-435fb81d2a71" />
<img width="260" height="278" alt="image" src="https://github.com/user-attachments/assets/4457b9f9-a858-4ed3-b515-c0e4389ef630" />
<img width="932" height="844" alt="image" src="https://github.com/user-attachments/assets/e336ccae-a448-49cd-84ee-8e930744c8ec" />
<img width="1078" height="772" alt="image" src="https://github.com/user-attachments/assets/4f2f26c7-d949-4de3-b50a-6a106e522fed" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
