### PR TITLE
Google Meet: Add Dia browser support

### DIFF
--- a/extensions/google-meet/CHANGELOG.md
+++ b/extensions/google-meet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Google Meet Changelog
 
+## [Improvement] - {PR_MERGE_DATE}
+
+- Add Dia browser support
+
+## [Improvement] - 2026-02-13
+
 ## [Improvement] - 2026-04-11
 
 - Add Dia browser support

--- a/extensions/google-meet/CHANGELOG.md
+++ b/extensions/google-meet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Meet Changelog
 
+## [Improvement] - 2026-04-11
+
+- Add Dia browser support
+
 ## [Improvement] - 2026-02-13
 
 - Make delay configurable by user

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -9,7 +9,6 @@
     "hughlaw",
     "iwex",
     "nexxai",
-    "sinan_aksay",
     "wunnle"
   ],
   "license": "MIT",

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -8,7 +8,9 @@
   "contributors": [
     "hughlaw",
     "iwex",
-    "nexxai"
+    "nexxai",
+    "sinan_aksay",
+    "wunnle"
   ],
   "license": "MIT",
   "commands": [

--- a/extensions/google-meet/src/helpers.ts
+++ b/extensions/google-meet/src/helpers.ts
@@ -3,6 +3,7 @@ import { runAppleScript } from "run-applescript";
 import {
   getOpenedBrowserScript,
   getOpenedUrlForArc,
+  getOpenedUrlForDia,
   getOpenedUrlForFirefox,
   getOpenedUrlsScript,
   supportedBrowsers,
@@ -36,6 +37,10 @@ async function getOpenTabs(): Promise<string> {
 
   if (browserName === "Arc") {
     return await runAppleScript(getOpenedUrlForArc());
+  }
+
+  if (browserName === "Dia") {
+    return await runAppleScript(getOpenedUrlForDia());
   }
 
   if (browserName === "Firefox" || browserName === "Firefox Developer Edition" || browserName === "Zen") {

--- a/extensions/google-meet/src/utils/scripts.ts
+++ b/extensions/google-meet/src/utils/scripts.ts
@@ -65,9 +65,36 @@ export function getOpenedUrlForFirefox(browserName: string) {
   `;
 }
 
+/**
+ * Dia uses Cmd+Shift+C to copy the current tab URL.
+ * 1. Focus the browser
+ * 2. Use `cmd + shift + c` to copy the URL
+ * 3. Returns the copied URL from the clipboard
+ */
+export function getOpenedUrlForDia() {
+  return `
+    tell application "Dia"
+      activate
+      delay 0.5
+
+      tell application "System Events"
+        keystroke "c" using {command down, shift down}
+        delay 0.5
+      end tell
+    end tell
+
+    delay 0.5
+
+    set copiedURL to do shell script "pbpaste"
+
+    return copiedURL
+  `;
+}
+
 export const supportedBrowsers = [
   "Arc",
   "Brave",
+  "Dia",
   "Firefox",
   "Firefox Developer Edition",
   "Google Chrome",


### PR DESCRIPTION
## Summary
- Adds [Dia browser](https://dia.google/) to the list of supported browsers
- Uses `Cmd+Shift+C` keystroke simulation (via AppleScript System Events) to copy the current tab URL, since Dia doesn't expose tab URLs through standard AppleScript
- Adds `wunnle` as a contributor

## How it works
Similar to the existing Firefox workaround, the Dia script:
1. Focuses the Dia browser window
2. Simulates `Cmd+Shift+C` to copy the URL to the clipboard
3. Reads the URL from the clipboard via `pbpaste`

## Test plan
- [ ] Set Dia as the preferred browser in extension preferences
- [ ] Run "Create Meet" command and verify the meeting link is copied to clipboard
- [ ] Run "Create Meet with Specified Profile" and verify the link is copied without query parameters
