### PR TITLE
Update bundles extension

### DIFF
--- a/extensions/bundles/CHANGELOG.md
+++ b/extensions/bundles/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Restructured README for better readability and removed inaccurate documentation
 - Removed dead code and unused exports
 
-## [Initial Release] - {PR_MERGE_DATE}
+## [Initial Release] - 2026-04-01
 
 - Custom bundles to organize applications, websites, and nested bundles
 - Custom icons from 100+ Raycast icons

--- a/extensions/bundles/CHANGELOG.md
+++ b/extensions/bundles/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Bundles
 
-## [iCloud Sync and Bug Fixes] - {PR_MERGE_DATE}
+## [iCloud Sync and Bug Fixes] - 2026-04-12
 
 - Bundles now sync automatically across Macs via iCloud Drive
 - Data stored in `~/iCloud Drive/Raycast Bundles/bundles.json`

--- a/extensions/bundles/CHANGELOG.md
+++ b/extensions/bundles/CHANGELOG.md
@@ -1,14 +1,11 @@
-# Bundles Changelog
+# Bundles
 
-## [iCloud Sync] - {PR_MERGE_DATE}
+## [iCloud Sync and Bug Fixes] - {PR_MERGE_DATE}
 
 - Bundles now sync automatically across Macs via iCloud Drive
 - Data stored in `~/iCloud Drive/Raycast Bundles/bundles.json`
 - Falls back to local storage if iCloud Drive is unavailable
 - Existing data is migrated to iCloud automatically on first run
-
-## [Bug Fixes & Cleanup] - {PR_MERGE_DATE}
-
 - Fixed "recent" sort direction being inverted (labels now match actual behavior)
 - Fixed React hooks being called conditionally in the main command
 - Fixed "Bundle not found" message flashing during initial load

--- a/extensions/bundles/CHANGELOG.md
+++ b/extensions/bundles/CHANGELOG.md
@@ -1,25 +1,33 @@
-# Bundles
+# Bundles Changelog
 
-## [Initial Release] - 2026-04-01
+## [iCloud Sync] - {PR_MERGE_DATE}
+
+- Bundles now sync automatically across Macs via iCloud Drive
+- Data stored in `~/iCloud Drive/Raycast Bundles/bundles.json`
+- Falls back to local storage if iCloud Drive is unavailable
+- Existing data is migrated to iCloud automatically on first run
+
+## [Bug Fixes & Cleanup] - {PR_MERGE_DATE}
+
+- Fixed "recent" sort direction being inverted (labels now match actual behavior)
+- Fixed React hooks being called conditionally in the main command
+- Fixed "Bundle not found" message flashing during initial load
+- Added cycle protection to export to prevent infinite loops from circular folder references
+- Restructured README for better readability and removed inaccurate documentation
+- Removed dead code and unused exports
+
+## [Initial Release] - {PR_MERGE_DATE}
 
 - Custom bundles to organize applications, websites, and nested bundles
-- Nested bundle support for hierarchical organization
 - Custom icons from 100+ Raycast icons
-- Custom colors via hex codes or CSS color names (e.g., `coral`, `skyblue`)
-- Shorthand hex support (e.g., `CCC` → `#CCCCCC`)
-- List view and Grid view options
-- Preview pane showing bundle contents
+- Custom colors via CSS color names or hex codes (including shorthand)
+- List and Grid view options with preview pane
 - Multi-level sorting (primary, secondary, tertiary)
-- Website support with automatic favicon fetching
-- Auto-fetch page titles for URLs
+- Website support with automatic favicon and title fetching
 - Markdown link syntax `[Title](URL)` for custom website names
-- URL "dot" text auto-conversion (`discorddotcom` → `discord.com`)
-- Copy as Markdown — URLs with nested bundle structure
-- Copy as List — plain URLs sorted by length
-- Move items between bundles with `⌘M`
+- Copy URLs as Markdown (nested structure) or plain list
+- Move, duplicate, and remove items between bundles
 - Export/Import bundles as JSON backups
-- Quicklink creation with custom bundle icons
-- Deeplink support for scripting and automation
-- Open All Applications / Websites actions
-- Quit All Running Applications action
+- Quicklink and deeplink support
+- Open all apps/websites and quit all running apps actions
 - Duplicate detection and removal

--- a/extensions/bundles/README.md
+++ b/extensions/bundles/README.md
@@ -1,8 +1,146 @@
 # Bundles
 
-> Organize applications, websites, and bundles into custom collections accessible directly from Raycast.
+Organize applications, websites, and nested collections into custom bundles — accessible instantly from Raycast.
 
-Think of it as Launchpad folders meets browser bookmarks, but faster, more powerful, and right in your command bar.
+Launchpad folders meets browser bookmarks, but faster and right in your command bar.
+
+---
+
+## Features
+
+### Bundle Management
+
+- **Custom bundles** — Group apps, websites, and other bundles into collections
+- **Nesting** — Create hierarchical structures; navigate with breadcrumb paths like `Work → Tools → Utilities`
+- **Custom icons** — Pick from 100+ Raycast icons per bundle
+- **Custom colors** — Tint icons with CSS names (`coral`, `skyblue`) or hex codes (`#FF5733`, `FF5733`)
+- **Default color** — Set a default color applied to every new bundle
+
+### Websites
+
+- **Auto favicon** — Fetched automatically via Raycast's built-in provider; falls back to a globe icon if unavailable
+- **Auto titles** — Page titles are fetched automatically, or use `[Custom Title](https://example.com)` for your own
+- **Open all** — Launch every website in a bundle at once with `⌘⇧O`
+
+### Display
+
+- **List or Grid view** for bundle contents
+- **Preview pane** — See what's inside a bundle without opening it
+- **Separate sections** — Group apps, websites, and nested bundles into labeled sections
+- **Tri-level sorting** — Primary, secondary, and tertiary sort (alphabetical, length, recency, or none)
+
+### Copy & Share
+
+- **Copy as Markdown** (`⌘⇧M`) — Hierarchical bullet list with nested bundle structure
+- **Copy as List** (`⌘⇧L`) — Flat URL list, sorted by length
+- Both include URLs from nested bundles recursively
+
+### Backup & Restore
+
+- **Export** a single bundle or all bundles to JSON (also copied to clipboard)
+- **Import** with merge or replace-all modes
+- Exports include your preferences (sort order, view type, display settings)
+
+### Quicklinks
+
+Pin any bundle to Raycast's root search:
+
+1. Select a bundle → `⌘⇧C` → save
+2. Search for it directly without opening the extension first
+
+Copy the deeplink URL with `⌘⌥C` for sharing or scripting.
+
+---
+
+## Keyboard Shortcuts
+
+### Bundle List
+
+| Shortcut | Action                            |
+| -------- | --------------------------------- |
+| `↵`      | Open bundle                       |
+| `⌘N`     | Create new bundle                 |
+| `⌘E`     | Edit bundle                       |
+| `⌘O`     | Open all apps                     |
+| `⌘⇧O`    | Open all websites                 |
+| `⌘⇧M`    | Copy URLs as markdown             |
+| `⌘⇧L`    | Copy URLs as list                 |
+| `⌘⇧C`    | Create quicklink                  |
+| `⌘⌥C`    | Copy quicklink URL                |
+| `⌘⇧E`    | Export bundle                     |
+| `⌃⇧X`    | Empty bundle (remove all items)   |
+| `⌃X`     | Delete bundle                     |
+
+### Bundle Contents
+
+| Shortcut | Action                                        |
+| -------- | --------------------------------------------- |
+| `↵`      | Open item                                     |
+| `⌘E`     | Edit item (website or nested bundle)          |
+| `⌘M`     | Move item to another bundle                   |
+| `⌘D`     | Duplicate item                                |
+| `⌘O`     | Open all apps                                 |
+| `⌘⇧O`    | Open all websites                             |
+| `⌘⇧M`    | Copy URLs as markdown                         |
+| `⌘⇧L`    | Copy URLs as list                             |
+| `⌘⇧Q`    | Quit all running apps                         |
+| `⌘⌫`     | Remove item                                   |
+
+---
+
+## Getting Started
+
+### Create a Bundle
+
+1. Open Raycast → search **"Bundles"**
+2. `⌘N` to create a new bundle
+3. Name it, pick an icon, optionally set a color
+4. Select apps and/or add website URLs (one per line)
+5. `⌘↵` to save
+
+### Add Websites
+
+Plain URLs auto-fetch titles. Use markdown links for custom names:
+
+```
+https://github.com
+[Raycast Store](https://raycast.com/store)
+[My Projects](https://github.com/username)
+```
+
+### Nest Bundles
+
+Edit a bundle (`⌘E`) → select existing bundles in the **"Nested Bundles"** field, or choose **"Create New Bundle..."** to create and nest in one step.
+
+Bundles can only have one parent — a bundle already nested elsewhere won't appear in the picker.
+
+### Move Items
+
+Select any item inside a bundle → `⌘M` → choose a destination.
+
+### Export & Import
+
+- **Export:** Select a bundle → `⌘⇧E` (or use "Export All Bundles" from the action panel). Saved to Downloads + clipboard.
+- **Import:** "Import Bundles" from the action panel → paste JSON → choose **Merge** or **Replace All**.
+
+---
+
+## Preferences
+
+Configure via Raycast Settings → Extensions → Bundles.
+
+**Sorting** — Up to three levels of priority for bundle contents:
+
+| Method       | Options                    |
+| ------------ | -------------------------- |
+| Alphabetical | A → Z or Z → A            |
+| Length       | Short → Long or vice versa |
+| Recent       | Old → New or vice versa    |
+| None         | Preserve order             |
+
+**Display** — List or Grid view, preview pane toggle, separate sections for apps/websites/bundles.
+
+**Appearance** — Default bundle color (CSS name or hex).
 
 ---
 
@@ -11,453 +149,56 @@ Think of it as Launchpad folders meets browser bookmarks, but faster, more power
 <details>
 <summary><strong>Where is my data stored?</strong></summary>
 
-All data is stored locally using Raycast's LocalStorage. Nothing is sent to external servers. Favicons are cached locally in `~/Library/Application Support/com.raycast.macos/extensions/bundles/`.
+If you have iCloud Drive enabled, bundles are stored in `~/iCloud Drive/Raycast Bundles/bundles.json` and sync automatically across your Macs. If iCloud Drive is unavailable, data is stored locally via Raycast's LocalStorage.
 
 </details>
 
 <details>
-<summary><strong>Can I sync bundles across multiple Macs?</strong></summary>
+<summary><strong>Do bundles sync across Macs?</strong></summary>
 
-Not automatically, but you can use **Export All Bundles** to create a backup JSON, then **Import Bundles** on another Mac. The JSON is also copied to your clipboard for easy transfer.
+Yes — if iCloud Drive is enabled, bundles sync automatically. Existing data is migrated to iCloud on first run. You can also manually export/import bundles as JSON backups.
 
 </details>
 
 <details>
 <summary><strong>Why isn't my favicon loading?</strong></summary>
 
-The extension tries 6 different favicon sources in parallel. If all fail, a globe icon is shown instead. You can manually refresh by selecting the website and pressing `⌘R` (Refresh Favicon).
+Favicons are fetched via Raycast's built-in provider. If it can't find one, a globe icon is shown instead.
 
 </details>
 
 <details>
-<summary><strong>How do I add a website with a custom name?</strong></summary>
+<summary><strong>What color formats work?</strong></summary>
 
-Use markdown link syntax: `[My Custom Name](https://example.com)`. Plain URLs will auto-fetch the page title instead.
-
-</details>
-
-<details>
-<summary><strong>Can bundles be nested multiple levels deep?</strong></summary>
-
-Yes! You can nest bundles inside other nested bundles. The breadcrumb path shows your location like `Work → Tools → Utilities`.
+CSS names (`coral`, `skyblue`), hex with hash (`#FF5733`), and hex without hash (`FF5733`).
 
 </details>
