### PR TITLE
Watchkey: Add Windows support via Windows Hello

### DIFF
--- a/extensions/watchkey/CHANGELOG.md
+++ b/extensions/watchkey/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Watchkey Changelog
 
-## [Windows Support] - {PR_MERGE_DATE}
+## [Windows Support] - 2026-04-12
 
 - Added cross-platform Windows support via watchkey-win CLI with Windows Hello authentication
 - Platform-aware binary path resolution with fallback for sandboxed environments

--- a/extensions/watchkey/CHANGELOG.md
+++ b/extensions/watchkey/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Watchkey Changelog
 
+## [Windows Support] - {PR_MERGE_DATE}
+
+- Added cross-platform Windows support via watchkey-win CLI with Windows Hello authentication
+- Platform-aware binary path resolution with fallback for sandboxed environments
+- Import Key command shows "not available" message on Windows
+- Update check and install guard point to correct platform-specific GitHub repo
+
 ## [Selection Lists & Update Key] - 2026-04-06
 
 - Get Key and Delete Key now display a searchable list of saved keys instead of requiring manual text input

--- a/extensions/watchkey/package-lock.json
+++ b/extensions/watchkey/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "watchkey",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "watchkey",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.0",

--- a/extensions/watchkey/package.json
+++ b/extensions/watchkey/package.json
@@ -2,11 +2,12 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "watchkey",
   "title": "Watchkey",
-  "description": "Store and retrieve keychain secrets with Touch ID & Apple Watch",
+  "description": "Store and retrieve secrets with biometric authentication (Touch ID, Apple Watch, or Windows Hello)",
   "icon": "extension-icon.png",
   "author": "etheirystech",
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ],
   "categories": [
     "Developer Tools",
@@ -62,7 +63,7 @@
     "prettier": "^3.5.3",
     "typescript": "^5.8.2"
   },
