### PR TITLE
Rewrite Twenty extension foundation for self-hosted instances

### DIFF
--- a/extensions/twenty/README.md
+++ b/extensions/twenty/README.md
@@ -14,15 +14,18 @@ With `Create Object Record` command, effortlessly create records in any standard
 
 ## 🚀 Getting Started
 
-Get your API Keys from [twenty developer settings](https://twenty.com/settings/developers) , navigate to Raycast Command settings or try to access command which will open up view to provide your API key.
+Generate an API key from your Twenty workspace in `Settings -> Developers`, then open the Raycast extension settings and enter:
+
+- `API Key`: your Twenty API key
+- `Twenty Base URL`: leave the default `https://app.twenty.com` for hosted Twenty, or replace it with your self-hosted workspace URL such as `https://twenty.example.com`
+
+The extension always derives the REST base automatically, so users should enter the workspace URL, not a `/rest` endpoint.
 
 <table>
   <tr>
   <td><img src="https://github.com/user-attachments/assets/7787e53b-c08a-4491-a66f-9d738195a2af" alt="Twenty Api Token View" /></td>
   </tr>
 </table>
-
-if you are selfhost user navigate to `<self-host-url>/settings/developers`, once you have your key, go to Raycast Command Settings to provide your `selfhost api url` and `API key`. If you don't provide selfhost url, extension will assume [https://api.twenty.com](https://api.twenty.com) as your instance.
 
 <table>
   <tr>

--- a/extensions/twenty/package-lock.json
+++ b/extensions/twenty/package-lock.json
@@ -18,7 +18,8 @@
         "@types/react": "19.0.10",
         "eslint": "^9.39.1",
         "prettier": "^3.6.2",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1029,6 +1030,13 @@
         }
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@oclif/core": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.0.tgz",
@@ -1187,6 +1195,413 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1464,6 +1879,121 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1559,6 +2089,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -1580,6 +2120,16 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1588,6 +2138,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1625,6 +2192,16 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/clean-stack": {
       "version": "3.0.1",
@@ -1733,6 +2310,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1767,6 +2354,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -2032,6 +2626,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2040,6 +2644,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2194,6 +2808,21 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-package-type": {
@@ -2392,6 +3021,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -2485,6 +3121,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -2513,6 +3166,25 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -2647,6 +3319,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2663,6 +3352,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -2720,6 +3438,51 @@
         "node": ">=4"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2761,6 +3524,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -2772,6 +3542,30 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2812,6 +3606,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -2827,6 +3634,20 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2841,6 +3662,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2935,6 +3786,661 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -2957,6 +4463,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/extensions/twenty/package.json
