### PR TITLE
Update qr-code-scanner extension

### DIFF
--- a/extensions/qr-code-scanner/.cursor/hooks/state/continual-learning.json
+++ b/extensions/qr-code-scanner/.cursor/hooks/state/continual-learning.json
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "lastRunAtMs": 0,
-  "turnsSinceLastRun": 1,
-  "lastTranscriptMtimeMs": null,
-  "lastProcessedGenerationId": "2ca4c0bb-8830-45d1-8203-2902c56c492e",
-  "trialStartedAtMs": null
-}

--- a/extensions/qr-code-scanner/.gitignore
+++ b/extensions/qr-code-scanner/.gitignore
@@ -15,3 +15,5 @@ tsconfig.tsbuildinfo
 
 # misc
 .DS_Store
+
+.cursor

--- a/extensions/qr-code-scanner/.gitignore
+++ b/extensions/qr-code-scanner/.gitignore
@@ -10,5 +10,8 @@ raycast-env.d.ts
 compiled_raycast_swift
 compiled_raycast_rust
 
+# Build
+tsconfig.tsbuildinfo
+
 # misc
 .DS_Store

--- a/extensions/qr-code-scanner/CHANGELOG.md
+++ b/extensions/qr-code-scanner/CHANGELOG.md
@@ -1,6 +1,6 @@
 # QR Code Scanner Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-04-04
 
 - Updated URL handling behavior and preference defaults:
 - **Old behavior:** scanned URLs opened automatically by default.

--- a/extensions/qr-code-scanner/CHANGELOG.md
+++ b/extensions/qr-code-scanner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # QR Code Scanner Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Updated URL handling behavior and preference defaults:
+- **Old behavior:** scanned URLs opened automatically by default.
+- **New behavior:** scanned URLs are copied only by default, and auto-open can be enabled via `Open URL Automatically`.
+
 ## [Fix] - 2026-03-30
 
 - Replaced the npm `open` package with Raycast's built-in `open` from `@raycast/api` for URL handling. The npm package bypassed macOS's native URL dispatch, causing all URLs to open in the browser instead of their registered app handlers (deep-links). Using Raycast's `open` correctly delegates to macOS's `open` command, which respects universal links and custom URL scheme registrations.

