### PR TITLE
time-tracking: Add summary dashboard, import, and enhanced editing

### DIFF
--- a/extensions/time-tracking/CHANGELOG.md
+++ b/extensions/time-tracking/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Time Tracking Changelog
 
+## [Summary Dashboard, Full History, Enhanced Export, Long Session Detection] - {PR_MERGE_DATE}
+
+- Add "Time Summary" command with project summaries and daily breakdowns for configurable date ranges (today, past week, past 30 days, custom)
+- Remove 50-timer limit in "View Project Timers" so full history is accessible, organized by date sections
+- Enhance CSV export with ISO datetime columns (`start_datetime`, `end_datetime`) and decimal `duration_hours`
+- Add long session detection to "Start Timer" — prompts when switching timers if the previous one exceeded a configurable threshold (1-8 hours)
+- Add "Import Timers" command to restore timer data from a previously exported CSV file
+- Add optional text timestamp input (`yyyy-mm-dd hh:mm`) alongside the date picker in the edit form for precise time entry
+
 ## [Windows Support] - 2026-02-04
 
 - Add Windows support (ref: [#25071](https://github.com/raycast/extensions/issues/25071))

--- a/extensions/time-tracking/CHANGELOG.md
+++ b/extensions/time-tracking/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Time Tracking Changelog
 
-## [Summary Dashboard, Full History, Enhanced Export, Long Session Detection] - {PR_MERGE_DATE}
+## [Summary Dashboard, Full History, Enhanced Export, Long Session Detection] - 2026-04-12
 
 - Add "Time Summary" command with project summaries and daily breakdowns for configurable date ranges (today, past week, past 30 days, custom)
 - Remove 50-timer limit in "View Project Timers" so full history is accessible, organized by date sections

--- a/extensions/time-tracking/package-lock.json
+++ b/extensions/time-tracking/package-lock.json
@@ -1152,7 +1152,6 @@
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.103.10.tgz",
       "integrity": "sha512-FOxqq47+YVCo4+Eq8eU8+esoLNwcxHHBVhw/JmZwsViTqMB3DF8WorXL+ZwrXW/8srruuzyyx9+ACyRdZ+zbSg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.5.4",
         "@oclif/plugin-autocomplete": "^3.2.35",
@@ -1255,7 +1254,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1315,7 +1313,6 @@
       "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.39.1",
         "@typescript-eslint/types": "8.39.1",
@@ -1521,7 +1518,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1886,7 +1882,6 @@
       "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2744,7 +2739,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2985,7 +2979,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3050,7 +3043,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/time-tracking/package.json
+++ b/extensions/time-tracking/package.json
@@ -56,7 +56,7 @@
       "title": "Start Timer",
       "subtitle": "Start a project timer",
       "description": "Starts a new project timer and pauses the current timer",
-      "mode": "no-view",
+      "mode": "view",
       "icon": "start_command.png",
       "arguments": [
         {
@@ -77,6 +77,31 @@
           "type": "textfield",
           "required": false,
           "description": "Enter a default tag to apply to timers"
+        },
+        {
+          "name": "longSessionCheck",
+          "title": "Long Session Detection",
+          "type": "checkbox",
+          "required": false,
+          "default": false,
+          "label": "Prompt when switching from a long-running timer",
+          "description": "When starting a new timer, prompt if the previous timer exceeded the threshold"
+        },
+        {
+          "name": "longSessionThreshold",
+          "title": "Long Session Threshold",
+          "type": "dropdown",
+          "required": false,
+          "description": "Duration after which a session is considered long",
+          "default": "3600000",
+          "data": [
+            { "title": "1 hour", "value": "3600000" },
+            { "title": "2 hours", "value": "7200000" },
+            { "title": "3 hours", "value": "10800000" },
+            { "title": "4 hours", "value": "14400000" },
+            { "title": "6 hours", "value": "21600000" },
+            { "title": "8 hours", "value": "28800000" }
+          ]
         }
       ]
     },
@@ -95,6 +120,22 @@
       "description": "Overview of all timers",
       "mode": "view",
       "icon": "list_command.png"
+    },
+    {
+      "name": "summary",
+      "title": "Time Summary",
+      "subtitle": "View time summaries",
+      "description": "View project time summaries by day, week, month, or custom date range",
+      "mode": "view",
+      "icon": "list_command.png"
+    },
+    {
+      "name": "import-timers",
+      "title": "Import Timers",
+      "subtitle": "Import timers from CSV",
+      "description": "Import timer data from a previously exported CSV file",
+      "mode": "no-view",
+      "icon": "start_command.png"
     }
   ],
   "dependencies": {

--- a/extensions/time-tracking/src/Timers.ts
+++ b/extensions/time-tracking/src/Timers.ts
@@ -122,8 +122,129 @@ export function formatDuration(duration: number): string {
   return `${hours.toString().padStart(2, "0")}:${(minutes % 60).toString().padStart(2, "0")}:${(seconds % 60).toString().padStart(2, "0")}`;
 }
 
+export function getTimersByDateRange(timers: Timer[], startDate: Date, endDate: Date): Timer[] {
+  const startMs = startDate.getTime();
+  const endMs = endDate.getTime();
+  return timers.filter((timer) => timer.start >= startMs && timer.start <= endMs);
+}
+
+export function groupTimersByProject(timers: Timer[]): Map<string, { totalDuration: number; count: number }> {
+  const groups = new Map<string, { totalDuration: number; count: number }>();
+  for (const timer of timers) {
+    const name = timer.name || "Unnamed timer";
+    const existing = groups.get(name) || { totalDuration: 0, count: 0 };
+    existing.totalDuration += getDuration(timer);
+    existing.count += 1;
+    groups.set(name, existing);
+  }
+  return groups;
+}
+
+export function groupTimersByDay(timers: Timer[]): Map<string, Timer[]> {
+  const groups = new Map<string, Timer[]>();
+  for (const timer of timers) {
+    const date = new Date(timer.start);
+    const dayKey = `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, "0")}-${date.getDate().toString().padStart(2, "0")}`;
+    const existing = groups.get(dayKey) || [];
+    existing.push(timer);
+    groups.set(dayKey, existing);
+  }
+  return groups;
+}
+
+export function formatDateLabel(dayKey: string): string {
+  const date = new Date(dayKey + "T00:00:00");
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const dateCheck = new Date(date);
+  dateCheck.setHours(0, 0, 0, 0);
+
+  if (dateCheck.getTime() === today.getTime()) return "Today";
+  if (dateCheck.getTime() === yesterday.getTime()) return "Yesterday";
+  return date.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" });
+}
+
+function formatISOLocal(ms: number): string {
+  const d = new Date(ms);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
 function generateTimerId(): string {
   return Math.random().toString(36).substring(2);
+}
+
+export async function importTimersFromCSV(csvContent: string): Promise<number> {
+  const lines = csvContent.trim().split("\n");
+  if (lines.length < 2) return 0;
+
+  const header = lines[0];
+  const timers = await getTimers();
+  let imported = 0;
+  let skipped = 0;
+
+  // Detect CSV format by header
+  const isNewFormat = header.includes("start_unix");
+  const isOldFormat = header.startsWith("id,name,tag,start,end");
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+
+    // Simple CSV parse (handles commas within the constraints of the export format)
+    const parts = line.split(",");
+    if (parts.length < 5) continue;
+
+    let id: string, name: string, tag: string, start: number, end: number;
+
+    if (isNewFormat) {
+      // New format: id,name,tag,start_unix,end_unix,start_datetime,end_datetime,...
+      id = parts[0];
+      name = parts[1];
+      tag = parts[2];
+      start = parseInt(parts[3]);
+      end = parseInt(parts[4]);
+    } else if (isOldFormat) {
+      // Old format: id,name,tag,start,end,duration,formatted
+      id = parts[0];
+      name = parts[1];
+      tag = parts[2];
+      start = parseInt(parts[3]);
+      end = parseInt(parts[4]);
+    } else {
+      continue;
+    }
+
+    if (isNaN(start) || (!isNaN(end) && end <= 0)) {
+      skipped++;
+      console.warn(`Import: skipped row ${i + 1} — invalid start/end values`);
+      continue;
+    }
+
+    // Skip if this timer already exists
+    if (timers[id]) continue;
+
+    timers[id] = {
+      id,
+      name: name || null,
+      tag: tag || undefined,
+      start,
+      end: isNaN(end) || end === 0 ? null : end,
+    };
+    imported++;
+  }
+
+  await LocalStorage.setItem("projecttimer.timers", JSON.stringify(timers));
+  if (skipped > 0) {
+    await showToast({
+      style: Toast.Style.Animated,
+      title: `${skipped} row(s) skipped`,
+      message: "Some rows had invalid data (possibly commas in names/tags)",
+    });
+  }
+  return imported;
 }
 
 export async function deleteTimer(timerId: string): Promise<TimerList> {
@@ -160,14 +281,24 @@ export async function exportTimers() {
   const timers = await getTimers();
   toast.title = "Exporting CSV";
   const csv =
-    "id,name,tag,start,end,duration,formatted\n" +
+    "id,name,tag,start_unix,end_unix,start_datetime,end_datetime,duration_ms,duration_formatted,duration_hours\n" +
     Object.values(timers)
       .map((timer) => {
         const duration = getDuration(timer);
+        const durationHours = (duration / 3600000).toFixed(2);
+        const name = (timer.name || "").replaceAll(",", commaReplacement);
+        const tag = (timer.tag || "").replaceAll(",", commaReplacement);
         return [
-          ...Object.values(timer).map((v) => `${v}`.replaceAll(",", commaReplacement)),
+          timer.id,
+          name,
+          tag,
+          timer.start,
+          timer.end || "",
+          formatISOLocal(timer.start),
+          timer.end ? formatISOLocal(timer.end) : "",
           duration,
           formatDuration(duration),
+          durationHours,
         ].join(",");
       })
       .join("\n");

--- a/extensions/time-tracking/src/Timers.ts
+++ b/extensions/time-tracking/src/Timers.ts
@@ -180,6 +180,7 @@ export async function importTimersFromCSV(csvContent: string): Promise<number> {
   const lines = csvContent.trim().split("\n");
   if (lines.length < 2) return 0;
 
+  const { commaReplacement } = getPreferenceValues<ExtensionPreferences>();
   const header = lines[0];
   const timers = await getTimers();
   let imported = 0;
@@ -226,6 +227,12 @@ export async function importTimersFromCSV(csvContent: string): Promise<number> {
     // Skip if this timer already exists
     if (timers[id]) continue;
 
+    // Reverse comma replacement applied during export
+    if (commaReplacement) {
+      name = name.replaceAll(commaReplacement, ",");
+      tag = tag.replaceAll(commaReplacement, ",");
+    }
+
     timers[id] = {
       id,
       name: name || null,
@@ -239,7 +246,7 @@ export async function importTimersFromCSV(csvContent: string): Promise<number> {
   await LocalStorage.setItem("projecttimer.timers", JSON.stringify(timers));
   if (skipped > 0) {
     await showToast({
-      style: Toast.Style.Animated,
+      style: Toast.Style.Failure,
       title: `${skipped} row(s) skipped`,
       message: "Some rows had invalid data (possibly commas in names/tags)",
     });

--- a/extensions/time-tracking/src/import-timers.tsx
+++ b/extensions/time-tracking/src/import-timers.tsx
@@ -1,0 +1,52 @@
+import { showHUD, showToast, Toast, getPreferenceValues, openExtensionPreferences } from "@raycast/api";
+import { readdir, readFile } from "fs/promises";
+import { join } from "path";
+import { importTimersFromCSV } from "./Timers";
+
+export default async function Command() {
+  const { exportDirectory } = getPreferenceValues<ExtensionPreferences>();
+  if (!exportDirectory) {
+    await showToast({
+      title: "Export directory not set",
+      message: "Set the export directory in preferences, then export from the store version first",
+      style: Toast.Style.Failure,
+      primaryAction: {
+        title: "Open Preferences",
+        onAction: () => openExtensionPreferences(),
+      },
+    });
+    return;
+  }
+
+  // Find the most recent CSV export in the export directory
+  let csvFiles: string[];
+  try {
+    csvFiles = (await readdir(exportDirectory))
+      .filter((f) => f.endsWith(".csv") && f.startsWith("projecttimer"))
+      .sort()
+      .reverse();
+  } catch {
+    await showHUD("Could not read export directory");
+    return;
+  }
+
+  if (csvFiles.length === 0) {
+    await showHUD("No CSV exports found. Export from the store version first.");
+    return;
+  }
+
+  const latestFile = join(exportDirectory, csvFiles[0]);
+  const toast = await showToast(Toast.Style.Animated, "Importing timers...");
+
+  try {
+    const content = await readFile(latestFile, "utf8");
+    const count = await importTimersFromCSV(content);
+    toast.style = Toast.Style.Success;
+    toast.title = `Imported ${count} timer${count !== 1 ? "s" : ""}`;
+    toast.message = `From ${csvFiles[0]}`;
+  } catch (error) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Import failed";
+    toast.message = `${error}`;
+  }
+}

--- a/extensions/time-tracking/src/start-timer.tsx
+++ b/extensions/time-tracking/src/start-timer.tsx
@@ -1,17 +1,190 @@
-import { LaunchProps, showHUD } from "@raycast/api";
-import { startTimer } from "./Timers";
+import {
+  LaunchProps,
+  ActionPanel,
+  Action,
+  List,
+  Form,
+  Icon,
+  popToRoot,
+  closeMainWindow,
+  showHUD,
+  getPreferenceValues,
+} from "@raycast/api";
+import { useEffect, useState } from "react";
+import {
+  startTimer,
+  stopTimer,
+  deleteTimer,
+  editTimer,
+  getTimers,
+  runningTimerId,
+  getDuration,
+  formatDuration,
+  Timer,
+} from "./Timers";
 
-export default async function Command(options: LaunchProps<{ arguments: Arguments.StartTimer }>) {
-  let name = options.arguments.name;
+interface LongSessionInfo {
+  timer: Timer;
+  timerId: string;
+  duration: number;
+}
+
+export default function Command(props: LaunchProps<{ arguments: Arguments.StartTimer }>) {
+  const [longSession, setLongSession] = useState<LongSessionInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  let name = props.arguments.name;
   if (name?.trim().length === 0) {
     name = "Unnamed timer";
   }
-  const timer = await startTimer(name, options.arguments.tag);
+  const tag = props.arguments.tag;
 
-  if (timer === null) {
-    await showHUD("Starting timer...");
-    return;
+  const { longSessionCheck, longSessionThreshold } = getPreferenceValues<Preferences.StartTimer>();
+
+  useEffect(() => {
+    (async () => {
+      const currentTimerId = await runningTimerId();
+
+      if (currentTimerId && longSessionCheck) {
+        const timers = await getTimers();
+        const currentTimer = timers[currentTimerId];
+
+        if (currentTimer) {
+          const thresholdMs = parseInt(longSessionThreshold || "3600000");
+          const duration = getDuration(currentTimer);
+
+          if (duration >= thresholdMs) {
+            setLongSession({ timer: currentTimer, timerId: currentTimerId, duration });
+            setIsLoading(false);
+            return;
+          }
+        }
+      }
+
+      // Normal flow — start timer and close immediately
+      const timer = await startTimer(name, tag);
+      await closeMainWindow();
+      await showHUD(`Started ${timer?.name || name}`);
+      await popToRoot();
+    })();
+  }, []);
+
+  if (isLoading || !longSession) {
+    return <List isLoading={true} />;
   }
 
-  await showHUD(`Started ${timer.name}`);
+  const prevName = longSession.timer.name || "Unnamed timer";
+  const formattedDuration = formatDuration(longSession.duration);
+
+  async function handleKeep() {
+    const timer = await startTimer(name, tag);
+    await closeMainWindow();
+    await showHUD(`Kept "${prevName}" (${formattedDuration}). Started ${timer?.name || name}`);
+    await popToRoot();
+  }
+
+  async function handleCancel() {
+    await deleteTimer(longSession!.timerId);
+    const timer = await startTimer(name, tag);
+    await closeMainWindow();
+    await showHUD(`Cancelled "${prevName}". Started ${timer?.name || name}`);
+    await popToRoot();
+  }
+
+  return (
+    <List searchBarPlaceholder={`"${prevName}" has been running for ${formattedDuration}`}>
+      <List.Item
+        title="Keep Full Duration"
+        subtitle={`Keep ${formattedDuration} for "${prevName}"`}
+        icon={Icon.Checkmark}
+        actions={
+          <ActionPanel>
+            <Action title="Keep Time" onAction={handleKeep} />
+          </ActionPanel>
+        }
+      />
+      <List.Item
+        title="Cancel Previous Timer"
+        subtitle={`Delete "${prevName}" entirely`}
+        icon={Icon.Trash}
+        actions={
+          <ActionPanel>
+            <Action title="Cancel Timer" onAction={handleCancel} />
+          </ActionPanel>
+        }
+      />
+      <List.Item
+        title="Update End Time"
+        subtitle={`Adjust when "${prevName}" actually ended`}
+        icon={Icon.Clock}
+        actions={
+          <ActionPanel>
+            <Action.Push
+              title="Update End Time"
+              target={<UpdateEndTimeForm previousTimer={longSession.timer} newTimerName={name} newTimerTag={tag} />}
+            />
+          </ActionPanel>
+        }
+      />
+    </List>
+  );
+}
+
+function UpdateEndTimeForm({
+  previousTimer,
+  newTimerName,
+  newTimerTag,
+}: {
+  previousTimer: Timer;
+  newTimerName: string;
+  newTimerTag?: string;
+}) {
+  async function handleSubmit(values: { endTime: Date; endTimeOverride: string }) {
+    let endMs: number;
+
+    if (values.endTimeOverride?.trim()) {
+      const parsed = new Date(values.endTimeOverride.trim().replace(" ", "T"));
+      if (isNaN(parsed.getTime())) {
+        await showHUD("Invalid date format. Use yyyy-mm-dd hh:mm");
+        return;
+      }
+      endMs = parsed.getTime();
+    } else {
+      endMs = values.endTime.getTime();
+    }
+
+    // Stop the running timer (sets end=now, clears running ref)
+    await stopTimer();
+    // Overwrite the end time with the user's chosen time
+    const updated = await editTimer({ ...previousTimer, end: endMs });
+    if (!updated) {
+      await showHUD("End time must be after the timer's start time");
+      return;
+    }
+    // Start the new timer (stopTimer inside is a no-op now)
+    const timer = await startTimer(newTimerName, newTimerTag);
+    await closeMainWindow();
+    await showHUD(
+      `Updated "${previousTimer.name || "Unnamed timer"}" end time. Started ${timer?.name || newTimerName}`,
+    );
+    await popToRoot();
+  }
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Update End Time" onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.DatePicker id="endTime" title="End Time" defaultValue={new Date()} type={Form.DatePicker.Type.DateTime} />
+      <Form.TextField
+        id="endTimeOverride"
+        title="Or Type Date"
+        placeholder="yyyy-mm-dd hh:mm"
+        info="If filled, this overrides the date picker above"
+      />
+    </Form>
+  );
 }

--- a/extensions/time-tracking/src/summary.tsx
+++ b/extensions/time-tracking/src/summary.tsx
@@ -1,0 +1,193 @@
+import { Action, ActionPanel, Color, Form, Icon, List, useNavigation } from "@raycast/api";
+
+import { useEffect, useState } from "react";
+import {
+  formatDateLabel,
+  formatDuration,
+  getDuration,
+  getTimers,
+  getTimersByDateRange,
+  groupTimersByDay,
+  groupTimersByProject,
+  Timer,
+} from "./Timers";
+
+type PeriodKey = "today" | "week" | "30days" | "custom";
+
+function getDateRange(period: PeriodKey): { start: Date; end: Date } {
+  const now = new Date();
+  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
+
+  switch (period) {
+    case "today": {
+      const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0);
+      return { start, end };
+    }
+    case "week": {
+      const start = new Date(now);
+      start.setDate(start.getDate() - 7);
+      start.setHours(0, 0, 0, 0);
+      return { start, end };
+    }
+    case "30days": {
+      const start = new Date(now);
+      start.setDate(start.getDate() - 30);
+      start.setHours(0, 0, 0, 0);
+      return { start, end };
+    }
+    default:
+      return { start: new Date(0), end };
+  }
+}
+
+function CustomDatePicker(props: { onSubmit: (start: Date, end: Date) => void }) {
+  const { pop } = useNavigation();
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm
+            title="Apply"
+            icon={Icon.Calendar}
+            onSubmit={(values: { start: Date; end: Date }) => {
+              props.onSubmit(values.start, values.end);
+              pop();
+            }}
+          />
+        </ActionPanel>
+      }
+    >
+      <Form.DatePicker id="start" title="Start Date" />
+      <Form.DatePicker id="end" title="End Date" />
+    </Form>
+  );
+}
+
+export default function Command() {
+  const [allTimers, setAllTimers] = useState<Timer[]>([]);
+  const [filteredTimers, setFilteredTimers] = useState<Timer[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [period, setPeriod] = useState<PeriodKey>("today");
+  const [customRange, setCustomRange] = useState<{ start: Date; end: Date } | null>(null);
+
+  useEffect(() => {
+    getTimers().then((list) => {
+      const timers = Object.values(list).sort((a, b) => b.start - a.start);
+      setAllTimers(timers);
+      setIsLoading(false);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (period === "custom" && customRange) {
+      setFilteredTimers(getTimersByDateRange(allTimers, customRange.start, customRange.end));
+    } else if (period !== "custom") {
+      const { start, end } = getDateRange(period);
+      setFilteredTimers(getTimersByDateRange(allTimers, start, end));
+    }
+  }, [allTimers, period, customRange]);
+
+  const projectGroups = groupTimersByProject(filteredTimers);
+  const dayGroups = groupTimersByDay(filteredTimers);
+  const sortedDayKeys = Array.from(dayGroups.keys()).sort((a, b) => b.localeCompare(a));
+  const totalDuration = filteredTimers.reduce((sum, t) => sum + getDuration(t), 0);
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarAccessory={
+        <List.Dropdown
+          tooltip="Time Period"
+          value={period}
+          onChange={(value) => {
+            setPeriod(value as PeriodKey);
+          }}
+        >
+          <List.Dropdown.Item title="Today" value="today" />
+          <List.Dropdown.Item title="Past Week" value="week" />
+          <List.Dropdown.Item title="Past 30 Days" value="30days" />
+          {customRange && <List.Dropdown.Item title="Custom Range" value="custom" />}
+        </List.Dropdown>
+      }
+    >
+      <List.Section title="Actions">
+        <List.Item
+          title="Custom Date Range..."
+          icon={Icon.Calendar}
+          actions={
+            <ActionPanel>
+              <Action.Push
+                title="Pick Custom Range"
+                target={
+                  <CustomDatePicker
+                    onSubmit={(start, end) => {
+                      setCustomRange({ start, end });
+                      setPeriod("custom");
+                    }}
+                  />
+                }
+              />
+            </ActionPanel>
+          }
+        />
+      </List.Section>
+      <List.Section title="Project Summary" subtitle={`Total: ${formatDuration(totalDuration)}`}>
+        {Array.from(projectGroups.entries())
+          .sort(([, a], [, b]) => b.totalDuration - a.totalDuration)
+          .map(([name, data]) => (
+            <List.Item
+              key={`project-${name}`}
+              title={name}
+              subtitle={`${data.count} session${data.count !== 1 ? "s" : ""}`}
+              accessories={[
+                {
+                  tag: { value: formatDuration(data.totalDuration), color: Color.Blue },
+                  icon: Icon.Clock,
+                },
+                {
+                  text: `${(data.totalDuration / 3600000).toFixed(1)}h`,
+                },
+              ]}
+              actions={
+                <ActionPanel>
+                  <Action.CopyToClipboard title="Copy Duration" content={formatDuration(data.totalDuration)} />
+                </ActionPanel>
+              }
+            />
+          ))}
+      </List.Section>
+
+      {sortedDayKeys.map((dayKey) => {
+        const dayTimers = dayGroups.get(dayKey) || [];
+        const dayTotal = dayTimers.reduce((sum, t) => sum + getDuration(t), 0);
+        return (
+          <List.Section key={dayKey} title={formatDateLabel(dayKey)} subtitle={formatDuration(dayTotal)}>
+            {dayTimers.map((timer) => (
+              <List.Item
+                key={timer.id}
+                title={timer.name ?? "Unnamed timer"}
+                subtitle={
+                  timer.end
+                    ? new Date(timer.start).toLocaleTimeString() + " - " + new Date(timer.end).toLocaleTimeString()
+                    : new Date(timer.start).toLocaleTimeString() + " (running)"
+                }
+                accessories={[{ tag: timer.tag }, { text: formatDuration(getDuration(timer)) }]}
+                actions={
+                  <ActionPanel>
+                    <Action.CopyToClipboard title="Copy Duration" content={formatDuration(getDuration(timer))} />
+                  </ActionPanel>
+                }
+              />
+            ))}
+          </List.Section>
+        );
+      })}
+
+      {filteredTimers.length === 0 && !isLoading && (
+        <List.Section title="No Timers Found">
+          <List.Item title="No tracked time for this period" icon={Icon.Clock} />
+        </List.Section>
+      )}
+    </List>
+  );
+}

--- a/extensions/time-tracking/src/view-project-timers.tsx
+++ b/extensions/time-tracking/src/view-project-timers.tsx
@@ -10,8 +10,8 @@ import {
   LaunchType,
   List,
   showToast,
+  Toast,
   Form,
-  getPreferenceValues,
 } from "@raycast/api";
 
 import { useEffect, useState } from "react";
@@ -20,25 +20,63 @@ import {
   editTimer,
   exportTimers,
   formatDuration,
+  formatDateLabel,
   getDuration,
   getTimers,
+  groupTimersByDay,
   Timer,
   TimerList,
 } from "./Timers";
 import { useForm } from "@raycast/utils";
 
+function parseTimestamp(value: string): Date | null {
+  // Accept yyyy-mm-dd hh:mm or yyyy-mm-ddThh:mm
+  const match = value.trim().match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})$/);
+  if (!match) return null;
+  const date = new Date(
+    parseInt(match[1]),
+    parseInt(match[2]) - 1,
+    parseInt(match[3]),
+    parseInt(match[4]),
+    parseInt(match[5]),
+  );
+  if (isNaN(date.getTime())) return null;
+  return date;
+}
+
 function EditForm(props: { timer: Timer; onUpdate: (start: Date, end: Date, name: string, tag: string) => void }) {
-  const { default_tag } = getPreferenceValues<Preferences.StartTimer>();
   type FormValues = {
     id: string;
     name: string;
     tag: string;
     start: Date | null;
     end: Date | null;
+    startText: string;
+    endText: string;
   };
   const { itemProps, handleSubmit, values, setValidationError } = useForm<FormValues>({
     onSubmit(values) {
-      const { start, end, name, tag } = values;
+      let start = values.start;
+      let end = values.end;
+
+      // Text fields override DatePicker when filled
+      if (values.startText.trim()) {
+        const parsed = parseTimestamp(values.startText);
+        if (!parsed) {
+          setValidationError("startText", "Use yyyy-mm-dd hh:mm format");
+          return;
+        }
+        start = parsed;
+      }
+      if (values.endText.trim()) {
+        const parsed = parseTimestamp(values.endText);
+        if (!parsed) {
+          setValidationError("endText", "Use yyyy-mm-dd hh:mm format");
+          return;
+        }
+        end = parsed;
+      }
+
       if (!start) {
         setValidationError("start", "The item is required");
         return;
@@ -47,7 +85,11 @@ function EditForm(props: { timer: Timer; onUpdate: (start: Date, end: Date, name
         setValidationError("end", "The item is required");
         return;
       }
-      props.onUpdate(start, end, name, tag);
+      if (end <= start) {
+        setValidationError("endText", "End must be after start");
+        return;
+      }
+      props.onUpdate(start, end, values.name, values.tag);
     },
     initialValues: {
       id: props.timer.id,
@@ -55,17 +97,17 @@ function EditForm(props: { timer: Timer; onUpdate: (start: Date, end: Date, name
       tag: props.timer.tag || "",
       start: new Date(props.timer.start),
       end: new Date(props.timer.end!),
+      startText: "",
+      endText: "",
     },
     validation: {
       start(value) {
-        if (!value) return "The item is required";
-        if (value > new Date()) return "Start Date must be a date in the past";
-        if (values.end && values.end <= value) return "Start Date must be before End Date";
+        if (!value && !values.startText?.trim()) return "The item is required";
+        if (value && value > new Date()) return "Start Date must be a date in the past";
       },
       end(value) {
-        if (!value) return "The item is required";
-        if (value > new Date()) return "End Date must be a date in the past";
-        if (values.start && values.start >= value) return "End Date must be after Start Date";
+        if (!value && !values.endText?.trim()) return "The item is required";
+        if (value && value > new Date()) return "End Date must be a date in the past";
       },
     },
   });
@@ -79,8 +121,18 @@ function EditForm(props: { timer: Timer; onUpdate: (start: Date, end: Date, name
     >
       <Form.TextField title="Name" placeholder="Unnamed timer" {...itemProps.name} />
       <Form.DatePicker title="Start Date" {...itemProps.start} />
+      <Form.TextField
+        title="Start Override"
+        placeholder="yyyy-mm-dd hh:mm (overrides picker above)"
+        {...itemProps.startText}
+      />
       <Form.DatePicker title="End Date" {...itemProps.end} />
-      <Form.TextField title="Tag" placeholder={default_tag || "Tag"} {...itemProps.tag} />
+      <Form.TextField
+        title="End Override"
+        placeholder="yyyy-mm-dd hh:mm (overrides picker above)"
+        {...itemProps.endText}
+      />
+      <Form.TextField title="Tag" placeholder="Tag" {...itemProps.tag} />
     </Form>
   );
 }
@@ -106,9 +158,7 @@ export default function Command() {
   }, [timers, search]);
 
   function refresh(list: TimerList) {
-    const sortedTimers = Object.values(list)
-      .sort((a, b) => b.start - a.start)
-      .slice(0, 50);
+    const sortedTimers = Object.values(list).sort((a, b) => b.start - a.start);
     setTimers(sortedTimers);
     setFilteredTimers(sortedTimers);
   }
@@ -118,13 +168,21 @@ export default function Command() {
       <EditForm
         timer={editingTimer}
         onUpdate={async (start, end, name, tag) => {
-          await editTimer({ ...editingTimer, start: start.getTime(), end: end.getTime(), name, tag });
-          getTimers().then(refresh);
+          const result = await editTimer({ ...editingTimer, start: start.getTime(), end: end.getTime(), name, tag });
+          if (result === null) {
+            showToast({ style: Toast.Style.Failure, title: "Timer no longer exists" });
+          } else {
+            getTimers().then(refresh);
+          }
           setEditingTimer(undefined);
         }}
       />
     );
   }
+
+  // Group filtered timers by day
+  const dayGroups = groupTimersByDay(filteredTimers);
+  const sortedDayKeys = Array.from(dayGroups.keys()).sort((a, b) => b.localeCompare(a));
 
   return (
     <List
@@ -133,102 +191,110 @@ export default function Command() {
       searchBarPlaceholder={"Search timers..."}
       onSearchTextChange={(text) => setSearch(text)}
     >
-      {filteredTimers.map((timer) => (
-        <List.Item
-          key={timer.id}
-          title={timer.name ?? "Unnamed timer"}
-          subtitle={
-            timer.end
-              ? new Date(timer.start).toLocaleString() + " - " + new Date(timer.end).toLocaleString()
-              : new Date(timer.start).toLocaleString()
-          }
-          accessories={[
-            { tag: timer.tag },
-            {
-              text: (timer.end ? "✅ " : "⏳ ") + formatDuration(getDuration(timer)),
-            },
-          ]}
-          actions={
-            <ActionPanel>
-              {!timer.end ? (
-                <Action
-                  icon={Icon.Stop}
-                  title={"Stop Timer"}
-                  onAction={() => {
-                    launchCommand({
-                      name: "stop-timer",
-                      type: LaunchType.UserInitiated,
-                    });
-                  }}
-                />
-              ) : (
-                <Action
-                  icon={Icon.Repeat}
-                  title={"Start Again"}
-                  onAction={() => {
-                    launchCommand({
-                      name: "start-timer",
-                      type: LaunchType.UserInitiated,
-                      arguments: {
-                        name: timer.name,
-                        tag: timer.tag,
-                      },
-                    });
-                  }}
-                />
-              )}
-              <Action.CopyToClipboard
-                icon={Icon.CopyClipboard}
-                title={"Copy Duration"}
-                content={formatDuration(getDuration(timer))}
+      {sortedDayKeys.map((dayKey) => {
+        const dayTimers = dayGroups.get(dayKey) || [];
+        const totalDuration = dayTimers.reduce((sum, t) => sum + getDuration(t), 0);
+        return (
+          <List.Section key={dayKey} title={formatDateLabel(dayKey)} subtitle={formatDuration(totalDuration)}>
+            {dayTimers.map((timer) => (
+              <List.Item
+                key={timer.id}
+                title={timer.name ?? "Unnamed timer"}
+                subtitle={
+                  timer.end
+                    ? new Date(timer.start).toLocaleTimeString() + " - " + new Date(timer.end).toLocaleTimeString()
+                    : new Date(timer.start).toLocaleTimeString()
+                }
+                accessories={[
+                  { tag: timer.tag },
+                  {
+                    text: (timer.end ? "\u2705 " : "\u23f3 ") + formatDuration(getDuration(timer)),
+                  },
+                ]}
+                actions={
+                  <ActionPanel>
+                    {!timer.end ? (
+                      <Action
+                        icon={Icon.Stop}
+                        title={"Stop Timer"}
+                        onAction={() => {
+                          launchCommand({
+                            name: "stop-timer",
+                            type: LaunchType.UserInitiated,
+                          });
+                        }}
+                      />
+                    ) : (
+                      <Action
+                        icon={Icon.Repeat}
+                        title={"Start Again"}
+                        onAction={() => {
+                          launchCommand({
+                            name: "start-timer",
+                            type: LaunchType.UserInitiated,
+                            arguments: {
+                              name: timer.name,
+                              tag: timer.tag,
+                            },
+                          });
+                        }}
+                      />
+                    )}
+                    <Action.CopyToClipboard
+                      icon={Icon.CopyClipboard}
+                      title={"Copy Duration"}
+                      content={formatDuration(getDuration(timer))}
+                    />
+                    {!!timer.end && (
+                      <Action
+                        icon={Icon.EditShape}
+                        title={"Edit Timer"}
+                        shortcut={Keyboard.Shortcut.Common.Edit}
+                        onAction={() => setEditingTimer(timer)}
+                      />
+                    )}
+                    <Action
+                      icon={Icon.Trash}
+                      title={"Delete Timer"}
+                      shortcut={Keyboard.Shortcut.Common.Remove}
+                      onAction={async () => {
+                        if (
+                          await confirmAlert({
+                            title: "Are you sure you want to delete this timer?",
+                            message: "This action cannot be undone.",
+                            icon: { source: Icon.Trash, tintColor: Color.Red },
+                            primaryAction: {
+                              style: Alert.ActionStyle.Destructive,
+                              title: "Delete timer",
+                            },
+                            rememberUserChoice: true,
+                          })
+                        ) {
+                          deleteTimer(timer.id).then(refresh);
+                          await showToast({
+                            title: "Timer with duration " + formatDuration(getDuration(timer)) + " deleted",
+                          });
+                        }
+                      }}
+                      style={Action.Style.Destructive}
+                    />
+                    <Action
+                      icon={Icon.Download}
+                      // eslint-disable-next-line @raycast/prefer-title-case
+                      title="Export Timers as CSV"
+                      shortcut={{
+                        macOS: { modifiers: ["cmd"], key: "s" },
+                        Windows: { modifiers: ["ctrl"], key: "s" },
+                      }}
+                      onAction={exportTimers}
+                    />
+                  </ActionPanel>
+                }
               />
-              {!!timer.end && (
-                <Action
-                  icon={Icon.EditShape}
-                  title={"Edit Timer"}
-                  shortcut={Keyboard.Shortcut.Common.Edit}
-                  onAction={() => setEditingTimer(timer)}
-                />
-              )}
-              <Action
-                icon={Icon.Trash}
-                title={"Delete Timer"}
-                shortcut={Keyboard.Shortcut.Common.Remove}
-                onAction={async () => {
-                  if (
-                    await confirmAlert({
-                      title: "Are you sure you want to delete this timer?",
-                      message: "This action cannot be undone.",
-                      icon: { source: Icon.Trash, tintColor: Color.Red },
-                      primaryAction: {
-                        style: Alert.ActionStyle.Destructive,
-                        title: "Delete timer",
-                      },
-                      rememberUserChoice: true,
-                    })
-                  ) {
-                    deleteTimer(timer.id).then(refresh);
-                    await showToast({
-                      title: "Timer with duration " + formatDuration(getDuration(timer)) + " deleted",
-                    });
-                  }
-                }}
-                style={Action.Style.Destructive}
-              />
-              <Action
-                icon={Icon.Download}
-                // eslint-disable-next-line @raycast/prefer-title-case
-                title="Export Timers as CSV"
-                shortcut={{
-                  macOS: { modifiers: ["cmd"], key: "s" },
-                  Windows: { modifiers: ["ctrl"], key: "s" },
-                }}
-                onAction={exportTimers}
-              />
-            </ActionPanel>
-          }
-        />
-      ))}
+            ))}
+          </List.Section>
+        );
+      })}
     </List>
   );
 }


### PR DESCRIPTION
> Supersedes #26677 (closed due to force-push during review fix). Includes all original changes plus review fixes.

## Summary
- Add **summary dashboard** with daily/weekly/monthly/custom date range views and per-project time breakdowns
- Add **CSV import command** for migrating timers from other instances (with skipped-row warnings)
- Enhance **edit form** with text-based date override fields (`yyyy-mm-dd hh:mm`) for precise time entry
- **Group timer list by day** with daily duration subtotals
- Improve **CSV export format** with unix timestamps, ISO datetimes, and decimal hours

## Review fixes (from #26677)
- Fix silent `editTimer` failure in `handleSubmit` — now shows error toast when timer no longer exists
- Use auto-generated `Preferences.StartTimer` type instead of manual interface
- Fix custom date picker navigation dead-end with `Action.Push`
- Fix `List.EmptyView` never rendering in summary (replaced with `List.Section`)
- Use async `readdir` instead of `readdirSync` in import
- Update changelog: add missing Import entry, fix long session check description
- Prettier formatting

## Test plan
- [ ] Verify summary dashboard shows correct totals for daily/weekly/monthly periods
- [ ] Test custom date range picker in summary
- [ ] Import a CSV exported from the store version and verify timers appear
- [ ] Edit a timer using both the date picker and text override fields
- [ ] Confirm timer list groups by day with correct subtotals
- [ ] Export timers and verify new CSV format columns
- [ ] Attempt to edit a timer that was deleted concurrently — should show error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>