+++ b/extensions/twenty/package.json
@@ -34,12 +34,12 @@
     },
     {
       "name": "url",
-      "description": "Enter your self-host API URL (Optional)",
+      "description": "Enter the Twenty workspace URL used for onboarding and API requests.",
       "type": "textfield",
-      "title": "Self Host API URL",
+      "title": "Twenty Base URL",
       "required": false,
-      "default": "https://api.twenty.com",
-      "placeholder": "https://api.twenty.com (default)"
+      "default": "https://app.twenty.com",
+      "placeholder": "https://app.twenty.com or https://twenty.example.com"
     },
     {
       "name": "object_creation_form_behaviour",
@@ -63,6 +63,7 @@
     "@types/react": "19.0.10",
     "eslint": "^9.39.1",
     "prettier": "^3.6.2",
+    "vitest": "^3.2.4",
     "typescript": "^5.9.3"
   },
   "scripts": {
@@ -70,7 +71,9 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "publish": "npx @raycast/api@latest publish"
+    "publish": "npx @raycast/api@latest publish",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "platforms": [
     "macOS",

--- a/extensions/twenty/src/components/BooleanField.tsx
+++ b/extensions/twenty/src/components/BooleanField.tsx
@@ -1,0 +1,19 @@
+import React, { forwardRef } from "react";
+import { Form, FormItemRef, ItemProps } from "@raycast/api";
+import { DataModelField } from "../services/zod/schema/recordFieldSchema";
+
+type BooleanFieldProps = {
+  field: DataModelField;
+  itemProps: Record<string, ItemProps>;
+};
+
+const BooleanField = forwardRef<FormItemRef, BooleanFieldProps>(({ field, itemProps }, ref) => {
+  const checkboxProps = { ...(itemProps[field.name] ?? {}) } as Record<string, unknown>;
+  delete checkboxProps.id;
+
+  return <Form.Checkbox id={field.name} label={field.label} ref={ref as React.Ref<FormItemRef>} {...checkboxProps} />;
+});
+
+BooleanField.displayName = "BooleanField";
+
+export default BooleanField;

--- a/extensions/twenty/src/components/CurrencyField.tsx
+++ b/extensions/twenty/src/components/CurrencyField.tsx
@@ -1,0 +1,37 @@
+import React, { Fragment, forwardRef } from "react";
+import { Form, FormItemRef, ItemProps } from "@raycast/api";
+import { DataModelField } from "../services/zod/schema/recordFieldSchema";
+
+type CurrencyFieldProps = {
+  field: DataModelField;
+  itemProps: Record<string, ItemProps>;
+};
+
+const CurrencyField = forwardRef<FormItemRef, CurrencyFieldProps>(({ field, itemProps }, ref) => {
+  const amountProps = { ...(itemProps[`${field.name}__amount`] ?? {}) } as Record<string, unknown>;
+  delete amountProps.id;
+  const currencyCodeProps = { ...(itemProps[`${field.name}__currencyCode`] ?? {}) } as Record<string, unknown>;
+  delete currencyCodeProps.id;
+
+  return (
+    <Fragment>
+      <Form.TextField
+        id={`${field.name}__amount`}
+        title={`${field.label} Amount`}
+        placeholder={`Enter ${field.label} amount...`}
+        ref={ref as React.Ref<FormItemRef>}
+        {...amountProps}
+      />
+      <Form.TextField
+        id={`${field.name}__currencyCode`}
+        title={`${field.label} Currency Code`}
+        placeholder="USD"
+        {...currencyCodeProps}
+      />
+    </Fragment>
+  );
+});
+
+CurrencyField.displayName = "CurrencyField";
+
+export default CurrencyField;

--- a/extensions/twenty/src/components/FieldComponent.tsx
+++ b/extensions/twenty/src/components/FieldComponent.tsx
@@ -4,32 +4,44 @@ import TextInput from "./TextInput";
 import Select from "./Select";
 import Rating from "./Rating";
 import MultiSelect from "./MultiSelect";
+import BooleanField from "./BooleanField";
+import CurrencyField from "./CurrencyField";
+import PhoneField from "./PhoneField";
 
 type FieldComponentProps = {
-  values: {
-    field: DataModelField;
-    itemProps: ItemProps;
-  };
+  field: DataModelField;
+  itemProps: Record<string, ItemProps>;
 };
-export default function FieldComponent({ values }: FieldComponentProps) {
-  const { field, itemProps } = values;
+
+export default function FieldComponent({ field, itemProps }: FieldComponentProps) {
   switch (field.type) {
     case "FULL_NAME":
     case "LINKS":
     case "EMAILS":
     case "TEXT": {
-      return <TextInput values={{ field, placeholder: `Enter ${field.name}...` }} {...itemProps} />;
+      return <TextInput values={{ field, placeholder: `Enter ${field.name}...` }} {...(itemProps[field.name] ?? {})} />;
     }
     case "SELECT": {
-      return <Select values={{ field }} {...itemProps} />;
+      return <Select values={{ field }} {...(itemProps[field.name] ?? {})} />;
     }
     case "RATING": {
-      return <Rating values={{ field }} {...itemProps} />;
+      return <Rating values={{ field }} {...(itemProps[field.name] ?? {})} />;
     }
     case "MULTI_SELECT": {
-      return <MultiSelect values={{ field, placeholder: `Select ${field.name}...` }} {...itemProps} />;
+      return (
+        <MultiSelect values={{ field, placeholder: `Select ${field.name}...` }} {...(itemProps[field.name] ?? {})} />
+      );
+    }
+    case "BOOLEAN": {
+      return <BooleanField field={field} itemProps={itemProps} />;
+    }
+    case "CURRENCY": {
+      return <CurrencyField field={field} itemProps={itemProps} />;
+    }
+    case "PHONES": {
+      return <PhoneField field={field} itemProps={itemProps} />;
     }
     default:
-      return <></>;
+      return null;
   }
 }

--- a/extensions/twenty/src/components/PhoneField.tsx
+++ b/extensions/twenty/src/components/PhoneField.tsx
@@ -1,0 +1,51 @@
+import React, { Fragment, forwardRef } from "react";
+import { Form, FormItemRef, ItemProps } from "@raycast/api";
+import { DataModelField } from "../services/zod/schema/recordFieldSchema";
+
+type PhoneFieldProps = {
+  field: DataModelField;
+  itemProps: Record<string, ItemProps>;
+};
+
+const PhoneField = forwardRef<FormItemRef, PhoneFieldProps>(({ field, itemProps }, ref) => {
+  const phoneNumberProps = { ...(itemProps[`${field.name}__primaryPhoneNumber`] ?? {}) } as Record<string, unknown>;
+  delete phoneNumberProps.id;
+  const countryCodeProps = { ...(itemProps[`${field.name}__primaryPhoneCountryCode`] ?? {}) } as Record<
+    string,
+    unknown
+  >;
+  delete countryCodeProps.id;
+  const callingCodeProps = { ...(itemProps[`${field.name}__primaryPhoneCallingCode`] ?? {}) } as Record<
+    string,
+    unknown
+  >;
+  delete callingCodeProps.id;
+
+  return (
+    <Fragment>
+      <Form.TextField
+        id={`${field.name}__primaryPhoneNumber`}
+        title={`${field.label} Number`}
+        placeholder={`Enter ${field.label} number...`}
+        ref={ref as React.Ref<FormItemRef>}
+        {...phoneNumberProps}
+      />
+      <Form.TextField
+        id={`${field.name}__primaryPhoneCountryCode`}
+        title={`${field.label} Country Code`}
+        placeholder="US"
+        {...countryCodeProps}
+      />
+      <Form.TextField
+        id={`${field.name}__primaryPhoneCallingCode`}
+        title={`${field.label} Calling Code`}
+        placeholder="+1"
+        {...callingCodeProps}
+      />
+    </Fragment>
+  );
+});
+
+PhoneField.displayName = "PhoneField";
+
+export default PhoneField;

--- a/extensions/twenty/src/components/index.ts
+++ b/extensions/twenty/src/components/index.ts
@@ -1,4 +1,7 @@
 import TextInput from "./TextInput";
 import FieldComponent from "./FieldComponent";
+import BooleanField from "./BooleanField";
+import CurrencyField from "./CurrencyField";
+import PhoneField from "./PhoneField";
 
-export { TextInput, FieldComponent };
+export { TextInput, FieldComponent, BooleanField, CurrencyField, PhoneField };

--- a/extensions/twenty/src/create-object-record-form.tsx
+++ b/extensions/twenty/src/create-object-record-form.tsx
@@ -40,7 +40,14 @@ function CreateObjectRecordForm({
       });
 
       const formattedValues = formatValues(values, objectRecordMetadata);
-      const isSuccess = await twenty.createObjectRecord(namePlural, formattedValues);
+
+      let isSuccess = false;
+      try {
+        isSuccess = await twenty.createObjectRecord(namePlural, formattedValues);
+      } catch {
+        await showToast(FailureToast);
+        return;
+      }
 
       if (isSuccess) {
         handleClearFormState();

--- a/extensions/twenty/src/create-object-record-form.tsx
+++ b/extensions/twenty/src/create-object-record-form.tsx
@@ -4,6 +4,7 @@ import {
   Form,
   Icon,
   PopToRootType,
+  ItemProps,
   Toast,
   getPreferenceValues,
   popToRoot,
@@ -99,7 +100,7 @@ function CreateObjectRecordForm({
           {...itemProps[primary.name]}
         />
         {rest.map((field) => {
-          return <FieldComponent key={field.name} values={{ field, itemProps: itemProps[field.name] }} />;
+          return <FieldComponent key={field.id} field={field} itemProps={itemProps as Record<string, ItemProps>} />;
         })}
       </Form>
     </Fragment>

--- a/extensions/twenty/src/create-object-record.tsx
+++ b/extensions/twenty/src/create-object-record.tsx
@@ -1,5 +1,4 @@
 import { Action, ActionPanel, Detail, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
-import { randomUUID } from "crypto";
 
 import twenty from "./services/TwentySDK";
 import { ObjectIcons } from "./enum/icons";
@@ -75,7 +74,7 @@ export default function CreateObjectRecord() {
                 )
               }
               icon={icon ? (ObjectIcons[icon] ?? Icon.BulletPoints) : Icon.BulletPoints}
-              key={randomUUID().toString()}
+              key={id}
             />
           );
         })}
@@ -117,7 +116,7 @@ export default function CreateObjectRecord() {
                   <></>
                 )
               }
-              key={randomUUID().toString()}
+              key={id}
             />
           );
         })}

--- a/extensions/twenty/src/enum/api.ts
+++ b/extensions/twenty/src/enum/api.ts
@@ -1,7 +1,6 @@
 import { Image, Keyboard, Toast } from "@raycast/api";
 
 export enum Api {
-  URL = "https://api-demo.twenty.com/rest",
   KEY = "Authorization",
   USER_GUIDE = "https://twenty.com",
 }

--- a/extensions/twenty/src/helper/createValidationsForRest.ts
+++ b/extensions/twenty/src/helper/createValidationsForRest.ts
@@ -39,8 +39,20 @@ export function createValidationsForRest(rest: DataModelWithFields["fields"]): a
         };
         break;
       }
-      case "PHONES":
+      case "PHONES": {
+        acc[`${field.name}__primaryPhoneCountryCode`] = (value) => {
+          if (value && !/^[A-Za-z]{2}$/.test(String(value).trim())) {
+            return `Invalid ${field.name}`;
+          }
+        };
+
+        acc[`${field.name}__primaryPhoneCallingCode`] = (value) => {
+          if (value && !/^\+\d+$/.test(String(value).trim())) {
+            return `Invalid ${field.name}`;
+          }
+        };
         break;
+      }
       case "DATE":
       case "DATE_TIME":
         break;
@@ -49,8 +61,21 @@ export function createValidationsForRest(rest: DataModelWithFields["fields"]): a
       case "NUMBER":
       case "NUMERIC":
         break;
-      case "CURRENCY":
+      case "CURRENCY": {
+        acc[`${field.name}__amount`] = (value) => {
+          const normalizedValue = String(value ?? "").trim();
+          if (normalizedValue && Number.isNaN(Number(normalizedValue))) {
+            return `Invalid ${field.name}`;
+          }
+        };
+
+        acc[`${field.name}__currencyCode`] = (value) => {
+          if (value && !/^[A-Za-z]{3}$/.test(String(value).trim())) {
+            return `Invalid ${field.name}`;
+          }
+        };
         break;
+      }
       case "RATING":
         break;
       case "SELECT":

--- a/extensions/twenty/src/helper/formatValues.test.ts
+++ b/extensions/twenty/src/helper/formatValues.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "vitest";
+
+import { formatValues } from "./formatValues";
+import { DataModelWithFields } from "../services/zod/schema/recordFieldSchema";
+
+const baseField = (overrides = {}) => ({
+  id: "field-1",
+  type: "TEXT",
+  name: "name",
+  label: "Name",
+  description: null,
+  isCustom: true,
+  isActive: true,
+  isSystem: false,
+  isNullable: false,
+  defaultValue: null,
+  options: null,
+  ...overrides,
+});
+
+const createObjectMetadata = (fields: Array<ReturnType<typeof baseField>>) =>
+  ({
+    id: "person",
+    dataSourceId: "source-1",
+    nameSingular: "person",
+    namePlural: "people",
+    labelSingular: "Person",
+    labelPlural: "People",
+    description: null,
+    isCustom: true,
+    isActive: true,
+    isSystem: false,
+    fields,
+  }) as DataModelWithFields;
+
+describe("formatValues", () => {
+  test("formats composite native field values for Twenty", () => {
+    const objectRecordMetadata = createObjectMetadata([
+      baseField({ id: "field-name", name: "name", type: "FULL_NAME", label: "Name" }),
+      baseField({ id: "field-emails", name: "emails", type: "EMAILS", label: "Emails" }),
+      baseField({ id: "field-website", name: "website", type: "LINKS", label: "Website" }),
+      baseField({ id: "field-active", name: "isActive", type: "BOOLEAN", label: "Active" }),
+      baseField({ id: "field-budget", name: "budget", type: "CURRENCY", label: "Budget" }),
+      baseField({ id: "field-phones", name: "phones", type: "PHONES", label: "Phones" }),
+    ]);
+
+    expect(
+      formatValues(
+        {
+          name: "Ada Lovelace",
+          emails: "ada@example.com, team@example.com",
+          website: "https://example.com",
+          isActive: true,
+          budget__amount: "12.5",
+          budget__currencyCode: "usd",
+          phones__primaryPhoneNumber: "+1 415 555 0101",
+          phones__primaryPhoneCountryCode: "US",
+          phones__primaryPhoneCallingCode: "+1",
+        },
+        objectRecordMetadata,
+      ),
+    ).toEqual({
+      name: {
+        firstName: "Ada",
+        lastName: "Lovelace",
+      },
+      emails: {
+        primaryEmail: "ada@example.com",
+        additionalEmails: ["team@example.com"],
+      },
+      website: {
+        primaryLinkUrl: "https://example.com",
+        primaryLinkLabel: "example.com",
+        secondaryLinks: [],
+      },
+      isActive: true,
+      budget: {
+        amountMicros: 12500000,
+        currencyCode: "USD",
+      },
+      phones: {
+        primaryPhoneNumber: "+1 415 555 0101",
+        primaryPhoneCountryCode: "US",
+        primaryPhoneCallingCode: "+1",
+        additionalPhones: null,
+      },
+    });
+  });
+});

--- a/extensions/twenty/src/helper/formatValues.ts
+++ b/extensions/twenty/src/helper/formatValues.ts
@@ -1,49 +1,52 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { DataModelWithFields } from "../services/zod/schema/recordFieldSchema";
 import { splitFullName } from "./splitFullName";
+import { createTwentyCurrencyObject } from "./twentyCurrencyObject";
 import { createTwentyEmailObject } from "./twentyEmailObject";
+import { createTwentyPhoneObject } from "./twentyPhoneObject";
 import { createTwentyUrlObject } from "./twentyUrlObject";
 
 export function formatValues(values: Record<string, any>, objectRecordMetadata: DataModelWithFields) {
-  const formattedValues: Record<string, any> = { ...values };
+  const formattedValues: Record<string, any> = {};
 
-  for (const key in values) {
-    const field = objectRecordMetadata.fields.find((field) => field.name === key);
-    if (field) {
-      switch (field.type) {
-        case "LINKS":
-          {
-            formattedValues[key] = createTwentyUrlObject(values[key]);
-          }
-          break;
-        case "FULL_NAME": {
-          formattedValues[key] = splitFullName(values[key]);
-          break;
-        }
-        case "EMAILS": {
-          formattedValues[key] = createTwentyEmailObject(values[key]);
-          break;
-        }
-        case "SELECT": {
-          if (formattedValues[key] === "") {
-            formattedValues[key] = null;
-          }
-          break;
-        }
-        case "RATING": {
-          if (formattedValues[key] === "") {
-            formattedValues[key] = null;
-          }
-          break;
-        }
-        case "MULTI_SELECT": {
-          if (formattedValues[key] === "") {
-            formattedValues[key] = null;
-          }
-          break;
-        }
-        default:
-          break;
+  for (const field of objectRecordMetadata.fields) {
+    switch (field.type) {
+      case "LINKS": {
+        formattedValues[field.name] = createTwentyUrlObject(values[field.name] ?? "");
+        break;
+      }
+      case "FULL_NAME": {
+        formattedValues[field.name] = splitFullName(values[field.name] ?? "");
+        break;
+      }
+      case "EMAILS": {
+        formattedValues[field.name] = createTwentyEmailObject(values[field.name] ?? "");
+        break;
+      }
+      case "CURRENCY": {
+        formattedValues[field.name] = createTwentyCurrencyObject(
+          values[`${field.name}__amount`] ?? "",
+          values[`${field.name}__currencyCode`] ?? "",
+        );
+        break;
+      }
+      case "PHONES": {
+        formattedValues[field.name] = createTwentyPhoneObject(
+          values[`${field.name}__primaryPhoneNumber`] ?? "",
+          values[`${field.name}__primaryPhoneCountryCode`] ?? "",
+          values[`${field.name}__primaryPhoneCallingCode`] ?? "",
+        );
+        break;
+      }
+      case "SELECT":
+      case "RATING":
+      case "MULTI_SELECT": {
+        formattedValues[field.name] = values[field.name] === "" ? null : values[field.name];
+        break;
+      }
+      default: {
+        formattedValues[field.name] = values[field.name];
+        break;
       }
     }
   }

--- a/extensions/twenty/src/helper/index.ts
+++ b/extensions/twenty/src/helper/index.ts
@@ -1,6 +1,15 @@
 import { createValidationsForRest } from "./createValidationsForRest";
 import { splitFullName } from "./splitFullName";
+import { createTwentyCurrencyObject } from "./twentyCurrencyObject";
 import { createTwentyEmailObject } from "./twentyEmailObject";
+import { createTwentyPhoneObject } from "./twentyPhoneObject";
 import { createTwentyUrlObject } from "./twentyUrlObject";
 
-export { createValidationsForRest, splitFullName, createTwentyEmailObject, createTwentyUrlObject };
+export {
+  createValidationsForRest,
+  splitFullName,
+  createTwentyEmailObject,
+  createTwentyUrlObject,
+  createTwentyCurrencyObject,
+  createTwentyPhoneObject,
+};

--- a/extensions/twenty/src/helper/selectPrimaryField.test.ts
+++ b/extensions/twenty/src/helper/selectPrimaryField.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+
+import { selectPrimaryField } from "./selectPrimaryField";
+
+const baseField = (overrides = {}) => ({
+  id: "field-1",
+  type: "TEXT",
+  name: "name",
+  label: "Name",
+  description: null,
+  isCustom: true,
+  isActive: true,
+  isSystem: false,
+  isNullable: false,
+  defaultValue: null,
+  options: null,
+  ...overrides,
+});
+
+const createObjectMetadata = (fields: Array<ReturnType<typeof baseField>>) => ({
+  id: "person",
+  dataSourceId: "source-1",
+  nameSingular: "person",
+  namePlural: "people",
+  labelSingular: "Person",
+  labelPlural: "People",
+  description: null,
+  isCustom: true,
+  isActive: true,
+  isSystem: false,
+  fields,
+});
+
+describe("selectPrimaryField", () => {
+  test("prefers field named name", () => {
+    const objectRecordMetadata = createObjectMetadata([
+      baseField({ id: "field-title", name: "title", label: "Title" }),
+      baseField({ id: "field-name", name: "name", label: "Name" }),
+      baseField({ id: "field-summary", name: "summary", label: "Summary" }),
+    ]);
+
+    expect(selectPrimaryField(objectRecordMetadata).name).toBe("name");
+  });
+
+  test("falls back to title when name is absent", () => {
+    const objectRecordMetadata = createObjectMetadata([
+      baseField({ id: "field-title", name: "title", label: "Title" }),
+      baseField({ id: "field-summary", name: "summary", label: "Summary" }),
+    ]);
+
+    expect(selectPrimaryField(objectRecordMetadata).name).toBe("title");
+  });
+
+  test("falls back to the first text-like field when neither name nor title exists", () => {
+    const objectRecordMetadata = createObjectMetadata([
+      baseField({ id: "field-status", name: "status", type: "SELECT", label: "Status" }),
+      baseField({ id: "field-full-name", name: "fullName", type: "FULL_NAME", label: "Full name" }),
+      baseField({ id: "field-summary", name: "summary", type: "TEXT", label: "Summary" }),
+    ]);
+
+    expect(selectPrimaryField(objectRecordMetadata).name).toBe("fullName");
+  });
+});

--- a/extensions/twenty/src/helper/selectPrimaryField.ts
+++ b/extensions/twenty/src/helper/selectPrimaryField.ts
@@ -1,0 +1,28 @@
+import type { DataModelField, DataModelWithFields } from "../services/zod/schema/recordFieldSchema";
+
+const PRIMARY_FIELD_NAMES = ["name", "title"] as const;
+const TEXT_LIKE_FIELD_TYPES = new Set(["FULL_NAME", "TEXT"]);
+
+export const selectPrimaryField = (objectRecordMetadata: DataModelWithFields): DataModelField => {
+  for (const fieldName of PRIMARY_FIELD_NAMES) {
+    const field = objectRecordMetadata.fields.find((candidate) => candidate.name === fieldName);
+
+    if (field) {
+      return field;
+    }
+  }
+
+  const textLikeField = objectRecordMetadata.fields.find((field) => TEXT_LIKE_FIELD_TYPES.has(field.type));
+
+  if (textLikeField) {
+    return textLikeField;
+  }
+
+  const firstField = objectRecordMetadata.fields[0];
+
+  if (firstField) {
+    return firstField;
+  }
+
+  throw new Error("Object metadata does not contain any active fields.");
+};

--- a/extensions/twenty/src/helper/twentyCurrencyObject.ts
+++ b/extensions/twenty/src/helper/twentyCurrencyObject.ts
@@ -1,0 +1,15 @@
+const MICROS_MULTIPLIER = 1_000_000;
+
+export const createTwentyCurrencyObject = (amount: string, currencyCode: string) => {
+  const normalizedAmount = amount?.trim();
+  const normalizedCurrencyCode = currencyCode?.trim();
+
+  if (!normalizedAmount && !normalizedCurrencyCode) {
+    return null;
+  }
+
+  return {
+    amountMicros: Math.round(Number(normalizedAmount || 0) * MICROS_MULTIPLIER),
+    currencyCode: normalizedCurrencyCode?.toUpperCase() ?? "",
+  };
+};

--- a/extensions/twenty/src/helper/twentyPhoneObject.ts
+++ b/extensions/twenty/src/helper/twentyPhoneObject.ts
@@ -1,0 +1,20 @@
+export const createTwentyPhoneObject = (
+  primaryPhoneNumber: string,
+  primaryPhoneCountryCode: string,
+  primaryPhoneCallingCode: string,
+) => {
+  const normalizedPrimaryPhoneNumber = primaryPhoneNumber?.trim();
+  const normalizedPrimaryPhoneCountryCode = primaryPhoneCountryCode?.trim();
+  const normalizedPrimaryPhoneCallingCode = primaryPhoneCallingCode?.trim();
+
+  if (!normalizedPrimaryPhoneNumber && !normalizedPrimaryPhoneCountryCode && !normalizedPrimaryPhoneCallingCode) {
+    return null;
+  }
+
+  return {
+    primaryPhoneNumber: normalizedPrimaryPhoneNumber ?? "",
+    primaryPhoneCountryCode: normalizedPrimaryPhoneCountryCode?.toUpperCase() ?? "",
+    primaryPhoneCallingCode: normalizedPrimaryPhoneCallingCode ?? "",
+    additionalPhones: null,
+  };
+};

--- a/extensions/twenty/src/pages/CreateObjectRecordForm.tsx
+++ b/extensions/twenty/src/pages/CreateObjectRecordForm.tsx
@@ -1,4 +1,5 @@
 import { DataModelWithFields } from "../services/zod/schema/recordFieldSchema";
+import { selectPrimaryField } from "../helper/selectPrimaryField";
 import CreateObjectRecordForm from "../create-object-record-form";
 
 export default function OpenCreateObjectRecordForm({
@@ -6,14 +7,7 @@ export default function OpenCreateObjectRecordForm({
 }: {
   objectRecordMetadata: DataModelWithFields;
 }) {
-  // Reason: Currently we don't have a way to know if its which field is primary, we can fix this hard coding.
-  // Something like a flag field (isPrimary) or maybe a TITLE type for primary in API or position
-  const isPrimaryFieldTitle =
-    objectRecordMetadata.labelPlural === "Tasks" || objectRecordMetadata.labelPlural === "Notes";
-
-  const primary = objectRecordMetadata.fields.find((field) =>
-    isPrimaryFieldTitle ? field.name === "title" : field.name === "name",
-  )!;
+  const primary = selectPrimaryField(objectRecordMetadata);
 
   const rest = objectRecordMetadata.fields.filter((field) => field.id !== primary.id);
 

--- a/extensions/twenty/src/services/TwentySDK.ts
+++ b/extensions/twenty/src/services/TwentySDK.ts
@@ -1,98 +1,35 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { getPreferenceValues } from "@raycast/api";
-import { Api } from "../enum/api";
-import fetch from "node-fetch";
-import { getActiveDataModelsSchema } from "./zod/schema/dataModelSchema";
-import { getDataModelWithFieldsSchema } from "./zod/schema/recordFieldSchema";
-import { removeTrailingSlash } from "../helper/removeTrailingSlash";
-import { isUrl } from "../helper/isUrl";
+import { createTwentyClient } from "./client";
+import { getTwentyConfig } from "./preferences";
+import { createMetadataService } from "./metadata";
+import { createRecordsService } from "./records";
 
-class TwentySDK {
-  private url!: string;
-  private token!: string;
+export const buildServices = () => {
+  const client = createTwentyClient(getTwentyConfig());
 
-  constructor() {
-    const { token, url: providedUrl } = getPreferenceValues<Preferences>();
-    const url = removeTrailingSlash(providedUrl);
-    this.token = `Bearer ${token}`;
-    this.url = isUrl(url) ? `${url}/rest` : `https://api.twenty.com/rest`;
-  }
+  return {
+    metadata: createMetadataService(client),
+    records: createRecordsService(client),
+  };
+};
 
-  async getActiveDataModels() {
+const services = buildServices();
+
+const getErrorMessage = (error: unknown) => (error instanceof Error ? error.message : String(error));
+
+const withLegacyMetadataFailureContract =
+  <TArgs extends unknown[], TResult>(fn: (...args: TArgs) => Promise<TResult>) =>
+  async (...args: TArgs): Promise<TResult | string> => {
     try {
-      const response = await fetch(this.url + "/metadata/objects", {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          [Api.KEY]: this.token,
-        },
-      });
-
-      if (response.ok) {
-        const rawData = await response.json();
-        const data = getActiveDataModelsSchema.parse(rawData);
-        const activeDataModel = data.data.objects.filter((model) => !model.isSystem && model.isActive);
-        return activeDataModel;
-      }
-
-      return response.statusText;
-    } catch (err) {
-      return err instanceof Error ? err.message : String(err);
+      return await fn(...args);
+    } catch (error) {
+      return getErrorMessage(error);
     }
-  }
+  };
 
-  async getRecordFieldsForDataModel(id: string) {
-    try {
-      const response = await fetch(this.url + `/metadata/objects/${id}`, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          [Api.KEY]: this.token,
-        },
-      });
+const twenty = {
+  getActiveDataModels: withLegacyMetadataFailureContract(services.metadata.getActiveDataModels),
+  getRecordFieldsForDataModel: withLegacyMetadataFailureContract(services.metadata.getRecordFieldsForDataModel),
+  createObjectRecord: services.records.createObjectRecord,
+};
 
-      if (response.ok) {
-        const rawData = await response.json();
-        const objectRecordWithFieldsMetadata = getDataModelWithFieldsSchema.parse(rawData);
-        const excludeFieldsWithName = ["updatedAt", "deletedAt"];
-        objectRecordWithFieldsMetadata.data.object.fields = objectRecordWithFieldsMetadata.data.object.fields
-          .filter((object) => !object.isSystem)
-          .filter((object) => object.isActive)
-          .filter((object) => object.type !== "RELATION" && object.type !== "ACTOR") // handle relation later
-          .filter((object) => !excludeFieldsWithName.includes(object.name));
-
-        return objectRecordWithFieldsMetadata.data.object;
-      }
-
-      return response.statusText;
-    } catch (err) {
-      return err instanceof Error ? err.message : String(err);
-    }
-  }
-
-  async createObjectRecord(namePlural: string, bodyParam: any) {
-    try {
-      const response = await fetch(this.url + `/${namePlural}`, {
-        method: "POST",
-        headers: {
-          "Content-type": "application/json",
-          [Api.KEY]: this.token,
-        },
-        body: JSON.stringify({
-          ...bodyParam,
-        }),
-      });
-
-      if (response.ok) {
-        return true;
-      }
-
-      return false;
-    } catch (err) {
-      throw new Error(err as string);
-    }
-  }
-}
-
-const twenty = new TwentySDK();
 export default twenty;

--- a/extensions/twenty/src/services/client.test.ts
+++ b/extensions/twenty/src/services/client.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { createTwentyClient, TwentyApiError } from "./client";
+
+describe("createTwentyClient", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("prefixes requests with /rest and sends JSON auth headers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const client = createTwentyClient({
+      token: "secret-token",
+      authHeader: "Bearer secret-token",
+      baseUrl: "https://app.twenty.com",
+      restBaseUrl: "https://app.twenty.com/rest",
+      keepObjectFormOpen: true,
+    });
+
+    await client.requestJson("/metadata/objects");
+
+    expect(fetchMock).toHaveBeenCalledWith("https://app.twenty.com/rest/metadata/objects", {
+      headers: {
+        authorization: "Bearer secret-token",
+        "content-type": "application/json",
+      },
+    });
+  });
+
+  test("throws a TwentyApiError for non-ok responses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("bad request", {
+        status: 400,
+        statusText: "Bad Request",
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const client = createTwentyClient({
+      token: "secret-token",
+      authHeader: "Bearer secret-token",
+      baseUrl: "https://app.twenty.com",
+      restBaseUrl: "https://app.twenty.com/rest",
+      keepObjectFormOpen: true,
+    });
+
+    await expect(client.requestJson("/metadata/objects")).rejects.toEqual(
+      new TwentyApiError("Twenty API request failed (400)", 400, "bad request"),
+    );
+  });
+
+  test("returns undefined for no-content responses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const client = createTwentyClient({
+      token: "secret-token",
+      authHeader: "Bearer secret-token",
+      baseUrl: "https://app.twenty.com",
+      restBaseUrl: "https://app.twenty.com/rest",
+      keepObjectFormOpen: true,
+    });
+
+    const result = await client.requestJson("/metadata/objects");
+    expect(result).toBeUndefined();
+  });
+
+  test("wraps rejected fetch calls in a TwentyApiError", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const client = createTwentyClient({
+      token: "secret-token",
+      authHeader: "Bearer secret-token",
+      baseUrl: "https://app.twenty.com",
+      restBaseUrl: "https://app.twenty.com/rest",
+      keepObjectFormOpen: true,
+    });
+
+    await expect(client.requestJson("/metadata/objects")).rejects.toEqual(
+      new TwentyApiError(
+        "Twenty API request failed (transport error)",
+        0,
+        "https://app.twenty.com/rest/metadata/objects: network down",
+      ),
+    );
+  });
+});

--- a/extensions/twenty/src/services/client.ts
+++ b/extensions/twenty/src/services/client.ts
@@ -1,0 +1,52 @@
+import type { TwentyConfig } from "./preferences";
+
+export class TwentyApiError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+    public details: string,
+  ) {
+    super(message);
+    this.name = "TwentyApiError";
+  }
+}
+
+export const createTwentyClient = (config: TwentyConfig) => {
+  const requestJson = async <T>(path: string, init: RequestInit = {}): Promise<T | undefined> => {
+    const normalizedPath = path.replace(/^\/+/, "");
+    const url = new URL(normalizedPath, `${config.restBaseUrl}/`).toString();
+    const headers = new Headers(init.headers);
+
+    headers.set("Authorization", config.authHeader);
+    headers.set("Content-Type", "application/json");
+    const mergedHeaders = Object.fromEntries(headers.entries());
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        ...init,
+        headers: mergedHeaders,
+      });
+    } catch (error) {
+      const details = error instanceof Error ? error.message : String(error);
+      throw new TwentyApiError("Twenty API request failed (transport error)", 0, `${url}: ${details}`);
+    }
+
+    if (!response.ok) {
+      const details = await response.text();
+      throw new TwentyApiError(`Twenty API request failed (${response.status})`, response.status, details);
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return (await response.json()) as T;
+  };
+
+  return {
+    requestJson,
+  };
+};
+
+export type TwentyClient = ReturnType<typeof createTwentyClient>;

--- a/extensions/twenty/src/services/metadata.test.ts
+++ b/extensions/twenty/src/services/metadata.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createMetadataService } from "./metadata";
+
+const createClient = (response: unknown) =>
+  ({
+    requestJson: vi.fn().mockResolvedValue(response),
+  }) as unknown as Parameters<typeof createMetadataService>[0];
+
+describe("createMetadataService", () => {
+  test("getActiveDataModels returns only active non-system objects", async () => {
+    const client = createClient({
+      data: {
+        objects: [
+          {
+            id: "person",
+            dataSourceId: "source-1",
+            nameSingular: "person",
+            namePlural: "people",
+            labelSingular: "Person",
+            labelPlural: "People",
+            description: null,
+            icon: null,
+            isCustom: true,
+            isActive: true,
+            isSystem: false,
+          },
+          {
+            id: "workspace",
+            dataSourceId: "source-1",
+            nameSingular: "workspace",
+            namePlural: "workspaces",
+            labelSingular: "Workspace",
+            labelPlural: "Workspaces",
+            description: null,
+            icon: null,
+            isCustom: false,
+            isActive: true,
+            isSystem: true,
+          },
+          {
+            id: "archived-project",
+            dataSourceId: "source-1",
+            nameSingular: "archived-project",
+            namePlural: "archived-projects",
+            labelSingular: "Archived Project",
+            labelPlural: "Archived Projects",
+            description: null,
+            icon: null,
+            isCustom: true,
+            isActive: false,
+            isSystem: false,
+          },
+        ],
+      },
+    });
+
+    await expect(createMetadataService(client).getActiveDataModels()).resolves.toEqual([
+      {
+        id: "person",
+        dataSourceId: "source-1",
+        nameSingular: "person",
+        namePlural: "people",
+        labelSingular: "Person",
+        labelPlural: "People",
+        description: null,
+        icon: null,
+        isCustom: true,
+        isActive: true,
+        isSystem: false,
+      },
+    ]);
+  });
+
+  test("getRecordFieldsForDataModel filters unsupported and system fields", async () => {
+    const client = createClient({
+      data: {
+        object: {
+          id: "person",
+          dataSourceId: "source-1",
+          nameSingular: "person",
+          namePlural: "people",
+          labelSingular: "Person",
+          labelPlural: "People",
+          description: null,
+          isCustom: true,
+          isActive: true,
+          isSystem: false,
+          fields: [
+            {
+              id: "field-name",
+              type: "TEXT",
+              name: "name",
+              label: "Name",
+              description: null,
+              isCustom: true,
+              isActive: true,
+              isSystem: false,
+              isNullable: false,
+              defaultValue: null,
+              options: null,
+            },
+            {
+              id: "field-updated-at",
+              type: "DATE_TIME",
+              name: "updatedAt",
+              label: "Updated At",
+              description: null,
+              isCustom: false,
+              isActive: true,
+              isSystem: true,
+              isNullable: true,
+              defaultValue: null,
+              options: null,
+            },
+            {
+              id: "field-company",
+              type: "RELATION",
+              name: "company",
+              label: "Company",
+              description: null,
+              isCustom: true,
+              isActive: true,
+              isSystem: false,
+              isNullable: true,
+              defaultValue: null,
+              options: null,
+            },
+          ],
+        },
+      },
+    });
+
+    await expect(createMetadataService(client).getRecordFieldsForDataModel("person")).resolves.toEqual({
+      id: "person",
+      dataSourceId: "source-1",
+      nameSingular: "person",
+      namePlural: "people",
+      labelSingular: "Person",
+      labelPlural: "People",
+      description: null,
+      isCustom: true,
+      isActive: true,
+      isSystem: false,
+      fields: [
+        {
+          id: "field-name",
+          type: "TEXT",
+          name: "name",
+          label: "Name",
+          description: null,
+          isCustom: true,
+          isActive: true,
+          isSystem: false,
+          isNullable: false,
+          defaultValue: null,
+          options: null,
+        },
+      ],
+    });
+  });
+});

--- a/extensions/twenty/src/services/metadata.ts
+++ b/extensions/twenty/src/services/metadata.ts
@@ -1,0 +1,42 @@
+import { getActiveDataModelsSchema } from "./zod/schema/dataModelSchema";
+import { getDataModelWithFieldsSchema } from "./zod/schema/recordFieldSchema";
+import type { TwentyClient } from "./client";
+
+const EXCLUDED_FIELD_NAMES = new Set(["updatedAt", "deletedAt"]);
+const UNSUPPORTED_CREATE_FIELD_TYPES = new Set(["RELATION", "ACTOR"]);
+
+export const createMetadataService = (client: TwentyClient) => ({
+  async getActiveDataModels() {
+    const rawData: unknown = await client.requestJson("/metadata/objects");
+
+    if (rawData === undefined) {
+      throw new Error("Twenty metadata request returned no data.");
+    }
+
+    const parsed = getActiveDataModelsSchema.parse(rawData);
+
+    return parsed.data.objects.filter((model) => model.isActive && !model.isSystem);
+  },
+
+  async getRecordFieldsForDataModel(id: string) {
+    const rawData: unknown = await client.requestJson(`/metadata/objects/${id}`);
+
+    if (rawData === undefined) {
+      throw new Error("Twenty metadata request returned no data.");
+    }
+
+    const parsed = getDataModelWithFieldsSchema.parse(rawData);
+    const object = parsed.data.object;
+
+    return {
+      ...object,
+      fields: object.fields.filter(
+        (field) =>
+          field.isActive &&
+          !field.isSystem &&
+          !EXCLUDED_FIELD_NAMES.has(field.name) &&
+          !UNSUPPORTED_CREATE_FIELD_TYPES.has(field.type),
+      ),
+    };
+  },
+});

--- a/extensions/twenty/src/services/preferences.test.ts
+++ b/extensions/twenty/src/services/preferences.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+
+import { buildTwentyConfig, normalizeTwentyBaseUrl } from "./preferences";
+
+describe("normalizeTwentyBaseUrl", () => {
+  test("returns the hosted Twenty URL for empty input", () => {
+    expect(normalizeTwentyBaseUrl("")).toBe("https://app.twenty.com");
+  });
+
+  test("normalizes a self-hosted rest URL", () => {
+    expect(normalizeTwentyBaseUrl("https://twenty.example.com/rest/")).toBe("https://twenty.example.com");
+  });
+
+  test("rejects inputs that are not full URLs", () => {
+    expect(() => normalizeTwentyBaseUrl("twenty.local")).toThrowError(/full URL/i);
+  });
+});
+
+describe("buildTwentyConfig", () => {
+  test("builds the typed preference config", () => {
+    expect(
+      buildTwentyConfig({
+        token: "secret-token",
+        url: "https://twenty.example.com/rest/",
+        object_creation_form_behaviour: true,
+      }),
+    ).toEqual({
+      token: "secret-token",
+      authHeader: "Bearer secret-token",
+      baseUrl: "https://twenty.example.com",
+      restBaseUrl: "https://twenty.example.com/rest",
+      keepObjectFormOpen: true,
+    });
+  });
+});

--- a/extensions/twenty/src/services/preferences.ts
+++ b/extensions/twenty/src/services/preferences.ts
@@ -1,0 +1,52 @@
+import { getPreferenceValues } from "@raycast/api";
+
+const DEFAULT_TWENTY_BASE_URL = "https://app.twenty.com";
+
+export interface TwentyConfig {
+  token: string;
+  authHeader: string;
+  baseUrl: string;
+  restBaseUrl: string;
+  keepObjectFormOpen: boolean;
+}
+
+type RawPreferences = Pick<Preferences, "token" | "url" | "object_creation_form_behaviour">;
+
+export const normalizeTwentyBaseUrl = (input?: string): string => {
+  const trimmed = input?.trim();
+  const value = trimmed ? trimmed : DEFAULT_TWENTY_BASE_URL;
+
+  try {
+    const url = new URL(value);
+    url.hash = "";
+    url.search = "";
+    url.pathname = url.pathname.replace(/\/+$/, "");
+
+    if (url.pathname.endsWith("/rest")) {
+      url.pathname = url.pathname.slice(0, -5);
+    }
+
+    const normalized = url.toString();
+    return normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+  } catch {
+    throw new Error(
+      "Invalid Twenty base URL. Enter a full URL such as https://app.twenty.com or https://twenty.example.com.",
+    );
+  }
+};
+
+export const buildTwentyConfig = (raw: RawPreferences): TwentyConfig => {
+  const baseUrl = normalizeTwentyBaseUrl(raw.url);
+
+  return {
+    token: raw.token,
+    authHeader: `Bearer ${raw.token}`,
+    baseUrl,
+    restBaseUrl: `${baseUrl}/rest`,
+    keepObjectFormOpen: raw.object_creation_form_behaviour,
+  };
+};
+
+export const getTwentyConfig = (): TwentyConfig => {
+  return buildTwentyConfig(getPreferenceValues<RawPreferences>());
+};

--- a/extensions/twenty/src/services/raycast-api.mock.ts
+++ b/extensions/twenty/src/services/raycast-api.mock.ts
@@ -1,0 +1,6 @@
+export const getPreferenceValues = <T>() =>
+  ({
+    token: "",
+    url: "",
+    object_creation_form_behaviour: false,
+  }) as T;

--- a/extensions/twenty/src/services/records.ts
+++ b/extensions/twenty/src/services/records.ts
@@ -1,0 +1,12 @@
+import type { TwentyClient } from "./client";
+
+export const createRecordsService = (client: TwentyClient) => ({
+  async createObjectRecord(namePlural: string, body: unknown) {
+    await client.requestJson(`/${namePlural}`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    return true;
+  },
+});

--- a/extensions/twenty/vitest.config.ts
+++ b/extensions/twenty/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    clearMocks: true,
+    restoreMocks: true,
+  },
+});

--- a/extensions/twenty/vitest.config.ts
+++ b/extensions/twenty/vitest.config.ts
@@ -1,6 +1,15 @@
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vitest/config";
 
+const raycastApiMockPath = fileURLToPath(new URL("./src/services/raycast-api.mock.ts", import.meta.url));
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@raycast/api": raycastApiMockPath,
+    },
+  },
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],


### PR DESCRIPTION
## Summary
- rewrite the Twenty extension foundation around a typed client plus metadata-driven services and form rendering
- add configurable server URL support alongside the API key so self-hosted Twenty instances work
- support native Twenty composite field handling for the current command surface and clarify setup in the docs

## Test Plan
- npm run test:run
- npm run lint
- npm run build

## Notes
- This is PR 1 of 3 in the stack.
- Follow-up stacked diffs currently live in salmonumbrella/extensions#1 and salmonumbrella/extensions#2 because GitHub cannot target upstream fork-only base branches directly.
- Manual Raycast smoke testing was completed locally during development.
