### PR TITLE
feat(tailscale): show account name and tailnet

### DIFF
--- a/extensions/tailscale/CHANGELOG.md
+++ b/extensions/tailscale/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Tailscale Changelog
 
+## [Fix Account Switcher] - {PR_MERGE_DATE}
+
+- Fix "Switch Account" not showing tailnet and account names correctly
+- Show tailnet name in "Switch Account" command if multiple tailnets are available
+
 ## [Better Status Command] - 2026-03-18
 
 - Optionally show hostname, tailnet name, and IP in the status command

--- a/extensions/tailscale/CHANGELOG.md
+++ b/extensions/tailscale/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tailscale Changelog
 
-## [Fix Account Switcher] - {PR_MERGE_DATE}
+## [Fix Account Switcher] - 2026-04-12
 
 - Fix "Switch Account" not showing tailnet and account names correctly
 - Show tailnet name in "Switch Account" command if multiple tailnets are available

--- a/extensions/tailscale/package-lock.json
+++ b/extensions/tailscale/package-lock.json
@@ -1104,7 +1104,6 @@
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.5.tgz",
       "integrity": "sha512-H2eyeTU5BPd2ZiP5p4bO3krh70xpdglgDRJBHSIg7Dnx4ICOOfvQDo39JMcuDlV7cI8Dca3Ht5kybLXg3G6Ibw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.5.4",
         "@oclif/plugin-autocomplete": "^3.2.35",
