### PR TITLE
[Home Assistant] Add custom HTTP headers support

### DIFF
--- a/extensions/homeassistant/CHANGELOG.md
+++ b/extensions/homeassistant/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Home Assistant Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-04-20
 
 - Add custom headers on all request
 

--- a/extensions/homeassistant/CHANGELOG.md
+++ b/extensions/homeassistant/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Home Assistant Changelog
 
+## [Update] - {PR_MERGE_DATE}
+
+- Add custom headers on all request
+
 ## [Update] - 2026-03-24
 
 - Show entity area/room names as subtitles in entity lists

--- a/extensions/homeassistant/package.json
+++ b/extensions/homeassistant/package.json
@@ -11,8 +11,7 @@
     "xilopaint",
     "krsntn",
     "mikikiv",
-    "techmaved",
-    "m4t1eu"
+    "techmaved"
   ],
   "license": "MIT",
   "description": "Manage your smart home with Raycast",

--- a/extensions/homeassistant/package.json
+++ b/extensions/homeassistant/package.json
@@ -11,7 +11,8 @@
     "xilopaint",
     "krsntn",
     "mikikiv",
-    "techmaved"
+    "techmaved",
+    "m4t1eu"
   ],
   "license": "MIT",
   "description": "Manage your smart home with Raycast",

--- a/extensions/homeassistant/package.json
+++ b/extensions/homeassistant/package.json
@@ -638,6 +638,14 @@
       "placeholder": "Ignore Certificates"
     },
     {
+      "name": "customHeaders",
+      "type": "textfield",
+      "required": false,
+      "title": "Custom HTTP Headers",
+      "description": "Additional HTTP headers sent with every request and WebSocket connection (format: Header1:Value1,Header2:Value2)",
+      "placeholder": "CF-Access-Client-Id:xxx,CF-Access-Client-Secret:yyy"
+    },
+    {
       "name": "showEntityId",
       "type": "checkbox",
       "label": "Show Entity IDs",

--- a/extensions/homeassistant/package.json
+++ b/extensions/homeassistant/package.json
@@ -639,11 +639,11 @@
     },
     {
       "name": "customHeaders",
-      "type": "textfield",
+      "type": "password",
       "required": false,
       "title": "Custom HTTP Headers",
-      "description": "Additional HTTP headers sent with every request and WebSocket connection (format: Header1:Value1,Header2:Value2)",
-      "placeholder": "CF-Access-Client-Id:xxx,CF-Access-Client-Secret:yyy"
+      "description": "Additional HTTP headers sent with every request and WebSocket connection (format: Header1:Value1;Header2:Value2)",
+      "placeholder": "CF-Access-Client-Id:xxx;CF-Access-Client-Secret:yyy"
     },
     {
       "name": "showEntityId",

--- a/extensions/homeassistant/src/lib/common.ts
+++ b/extensions/homeassistant/src/lib/common.ts
@@ -62,7 +62,10 @@ export async function getHAWSConnection(): Promise<Connection> {
     const instance = await ha.nearestURL();
     console.log(`Nearest Instance URL ${instance}`);
     const auth = createLongLivedTokenAuth(instance, ha.token);
-    con = await createConnection({ auth, createSocket: async () => createSocket(auth, ha.ignoreCerts, ha.customHeaders) });
+    con = await createConnection({
+      auth,
+      createSocket: async () => createSocket(auth, ha.ignoreCerts, ha.customHeaders),
+    });
     return con;
   }
 }

--- a/extensions/homeassistant/src/lib/common.ts
+++ b/extensions/homeassistant/src/lib/common.ts
@@ -11,6 +11,25 @@ function ensureNoTrailingSlash(url: string | undefined): string | undefined {
   return url;
 }
 
