### PR TITLE
[hop] Add Ghostty support and generic custom terminal handler

### DIFF
--- a/extensions/hop/CHANGELOG.md
+++ b/extensions/hop/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Ghostty Support] - 2026-04-02
+
+### Features
+
+- Added Ghostty as a first-class terminal option
+- Generic handler for custom terminals — "Other (specify below)" now works with any terminal app
+
+### Fixes
+
+- Custom terminals no longer fall back to Terminal.app silently
+
 ## [Initial Release] - 2026-02-28
 
 ### Features

--- a/extensions/hop/README.md
+++ b/extensions/hop/README.md
@@ -25,12 +25,12 @@ Fast SSH connection manager for Raycast. Fuzzy search and connect to servers fro
 
 ## Keyboard Shortcuts
 
-| Action | Shortcut |
-|--------|----------|
-| Connect | Enter |
-| Copy SSH Command | Cmd+C |
-| Copy Host | Cmd+Shift+C |
-| Copy User@Host | Cmd+Option+C |
+| Action           | Shortcut     |
+| ---------------- | ------------ |
+| Connect          | Enter        |
+| Copy SSH Command | Cmd+C        |
+| Copy Host        | Cmd+Shift+C  |
+| Copy User@Host   | Cmd+Option+C |
 
 ## Configuration
 

--- a/extensions/hop/package-lock.json
+++ b/extensions/hop/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@raycast/eslint-config": "^1.0.8",
-        "@types/node": "^20.10.0",
+        "@types/node": "^20.19.37",
         "@types/react": "^19.0.10",
         "eslint": "^8.55.0",
         "typescript": "^5.3.2"
@@ -1159,11 +1159,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.31.tgz",
-      "integrity": "sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A==",
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1252,6 +1253,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1542,6 +1544,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1943,6 +1946,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3235,6 +3239,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3322,6 +3327,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/hop/package.json
+++ b/extensions/hop/package.json
@@ -63,6 +63,10 @@
           "value": "kitty"
         },
         {
+          "title": "Ghostty",
+          "value": "ghostty"
+        },
+        {
           "title": "Other (specify below)",
           "value": "other"
         }

