### PR TITLE
Datafast: Remove inaccurate session time metric

### DIFF
--- a/extensions/datafast/src/dashboard-overview.tsx
+++ b/extensions/datafast/src/dashboard-overview.tsx
@@ -16,7 +16,6 @@ import {
   formatNumber,
   formatCurrency,
   formatPercentage,
-  formatDuration,
   formatChange,
 } from "./lib/format";
 
@@ -124,18 +123,6 @@ export default function DashboardOverview() {
           icon: Icon.ArrowCounterClockwise,
           trend: previous
             ? trendTag(current.bounce_rate, previous.bounce_rate, true)
-            : undefined,
-        },
-        {
-          id: "session",
-          label: "Session Time",
-          value: formatDuration(current.avg_session_duration),
-          icon: Icon.Clock,
-          trend: previous
-            ? trendTag(
-                current.avg_session_duration,
-                previous.avg_session_duration,
-              )
             : undefined,
         },
         {

--- a/extensions/datafast/src/lib/format.ts
+++ b/extensions/datafast/src/lib/format.ts
@@ -34,14 +34,6 @@ export function formatPercentage(n: number | undefined | null): string {
   return `${(n ?? 0).toFixed(1)}%`;
 }
 
-export function formatDuration(value: number | undefined | null): string {
-  let secs = value ?? 0;
-  // API may return milliseconds — if value > 1 hour in seconds, assume ms
-  if (secs > 86400) secs = secs / 1000;
-  const m = Math.floor(secs / 60);
-  const s = Math.round(secs % 60);
-  return `${m}m ${s}s`;
-}
 
 export function formatCompact(n: number | undefined | null): string {
   const val = n ?? 0;


### PR DESCRIPTION
## Summary
- Remove Session Time from the dashboard overview — the API's `avg_session_duration` value uses a different calculation than the Datafast dashboard, causing inaccurate display
- Remove the unused `formatDuration` function from format utilities

## Test plan
- [x] Open Dashboard Overview and verify Session Time row is no longer shown
- [x] Confirm all other metrics (Visitors, Revenue, Conversion Rate, Revenue/Visitor, Bounce Rate, Online Now) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)