### PR TITLE
Update single-disk-eject extension

### DIFF
--- a/extensions/single-disk-eject/CHANGELOG.md
+++ b/extensions/single-disk-eject/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Single Disk Eject Changelog
 
-## [Windows Ejection Rework] - {PR_MERGE_DATE}
+## [Windows Ejection Rework] - 2026-04-20
 
 - Replaced deprecated `wmic` command with PowerShell/CIM cmdlets that should work on all modern Windows versions
 - Overhauled the ejection logic to better align with native Windows hardware removal behavior

--- a/extensions/single-disk-eject/CHANGELOG.md
+++ b/extensions/single-disk-eject/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Single Disk Eject Changelog
 
+## [Windows Ejection Rework] - {PR_MERGE_DATE}
+
+- Replaced deprecated `wmic` command with PowerShell/CIM cmdlets that should work on all modern Windows versions
+- Overhauled the ejection logic to better align with native Windows hardware removal behavior
+- Improved compatibility across a wider range of removable devices, like SD cards and Docks
+
 ## [Dependency update] - 2026-03-08
 
 - Updated dependencies

--- a/extensions/single-disk-eject/assets/USBEjector.cs
+++ b/extensions/single-disk-eject/assets/USBEjector.cs
@@ -54,8 +54,23 @@ public class USBEjector {
         PNP_VETO_TYPE vetoType;
         StringBuilder vetoName = new StringBuilder(1024);
 
-        // 3. Request Eject on the Parent
-        result = CM_Request_Device_EjectW(targetDevInst, out vetoType, vetoName, 1024, 0);
+        // 3. Request Eject on the Disk Node directly (Media Eject)
+        // This flawlessly supports multi-LUN card readers and docks without killing sister drives.
+        result = CM_Request_Device_EjectW(diskDevInst, out vetoType, vetoName, 1024, 0);
+
+        if (result == CR_SUCCESS && vetoType == PNP_VETO_TYPE.Ok) {
+            return; // Excellent, the media was safely removed!
+        }
+
+        // 4. Fallback: Request Eject on the Parent
+        // If the leaf node specifically refuses (or is a mechanical external drive that prefers full power-down), 
+        // try safely removing the entire enclosing USB hardware.
+        if (targetDevInst != diskDevInst) {
+            result = CM_Request_Device_EjectW(targetDevInst, out vetoType, vetoName, 1024, 0);
+            if (result == CR_SUCCESS && vetoType == PNP_VETO_TYPE.Ok) {
+                return;
+            }
+        }
 
         if (result != CR_SUCCESS || vetoType != PNP_VETO_TYPE.Ok) {
             // Throw a descriptive error that Raycast can show to the user

--- a/extensions/single-disk-eject/assets/eject.ps1
+++ b/extensions/single-disk-eject/assets/eject.ps1
@@ -25,7 +25,18 @@ try {
         throw "Could not resolve physical device ID for $cleanDrive"
     }
 
-    # 3. Load C# and Eject
+    # 3. Release CIM object handles to the volume to avoid self-vetoing the eject
+    $logicalDisk = $null
+    $partition = $null
+    $diskDrive = $null
+    Remove-Variable logicalDisk, partition, diskDrive -ErrorAction SilentlyContinue
+    
+    # Force WMI/COM to release underlying volume locks
+    [System.GC]::Collect()
+    [System.GC]::WaitForPendingFinalizers()
+    Start-Sleep -Milliseconds 250
+
+    # 4. Load C# and Eject
     $CsFilePath = Join-Path $PSScriptRoot "USBEjector.cs"
 
     if (-not ([System.Management.Automation.PSTypeName]'USBEjector').Type) {

--- a/extensions/single-disk-eject/src/utils.ts
+++ b/extensions/single-disk-eject/src/utils.ts
@@ -68,13 +68,16 @@ function getVolumesFromLsCommandMac(raw: string): Volume[] {
 async function listVolumesWindows(): Promise<Volume[]> {
   let volumes: Volume[] = [];
   try {
-    // Use wmic to list removable drives (DriveType=2)
-    const { stdout } = await exec('wmic logicaldisk where "drivetype=2" get deviceid,volumename /format:csv', {
-      timeout: 10000,
-      windowsHide: true, // Prevents console handle from interfering with event loop
-    });
+    // Use PowerShell to list removable drives (DriveType=2)
+    const { stdout } = await exec(
+      "powershell -NoProfile -NonInteractive -Command \"Get-CimInstance -ClassName Win32_LogicalDisk -Filter 'DriveType=2' | Select-Object DeviceID, VolumeName | ConvertTo-Csv -NoTypeInformation\"",
+      {
+        timeout: 10000,
+        windowsHide: true, // Prevents console handle from interfering with event loop
+      },
+    );
 
-    volumes = getVolumesFromWmicWindows(stdout);
+    volumes = getVolumesFromPowerShellWindows(stdout);
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
     console.log(error.message);
@@ -84,26 +87,27 @@ async function listVolumesWindows(): Promise<Volume[]> {
   return volumes;
 }
 
-function getVolumesFromWmicWindows(raw: string): Volume[] {
+function getVolumesFromPowerShellWindows(raw: string): Volume[] {
   const prefs = getPreferenceValues<Preferences>();
   const volumesToIgnore = prefs?.ignoredVolumes?.split(",").map((v) => v.trim());
 
   try {
-    // Parse CSV output from wmic
-    // Format is: Node,DeviceID,VolumeName
+    // Parse CSV output from PowerShell
+    // Format is: "DeviceID","VolumeName"
     const lines = raw
       .trim()
-      .split("\r\r\n")
-      .slice(1) // Skip header line (Node,DeviceID,VolumeName)
+      .split(/\r?\n/)
+      .slice(1) // Skip header line
       .filter((line) => line.trim() !== "");
 
     let volumes: Volume[] = lines
       .map((line) => {
-        const parts = line.split(",");
-        if (parts.length < 2) return null;
+        const cleanLine = line.replace(/"/g, "");
+        const parts = cleanLine.split(",");
+        if (parts.length < 1) return null;
 
-        const driveLetter = parts[1]?.trim(); // DeviceID (e.g., "E:")
-        const rawLabel = parts[2]?.trim() || ""; // VolumeName
+        const driveLetter = parts[0]?.trim(); // DeviceID (e.g., "E:")
+        const rawLabel = parts[1]?.trim() || ""; // VolumeName
 
         if (!driveLetter) return null;
 
@@ -124,7 +128,7 @@ function getVolumesFromWmicWindows(raw: string): Volume[] {
     return volumes;
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
-    console.log("Error parsing wmic output:", error.message);
+    console.log("Error parsing PowerShell output:", error.message);
     return [];
   }
 }

--- a/extensions/single-disk-eject/src/utils.ts
+++ b/extensions/single-disk-eject/src/utils.ts
@@ -104,7 +104,7 @@ function getVolumesFromPowerShellWindows(raw: string): Volume[] {
       .map((line) => {
         const cleanLine = line.replace(/"/g, "");
         const parts = cleanLine.split(",");
-        if (parts.length < 1) return null;
+        if (parts.length < 2) return null;
 
         const driveLetter = parts[0]?.trim(); // DeviceID (e.g., "E:")
         const rawLabel = parts[1]?.trim() || ""; // VolumeName
@@ -165,10 +165,8 @@ async function ejectVolumeMac(volume: Volume): Promise<void> {
 }
 
 async function ejectVolumeWindows(volume: Volume): Promise<void> {
-  // Extract drive letter from volume name (e.g., "Backup Stick (E:)" -> "E")
-  // The format is now "Label (Drive:)" so we need to extract from the parentheses
-  const match = volume.name.match(/\(([A-Z]):?\)/i);
-  const driveLetter = match ? match[1] : volume.name.split(":")[0];
+  // Extract drive letter from the "E: (Label)" format
+  const driveLetter = volume.name.split(":")[0];
 
   // Path to PowerShell script in the assets folder using Raycast environment
   const scriptPath = path.join(environment.assetsPath, "eject.ps1");


### PR DESCRIPTION
## Description

### Windows Ejection Rework

- **Removed Deprecated `wmic`**: Replaced legacy `wmic` calls with modern PowerShell `Get-CimInstance` cmdlets to trace logical drives to their underlying physical PnP Device IDs. This should work on all modern Windows systems. Fixes #26897 .
- **Fix for "Vetoed by: Driver" Errors**: Querying drives inherently opens WMI/COM handles which can block the OS from ejecting them. The script now aggressively nullifies variables and forces .NET garbage collection prior to the ejection command, preventing self-inflicted "in-use" deadlocks.
- **Improved Native Ejection Flow**: New, two-step device removal to support more device types:
  1. Safely ejects the logical disk node first, which flawlessly supports multi-LUN devices like SD card readers and docks without killing sibling drives.
  2. If the media rejects ejection, it automatically climbs the PnP tree and gracefully removes the entire parent USB hardware stack (ideal for mechanical external drives).

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