-  "version": "1.1.0",
+  "version": "1.2.0",
   "scripts": {
     "build": "ray build",
     "dev": "ray develop",

--- a/extensions/watchkey/src/import-key.tsx
+++ b/extensions/watchkey/src/import-key.tsx
@@ -1,5 +1,6 @@
-import { Action, ActionPanel, Form, Icon, showToast, Toast, popToRoot } from "@raycast/api";
+import { Action, ActionPanel, Detail, Form, Icon, showToast, Toast, popToRoot } from "@raycast/api";
 import { useForm, FormValidation } from "@raycast/utils";
+import { platform } from "node:os";
 import { useInstallGuard } from "./install-guard";
 import { useUpdateCheck } from "./use-update-check";
 import { watchkeyImport } from "./watchkey";
@@ -11,6 +12,12 @@ interface FormValues {
 export default function ImportKey() {
   const { installed, installView } = useInstallGuard();
   useUpdateCheck();
+
+  if (platform() === "win32") {
+    return (
+      <Detail markdown="# Not Available\n\nImport Key is only available on macOS. It imports existing macOS Keychain items into watchkey." />
+    );
+  }
 
   const { handleSubmit, itemProps } = useForm<FormValues>({
     onSubmit: async (values) => {

--- a/extensions/watchkey/src/install-guard.tsx
+++ b/extensions/watchkey/src/install-guard.tsx
@@ -1,6 +1,16 @@
 import { Action, ActionPanel, Detail } from "@raycast/api";
 import { useState } from "react";
+import { platform } from "node:os";
 import { isWatchkeyInstalled } from "./watchkey";
+
+const IS_WINDOWS = platform() === "win32";
+const REPO_URL = IS_WINDOWS
+  ? "https://github.com/Etheirystech/watchkey-win"
+  : "https://github.com/Etheirystech/watchkey";
+const INSTALL_CMD = IS_WINDOWS
+  ? "git clone https://github.com/Etheirystech/watchkey-win.git && cd watchkey-win && cargo build --release"
+  : "git clone https://github.com/Etheirystech/watchkey.git && cd watchkey && sudo make install";
+const AUTH_METHOD = IS_WINDOWS ? "Windows Hello" : "Touch ID & Apple Watch";
 
 export function useInstallGuard() {
   const [installed, setInstalled] = useState(isWatchkeyInstalled());
@@ -9,17 +19,16 @@ export function useInstallGuard() {
     <Detail
       markdown={`# watchkey not found
 
-This extension requires [watchkey](https://github.com/Etheirystech/watchkey) to be installed.
+This extension requires [watchkey](${REPO_URL}) to be installed.
+
+It provides biometric authentication (${AUTH_METHOD}) for accessing secrets.
 
 Press **Enter** to open the GitHub repo and follow the installation instructions.
 `}
       actions={
         <ActionPanel>
-          <Action.OpenInBrowser title="Open GitHub Repo" url="https://github.com/Etheirystech/watchkey" />
-          <Action.CopyToClipboard
-            title="Copy Install Command"
-            content="git clone https://github.com/Etheirystech/watchkey.git && cd watchkey && sudo make install"
-          />
+          <Action.OpenInBrowser title="Open GitHub Repo" url={REPO_URL} />
+          <Action.CopyToClipboard title="Copy Install Command" content={INSTALL_CMD} />
           <Action title="Check Again" onAction={() => setInstalled(isWatchkeyInstalled())} />
         </ActionPanel>
       }

--- a/extensions/watchkey/src/use-update-check.ts
+++ b/extensions/watchkey/src/use-update-check.ts
@@ -1,6 +1,12 @@
 import { showToast, Toast, open } from "@raycast/api";
 import { useEffect, useRef } from "react";
+import { platform } from "node:os";
 import { checkForUpdate } from "./watchkey";
+
+const RELEASES_URL =
+  platform() === "win32"
+    ? "https://github.com/Etheirystech/watchkey-win/releases/latest"
+    : "https://github.com/Etheirystech/watchkey/releases/latest";
 
 export function useUpdateCheck() {
   const checked = useRef(false);
@@ -17,7 +23,7 @@ export function useUpdateCheck() {
         message: update.installed !== "unknown" ? `Installed: v${update.installed}` : undefined,
         primaryAction: {
           title: "Open GitHub",
-          onAction: () => open("https://github.com/Etheirystech/watchkey/releases/latest"),
+          onAction: () => open(RELEASES_URL),
         },
       });
     });

--- a/extensions/watchkey/src/watchkey.ts
+++ b/extensions/watchkey/src/watchkey.ts
@@ -1,8 +1,17 @@
 import { execFile, spawn } from "node:child_process";
 import { accessSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+
+const IS_WINDOWS = platform() === "win32";
 
 function resolveWatchkeyPath(): string | null {
-  for (const p of ["/usr/local/bin/watchkey", "/opt/homebrew/bin/watchkey"]) {
+  const localAppData = process.env.LOCALAPPDATA || (IS_WINDOWS ? join(homedir(), "AppData", "Local") : "");
+  const candidates = IS_WINDOWS
+    ? [join(localAppData, "watchkey", "watchkey.exe"), join(process.env.PROGRAMFILES || "", "watchkey", "watchkey.exe")]
+    : ["/usr/local/bin/watchkey", "/opt/homebrew/bin/watchkey"];
+
+  for (const p of candidates) {
     try {
       accessSync(p);
       return p;
@@ -99,16 +108,18 @@ export async function watchkeyList(): Promise<string[]> {
   try {
     return await listViaCli();
   } catch {
+    if (IS_WINDOWS) return [];
     return await listViaKeychain();
   }
 }
 
-const WATCHKEY_REPO = "Etheirystech/watchkey";
+const WATCHKEY_REPO = IS_WINDOWS ? "Etheirystech/watchkey-win" : "Etheirystech/watchkey";
 
 async function getInstalledVersion(): Promise<string | null> {
   try {
     const output = await execPromise(WATCHKEY_PATH!, ["--version"]);
-    return output.trim();
+    const match = output.trim().match(/[\d]+\.[\d]+\.[\d]+(?:[.\-\w]+)?/);
+    return match ? match[0] : output.trim();
   } catch {
     return null;
   }
@@ -116,7 +127,8 @@ async function getInstalledVersion(): Promise<string | null> {
 
 async function getLatestVersion(): Promise<string | null> {
   try {
-    const output = await execPromise("/usr/bin/curl", [
+    const curl = IS_WINDOWS ? "curl" : "/usr/bin/curl";
+    const output = await execPromise(curl, [
       "-s",
       "-H",
       "Accept: application/vnd.github+json",


### PR DESCRIPTION
## Summary

- Added cross-platform Windows support using [watchkey-win](https://github.com/Etheirystech/watchkey-win) CLI with Windows Hello biometric authentication
- Platform-aware binary path resolution (macOS: `/usr/local/bin`, `/opt/homebrew/bin`; Windows: `%LOCALAPPDATA%\watchkey`)
- Fallback to `os.homedir()` when `LOCALAPPDATA` env var is unavailable (Raycast sandboxed environment)
- Update checker and install guard point to the correct platform-specific GitHub repo
- Import Key command shows "not available" message on Windows (macOS Keychain only)
- Added `"windows"` to the `platforms` array

## Test plan

- [ ] On macOS: verify all commands still work as before (no regressions)
- [ ] On Windows: verify install guard detects watchkey-win at `%LOCALAPPDATA%\watchkey\watchkey.exe`
- [ ] On Windows: verify Get Key, Set Key, Delete Key, Update Key, and List commands work with Windows Hello
- [ ] On Windows: verify Import Key shows "Not Available" message
- [ ] On Windows: verify update check toast points to watchkey-win releases