### PR TITLE
[Kafka UI] Fix author username in package.json

### DIFF
--- a/extensions/kafka-ui/CHANGELOG.md
+++ b/extensions/kafka-ui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Kafka UI
 
+## [Fix] - 2026-04-02
+
+- Fixed author username in package.json
+
 ## [Initial Version] - 2026-04-02
 
 - Search consumer groups and inspect lag per topic and partition

--- a/extensions/kafka-ui/CHANGELOG.md
+++ b/extensions/kafka-ui/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kafka UI
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-04-02
 
 - Fixed author username in package.json
 

--- a/extensions/kafka-ui/CHANGELOG.md
+++ b/extensions/kafka-ui/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kafka UI
 
-## [Fix] - 2026-04-02
+## [Fix] - {PR_MERGE_DATE}
 
 - Fixed author username in package.json
 

--- a/extensions/kafka-ui/package.json
+++ b/extensions/kafka-ui/package.json
@@ -4,7 +4,7 @@
   "title": "Kafka UI",
   "description": "Inspect Kafka consumer group lag, browse topics, and open Kafka UI dashboards. Powered by the Kafka UI open-source project.",
   "icon": "command-icon.png",
-  "author": "nir",
+  "author": "nirrosh",
   "license": "MIT",
   "platforms": [
     "macOS"


### PR DESCRIPTION
## Summary
- Fix the `author` field in `extensions/kafka-ui/package.json` from `"nir"` to `"nirrosh"` to match the correct Raycast store username.

## Test plan
- [x] Verified the author field is updated correctly in package.json
- [ ] Confirm the extension page on the Raycast store reflects the correct author


Made with [Cursor](https://cursor.com)