### PR TITLE
fix(espanso): source user shell rc to fix PATH for shell-type var evaluation

### DIFF
--- a/extensions/espanso/CHANGELOG.md
+++ b/extensions/espanso/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Espanso Changelog
 
+## [Patch] - PR_MERGE_DATE
+
+### Bug Fixes
+
+- Fixed shell-type var preview not resolving user PATH: shell vars now run via an interactive shell (`zsh`/`bash`) so `.zshrc` is sourced. Respects the `shell:` param in Espanso YAML if specified. ANSI escape sequences from shell startup are stripped from output.
+
 ## [Improvements] - 2026-04-07
 
 ### New Features

--- a/extensions/espanso/CHANGELOG.md
+++ b/extensions/espanso/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Espanso Changelog
 
-## [Patch] - PR_MERGE_DATE
+## [Patch] - {PR_MERGE_DATE}
 
 ### Bug Fixes
 

--- a/extensions/espanso/CHANGELOG.md
+++ b/extensions/espanso/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Espanso Changelog
 
-## [Patch] - {PR_MERGE_DATE}
+## [Patch] - 2026-04-09
 
 ### Bug Fixes
 

--- a/extensions/espanso/package.json
+++ b/extensions/espanso/package.json
@@ -14,6 +14,7 @@
     "System",
     "Productivity"
   ],
+  "version": "1.0.0",
   "license": "MIT",
   "commands": [
     {

--- a/extensions/espanso/src/lib/utils.ts
+++ b/extensions/espanso/src/lib/utils.ts
@@ -279,8 +279,14 @@ const evaluateVar = async (v: EspansoVar): Promise<string> => {
     case "shell": {
       if (!v.params?.cmd) return `{{${v.name}}}`;
       try {
-        const { stdout } = await execPromise(v.params.cmd);
-        return stdout.trim();
+        const rawShell = typeof v.params.shell === "string" && v.params.shell.trim() ? v.params.shell.trim() : "zsh";
+        const shellPath = rawShell.includes("/") ? rawShell : `/bin/${rawShell}`;
+        const shellBase = rawShell.includes("/") ? rawShell.split("/").pop()! : rawShell;
+        const interactive = shellBase === "zsh" || shellBase === "bash";
+        const shellArgs = interactive ? ["-i", "-c", v.params.cmd] : ["-c", v.params.cmd];
+        const { stdout } = await execFilePromise(shellPath, shellArgs);
+        // eslint-disable-next-line no-control-regex
+        return stdout.replace(/\x1b\[[0-9;]*[ -/]*[@-~]/g, "").trim();
       } catch {
         return `{{${v.name}}}`;
       }

--- a/extensions/espanso/src/lib/utils.ts
+++ b/extensions/espanso/src/lib/utils.ts
@@ -280,13 +280,21 @@ const evaluateVar = async (v: EspansoVar): Promise<string> => {
       if (!v.params?.cmd) return `{{${v.name}}}`;
       try {
         const rawShell = typeof v.params.shell === "string" && v.params.shell.trim() ? v.params.shell.trim() : "zsh";
-        const shellPath = rawShell.includes("/") ? rawShell : `/bin/${rawShell}`;
         const shellBase = rawShell.includes("/") ? rawShell.split("/").pop()! : rawShell;
         const interactive = shellBase === "zsh" || shellBase === "bash";
-        const shellArgs = interactive ? ["-i", "-c", v.params.cmd] : ["-c", v.params.cmd];
-        const { stdout } = await execFilePromise(shellPath, shellArgs);
+        const shellArgs = interactive ? [rawShell, "-i", "-c", v.params.cmd] : [rawShell, "-c", v.params.cmd];
+        const { stdout } = await execFilePromise("/usr/bin/env", shellArgs);
         // eslint-disable-next-line no-control-regex
-        return stdout.replace(/\x1b\[[0-9;]*[ -/]*[@-~]/g, "").trim();
+        return (
+          stdout
+            // eslint-disable-next-line no-control-regex
+            .replace(/\x1b\[[0-9;]*[ -/]*[@-~]/g, "")
+            // eslint-disable-next-line no-control-regex
+            .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
+            // eslint-disable-next-line no-control-regex
+            .replace(/\x1b[@-_]/g, "")
+            .trim()
+        );
       } catch {
         return `{{${v.name}}}`;
       }


### PR DESCRIPTION
## Description

Fixes shell-type variable evaluation in the Espanso extension. When an Espanso match uses `type: shell`, the extension evaluates the command via Node's child process API. Previously it called `exec` directly, which inherits Raycast's stripped-down `PATH`. Any command that depended on the user's custom `PATH` (set in `.zshrc` or `.bashrc`) would fail silently, leaving `{{varName}}` unexpanded in the preview.

**Changes in `src/lib/utils.ts` — `evaluateVar` shell case:**

1. Reads `v.params.shell` to determine which shell to use, defaulting to `zsh`.
2. Resolves bare shell names (e.g. `zsh`, `bash`) to `/bin/<name>`; absolute paths are used verbatim.
3. Passes `-i` (interactive) only for `zsh` and `bash`, so the user's rc file is sourced and their `PATH` is available.
4. Switches from `execPromise` to `execFilePromise` to avoid an extra shell-quoting layer.
5. Strips ANSI escape sequences from stdout, as `zsh` emits cursor codes during interactive startup that would otherwise appear in the expanded value.

## Screencast

No visual changes — the fix restores correct text expansion for shell-type variables that were silently broken when commands relied on a custom `PATH`.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
