### PR TITLE
Datafast: Remove inaccurate session time metric and add sale notification preference

### DIFF
--- a/extensions/datafast/CHANGELOG.md
+++ b/extensions/datafast/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Datafast Changelog
 
-## [Initial Version] - 2026-04-09
+## [Update] - {PR_MERGE_DATE}
+
+- Remove inaccurate session time metric from Dashboard Overview
+- Remove unused `formatDuration` function
+- Add preference to disable sale notifications
+
+## [Initial Version] - {PR_MERGE_DATE}
 
 - Dashboard Overview with KPI metrics and period-over-period trend comparison
 - Realtime Visitors with live visitor details, location, device, and conversion likelihood

--- a/extensions/datafast/CHANGELOG.md
+++ b/extensions/datafast/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Datafast Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-04-12
 
 - Remove inaccurate session time metric from Dashboard Overview
 - Remove unused `formatDuration` function
 - Add preference to disable sale notifications
 
-## [Initial Version] - {PR_MERGE_DATE}
+## [Initial Version] - 2026-04-12
 
 - Dashboard Overview with KPI metrics and period-over-period trend comparison
 - Realtime Visitors with live visitor details, location, device, and conversion likelihood

--- a/extensions/datafast/README.md
+++ b/extensions/datafast/README.md
@@ -16,7 +16,7 @@ View your Datafast web analytics in Raycast.
 
 **Countries** – View traffic and revenue by country with drill-down into regions and cities.
 
-**Enable Menu Bar** – Show the number of active visitors in your Mac menu bar, updated every minute. Also detects new sales and celebrates with confetti. To toggle this on or off, open the **Enable Menu Bar** command preferences and check or uncheck **Enable sale notifications** under **Sale Notifications**.
+**Enable Menu Bar** – Show the number of active visitors in your Mac menu bar, updated every minute. Also detects new sales and celebrates with confetti. To toggle this, open the **Enable Menu Bar** command preferences and check or uncheck **Enable sale notifications** under **Sale Notifications**.
 
 ## Getting Started
 

--- a/extensions/datafast/README.md
+++ b/extensions/datafast/README.md
@@ -4,7 +4,7 @@ View your Datafast web analytics in Raycast.
 
 ## Commands
 
-**Dashboard Overview** – View key metrics including visitors, revenue, conversion rate, revenue per visitor, bounce rate, session time, and online users with period-over-period trend comparisons.
+**Dashboard Overview** – View key metrics including visitors, revenue, conversion rate, revenue per visitor, bounce rate, and online users with period-over-period trend comparisons.
 
 **Realtime Visitors** – See who's on your site right now with location, device, browser, referral source, and conversion likelihood for each active visitor.
 

--- a/extensions/datafast/package.json
+++ b/extensions/datafast/package.json
@@ -5,22 +5,10 @@
   "description": "View your Datafast web analytics — visitors, revenue, pages, referrers, campaigns, and real-time data",
   "icon": "icon.png",
   "author": "joshmillgate",
-  "categories": [
-    "Data",
-    "Web",
-    "Productivity"
-  ],
+  "categories": ["Data", "Web", "Productivity"],
   "license": "MIT",
