### PR TITLE
[Letterboxd] Fix genre tag visibility in light mode

### DIFF
--- a/extensions/letterboxd/CHANGELOG.md
+++ b/extensions/letterboxd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # letterboxd Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-04-06
 
 - Fixed genre tag color for better visibility in light mode
 

--- a/extensions/letterboxd/CHANGELOG.md
+++ b/extensions/letterboxd/CHANGELOG.md
@@ -1,5 +1,9 @@
 # letterboxd Changelog
 
+## [Fix] - 2026-04-04
+
+- Fixed genre tag color for better visibility in light mode
+
 ## [Maintenance] - 2026-02-07
 
 - Add support for Windows platform

--- a/extensions/letterboxd/CHANGELOG.md
+++ b/extensions/letterboxd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # letterboxd Changelog
 
-## [Fix] - 2026-04-04
+## [Fix] - {PR_MERGE_DATE}
 
 - Fixed genre tag color for better visibility in light mode
 

--- a/extensions/letterboxd/src/movie-details.tsx
+++ b/extensions/letterboxd/src/movie-details.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useCachedPromise } from "@raycast/utils";
 import { AsyncStatus, fetchMovieDetails } from "./letterboxd-api";
-import { Action, ActionPanel, Detail } from "@raycast/api";
+import { Action, ActionPanel, Color, Detail } from "@raycast/api";
 import { STRINGS } from "./strings";
 import type { MovieDetails, Review } from "./types";
 import { ErrorScreen } from "./components/error-screen";
@@ -179,7 +179,7 @@ function Metadata(props: MetadataProps) {
           <Detail.Metadata.TagList.Item
             key={genre}
             text={genre}
-            color={"#ecf0f1"}
+            color={Color.SecondaryText}
           />
         ))}
       </Detail.Metadata.TagList>


### PR DESCRIPTION
## Description

Genre tags on the movie detail page used a hardcoded color (`#ecf0f1`) that's nearly invisible against light mode backgrounds. Replaced it with `Color.SecondaryText` from the Raycast API, which adapts to the current theme automatically.

The fix is in `extensions/letterboxd/src/movie-details.tsx` - changed the `color` prop on the genre `TagList.Item` from a static hex value to the theme-aware constant.

Fixes #26920

## Screencast

The change is a single color value swap. Genre tags will now be readable in both light and dark mode.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

This contribution was developed with AI assistance (Codex).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)