### PR TITLE
fix(toggl-track): Fix negative duration in today's total

### DIFF
--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Toggl Track Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-04-13
 
 - Fix negative duration display in today's total when a running time entry is not first in the array
 

--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - Fix negative duration display in today's total when a running time entry is not first in the array
 
+## [Bug Fixes] - 2026-04-07
+
+- Fix infinite retry loop on HTTP 429: add exponential backoff (1s, 5s, 15s) with a 3-retry cap and surface a Raycast error toast after retries are exhausted
+- Add non-retryable error path for HTTP 402 quota-exhausted responses
+
+## [New Feature] - 2026-03-10
+
+- Add optional Script Triggers preferences to run local shell scripts when a timer starts, stops, or is fetched, enabling integration with tools like Sketchybar or Hammerspoon without independent API polling
+
 ## [Bug Fixes] - 2026-02-23
 
 - Reduced Menu Bar background refresh interval from 10 seconds to 3 minutes to prevent API rate limit exhaustion (240 calls/hour limit)

--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,13 +1,8 @@
 # Toggl Track Changelog
 
-## [Bug Fixes] - 2026-04-07
+## [Bug Fixes] - {PR_MERGE_DATE}
 
-- Fix infinite retry loop on HTTP 429: add exponential backoff (1s, 5s, 15s) with a 3-retry cap and surface a Raycast error toast after retries are exhausted
-- Add non-retryable error path for HTTP 402 quota-exhausted responses
-
-## [New Feature] - 2026-03-10
-
-- Add optional Script Triggers preferences to run local shell scripts when a timer starts, stops, or is fetched, enabling integration with tools like Sketchybar or Hammerspoon without independent API polling
+- Fix negative duration display in today's total when a running time entry is not first in the array
 
 ## [Bug Fixes] - 2026-02-23
 

--- a/extensions/toggl-track/src/helpers/formatSeconds.ts
+++ b/extensions/toggl-track/src/helpers/formatSeconds.ts
@@ -1,4 +1,5 @@
 export function formatSeconds(seconds: number) {
+  seconds = Math.max(0, seconds);
   const h = Math.floor(seconds / 3600);
   seconds %= 3600;
   const m = Math.floor(seconds / 60);

--- a/extensions/toggl-track/src/hooks/useTotalDurationToday.ts
+++ b/extensions/toggl-track/src/hooks/useTotalDurationToday.ts
@@ -6,8 +6,7 @@ import { TimeEntry } from "@/api";
 export function useTotalDurationToday(timeEntries: TimeEntry[], runningTimeEntry?: TimeEntry) {
   return useMemo(() => {
     let seconds = timeEntries
-      .slice(runningTimeEntry ? 1 : 0)
-      .filter((timeEntry) => dayjs(timeEntry.start).isSame(dayjs(), "day"))
+      .filter((timeEntry) => timeEntry.duration >= 0 && dayjs(timeEntry.start).isSame(dayjs(), "day"))
       .reduce((acc, timeEntry) => acc + timeEntry.duration, 0);
     if (runningTimeEntry) seconds += dayjs().diff(dayjs(runningTimeEntry.start), "second");
     return seconds;


### PR DESCRIPTION
## Summary
- Running time entries have negative `duration` values (Toggl API convention: `-1 * unix_start_time`). The previous code used `.slice(1)` to skip the running entry, assuming it was always at array index 0. When the `at`-based sort order placed it elsewhere, its large negative duration leaked into the sum, producing displays like `Today: -2465982:-20:-55`.
- Replaced position-based skipping with a `duration >= 0` filter — the API-guaranteed way to identify completed entries.
- Added `Math.max(0, seconds)` guard in `formatSeconds` as defense in depth.

## Test plan
- [ ] Start a timer → verify "Today: HH:MM:SS" shows correct positive duration
- [ ] Stop the timer → verify total updates correctly
- [ ] With multiple entries today → verify sum is accurate
- [ ] Menu bar and list view both display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)