### PR TITLE
Add optional space support to Nowledge Mem

### DIFF
--- a/extensions/nowledge-mem/CHANGELOG.md
+++ b/extensions/nowledge-mem/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## [Unreleased]
+## [Ambient Space Support] - {PR_MERGE_DATE}
 
 - Added an optional **Space** preference so one Raycast profile can stay in one named Nowledge Mem lane
 - Search, Add Memory, and Read Working Memory now follow that configured lane, or fall back to shared `~/.nowledge-mem/config.json` when Raycast preferences are blank
 - Fixed POST and GET requests to handle the Default space consistently, so blank space settings no longer send `space_id: ""`
 - `Edit Working Memory` now stays explicitly Default-only and points users to the Mem app or API for non-default spaces
+
 ## [Remote Access Support] - 2026-03-11
 
 - **Remote Working Memory**: the Working Memory command now reads from the Mem API, so remote Mem setups work correctly

--- a/extensions/nowledge-mem/CHANGELOG.md
+++ b/extensions/nowledge-mem/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Ambient Space Support] - {PR_MERGE_DATE}
+## [Ambient Space Support] - 2026-04-12
 
 - Added an optional **Space** preference so one Raycast profile can stay in one named Nowledge Mem lane
 - Search, Add Memory, and Read Working Memory now follow that configured lane, or fall back to shared `~/.nowledge-mem/config.json` when Raycast preferences are blank

--- a/extensions/nowledge-mem/CHANGELOG.md
+++ b/extensions/nowledge-mem/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+- Added an optional **Space** preference so one Raycast profile can stay in one named Nowledge Mem lane
+- Search, Add Memory, and Read Working Memory now follow that configured lane, or fall back to shared `~/.nowledge-mem/config.json` when Raycast preferences are blank
+- Fixed POST and GET requests to handle the Default space consistently, so blank space settings no longer send `space_id: ""`
+- `Edit Working Memory` now stays explicitly Default-only and points users to the Mem app or API for non-default spaces
 ## [Remote Access Support] - 2026-03-11
 
 - **Remote Working Memory**: the Working Memory command now reads from the Mem API, so remote Mem setups work correctly

--- a/extensions/nowledge-mem/README.md
+++ b/extensions/nowledge-mem/README.md
@@ -9,13 +9,15 @@ Search and browse your personal knowledge base from Raycast. Find memories, save
 3. Choose one connection path:
    - **Local default**: leave settings alone and use the local Mem server at `http://127.0.0.1:14242`
    - **Remote Mem**: set **Server URL** and **API Key** in Raycast preferences, or configure `~/.nowledge-mem/config.json`
+4. Optional: set **Space** in Raycast preferences if this profile should stay in one named memory lane
 
 The extension now supports the same remote auth shape used across other Nowledge integrations.
 
 ```json
 {
   "apiUrl": "https://mem.example.com",
-  "apiKey": "nmem_your_key"
+  "apiKey": "nmem_your_key",
+  "space": "Research Agent"
 }
 ```
 
@@ -23,10 +25,10 @@ The extension now supports the same remote auth shape used across other Nowledge
 
 | Command | Description |
 |---------|-------------|
-| **Search Memories** | Search your knowledge base with natural language. Shows results ranked by relevance. When empty, shows recent memories. |
-| **Add Memory** | Save a quick memory with title, content, and importance level. |
-| **Read Working Memory** | Read today's Working Memory briefing from the Mem API. |
-| **Edit Working Memory** | Open `~/ai-now/memory.md` in your default editor for quick local edits. |
+| **Search Memories** | Search your knowledge base with natural language. Shows results ranked by relevance. When empty, shows recent memories from the configured space. |
+| **Add Memory** | Save a quick memory with title, content, and importance level into the configured space. |
+| **Read Working Memory** | Read today's Working Memory briefing from the Mem API, following the configured space if one is set. |
+| **Edit Working Memory** | Open the Default Working Memory file in your default editor for quick local edits. |
 
 ### Actions
 
@@ -43,7 +45,7 @@ The Working Memory view supports:
 
 ## What Is Working Memory?
 
-Each morning, Nowledge Mem generates a briefing at `~/ai-now/memory.md` summarizing what you're focused on, what needs attention, and what changed. Connected tools can read it through the API or MCP so your assistant knows your context before you type a word.
+Each morning, Nowledge Mem generates a Working Memory briefing summarizing what you're focused on, what needs attention, and what changed. The Default space keeps `~/ai-now/memory.md`; connected tools read the right briefing through the API or MCP when they know the active lane.
 
 ## Configuration
 
@@ -51,11 +53,23 @@ Each morning, Nowledge Mem generates a briefing at `~/ai-now/memory.md` summariz
 |---|---|---|
 | Server URL | `http://127.0.0.1:14242` | Nowledge Mem server address. Leave as local default, or point it at your remote Mem URL. |
 | API Key | empty | Optional remote Mem API key. Sent as `Authorization: Bearer ...` and `X-NMEM-API-Key`. |
