### PR TITLE
[brew] fix cold start bug and add query launch argument to search command

### DIFF
--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Launch Arguments] - {PR_MERGE_DATE}
 
 - Added launch argument to Search command for pre-filling the search query before opening
+- Fixed search not working while the formulae/cask index is being downloaded on cold start
 
 ## [Cask Id] - 2026-03-24
 

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## [Launch Arguments] - {PR_MERGE_DATE}
 
-- Added launch arguments to Search command for pre-filling query and filter (All/Formulae/Casks) before opening
-- Filter dropdown in the list stays in sync with the launch argument selection
+- Added launch argument to Search command for pre-filling the search query before opening
 
 ## [Cask Id] - 2026-03-24
 

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Brew Changelog
 
+## [Launch Arguments] - {PR_MERGE_DATE}
+
+- Added launch arguments to Search command for pre-filling query and filter (All/Formulae/Casks) before opening
+- Filter dropdown in the list stays in sync with the launch argument selection
+
 ## [Cask Id] - 2026-03-24
 
 - Add cask id to the cask metadata

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Brew Changelog
 
-## [Launch Arguments] - {PR_MERGE_DATE}
+## [Bug Fix & Launch Argument] - {PR_MERGE_DATE}
 
 - Added launch argument to Search command for pre-filling the search query before opening
 - Fixed search not working while the formulae/cask index is being downloaded on cold start

--- a/extensions/brew/package.json
+++ b/extensions/brew/package.json
@@ -47,7 +47,7 @@
           "name": "filter",
           "placeholder": "Filter",
           "type": "dropdown",
-          "default": "all",
+          "required": false,
           "data": [
             { "title": "All", "value": "all" },
             { "title": "Formulae", "value": "formulae" },

--- a/extensions/brew/package.json
+++ b/extensions/brew/package.json
@@ -17,7 +17,8 @@
     "alexandercato",
     "ViGeng",
     "ridemountainpig",
-    "chrismessina"
+    "chrismessina",
+    "clins1994"
   ],
   "license": "MIT",
   "icon": "icon.png",
@@ -35,6 +36,25 @@
       "subtitle": "Brew",
       "description": "Search brew formulae & casks",
       "mode": "view",
