### PR TITLE
[ray.so] Add missing partner themes to Generate Image settings

### DIFF
--- a/extensions/ray-so/CHANGELOG.md
+++ b/extensions/ray-so/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ray.so Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Chore: Added partner themes] - {PR_MERGE_DATE}
 
 - Added 12 missing partner themes to Generate Image settings (OpenAI, Mintlify, Prisma, Clerk, ElevenLabs, Resend, Trigger.dev, Browserbase, Cloudflare, Gemini, Stripe, Firecrawl)
 

--- a/extensions/ray-so/CHANGELOG.md
+++ b/extensions/ray-so/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ray.so Changelog
 
-## [Chore: Added partner themes] - {PR_MERGE_DATE}
+## [Chore: Added partner themes] - 2026-04-05
 
 - Added 12 missing partner themes to Generate Image settings (OpenAI, Mintlify, Prisma, Clerk, ElevenLabs, Resend, Trigger.dev, Browserbase, Cloudflare, Gemini, Stripe, Firecrawl)
 

--- a/extensions/ray-so/CHANGELOG.md
+++ b/extensions/ray-so/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Ray.so Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Added 12 missing partner themes to Generate Image settings (OpenAI, Mintlify, Prisma, Clerk, ElevenLabs, Resend, Trigger.dev, Browserbase, Cloudflare, Gemini, Stripe, Firecrawl)
+
 ## [New theme] - 2025-11-07
 
 - Added Nuxt theme

--- a/extensions/ray-so/package.json
+++ b/extensions/ray-so/package.json
@@ -51,12 +51,60 @@
               "value": "supabase"
             },
             {
+              "title": "Tailwind",
+              "value": "tailwind"
+            },
+            {
+              "title": "OpenAI",
+              "value": "openai"
+            },
+            {
+              "title": "Mintlify",
+              "value": "mintlify"
+            },
+            {
+              "title": "Prisma",
+              "value": "prisma"
+            },
+            {
+              "title": "Clerk",
+              "value": "clerk"
+            },
+            {
+              "title": "ElevenLabs",
+              "value": "elevenlabs"
+            },
+            {
+              "title": "Resend",
+              "value": "resend"
+            },
+            {
+              "title": "Trigger.dev",
+              "value": "triggerdev"
+            },
+            {
               "title": "Nuxt",
               "value": "nuxt"
             },
             {
-              "title": "Tailwind",
-              "value": "tailwind"
+              "title": "Browserbase",
+              "value": "browserbase"
+            },
+            {
+              "title": "Cloudflare",
+              "value": "cloudflare"
+            },
+            {
+              "title": "Gemini",
+              "value": "gemini"
+            },
+            {
+              "title": "Stripe",
+              "value": "stripe"
+            },
+            {
+              "title": "Firecrawl",
+              "value": "firecrawl"
             },
             {
               "title": "Bitmap",


### PR DESCRIPTION
## Description

The Generate Image command's theme dropdown was missing 12 partner themes that are available on ray.so. These themes were confirmed via the `ray.so/api/config` endpoint which the Create Image from Code command already uses dynamically.

Added: OpenAI, Mintlify, Prisma, Clerk, ElevenLabs, Resend, Trigger.dev, Browserbase, Cloudflare, Gemini, Stripe, Firecrawl.

The Create Image from Code command fetches themes at runtime from the API so it stays current. The Generate Image command uses a hardcoded list in `package.json` preferences since it's a no-view command.

Fixes #26905

## Screencast

This is a package.json preference change. The updated theme list will appear in Raycast's extension settings.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)