--- a/extensions/qr-code-scanner/package.json
+++ b/extensions/qr-code-scanner/package.json
@@ -6,7 +6,8 @@
   "icon": "command-icon.png",
   "author": "StevenRCE0",
   "contributors": [
-    "MoienTajik"
+    "MoienTajik",
+    "0xdhrv"
   ],
   "license": "MIT",
   "commands": [
@@ -49,10 +50,10 @@
       "name": "openUrlAfterScan",
       "title": "Open URL After Scan",
       "label": "Open URL Automatically",
-      "description": "Open decoded URLs automatically after scanning. Disable to only copy to clipboard.",
+      "description": "Open decoded URLs automatically after scanning. Disable to copy or inspect links first.",
       "type": "checkbox",
       "required": false,
-      "default": true
+      "default": false
     }
   ],
   "dependencies": {

--- a/extensions/qr-code-scanner/package.json
+++ b/extensions/qr-code-scanner/package.json
@@ -5,6 +5,9 @@
   "description": "Simple on-screen QR code scanner. (\"Screen recording\" permission is required)",
   "icon": "command-icon.png",
   "author": "StevenRCE0",
+  "categories": [
+    "Productivity"
+  ],
   "contributors": [
     "MoienTajik",
     "0xdhrv"

--- a/extensions/qr-code-scanner/src/index.tsx
+++ b/extensions/qr-code-scanner/src/index.tsx
@@ -17,12 +17,6 @@ import { randomInt } from "crypto";
 import jsQR from "jsqr";
 import { useEffect, useRef } from "react";
 
-interface Preferences {
-  captureMode: "area" | "fullscreen";
-  silence: boolean;
-  openUrlAfterScan: boolean;
-}
-
 const NO_QR_FOUND_MESSAGE = "Found No Data in the QR Code :(";
 const NO_QR_ANY_SCREEN_MESSAGE = "No QR Code Found on Any Screen :(";
 const IMAGE_DECODING_ERROR_MESSAGE = "Image decoding error...";
@@ -58,7 +52,6 @@ async function qrDecode(filepath: string): Promise<string | null> {
     const result = jsQR(new Uint8ClampedArray(image.bitmap.data.buffer), image.bitmap.width, image.bitmap.height, {
       inversionAttempts: "attemptBoth",
     });
-    await removeFile(filepath);
 
     if (result) {
       const decoder = new TextDecoder("shift-jis");
@@ -71,6 +64,8 @@ async function qrDecode(filepath: string): Promise<string | null> {
       await showToast(Toast.Style.Failure, IMAGE_DECODING_ERROR_MESSAGE);
     }
     return null;
+  } finally {
+    await removeFile(filepath);
   }
 }
 
@@ -82,7 +77,8 @@ function getOpenTarget(value: string): string | null {
 
   try {
     const parsed = new URL(trimmed);
-    return parsed.protocol.length > 0 ? parsed.toString() : null;
+    const safeProtocols = ["http:", "https:", "ftp:", "mailto:"];
+    return safeProtocols.includes(parsed.protocol) ? parsed.toString() : null;
   } catch {
     const hasNoWhitespace = !/\s/.test(trimmed);
     const looksLikeDomain = /^[\w.-]+\.[a-z]{2,}(\/.*)?$/i.test(trimmed);

--- a/extensions/qr-code-scanner/src/index.tsx
+++ b/extensions/qr-code-scanner/src/index.tsx
@@ -10,9 +10,12 @@ import {
   Toast,
 } from "@raycast/api";
 import { exec } from "child_process";
+import { constants } from "fs";
+import { access, unlink } from "fs/promises";
 import { Jimp } from "jimp";
 import { randomInt } from "crypto";
 import jsQR from "jsqr";
+import { useEffect, useRef } from "react";
 
 interface Preferences {
   captureMode: "area" | "fullscreen";
@@ -20,76 +23,153 @@ interface Preferences {
   openUrlAfterScan: boolean;
 }
 
-async function qrDecode(filepath: string, callback: (data: string | boolean) => void) {
-  try {
-    const image = await Jimp.read(filepath);
-    if (!image) {
-      popToRoot();
-      return;
-    }
-    const result = jsQR(new Uint8ClampedArray(image.bitmap.data.buffer), image.bitmap.width, image.bitmap.height, {
-      inversionAttempts: "attemptBoth",
-    });
-    exec(`rm ${filepath}`);
-    if (result) {
-      const decoder = new TextDecoder("shift-jis");
-      const code = decoder.decode(Uint8Array.from(result.binaryData).buffer);
-      callback(code);
-      return;
-    }
-    callback(false);
-  } catch {
-    showToast(Toast.Style.Failure, "Image decoder error...");
-    return;
-  }
-}
+const NO_QR_FOUND_MESSAGE = "Found No Data in the QR Code :(";
+const NO_QR_ANY_SCREEN_MESSAGE = "No QR Code Found on Any Screen :(";
+const IMAGE_DECODING_ERROR_MESSAGE = "Image decoding error...";
 
-function isUrl(value: string): boolean {
-  return /^[a-zA-Z][a-zA-Z\d+.-]*:\/\/\S+$/i.test(value);
-}
-
-function trigger(randName: string, preferences: Preferences, displayNumber = 1) {
-  closeMainWindow({ popToRootType: PopToRootType.Suspended });
-
-  function captureScreenCommand(): string {
-    switch (preferences.captureMode) {
-      case "fullscreen":
-        return `/usr/sbin/screencapture ${
-          preferences.silence ? "-x" : ""
-        } -D ${displayNumber.toString()} /tmp/shotTemp${randName}.jpg`;
-      default:
-        return `/usr/sbin/screencapture ${preferences.silence ? "-x" : ""} -i /tmp/shotTemp${randName}.jpg`;
-    }
-  }
-
-  exec(captureScreenCommand(), function (exception) {
-    if (exception && exception.message.indexOf("Invalid display specified") > -1) {
-      showHUD("No QR Code Found on Any Screen :(");
-      popToRoot();
-    }
-    qrDecode("/tmp/shotTemp" + randName + ".jpg", (data: string | boolean) => {
-      if (!data && preferences.captureMode === "fullscreen") {
-        trigger(randName, preferences, displayNumber + 1);
-      } else if (!data) {
-        showHUD("Found No Data in the QR Code :(");
-        popToRoot();
-      } else if (typeof data === "string") {
-        Clipboard.copy(data);
-        if (preferences.openUrlAfterScan && isUrl(data)) {
-          open(data).then(() => {
-            closeMainWindow({ clearRootSearch: true, popToRootType: PopToRootType.Immediate });
-          });
-        } else {
-          showHUD("Copied: " + (data.length > 20 ? data.substring(0, 30) + "..." : data));
-          popToRoot();
-        }
-      }
+function runCapture(command: string): Promise<Error | null> {
+  return new Promise((resolve) => {
+    exec(command, (exception) => {
+      resolve(exception ?? null);
     });
   });
 }
 
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function removeFile(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch {
+    // Ignore cleanup errors.
+  }
+}
+
+async function qrDecode(filepath: string): Promise<string | null> {
+  try {
+    const image = await Jimp.read(filepath);
+    const result = jsQR(new Uint8ClampedArray(image.bitmap.data.buffer), image.bitmap.width, image.bitmap.height, {
+      inversionAttempts: "attemptBoth",
+    });
+    await removeFile(filepath);
+
+    if (result) {
+      const decoder = new TextDecoder("shift-jis");
+      return decoder.decode(Uint8Array.from(result.binaryData).buffer).trim();
+    }
+    return null;
+  } catch (error) {
+    const maybeErr = error as NodeJS.ErrnoException;
+    if (maybeErr.code !== "ENOENT") {
+      await showToast(Toast.Style.Failure, IMAGE_DECODING_ERROR_MESSAGE);
+    }
+    return null;
+  }
+}
+
+function getOpenTarget(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol.length > 0 ? parsed.toString() : null;
+  } catch {
+    const hasNoWhitespace = !/\s/.test(trimmed);
+    const looksLikeDomain = /^[\w.-]+\.[a-z]{2,}(\/.*)?$/i.test(trimmed);
+    if (!hasNoWhitespace || !looksLikeDomain) {
+      return null;
+    }
+
+    try {
+      const parsed = new URL(`https://${trimmed}`);
+      return parsed.toString();
+    } catch {
+      return null;
+    }
+  }
+}
+
+async function trigger(randName: string, preferences: Preferences, displayNumber = 1): Promise<void> {
+  closeMainWindow({ popToRootType: PopToRootType.Suspended });
+
+  const filepath = `/tmp/shotTemp${randName}.jpg`;
+
+  function captureScreenCommand(): string {
+    switch (preferences.captureMode) {
+      case "fullscreen":
+        return `/usr/sbin/screencapture ${preferences.silence ? "-x" : ""} -D ${displayNumber.toString()} ${filepath}`;
+      default:
+        return `/usr/sbin/screencapture ${preferences.silence ? "-x" : ""} -i ${filepath}`;
+    }
+  }
+
+  const exception = await runCapture(captureScreenCommand());
+  const invalidDisplay = exception?.message.includes("Invalid display specified") ?? false;
+  if (invalidDisplay) {
+    await showHUD(NO_QR_ANY_SCREEN_MESSAGE);
+    popToRoot();
+    return;
+  }
+
+  const capturedFileExists = await fileExists(filepath);
+  if (!capturedFileExists) {
+    // Users can cancel interactive selection capture with ESC.
+    popToRoot();
+    return;
+  }
+
+  const data = await qrDecode(filepath);
+  if (!data) {
+    if (preferences.captureMode === "fullscreen") {
+      await trigger(randName, preferences, displayNumber + 1);
+      return;
+    }
+    await showHUD(NO_QR_FOUND_MESSAGE);
+    popToRoot();
+    return;
+  }
+
+  await Clipboard.copy(data);
+
+  const openTarget = getOpenTarget(data);
+  const shouldOpenAfterScan = preferences.openUrlAfterScan === true;
+  if (shouldOpenAfterScan && openTarget !== null) {
+    try {
+      await open(openTarget);
+      closeMainWindow({ clearRootSearch: true, popToRootType: PopToRootType.Immediate });
+      return;
+    } catch {
+      await showToast(Toast.Style.Failure, "Failed to open URL. Copied to clipboard instead.");
+    }
+  }
+
+  await showHUD("Copied: " + (data.length > 20 ? data.substring(0, 30) + "..." : data));
+  popToRoot();
+}
+
 export default function main() {
-  const randName = randomInt(100, 999).toString();
+  const hasStartedRef = useRef(false);
   const preferences = getPreferenceValues<Preferences>();
-  trigger(randName, preferences);
+
+  useEffect(() => {
+    if (hasStartedRef.current) {
+      return;
+    }
+
+    hasStartedRef.current = true;
+    const randName = randomInt(100, 999).toString();
+    void trigger(randName, preferences);
+  }, [preferences]);
+
+  return null;
 }

--- a/extensions/qr-code-scanner/tsconfig.json
+++ b/extensions/qr-code-scanner/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node 16",
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "raycast-env.d.ts"],
   "compilerOptions": {
     "lib": ["es2020", "dom"],
     "module": "commonjs",


### PR DESCRIPTION
## Description

Set `Open URL Automatically` default to false so decoded URLs are copied by default.
Improve URL detection, safe open flow, temp-file cleanup, and multi-display capture.

Refs:
- #24534 — "Add an option to copy URL?": request to copy QR URL to clipboard instead of opening.
- #26794 — "recognize links": request to recognize links in screenshot or whole screen.

Updates:
- Closes: #24534
- Closes: #26794

## Screencast

N/A

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
