### PR TITLE
Update linkwarden extension - fix undefined .map crash in Add Website and Search

### DIFF
--- a/extensions/linkwarden/CHANGELOG.md
+++ b/extensions/linkwarden/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Replaced unchecked `as Collection` cast in the submit handler with a graceful failure toast
 - Guarded the same latent `.map` / `.length` call sites in the "Search Linkwarden" command
 
-## [Fix Potential Search Errors] - {PR_MERGE_DATE}
+## [Fix Potential Search Errors] - 2026-03-23
 
 - Fixed "Bad Request" error caused by sending empty `collectionId` to the API
 - Fixed search text not being URL-encoded, causing malformed requests with special characters

--- a/extensions/linkwarden/CHANGELOG.md
+++ b/extensions/linkwarden/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Linkwarden Changelog
 
-## [Fix Undefined Data Crash] - {PR_MERGE_DATE}
+## [Fix Undefined Data Crash] - 2026-04-22
 
 - Fixed `TypeError: Cannot read properties of undefined (reading 'map')` crash in the "Add Website to Linkwarden" command when the API returns an unexpected body shape
 - Hardened `useTags` and `useCollections` so `data` is always an array, regardless of the API response shape

--- a/extensions/linkwarden/CHANGELOG.md
+++ b/extensions/linkwarden/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Linkwarden Changelog
 
-## [Fix Potential Search Errors] - 2026-03-23
+## [Fix Undefined Data Crash] - {PR_MERGE_DATE}
+
+- Fixed `TypeError: Cannot read properties of undefined (reading 'map')` crash in the "Add Website to Linkwarden" command when the API returns an unexpected body shape
+- Hardened `useTags` and `useCollections` so `data` is always an array, regardless of the API response shape
+- Replaced unchecked `as Collection` cast in the submit handler with a graceful failure toast
+- Guarded the same latent `.map` / `.length` call sites in the "Search Linkwarden" command
+
+## [Fix Potential Search Errors] - {PR_MERGE_DATE}
 
 - Fixed "Bad Request" error caused by sending empty `collectionId` to the API
 - Fixed search text not being URL-encoded, causing malformed requests with special characters

--- a/extensions/linkwarden/src/add.tsx
+++ b/extensions/linkwarden/src/add.tsx
@@ -110,7 +110,17 @@ export default () => {
 
   const { itemProps, handleSubmit, reset } = useForm<FormValues>({
     async onSubmit(values) {
-      const collection = collections.find((collection) => collection.id === Number(values.collectionId)) as Collection;
+      const collection = (collections ?? []).find((collection) => collection.id === Number(values.collectionId)) as
+        | Collection
+        | undefined;
+      if (!collection) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Collection not found",
+          message: "Please pick a collection before submitting.",
+        });
+        return;
+      }
       await fetchLink(preferences, values, collection);
     },
     initialValues: {
@@ -143,7 +153,7 @@ export default () => {
     >
       <Form.TextField {...itemProps.url} title="URL" placeholder="http://example.com/" />
       <Form.Dropdown title="Collection" {...itemProps.collectionId}>
-        {collections.map((collection) => (
+        {(collections ?? []).map((collection) => (
           <Form.Dropdown.Item
             key={collection.id}
             icon={{ source: Icon.Folder, tintColor: collection.color }}
@@ -154,7 +164,7 @@ export default () => {
       </Form.Dropdown>
       <Form.TextField {...itemProps.name} title="Name" placeholder="Will be auto generated if left empty" autoFocus />
       <Form.TagPicker {...itemProps.tagPicker} title="Tag Picker" placeholder="Select...">
-        {tags.map((tag) => (
+        {(tags ?? []).map((tag) => (
           <Form.TagPicker.Item value={tag.name} title={tag.name} key={tag.id} />
         ))}
       </Form.TagPicker>

--- a/extensions/linkwarden/src/hooks.ts
+++ b/extensions/linkwarden/src/hooks.ts
@@ -13,10 +13,12 @@ export const useTags = () =>
     headers,
     mapResult(result: ApiResponse<Tag[]>) {
       return {
-        data: result.response,
+        // Fall back to [] if the API returns an unexpected body shape so that
+        // consumers can always safely call `.map` on `data`.
+        data: Array.isArray(result?.response) ? result.response : [],
       };
     },
-    initialData: [],
+    initialData: [] as Tag[],
     keepPreviousData: true,
   });
 
@@ -25,9 +27,11 @@ export const useCollections = () =>
     headers,
     mapResult(result: ApiResponse<Collection[]>) {
       return {
-        data: result.response,
+        // Fall back to [] if the API returns an unexpected body shape so that
+        // consumers can always safely call `.map` on `data`.
+        data: Array.isArray(result?.response) ? result.response : [],
       };
     },
-    initialData: [],
+    initialData: [] as Collection[],
     keepPreviousData: true,
   });

--- a/extensions/linkwarden/src/search.tsx
+++ b/extensions/linkwarden/src/search.tsx
@@ -36,7 +36,7 @@ export default function Command() {
     headers,
     mapResult(result: ApiResponse<Link[]>) {
       return {
-        data: result.response,
+        data: Array.isArray(result?.response) ? result.response : [],
       };
     },
     initialData: [],

--- a/extensions/linkwarden/src/search.tsx
+++ b/extensions/linkwarden/src/search.tsx
@@ -87,7 +87,7 @@ export default function Command() {
       searchBarAccessory={
         <List.Dropdown tooltip="Collection" onChange={setCollectionId}>
           <List.Dropdown.Item title="All" value="" />
-          {collections.map((collection) => (
+          {(collections ?? []).map((collection) => (
             <List.Dropdown.Item
               key={collection.id}
               icon={{ source: Icon.Folder, tintColor: collection.color }}
@@ -98,7 +98,7 @@ export default function Command() {
         </List.Dropdown>
       }
     >
-      {!isLoading && !data.length && (
+      {!isLoading && !(data ?? []).length && (
         <>
           {!collectionId ? (
             <EmptyView title="You Haven't Created Any Links Yet" />
@@ -107,7 +107,7 @@ export default function Command() {
           )}
         </>
       )}
-      {data.map((item) => {
+      {(data ?? []).map((item) => {
         return (
           <List.Item
             key={item.id}


### PR DESCRIPTION
## Description

Fixes #27059. The **Add Website** command crashes on render when the tags/collections fetch resolves to `undefined` data; **Search** has the same latent bug.

**Root cause**

`useFetch` + `mapResult` doesn't guarantee `data` is an array, even with `initialData: []`. If the API returns a 2xx with an unexpected body shape, `mapResult` returns `{ data: undefined }`, overriding `initialData`, and unguarded `.map` / `.find` calls in render throw. The Raycast `AsyncState` docs also list `data: undefined` as a valid state.

**Prior similar issues**

Same error, same class of fix, previously landed in `raycast/extensions`:

- [#17464](https://github.com/raycast/extensions/pull/17464) — *Bugfix: Ensure fetched data is always mapable* (can-i-php)
- [#21118](https://github.com/raycast/extensions/pull/21118) — Radarr: fixed `TypeError: c.map is not a function` via `(list || []).map(...)`
- [#5786](https://github.com/raycast/extensions/issues/5786) — Flaticon: identical crash
- The official [`useFetch` docs](https://developers.raycast.com/utilities/react-hooks/usefetch) use `{(data || []).map(...)}` in their canonical example for exactly this reason.

---

**For transparency:** this fix was prepared with the help of AI (investigation, root-cause analysis, and patch drafting). All changes were reviewed, tested locally (`tsc`, `ray lint`, `ray build`), and verified in Raycast before opening the PR.


## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