+| Space | empty | Optional fixed space name for this Raycast profile. Leave empty to use `~/.nowledge-mem/config.json` if it defines a space, or `Default` if it does not. |
 
-If preferences are empty, the extension also checks `~/.nowledge-mem/config.json` for `apiUrl` and `apiKey`.
+If preferences are empty, the extension also checks `~/.nowledge-mem/config.json` for `apiUrl`, `apiKey`, and `space`.
+
+## Spaces
+
+Raycast is a launcher, not a multi-agent harness. The right model here is one optional fixed lane:
+
+- Leave **Space** empty to follow `~/.nowledge-mem/config.json` when it defines a lane, or `Default` when it does not
+- Set **Space** when this Raycast profile always belongs to one stable lane, such as `Research Agent` or `Personal`
+- Do not expect Raycast to derive per-agent routing on its own
+
+`Edit Working Memory` remains a local convenience command for the **Default** file at `~/ai-now/memory.md`. If you configure another space, read it through the API-backed command and edit it in the Mem app.
 
 ## Notes
 
 - **Remote support**: search, add memory, and read Working Memory all support authenticated remote Mem access.
-- **Edit Working Memory** remains a local-file convenience command. For remote-only setups, edit through the Nowledge Mem app or API instead.
+- **Space-aware recall**: Search, Add Memory, and Read Working Memory follow the optional fixed space from Raycast preferences or `~/.nowledge-mem/config.json`.
+- **Edit Working Memory** remains a local-file convenience command for the Default space. For remote-only setups, or for other spaces, edit through the Nowledge Mem app or API instead.
 - **Graph visualization** is available through the desktop app and MCP-native hosts (Claude Code, Codex) which support interactive canvas rendering. Raycast's UI model does not support embedded web views, so graph exploration is not included in this extension.

--- a/extensions/nowledge-mem/package.json
+++ b/extensions/nowledge-mem/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "nowledge-mem",
   "title": "Nowledge Mem",
-  "description": "Search memories, read Working Memory, add insights, and explore your knowledge graph.",
+  "description": "Search memories, add a quick memory, and read Working Memory from Raycast.",
   "icon": "extension-icon.png",
   "author": "wey-gu",
   "categories": [
@@ -83,6 +83,13 @@
       "title": "API Key",
       "description": "Optional Mem API key for remote access. Supports nmem_... keys.",
       "type": "password",
+      "required": false
+    },
+    {
+      "name": "space",
+      "title": "Space",
+      "description": "Optional fixed memory space name for this Raycast profile. Leave empty to use shared nmem config, or Default if none is configured.",
+      "type": "textfield",
       "required": false
     }
   ],

--- a/extensions/nowledge-mem/src/api.ts
+++ b/extensions/nowledge-mem/src/api.ts
@@ -6,11 +6,13 @@ import { join } from "path";
 interface ConfigFile {
   apiUrl?: string;
   apiKey?: string;
+  space?: string;
 }
 
 export interface ConnectionConfig {
   baseUrl: string;
   apiKey?: string;
+  space?: string;
 }
 
 const DEFAULT_BASE_URL = "http://127.0.0.1:14242";
@@ -29,19 +31,37 @@ function readConfigFile(): ConfigFile {
     return {
       apiUrl: normalizeUrl(raw.apiUrl),
       apiKey: raw.apiKey?.trim() || undefined,
+      space: normalizeSpace(raw.space),
     };
   } catch {
     return {};
   }
 }
 
+function normalizeSpace(space?: string): string | undefined {
+  const trimmed = space?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function resolveConfiguredSpacePreference(
+  preferenceSpace: string | undefined,
+  configSpace: string | undefined,
+): string | undefined {
+  const normalizedPreference = normalizeSpace(preferenceSpace);
+  if (normalizedPreference) {
+    return normalizedPreference;
+  }
+  return configSpace;
+}
+
 export function getConnectionConfig(): ConnectionConfig {
-  const { serverUrl, apiKey } = getPreferenceValues<Preferences>();
+  const { serverUrl, apiKey, space } = getPreferenceValues<Preferences>();
   const config = readConfigFile();
 
   return {
     baseUrl: normalizeUrl(serverUrl) || config.apiUrl || DEFAULT_BASE_URL,
     apiKey: apiKey?.trim() || config.apiKey,
+    space: resolveConfiguredSpacePreference(space, config.space),
   };
 }
 
@@ -94,6 +114,27 @@ async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
   return res;
 }
 
