### PR TITLE
[kafka-ui] Fix environment dropdown showing stale data, add edit shortcut

### DIFF
--- a/extensions/kafka-ui/CHANGELOG.md
+++ b/extensions/kafka-ui/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Kafka UI
 
+## [Fix] - 2026-04-05
+
+- Fixed environment dropdown showing stale data when multiple environments are configured
+- Added cmd+e shortcut to Edit Environment action in Configuration Manager
+
 ## [Fix] - 2026-04-02
 
 - Fixed author username in package.json

--- a/extensions/kafka-ui/CHANGELOG.md
+++ b/extensions/kafka-ui/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kafka UI
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-04-05
 
 - Fixed environment dropdown showing stale data when multiple environments are configured
 - Added cmd+e shortcut to Edit Environment action in Configuration Manager

--- a/extensions/kafka-ui/CHANGELOG.md
+++ b/extensions/kafka-ui/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kafka UI
 
-## [Fix] - 2026-04-05
+## [Fix] - {PR_MERGE_DATE}
 
 - Fixed environment dropdown showing stale data when multiple environments are configured
 - Added cmd+e shortcut to Edit Environment action in Configuration Manager

--- a/extensions/kafka-ui/src/env-actions.tsx
+++ b/extensions/kafka-ui/src/env-actions.tsx
@@ -1,11 +1,11 @@
 import { Icon, List } from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
+import { usePromise } from "@raycast/utils";
 import { StoredEnvironment } from "./types";
 import { getEnvironments } from "./storage";
 import { resolveEnvColor } from "./colors";
 
 export function useEnvironments() {
-  return useCachedPromise(getEnvironments);
+  return usePromise(getEnvironments);
 }
 
 export function EnvDropdown({

--- a/extensions/kafka-ui/src/manage-environments.tsx
+++ b/extensions/kafka-ui/src/manage-environments.tsx
@@ -10,7 +10,7 @@ import {
   Toast,
   useNavigation,
 } from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
+import { usePromise } from "@raycast/utils";
 import { getEnvironments, addEnvironment, updateEnvironment, deleteEnvironment, generateId } from "./storage";
 import { ENV_COLOR_OPTIONS, EnvColorValue, StoredEnvironment } from "./types";
 import { resolveEnvColor, COLOR_ICON_MAP } from "./colors";
@@ -125,7 +125,7 @@ function EnvironmentForm({ environment, onSave }: { environment?: StoredEnvironm
 }
 
 export default function ManageEnvironments() {
-  const { data: environments = [], isLoading, revalidate } = useCachedPromise(getEnvironments);
+  const { data: environments = [], isLoading, revalidate } = usePromise(getEnvironments);
 
   async function handleDelete(env: StoredEnvironment) {
     const confirmed = await confirmAlert({
@@ -183,6 +183,7 @@ export default function ManageEnvironments() {
                     icon={Icon.Pencil}
                     title="Edit Environment"
                     target={<EnvironmentForm environment={env} onSave={revalidate} />}
+                    shortcut={{ modifiers: ["cmd"], key: "e" }}
                   />
                   <Action.Push
                     icon={Icon.Plus}


### PR DESCRIPTION
## Summary

- Replaced `useCachedPromise` with `usePromise` in `env-actions.tsx` and `manage-environments.tsx` to fix the environment dropdown only showing one environment (stale cached data) when multiple are configured via the Configuration Manager.
- Added `cmd+e` keyboard shortcut to the Edit Environment action in the Configuration Manager.

## Test plan

- [ ] Configure multiple Kafka UI environments via Configuration Manager
- [ ] Open Search Topics and verify all environments appear in the dropdown
- [ ] Open Search Consumer Groups and verify all environments appear in the dropdown
- [ ] In Configuration Manager, press cmd+e on a selected environment to confirm edit shortcut works