--- a/extensions/hop/package.json
+++ b/extensions/hop/package.json
@@ -96,7 +96,7 @@
   },
   "devDependencies": {
     "@raycast/eslint-config": "^1.0.8",
-    "@types/node": "^20.10.0",
+    "@types/node": "^20.19.37",
     "@types/react": "^19.0.10",
     "eslint": "^8.55.0",
     "typescript": "^5.3.2"

--- a/extensions/hop/src/index.tsx
+++ b/extensions/hop/src/index.tsx
@@ -151,7 +151,7 @@ function ConnectionItem({ connection }: { connection: ConnectionWithHistory }) {
           <ActionPanel.Section>
             <Action title="Connect in Terminal" icon={Icon.Terminal} onAction={connectInTerminal} />
             <Action.CopyToClipboard
-              title="Copy SSH Command"
+              title="Copy Ssh Command"
               content={sshCommand}
               shortcut={{ modifiers: ["cmd"], key: "c" }}
             />
@@ -164,7 +164,7 @@ function ConnectionItem({ connection }: { connection: ConnectionWithHistory }) {
             />
             {connection.user && (
               <Action.CopyToClipboard
-                title="Copy User@Host"
+                title="Copy User@host"
                 content={`${connection.user}@${connection.host}`}
                 shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
               />
@@ -276,19 +276,27 @@ function getAppleScript(terminal: string | undefined, command: string): string {
         end tell
       `;
 
-    default:
+    default: {
       // Generic handler for custom terminals
+      // If terminal is undefined (e.g. "Other" selected but custom name left blank), bail out early
+      if (!terminal) {
+        throw new Error("No terminal specified. Please set a terminal in Preferences.");
+      }
+
+      const escapedTerminal = terminal.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
       return `
-        tell application "${terminal}"
+        tell application "${escapedTerminal}"
           activate
         end tell
         delay 0.5
         tell application "System Events"
-          tell process "${terminal}"
+          tell process "${escapedTerminal}"
             keystroke "${escapedCommand}"
             key code 36
           end tell
         end tell
       `;
+    }
   }
 }

--- a/extensions/hop/src/index.tsx
+++ b/extensions/hop/src/index.tsx
@@ -250,8 +250,21 @@ function getAppleScript(terminal: string | undefined, command: string): string {
         end tell
       `;
 
+    case "Ghostty":
+      return `
+        tell application "Ghostty"
+          activate
+        end tell
+        delay 0.5
+        tell application "System Events"
+          tell process "Ghostty"
+            keystroke "${escapedCommand}"
+            key code 36
+          end tell
+        end tell
+      `;
+
     case "Terminal":
-    default:
       return `
         tell application "Terminal"
           activate
@@ -260,6 +273,21 @@ function getAppleScript(terminal: string | undefined, command: string): string {
           else
             do script "${escapedCommand}" in front window
           end if
+        end tell
+      `;
+
+    default:
+      // Generic handler for custom terminals
+      return `
+        tell application "${terminal}"
+          activate
+        end tell
+        delay 0.5
+        tell application "System Events"
+          tell process "${terminal}"
+            keystroke "${escapedCommand}"
+            key code 36
+          end tell
         end tell
       `;
   }

--- a/extensions/hop/src/utils/config.ts
+++ b/extensions/hop/src/utils/config.ts
@@ -38,12 +38,7 @@ interface HopHistory {
   connections: HistoryEntry[];
 }
 
-// Preferences interface is auto-generated from package.json by Raycast
-type Preferences = {
-  terminal: string;
-  customTerminal: string;
-  configPath: string;
-};
+// Preferences interface is auto-generated from package.json by Raycast (do not redefine locally)
 
 function expandTilde(filePath: string): string {
   if (filePath.startsWith("~/")) {
@@ -56,7 +51,7 @@ function expandTilde(filePath: string): string {
 }
 
 export function getConfigPath(): string {
-  const preferences = getPreferenceValues<Preferences>();
+  const preferences = getPreferenceValues();
   if (preferences.configPath) return expandTilde(preferences.configPath);
 
   const envPath = process.env.HOP_CONFIG;
@@ -169,7 +164,7 @@ export function buildSSHCommand(conn: Connection): string {
 }
 
 export function getTerminalApp(): string | undefined {
-  const preferences = getPreferenceValues<Preferences>();
+  const preferences = getPreferenceValues();
 
   const terminalMap: Record<string, string> = {
     terminal: "Terminal",

--- a/extensions/hop/src/utils/config.ts
+++ b/extensions/hop/src/utils/config.ts
@@ -177,6 +177,7 @@ export function getTerminalApp(): string | undefined {
     warp: "Warp",
     alacritty: "Alacritty",
     kitty: "kitty",
+    ghostty: "Ghostty",
   };
 
   if (preferences.terminal === "other" && preferences.customTerminal) {


### PR DESCRIPTION
## Summary
- Added Ghostty as a first-class terminal option in the dropdown preferences
- Added Ghostty-specific AppleScript handler
- Made the `default` case in `getAppleScript()` work as a generic handler for arbitrary custom terminals instead of falling back to Terminal.app

## Fixes
Closes #26799 — custom terminals (like Ghostty) selected via "Other (specify below)" fell through to Terminal.app because there was no matching case and the default was hardcoded to Terminal.

## Test Plan
- [ ] Select Ghostty from the terminal dropdown — should open Ghostty and execute SSH command
- [ ] Select "Other" and type a custom terminal name — should activate that app and type the command via System Events
- [ ] Verify existing terminals (Terminal, iTerm, Warp, Alacritty, kitty) still work as before