### PR TITLE
feat(visual-studio-code-recent-projects): add Qoder IDE support

### DIFF
--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Visual Studio Code Changelog
 
+## [Update] - {PR_MERGE_DATE}
+
+- Added support for Qoder.
+
 ## [Update] - 2026-03-30
 
 - Added support for Lingma.

--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Visual Studio Code Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-04-07
 
 - Added support for Qoder.
 

--- a/extensions/visual-studio-code-recent-projects/package.json
+++ b/extensions/visual-studio-code-recent-projects/package.json
@@ -111,6 +111,10 @@
           "value": "Positron"
         },
         {
+          "title": "Qoder",
+          "value": "Qoder"
+        },
+        {
           "title": "Trae",
           "value": "Trae"
         },

--- a/extensions/visual-studio-code-recent-projects/src/lib/vscode.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/vscode.ts
@@ -96,6 +96,7 @@ function cliPaths(): Record<string, string> {
       Cursor: "/Applications/Cursor.app/Contents/Resources/app/bin/cursor", // it also has code, which is an alias
       Kiro: "/Applications/Kiro.app/Contents/Resources/app/bin/kiro",
       Positron: "/Applications/Positron.app/Contents/Resources/app/bin/code",
+      Qoder: "/Applications/Qoder.app/Contents/Resources/app/bin/code",
       Trae: "/Applications/Trae.app/Contents/Resources/app/bin/marscode",
       "Trae CN": "/Applications/Trae CN.app/Contents/Resources/app/bin/marscode",
       VSCodium: "/Applications/VSCodium.app/Contents/Resources/app/bin/codium",
@@ -229,6 +230,7 @@ const buildSchemes: Record<string, string> = {
   Kiro: "kiro",
   VSCodium: "vscode-oss",
   Positron: "positron",
+  Qoder: "qoder",
   Windsurf: "windsurf",
   Trae: "trae",
   "Trae CN": "trae-cn",

--- a/extensions/visual-studio-code-recent-projects/src/lib/vscode.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/vscode.ts
@@ -79,6 +79,7 @@ function cliPaths(): Record<string, string> {
       Kiro: path.join(programsFolder, "Kiro", "bin", "kiro.cmd"),
       Cursor: path.join(programsFolder, "cursor", "resources", "app", "bin", "cursor.cmd"),
       Positron: path.join(programsFolder, "Positron", "bin", "positron.cmd"),
+      Qoder: path.join(programsFolder, "Qoder", "bin", "code.cmd"),
       Trae: path.join(programsFolder, "Trae", "bin", "trae.cmd"),
       "Trae CN": path.join(programsFolder, "Trae CN", "bin", "trae-cn.cmd"),
       VSCodium: path.join(programsFolder, "VSCodium", "bin", "codium.cmd"),

--- a/extensions/visual-studio-code-recent-projects/src/utils/editor.ts
+++ b/extensions/visual-studio-code-recent-projects/src/utils/editor.ts
@@ -15,6 +15,7 @@ const bundleIdMap: Record<string, { macos: string; windows: { name: string; exe:
   Cursor: { macos: "com.todesktop.230313mzl4w4u92", windows: { name: "Cursor", exe: "Cursor.exe" } },
   Kiro: { macos: "dev.kiro.desktop", windows: { name: "Kiro", exe: "Kiro.exe" } },
   Positron: { macos: "com.rstudio.positron", windows: { name: "Positron", exe: "Positron.exe" } },
+  Qoder: { macos: "com.qoder.ide", windows: { name: "Qoder", exe: "Qoder.exe" } },
   Trae: { macos: "com.trae.app", windows: { name: "Trae", exe: "Trae.exe" } },
   "Trae CN": { macos: "cn.trae.app", windows: { name: "Trae CN", exe: "Trae - CN.exe" } },
   VSCodium: { macos: "com.vscodium", windows: { name: "VSCodium", exe: "VSCodium.exe" } },


### PR DESCRIPTION
## Description

Adds [Qoder](https://qoder.com/) as a supported IDE in the `visual-studio-code-recent-projects` extension.

- **`package.json`**: Add `Qoder` to the build preference dropdown (alphabetically between Positron and Trae)
- **`src/lib/vscode.ts`**: Add macOS CLI path (`/Applications/Qoder.app/Contents/Resources/app/bin/code`) and `qoder://` URL scheme in `buildSchemes`
- **`src/utils/editor.ts`**: Add bundle ID mapping — `com.qoder.ide` (macOS) / `Qoder.exe` (Windows)

## Screencast

N/A — straightforward parity change matching the pattern of other supported IDEs.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)