+function appendSpaceQuery(path: string, space?: string): string {
+  if (!space) {
+    return path;
+  }
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}space_id=${encodeURIComponent(space)}`;
+}
+
+function withOptionalSpaceId<T extends Record<string, unknown>>(
+  body: T,
+  space?: string,
+): T & { space_id?: string } {
+  if (!space) {
+    return body;
+  }
+  return {
+    ...body,
+    space_id: space,
+  };
+}
+
 /** Memory as returned by the search endpoint. */
 export interface SearchMemory {
   id: string;
@@ -136,17 +177,23 @@ export async function searchMemories(
   query: string,
   limit = 10,
 ): Promise<SearchResult[]> {
+  const { space } = getConnectionConfig();
   const res = await apiFetch("/memories/search", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ query, limit, mode: "fast" }),
+    body: JSON.stringify(
+      withOptionalSpaceId({ query, limit, mode: "fast" }, space),
+    ),
   });
 
   return (await res.json()) as SearchResult[];
 }
 
 export async function listMemories(limit = 20): Promise<ListMemory[]> {
-  const res = await apiFetch(`/memories?limit=${limit}`);
+  const { space } = getConnectionConfig();
+  const res = await apiFetch(
+    appendSpaceQuery(`/memories?limit=${limit}`, space),
+  );
   const data = (await res.json()) as { memories: ListMemory[] };
   return data.memories;
 }
@@ -161,16 +208,18 @@ export interface CreateMemoryRequest {
 export async function createMemory(
   req: CreateMemoryRequest,
 ): Promise<SearchMemory> {
+  const { space } = getConnectionConfig();
   const res = await apiFetch("/memories", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(req),
+    body: JSON.stringify(withOptionalSpaceId({ ...req }, space)),
   });
 
   return (await res.json()) as SearchMemory;
 }
 
 export async function readWorkingMemory(): Promise<WorkingMemoryResponse> {
-  const res = await apiFetch("/agent/working-memory");
+  const { space } = getConnectionConfig();
+  const res = await apiFetch(appendSpaceQuery("/agent/working-memory", space));
   return (await res.json()) as WorkingMemoryResponse;
 }

--- a/extensions/nowledge-mem/src/edit-working-memory.tsx
+++ b/extensions/nowledge-mem/src/edit-working-memory.tsx
@@ -5,12 +5,22 @@ import { existsSync } from "fs";
 import { getConnectionConfig, isLocalConnection } from "./api";
 
 export default async function EditWorkingMemory() {
+  const { baseUrl, space } = getConnectionConfig();
+
+  if (space && space.toLowerCase() !== "default") {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Default Space Only",
+      message: `This shortcut edits ~/ai-now/memory.md. Use the Mem app or API to edit Working Memory for "${space}".`,
+    });
+    return;
+  }
+
   if (!isLocalConnection()) {
-    const { baseUrl } = getConnectionConfig();
     await showToast({
       style: Toast.Style.Failure,
       title: "Local File Editing Only",
-      message: `This command edits ~/ai-now/memory.md on the local machine. Current connection: ${baseUrl}`,
+      message: `This command edits the Default Working Memory file on the local machine. Current connection: ${baseUrl}`,
     });
     return;
   }
@@ -22,7 +32,7 @@ export default async function EditWorkingMemory() {
       style: Toast.Style.Failure,
       title: "Working Memory Not Found",
       message:
-        "Enable Background Intelligence in Nowledge Mem to generate your daily briefing.",
+        "Enable Background Intelligence in Nowledge Mem to generate the Default-space daily briefing.",
     });
     return;
   }

--- a/extensions/nowledge-mem/src/working-memory.tsx
+++ b/extensions/nowledge-mem/src/working-memory.tsx
@@ -4,7 +4,7 @@ import { getConnectionConfig, readWorkingMemory } from "./api";
 
 export default function WorkingMemory() {
   const { isLoading, data } = useCachedPromise(readWorkingMemory);
-  const { baseUrl } = getConnectionConfig();
+  const { baseUrl, space } = getConnectionConfig();
 
   if (!data?.exists) {
     return (
@@ -38,6 +38,13 @@ The Working Memory API is the source of truth for this command.`
             text={baseUrl}
             icon={Icon.Network}
           />
+          {space && (
+            <Detail.Metadata.Label
+              title="Space"
+              text={space}
+              icon={Icon.Folder}
+            />
+          )}
           {data.date && (
             <Detail.Metadata.Label
               title="Date"


### PR DESCRIPTION
## Description

Adds optional ambient space support to the Nowledge Mem Raycast extension.

This lets one Raycast profile stay in one named Nowledge Mem lane through the new `Space` preference, while still falling back to shared `~/.nowledge-mem/config.json` when Raycast preferences are blank.

What changed:

- added an optional `Space` preference
- made Search Memories, Add Memory, and Read Working Memory follow the resolved lane
- kept blank/default space handling consistent across GET and POST requests
- kept Edit Working Memory explicitly Default-only
- updated the README and changelog to explain the lane model clearly

## Screencast

No new commands or assets were added. This change is preference-driven and affects request routing plus the existing Working Memory metadata view.

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build`
- [ ] I tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with the metadata tool
