### PR TITLE
[codex] Follow up on skills extension maintainability

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Follow Up on Maintainability] - 2026-04-03
+
+- Add hook-level tests for `useSkillContent` and expand `skills-cli` coverage around CLI error normalization and agent id mapping
+- Standardize `search` and `manage` empty/error states with shared retry handling and clearer recovery copy
+- Document the maintainer validation workflow in `README.md` and add a manual smoke checklist in `TESTING.md`
+
 ## [Improve Maintainability] - 2026-04-02
 
 - Add `vitest`-based unit tests and an opt-in live API test for the `skills` extension

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Follow Up on Maintainability] - 2026-04-03
+## [Follow Up on Maintainability]
 
 - Add hook-level tests for `useSkillContent` and expand `skills-cli` coverage around CLI error normalization and agent id mapping
 - Standardize `search` and `manage` empty/error states with shared retry handling and clearer recovery copy

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Follow Up on Maintainability] - {PR_MERGE_DATE}
+## [Follow Up on Maintainability] - 2026-04-03
 
 - Add hook-level tests for `useSkillContent` and expand `skills-cli` coverage around CLI error normalization and agent id mapping
 - Standardize `search` and `manage` empty/error states with shared retry handling and clearer recovery copy

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Follow Up on Maintainability]
+## [Follow Up on Maintainability] - {PR_MERGE_DATE}
 
 - Add hook-level tests for `useSkillContent` and expand `skills-cli` coverage around CLI error normalization and agent id mapping
 - Standardize `search` and `manage` empty/error states with shared retry handling and clearer recovery copy

--- a/extensions/skills/README.md
+++ b/extensions/skills/README.md
@@ -28,6 +28,14 @@ Search for agent skills from skills.sh with real-time results. View skill detail
 
 View, update, and remove installed skills. Outdated skills are highlighted with an orange icon and grouped in the "Updates Available" section. Filter by agent to see which skills are available for each AI agent.
 
+## Development
+
+- `npm run validate` runs lint, typecheck, and unit tests.
+- `npm run build` confirms the Raycast extension still builds.
+- `npm run test:api-live` runs the opt-in live API check against `skills.sh`.
+- `test/raycast-api.ts` provides the `@raycast/api` stub used by Vitest.
+- [TESTING.md](./TESTING.md) contains the manual UI smoke checklist.
+
 ## Screenshots
 
 ![Search Skills](metadata/skills-1.png)

--- a/extensions/skills/TESTING.md
+++ b/extensions/skills/TESTING.md
@@ -1,0 +1,43 @@
+# Testing
+
+## Automated Checks
+
+- `npm run validate`
+  Runs lint, typecheck, and the Vitest unit test suite.
+- `npm run build`
+  Confirms the extension still builds with Raycast.
+- `npm run test:api-live`
+  Runs the opt-in live API check against `skills.sh`.
+
+## UI Smoke Checklist
+
+Run these checks in Raycast before shipping UI-affecting changes.
+
+### Search Skills
+
+- Enter fewer than 2 characters and confirm the guidance empty state is shown.
+- Run a normal search and confirm results render with the detail panel.
+- Search for a query with no matches and confirm the empty result copy is shown.
+- Trigger an API failure and confirm the error detail view shows `Retry` and `Report Issue on GitHub`.
+
+### Manage Skills
+
+- Confirm installed skills load normally, including the detail panel and update badges.
+- Select an agent filter with no matching installed skills and confirm the filter empty state is shown.
+- Trigger a CLI failure and confirm the error detail view shows `Retry`.
+- Trigger an `npx` resolution failure and confirm the recovery guidance points to **Custom npx Path**.
+
+### Skill Detail
+
+- Confirm `SKILL.md` content renders when available.
+- Confirm the fallback to repository `README.md` works when `SKILL.md` is missing.
+
+### Actions
+
+- Install a skill and confirm the list refreshes.
+- Remove a skill and confirm the list refreshes.
+- Update a skill and confirm the update badge disappears afterward.
+
+### Preferences
+
+- Set a custom `npx` path in extension preferences and confirm Manage Skills still loads correctly.

