### PR TITLE
Asana: Add Search Tasks command

### DIFF
--- a/extensions/asana/CHANGELOG.md
+++ b/extensions/asana/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Asana Changelog
 
+## [Enhancements] - 2026-04-05
+
+- Added new "Search Tasks" command to search across all tasks and projects in a workspace
+- Search results show projects and tasks in separate sections, sorted by last activity
+
 ## [Security Fix] - 2026-03-17
 
 - Bump lodash/lodash-es to fix prototype pollution vulnerability (CVE-2025-13465)

--- a/extensions/asana/package.json
+++ b/extensions/asana/package.json
@@ -43,6 +43,12 @@
       ]
     },
     {
+      "name": "search-tasks",
+      "title": "Search Tasks",
+      "description": "Search all tasks in your workspace.",
+      "mode": "view"
+    },
+    {
       "name": "my-tasks",
       "title": "My Tasks",
       "description": "List of your tasks.",

--- a/extensions/asana/src/api/projects.ts
+++ b/extensions/asana/src/api/projects.ts
@@ -36,7 +36,7 @@ export type SearchProject = {
   permalink_url: string;
   color: string | null;
   icon: string | null;
-  modified_at: string;
+  modified_at: string | null;
 };
 
 export async function searchProjects(workspace: string, query: string) {

--- a/extensions/asana/src/api/projects.ts
+++ b/extensions/asana/src/api/projects.ts
@@ -30,6 +30,27 @@ export async function getProjects(workspace: string) {
   return data.data;
 }
 
+export type SearchProject = {
+  gid: string;
+  name: string;
+  permalink_url: string;
+  color: string | null;
+  icon: string | null;
+  modified_at: string;
+};
+
+export async function searchProjects(workspace: string, query: string) {
+  const { data } = await request<{ data: SearchProject[] }>(`/workspaces/${workspace}/typeahead`, {
+    params: {
+      resource_type: "project",
+      query,
+      opt_fields: "gid,name,permalink_url,color,icon,modified_at",
+    },
+  });
+
+  return data.data;
+}
+
 export async function addProject(taskId: string, projectId: string) {
   const payload = { project: projectId };
   const { data } = await request<{ data: Task }>(`/tasks/${taskId}/addProject`, {

--- a/extensions/asana/src/api/tasks.ts
+++ b/extensions/asana/src/api/tasks.ts
@@ -60,16 +60,17 @@ export type Task = {
   completed: boolean;
   permalink_url: string;
   projects: Project[];
-  assignee_section: AssigneeSection;
+  assignee_section?: AssigneeSection;
   assignee: Assignee | null;
   custom_fields: CustomField[];
   memberships: Membership[];
   tags: Tag[];
   parent: Parent | null;
+  modified_at?: string;
 };
 
 const taskFields =
-  "id,name,due_on,due_at,start_on,completed,projects.name,projects.color,assignee_section.name,permalink_url,custom_fields,assignee.name,memberships.project.name,memberships.section.name,tags.name,parent.name";
+  "id,name,due_on,due_at,start_on,completed,projects.name,projects.color,assignee_section.name,permalink_url,custom_fields,assignee.name,memberships.project.name,memberships.section.name,tags.name,parent.name,modified_at";
 
 export async function getMyTasks(workspace: string, showCompletedTasks: boolean) {
   const {
@@ -179,6 +180,18 @@ export async function removeTaskParent(taskId: string) {
     method: "POST",
     data: { data: { parent: null } },
   });
+  return data.data;
+}
+
+export async function searchAllTasks(workspace: string, query: string) {
+  const { data } = await request<{ data: Task[] }>(`/workspaces/${workspace}/tasks/search`, {
+    params: {
+      text: query,
+      opt_fields: taskFields,
+      is_subtask: false,
+    },
+  });
+
   return data.data;
 }
 

--- a/extensions/asana/src/components/TaskListItem.tsx
+++ b/extensions/asana/src/components/TaskListItem.tsx
@@ -14,12 +14,15 @@ type TaskListItemProps = {
 
 export default function TaskListItem({ task, workspace, mutateList }: TaskListItemProps) {
   // Add section name and individual words from section name as keywords for better filtering
-  const sectionWords = task.assignee_section.name
-    .toLowerCase()
-    .split(/[\s[\]()\-_]+/)
-    .filter(Boolean);
+  const keywords: string[] = [];
 
-  const keywords = [task.assignee_section.name, ...sectionWords];
+  if (task.assignee_section?.name) {
+    const sectionWords = task.assignee_section.name
+      .toLowerCase()
+      .split(/[\s[\]()\-_]+/)
+      .filter(Boolean);
+    keywords.push(task.assignee_section.name, ...sectionWords);
+  }
 
   // Add project sections to keywords
   if (task.memberships && task.memberships.length > 0) {

--- a/extensions/asana/src/hooks/useSearchAllTasks.ts
+++ b/extensions/asana/src/hooks/useSearchAllTasks.ts
@@ -1,0 +1,12 @@
+import { useCachedPromise } from "@raycast/utils";
+import { searchAllTasks } from "../api/tasks";
+import { handleUseCachedPromiseError } from "../helpers/errors";
+
+export function useSearchAllTasks(workspace: string, query: string) {
+  return useCachedPromise((ws, q) => searchAllTasks(ws, q), [workspace, query], {
+    execute: !!workspace && query.length > 0,
+    onError(error) {
+      handleUseCachedPromiseError(error);
+    },
+  });
+}

--- a/extensions/asana/src/my-tasks.tsx
+++ b/extensions/asana/src/my-tasks.tsx
@@ -25,15 +25,17 @@ function MyTasks() {
   const sections = uniqBy(
     tasks?.map((task) => task.assignee_section),
     "gid",
-  ).filter(Boolean).map((section) => {
-    const tasks = tasksBySection[section!.gid];
+  )
+    .filter(Boolean)
+    .map((section) => {
+      const tasks = tasksBySection[section!.gid];
 
-    return {
-      ...section!,
-      subtitle: tasks.length === 1 ? "1 task" : `${tasks.length} tasks`,
-      tasks: sortBy(tasksBySection[section!.gid], "due_on", "due_at"),
-    };
-  });
+      return {
+        ...section!,
+        subtitle: tasks.length === 1 ? "1 task" : `${tasks.length} tasks`,
+        tasks: sortBy(tasksBySection[section!.gid], "due_on", "due_at"),
+      };
+    });
 
   return (
     <List

--- a/extensions/asana/src/my-tasks.tsx
+++ b/extensions/asana/src/my-tasks.tsx
@@ -25,13 +25,13 @@ function MyTasks() {
   const sections = uniqBy(
     tasks?.map((task) => task.assignee_section),
     "gid",
-  ).map((section) => {
-    const tasks = tasksBySection[section.gid];
+  ).filter(Boolean).map((section) => {
+    const tasks = tasksBySection[section!.gid];
 
     return {
-      ...section,
+      ...section!,
       subtitle: tasks.length === 1 ? "1 task" : `${tasks.length} tasks`,
-      tasks: sortBy(tasksBySection[section.gid], "due_on", "due_at"),
+      tasks: sortBy(tasksBySection[section!.gid], "due_on", "due_at"),
     };
   });
 

--- a/extensions/asana/src/search-tasks.tsx
+++ b/extensions/asana/src/search-tasks.tsx
@@ -74,11 +74,13 @@ function SearchTasks() {
             </List.Section>
           )}
 
-          <List.Section title="Tasks" subtitle={`${sortedTasks.length}`}>
-            {sortedTasks.map((task) => (
-              <TaskListItem key={task.gid} task={task} workspace={workspace} mutateList={mutateList} />
-            ))}
-          </List.Section>
+          {sortedTasks.length > 0 && (
+            <List.Section title="Tasks" subtitle={`${sortedTasks.length}`}>
+              {sortedTasks.map((task) => (
+                <TaskListItem key={task.gid} task={task} workspace={workspace} mutateList={mutateList} />
+              ))}
+            </List.Section>
+          )}
 
           {sortedProjects.length === 0 && sortedTasks.length === 0 && (
             <List.EmptyView

--- a/extensions/asana/src/search-tasks.tsx
+++ b/extensions/asana/src/search-tasks.tsx
@@ -1,0 +1,120 @@
+import { ActionPanel, Action, Icon, List, Color } from "@raycast/api";
+import { useState, useEffect, useMemo } from "react";
+import { useSearchAllTasks } from "./hooks/useSearchAllTasks";
+import { useWorkspaces } from "./hooks/useWorkspaces";
+import withAsanaAuth from "./components/withAsanaAuth";
+import TaskListItem from "./components/TaskListItem";
+import CreateTaskForm from "./components/CreateTaskForm";
+import { searchProjects, SearchProject } from "./api/projects";
+import { useCachedPromise } from "@raycast/utils";
+import { handleUseCachedPromiseError } from "./helpers/errors";
+import { asanaToRaycastColor } from "./helpers/colors";
+
+function useSearchProjects(workspace: string, query: string) {
+  return useCachedPromise((ws, q) => searchProjects(ws, q), [workspace, query], {
+    execute: !!workspace && query.length > 0,
+    onError(error) {
+      handleUseCachedPromiseError(error);
+    },
+  });
+}
+
+function SearchTasks() {
+  const [workspace, setWorkspace] = useState<string>("");
+  const [searchText, setSearchText] = useState("");
+
+  const { data: workspaces, isLoading: isLoadingWorkspaces } = useWorkspaces();
+  const { data: tasks, isLoading: isLoadingTasks, mutate: mutateList } = useSearchAllTasks(workspace, searchText);
+  const { data: projects, isLoading: isLoadingProjects } = useSearchProjects(workspace, searchText);
+
+  useEffect(() => {
+    if (workspaces?.length === 1) {
+      setWorkspace(workspaces[0].gid);
+    }
+  }, [workspaces]);
+
+  const sortedProjects = useMemo(() => {
+    if (!projects) return [];
+    return [...projects].sort((a, b) => (b.modified_at || "").localeCompare(a.modified_at || ""));
+  }, [projects]);
+
+  const sortedTasks = useMemo(() => {
+    if (!tasks) return [];
+    return [...tasks].sort((a, b) => (b.modified_at || "").localeCompare(a.modified_at || ""));
+  }, [tasks]);
+
+  return (
+    <List
+      searchBarPlaceholder="Search tasks and projects..."
+      isLoading={isLoadingWorkspaces || isLoadingTasks || isLoadingProjects}
+      filtering={false}
+      onSearchTextChange={setSearchText}
+      throttle
+      {...(workspaces && workspaces.length > 1
+        ? {
+            searchBarAccessory: (
+              <List.Dropdown tooltip="Change Workspace" onChange={setWorkspace} storeValue>
+                {workspaces?.map((ws) => (
+                  <List.Dropdown.Item key={ws.gid} value={ws.gid} title={ws.name} />
+                ))}
+              </List.Dropdown>
+            ),
+          }
+        : {})}
+    >
+      {searchText.length === 0 ? (
+        <List.EmptyView title="Search" description="Type to search tasks and projects in your workspace." />
+      ) : (
+        <>
+          {sortedProjects.length > 0 && (
+            <List.Section title="Projects" subtitle={`${sortedProjects.length}`}>
+              {sortedProjects.map((project) => (
+                <ProjectListItem key={project.gid} project={project} />
+              ))}
+            </List.Section>
+          )}
+
+          <List.Section title="Tasks" subtitle={`${sortedTasks.length}`}>
+            {sortedTasks.map((task) => (
+              <TaskListItem key={task.gid} task={task} workspace={workspace} mutateList={mutateList} />
+            ))}
+          </List.Section>
+
+          {sortedProjects.length === 0 && sortedTasks.length === 0 && (
+            <List.EmptyView
+              title="No results found"
+              description="No tasks or projects match your search."
+              actions={
+                <ActionPanel>
+                  <Action.Push
+                    title="Create Task"
+                    target={<CreateTaskForm workspace={workspace} fromEmptyView={true} />}
+                  />
+                </ActionPanel>
+              }
+            />
+          )}
+        </>
+      )}
+    </List>
+  );
+}
+
+function ProjectListItem({ project }: { project: SearchProject }) {
+  return (
+    <List.Item
+      icon={{
+        source: project.icon ? `asana-project-icon-${project.icon}-16.svg` : Icon.List,
+        tintColor: project.color ? asanaToRaycastColor(project.color) : Color.PrimaryText,
+      }}
+      title={project.name}
+      actions={
+        <ActionPanel>
+          <Action.OpenInBrowser title="Open in Asana" url={project.permalink_url} />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+export default withAsanaAuth(SearchTasks);


### PR DESCRIPTION
## Summary

- Adds a new **Search Tasks** command that searches across all tasks and projects in a workspace using the Asana search API (`/workspaces/{gid}/tasks/search`).
- Results are displayed in two sections: **Projects** on top, **Tasks** below, both sorted by last activity (most recent first).
- Projects open directly in Asana via browser. Tasks show the full detail view with all existing actions.
- Makes `assignee_section` optional on the `Task` type since the search endpoint does not return it.

## Motivation

The existing "My Tasks" command only shows tasks assigned to the current user. There was no way to search across all tasks in a workspace — a common need when looking for tasks assigned to others or unassigned work.

## Changes

- `src/search-tasks.tsx` — New command entry point
- `src/hooks/useSearchAllTasks.ts` — New hook wrapping the search API
- `src/api/tasks.ts` — Added `searchAllTasks()`, `modified_at` to Task type, made `assignee_section` optional
- `src/api/projects.ts` — Added `searchProjects()` for project typeahead with `modified_at`
- `src/components/TaskListItem.tsx` — Guard against missing `assignee_section`
- `package.json` — Registered new command

## Test plan

- [ ] Search by task name returns matching tasks
- [ ] Search results show projects in top section, tasks below
- [ ] Results are sorted by last activity (most recent first)
- [ ] Opening a project navigates to Asana in the browser
- [ ] Opening a task shows the detail view with all actions
- [ ] "My Tasks" command still works as before
- [ ] Workspace dropdown works with multiple workspaces
- [ ] Empty search shows placeholder text