@@ -1206,7 +1205,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1265,7 +1263,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1470,7 +1467,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1837,7 +1833,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2622,7 +2617,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2646,7 +2640,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2874,7 +2867,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/tailscale/src/account-switcher.tsx
+++ b/extensions/tailscale/src/account-switcher.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from "react";
 import { ErrorDetails, getErrorDetails, tailscale } from "./shared";
 
 interface User {
+  id: string;
   active: boolean;
   name: string;
   tailnet: string | undefined;
@@ -36,22 +37,26 @@ function loadUsers(unparsedUsers: string[]) {
     if (unparsedUserList.length == 3) {
       // accounts with 'ID Tailnet Account'
       user = {
+        id: unparsedUserList[0],
         name: unparsedUserList[2].replace(/\*$/, ""),
         active: unparsedUserList[2].includes("*"),
         tailnet: unparsedUserList[1],
       };
     } else if (unparsedUserList.length == 2) {
       // accounts without ID column: '<tailnet> <account>'
+      const name = unparsedUserList[1].replace(/\*$/, "");
       user = {
-        name: unparsedUserList[1].replace(/\*$/, ""),
+        id: name,
+        name,
         active: unparsedUserList[1].includes("*"),
         tailnet: unparsedUserList[0] || undefined,
       };
-    }
-    if (unparsedUserList.length == 1) {
+    } else if (unparsedUserList.length == 1) {
       // older clients
+      const name = unparsedUserList[0].replace(/\*$/, "");
       user = {
-        name: unparsedUserList[0].replace(/\*$/, ""),
+        id: name,
+        name,
         active: unparsedUserList[0].includes("*"),
         tailnet: undefined,
       };
@@ -82,6 +87,11 @@ export default function AccountSwitchList() {
   const activeUserIcon = { source: Icon.PersonCircle, tintColor: Color.Green };
   const inactiveUserIcon = { source: Icon.PersonCircle };
 
+  // see if user is logged in to multiple tailnets
+  // if only one, then there's no need to show "on tailnet" because it's redundant
+  const multipleTailnets = new Set((users ?? []).map((u) => u.tailnet).filter(Boolean)).size > 1;
+  const userLabel = (user: User) => (multipleTailnets && user.tailnet ? `${user.name} on ${user.tailnet}` : user.name);
+
   // return a list of users, starting with all of the inactive users.
   // output the active user last.
   return (
@@ -94,7 +104,7 @@ export default function AccountSwitchList() {
           .map((user) => (
             <List.Item
               title={user.name}
-              key={user.name}
+              key={user.id}
               icon={user.active ? activeUserIcon : inactiveUserIcon}
               subtitle={user.tailnet}
               actions={
@@ -105,16 +115,16 @@ export default function AccountSwitchList() {
                       await showToast({
                         style: Toast.Style.Animated,
                         title: "Switching user account",
-                        message: `${user.name}`,
+                        message: userLabel(user),
                       });
                       popToRoot();
                       closeMainWindow();
-                      const ret = tailscale(`switch ${user.name}`);
+                      const ret = tailscale(`switch ${user.id}`);
 
                       if (ret.includes("Success") || ret.includes("Already")) {
-                        showHUD(`Active Tailscale user is ${user.name}`);
+                        showHUD(`Active Tailscale user is ${userLabel(user)}`);
                       } else {
-                        showHUD(`Tailscale user failed to switch to ${user.name}`);
+                        showHUD(`Tailscale user failed to switch to ${userLabel(user)}`);
                       }
                     }}
                   />

--- a/extensions/tailscale/src/account-switcher.tsx
+++ b/extensions/tailscale/src/account-switcher.tsx
@@ -16,6 +16,7 @@ import { ErrorDetails, getErrorDetails, tailscale } from "./shared";
 interface User {
   active: boolean;
   name: string;
+  tailnet: string | undefined;
 }
 
 function loadUsers(unparsedUsers: string[]) {
@@ -28,19 +29,23 @@ function loadUsers(unparsedUsers: string[]) {
 
   for (const unparsedUser of unparsedUsers as string[]) {
     const unparsedUserList: string[] = unparsedUser.split(" ").filter(Boolean);
+    // if no accounts, fail nicely
+    if (unparsedUserList.length === 0) continue;
     let user = {} as User;
 
     if (unparsedUserList.length == 3) {
       // accounts with 'ID Tailnet Account'
       user = {
-        name: unparsedUserList[1],
+        name: unparsedUserList[2].replace(/\*$/, ""),
         active: unparsedUserList[2].includes("*"),
+        tailnet: unparsedUserList[1],
       };
     } else if (unparsedUserList.length == 2) {
-      // accounts with empty tailnet name
+      // accounts without ID column: '<tailnet> <account>'
       user = {
         name: unparsedUserList[1].replace(/\*$/, ""),
         active: unparsedUserList[1].includes("*"),
+        tailnet: unparsedUserList[0] || undefined,
       };
     }
     if (unparsedUserList.length == 1) {
@@ -48,6 +53,7 @@ function loadUsers(unparsedUsers: string[]) {
       user = {
         name: unparsedUserList[0].replace(/\*$/, ""),
         active: unparsedUserList[0].includes("*"),
+        tailnet: undefined,
       };
     }
 
@@ -90,7 +96,7 @@ export default function AccountSwitchList() {
               title={user.name}
               key={user.name}
               icon={user.active ? activeUserIcon : inactiveUserIcon}
-              subtitle={user.active ? "Active user" : ""}
+              subtitle={user.tailnet}
               actions={
                 <ActionPanel>
                   <Action

--- a/extensions/tailscale/src/account-switcher.tsx
+++ b/extensions/tailscale/src/account-switcher.tsx
@@ -43,14 +43,27 @@ function loadUsers(unparsedUsers: string[]) {
         tailnet: unparsedUserList[1],
       };
     } else if (unparsedUserList.length == 2) {
-      // accounts without ID column: '<tailnet> <account>'
-      const name = unparsedUserList[1].replace(/\*$/, "");
-      user = {
-        id: name,
-        name,
-        active: unparsedUserList[1].includes("*"),
-        tailnet: unparsedUserList[0] || undefined,
-      };
+      // two-column output can be either '<tailnet> <account>' or 'ID <account>'
+      const first = unparsedUserList[0];
+      const second = unparsedUserList[1];
+      const name = second.replace(/\*$/, "");
+      // if the first column is purely numeric, treat it as an ID (older CLI format)
+      if (/^\d+$/.test(first)) {
+        user = {
+          id: first,
+          name,
+          active: second.includes("*"),
+          tailnet: undefined,
+        };
+      } else {
+        // assume '<tailnet> <account>'
+        user = {
+          id: name,
+          name,
+          active: second.includes("*"),
+          tailnet: first || undefined,
+        };
+      }
     } else if (unparsedUserList.length == 1) {
       // older clients
       const name = unparsedUserList[0].replace(/\*$/, "");


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->
shows the tailnet name and account name in account switcher, as both are important.
it is possible to have:
- two tailnets, one username
- one tailnet, two username

and to prevent confusion, we should show both tailnet and username.


show tailnet name that was switched to if exists more than one tailnet that is logged in

closes #25581 (issue most likely was no accounts).
fix was on L33, adding a check if zero rows

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->


before

<img width="500" alt="CleanShot 2026-04-03 at 18 37 17" src="https://github.com/user-attachments/assets/c0627c27-f902-4633-867e-726218fe30f9" />


after

<img width="500" alt="CleanShot 2026-04-03 at 18 37 11" src="https://github.com/user-attachments/assets/36ebbd79-d71d-42c9-94b5-1c5ff8e3767c" />



## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
