### PR TITLE
Update zotero extension

### DIFF
--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zotero Changelog
 
+## [Features] - {PR_MERGE_DATE}
+
+- Add "Open PDF in System Viewer" action to open the attachment with the system's default viewer
+
 ## [Features] - 2026-03-23
 
 - Add Pandoc Citation Key copy and paste actions

--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zotero Changelog
 
-## [Features] - {PR_MERGE_DATE}
+## [Features] - 2026-04-05
 
 - Add "Open PDF in System Viewer" action to open the attachment with the system's default viewer
 

--- a/extensions/zotero/src/common/View.tsx
+++ b/extensions/zotero/src/common/View.tsx
@@ -8,7 +8,10 @@ import {
   Clipboard,
   closeMainWindow,
   showHUD,
+  open,
 } from "@raycast/api";
+import { homedir } from "os";
+import { dirname, join } from "path";
 import { RefData, Preferences } from "./zoteroApi";
 import { useVisitedUrls } from "./useVisitedUrls";
 import {
@@ -61,6 +64,17 @@ const copyTitleShortcut: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key:
 const copyAuthorsShortcut: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "b" };
 const copyZoteroUrlShortcut: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "c" };
 const copyDoiShortcut: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "d" };
+
+function resolveAttachmentPath(item: RefData, zoteroPath: string): string | null {
+  if (!item.attachment?.path || !item.attachment?.key) return null;
+  const attachmentPath = item.attachment.path;
+  if (!attachmentPath.startsWith("storage:")) {
+    return attachmentPath;
+  }
+  const filename = attachmentPath.slice("storage:".length);
+  const expandedZoteroPath = zoteroPath.replace(/^~/, homedir());
+  return join(dirname(expandedZoteroPath), "storage", item.attachment.key, filename);
+}
 
 function getURL(item: RefData): string {
   return `${
@@ -247,6 +261,20 @@ export const View = ({
                         onOpen={onOpen}
                       />
                     )}
+                    {item.attachment &&
+                      item.attachment.key &&
+                      item.attachment.key !== `` &&
+                      resolveAttachmentPath(item, preferences.zotero_path) && (
+                        <Action
+                          icon={Icon.ArrowRightCircleFilled}
+                          title="Open PDF in System Viewer"
+                          onAction={async () => {
+                            const filePath = resolveAttachmentPath(item, preferences.zotero_path)!;
+                            await open(filePath);
+                            closeMainWindow();
+                          }}
+                        />
+                      )}
                     <Action.OpenInBrowser
                       icon={Icon.Link}
                       title="Open in Zotero"

--- a/extensions/zotero/src/common/View.tsx
+++ b/extensions/zotero/src/common/View.tsx
@@ -10,9 +10,8 @@ import {
   showHUD,
   open,
 } from "@raycast/api";
-import { homedir } from "os";
 import { dirname, join } from "path";
-import { RefData, Preferences } from "./zoteroApi";
+import { RefData, Preferences, resolveHome } from "./zoteroApi";
 import { useVisitedUrls } from "./useVisitedUrls";
 import {
   exportRef,
@@ -72,7 +71,7 @@ function resolveAttachmentPath(item: RefData, zoteroPath: string): string | null
     return attachmentPath;
   }
   const filename = attachmentPath.slice("storage:".length);
-  const expandedZoteroPath = zoteroPath.replace(/^~/, homedir());
+  const expandedZoteroPath = resolveHome(zoteroPath);
   return join(dirname(expandedZoteroPath), "storage", item.attachment.key, filename);
 }
 
@@ -244,82 +243,85 @@ export const View = ({
         <List.Section key={sectionIndex} title={sectionName} subtitle={`${queryResults[sectionIndex].length}`}>
           {queryResults[sectionIndex]
             .filter((item) => item.collection?.includes(collection) || collection == "All")
-            .map((item) => (
-              <List.Item
-                key={item.key}
-                id={`${item.id}`}
-                title={item.title + (urls.includes(item.url) ? " (visited)" : "")}
-                icon={getItemIcon(item)}
-                detail={<List.Item.Detail markdown={getItemDetail(item)} />}
-                actions={
-                  <ActionPanel>
-                    {item.attachment && item.attachment.key && item.attachment.key !== `` && (
-                      <Action.OpenInBrowser
-                        icon={Icon.ArrowRightCircleFilled}
-                        title="Open PDF"
-                        url={`zotero://open-pdf/library/items/${item.attachment.key}`}
-                        onOpen={onOpen}
-                      />
-                    )}
-                    {item.attachment &&
-                      item.attachment.key &&
-                      item.attachment.key !== `` &&
-                      resolveAttachmentPath(item, preferences.zotero_path) && (
+            .map((item) => {
+              const attachmentFilePath = resolveAttachmentPath(item, preferences.zotero_path);
+              return (
+                <List.Item
+                  key={item.key}
+                  id={`${item.id}`}
+                  title={item.title + (urls.includes(item.url) ? " (visited)" : "")}
+                  icon={getItemIcon(item)}
+                  detail={<List.Item.Detail markdown={getItemDetail(item)} />}
+                  actions={
+                    <ActionPanel>
+                      {item.attachment?.key && item.attachment.key !== `` && (
+                        <Action.OpenInBrowser
+                          icon={Icon.ArrowRightCircleFilled}
+                          title="Open PDF"
+                          url={`zotero://open-pdf/library/items/${item.attachment.key}`}
+                          onOpen={onOpen}
+                        />
+                      )}
+                      {item.attachment?.key && item.attachment.key !== `` && attachmentFilePath && (
                         <Action
                           icon={Icon.ArrowRightCircleFilled}
                           title="Open PDF in System Viewer"
                           onAction={async () => {
-                            const filePath = resolveAttachmentPath(item, preferences.zotero_path)!;
-                            await open(filePath);
-                            closeMainWindow();
+                            try {
+                              await open(attachmentFilePath);
+                              closeMainWindow();
+                            } catch {
+                              await showHUD("Failed to open attachment");
+                            }
                           }}
                         />
                       )}
-                    <Action.OpenInBrowser
-                      icon={Icon.Link}
-                      title="Open in Zotero"
-                      url={`zotero://select/items/${item.library ? item.library : 0}_${item.key}`}
-                      onOpen={onOpen}
-                    />
-                    {getURL(item) !== "" && (
                       <Action.OpenInBrowser
-                        title="Open Original Link"
-                        url={getURL(item)}
-                        shortcut={openExtLinkCommandShortcut}
+                        icon={Icon.Link}
+                        title="Open in Zotero"
+                        url={`zotero://select/items/${item.library ? item.library : 0}_${item.key}`}
                         onOpen={onOpen}
                       />
-                    )}
-
-                    {preferences.use_bibtex && item.citekey && (
-                      <Action.CopyToClipboard
-                        title="Copy Bibtex Citation Key"
-                        content={item.citekey}
-                        shortcut={copyRefCommandShortcut}
-                      />
-                    )}
-                    {preferences.use_bibtex && item.citekey && <RefCopyToClipboardAction selected={item.citekey} />}
-                    {preferences.use_bibtex && item.citekey && <BibCopyToClipboardAction selected={item.citekey} />}
-                    {preferences.use_bibtex && item.citekey && <PandocCopyAction selected={item.citekey} />}
-                    {preferences.use_bibtex && item.citekey && <RefPasteAction selected={item.citekey} />}
-                    {preferences.use_bibtex && item.citekey && <BibPasteAction selected={item.citekey} />}
-                    {preferences.use_bibtex && item.citekey && <PandocPasteAction selected={item.citekey} />}
-
-                    <ActionPanel.Section>
-                      {item.attachment && item.attachment.key && item.attachment.key !== `` && (
-                        <PDFURLCopyToClipboardAction
-                          itemURL={`zotero://open-pdf/library/items/${item.attachment.key}`}
+                      {getURL(item) !== "" && (
+                        <Action.OpenInBrowser
+                          title="Open Original Link"
+                          url={getURL(item)}
+                          shortcut={openExtLinkCommandShortcut}
+                          onOpen={onOpen}
                         />
                       )}
-                      {getURL(item) !== "" && <URLCopyToClipboardAction itemURL={getURL(item)} />}
-                      {getItemTitle(item) !== "" && <TitleCopyToClipboardAction itemTitle={getItemTitle(item)} />}
-                      {getItemAuthors(item) !== "" && <AuthorsCopyToClipboardAction authors={getItemAuthors(item)} />}
-                      {getItemZotUrl(item) && <ZoteroUrlCopyToClipboard zotUrl={getItemZotUrl(item)} />}
-                      {getItemDoi(item) !== "" && <DoiCopyToClipboardAction itemDoi={getItemDoi(item)} />}
-                    </ActionPanel.Section>
-                  </ActionPanel>
-                }
-              />
-            ))}
+
+                      {preferences.use_bibtex && item.citekey && (
+                        <Action.CopyToClipboard
+                          title="Copy Bibtex Citation Key"
+                          content={item.citekey}
+                          shortcut={copyRefCommandShortcut}
+                        />
+                      )}
+                      {preferences.use_bibtex && item.citekey && <RefCopyToClipboardAction selected={item.citekey} />}
+                      {preferences.use_bibtex && item.citekey && <BibCopyToClipboardAction selected={item.citekey} />}
+                      {preferences.use_bibtex && item.citekey && <PandocCopyAction selected={item.citekey} />}
+                      {preferences.use_bibtex && item.citekey && <RefPasteAction selected={item.citekey} />}
+                      {preferences.use_bibtex && item.citekey && <BibPasteAction selected={item.citekey} />}
+                      {preferences.use_bibtex && item.citekey && <PandocPasteAction selected={item.citekey} />}
+
+                      <ActionPanel.Section>
+                        {item.attachment && item.attachment.key && item.attachment.key !== `` && (
+                          <PDFURLCopyToClipboardAction
+                            itemURL={`zotero://open-pdf/library/items/${item.attachment.key}`}
+                          />
+                        )}
+                        {getURL(item) !== "" && <URLCopyToClipboardAction itemURL={getURL(item)} />}
+                        {getItemTitle(item) !== "" && <TitleCopyToClipboardAction itemTitle={getItemTitle(item)} />}
+                        {getItemAuthors(item) !== "" && <AuthorsCopyToClipboardAction authors={getItemAuthors(item)} />}
+                        {getItemZotUrl(item) && <ZoteroUrlCopyToClipboard zotUrl={getItemZotUrl(item)} />}
+                        {getItemDoi(item) !== "" && <DoiCopyToClipboardAction itemDoi={getItemDoi(item)} />}
+                      </ActionPanel.Section>
+                    </ActionPanel>
+                  }
+                />
+              );
+            })}
         </List.Section>
       ))}
     </List>


### PR DESCRIPTION
## Description
Add "Open PDF in System Viewer" action to open the attachment with the system's default viewer. Close #26817.
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1000" height="625" alt="zotero 2026-04-05 at 18 22 38" src="https://github.com/user-attachments/assets/2aab0b3d-5aef-4a48-a172-4fba69d9cfc9" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