--- a/extensions/skills/src/components/CommandStates.tsx
+++ b/extensions/skills/src/components/CommandStates.tsx
@@ -1,0 +1,33 @@
+import { Action, Detail, Icon, List } from "@raycast/api";
+import type { ComponentProps } from "react";
+
+type RetryActionProps = {
+  onAction: () => void;
+  title?: string;
+};
+
+export function RetryAction({ onAction, title = "Retry" }: RetryActionProps) {
+  return <Action title={title} onAction={onAction} icon={Icon.RotateClockwise} />;
+}
+
+type CommandErrorDetailProps = {
+  title: string;
+  message: string;
+  detailsMarkdown: string;
+  actions?: ComponentProps<typeof Detail>["actions"];
+};
+
+export function CommandErrorDetail({ title, message, detailsMarkdown, actions }: CommandErrorDetailProps) {
+  return <Detail markdown={`# ${title}\n\n**Error:** ${message}\n\n---\n\n${detailsMarkdown}`} actions={actions} />;
+}
+
+type CommandEmptyViewProps = {
+  title: string;
+  description: string;
+  icon: Icon;
+  actions?: ComponentProps<typeof List.EmptyView>["actions"];
+};
+
+export function CommandEmptyView({ title, description, icon, actions }: CommandEmptyViewProps) {
+  return <List.EmptyView title={title} description={description} icon={icon} actions={actions} />;
+}

--- a/extensions/skills/src/hooks/skill-content.test.ts
+++ b/extensions/skills/src/hooks/skill-content.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Skill } from "../shared";
+import { buildSkillContentUrls, fetchSkillContent } from "./skill-content";
+
+const sampleSkill: Skill = {
+  id: "vercel-labs/example",
+  skillId: "vercel-example-skill",
+  name: "example-skill",
+  installs: 42,
+  source: "vercel-labs/agent-skills",
+};
+
+describe("buildSkillContentUrls", () => {
+  it("builds candidate URLs for SKILL.md and README.md", () => {
+    const { skillUrls, readmeUrls } = buildSkillContentUrls(sampleSkill);
+
+    expect(skillUrls).toContain(
+      "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/skills/vercel-example-skill/SKILL.md",
+    );
+    expect(skillUrls).toContain(
+      "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/skills/example-skill/SKILL.md",
+    );
+    expect(readmeUrls).toEqual([
+      "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/README.md",
+      "https://raw.githubusercontent.com/vercel-labs/agent-skills/master/README.md",
+    ]);
+  });
+});
+
+describe("fetchSkillContent", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns SKILL.md content when available", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/SKILL.md")) {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "text/plain" }),
+          text: async () => "---\ntitle: Example\n---\n# Skill Body",
+        } as Response;
+      }
+      return {
+        ok: false,
+        headers: new Headers({ "content-type": "text/plain" }),
+        text: async () => "",
+      } as Response;
+    });
+
+    await expect(fetchSkillContent(sampleSkill)).resolves.toEqual({
+      frontmatter: { title: "Example" },
+      body: "# Skill Body",
+    });
+  });
+
+  it("falls back to README.md when all SKILL.md attempts fail", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/README.md")) {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "text/plain" }),
+          text: async () => "# README Body",
+        } as Response;
+      }
+      return {
+        ok: false,
+        headers: new Headers({ "content-type": "text/plain" }),
+        text: async () => "",
+      } as Response;
+    });
+
+    await expect(fetchSkillContent(sampleSkill)).resolves.toEqual({
+      frontmatter: {},
+      body: "# README Body",
+    });
+  });
+
+  it("returns undefined when every candidate fails", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue({
+      ok: false,
+      headers: new Headers({ "content-type": "text/plain" }),
+      text: async () => "",
+    } as Response);
+
+    await expect(fetchSkillContent(sampleSkill)).resolves.toBeUndefined();
+  });
+});

--- a/extensions/skills/src/hooks/useSkillContent.test.ts
+++ b/extensions/skills/src/hooks/useSkillContent.test.ts
@@ -1,7 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { useCachedPromise } from "@raycast/utils";
 import type { Skill } from "../shared";
