### PR TITLE
Mailsy: Add browser inbox bridge page

### DIFF
--- a/extensions/mailsy/CHANGELOG.md
+++ b/extensions/mailsy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mailsy Changelog
 
+## [Changes] - {PR_MERGE_DATE}
+
+- Added browser inbox bridge page for the account action.
+
 ## [Changes] - 2026-03-19
 
 - Upgraded the extension to the latest Raycast API and tooling versions.

--- a/extensions/mailsy/src/components/Mail.tsx
+++ b/extensions/mailsy/src/components/Mail.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement } from "react";
 import { useCallback, useState } from "react";
-import { Action, ActionPanel, Color, Detail, Icon, Keyboard, List, open, popToRoot, showHUD } from "@raycast/api";
+import { Action, ActionPanel, Color, Detail, Icon, Keyboard, List, open, popToRoot } from "@raycast/api";
 import { useAccount } from "../hooks/useAccount";
-import { deleteAccount, deleteMail, getAccount, getMails, getMessageFilePath, writeBridgePage } from "../libs/api";
+import { deleteAccount, deleteBridgePage, deleteMail, getAccount, getMails, getMessageFilePath, writeBridgePage } from "../libs/api";
 import { handleAction, removeAccount, timeAgo } from "../libs/utils";
 import { Message } from "./Message";
 
@@ -112,7 +112,10 @@ export function Mail(): ReactElement {
                   shortcut={logoutShortcut}
                   onAction={() =>
                     handleAction(
-                      () => removeAccount(),
+                      async () => {
+                        await removeAccount();
+                        await deleteBridgePage();
+                      },
                       () => popToRoot(),
                       `Logging out...`,
                       `Logout successful`,
@@ -124,11 +127,19 @@ export function Mail(): ReactElement {
               <Action
                 title="Open in Browser"
                 icon={{ source: Icon.Globe, tintColor: Color.Blue }}
-                onAction={async () => {
-                  if (!account) return;
-                  const filePath = await writeBridgePage(account);
-                  await open(`file://${filePath}`);
-                }}
+                onAction={() =>
+                  handleAction(
+                    async () => {
+                      if (!account) return;
+                      const filePath = await writeBridgePage(account);
+                      await open(`file://${filePath}`);
+                    },
+                    () => {},
+                    `Opening inbox...`,
+                    `Inbox opened in browser`,
+                    `Could not open inbox in browser`,
+                  )
+                }
               />
             </ActionPanel>
           }

--- a/extensions/mailsy/src/components/Mail.tsx
+++ b/extensions/mailsy/src/components/Mail.tsx
@@ -2,7 +2,15 @@ import type { ReactElement } from "react";
 import { useCallback, useState } from "react";
 import { Action, ActionPanel, Color, Detail, Icon, Keyboard, List, open, popToRoot } from "@raycast/api";
 import { useAccount } from "../hooks/useAccount";
-import { deleteAccount, deleteBridgePage, deleteMail, getAccount, getMails, getMessageFilePath, writeBridgePage } from "../libs/api";
+import {
+  deleteAccount,
+  deleteBridgePage,
+  deleteMail,
+  getAccount,
+  getMails,
+  getMessageFilePath,
+  writeBridgePage,
+} from "../libs/api";
 import { handleAction, removeAccount, timeAgo } from "../libs/utils";
 import { Message } from "./Message";
 

--- a/extensions/mailsy/src/components/Mail.tsx
+++ b/extensions/mailsy/src/components/Mail.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement } from "react";
 import { useCallback, useState } from "react";
-import { Action, ActionPanel, Color, Detail, Icon, Keyboard, List, popToRoot, showHUD } from "@raycast/api";
+import { Action, ActionPanel, Color, Detail, Icon, Keyboard, List, open, popToRoot, showHUD } from "@raycast/api";
 import { useAccount } from "../hooks/useAccount";
-import { deleteAccount, deleteMail, getAccount, getMails, getMessageFilePath } from "../libs/api";
+import { deleteAccount, deleteMail, getAccount, getMails, getMessageFilePath, writeBridgePage } from "../libs/api";
 import { handleAction, removeAccount, timeAgo } from "../libs/utils";
 import { Message } from "./Message";
 
@@ -121,11 +121,14 @@ export function Mail(): ReactElement {
                   }
                 />
               </ActionPanel.Section>
-              <Action.OpenInBrowser
+              <Action
                 title="Open in Browser"
-                url="https://mail.tm/"
                 icon={{ source: Icon.Globe, tintColor: Color.Blue }}
-                onOpen={() => showHUD("Login to view your account")}
+                onAction={async () => {
+                  if (!account) return;
+                  const filePath = await writeBridgePage(account);
+                  await open(`file://${filePath}`);
+                }}
               />
             </ActionPanel>
           }

--- a/extensions/mailsy/src/libs/api.ts
+++ b/extensions/mailsy/src/libs/api.ts
@@ -106,6 +106,16 @@ export const getBridgePagePath = (): string => {
   return `${environment.assetsPath}/inbox.html`;
 };
 
+export const deleteBridgePage = async (): Promise<void> => {
+  try {
+    await fs.unlink(getBridgePagePath());
+  } catch (error) {
+    if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+};
+
 export const writeBridgePage = async (account: Account): Promise<string> => {
   const filePath = getBridgePagePath();
   const html = `<!DOCTYPE html>
@@ -174,7 +184,7 @@ el.innerHTML='<div class="msg-view">'
 +'<a class="back" onclick="loadInbox()">\\u2190 Back to Inbox</a>'
 +'<h2>'+esc(m.subject||'No Subject')+'</h2>'
 +'<div class="meta">From: '+esc((m.from&&m.from.name)||'')+' &lt;'+esc((m.from&&m.from.address)||'')+'&gt; \\u00b7 '+new Date(m.createdAt).toLocaleString()+'</div>'
-+(h?'<iframe sandbox="allow-same-origin" srcdoc="'+h.replace(/&/g,'&amp;').replace(/"/g,'&quot;')+'"></iframe>':'<p>'+esc(m.text||'No content')+'</p>')
++(h?'<iframe sandbox srcdoc="'+h.replace(/&/g,'&amp;').replace(/"/g,'&quot;')+'"></iframe>':'<p>'+esc(m.text||'No content')+'</p>')
 +'</div>';
 }).catch(function(e){el.innerHTML='<div class="err">'+esc(e.message)+'<br><a class="back" onclick="loadInbox()">\\u2190 Back</a></div>'})
 }
@@ -260,6 +270,7 @@ export const deleteAccount = async (): Promise<void> => {
 
   await deleteRemoteAccount(account.id, account.token);
   await LocalStorage.removeItem(ACCOUNT_STORAGE_KEY);
+  await deleteBridgePage();
 };
 
 export const getMails = async (): Promise<Message[]> => {

--- a/extensions/mailsy/src/libs/api.ts
+++ b/extensions/mailsy/src/libs/api.ts
@@ -102,6 +102,90 @@ export const getMessageFilePath = (messageId: string): string => {
   return `${environment.assetsPath}/${messageId}.html`;
 };
 
+export const getBridgePagePath = (): string => {
+  return `${environment.assetsPath}/inbox.html`;
+};
+
+export const writeBridgePage = async (account: Account): Promise<string> => {
+  const filePath = getBridgePagePath();
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Mailsy \u2013 ${account.email}</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#f5f5f7;color:#1d1d1f}
+.header{background:#fff;border-bottom:1px solid #e5e5e5;padding:16px 24px;display:flex;align-items:center;justify-content:space-between}
+.header h1{font-size:18px;font-weight:600}
+.header .email{color:#6e6e73;font-size:14px}
+.container{max-width:800px;margin:24px auto;padding:0 16px}
+.msg-list{background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.1)}
+.msg-item{padding:16px 20px;border-bottom:1px solid #f0f0f0;cursor:pointer;transition:background .15s}
+.msg-item:hover{background:#f5f5f7}
+.msg-item:last-child{border-bottom:none}
+.msg-from{font-weight:600;font-size:14px}
+.msg-subject{font-size:14px;margin-top:2px}
+.msg-date{font-size:12px;color:#6e6e73;margin-top:4px}
+.msg-intro{font-size:13px;color:#6e6e73;margin-top:4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.msg-view{background:#fff;border-radius:12px;box-shadow:0 1px 3px rgba(0,0,0,.1);padding:24px}
+.back{cursor:pointer;color:#007aff;font-size:14px;margin-bottom:16px;display:inline-block;text-decoration:none}
+.back:hover{text-decoration:underline}
+.msg-view h2{font-size:20px;margin-bottom:8px}
+.msg-view .meta{color:#6e6e73;font-size:13px;margin-bottom:16px}
+.msg-view iframe{width:100%;border:none;min-height:500px;border-radius:8px}
+.empty,.loading{text-align:center;padding:48px;color:#6e6e73}
+.err{text-align:center;padding:48px;color:#ff3b30}
+.btn{background:none;border:1px solid #e5e5e5;border-radius:8px;padding:6px 12px;cursor:pointer;font-size:13px;color:#007aff}
+.btn:hover{background:#f5f5f7}
+</style>
+</head>
+<body>
+<div class="header">
+<div><h1>Mailsy</h1><div class="email">${account.email}</div></div>
+<button class="btn" onclick="loadInbox()">Refresh</button>
+</div>
+<div class="container"><div id="c"><div class="loading">Loading\u2026</div></div></div>
+<script>
+var T='${account.token}',A='${BASE_URL}',H={Authorization:'Bearer '+T};
+function esc(s){var d=document.createElement('div');d.textContent=s;return d.innerHTML}
+function loadInbox(){
+var el=document.getElementById('c');
+el.innerHTML='<div class="loading">Loading\u2026</div>';
+fetch(A+'/messages',{headers:H}).then(function(r){if(!r.ok)throw new Error('Failed to load ('+r.status+')');return r.json()}).then(function(d){
+var m=d['hydra:member']||[];
+if(!m.length){el.innerHTML='<div class="empty">No messages yet</div>';return}
+el.innerHTML='<div class="msg-list">'+m.map(function(x){
+return '<div class="msg-item" onclick="viewMsg(\\''+x.id+'\\')">'
++'<div class="msg-from">'+esc(x.from&&(x.from.name||x.from.address)||'Unknown')+'</div>'
++'<div class="msg-subject">'+esc(x.subject||'No Subject')+'</div>'
++'<div class="msg-intro">'+esc(x.intro||'')+'</div>'
++'<div class="msg-date">'+new Date(x.createdAt).toLocaleString()+'</div></div>';
+}).join('')+'</div>';
+}).catch(function(e){el.innerHTML='<div class="err">'+esc(e.message)+'</div>'})
+}
+function viewMsg(id){
+var el=document.getElementById('c');
+el.innerHTML='<div class="loading">Loading\u2026</div>';
+fetch(A+'/messages/'+id,{headers:H}).then(function(r){if(!r.ok)throw new Error('Failed to load message');return r.json()}).then(function(m){
+var h=(m.html&&m.html[0])||'';
+el.innerHTML='<div class="msg-view">'
++'<a class="back" onclick="loadInbox()">\\u2190 Back to Inbox</a>'
++'<h2>'+esc(m.subject||'No Subject')+'</h2>'
++'<div class="meta">From: '+esc((m.from&&m.from.name)||'')+' &lt;'+esc((m.from&&m.from.address)||'')+'&gt; \\u00b7 '+new Date(m.createdAt).toLocaleString()+'</div>'
++(h?'<iframe sandbox="allow-same-origin" srcdoc="'+h.replace(/&/g,'&amp;').replace(/"/g,'&quot;')+'"></iframe>':'<p>'+esc(m.text||'No content')+'</p>')
++'</div>';
+}).catch(function(e){el.innerHTML='<div class="err">'+esc(e.message)+'<br><a class="back" onclick="loadInbox()">\\u2190 Back</a></div>'})
+}
+loadInbox();
+</script>
+</body>
+</html>`;
+  await fs.writeFile(filePath, html, "utf-8");
+  return filePath;
+};
+
 const writeMessageFile = async (message: Message): Promise<void> => {
   const content = message.html?.[0] ?? "No Content";
   await fs.writeFile(getMessageFilePath(message.id), content, "utf-8");


### PR DESCRIPTION
## Summary
- Replaces the "Open in Browser" action on the account item with a local HTML bridge page that provides a full browser-based inbox experience using the mail.tm API
- Adds `getBridgePagePath()` and `writeBridgePage()` functions to generate a self-contained HTML page with inline CSS/JS that fetches messages directly via the mail.tm API
- Users can now view their inbox, read individual messages, and navigate between messages entirely in the browser

## Changes
- `src/components/Mail.tsx` — Updated "Open in Browser" action to generate and open the bridge page instead of linking to mail.tm
- `src/libs/api.ts` — Added `getBridgePagePath()` and `writeBridgePage()` functions (~84 lines)