### PR TITLE
Calendly event duration

### DIFF
--- a/extensions/calendly/CHANGELOG.md
+++ b/extensions/calendly/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Calendly Changelog
 
+## [Added event duration] - {PR_MERGE_DATE}
+
+- Display event duration as a right-aligned accessory on each event type
+
 ## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`

--- a/extensions/calendly/CHANGELOG.md
+++ b/extensions/calendly/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Calendly Changelog
 
-## [Added event duration] - {PR_MERGE_DATE}
+## [Added event duration] - 2026-04-12
 
 - Display event duration as a right-aligned accessory on each event type
 

--- a/extensions/calendly/package.json
+++ b/extensions/calendly/package.json
@@ -5,6 +5,7 @@
   "description": "Quickly share your Calendly meeting links",
   "icon": "logo.png",
   "author": "eluce2",
+  "contributors": ["eric_dumesnil"],
   "license": "MIT",
   "commands": [
     {

--- a/extensions/calendly/src/calendly.tsx
+++ b/extensions/calendly/src/calendly.tsx
@@ -84,6 +84,7 @@ export default function Calendly() {
             key={event.uri}
             icon={{ source: Icon.Circle, tintColor: event.color }}
             subtitle={event.slug ? `/${event.slug}` : ""}
+            accessories={[{ text: `${event.duration} min` }]}
             actions={
               <ActionPanel title="Calendly">
                 {defaultAction === "meeting" ? (


### PR DESCRIPTION
Display duration as a right-aligned text accessory on each event item.

## Description

Add event duration to the Calendly extension list view. When you have multiple event types with similar names but different durations (e.g. "Meeting" at 30 min vs 60 min), there is no way to distinguish them. Duration now appears as a right-aligned text accessory on each event type row.

  ## Screencast

<img width="1756" height="1204" alt="image" src="https://github.com/user-attachments/assets/fbb57f30-94f3-4262-946b-d3c920e56713" />


  ## Checklist

  - [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
  - [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
  - [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
  - [x] I checked that files in the `assets` folder are used by the extension itself
  - [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)