+function parseCustomHeaders(raw: string | undefined): Record<string, string> | undefined {
+  if (!raw || raw.trim().length === 0) {
+    return undefined;
+  }
+  const result: Record<string, string> = {};
+  for (const entry of raw.split(",")) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    const colonIndex = trimmed.indexOf(":");
+    if (colonIndex <= 0) continue;
+    const key = trimmed.substring(0, colonIndex).trim();
+    const value = trimmed.substring(colonIndex + 1).trim();
+    if (key) {
+      result[key] = value;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
 function createHomeAssistantClient(): HomeAssistant {
   const preferences = getPreferenceValues();
   const instance = ensureNoTrailingSlash((preferences.instance as string) || undefined) || "";
@@ -20,11 +39,13 @@ function createHomeAssistantClient(): HomeAssistant {
   const wifiSSIDs = ((preferences.homeSSIDs as string) || "").split(",").map((v) => v.trim());
   const usePing = preferences.usePing as boolean;
   const preferredApp = preferences.preferredapp as string | undefined;
+  const customHeaders = parseCustomHeaders((preferences.customHeaders as string) || undefined);
   const hac = new HomeAssistant(instance, token, ignoreCerts, {
     urlInternal: instanceInternal,
     wifiSSIDs: wifiSSIDs,
     usePing: usePing,
     preferCompanionApp: preferredApp === "companion",
+    customHeaders: customHeaders,
   });
   return hac;
 }
@@ -41,7 +62,7 @@ export async function getHAWSConnection(): Promise<Connection> {
     const instance = await ha.nearestURL();
     console.log(`Nearest Instance URL ${instance}`);
     const auth = createLongLivedTokenAuth(instance, ha.token);
-    con = await createConnection({ auth, createSocket: async () => createSocket(auth, ha.ignoreCerts) });
+    con = await createConnection({ auth, createSocket: async () => createSocket(auth, ha.ignoreCerts, ha.customHeaders) });
     return con;
   }
 }

--- a/extensions/homeassistant/src/lib/common.ts
+++ b/extensions/homeassistant/src/lib/common.ts
@@ -16,7 +16,7 @@ function parseCustomHeaders(raw: string | undefined): Record<string, string> | u
     return undefined;
   }
   const result: Record<string, string> = {};
-  for (const entry of raw.split(",")) {
+  for (const entry of raw.split(";")) {
     const trimmed = entry.trim();
     if (!trimmed) continue;
     const colonIndex = trimmed.indexOf(":");

--- a/extensions/homeassistant/src/lib/haapi.ts
+++ b/extensions/homeassistant/src/lib/haapi.ts
@@ -42,6 +42,7 @@ export interface HomeAssistantOptions {
   wifiSSIDs?: string[];
   usePing?: boolean;
   preferCompanionApp?: boolean;
+  customHeaders?: Record<string, string>;
 }
 
 export class HomeAssistant {
@@ -54,6 +55,7 @@ export class HomeAssistant {
   private usePing = true;
   private messageSubscription?: object | null;
   public preferCompanionApp = false;
+  public customHeaders: Record<string, string> | undefined;
 
   constructor(url: string, token: string, ignoreCerts: boolean, options: HomeAssistantOptions | undefined = undefined) {
     this.token = token;
@@ -63,6 +65,7 @@ export class HomeAssistant {
     this.usePing = options?.usePing ?? true;
     this._ignoreCerts = ignoreCerts;
     this.preferCompanionApp = options?.preferCompanionApp === undefined ? false : options.preferCompanionApp;
+    this.customHeaders = options?.customHeaders;
   }
 
   private httpsAgent(url: string): Agent | undefined {
@@ -190,6 +193,7 @@ export class HomeAssistant {
         agent: this.httpsAgent(fullUrl),
         method: "GET",
         headers: {
+          ...this.customHeaders,
           "Content-Type": "application/json",
           Authorization: `Bearer ${this.token}`,
         },
@@ -212,6 +216,7 @@ export class HomeAssistant {
       agent: this.httpsAgent(fullUrl),
       method: "POST",
       headers: {
+        ...this.customHeaders,
         "Content-Type": "application/json",
         Authorization: `Bearer ${this.token}`,
       },
@@ -395,6 +400,7 @@ export class HomeAssistant {
     const response = await fetch(fullUrl, {
       method: "GET",
       headers: {
+        ...this.customHeaders,
         "Content-Type": "application/json",
         Authorization: `Bearer ${this.token}`,
       },

--- a/extensions/homeassistant/src/lib/socket.ts
+++ b/extensions/homeassistant/src/lib/socket.ts
@@ -14,7 +14,11 @@ const MSG_TYPE_AUTH_REQUIRED = "auth_required";
 const MSG_TYPE_AUTH_INVALID = "auth_invalid";
 const MSG_TYPE_AUTH_OK = "auth_ok";
 
-export function createSocket(auth: Auth, ignoreCertificates: boolean): Promise<any> {
+export function createSocket(
+  auth: Auth,
+  ignoreCertificates: boolean,
+  customHeaders?: Record<string, string>,
+): Promise<any> {
   // Convert from http:// -> ws://, https:// -> wss://
   const url = auth.wsUrl;
 
@@ -25,6 +29,7 @@ export function createSocket(auth: Auth, ignoreCertificates: boolean): Promise<a
 
     const socket = new WebSocket(url, {
       rejectUnauthorized: !ignoreCertificates,
+      headers: customHeaders,
     });
 
     // If invalid auth, we will not try to reconnect.


### PR DESCRIPTION
## Description

Adds support for custom HTTP headers on all requests (REST API and WebSocket).

This enables users behind reverse proxies with header-based authentication 
(Cloudflare Zero Trust, Authentik, Authelia, Traefik Forward Auth, etc.) 
to use the extension without disabling their auth layer.

A new optional preference `Custom HTTP Headers` accepts key-value pairs 
in the format `Header1:Value1,Header2:Value2`. These headers are injected 
into all HTTP fetch calls and the WebSocket handshake.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the README are placed outside of the `metadata` folder