-  "platforms": [
-    "macOS"
-  ],
-  "keywords": [
-    "analytics",
-    "datafast",
-    "revenue",
-    "visitors",
-    "web analytics"
-  ],
+  "platforms": ["macOS"],
+  "keywords": ["analytics", "datafast", "revenue", "visitors", "web analytics"],
   "preferences": [
     {
       "name": "apiKey",
@@ -46,13 +34,7 @@
       "subtitle": "View dashboard data and choose timeframes",
       "description": "View key metrics: visitors, sessions, bounce rate, revenue, conversion rate",
       "mode": "view",
-      "keywords": [
-        "stats",
-        "metrics",
-        "overview",
-        "revenue",
-        "visitors"
-      ]
+      "keywords": ["stats", "metrics", "overview", "revenue", "visitors"]
     },
     {
       "name": "realtime-visitors",
@@ -60,12 +42,7 @@
       "subtitle": "View active visitors data",
       "description": "View active visitors on your site right now",
       "mode": "view",
-      "keywords": [
-        "live",
-        "online",
-        "realtime",
-        "active"
-      ]
+      "keywords": ["live", "online", "realtime", "active"]
     },
     {
       "name": "top-pages",
@@ -73,11 +50,7 @@
       "subtitle": "Show top pages data",
       "description": "View pages ranked by visitors or revenue",
       "mode": "view",
-      "keywords": [
-        "pages",
-        "urls",
-        "paths"
-      ]
+      "keywords": ["pages", "urls", "paths"]
     },
     {
       "name": "top-referrers",
@@ -85,11 +58,7 @@
       "subtitle": "Show your top referrers data",
       "description": "View traffic sources ranked by visitors or revenue",
       "mode": "view",
-      "keywords": [
-        "referrers",
-        "sources",
-        "traffic"
-      ]
+      "keywords": ["referrers", "sources", "traffic"]
     },
     {
       "name": "campaigns",
@@ -97,11 +66,7 @@
       "subtitle": "Show your campaigns data",
       "description": "View campaign performance with UTM breakdowns",
       "mode": "view",
-      "keywords": [
-        "utm",
-        "campaigns",
-        "marketing"
-      ]
+      "keywords": ["utm", "campaigns", "marketing"]
     },
     {
       "name": "countries",
@@ -109,11 +74,7 @@
       "subtitle": "Show countries data",
       "description": "View traffic and revenue by country",
       "mode": "view",
-      "keywords": [
-        "countries",
-        "geo",
-        "location"
-      ]
+      "keywords": ["countries", "geo", "location"]
     },
     {
       "name": "menu-bar-realtime",
@@ -122,12 +83,7 @@
       "description": "Show live visitor count in your menu bar",
       "mode": "menu-bar",
       "interval": "1m",
-      "keywords": [
-        "visitors",
-        "realtime",
-        "menu bar",
-        "live"
-      ],
+      "keywords": ["visitors", "realtime", "menu bar", "live"],
       "preferences": [
         {
           "name": "saleNotifications",

--- a/extensions/datafast/src/dashboard-overview.tsx
+++ b/extensions/datafast/src/dashboard-overview.tsx
@@ -16,7 +16,6 @@ import {
   formatNumber,
   formatCurrency,
   formatPercentage,
-  formatDuration,
   formatChange,
 } from "./lib/format";
 
@@ -124,18 +123,6 @@ export default function DashboardOverview() {
           icon: Icon.ArrowCounterClockwise,
           trend: previous
             ? trendTag(current.bounce_rate, previous.bounce_rate, true)
-            : undefined,
-        },
-        {
-          id: "session",
-          label: "Session Time",
-          value: formatDuration(current.avg_session_duration),
-          icon: Icon.Clock,
-          trend: previous
-            ? trendTag(
-                current.avg_session_duration,
-                previous.avg_session_duration,
-              )
             : undefined,
         },
         {

--- a/extensions/datafast/src/lib/format.ts
+++ b/extensions/datafast/src/lib/format.ts
@@ -34,15 +34,6 @@ export function formatPercentage(n: number | undefined | null): string {
   return `${(n ?? 0).toFixed(1)}%`;
 }
 
-export function formatDuration(value: number | undefined | null): string {
-  let secs = value ?? 0;
-  // API may return milliseconds — if value > 1 hour in seconds, assume ms
-  if (secs > 86400) secs = secs / 1000;
-  const m = Math.floor(secs / 60);
-  const s = Math.round(secs % 60);
-  return `${m}m ${s}s`;
-}
-
 export function formatCompact(n: number | undefined | null): string {
   const val = n ?? 0;
   if (val < 1000) return String(val);

--- a/extensions/datafast/src/menu-bar-realtime.tsx
+++ b/extensions/datafast/src/menu-bar-realtime.tsx
@@ -13,7 +13,7 @@ import {
 import { useCachedPromise } from "@raycast/utils";
 import { useEffect } from "react";
 import { fetchRealtimeMap } from "./lib/api";
-import { formatNumber, formatCompact, formatCurrency } from "./lib/format";
+import { formatNumber, formatCompact } from "./lib/format";
 
 const LAST_SEEN_KEY = "last-seen-payment-timestamps";
 
@@ -41,11 +41,11 @@ async function checkForNewSales(
       environment.launchType === LaunchType.Background
     ) {
       const total = newPayments.reduce((sum, p) => sum + p.amount, 0);
-      const currency = newPayments[0].currency ?? "";
+      const currency = newPayments[0].currency || "$";
       const label =
         newPayments.length === 1
-          ? `New sale: ${formatCurrency(newPayments[0].amount, currency)}`
-          : `${newPayments.length} new sales: ${formatCurrency(total, currency)}`;
+          ? `New sale: ${currency}${newPayments[0].amount}`
+          : `${newPayments.length} new sales: ${currency}${total}`;
 
       await open("raycast://confetti");
       await showHUD(`🎉 ${label}`);


### PR DESCRIPTION
## Description

- Remove Session Time from the dashboard overview — the API's `avg_session_duration` value uses a different calculation than the Datafast dashboard, causing inaccurate display
- Remove the unused `formatDuration` function
- Add preference to disable sale notifications
- Document sale notification toggle in README

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder