### PR TITLE
Dia: Add broken URL detection and fix

### DIFF
--- a/extensions/dia/CHANGELOG.md
+++ b/extensions/dia/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dia Changelog
 
-## [Broken URL detection and fix] - 2026-04-07
+## [Broken URL detection and fix] - {PR_MERGE_DATE}
 
 - **Fix Broken URL**: New no-view command that detects broken URLs in clipboard (split across lines from terminals, emails, or narrow viewports), joins them, and copies the clean URL back
 - **Broken URL detection in Search**: Pasting a multi-line broken URL shows a "Fixed URL" section with the repaired link ready to open in Dia or copy

--- a/extensions/dia/CHANGELOG.md
+++ b/extensions/dia/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Dia Changelog
 
+## [Broken URL detection and fix] - 2026-04-07
+
+- **Fix Broken URL**: New no-view command that detects broken URLs in clipboard (split across lines from terminals, emails, or narrow viewports), joins them, and copies the clean URL back
+- **Broken URL detection in Search**: Pasting a multi-line broken URL shows a "Fixed URL" section with the repaired link ready to open in Dia or copy
+
 ## [Fixed SQL query escaping] - 2026-03-27
 
 - Fixed single quote escaping in SQL queries to use proper SQL string literals instead of double quotes

--- a/extensions/dia/package.json
+++ b/extensions/dia/package.json
@@ -107,6 +107,13 @@
           "required": false
         }
       ]
+    },
+    {
+      "name": "fix-url",
+      "title": "Fix Broken URL",
+      "subtitle": "Dia",
+      "description": "Detect and fix a broken URL in your clipboard (split across lines) and copy the clean version.",
+      "mode": "no-view"
     }
   ],
   "dependencies": {

--- a/extensions/dia/src/components/FixedURLListItem.tsx
+++ b/extensions/dia/src/components/FixedURLListItem.tsx
@@ -1,0 +1,34 @@
+import { Action, ActionPanel, closeMainWindow, Icon, Keyboard, List } from "@raycast/api";
+import { getFavicon } from "@raycast/utils";
+import { getSubtitle } from "../utils";
+
+const DIA_BUNDLE_ID = "company.thebrowser.dia";
+
+interface FixedURLListItemProps {
+  fixedUrl: string;
+}
+
+export function FixedURLListItem({ fixedUrl }: FixedURLListItemProps) {
+  return (
+    <List.Item
+      icon={getFavicon(fixedUrl)}
+      title="Open fixed URL"
+      subtitle={getSubtitle(fixedUrl)}
+      accessories={[{ icon: Icon.Wand, tooltip: "URL was broken across lines" }]}
+      actions={
+        <ActionPanel>
+          <Action.Open
+            icon={Icon.Globe}
+            title="Open in Dia"
+            target={fixedUrl}
+            application={DIA_BUNDLE_ID}
+            onOpen={async () => {
+              await closeMainWindow();
+            }}
+          />
+          <Action.CopyToClipboard content={fixedUrl} title="Copy Fixed URL" shortcut={Keyboard.Shortcut.Common.Copy} />
+        </ActionPanel>
+      }
+    />
+  );
+}

--- a/extensions/dia/src/fix-url.ts
+++ b/extensions/dia/src/fix-url.ts
@@ -1,31 +1,11 @@
 import { Clipboard, closeMainWindow, showHUD, showToast, Toast } from "@raycast/api";
-
-/**
- * Detects if text contains a URL that was broken across multiple lines
- * (e.g., copied from a terminal, email, or narrow viewport).
- */
-function containsBrokenURL(text: string): boolean {
-  if (!text.includes("\n") && !text.includes("\r")) return false;
-  const joined = text.replace(/[\r\n]+\s*/g, "");
-  return /^https?:\/\/\S+/.test(joined) || /^[\w-]+:\/\/\S+/.test(joined);
-}
-
-/**
- * Joins a broken URL: strips line breaks, trailing/leading whitespace per line,
- * and any spaces introduced by word-wrap.
- */
-function joinBrokenURL(text: string): string {
-  return text
-    .split(/[\r\n]+/)
-    .map((line) => line.trim())
-    .join("");
-}
+import { fixBrokenURL } from "./utils";
 
 export default async function Command() {
   try {
     const clipboard = await Clipboard.readText();
 
-    if (!clipboard || !clipboard.trim()) {
+    if (!clipboard?.trim()) {
       await showToast({
         style: Toast.Style.Failure,
         title: "Clipboard is empty",
@@ -34,18 +14,9 @@ export default async function Command() {
       return;
     }
 
-    const raw = clipboard.trim();
+    const fixed = fixBrokenURL(clipboard.trim());
 
-    if (!containsBrokenURL(raw)) {
-      // Maybe it's a single-line URL with stray spaces
-      const cleaned = raw.replace(/\s+/g, "");
-      if (/^https?:\/\/\S+/.test(cleaned) && cleaned !== raw) {
-        await Clipboard.copy(cleaned);
-        await closeMainWindow();
-        await showHUD("URL cleaned and copied");
-        return;
-      }
-
+    if (!fixed) {
       await showToast({
         style: Toast.Style.Failure,
         title: "No broken URL detected",
@@ -54,7 +25,6 @@ export default async function Command() {
       return;
     }
 
-    const fixed = joinBrokenURL(raw);
     await Clipboard.copy(fixed);
     await closeMainWindow();
     await showHUD("URL fixed and copied");

--- a/extensions/dia/src/fix-url.ts
+++ b/extensions/dia/src/fix-url.ts
@@ -1,0 +1,64 @@
+import { Clipboard, closeMainWindow, showHUD, showToast, Toast } from "@raycast/api";
+
+/**
+ * Detects if text contains a URL that was broken across multiple lines
+ * (e.g., copied from a terminal, email, or narrow viewport).
+ */
+function containsBrokenURL(text: string): boolean {
+  if (!text.includes("\n") && !text.includes("\r")) return false;
+  const joined = text.replace(/[\r\n]+\s*/g, "");
+  return /^https?:\/\/\S+/.test(joined) || /^[\w-]+:\/\/\S+/.test(joined);
+}
+
+/**
+ * Joins a broken URL: strips line breaks, trailing/leading whitespace per line,
+ * and any spaces introduced by word-wrap.
+ */
+function joinBrokenURL(text: string): string {
+  return text
+    .split(/[\r\n]+/)
+    .map((line) => line.trim())
+    .join("");
+}
+
+export default async function Command() {
+  try {
+    const clipboard = await Clipboard.readText();
+
+    if (!clipboard || !clipboard.trim()) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Clipboard is empty",
+        message: "Copy a broken URL first",
+      });
+      return;
+    }
+
+    const raw = clipboard.trim();
+
+    if (!containsBrokenURL(raw)) {
+      // Maybe it's a single-line URL with stray spaces
+      const cleaned = raw.replace(/\s+/g, "");
+      if (/^https?:\/\/\S+/.test(cleaned) && cleaned !== raw) {
+        await Clipboard.copy(cleaned);
+        await closeMainWindow();
+        await showHUD("URL cleaned and copied");
+        return;
+      }
+
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "No broken URL detected",
+        message: "Clipboard doesn't contain a split URL",
+      });
+      return;
+    }
+
+    const fixed = joinBrokenURL(raw);
+    await Clipboard.copy(fixed);
+    await closeMainWindow();
+    await showHUD("URL fixed and copied");
+  } catch {
+    await showToast({ style: Toast.Style.Failure, title: "Failed to fix URL" });
+  }
+}

--- a/extensions/dia/src/search.tsx
+++ b/extensions/dia/src/search.tsx
@@ -6,10 +6,11 @@ import { HistoryListItem } from "./components/HistoryListItem";
 import { SuggestionListItem } from "./components/SuggestionListItem";
 import { TabListItem } from "./components/TabListItem";
 import { URLListItem } from "./components/URLListItem";
+import { FixedURLListItem } from "./components/FixedURLListItem";
 import withVersionCheck from "./components/VersionCheck";
 import { useSearchHistory, useTabs, useBookmarks } from "./dia";
 import { useGoogleSuggestions } from "./google";
-import { filterHistory, filterTabs, isLikelyURL } from "./utils";
+import { filterHistory, filterTabs, fixBrokenURL, isLikelyURL } from "./utils";
 
 type ViewMode = "all" | "pinned-tabs" | "open-tabs" | "bookmarks" | "history" | "suggestions";
 
@@ -48,6 +49,7 @@ function Command() {
 
   const shouldShow = (section: ViewMode) => viewMode === "all" || viewMode === section;
   const detectedURL = searchText && isLikelyURL(searchText) ? searchText.trim() : null;
+  const brokenURLFixed = !detectedURL && searchText ? fixBrokenURL(searchText) : null;
 
   return (
     <List
@@ -74,6 +76,12 @@ function Command() {
         </List.Dropdown>
       }
     >
+      {brokenURLFixed && (
+        <List.Section title="Fixed URL">
+          <FixedURLListItem fixedUrl={brokenURLFixed} />
+        </List.Section>
+      )}
+
       {detectedURL && (
         <List.Section title="Open URL">
           <URLListItem url={detectedURL} searchText={searchText} />

--- a/extensions/dia/src/utils.ts
+++ b/extensions/dia/src/utils.ts
@@ -60,6 +60,23 @@ export function isLikelyURL(str: string): boolean {
   return /^[\w-]+(\.[\w-]+)+/.test(trimmed);
 }
 
+/**
+ * Detects if text contains a URL broken across multiple lines
+ * (e.g., copied from a terminal, email, or narrow viewport).
+ * Returns the fixed URL if broken, or null if not.
+ */
+export function fixBrokenURL(text: string): string | null {
+  if (!text.includes("\n") && !text.includes("\r")) return null;
+  const joined = text
+    .split(/[\r\n]+/)
+    .map((line) => line.trim())
+    .join("");
+  if (/^https?:\/\/\S+$/.test(joined) || /^[\w-]+:\/\/\S+$/.test(joined)) {
+    return joined;
+  }
+  return null;
+}
+
 export function filterTabs(tabs: Tab[] | undefined, query: string) {
   if (!query || !tabs) return tabs;
 


### PR DESCRIPTION
## Summary

URLs copied from terminals, emails, or narrow viewports often get split across multiple lines, making them impossible to open directly. This PR adds automatic detection and repair:

- **Fix Broken URL** standalone command: reads the clipboard, joins broken lines into a clean URL, and copies it back. Works silently with a HUD confirmation.
- **Inline detection in Search Dia**: when a multi-line URL is pasted into the search bar, a "Fixed URL" section appears at the top with the repaired link ready to open in Dia or copy.

The detection logic (`fixBrokenURL` in `utils.ts`) checks if joining lines produces a valid URL pattern, so it only triggers when there's actually a broken URL to fix.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Plan

- Copy a long URL, paste it into a text editor, add line breaks in the middle, copy that broken version
- Open Search Dia and paste it: "Fixed URL" section should appear with the correct URL and a wand icon
- Run "Fix Broken URL" command: clipboard should now contain the clean URL, confirmed by HUD
- Paste a normal search query: no "Fixed URL" section should appear
- Paste a single-line URL: only "Open URL" section should appear, not "Fixed URL"