### PR TITLE
Watchkey: Add searchable key selection lists and Update Key command

### DIFF
--- a/extensions/watchkey/CHANGELOG.md
+++ b/extensions/watchkey/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Watchkey Changelog
 
+## [Selection Lists & Update Key] - {PR_MERGE_DATE}
+
+- Get Key and Delete Key now display a searchable list of saved keys instead of requiring manual text input
+- Added new Update Key command for updating existing secrets
+- Keys are enumerated from the macOS keychain automatically
+
 ## [Initial Release] - 2026-03-31
 
 - Set, get, delete, and import keychain secrets via Raycast

--- a/extensions/watchkey/CHANGELOG.md
+++ b/extensions/watchkey/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Watchkey Changelog
 
-## [Selection Lists & Update Key] - {PR_MERGE_DATE}
+## [Selection Lists & Update Key] - 2026-04-06
 
 - Get Key and Delete Key now display a searchable list of saved keys instead of requiring manual text input
 - Added new Update Key command for updating existing secrets

--- a/extensions/watchkey/package.json
+++ b/extensions/watchkey/package.json
@@ -36,6 +36,13 @@
       "mode": "view"
     },
     {
+      "name": "update-key",
+      "title": "Update Key",
+      "subtitle": "Watchkey",
+      "description": "Update an existing secret in the keychain",
+      "mode": "view"
+    },
+    {
       "name": "import-key",
       "title": "Import Key",
       "subtitle": "Watchkey",
@@ -55,7 +62,7 @@
     "prettier": "^3.5.3",
     "typescript": "^5.8.2"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "scripts": {
     "build": "ray build",
     "dev": "ray develop",

--- a/extensions/watchkey/src/delete-key.tsx
+++ b/extensions/watchkey/src/delete-key.tsx
@@ -1,10 +1,12 @@
 import { Action, ActionPanel, List, showToast, Toast, confirmAlert, Alert, Icon } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
 import { useInstallGuard } from "./install-guard";
+import { useUpdateCheck } from "./use-update-check";
 import { watchkeyDelete, watchkeyList } from "./watchkey";
 
 export default function DeleteKey() {
   const { installed, installView } = useInstallGuard();
+  useUpdateCheck();
   const { data: keys, isLoading, revalidate } = usePromise(watchkeyList, [], { execute: installed });
 
   if (!installed) return installView;
@@ -32,6 +34,7 @@ export default function DeleteKey() {
 
   return (
     <List isLoading={isLoading} searchBarPlaceholder="Search keys...">
+      <List.EmptyView title="No Keys Found" description="Use Set Key to store a secret first." />
       {keys?.map((key) => (
         <List.Item
           key={key}

--- a/extensions/watchkey/src/delete-key.tsx
+++ b/extensions/watchkey/src/delete-key.tsx
@@ -1,52 +1,54 @@
-import { Action, ActionPanel, Form, Icon, showToast, Toast, popToRoot, confirmAlert, Alert } from "@raycast/api";
-import { useForm, FormValidation } from "@raycast/utils";
+import { Action, ActionPanel, List, showToast, Toast, confirmAlert, Alert, Icon } from "@raycast/api";
+import { usePromise } from "@raycast/utils";
 import { useInstallGuard } from "./install-guard";
-import { watchkeyDelete } from "./watchkey";
-
-interface FormValues {
-  service: string;
-}
+import { watchkeyDelete, watchkeyList } from "./watchkey";
 
 export default function DeleteKey() {
   const { installed, installView } = useInstallGuard();
-
-  const { handleSubmit, itemProps } = useForm<FormValues>({
-    onSubmit: async (values) => {
-      const confirmed = await confirmAlert({
-        title: `Delete "${values.service}"?`,
-        message: "This cannot be undone.",
-        primaryAction: { title: "Delete", style: Alert.ActionStyle.Destructive },
-      });
-      if (!confirmed) return;
-
-      const toast = await showToast({ style: Toast.Style.Animated, title: "Deleting secret..." });
-      try {
-        await watchkeyDelete(values.service);
-        toast.style = Toast.Style.Success;
-        toast.title = `Deleted "${values.service}"`;
-        await popToRoot();
-      } catch (error) {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Failed to delete secret";
-        toast.message = error instanceof Error ? error.message : String(error);
-      }
-    },
-    validation: {
-      service: FormValidation.Required,
-    },
-  });
+  const { data: keys, isLoading, revalidate } = usePromise(watchkeyList, [], { execute: installed });
 
   if (!installed) return installView;
 
+  async function handleDelete(service: string) {
+    const confirmed = await confirmAlert({
+      title: `Delete "${service}"?`,
+      message: "This cannot be undone.",
+      primaryAction: { title: "Delete", style: Alert.ActionStyle.Destructive },
+    });
+    if (!confirmed) return;
+
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Deleting secret..." });
+    try {
+      await watchkeyDelete(service);
+      toast.style = Toast.Style.Success;
+      toast.title = `Deleted "${service}"`;
+      revalidate();
+    } catch (error) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Failed to delete secret";
+      toast.message = error instanceof Error ? error.message : String(error);
+    }
+  }
+
   return (
-    <Form
-      actions={
-        <ActionPanel>
-          <Action.SubmitForm title="Delete Secret" icon={Icon.Trash} onSubmit={handleSubmit} />
-        </ActionPanel>
-      }
-    >
-      <Form.TextField title="Key Name" placeholder="DOPPLER_TOKEN_DEV" {...itemProps.service} />
-    </Form>
+    <List isLoading={isLoading} searchBarPlaceholder="Search keys...">
+      {keys?.map((key) => (
+        <List.Item
+          key={key}
+          title={key}
+          icon={Icon.Key}
+          actions={
+            <ActionPanel>
+              <Action
+                title="Delete Secret"
+                icon={Icon.Trash}
+                style={Action.Style.Destructive}
+                onAction={() => handleDelete(key)}
+              />
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
   );
 }

--- a/extensions/watchkey/src/get-key.tsx
+++ b/extensions/watchkey/src/get-key.tsx
@@ -1,10 +1,12 @@
 import { Action, ActionPanel, List, showToast, Toast, Clipboard, popToRoot, Icon } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
 import { useInstallGuard } from "./install-guard";
+import { useUpdateCheck } from "./use-update-check";
 import { watchkeyGet, watchkeyList } from "./watchkey";
 
 export default function GetKey() {
   const { installed, installView } = useInstallGuard();
+  useUpdateCheck();
   const { data: keys, isLoading } = usePromise(watchkeyList, [], { execute: installed });
 
   if (!installed) return installView;
@@ -26,6 +28,7 @@ export default function GetKey() {
 
   return (
     <List isLoading={isLoading} searchBarPlaceholder="Search keys...">
+      <List.EmptyView title="No Keys Found" description="Use Set Key to store a secret first." />
       {keys?.map((key) => (
         <List.Item
           key={key}

--- a/extensions/watchkey/src/get-key.tsx
+++ b/extensions/watchkey/src/get-key.tsx
@@ -1,46 +1,43 @@
-import { Action, ActionPanel, Form, Icon, showToast, Toast, Clipboard, popToRoot } from "@raycast/api";
-import { useForm, FormValidation } from "@raycast/utils";
+import { Action, ActionPanel, List, showToast, Toast, Clipboard, popToRoot, Icon } from "@raycast/api";
+import { usePromise } from "@raycast/utils";
 import { useInstallGuard } from "./install-guard";
-import { watchkeyGet } from "./watchkey";
-
-interface FormValues {
-  service: string;
-}
+import { watchkeyGet, watchkeyList } from "./watchkey";
 
 export default function GetKey() {
   const { installed, installView } = useInstallGuard();
-
-  const { handleSubmit, itemProps } = useForm<FormValues>({
-    onSubmit: async (values) => {
-      const toast = await showToast({ style: Toast.Style.Animated, title: "Retrieving secret..." });
-      try {
-        const value = await watchkeyGet(values.service);
-        await Clipboard.copy(value);
-        toast.style = Toast.Style.Success;
-        toast.title = `Copied "${values.service}" to clipboard`;
-        await popToRoot();
-      } catch (error) {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Failed to retrieve secret";
-        toast.message = error instanceof Error ? error.message : String(error);
-      }
-    },
-    validation: {
-      service: FormValidation.Required,
-    },
-  });
+  const { data: keys, isLoading } = usePromise(watchkeyList, [], { execute: installed });
 
   if (!installed) return installView;
 
+  async function handleGet(service: string) {
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Retrieving secret..." });
+    try {
+      const value = await watchkeyGet(service);
+      await Clipboard.copy(value);
+      toast.style = Toast.Style.Success;
+      toast.title = `Copied "${service}" to clipboard`;
+      await popToRoot();
+    } catch (error) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Failed to retrieve secret";
+      toast.message = error instanceof Error ? error.message : String(error);
+    }
+  }
+
   return (
-    <Form
-      actions={
-        <ActionPanel>
-          <Action.SubmitForm title="Get Secret" icon={Icon.Key} onSubmit={handleSubmit} />
-        </ActionPanel>
-      }
-    >
-      <Form.TextField title="Key Name" placeholder="DOPPLER_TOKEN_DEV" {...itemProps.service} />
-    </Form>
+    <List isLoading={isLoading} searchBarPlaceholder="Search keys...">
+      {keys?.map((key) => (
+        <List.Item
+          key={key}
+          title={key}
+          icon={Icon.Key}
+          actions={
+            <ActionPanel>
+              <Action title="Get Secret" icon={Icon.Clipboard} onAction={() => handleGet(key)} />
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
   );
 }

--- a/extensions/watchkey/src/import-key.tsx
+++ b/extensions/watchkey/src/import-key.tsx
@@ -1,6 +1,7 @@
 import { Action, ActionPanel, Form, Icon, showToast, Toast, popToRoot } from "@raycast/api";
 import { useForm, FormValidation } from "@raycast/utils";
 import { useInstallGuard } from "./install-guard";
+import { useUpdateCheck } from "./use-update-check";
 import { watchkeyImport } from "./watchkey";
 
 interface FormValues {
@@ -9,6 +10,7 @@ interface FormValues {
 
 export default function ImportKey() {
   const { installed, installView } = useInstallGuard();
+  useUpdateCheck();
 
   const { handleSubmit, itemProps } = useForm<FormValues>({
     onSubmit: async (values) => {

--- a/extensions/watchkey/src/set-key.tsx
+++ b/extensions/watchkey/src/set-key.tsx
@@ -1,6 +1,7 @@
 import { Action, ActionPanel, Form, Icon, showToast, Toast, popToRoot } from "@raycast/api";
 import { useForm, FormValidation } from "@raycast/utils";
 import { useInstallGuard } from "./install-guard";
+import { useUpdateCheck } from "./use-update-check";
 import { watchkeySet } from "./watchkey";
 
 interface FormValues {
@@ -10,6 +11,7 @@ interface FormValues {
 
 export default function SetKey() {
   const { installed, installView } = useInstallGuard();
+  useUpdateCheck();
 
   const { handleSubmit, itemProps } = useForm<FormValues>({
     onSubmit: async (values) => {

--- a/extensions/watchkey/src/update-key.tsx
+++ b/extensions/watchkey/src/update-key.tsx
@@ -1,6 +1,7 @@
 import { Action, ActionPanel, Form, List, showToast, Toast, popToRoot, Icon } from "@raycast/api";
 import { useForm, usePromise, FormValidation } from "@raycast/utils";
 import { useInstallGuard } from "./install-guard";
+import { useUpdateCheck } from "./use-update-check";
 import { watchkeySet, watchkeyList } from "./watchkey";
 
 function UpdateForm({ service }: { service: string }) {
@@ -39,12 +40,14 @@ function UpdateForm({ service }: { service: string }) {
 
 export default function UpdateKey() {
   const { installed, installView } = useInstallGuard();
+  useUpdateCheck();
   const { data: keys, isLoading } = usePromise(watchkeyList, [], { execute: installed });
 
   if (!installed) return installView;
 
   return (
     <List isLoading={isLoading} searchBarPlaceholder="Search keys...">
+      <List.EmptyView title="No Keys Found" description="Use Set Key to store a secret first." />
       {keys?.map((key) => (
         <List.Item
           key={key}

--- a/extensions/watchkey/src/update-key.tsx
+++ b/extensions/watchkey/src/update-key.tsx
@@ -1,0 +1,62 @@
+import { Action, ActionPanel, Form, List, showToast, Toast, popToRoot, Icon } from "@raycast/api";
+import { useForm, usePromise, FormValidation } from "@raycast/utils";
+import { useInstallGuard } from "./install-guard";
+import { watchkeySet, watchkeyList } from "./watchkey";
+
+function UpdateForm({ service }: { service: string }) {
+  const { handleSubmit, itemProps } = useForm<{ value: string }>({
+    onSubmit: async (values) => {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Updating secret..." });
+      try {
+        await watchkeySet(service, values.value);
+        toast.style = Toast.Style.Success;
+        toast.title = `Updated "${service}"`;
+        await popToRoot();
+      } catch (error) {
+        toast.style = Toast.Style.Failure;
+        toast.title = "Failed to update secret";
+        toast.message = error instanceof Error ? error.message : String(error);
+      }
+    },
+    validation: {
+      value: FormValidation.Required,
+    },
+  });
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Update Secret" icon={Icon.Key} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.Description title="Key Name" text={service} />
+      <Form.PasswordField title="New Secret Value" placeholder="Enter new secret" {...itemProps.value} />
+    </Form>
+  );
+}
+
+export default function UpdateKey() {
+  const { installed, installView } = useInstallGuard();
+  const { data: keys, isLoading } = usePromise(watchkeyList, [], { execute: installed });
+
+  if (!installed) return installView;
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Search keys...">
+      {keys?.map((key) => (
+        <List.Item
+          key={key}
+          title={key}
+          icon={Icon.Key}
+          actions={
+            <ActionPanel>
+              <Action.Push title="Update Secret" icon={Icon.Pencil} target={<UpdateForm service={key} />} />
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
+  );
+}

--- a/extensions/watchkey/src/use-update-check.ts
+++ b/extensions/watchkey/src/use-update-check.ts
@@ -1,0 +1,25 @@
+import { showToast, Toast, open } from "@raycast/api";
+import { useEffect, useRef } from "react";
+import { checkForUpdate } from "./watchkey";
+
+export function useUpdateCheck() {
+  const checked = useRef(false);
+
+  useEffect(() => {
+    if (checked.current) return;
+    checked.current = true;
+
+    checkForUpdate().then(async (update) => {
+      if (!update) return;
+      await showToast({
+        style: Toast.Style.Failure,
+        title: `watchkey update available: v${update.latest}`,
+        message: update.installed !== "unknown" ? `Installed: v${update.installed}` : undefined,
+        primaryAction: {
+          title: "Open GitHub",
+          onAction: () => open("https://github.com/Etheirystech/watchkey/releases/latest"),
+        },
+      });
+    });
+  }, []);
+}

--- a/extensions/watchkey/src/watchkey.ts
+++ b/extensions/watchkey/src/watchkey.ts
@@ -55,6 +55,41 @@ export async function watchkeyDelete(service: string): Promise<void> {
   });
 }
 
+function execPromise(cmd: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, (error, stdout, stderr) => {
+      if (error) reject(new Error(stderr.trim() || error.message));
+      else resolve(stdout);
+    });
+  });
+}
+
+export async function watchkeyList(): Promise<string[]> {
+  const output = await execPromise("/usr/bin/security", ["dump-keychain"]);
+  const services: string[] = [];
+  const blocks = output.split("keychain:");
+
+  for (const block of blocks) {
+    const lines = block.split("\n");
+    let svce = "";
+    let isWatchkey = false;
+
+    for (const line of lines) {
+      const svceMatch = line.match(/"svce"<blob>="(.+?)"/);
+      if (svceMatch) svce = svceMatch[1];
+
+      const acctMatch = line.match(/"acct"<blob>="(.+?)"/);
+      if (acctMatch && acctMatch[1] === "watchkey") isWatchkey = true;
+    }
+
+    if (isWatchkey && svce) {
+      services.push(svce);
+    }
+  }
+
+  return [...new Set(services)].sort();
+}
+
 export async function watchkeyImport(service: string): Promise<void> {
   return new Promise((resolve, reject) => {
     execFile(WATCHKEY_PATH!, ["set", service, "--import"], (error, _stdout, stderr) => {

--- a/extensions/watchkey/src/watchkey.ts
+++ b/extensions/watchkey/src/watchkey.ts
@@ -64,7 +64,12 @@ function execPromise(cmd: string, args: string[]): Promise<string> {
   });
 }
 
-export async function watchkeyList(): Promise<string[]> {
+async function listViaCli(): Promise<string[]> {
+  const output = await execPromise(WATCHKEY_PATH!, ["list"]);
+  return output.trim().split("\n").filter(Boolean);
+}
+
+async function listViaKeychain(): Promise<string[]> {
   const output = await execPromise("/usr/bin/security", ["dump-keychain"]);
   const services: string[] = [];
   const blocks = output.split("keychain:");
@@ -88,6 +93,47 @@ export async function watchkeyList(): Promise<string[]> {
   }
 
   return [...new Set(services)].sort();
+}
+
+export async function watchkeyList(): Promise<string[]> {
+  try {
+    return await listViaCli();
+  } catch {
+    return await listViaKeychain();
+  }
+}
+
+const WATCHKEY_REPO = "Etheirystech/watchkey";
+
+async function getInstalledVersion(): Promise<string | null> {
+  try {
+    const output = await execPromise(WATCHKEY_PATH!, ["--version"]);
+    return output.trim();
+  } catch {
+    return null;
+  }
+}
+
+async function getLatestVersion(): Promise<string | null> {
+  try {
+    const output = await execPromise("/usr/bin/curl", [
+      "-s",
+      "-H",
+      "Accept: application/vnd.github+json",
+      `https://api.github.com/repos/${WATCHKEY_REPO}/releases/latest`,
+    ]);
+    const match = output.match(/"tag_name"\s*:\s*"v?([^"]+)"/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function checkForUpdate(): Promise<{ installed: string; latest: string } | null> {
+  const [installed, latest] = await Promise.all([getInstalledVersion(), getLatestVersion()]);
+  if (!latest) return null;
+  if (!installed || installed !== latest) return { installed: installed ?? "unknown", latest };
+  return null;
 }
 
 export async function watchkeyImport(service: string): Promise<void> {


### PR DESCRIPTION
## Summary

- **Get Key** and **Delete Key** commands now display a searchable list of saved keys instead of requiring manual text input
- Added new **Update Key** command for updating existing secrets (list → select → enter new value)
- Keys are enumerated from the macOS keychain by querying entries with account `watchkey`

Closes #26940

## Test plan

- [ ] Open Get Key — verify all stored watchkey secrets appear in a searchable list
- [ ] Select a key — verify Touch ID/Apple Watch auth triggers and secret is copied to clipboard
- [ ] Open Delete Key — verify keys appear in a searchable list
- [ ] Delete a key — verify confirmation dialog appears and list refreshes after deletion
- [ ] Open Update Key — verify keys appear in a searchable list
- [ ] Select a key — verify form shows key name (read-only) and password field for new value
- [ ] Submit new value — verify secret is updated successfully