-import { buildSkillContentUrls, fetchSkillContent } from "./skill-content";
+import { fetchSkillContent } from "./skill-content";
+import { useSkillContent } from "./useSkillContent";
+
+vi.mock("@raycast/utils", () => ({
+  useCachedPromise: vi.fn(),
+}));
+
+vi.mock("./skill-content", () => ({
+  fetchSkillContent: vi.fn(),
+}));
 
 const sampleSkill: Skill = {
   id: "vercel-labs/example",
@@ -11,88 +21,88 @@ const sampleSkill: Skill = {
   source: "vercel-labs/agent-skills",
 };
 
-describe("buildSkillContentUrls", () => {
-  it("builds candidate URLs for SKILL.md and README.md", () => {
-    const { skillUrls, readmeUrls } = buildSkillContentUrls(sampleSkill);
-
-    expect(skillUrls).toContain(
-      "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/skills/vercel-example-skill/SKILL.md",
-    );
-    expect(skillUrls).toContain(
-      "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/skills/example-skill/SKILL.md",
-    );
-    expect(readmeUrls).toEqual([
-      "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/README.md",
-      "https://raw.githubusercontent.com/vercel-labs/agent-skills/master/README.md",
-    ]);
-  });
-});
-
-describe("fetchSkillContent", () => {
+describe("useSkillContent", () => {
   beforeEach(() => {
-    vi.stubGlobal("fetch", vi.fn());
+    vi.mocked(useCachedPromise).mockReset();
+    vi.mocked(fetchSkillContent).mockReset();
   });
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
+  it("returns content and frontmatter from cached data", () => {
+    vi.mocked(useCachedPromise).mockReturnValue({
+      data: {
+        body: "# Skill Body",
+        frontmatter: { title: "Example", description: "Sample skill" },
+      },
+      isLoading: false,
+    } as ReturnType<typeof useCachedPromise>);
 
-  it("returns SKILL.md content when available", async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock.mockImplementation(async (input) => {
-      const url = String(input);
-      if (url.includes("/SKILL.md")) {
-        return {
-          ok: true,
-          headers: new Headers({ "content-type": "text/plain" }),
-          text: async () => "---\ntitle: Example\n---\n# Skill Body",
-        } as Response;
-      }
-      return {
-        ok: false,
-        headers: new Headers({ "content-type": "text/plain" }),
-        text: async () => "",
-      } as Response;
-    });
+    const result = useSkillContent(sampleSkill);
 
-    await expect(fetchSkillContent(sampleSkill)).resolves.toEqual({
-      frontmatter: { title: "Example" },
-      body: "# Skill Body",
+    expect(result).toEqual({
+      content: "# Skill Body",
+      frontmatter: { title: "Example", description: "Sample skill" },
+      isLoading: false,
     });
   });
 
-  it("falls back to README.md when all SKILL.md attempts fail", async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock.mockImplementation(async (input) => {
-      const url = String(input);
-      if (url.includes("/README.md")) {
-        return {
-          ok: true,
-          headers: new Headers({ "content-type": "text/plain" }),
-          text: async () => "# README Body",
-        } as Response;
-      }
-      return {
-        ok: false,
-        headers: new Headers({ "content-type": "text/plain" }),
-        text: async () => "",
-      } as Response;
-    });
+  it("falls back to an empty frontmatter object when data is unavailable", () => {
+    vi.mocked(useCachedPromise).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as ReturnType<typeof useCachedPromise>);
 
-    await expect(fetchSkillContent(sampleSkill)).resolves.toEqual({
+    const result = useSkillContent(sampleSkill);
+
+    expect(result).toEqual({
+      content: undefined,
       frontmatter: {},
-      body: "# README Body",
+      isLoading: false,
     });
   });
 
-  it("returns undefined when every candidate fails", async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValue({
-      ok: false,
-      headers: new Headers({ "content-type": "text/plain" }),
-      text: async () => "",
-    } as Response);
+  it("passes through the loading state", () => {
+    vi.mocked(useCachedPromise).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useCachedPromise>);
 
-    await expect(fetchSkillContent(sampleSkill)).resolves.toBeUndefined();
+    const result = useSkillContent(sampleSkill);
+
+    expect(result.isLoading).toBe(true);
+  });
+
+  it("forwards the execute option to useCachedPromise", () => {
+    vi.mocked(useCachedPromise).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as ReturnType<typeof useCachedPromise>);
+
+    useSkillContent(sampleSkill, false);
+
+    expect(useCachedPromise).toHaveBeenCalledWith(expect.any(Function), [sampleSkill], {
+      keepPreviousData: true,
+      execute: false,
+    });
+  });
+
+  it("uses fetchSkillContent as the cached promise factory", async () => {
+    vi.mocked(useCachedPromise).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as ReturnType<typeof useCachedPromise>);
+    vi.mocked(fetchSkillContent).mockResolvedValue({
+      body: "# Skill Body",
+      frontmatter: {},
+    });
+
+    useSkillContent(sampleSkill);
+
+    const [loader] = vi.mocked(useCachedPromise).mock.calls[0];
+
+    await expect(loader(sampleSkill)).resolves.toEqual({
+      body: "# Skill Body",
+      frontmatter: {},
+    });
+    expect(fetchSkillContent).toHaveBeenCalledWith(sampleSkill);
   });
 });

--- a/extensions/skills/src/manage-skills.tsx
+++ b/extensions/skills/src/manage-skills.tsx
@@ -1,5 +1,6 @@
-import { List, Icon, Detail, ActionPanel, Action, Color, openExtensionPreferences } from "@raycast/api";
+import { List, Icon, ActionPanel, Action, Color, openExtensionPreferences } from "@raycast/api";
 import { useState } from "react";
+import { CommandEmptyView, CommandErrorDetail, RetryAction } from "./components/CommandStates";
 import { useInstalledSkills } from "./hooks/useInstalledSkills";
 import { isNpxResolutionError } from "./utils/skills-cli";
 import { InstalledSkillListItem } from "./components/InstalledSkillListItem";
@@ -14,42 +15,18 @@ export default function Command() {
   const hasNpxResolutionError = error ? isNpxResolutionError(error) : false;
 
   if (error && skills.length === 0) {
-    let errorMarkdown = `# Error Loading Installed Skills
-
-**Error:** ${error?.message}
-
----
-
-This is a local skills CLI execution failure.
-
-If this persists:
-
-1. Retry the command.
-2. Open Extension Preferences and verify **Custom npx Path** if you use a non-standard Node.js setup.
-3. Run \`npx -y skills@latest list -g\` in Terminal to inspect the underlying CLI error.
-`;
-
-    if (hasNpxResolutionError) {
-      errorMarkdown = `# Error Loading Installed Skills
-
-**Error:** ${error?.message}
-
----
-
-This is an npx resolution issue in the local CLI runtime.
-
-1. Run \`which npx\` in Terminal.
-2. Open Extension Preferences (\`Cmd+Shift+,\`).
-3. Set **Custom npx Path** to the path from step 1, then retry.
-`;
-    }
-
     return (
-      <Detail
-        markdown={errorMarkdown}
+      <CommandErrorDetail
+        title="Unable to Load Installed Skills"
+        message={error.message}
+        detailsMarkdown={
+          hasNpxResolutionError
+            ? "This is an `npx` resolution issue in the local CLI runtime.\n\n1. Run `which npx` in Terminal.\n2. Open Extension Preferences (`Cmd+Shift+,`).\n3. Set **Custom npx Path** to the path from step 1, then retry."
+            : "This is a local Skills CLI execution failure.\n\n1. Retry the command.\n2. Open Extension Preferences and verify **Custom npx Path** if you use a non-standard Node.js setup.\n3. Run `npx -y skills@latest list -g` in Terminal to inspect the underlying CLI error."
+        }
         actions={
           <ActionPanel>
-            <Action title="Retry" onAction={revalidate} icon={Icon.RotateClockwise} />
+            <RetryAction onAction={revalidate} />
             <Action title="Open Preferences" onAction={openExtensionPreferences} icon={Icon.Gear} />
           </ActionPanel>
         }
@@ -89,24 +66,24 @@ This is an npx resolution issue in the local CLI runtime.
       }
     >
       {skills.length === 0 && !isLoading ? (
-        <List.EmptyView
+        <CommandEmptyView
           title="No Installed Skills"
-          description="Install skills using the Search Skills command"
+          description="Install skills from Search Skills to manage them here."
           icon={Icon.Box}
           actions={
             <ActionPanel>
-              <Action title="Refresh" onAction={revalidate} icon={Icon.RotateClockwise} />
+              <RetryAction onAction={revalidate} />
             </ActionPanel>
           }
         />
       ) : filteredSkills.length === 0 && !isLoading ? (
-        <List.EmptyView
-          title="No Skills for This Agent"
+        <CommandEmptyView
+          title="No Results for Current Filter"
           description={`No installed skills match the "${selectedAgent}" filter. Try selecting a different agent.`}
           icon={Icon.Filter}
           actions={
             <ActionPanel>
-              <Action title="Refresh" onAction={revalidate} icon={Icon.RotateClockwise} />
+              <RetryAction onAction={revalidate} />
             </ActionPanel>
           }
         />

--- a/extensions/skills/src/search-skills.tsx
+++ b/extensions/skills/src/search-skills.tsx
@@ -1,6 +1,7 @@
-import { List, ActionPanel, Action, Icon, Detail } from "@raycast/api";
+import { List, ActionPanel, Action, Icon } from "@raycast/api";
 import { useState } from "react";
 
+import { CommandEmptyView, CommandErrorDetail, RetryAction } from "./components/CommandStates";
 import { SkillListItem } from "./components/SkillListItem";
 import { useOwnerFilter } from "./hooks/useOwnerFilter";
 import { useDebouncedSearch } from "./hooks/useDebouncedSearch";
@@ -18,11 +19,13 @@ export default function Command() {
 
   if (error && !data) {
     return (
-      <Detail
-        markdown={`# API Error\n\nFailed to fetch data from the Skills API.\n\n**Error:** ${error.message}\n\n---\n\nIf the problem persists, please report it via **Report Issue on GitHub**.`}
+      <CommandErrorDetail
+        title="Unable to Load Search Results"
+        message={error.message}
+        detailsMarkdown="The Skills API request failed, so the primary search content could not be shown.\n\nRetry the search. If the problem persists, report it on GitHub."
         actions={
           <ActionPanel>
-            <Action title="Clear Cache & Retry" onAction={revalidate} icon={Icon.RotateClockwise} />
+            <RetryAction onAction={revalidate} />
             <Action.OpenInBrowser
               title="Report Issue on GitHub"
               url={buildGithubIssueUrl({
@@ -61,21 +64,21 @@ export default function Command() {
         </List.Dropdown>
       }
     >
-      {searchText.length < 2 || (skills.length === 0 && !isLoading) ? (
-        <List.EmptyView
-          title={searchText.length >= 2 ? "No Skills Found" : "Search Skills"}
-          description={
-            searchText.length >= 2
-              ? `No results for "${searchText}". Try different keywords.`
-              : "Type at least 2 characters to search"
-          }
-          icon={searchText.length >= 2 ? Icon.XMarkCircle : Icon.MagnifyingGlass}
+      {searchText.length < 2 ? (
+        <CommandEmptyView
+          title="Search Skills"
+          description="Type at least 2 characters to search."
+          icon={Icon.MagnifyingGlass}
+        />
+      ) : skills.length === 0 && !isLoading ? (
+        <CommandEmptyView
+          title="No Search Results"
+          description={`No results found for "${searchText}". Try different keywords.`}
+          icon={Icon.MagnifyingGlass}
           actions={
-            searchText.length >= 2 ? (
-              <ActionPanel>
-                <Action title="Clear Cache & Retry" onAction={revalidate} icon={Icon.RotateClockwise} />
-              </ActionPanel>
-            ) : undefined
+            <ActionPanel>
+              <RetryAction onAction={revalidate} />
+            </ActionPanel>
           }
         />
       ) : (

--- a/extensions/skills/src/utils/skills-cli.test.ts
+++ b/extensions/skills/src/utils/skills-cli.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { parseSkillsListJson, stripAnsi } from "./skills-cli";
+import {
+  NpxResolutionError,
+  agentDisplayNameToId,
+  normalizeCliError,
+  parseSkillsListJson,
+  stripAnsi,
+} from "./skills-cli";
 
 describe("stripAnsi", () => {
   it("removes ANSI escape codes", () => {
@@ -67,5 +73,52 @@ describe("parseSkillsListJson", () => {
         agentCount: 0,
       },
     ]);
+  });
+});
+
+describe("normalizeCliError", () => {
+  it("classifies a shell command-not-found error as npx resolution failure", () => {
+    const error = new Error("command not found: npx");
+
+    const normalized = normalizeCliError(error, "npx");
+
+    expect(normalized).toBeInstanceOf(NpxResolutionError);
+  });
+
+  it("classifies a spawn ENOENT error as npx resolution failure", () => {
+    const normalized = normalizeCliError(
+      {
+        message: "spawn /opt/homebrew/bin/npx ENOENT",
+        code: "ENOENT",
+      },
+      "/opt/homebrew/bin/npx",
+    );
+
+    expect(normalized).toBeInstanceOf(NpxResolutionError);
+  });
+
+  it("classifies a Windows-style not-found error as npx resolution failure", () => {
+    const error = new Error("'npx' is not recognized as an internal or external command");
+
+    const normalized = normalizeCliError(error, "npx.exe");
+
+    expect(normalized).toBeInstanceOf(NpxResolutionError);
+  });
+
+  it("returns regular Error instances unchanged when the failure is unrelated", () => {
+    const error = new Error("skills list failed");
+
+    expect(normalizeCliError(error, "npx")).toBe(error);
+  });
+});
+
+describe("agentDisplayNameToId", () => {
+  it("maps known agent display names to the expected CLI ids", () => {
+    expect(agentDisplayNameToId("Claude Code")).toBe("claude-code");
+    expect(agentDisplayNameToId("Deep Agents")).toBe("deepagents");
+  });
+
+  it("falls back to lowercase kebab-case for unknown agents", () => {
+    expect(agentDisplayNameToId("My Custom Agent")).toBe("my-custom-agent");
   });
 });

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -58,7 +58,7 @@ export function shellEscape(arg: string): string {
   return `'${arg.replace(/'/g, "'\\''")}'`;
 }
 
-function normalizeCliError(error: unknown, npxCommand: string): Error {
+export function normalizeCliError(error: unknown, npxCommand: string): Error {
   if (isNpxCommandResolutionFailure(error, npxCommand)) {
     return new NpxResolutionError(
       "Unable to find a working npx command. Run `which npx` in Terminal, then set that path in Extension Preferences under 'Custom npx Path'.",
@@ -190,7 +190,7 @@ const AGENT_DISPLAY_TO_ID = new Map<string, string>([
   ["Zencoder", "zencoder"],
 ]);
 
-function agentDisplayNameToId(displayName: string): string {
+export function agentDisplayNameToId(displayName: string): string {
   return AGENT_DISPLAY_TO_ID.get(displayName) ?? displayName.toLowerCase().replace(/\s+/g, "-");
 }
 


### PR DESCRIPTION
## Summary
- add hook-level tests for `useSkillContent` and restore lower-level `skill-content` tests
- expand `skills-cli` coverage around CLI error normalization and agent id mapping
- unify search and manage empty/error states with shared retry UI
- document the maintainer workflow and add a manual smoke checklist

## Why
- follow up on the recent maintainability work for the `skills` extension
- make regressions easier to catch in both tests and routine manual verification

## Validation
- `npm run validate`
- `npm run build`
- `npm run test:api-live`

## Notes
- `extensions/skills/MAINTAINABILITY_FOLLOWUP_PLAN.md` is intentionally left out of this PR
