### PR TITLE
update Databuddy extension

### DIFF
--- a/extensions/databuddy/CHANGELOG.md
+++ b/extensions/databuddy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Databuddy
 
+## Open Website Directly in Databuddy - {PR_MERGE_DATE}
+
+- Deep link website "Open in Databuddy" actions to the selected website page
+
 ## [Initial Version] - 2026-04-01
 
 - View all websites connected to your Databuddy account

--- a/extensions/databuddy/CHANGELOG.md
+++ b/extensions/databuddy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Databuddy
 
-## [Open Website Directly in Databuddy] - {PR_MERGE_DATE}
+## [Open Website Directly in Databuddy] - 2026-04-04
 
 - Deep link website "Open in Databuddy" actions to the selected website page
 

--- a/extensions/databuddy/CHANGELOG.md
+++ b/extensions/databuddy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Databuddy
 
-## Open Website Directly in Databuddy - {PR_MERGE_DATE}
+## [Open Website Directly in Databuddy] - {PR_MERGE_DATE}
 
 - Deep link website "Open in Databuddy" actions to the selected website page
 

--- a/extensions/databuddy/package.json
+++ b/extensions/databuddy/package.json
@@ -6,6 +6,9 @@
   "description": "Privacy-first web analytics and link shortener. View websites, track visitors, and manage short links — all from Raycast.",
   "icon": "extension-icon.png",
   "author": "izadoesdev",
+  "contributors": [
+    "dominikdev"
+  ],
   "platforms": [
     "macOS",
     "Windows"

--- a/extensions/databuddy/src/components/websites/website-analytics.tsx
+++ b/extensions/databuddy/src/components/websites/website-analytics.tsx
@@ -9,6 +9,7 @@ function ChartView({ site, preset, filters, title }: ChartProps) {
   const { data, isLoading } = useCachedPromise(fetchTimeSeries, [site.id, preset, filters], {
     keepPreviousData: true,
   });
+  const websiteDashboardUrl = `${DASHBOARD_URL}/websites/${site.id}`;
 
   return (
     <Detail
@@ -19,7 +20,7 @@ function ChartView({ site, preset, filters, title }: ChartProps) {
       }
       actions={
         <ActionPanel>
-          <Action.OpenInBrowser title="Open in Databuddy" url={DASHBOARD_URL} />
+          <Action.OpenInBrowser title="Open in Databuddy" url={websiteDashboardUrl} />
         </ActionPanel>
       }
     />
@@ -27,6 +28,8 @@ function ChartView({ site, preset, filters, title }: ChartProps) {
 }
 
 function itemActions({ site, preset, filters, title }: ChartProps) {
+  const websiteDashboardUrl = `${DASHBOARD_URL}/websites/${site.id}`;
+
   return (
     <ActionPanel>
       <Action.Push
@@ -34,7 +37,7 @@ function itemActions({ site, preset, filters, title }: ChartProps) {
         icon={Icon.LineChart}
         target={<ChartView site={site} preset={preset} filters={filters} title={title} />}
       />
-      <Action.OpenInBrowser title="Open in Databuddy" url={DASHBOARD_URL} />
+      <Action.OpenInBrowser title="Open in Databuddy" url={websiteDashboardUrl} />
       <Action.OpenInBrowser
         title="Open Website"
         url={`https://${site.domain}`}

--- a/extensions/databuddy/src/components/websites/website-item.tsx
+++ b/extensions/databuddy/src/components/websites/website-item.tsx
@@ -8,6 +8,7 @@ import { WebsiteAnalytics } from "./website-analytics";
 
 export function WebsiteItem({ site, preset, onMutate }: { site: Website; preset: DatePreset; onMutate: () => void }) {
   const { data, isLoading, error } = useCachedPromise(fetchSummary, [site.id, preset], { keepPreviousData: true });
+  const websiteDashboardUrl = `${DASHBOARD_URL}/websites/${site.id}`;
 
   async function handleDelete() {
     if (
@@ -81,7 +82,7 @@ export function WebsiteItem({ site, preset, onMutate }: { site: Website; preset:
                 icon={{ source: Icon.Clock, tintColor: Color.Yellow }}
               />
               <List.Item.Detail.Metadata.Separator />
-              <List.Item.Detail.Metadata.Link title="Dashboard" text="Open in Databuddy" target={DASHBOARD_URL} />
+              <List.Item.Detail.Metadata.Link title="Dashboard" text="Open in Databuddy" target={websiteDashboardUrl} />
             </List.Item.Detail.Metadata>
           }
         />
@@ -99,7 +100,7 @@ export function WebsiteItem({ site, preset, onMutate }: { site: Website; preset:
             target={<EditWebsite site={site} onUpdate={onMutate} />}
             shortcut={{ modifiers: ["cmd"], key: "e" }}
           />
-          <Action.OpenInBrowser title="Open in Databuddy" url={DASHBOARD_URL} />
+          <Action.OpenInBrowser title="Open in Databuddy" url={websiteDashboardUrl} />
           <Action.OpenInBrowser
             title="Open Website"
             url={`https://${site.domain}`}


### PR DESCRIPTION
## Description

Opens the selected website directly inside Databuddy

## Screencast

https://github.com/user-attachments/assets/77834706-6243-497e-a9e1-8ea60960343e

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
