### PR TITLE
Update wispr-flow extension

### DIFF
--- a/extensions/wispr-flow/.gitignore
+++ b/extensions/wispr-flow/.gitignore
@@ -1,0 +1,14 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# Raycast specific files
+raycast-env.d.ts
+.raycast-swift-build
+.swiftpm
+compiled_raycast_swift
+compiled_raycast_rust
+
+# misc
+.DS_Store

--- a/extensions/wispr-flow/CHANGELOG.md
+++ b/extensions/wispr-flow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Wispr Flow Changelog
 
-## [Update] - 2026-04-08
+## [Update] - {PR_MERGE_DATE}
 
 ### Voice Control
 - Added Toggle Recording command to start/stop dictation with a single hotkey

--- a/extensions/wispr-flow/CHANGELOG.md
+++ b/extensions/wispr-flow/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Wispr Flow Changelog
 
+## [Update] - 2026-04-08
+
+### Voice Control
+- Added Toggle Recording command to start/stop dictation with a single hotkey
+
 ## [Update] - 2026-03-23
 
 ### Transcription History

--- a/extensions/wispr-flow/CHANGELOG.md
+++ b/extensions/wispr-flow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Wispr Flow Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-04-22
 
 ### Voice Control
 - Added Toggle Recording command to start/stop dictation with a single hotkey

--- a/extensions/wispr-flow/README.md
+++ b/extensions/wispr-flow/README.md
@@ -16,6 +16,7 @@ The all-in-one [Wispr Flow](https://wisprflow.ai) companion for Raycast. Search 
 | **Search Transcripts** | Browse and search your full voice transcription history |
 | **Add Word to Dictionary** | Teach Wispr Flow new words, names, or technical terms |
 | **Manage Dictionary** | View, edit, search, and delete dictionary entries |
+| **Toggle Recording** | Toggle voice dictation on/off with a single hotkey |
 | **Start Recording** | Begin voice dictation instantly |
 | **Stop Recording** | End voice dictation |
 | **Paste Last Transcript** | Paste your latest unarchived transcript into the active app |
@@ -51,6 +52,7 @@ The all-in-one [Wispr Flow](https://wisprflow.ai) companion for Raycast. Search 
 
 ## Voice Control
 
+- **Toggle Recording** — start or stop dictation with a single command, ideal for binding to one hotkey
 - **Start/Stop Recording** — trigger Wispr Flow dictation via Raycast with no-view commands
 - **Install detection** — commands gracefully handle Wispr Flow not being installed
 

--- a/extensions/wispr-flow/package.json
+++ b/extensions/wispr-flow/package.json
@@ -5,7 +5,8 @@
   "description": "Search transcription history, manage your custom dictionary, and control voice recording with Wispr Flow",
   "icon": "icon.png",
   "author": "carterm",
-  "contributors": ["christi4nity", "mattiacolombomc"],
+  "contributors": ["christi4nity", "mattiacolombomc",
+    "traviscooksfdc"],
   "categories": [
     "Productivity",
     "Applications"
@@ -80,6 +81,13 @@
       "subtitle": "Wispr Flow",
       "description": "View, search, edit, and delete words in your Wispr Flow dictionary",
       "mode": "view"
+    },
+    {
+      "name": "toggle-recording",
+      "title": "Toggle Recording",
+      "subtitle": "Wispr Flow",
+      "description": "Toggle Wispr Flow voice dictation on/off",
+      "mode": "no-view"
     },
     {
       "name": "start-recording",

--- a/extensions/wispr-flow/src/start-recording.ts
+++ b/extensions/wispr-flow/src/start-recording.ts
@@ -1,8 +1,10 @@
-import { open, showToast, Toast } from "@raycast/api";
+import { LocalStorage, open, showToast, Toast } from "@raycast/api";
 import { WISPR_FLOW_BUNDLE_ID, ensureWisprFlowInstalled } from "./db";
+import { RECORDING_KEY } from "./toggle-recording";
 
 export default async function main() {
   if (!(await ensureWisprFlowInstalled())) return;
   await open("wispr-flow://start-hands-free", WISPR_FLOW_BUNDLE_ID);
+  await LocalStorage.setItem(RECORDING_KEY, true);
   await showToast({ style: Toast.Style.Success, title: "Recording started" });
 }

--- a/extensions/wispr-flow/src/stop-recording.ts
+++ b/extensions/wispr-flow/src/stop-recording.ts
@@ -1,8 +1,10 @@
-import { open, showToast, Toast } from "@raycast/api";
+import { LocalStorage, open, showToast, Toast } from "@raycast/api";
 import { WISPR_FLOW_BUNDLE_ID, ensureWisprFlowInstalled } from "./db";
+import { RECORDING_KEY } from "./toggle-recording";
 
 export default async function main() {
   if (!(await ensureWisprFlowInstalled())) return;
   await open("wispr-flow://stop-hands-free", WISPR_FLOW_BUNDLE_ID);
+  await LocalStorage.setItem(RECORDING_KEY, false);
   await showToast({ style: Toast.Style.Success, title: "Recording stopped" });
 }

--- a/extensions/wispr-flow/src/toggle-recording.ts
+++ b/extensions/wispr-flow/src/toggle-recording.ts
@@ -1,0 +1,21 @@
+import { LocalStorage, open, showToast, Toast } from "@raycast/api";
+import { WISPR_FLOW_BUNDLE_ID, ensureWisprFlowInstalled } from "./db";
+
+const RECORDING_KEY = "isRecording";
+
+export default async function main() {
+  if (!(await ensureWisprFlowInstalled())) return;
+
+  const isRecording =
+    (await LocalStorage.getItem<boolean>(RECORDING_KEY)) ?? false;
+
+  if (isRecording) {
+    await open("wispr-flow://stop-hands-free", WISPR_FLOW_BUNDLE_ID);
+    await showToast({ style: Toast.Style.Success, title: "Recording stopped" });
+  } else {
+    await open("wispr-flow://start-hands-free", WISPR_FLOW_BUNDLE_ID);
+    await showToast({ style: Toast.Style.Success, title: "Recording started" });
+  }
+
+  await LocalStorage.setItem(RECORDING_KEY, !isRecording);
+}

--- a/extensions/wispr-flow/src/toggle-recording.ts
+++ b/extensions/wispr-flow/src/toggle-recording.ts
@@ -1,7 +1,7 @@
 import { LocalStorage, open, showToast, Toast } from "@raycast/api";
 import { WISPR_FLOW_BUNDLE_ID, ensureWisprFlowInstalled } from "./db";
 
-const RECORDING_KEY = "isRecording";
+export const RECORDING_KEY = "isRecording";
 
 export default async function main() {
   if (!(await ensureWisprFlowInstalled())) return;


### PR DESCRIPTION
## Description

Add toggle recording command

## Why?
The wispr-flow extension has separate start/stop recording commands, but Raycast
doesn't allow two commands to share the same hotkey. A single toggle
command lets users bind one key to control recording.

## What
- New "Toggle Recording" command that alternates between starting and
stopping voice dictation on each invocation

## Technical notes
Uses Raycast LocalStorage to track recording state between
invocations. Reuses the existing wispr-flow:// URL schemes for
start/stop.

## Screencast
Here's the option showing in prefs:
<img width="685" height="292" alt="image" src="https://github.com/user-attachments/assets/3269b713-7d47-440b-a1cd-11230532cc07" />

Because of the way wispr-flow works, it's tricky to record a screencap, but here's a gif of me using it to type this description:
![Apr-08-2026 22-30-02](https://github.com/user-attachments/assets/b27a9343-e1e5-487e-8452-e6dcadd53bec)

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