-
-<details>
-<summary><strong>How do I move an item to a different bundle?</strong></summary>
-
-Select any item inside a bundle and press `⌘M` to open the move dialog. Choose a destination and the item is moved instantly.
-
-</details>
-
-<details>
-<summary><strong>What color formats are supported?</strong></summary>
-
-CSS color names (`coral`, `skyblue`), hex with hash (`#FF5733`), hex without hash (`FF5733`), and shorthand hex (`F53` → `#FF5533`).
-
-</details>
-
-<details>
-<summary><strong>How do I pin a bundle to Raycast's root search?</strong></summary>
-
-Create a **Quicklink** for the bundle:
-
-1. Select your bundle in the list
-2. Press `⌘⇧C` (Create Quicklink)
-3. Give it a name and save
-
-Now you can search for that bundle directly from Raycast's root search without opening the Bundles extension first. Your bundle's custom icon is automatically applied to the quicklink.
-
-</details>
-
----
-
-## Table of Contents
-
-> **Note:** Links below work on GitHub but not on the Raycast Store website.
-
-- [Features](#features)
-  - [Bundle Management](#-bundle-management)
-  - [Website Support](#-website-support)
-  - [Smart Search & Navigation](#-smart-search--navigation)
-  - [Display Options](#-display-options)
-  - [Copy & Share](#-copy--share)
-  - [Backup & Restore](#-backup--restore)
-- [Keyboard Shortcuts](#keyboard-shortcuts)
-- [Preferences](#preferences)
-- [Usage Guide](#usage-guide)
-  - [Creating Your First Bundle](#creating-your-first-bundle)
-  - [Adding Websites](#adding-websites)
-  - [Organizing with Nested Bundles](#organizing-with-nested-bundles)
-  - [Copying URLs](#copying-urls)
-  - [Moving Items Between Bundles](#moving-items-between-bundles)
-  - [Creating Quicklinks](#creating-quicklinks)
-  - [Exporting & Importing](#exporting--importing)
-- [Development](#development)
-- [Privacy](#privacy)
-- [License](#license)
-
----
-
-## Features
-
-### Bundle Management
-
-| Feature             | Description                                                                |
-| ------------------- | -------------------------------------------------------------------------- |
-| **Custom Bundles**  | Group applications, websites, and other bundles into organized collections |
-| **Nested Bundles**  | Create hierarchical bundle structures for deeper organization              |
-| **Custom Icons**    | Choose from 100+ Raycast icons to personalize each bundle                  |
-| **Custom Colors**   | Tint bundle icons with CSS color names or hex codes                        |
-| **Default Color**   | Configure a default color for all newly created bundles                    |
-
-#### Supported Color Formats
-
-You can specify bundle colors in multiple formats:
-
-| Format          | Example   | Result    |
-| --------------- | --------- | --------- |
-| CSS color name  | `coral`   | `#FF7F50` |
-| Hex (with #)    | `#FF5733` | `#FF5733` |
-| Hex (without #) | `FF5733`  | `#FF5733` |
-
-**Common CSS colors:** `red`, `orange`, `yellow`, `green`, `blue`, `purple`, `pink`, `coral`, `gold`, `crimson`, `indigo`, `teal`, `navy`, `skyblue`, `salmon`, `turquoise`, `violet`, and [80+ more](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color).
-
-### Website Support
-
-| Feature             | Description                                                                                         |
-| ------------------- | --------------------------------------------------------------------------------------------------- |
-| **Add URLs**        | Include website bookmarks in any bundle                                                             |
-| **Auto Favicon**    | Favicons fetched from 6 sources in parallel (Google, DuckDuckGo, Icon Horse, Yandex, direct, Apple) |
-| **Refresh Favicon** | Manually re-fetch favicon with `⌘R` if it didn't load correctly                                     |
-| **Auto Titles**     | Page titles are fetched automatically from websites                                                 |
-| **Custom Titles**   | Use markdown syntax `[Title](URL)` for custom names                                                 |
-| **Edit Websites**   | Modify website names and URLs after adding                                                          |
-| **Open All**        | Launch all websites in a bundle at once                                                             |
-
-#### Markdown Link Syntax
-
-When adding websites, you can use markdown link syntax to specify custom titles:
-
-```
-https://github.com
-[My Projects](https://github.com/username)
-[Raycast Store](https://raycast.com/store)
-https://google.com
-```
-
-- Plain URLs auto-fetch the page title
-- `[Title](URL)` uses your custom title instead
-- Custom titles are preserved when editing bundles
-
-### Smart Search & Navigation
-
-| Feature              | Description                                               |
-| -------------------- | --------------------------------------------------------- |
-| **Instant Search**   | Find bundles with Raycast's blazing-fast fuzzy search     |
-| **Breadcrumb Paths** | See full navigation paths like `Work → Tools → Utilities` |
-| **Section Grouping** | Top-level and nested bundles are displayed separately     |
-| **Recent Access**    | Items track when they were last accessed for sorting      |
-
-### Display Options
-
-| Feature               | Description                                              |
-| --------------------- | -------------------------------------------------------- |
-| **List View**         | Classic list with icons, titles, and subtitles           |
-| **Grid View**         | Visual grid layout for browsing                          |
-| **Preview Pane**      | Side panel showing bundle contents without opening       |
-| **Separate Sections** | Group apps, websites, and bundles into labeled sections  |
-| **Item Counts**       | See how many items are in each section                   |
-
-### Copy & Share
-
-| Feature                     | Description                                              |
-| --------------------------- | -------------------------------------------------------- |
-| **Copy as Markdown**        | Copy bundle URLs as bullet points with nested structure  |
-| **Copy as List**            | Copy all URLs as a plain list, sorted by length          |
-| **Includes Nested Bundles** | Recursively includes URLs from all nested bundles        |
-
-### Backup & Restore
-
-| Feature                   | Description                                                      |
-| ------------------------- | ---------------------------------------------------------------- |
-| **Export Single Bundle**  | Export one bundle (including nested bundles) to JSON             |
-| **Export All Bundles**    | Create a complete backup of all bundles                          |
-| **Import Bundles**        | Restore from backup with merge or replace options                |
-| **Clipboard Copy**        | Exports are also copied to clipboard for easy sharing            |
-| **Preferences Included** | Exports include your sort order, view type, and display settings |
-
----
-
-## Keyboard Shortcuts
-
-### From the Bundle List
-
-| Shortcut | Action                              |
-| -------- | ----------------------------------- |
-| `↵`      | Open selected bundle                |
-| `⌘N`     | Create new bundle                   |
-| `⌘E`     | Edit selected bundle                |
-| `⌘O`     | Open all applications in bundle     |
-| `⌘⇧O`    | Open all websites in bundle         |
-| `⌘⇧M`    | Copy all URLs as markdown           |
-| `⌘⇧L`    | Copy all URLs as list               |
-| `⌘⇧C`    | Create quicklink to bundle          |
-| `⌘⌥C`    | Copy quicklink URL                  |
-| `⌘⇧E`    | Export selected bundle              |
-| `⌃⇧X`    | Empty bundle (remove all contents)  |
-| `⌃X`     | Delete bundle                       |
-
-### From Bundle Contents
-
-| Shortcut | Action                                         |
-| -------- | ---------------------------------------------- |
-| `↵`      | Open selected item                             |
-| `⌘E`     | Edit selected item (website or nested bundle)  |
-| `⌘R`     | Refresh favicon (websites only)                |
-| `⌘M`     | Move item to another bundle                    |
-| `⌘D`     | Duplicate item                                 |
-| `⌘O`     | Open all applications                          |
-| `⌘⇧O`    | Open all websites                              |
-| `⌘⇧M`    | Copy all URLs as markdown                      |
-| `⌘⇧L`    | Copy all URLs as list                          |
-| `⌘⇧Q`    | Quit all running applications                  |
-| `⌘⌫`     | Remove item from bundle                        |
-
----
-
-## Preferences
-
-Access preferences via Raycast Settings → Extensions → Bundles.
-
-### Sorting
-
-Configure up to three levels of sorting priority for bundle contents:
-
-| Level                 | Purpose                         |
-| --------------------- | ------------------------------- |
-| **Primary Sort**      | Main sorting method             |
-| **Secondary Sort**    | Tiebreaker when items are equal |
-| **Tertiary Sort**     | Final tiebreaker                |
-
-**Available sort methods:**
-
-| Method       | Options                     |
-| ------------ | --------------------------- |
-| Alphabetical | A → Z, Z → A                |
-| Length       | Short → Long, Long → Short  |
-| Recent       | Old → New, New → Old        |
-| None         | No sorting (preserve order) |
-
-### Display
-
-| Preference            | Description                                   |
-| --------------------- | --------------------------------------------- |
-| **View Type**         | List or Grid view for bundle contents         |
-| **Preview Pane**      | Show bundle contents in a side panel          |
-| **Separate Sections** | Group apps, websites, and bundles separately  |
-
-### Appearance
-
-| Preference               | Description                                      |
-| ------------------------ | ------------------------------------------------ |
-| **Default Bundle Color** | Hex color to pre-fill when creating new bundles  |
-
----
-
-## Usage Guide
-
-### Creating Your First Bundle
-
-1. Open Raycast and search for **"Bundles"**
-2. Press `⌘N` to create a new bundle
-3. Enter a name (e.g., "Work Apps")
-4. Choose an icon from the dropdown
-5. Optionally set a custom color (e.g., `coral`, `skyblue`, or `#3498db`)
-6. Select applications to include
-7. Add website URLs (one per line)
-8. Press `⌘↵` to save
-
-### Adding Websites
-
-You can add websites in two ways:
-
-**Plain URLs** — Titles are fetched automatically:
-
-```
-https://github.com
-https://raycast.com
-https://google.com
-```
-
-**Markdown Links** — Specify custom titles:
-
-```
-[GitHub](https://github.com)
-[Raycast](https://raycast.com)
-[Search](https://google.com)
-```
-
-Mix and match as needed. Favicons are cached locally for fast loading.
-
-### Organizing with Nested Bundles
-
-1. Edit an existing bundle (`⌘E`) or create a new one
-2. In the **"Nested Bundles"** field, select existing bundles to nest
-3. Or choose **"Create New Bundle..."** to create and nest in one step
-4. The new bundle is automatically added to the parent
-
-**Note:** Bundles can only have one parent. A bundle already nested elsewhere won't appear in the selection.
-
-### Copying URLs
-
-You can copy all URLs from a bundle (including nested bundles) in two formats:
-
-#### Copy as Markdown (`⌘⇧M`)
-
-Produces a hierarchical bullet list. If the bundle contains nested bundles, it includes the root bundle name:
-
-**Bundle without nested bundles:**
-
-```markdown
-- https://github.com
-- https://raycast.com
-- https://google.com
-```
-
-**Bundle with nested bundles:**
-
-```markdown
-- **My Bundle**
-  - https://github.com
-  - https://raycast.com
-  - **Subbundle**
-    - https://docs.github.com
-    - https://api.github.com
-```
-
-#### Copy as List (`⌘⇧L`)
-
-Produces a flat list sorted by URL length (shortest first):
-
-```
-https://google.com
-https://github.com
-https://raycast.com
-https://docs.github.com
-```
-
-### Moving Items Between Bundles
-
-1. Select any item inside a bundle
-2. Press `⌘M` to open the move dialog
-3. Choose a destination bundle (shows both top-level and nested bundles)
-4. The item is moved instantly
-
-### Creating Quicklinks
-
-Quicklinks let you open specific bundles directly from Raycast:
-
-1. Select a bundle in the list
-2. Press `⌘⇧C` to create a quicklink
-3. Your bundle's custom icon is automatically applied
-4. Save and access the bundle instantly from anywhere
-
-You can also copy the deeplink URL with `⌘⌥C` for sharing or scripting.
-
-### Exporting & Importing
-
-#### Exporting
-
-1. Select a bundle and press `⌘⇧E` to export it (includes nested bundles)
-2. Or use **"Export All Bundles"** from the action panel
-3. A JSON file is saved to Downloads and copied to clipboard
-
-#### Importing
-
-1. Select **"Import Bundles"** from any bundle's action panel
-2. Paste your backup JSON
-3. Choose import mode:
-   - **Merge**: Add new bundles, keep existing ones
-   - **Replace All**: Delete all existing bundles first
 
 ---
 
 ## Development
 
 ```bash
-# Install dependencies
-npm install
-
-# Start development mode (hot reload)
-npm run dev
-
-# Build for production
-npm run build
-
-# Fix linting issues
-npm run fix-lint
-
-# Publish to store
-npm run publish
+npm install        # Install dependencies
+npm run dev        # Development mode (hot reload)
+npm run build      # Build for production
+npm run fix-lint   # Fix linting issues
+npm run publish    # Publish to store
 ```
 
-### Requirements
-
-- **Raycast** 1.69.0+
-- **Node.js** 20+
-- **macOS** (required for application launching)
-
-### Project Structure
-
-```
-src/
-├── index.tsx              # Main command entry point
-├── folder-contents.tsx    # Bundle contents view
-├── folder-edit-form.tsx   # Create/edit bundle form
-├── storage.ts             # LocalStorage operations
-├── types.ts               # TypeScript interfaces
-├── utils.ts               # Utility functions
-├── favicon.ts             # Favicon fetching & caching
-├── form-utils.ts          # Form helpers & URL parsing
-├── backup.ts              # Export/import functions
-├── constants.ts           # Shared constants
-├── components/            # Reusable components
-│   ├── add-items-form.tsx
-│   ├── folder-item-actions.tsx
-│   ├── folder-preview-detail.tsx
-│   ├── import-folders-form.tsx
-│   ├── move-to-folder-form.tsx
-│   └── website-edit-form.tsx
-└── hooks/                 # Custom React hooks
-    ├── use-applications.ts
-    ├── use-folders.ts
-    ├── use-nested-folder-creation.tsx
-    ├── use-preferences.ts
-    └── use-running-apps.ts
-```
+Requires **Raycast** 1.69.0+, **Node.js** 20+, **macOS**.
 
 ---
 
 ## Privacy
 
-This extension:
-
-- Stores all data locally using Raycast's LocalStorage
-- Caches favicons locally for performance
+- Data stored in iCloud Drive (syncs across Macs) or Raycast LocalStorage as fallback
 - Only accesses applications you explicitly add
-- Uses AppleScript solely for detecting running apps
-- Does **not** send any data to external servers
-- Does **not** track usage or analytics
+- AppleScript used solely for detecting running apps
+- No third-party servers, no tracking, no analytics
 
 ---
 
 ## License
 
-MIT License — Free to use, modify, and distribute.
-
----
-
-<p align="center">
-  <strong>Made with love for Raycast</strong>
-</p>
+MIT

--- a/extensions/bundles/src/backup.ts
+++ b/extensions/bundles/src/backup.ts
@@ -33,7 +33,10 @@ function getCurrentPreferences(): Partial<Preferences> {
  * Get all nested folders recursively
  * If a folder contains nested folder items, include those folders too
  */
-async function getNestedFolders(folder: Folder, allFolders: Folder[]): Promise<Folder[]> {
+async function getNestedFolders(folder: Folder, allFolders: Folder[], visited = new Set<string>()): Promise<Folder[]> {
+  if (visited.has(folder.id)) return [];
+  visited.add(folder.id);
+
   const result: Folder[] = [folder];
   const nestedIds = folder.items
     .filter((item) => item.type === "folder" && item.folderId)
@@ -42,7 +45,7 @@ async function getNestedFolders(folder: Folder, allFolders: Folder[]): Promise<F
   for (const nestedId of nestedIds) {
     const nestedFolder = allFolders.find((f) => f.id === nestedId);
     if (nestedFolder) {
-      const deepNested = await getNestedFolders(nestedFolder, allFolders);
+      const deepNested = await getNestedFolders(nestedFolder, allFolders, visited);
       result.push(...deepNested);
     }
   }

--- a/extensions/bundles/src/components/import-folders-form.tsx
+++ b/extensions/bundles/src/components/import-folders-form.tsx
@@ -1,19 +1,8 @@
-import {
-  Action,
-  ActionPanel,
-  Form,
-  Icon,
-  showToast,
-  Toast,
-  popToRoot,
-  confirmAlert,
-  Alert,
-  LocalStorage,
-} from "@raycast/api";
+import { Action, ActionPanel, Form, Icon, showToast, Toast, popToRoot, confirmAlert, Alert } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import React, { useState } from "react";
-import { Folder, STORAGE_KEY } from "../types";
-import { getFolders, invalidateFoldersCache } from "../storage";
+import { Folder } from "../types";
+import { getFolders, invalidateFoldersCache, saveFolders } from "../storage";
 import { pluralize } from "../utils";
 import { validateImportData } from "../backup";
 
@@ -91,8 +80,8 @@ export default function ImportFoldersForm() {
       }
 
       // Save to storage
-      await LocalStorage.setItem(STORAGE_KEY, JSON.stringify(finalFolders));
       invalidateFoldersCache();
+      await saveFolders(finalFolders);
 
       await showToast({
         style: Toast.Style.Success,

--- a/extensions/bundles/src/components/website-edit-form.tsx
+++ b/extensions/bundles/src/components/website-edit-form.tsx
@@ -3,7 +3,7 @@ import { useForm, FormValidation } from "@raycast/utils";
 import React from "react";
 import { Folder, FolderItem } from "../types";
 import { updateFolder } from "../storage";
-import { isValidUrl, normalizeUrl } from "../favicon";
+import { isValidUrl, normalizeUrl } from "../url";
 
 interface WebsiteEditFormProps {
   folder: Folder;

--- a/extensions/bundles/src/folder-contents.tsx
+++ b/extensions/bundles/src/folder-contents.tsx
@@ -656,11 +656,7 @@ export default function FolderContentsView({ folderId, folderName, parentPath }:
   const separateSections = prefs.gridSeparateSections ?? true;
 
   if (!folder) {
-    return (
-      <List isLoading={isLoading}>
-        <List.EmptyView {...FOLDER_NOT_FOUND_VIEW} />
-      </List>
-    );
+    return <List isLoading={isLoading}>{!isLoading && <List.EmptyView {...FOLDER_NOT_FOUND_VIEW} />}</List>;
   }
 
   const commonProps = {

--- a/extensions/bundles/src/folder-edit-form.tsx
+++ b/extensions/bundles/src/folder-edit-form.tsx
@@ -20,9 +20,8 @@ import {
   getFolderIcon,
   createApplicationItem,
   createNestedFolderItem,
-  isValidHexColor,
-  normalizeHexColor,
 } from "./utils";
+import { isValidHexColor, normalizeHexColor } from "./css-colors";
 import { useApplicationsData, useFoldersData, useNestedFolderCreation } from "./hooks";
 import {
   getFolderParentMap,

--- a/extensions/bundles/src/form-utils.ts
+++ b/extensions/bundles/src/form-utils.ts
@@ -1,10 +1,7 @@
 import { showToast, Toast, confirmAlert } from "@raycast/api";
 import { Folder, FolderItem } from "./types";
 import { AppLookupMap, createWebsiteItem } from "./utils";
-import { normalizeUrl, isValidUrl, fetchWebsiteTitle, extractDomain } from "./favicon";
-
-// Shared content type for both forms
-export type ContentType = "applications" | "websites" | "folders";
+import { normalizeUrl, isValidUrl, fetchWebsiteTitle, extractDomain } from "./url";
 
 // Type-safe item filtering helpers (single source of truth)
 export const filterWebsites = (items: FolderItem[]): Array<FolderItem & { url: string }> =>
@@ -15,14 +12,6 @@ export const filterApplications = (items: FolderItem[]): Array<FolderItem & { pa
 
 export const filterFolders = (items: FolderItem[]): Array<FolderItem & { folderId: string }> =>
   items.filter((i): i is FolderItem & { folderId: string } => i.type === "folder" && !!i.folderId);
-
-/**
- * Create a Map for O(1) folder lookups by ID
- * Use this instead of repeated folders.find() calls
- */
-export function createFolderMap(folders: Folder[]): Map<string, Folder> {
-  return new Map(folders.map((f) => [f.id, f]));
-}
 
 /**
  * Create a Map for O(1) website lookups by normalized URL
@@ -180,7 +169,6 @@ export function findDuplicateUrls(urlInput: string, existingItems: FolderItem[])
 
   const existingByUrl = createWebsiteUrlMap(existingItems);
 
-  // Find duplicates
   return urlLines.filter((url) => existingByUrl.has(url)).map((url) => ({ url, name: existingByUrl.get(url)!.name }));
 }
 
@@ -213,11 +201,10 @@ export async function confirmDuplicates(
 
   const duplicateList = duplicates.map((d) => (d.type ? `• ${d.name} (${d.type})` : `• ${d.name}`)).join("\n");
 
-  const itemWord = duplicates.length === 1 ? itemType : `${itemType}s`;
   const message =
     duplicates.length === 1
       ? `This ${itemType} already exists in the folder:\n\n${duplicateList}`
-      : `These ${duplicates.length} ${itemWord} already exist in the folder:\n\n${duplicateList}`;
+      : `These ${duplicates.length} ${itemType}s already exist in the folder:\n\n${duplicateList}`;
 
   return confirmAlert({
     title,
@@ -258,7 +245,6 @@ export async function processWebsiteUrls(
 
   const existingByUrl = createWebsiteUrlMap(existingItems);
 
-  // Determine which entries to process
   const entriesToProcess = includeDuplicates ? urlEntries : urlEntries.filter((entry) => !existingByUrl.has(entry.url));
 
   if (entriesToProcess.length === 0) return [];
@@ -273,18 +259,14 @@ export async function processWebsiteUrls(
     });
   }
 
-  // Process all entries - reuse existing or create new
   const items: FolderItem[] = [];
   for (const entry of entriesToProcess) {
     const existing = existingByUrl.get(entry.url);
     if (existing && !entry.title) {
-      // For duplicates without custom title, create a new item (copy) with a new ID
       items.push(createWebsiteItem(entry.url, existing.name));
     } else if (entry.title) {
-      // Custom title provided via markdown syntax
       items.push(createWebsiteItem(entry.url, entry.title));
     } else {
-      // Fetch title for new URLs (favicons handled by getFavicon at render time)
       const title = await fetchWebsiteTitle(entry.url);
       items.push(createWebsiteItem(entry.url, title));
     }

--- a/extensions/bundles/src/hooks/index.ts
+++ b/extensions/bundles/src/hooks/index.ts
@@ -1,5 +1,5 @@
-export { useApplications, useApplicationsData } from "./use-applications";
-export { useFolders, useFoldersData } from "./use-folders";
+export { useApplicationsData } from "./use-applications";
+export { useFoldersData } from "./use-folders";
 export { useFolderContentsPreferences } from "./use-preferences";
 export { useRunningApps } from "./use-running-apps";
 export { useNestedFolderCreation } from "./use-nested-folder-creation";

--- a/extensions/bundles/src/hooks/use-applications.ts
+++ b/extensions/bundles/src/hooks/use-applications.ts
@@ -4,29 +4,18 @@ import { useMemo } from "react";
 import { AppLookupMap, buildAppLookupMap } from "../utils";
 
 /**
- * Shared hook for fetching applications with caching and error handling
- * Uses Raycast's built-in failureToastOptions for automatic error handling
- */
-export function useApplications() {
-  return useCachedPromise(getApplications, [], {
-    keepPreviousData: true,
-    failureToastOptions: {
-      title: "Failed to load applications",
-    },
-  });
-}
-
-/**
  * Get applications data, lookup map, and loading state.
  * The appMap is built once per data change for O(1) lookups.
- * The raw applications array is still returned for form tag pickers.
  */
 export function useApplicationsData(): {
   applications: Application[];
   appMap: AppLookupMap;
   isLoading: boolean;
 } {
-  const { data = [], isLoading } = useApplications();
+  const { data = [], isLoading } = useCachedPromise(getApplications, [], {
+    keepPreviousData: true,
+    failureToastOptions: { title: "Failed to load applications" },
+  });
   const appMap = useMemo(() => buildAppLookupMap(data), [data]);
   return { applications: data, appMap, isLoading };
 }

--- a/extensions/bundles/src/hooks/use-copy-urls.ts
+++ b/extensions/bundles/src/hooks/use-copy-urls.ts
@@ -1,18 +1,9 @@
 import { useCallback, useMemo } from "react";
 import { Clipboard, showToast, Toast } from "@raycast/api";
 import { Folder } from "../types";
-import {
-  collectFolderUrls,
-  formatUrlsAsMarkdown,
-  formatUrlsAsList,
-  countUrls,
-  pluralize,
-  CollectedUrl,
-} from "../utils";
+import { collectFolderUrls, formatUrlsAsMarkdown, formatUrlsAsList, pluralize } from "../utils";
 
 interface UseCopyUrlsResult {
-  /** All collected URLs from the folder (including nested) */
-  collectedUrls: CollectedUrl[];
   /** Whether there are any URLs to copy */
   hasUrls: boolean;
   /** Copy URLs as markdown with nested structure */
@@ -40,7 +31,7 @@ export function useCopyUrls(folder: Folder | undefined, allFolders: Folder[]): U
     const markdown = formatUrlsAsMarkdown(collectedUrls, folder.name);
     await Clipboard.copy(markdown);
 
-    const urlCount = countUrls(collectedUrls);
+    const urlCount = collectedUrls.length;
     await showToast({
       title: "Copied as Markdown",
       message: `${urlCount} ${pluralize(urlCount, "URL")}`,
@@ -57,7 +48,7 @@ export function useCopyUrls(folder: Folder | undefined, allFolders: Folder[]): U
     const list = formatUrlsAsList(collectedUrls);
     await Clipboard.copy(list);
 
-    const urlCount = countUrls(collectedUrls);
+    const urlCount = collectedUrls.length;
     await showToast({
       title: "Copied as List",
       message: `${urlCount} ${pluralize(urlCount, "URL")} (sorted by length)`,
@@ -66,7 +57,6 @@ export function useCopyUrls(folder: Folder | undefined, allFolders: Folder[]): U
   }, [collectedUrls, hasUrls]);
 
   return {
-    collectedUrls,
     hasUrls,
     copyAsMarkdown,
     copyAsList,

--- a/extensions/bundles/src/hooks/use-folders.ts
+++ b/extensions/bundles/src/hooks/use-folders.ts
@@ -1,4 +1,4 @@
-import { useCachedPromise, MutatePromise } from "@raycast/utils";
+import { useCachedPromise } from "@raycast/utils";
 import { getFolders, invalidateFoldersCache, deleteFolder } from "../storage";
 import { Folder } from "../types";
 import { useCallback, useMemo } from "react";
@@ -8,44 +8,35 @@ import { getNestedFolderIds } from "../form-utils";
 import { DEFAULT_SORT, NO_SORT } from "../constants";
 
 /**
- * Shared hook for fetching folders with caching and error handling
- * Uses Raycast's built-in failureToastOptions for automatic error handling
- */
-export function useFolders() {
-  return useCachedPromise(getFolders, [], {
-    keepPreviousData: true,
-    failureToastOptions: {
-      title: "Failed to load bundles",
-    },
-  });
-}
-
-/**
  * Get folders data with common operations and computed properties
  * Uses onPop callbacks on Action.Push for data refresh instead of polling.
  */
 export function useFoldersData(): {
   folders: Folder[];
-  sortedFolders: Folder[];
-  nestedFolderIds: Set<string>;
   topLevelFolders: Folder[];
   nestedFolders: Folder[];
   isLoading: boolean;
   revalidate: () => void;
-  mutate: MutatePromise<Folder[] | undefined>;
   handleSave: () => void;
   handleDelete: (folderId: string, folderName: string) => Promise<void>;
 } {
-  const { data = [], isLoading, revalidate, mutate } = useFolders();
+  const {
+    data = [],
+    isLoading,
+    revalidate,
+    mutate,
+  } = useCachedPromise(getFolders, [], {
+    keepPreviousData: true,
+    failureToastOptions: { title: "Failed to load bundles" },
+  });
 
   // Find all folder IDs that are nested within other folders (reuse form-utils function)
   const nestedFolderIds = useMemo(() => getNestedFolderIds(data), [data]);
 
   // Sort folders and separate by nesting status
-  const { sortedFolders, topLevelFolders, nestedFolders } = useMemo(() => {
+  const { topLevelFolders, nestedFolders } = useMemo(() => {
     const sorted = sortFolders(data, DEFAULT_SORT, NO_SORT, NO_SORT);
     return {
-      sortedFolders: sorted,
       topLevelFolders: sorted.filter((f) => !nestedFolderIds.has(f.id)),
       nestedFolders: sorted.filter((f) => nestedFolderIds.has(f.id)),
     };
@@ -90,13 +81,10 @@ export function useFoldersData(): {
 
   return {
     folders: data,
-    sortedFolders,
-    nestedFolderIds,
     topLevelFolders,
     nestedFolders,
     isLoading,
     revalidate,
-    mutate,
     handleSave,
     handleDelete,
   };

--- a/extensions/bundles/src/hooks/use-nested-folder-creation.tsx
+++ b/extensions/bundles/src/hooks/use-nested-folder-creation.tsx
@@ -24,8 +24,6 @@ interface UseNestedFolderCreationOptions {
 interface UseNestedFolderCreationResult {
   /** Callback to handle newly created folder */
   handleFolderCreated: (newFolderId: string) => Promise<void>;
-  /** Navigate to create folder form - call when CREATE_NEW_FOLDER_VALUE is selected */
-  navigateToCreateFolder: () => void;
 }
 
 /**
@@ -108,5 +106,5 @@ export function useNestedFolderCreation({
     }
   }, [folderValues, setValue, navigateToCreateFolder]);
 
-  return { handleFolderCreated, navigateToCreateFolder };
+  return { handleFolderCreated };
 }

--- a/extensions/bundles/src/hooks/use-preferences.ts
+++ b/extensions/bundles/src/hooks/use-preferences.ts
@@ -4,7 +4,7 @@ import { PREF_POLL_INTERVAL } from "../constants";
 
 /**
  * Hook for folder contents preferences with polling
- * Polls for changes every 2 seconds to reflect preference updates
+ * Polls for changes every 5 seconds to reflect preference updates
  */
 export function useFolderContentsPreferences(): Preferences {
   const [prefs, setPrefs] = useState<Preferences>(() => getPreferenceValues<Preferences>());

--- a/extensions/bundles/src/index.tsx
+++ b/extensions/bundles/src/index.tsx
@@ -15,11 +15,7 @@ interface LaunchContext {
 }
 
 export default function Command(props: LaunchProps<{ launchContext?: LaunchContext }>) {
-  // Handle deeplink context - render folder contents directly if opened via quicklink
-  const context = props.launchContext as LaunchContext | undefined;
-  if (context?.folderId) {
-    return <FolderContentsView folderId={context.folderId} folderName={context.folderName || "Bundle"} />;
-  }
+  const context = props.launchContext;
 
   const { showPreviewPane = false } = getPreferenceValues<Preferences>();
   const {
@@ -31,6 +27,11 @@ export default function Command(props: LaunchProps<{ launchContext?: LaunchConte
     handleDelete,
   } = useFoldersData();
   const { appMap, isLoading: isLoadingApps } = useApplicationsData();
+
+  // Handle deeplink context - render folder contents directly if opened via quicklink
+  if (context?.folderId) {
+    return <FolderContentsView folderId={context.folderId} folderName={context.folderName || "Bundle"} />;
+  }
 
   const isLoading = isLoadingFolders || isLoadingApps;
 

--- a/extensions/bundles/src/storage.ts
+++ b/extensions/bundles/src/storage.ts
@@ -1,5 +1,6 @@
 import { LocalStorage } from "@raycast/api";
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { existsSync, mkdirSync } from "fs";
+import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
 import { Folder } from "./types";
@@ -25,7 +26,7 @@ async function readFromBackend(): Promise<string | undefined> {
   if (useICloud) {
     if (!existsSync(BUNDLES_FILE)) return undefined;
     try {
-      return readFileSync(BUNDLES_FILE, "utf-8");
+      return await readFile(BUNDLES_FILE, "utf-8");
     } catch {
       return undefined;
     }
@@ -41,7 +42,7 @@ async function writeToBackend(json: string): Promise<void> {
     if (!existsSync(BUNDLES_DIR)) {
       mkdirSync(BUNDLES_DIR, { recursive: true });
     }
-    writeFileSync(BUNDLES_FILE, json, "utf-8");
+    await writeFile(BUNDLES_FILE, json, "utf-8");
   } else {
     await LocalStorage.setItem(STORAGE_KEY, json);
   }

--- a/extensions/bundles/src/storage.ts
+++ b/extensions/bundles/src/storage.ts
@@ -1,13 +1,75 @@
 import { LocalStorage } from "@raycast/api";
-import { Folder, STORAGE_KEY } from "./types";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { Folder } from "./types";
+
+const STORAGE_KEY = "launchpad-folders";
+
+// iCloud Drive paths
+const ICLOUD_BASE = join(homedir(), "Library", "Mobile Documents", "com~apple~CloudDocs");
+const BUNDLES_DIR = join(ICLOUD_BASE, "Raycast Bundles");
+const BUNDLES_FILE = join(BUNDLES_DIR, "bundles.json");
+
+const useICloud = existsSync(ICLOUD_BASE);
 
 // In-memory cache
 let cache: Folder[] | null = null;
 let pendingPromise: Promise<Folder[]> | null = null;
+let migrationDone = false;
+
+/**
+ * Read raw JSON from the active backend (iCloud file or LocalStorage)
+ */
+async function readFromBackend(): Promise<string | undefined> {
+  if (useICloud) {
+    if (!existsSync(BUNDLES_FILE)) return undefined;
+    try {
+      return readFileSync(BUNDLES_FILE, "utf-8");
+    } catch {
+      return undefined;
+    }
+  }
+  return await LocalStorage.getItem<string>(STORAGE_KEY);
+}
+
+/**
+ * Write raw JSON to the active backend (iCloud file or LocalStorage)
+ */
+async function writeToBackend(json: string): Promise<void> {
+  if (useICloud) {
+    if (!existsSync(BUNDLES_DIR)) {
+      mkdirSync(BUNDLES_DIR, { recursive: true });
+    }
+    writeFileSync(BUNDLES_FILE, json, "utf-8");
+  } else {
+    await LocalStorage.setItem(STORAGE_KEY, json);
+  }
+}
+
+/**
+ * One-time migration: copy LocalStorage data to iCloud if applicable
+ */
+async function migrateLocalStorageToICloud(): Promise<void> {
+  if (migrationDone || !useICloud) return;
+  migrationDone = true;
+
+  if (existsSync(BUNDLES_FILE)) return;
+
+  const localData = await LocalStorage.getItem<string>(STORAGE_KEY);
+  if (!localData) return;
+
+  try {
+    JSON.parse(localData);
+  } catch {
+    return;
+  }
+
+  await writeToBackend(localData);
+}
 
 /**
  * Clean up orphaned nested folder references
- * Removes items that reference folders that no longer exist
  */
 function cleanupOrphanedReferences(folders: Folder[]): Folder[] {
   const folderIds = new Set(folders.map((f) => f.id));
@@ -17,7 +79,7 @@ function cleanupOrphanedReferences(folders: Folder[]): Folder[] {
     const cleanedItems = f.items.filter((item) => {
       if (item.type === "folder" && item.folderId && !folderIds.has(item.folderId)) {
         hasChanges = true;
-        return false; // Remove orphaned reference
+        return false;
       }
       return true;
     });
@@ -37,14 +99,14 @@ export async function getFolders(): Promise<Folder[]> {
 
   pendingPromise = (async () => {
     try {
-      const stored = await LocalStorage.getItem<string>(STORAGE_KEY);
+      await migrateLocalStorageToICloud();
+
+      const stored = await readFromBackend();
       let folders = stored ? (JSON.parse(stored) as Folder[]) : [];
 
-      // Clean up any orphaned references on load
       const cleaned = cleanupOrphanedReferences(folders);
       if (cleaned !== folders) {
-        // Save the cleaned data
-        await LocalStorage.setItem(STORAGE_KEY, JSON.stringify(cleaned));
+        await writeToBackend(JSON.stringify(cleaned));
         folders = cleaned;
       }
 
@@ -64,9 +126,9 @@ export async function getFolders(): Promise<Folder[]> {
 /**
  * Save folders and update cache
  */
-async function saveFolders(folders: Folder[]): Promise<void> {
+export async function saveFolders(folders: Folder[]): Promise<void> {
   cache = folders;
-  await LocalStorage.setItem(STORAGE_KEY, JSON.stringify(folders));
+  await writeToBackend(JSON.stringify(folders));
 }
 
 /**
@@ -106,12 +168,10 @@ export async function deleteFolder(folderId: string): Promise<void> {
   const folderExists = folders.some((f) => f.id === folderId);
   if (!folderExists) throw new Error(`Folder not found: ${folderId}`);
 
-  // Remove the folder and clean up references in all other folders
   const updated = folders
     .filter((f) => f.id !== folderId)
     .map((f) => ({
       ...f,
-      // Remove any nested folder items that reference the deleted folder
       items: f.items.filter((item) => !(item.type === "folder" && item.folderId === folderId)),
     }));
 

--- a/extensions/bundles/src/types.ts
+++ b/extensions/bundles/src/types.ts
@@ -17,5 +17,3 @@ export interface Folder {
   icon?: string; // Icon name from Icon enum (e.g., "Folder", "Document", "Star")
   color?: string; // Hex color code for icon tint (e.g., "#FF5733")
 }
-
-export const STORAGE_KEY = "launchpad-folders";

--- a/extensions/bundles/src/url.ts
+++ b/extensions/bundles/src/url.ts
@@ -1,6 +1,5 @@
 /**
- * URL utilities for website handling
- * Favicon fetching is handled by @raycast/utils getFavicon
+ * URL utilities: parsing, validation, normalization, and title fetching
  */
 
 /**
@@ -35,8 +34,6 @@ export function isValidUrl(url: string): boolean {
  * Handles: discorddotcom → discord.com, jadotmt → ja.mt, githubdotcodotuk → github.co.uk
  */
 function convertDotText(input: string): string {
-  // Match "dot" surrounded by alphanumeric characters (case-insensitive)
-  // This converts "discorddotcom" → "discord.com" but won't break actual words
   return input.replace(/([a-z0-9])dot([a-z0-9])/gi, "$1.$2");
 }
 

--- a/extensions/bundles/src/utils.ts
+++ b/extensions/bundles/src/utils.ts
@@ -1,7 +1,7 @@
 import { Application, Icon, Image, open, showToast, Toast } from "@raycast/api";
 import { getFavicon } from "@raycast/utils";
 import { FolderItem, Folder } from "./types";
-import { extractDomain } from "./favicon";
+import { extractDomain } from "./url";
 import { isValidHexColor } from "./css-colors";
 
 // Types
@@ -89,7 +89,7 @@ export function findApplicationByItemPath(itemPath: string, appMap: AppLookupMap
 }
 
 // Icon type that includes tinted icons and source URLs
-export type FolderIconType = Icon | { source: Icon; tintColor: string } | { fileIcon: string } | Image.ImageLike;
+type FolderIconType = Icon | { source: Icon; tintColor: string } | { fileIcon: string } | Image.ImageLike;
 
 /**
  * Get icon for a folder item
@@ -187,7 +187,7 @@ function compare<T>(
       result = getName(a).length - getName(b).length;
       break;
     case "recent":
-      result = (getTime?.(b) ?? 0) - (getTime?.(a) ?? 0);
+      result = (getTime?.(a) ?? 0) - (getTime?.(b) ?? 0);
       break;
     default:
       return 0;
@@ -303,9 +303,6 @@ export function getFolderIcon(iconName?: string, color?: string): Icon | { sourc
 export function getFolderIconPlain(iconName?: string): Icon {
   return iconName ? (Icon as Record<string, Icon>)[iconName] || Icon.Folder : Icon.Folder;
 }
-
-// Re-export color utilities from css-colors.ts for backward compatibility
-export { isValidHexColor, normalizeHexColor } from "./css-colors";
 
 /**
  * Pluralize a word based on count
@@ -556,11 +553,4 @@ export function formatUrlsAsList(urls: CollectedUrl[]): string {
     .map((u) => u.url)
     .sort((a, b) => a.length - b.length)
     .join("\n");
-}
-
-/**
- * Count total URLs in collected results
- */
-export function countUrls(urls: CollectedUrl[]): number {
-  return urls.length;
 }


### PR DESCRIPTION
## Description

Update to the Bundles extension with iCloud sync, bug fixes, and code cleanup.

**iCloud Sync**
- Bundles now sync automatically across Macs via iCloud Drive
- Data stored in `~/iCloud Drive/Raycast Bundles/bundles.json`
- Falls back to local storage if iCloud Drive is unavailable
- Existing data is migrated to iCloud automatically on first run

**Bug Fixes**
- Fixed "recent" sort direction being inverted (labels now match actual behavior)
- Fixed React hooks being called conditionally in the main command
- Fixed "Bundle not found" message flashing during initial load
- Added cycle protection to export to prevent infinite loops from circular folder references

**Cleanup**
- Restructured README for better readability and accuracy
- Removed dead code and unused exports
- Renamed `favicon.ts` to `url.ts` (file contained URL utilities, not favicon logic)
- Routed import form through storage layer instead of direct LocalStorage access

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder