### PR TITLE
 Fix duplicate collection names producing React key warnings

### DIFF
--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zotero Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Fix duplicate collection names in dropdown by using DISTINCT query, preventing React duplicate key warnings
+
 ## [Features] - 2026-04-05
 
 - Add "Open PDF in System Viewer" action to open the attachment with the system's default viewer

--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zotero Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-04-12
 
 - Fix duplicate collection names in dropdown by using DISTINCT query, preventing React duplicate key warnings
 

--- a/extensions/zotero/package.json
+++ b/extensions/zotero/package.json
@@ -12,7 +12,8 @@
     "lazarjov",
     "joshuahhh",
     "faridrashidi",
-    "ridemountainpig"
+    "ridemountainpig",
+    "kszenes"
   ],
   "version": "1.0.0",
   "license": "MIT",

--- a/extensions/zotero/src/common/zoteroApi.ts
+++ b/extensions/zotero/src/common/zoteroApi.ts
@@ -136,7 +136,7 @@ ORDER BY "index" ASC
 `;
 
 const ALL_COLLECTIONS_SQL = `
-SELECT  collections.collectionName AS name
+SELECT DISTINCT collections.collectionName AS name
     FROM collections
 `;
 


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Use SELECT DISTINCT for the collections query so that identically-named subcollections no longer produce duplicate React keys in the CollectionDropdown.

Fixes #27088

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