+      "arguments": [
+        {
+          "name": "search",
+          "placeholder": "Query",
+          "type": "text",
+          "required": false
+        },
+        {
+          "name": "filter",
+          "placeholder": "Filter",
+          "type": "dropdown",
+          "default": "all",
+          "data": [
+            { "title": "All", "value": "all" },
+            { "title": "Formulae", "value": "formulae" },
+            { "title": "Casks", "value": "casks" }
+          ]
+        }
+      ],
       "preferences": [
         {
           "name": "showMetadataPanel",

--- a/extensions/brew/package.json
+++ b/extensions/brew/package.json
@@ -42,17 +42,6 @@
           "placeholder": "Query",
           "type": "text",
           "required": false
-        },
-        {
-          "name": "filter",
-          "placeholder": "Filter",
-          "type": "dropdown",
-          "required": false,
-          "data": [
-            { "title": "All", "value": "all" },
-            { "title": "Formulae", "value": "formulae" },
-            { "title": "Casks", "value": "casks" }
-          ]
         }
       ],
       "preferences": [

--- a/extensions/brew/src/components/filter.tsx
+++ b/extensions/brew/src/components/filter.tsx
@@ -13,7 +13,7 @@ export function InstallableFilterDropdown(props: {
   return (
     <List.Dropdown
       tooltip="Filter by formula or cask"
-      value={props.value}
+      {...(props.value !== undefined ? { value: props.value } : { storeValue: true })}
       onChange={(value) => {
         props.onSelect(value as InstallableFilterType);
       }}

--- a/extensions/brew/src/components/filter.tsx
+++ b/extensions/brew/src/components/filter.tsx
@@ -6,17 +6,14 @@ export enum InstallableFilterType {
   casks = "casks",
 }
 
-export function InstallableFilterDropdown(props: {
-  value?: InstallableFilterType;
-  onSelect: (value: InstallableFilterType) => void;
-}) {
+export function InstallableFilterDropdown(props: { onSelect: (value: InstallableFilterType) => void }) {
   return (
     <List.Dropdown
       tooltip="Filter by formula or cask"
-      {...(props.value !== undefined ? { value: props.value } : { storeValue: true })}
       onChange={(value) => {
         props.onSelect(value as InstallableFilterType);
       }}
+      storeValue
     >
       <List.Dropdown.Item value={InstallableFilterType.all} title="All" />
       <List.Dropdown.Item value={InstallableFilterType.formulae} title="Formulae" />

--- a/extensions/brew/src/components/filter.tsx
+++ b/extensions/brew/src/components/filter.tsx
@@ -6,14 +6,17 @@ export enum InstallableFilterType {
   casks = "casks",
 }
 
-export function InstallableFilterDropdown(props: { onSelect: (value: InstallableFilterType) => void }) {
+export function InstallableFilterDropdown(props: {
+  value?: InstallableFilterType;
+  onSelect: (value: InstallableFilterType) => void;
+}) {
   return (
     <List.Dropdown
       tooltip="Filter by formula or cask"
+      value={props.value}
       onChange={(value) => {
         props.onSelect(value as InstallableFilterType);
       }}
-      storeValue
     >
       <List.Dropdown.Item value={InstallableFilterType.all} title="All" />
       <List.Dropdown.Item value={InstallableFilterType.formulae} title="Formulae" />

--- a/extensions/brew/src/components/list.tsx
+++ b/extensions/brew/src/components/list.tsx
@@ -16,6 +16,7 @@ export interface FormulaListProps {
   casks: Cask[];
   searchBarPlaceholder: string;
   searchBarAccessory?: React.ComponentProps<typeof List>["searchBarAccessory"];
+  searchText?: string;
   onSearchTextChange?: (q: string) => void;
   isInstalled: (name: string) => boolean;
   onAction: () => void;
@@ -34,6 +35,7 @@ export function FormulaList(props: FormulaListProps) {
     <List
       searchBarPlaceholder={props.searchBarPlaceholder}
       searchBarAccessory={props.searchBarAccessory}
+      searchText={props.searchText}
       onSearchTextChange={props.onSearchTextChange}
       isLoading={props.isLoading}
       filtering={props.filtering ?? true}

--- a/extensions/brew/src/search.tsx
+++ b/extensions/brew/src/search.tsx
@@ -20,8 +20,9 @@ function formatNumber(num: number): string {
   return num.toLocaleString();
 }
 
-export default function SearchView(props: LaunchProps<{ arguments: { search: string; filter: string } }>) {
+export default function SearchView(props: LaunchProps<{ arguments: Arguments.Search }>) {
   const [searchText, setSearchText] = useState(props.arguments.search ?? "");
+  const hasFilterArg = !!props.arguments.filter;
   const initialFilter = (props.arguments.filter as InstallableFilterType) || InstallableFilterType.all;
   const [filter, setFilter] = useState(initialFilter);
   const { showMetadataPanel } = getPreferenceValues<SearchPreferences>();
@@ -129,7 +130,7 @@ export default function SearchView(props: LaunchProps<{ arguments: { search: str
       casks={casks}
       searchText={searchText}
       searchBarPlaceholder={placeholder(filter)}
-      searchBarAccessory={<InstallableFilterDropdown value={filter} onSelect={setFilter} />}
+      searchBarAccessory={<InstallableFilterDropdown value={hasFilterArg ? filter : undefined} onSelect={setFilter} />}
       isLoading={(isLoadingInstalled && !installed) || isLoadingSearch}
       onSearchTextChange={(searchText) => setSearchText(searchText.trim())}
       filtering={false}

--- a/extensions/brew/src/search.tsx
+++ b/extensions/brew/src/search.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { getPreferenceValues, showToast, Toast } from "@raycast/api";
+import { getPreferenceValues, LaunchProps, showToast, Toast } from "@raycast/api";
 import { useBrewInstalled } from "./hooks/useBrewInstalled";
 import { useBrewSearch, isInstalled } from "./hooks/useBrewSearch";
 import { InstallableFilterDropdown, InstallableFilterType, placeholder } from "./components/filter";
@@ -20,9 +20,10 @@ function formatNumber(num: number): string {
   return num.toLocaleString();
 }
 
-export default function SearchView() {
-  const [searchText, setSearchText] = useState("");
-  const [filter, setFilter] = useState(InstallableFilterType.all);
+export default function SearchView(props: LaunchProps<{ arguments: { search: string; filter: string } }>) {
+  const [searchText, setSearchText] = useState(props.arguments.search ?? "");
+  const initialFilter = (props.arguments.filter as InstallableFilterType) || InstallableFilterType.all;
+  const [filter, setFilter] = useState(initialFilter);
   const { showMetadataPanel } = getPreferenceValues<SearchPreferences>();
 
   const { isLoading: isLoadingInstalled, data: installed, revalidate: revalidateInstalled } = useBrewInstalled();
@@ -126,8 +127,9 @@ export default function SearchView() {
     <FormulaList
       formulae={formulae}
       casks={casks}
+      searchText={searchText}
       searchBarPlaceholder={placeholder(filter)}
-      searchBarAccessory={<InstallableFilterDropdown onSelect={setFilter} />}
+      searchBarAccessory={<InstallableFilterDropdown value={filter} onSelect={setFilter} />}
       isLoading={(isLoadingInstalled && !installed) || isLoadingSearch}
       onSearchTextChange={(searchText) => setSearchText(searchText.trim())}
       filtering={false}

--- a/extensions/brew/src/search.tsx
+++ b/extensions/brew/src/search.tsx
@@ -22,9 +22,7 @@ function formatNumber(num: number): string {
 
 export default function SearchView(props: LaunchProps<{ arguments: Arguments.Search }>) {
   const [searchText, setSearchText] = useState(props.arguments.search ?? "");
-  const hasFilterArg = !!props.arguments.filter;
-  const initialFilter = (props.arguments.filter as InstallableFilterType) || InstallableFilterType.all;
-  const [filter, setFilter] = useState(initialFilter);
+  const [filter, setFilter] = useState(InstallableFilterType.all);
   const { showMetadataPanel } = getPreferenceValues<SearchPreferences>();
 
   const { isLoading: isLoadingInstalled, data: installed, revalidate: revalidateInstalled } = useBrewInstalled();
@@ -130,7 +128,7 @@ export default function SearchView(props: LaunchProps<{ arguments: Arguments.Sea
       casks={casks}
       searchText={searchText}
       searchBarPlaceholder={placeholder(filter)}
-      searchBarAccessory={<InstallableFilterDropdown value={hasFilterArg ? filter : undefined} onSelect={setFilter} />}
+      searchBarAccessory={<InstallableFilterDropdown onSelect={setFilter} />}
       isLoading={(isLoadingInstalled && !installed) || isLoadingSearch}
       onSearchTextChange={(searchText) => setSearchText(searchText.trim())}
       filtering={false}

--- a/extensions/brew/src/utils/brew/search.ts
+++ b/extensions/brew/src/utils/brew/search.ts
@@ -48,6 +48,10 @@ export async function brewSearch(
   let formulaeProgress: DownloadProgress | undefined;
 
   // Phase 1: Load indexes concurrently (small, ~600KB each)
+  // IMPORTANT: Do NOT pass the abort signal to index fetching.
+  // The index download is a shared resource that must complete regardless of
+  // search query changes. useCachedPromise aborts on every keystroke, which
+  // would repeatedly restart the (slow) initial index download.
   onProgress?.({ phase: "casks" });
 
   const [caskIndex, formulaIndex] = await Promise.all([
@@ -58,7 +62,7 @@ export async function brewSearch(
         casksProgress: progress,
         formulaeProgress,
       });
-    }, signal),
+    }),
     fetchFormulaIndex((progress) => {
       formulaeProgress = progress;
       onProgress?.({
@@ -66,9 +70,10 @@ export async function brewSearch(
         casksProgress,
         formulaeProgress: progress,
       });
-    }, signal),
+    }),
   ]);
 
+  // Check for abort after index load (search query may have changed)
   if (signal?.aborted) {
     const error = new Error("Aborted");
     error.name = "AbortError";


### PR DESCRIPTION
## Description

- 🐛 Fixed search not working while the formulae/cask index is being downloaded on cold start
- ✨ Added query launch argument to search command

### Bug Fix

![Kapture 2026-04-10 at 18 09 04](https://github.com/user-attachments/assets/3463ac53-467f-4737-88eb-1c91fde6e6f9)

### Launch Argument

![Kapture 2026-04-10 at 17 55 29](https://github.com/user-attachments/assets/c2173d07-8b23-4e23-903f-3405bb78663c)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder