### PR TITLE
fix(google-calendar): correct timezone offset for half-hour timezones

### DIFF
--- a/extensions/google-calendar/CHANGELOG.md
+++ b/extensions/google-calendar/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Calendar Changelog
 
-## [1.4.2] - {PR_MERGE_DATE}
+## [1.4.2] - 2026-04-09
 
 - Fix timezone offset calculation for half-hour timezones (e.g. IST +05:30) that caused events to be scheduled one hour off
 

--- a/extensions/google-calendar/CHANGELOG.md
+++ b/extensions/google-calendar/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Calendar Changelog
 
+## [1.4.2] - {PR_MERGE_DATE}
+
+- Fix timezone offset calculation for half-hour timezones (e.g. IST +05:30) that caused events to be scheduled one hour off
+
 ## [1.4.1] - 2026-02-13
 
 - Add new command: create-quick-event – create Google Calendar events using a rule-based natural language parser (no AI setup required)

--- a/extensions/google-calendar/src/lib/utils.ts
+++ b/extensions/google-calendar/src/lib/utils.ts
@@ -132,7 +132,7 @@ export function toISO8601WithTimezoneOffset(date = new Date()) {
   const seconds = date.getSeconds().toString().padStart(2, "0");
 
   const offset = date.getTimezoneOffset();
-  const offsetHours = Math.abs(Math.floor(offset / 60))
+  const offsetHours = Math.floor(Math.abs(offset) / 60)
     .toString()
     .padStart(2, "0");
   const offsetMinutes = Math.abs(offset % 60)


### PR DESCRIPTION
## Description

Fixes incorrect timezone offset calculation in `toISO8601WithTimezoneOffset()` that affects any timezone with a non-zero minute component (IST +05:30, Nepal +05:45, Iran +03:30, Newfoundland -03:30, etc.).

The bug is in the order of operations when computing `offsetHours`:

```js
// Before — floors first, then takes absolute value
// For IST (offset = -330): abs(floor(-330/60)) = abs(floor(-5.5)) = abs(-6) = 6 ❌
const offsetHours = Math.abs(Math.floor(offset / 60))

// After — absolute value first, then floors
// For IST (offset = -330): floor(abs(-330)/60) = floor(330/60) = floor(5.5) = 5 ✅
const offsetHours = Math.floor(Math.abs(offset) / 60)
```

This caused events created via the Google Calendar extension to be scheduled one hour off in affected timezones, because the formatted timezone string was `+06:30` instead of the correct `+05:30`.

**Change in `src/lib/utils.ts`:** one-line fix — swap `Math.abs(Math.floor(offset / 60))` → `Math.floor(Math.abs(offset) / 60)`.

Fixes #21062

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)