### PR TITLE
[Forked Extensions] Improve sparse clone sync and respository path resolution

### DIFF
--- a/extensions/forked-extensions/CHANGELOG.md
+++ b/extensions/forked-extensions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Raycast Fork Extensions Changelog
 
-## [Improvements] - 2026-04-12
+## [Improvements] - {PR_MERGE_DATE}
 
 - Optimize clone and fetch behavior with the "tree:0" partial clone filter, "--no-tags", and "upstream/main"-only tracking
 - Fix "Pull Changes" to update from "origin/main" instead of syncing "upstream/main"

--- a/extensions/forked-extensions/CHANGELOG.md
+++ b/extensions/forked-extensions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Raycast Fork Extensions Changelog
 
+## [Improvements] - 2026-04-12
+
+- Optimize clone and fetch behavior with the "tree:0" partial clone filter, "--no-tags", and "upstream/main"-only tracking
+- Fix "Pull Changes" to update from "origin/main" instead of syncing "upstream/main"
+- Change the default repository directory to "~/Developer", reuse an existing fork repository when selected directly, and warn before initializing inside potentially cloud-synced folders
+
 ## [Chore] - 2026-02-24
 
 - Update extension instruction

--- a/extensions/forked-extensions/CHANGELOG.md
+++ b/extensions/forked-extensions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Raycast Fork Extensions Changelog
 
-## [Improvements] - {PR_MERGE_DATE}
+## [Improvements] - 2026-04-11
 
 - Optimize clone and fetch behavior with the "tree:0" partial clone filter, "--no-tags", and "upstream/main"-only tracking
 - Fix "Pull Changes" to update from "origin/main" instead of syncing "upstream/main"

--- a/extensions/forked-extensions/CHEATSHEET.md
+++ b/extensions/forked-extensions/CHEATSHEET.md
@@ -2,10 +2,10 @@
 
 ## Git Commands
 
-### Clone a repository with `blob:none` filter
+### Clone a repository with `tree:0` filter
 
 ```shell
-git clone --filter=tree:0 --no-checkout <fork-repository-url>
+git clone --filter=tree:0 --no-checkout --no-tags <fork-repository-url>
 ```
 
 ### Convert full checkout to sparse checkout with cone mode
@@ -19,14 +19,29 @@ git checkout main
 
 ```shell
 git remote add upstream <upstream-repository-url>
+git config remote.origin.promisor true
+git config remote.origin.partialclonefilter tree:0
+git config remote.origin.tagOpt --no-tags
+git config remote.upstream.promisor true
+git config remote.upstream.partialclonefilter tree:0
+git config remote.upstream.tagOpt --no-tags
+git config --replace-all remote.upstream.fetch +refs/heads/main:refs/remotes/upstream/main
 ```
 
 ### Sync the forked repository with the upstream on local
 
 ```shell
-git fetch --prune --filter=tree:0 upstream
+git fetch --prune --no-tags --filter=tree:0 upstream +refs/heads/main:refs/remotes/upstream/main
 git checkout main
 git merge --ff-only upstream/main
+```
+
+### Pull the latest changes from your fork on local
+
+```shell
+git fetch --prune --no-tags --filter=tree:0 origin +refs/heads/main:refs/remotes/origin/main
+git checkout main
+git merge --ff-only origin/main
 ```
 
 ### Add a sparse-checkout directory

--- a/extensions/forked-extensions/README.md
+++ b/extensions/forked-extensions/README.md
@@ -4,7 +4,7 @@ Efficiently manage your forked Raycast extensions using Git sparse-checkout. Exp
 
 ## Principles
 
-This extension leverages the [Git sparse-checkout](https://git-scm.com/docs/git-sparse-checkout) feature to efficiently manage your forked extensions. Our goal is to eliminate the need for cloning the entire repository, which can exceed 20 GB in size, by enabling sparse-checkout. With this extension, you can forgo Ray CLI's commands, allowing you to use Git commands directly and regular [GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow) for managing your extensions.
+This extension leverages [Git sparse-checkout](https://git-scm.com/docs/git-sparse-checkout) together with partial clone filters to efficiently manage your forked extensions. Our goal is to eliminate the need for cloning the entire repository, which can exceed 20 GB in size, by only checking out the directories you need and by limiting future fetches to the smallest useful object set. With this extension, you can forgo Ray CLI's commands, allowing you to use Git commands directly and regular [GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow) for managing your extensions.
 
 Please note with this extension you no longer need to use Ray CLI's `pull-contributions` and `publish` commands. Just use Git commands or your favorite Git GUI tool to manage your forked extensions.
 
@@ -48,12 +48,13 @@ You can add a directory with the `git sparse-checkout add` command. Or use this 
 
 You might need some manual cleanup to reduce the size of your `.git` folder. Here are a few methods you can take:
 
+- New repositories created or reconfigured by this extension now use the `tree:0` partial clone filter, disable automatic tag downloads, and only track `upstream/main` by default to keep future fetches smaller
 - Use [git-gc](https://git-scm.com/docs/git-gc) to clean up unnecessary files and optimize the local repository
 - Use [git-fsck](https://git-scm.com/docs/git-fsck) to check the integrity of the repository
 - Use [git-prune](https://git-scm.com/docs/git-prune) to remove any objects that are no longer referenced by your branches
 - Use [git-maintenance](https://git-scm.com/docs/git-maintenance) to perform various maintenance tasks on your repository
 
-But we recommend using a new clone of the repository to start fresh with a smaller `.git` folder.
+These steps can reduce future growth and reclaim garbage, but they cannot remove reachable objects that are already in an existing clone. If your `.git` folder is already very large, we still recommend starting fresh with a new clone.
 
 ## License
 

--- a/extensions/forked-extensions/package.json
+++ b/extensions/forked-extensions/package.json
@@ -49,11 +49,11 @@
     },
     {
       "name": "repositoryConfigurationPath",
-      "title": "Repository Path",
-      "description": "Path to the repository where the extension is located.",
+      "title": "Repository Directory",
+      "description": "Directory where the extension should create or reuse a `forked-extensions` repository.",
       "type": "directory",
       "required": true,
-      "default": "~/Documents/forked-extensions"
+      "default": "~/Developer"
     },
     {
       "name": "gitRemoteType",

--- a/extensions/forked-extensions/src/components/diagnostics.tsx
+++ b/extensions/forked-extensions/src/components/diagnostics.tsx
@@ -3,7 +3,7 @@ import { Action, ActionPanel, Detail, useNavigation } from "@raycast/api";
 import * as api from "../api.js";
 import { catchError } from "../errors.js";
 import * as git from "../git.js";
-import { getCommitDiffMessage } from "../utils.js";
+import { getCloudSyncedPathRoot, getCommitDiffMessage, simplifyPath } from "../utils.js";
 
 export default function Diagnostics() {
   const [status, setStatus] = useState<string>("Running diagnostics...");
@@ -11,6 +11,8 @@ export default function Diagnostics() {
 
   useEffect(() => {
     catchError(async () => {
+      const forkedRepository = await api.getForkedRepository().catch(() => undefined);
+      await git.resolveRepositoryPath(forkedRepository);
       const isGitInstalled = await git.checkIfGitIsValid();
       const isStatusClean = await git
         .checkIfStatusClean()
@@ -18,6 +20,7 @@ export default function Diagnostics() {
         .catch(() => false);
       const currentBranch = await git.getCurrentBranch().catch(() => undefined);
       const isMainBranch = currentBranch === "main";
+      const cloudSyncedPathRoot = getCloudSyncedPathRoot(git.repositoryPath);
       const localForkedRepository = await git.getForkedRepository();
       const remoteForkedRepository = localForkedRepository
         ? await api.repositoryExists(localForkedRepository)
@@ -56,6 +59,10 @@ export default function Diagnostics() {
               : "- ⚠️ You have uncommitted changes. Please commit or stash them before performing operations."
             : `- ⚠️ You're not on the 'main' branch (current on '${currentBranch}'). Please switch to the 'main' branch to ensure proper functionality.`
           : "- ⚠️ Git is not installed or not found. Please set up your Git executable file path manually in the extension preferences.",
+        "### Repository path",
+        cloudSyncedPathRoot
+          ? `- ⚠️ [${simplifyPath(git.repositoryPath)} 📁](file://${git.repositoryPath}) is inside ${cloudSyncedPathRoot} and may be affected by iCloud or other cloud sync tools.`
+          : `- ✅ [${simplifyPath(git.repositoryPath)} 📁](file://${git.repositoryPath})`,
         "### Local forked repository",
         isMainBranch
           ? localForkedRepository

--- a/extensions/forked-extensions/src/git.ts
+++ b/extensions/forked-extensions/src/git.ts
@@ -1,14 +1,19 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import process from "node:process";
 import { confirmAlert } from "@raycast/api";
 import spawn from "nano-spawn";
 import * as api from "./api.js";
-import { defaultGitExecutableFilePath } from "./constants.js";
+import { defaultGitExecutableFilePath, upstreamRepository } from "./constants.js";
 import { catchError } from "./errors.js";
 import operation from "./operation.js";
 import { ForkedExtension } from "./types.js";
-import { gitExecutableFilePath, getRemoteUrl, repositoryConfigurationPath, addQuotesIfInWindows } from "./utils.js";
+import {
+  gitExecutableFilePath,
+  getRemoteUrl,
+  repositoryConfigurationPath,
+  addQuotesIfInWindows,
+  resolvePath,
+} from "./utils.js";
 
 /**
  * The path to the Git executable file.
@@ -19,18 +24,119 @@ import { gitExecutableFilePath, getRemoteUrl, repositoryConfigurationPath, addQu
 const gitFilePath = addQuotesIfInWindows(gitExecutableFilePath || defaultGitExecutableFilePath);
 
 /**
- * Resolves the path to the repository configuration.
- * @remarks If the path starts with `~/`, it will be resolved to the user's home directory.
- * @param input The input path to resolve.
- * @returns The resolved path.
+ * The configured directory from extension preferences.
  */
-const resolvePath = (input: string) =>
-  input.startsWith("~/") ? path.join(process.env.HOME || "", input.slice(2)) : input;
+export const repositoryConfigurationRootPath = resolvePath(repositoryConfigurationPath);
 
 /**
- * The path to the repository where forked extensions are managed.
+ * The default directory name used for the managed repository.
  */
-export const repositoryPath = resolvePath(repositoryConfigurationPath);
+const repositoryDirectoryName = "forked-extensions";
+
+/**
+ * The default repository path derived from the configured directory.
+ */
+const defaultRepositoryPath =
+  path.basename(repositoryConfigurationRootPath) === repositoryDirectoryName
+    ? repositoryConfigurationRootPath
+    : path.join(repositoryConfigurationRootPath, repositoryDirectoryName);
+
+/**
+ * The effective path to the repository where forked extensions are managed.
+ * @remarks This can resolve either to the configured directory itself or to its `forked-extensions` child directory.
+ */
+export let repositoryPath = defaultRepositoryPath;
+
+/**
+ * Whether the effective repository path has already been resolved.
+ */
+let repositoryPathResolved = false;
+
+/**
+ * The partial clone filter used for clone and fetch operations.
+ */
+const partialCloneFilter = "tree:0";
+
+/**
+ * The default branch used for synchronization operations.
+ */
+const mainBranch = "main";
+
+/**
+ * Executes a git command in a specific repository directory.
+ * @param args The arguments to pass to the git command.
+ * @param cwd The working directory where the git command should run.
+ * @returns The subprocess result of the git command execution.
+ */
+const gitAtPath = async (args: string[], cwd: string) => spawn(gitFilePath, args, { cwd, shell: true });
+
+/**
+ * Normalizes a GitHub remote URL into a `owner/repository` string.
+ * @param input The remote URL to normalize.
+ * @returns The normalized repository full name.
+ */
+const normalizeRepositoryRemote = (input: string) =>
+  input
+    .trim()
+    .replace(/^(https:\/\/github.com\/|git@github\.com:)/, "")
+    .replace(/\.git$/, "");
+
+/**
+ * Returns the normalized repository full name for a remote in a repository path.
+ * @param input The repository path to inspect.
+ * @param remote The remote name to inspect.
+ * @returns The normalized remote repository full name.
+ */
+const getRemoteRepositoryAtPath = async (input: string, remote: string) => {
+  const { output } = await gitAtPath(["remote", "get-url", remote], input).catch(() => ({ output: "" }));
+  return normalizeRepositoryRemote(output);
+};
+
+/**
+ * Returns whether a repository path is already a managed forked extensions repository.
+ * @param input The repository path to inspect.
+ * @param forkedRepository Optional. The expected forked repository full name.
+ * @returns Whether the path is already a managed forked extensions repository.
+ */
+const isManagedForkedRepository = async (input: string, forkedRepository?: string) => {
+  const gitExists = await fileExists(path.join(input, ".git"));
+  if (!gitExists) return false;
+
+  const originRepository = await getRemoteRepositoryAtPath(input, "origin");
+  if (!originRepository) return false;
+
+  const upstreamRemote = await getRemoteRepositoryAtPath(input, "upstream");
+  if (forkedRepository)
+    return originRepository === forkedRepository && (upstreamRemote === "" || upstreamRemote === upstreamRepository);
+  return upstreamRemote === upstreamRepository && originRepository !== upstreamRepository;
+};
+
+/**
+ * Resolves the effective repository path based on the configured directory.
+ * @param forkedRepository Optional. The expected forked repository full name.
+ * @returns The resolved repository path.
+ */
+export const resolveRepositoryPath = async (forkedRepository?: string) => {
+  if (await isManagedForkedRepository(repositoryConfigurationRootPath, forkedRepository)) {
+    repositoryPath = repositoryConfigurationRootPath;
+    repositoryPathResolved = true;
+    return repositoryPath;
+  }
+
+  if (
+    repositoryConfigurationRootPath !== defaultRepositoryPath &&
+    (await isManagedForkedRepository(defaultRepositoryPath, forkedRepository))
+  ) {
+    repositoryPath = defaultRepositoryPath;
+    repositoryPathResolved = true;
+    return repositoryPath;
+  }
+
+  if (repositoryPathResolved) return repositoryPath;
+  repositoryPath = defaultRepositoryPath;
+  repositoryPathResolved = true;
+  return repositoryPath;
+};
 
 /**
  * Checks if a file or directory exists and is readable and writable.
@@ -48,6 +154,7 @@ export const fileExists = async (input: string) =>
  * @returns A promise that resolves to an array of ForkedExtension objects.
  */
 export const getExtensionList = async () => {
+  await resolveRepositoryPath();
   const repositoryExists = await fileExists(repositoryPath);
   if (!repositoryExists) return [];
 
@@ -86,7 +193,10 @@ export const getExtensionList = async () => {
  * @param args The arguments to pass to the git command.
  * @returns The subprocess result of the git command execution.
  */
-export const git = async (args: string[]) => spawn(gitFilePath, args, { cwd: repositoryPath, shell: true });
+export const git = async (args: string[]) => {
+  await resolveRepositoryPath();
+  return gitAtPath(args, repositoryPath);
+};
 
 /**
  * Checks if Git is valid by running `git --version`.
@@ -111,6 +221,44 @@ export const getCurrentBranch = async () => {
 };
 
 /**
+ * Configures a remote to use the optimized partial clone settings.
+ * @param remote The remote name to configure.
+ * @param mainOnly Whether the remote should only track the main branch.
+ */
+const configureOptimizedRemote = async (remote: string, mainOnly?: boolean) => {
+  await git(["config", `remote.${remote}.promisor`, "true"]);
+  await git(["config", `remote.${remote}.partialclonefilter`, partialCloneFilter]);
+  await git(["config", `remote.${remote}.tagOpt`, "--no-tags"]);
+  if (mainOnly) {
+    await git([
+      "config",
+      "--replace-all",
+      `remote.${remote}.fetch`,
+      `+refs/heads/${mainBranch}:refs/remotes/${remote}/${mainBranch}`,
+    ]);
+  }
+};
+
+/**
+ * Fetches and fast-forwards the local main branch from a remote main branch.
+ * @param remote The remote name to update from.
+ */
+const updateFromRemoteMain = async (remote: string) => {
+  const currentBranch = await getCurrentBranch();
+  await git([
+    "fetch",
+    "--prune",
+    "--no-tags",
+    `--filter=${partialCloneFilter}`,
+    remote,
+    `+refs/heads/${mainBranch}:refs/remotes/${remote}/${mainBranch}`,
+  ]);
+  if (currentBranch !== mainBranch) await git(["checkout", mainBranch]);
+  await git(["merge", "--ff-only", `${remote}/${mainBranch}`]);
+  if (currentBranch !== mainBranch) await git(["checkout", currentBranch]);
+};
+
+/**
  * Gets the last full commit hash of the current branch.
  * @remarks Returns an empty string if the repository is not initialized.
  * @returns The last commit hash as a string.
@@ -125,38 +273,55 @@ export const getLastCommitHash = async () => {
  * @returns An object containing the forked repository full name and a boolean indicating if it's newly cloned.
  */
 export const getForkedRepository = async () => {
+  await resolveRepositoryPath();
   const gitExists = await fileExists(path.join(repositoryPath, ".git"));
   if (!gitExists) return "";
   const { output } = await git(["remote", "get-url", "origin"]);
-  const existingRepository = output.replace(/^(https:\/\/github.com\/|git@github\.com:)/, "").replace(/\.git$/, "");
+  const existingRepository = normalizeRepositoryRemote(output);
   return existingRepository;
+};
+
+/**
+ * Gets the forked repository full name only when the resolved repository path already points to a managed fork.
+ * @returns The forked repository full name, or an empty string if the current path is not a managed fork.
+ */
+export const getManagedForkedRepository = async () => {
+  await resolveRepositoryPath();
+  if (!(await isManagedForkedRepository(repositoryPath))) return "";
+  return getForkedRepository();
 };
 
 /**
  * Converts a full checkout to a sparse checkout with cone mode.
  */
 export const convertFullCheckoutToSparseCheckout = async () => {
-  await git(["config", "remote.origin.promisor", "true"]);
-  await git(["config", "remote.origin.partialclonefilter", "blob:none"]);
+  const { output } = await git(["remote"]);
+  const remotes = output.split("\n").map((x) => x.trim());
+  await configureOptimizedRemote("origin");
+  if (remotes.includes("upstream")) await configureOptimizedRemote("upstream", true);
   await git(["sparse-checkout", "set", "--cone"]);
-  await git(["checkout", "main"]);
+  await git(["checkout", mainBranch]);
 };
 
 /**
  * Initializes the repository by cloning it if it doesn't exist.
+ * @param forkedRepository The full name of the forked repository.
  * @returns The full name of the forked repository.
  */
-export const initRepository = async () => {
+export const initRepository = async (forkedRepository?: string) => {
+  const resolvedForkedRepository = forkedRepository ?? (await api.getForkedRepository());
+  await resolveRepositoryPath(resolvedForkedRepository);
   const localForkedRepository = await getForkedRepository();
-  if (localForkedRepository) return localForkedRepository;
-  const forkedRepository = await api.getForkedRepository();
+  if (localForkedRepository === resolvedForkedRepository) return localForkedRepository;
+  await fs.mkdir(path.dirname(repositoryPath), { recursive: true });
   await spawn(
     gitFilePath,
     [
       "clone",
-      "--filter=blob:none",
+      `--filter=${partialCloneFilter}`,
       "--no-checkout",
-      getRemoteUrl(forkedRepository),
+      "--no-tags",
+      getRemoteUrl(resolvedForkedRepository),
       addQuotesIfInWindows(repositoryPath),
     ],
     {
@@ -164,7 +329,7 @@ export const initRepository = async () => {
     },
   );
   await convertFullCheckoutToSparseCheckout();
-  return forkedRepository;
+  return resolvedForkedRepository;
 };
 
 /**
@@ -177,6 +342,8 @@ export const setUpstream = async (forkedRepository: string) => {
   const remotes = output.split("\n").map((x) => x.trim());
   await git(["remote", remotes.includes("upstream") ? "set-url" : "add", "upstream", getRemoteUrl()]);
   await git(["remote", "set-url", "origin", getRemoteUrl(forkedRepository)]);
+  await configureOptimizedRemote("origin");
+  await configureOptimizedRemote("upstream", true);
 };
 
 /**
@@ -233,12 +400,15 @@ export const getAheadBehindCommits = async () => {
  * @see {@link https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork#syncing-a-fork-branch-from-the-command-line|Syncing a fork}
  */
 export const syncFork = async () => {
-  const { output } = await git(["branch", "--show-current"]);
-  const currentBranch = output.trim();
-  await git(["fetch", "--prune", "--filter=tree:0", "upstream"]);
-  if (currentBranch !== "main") await git(["checkout", "main"]);
-  await git(["merge", "--ff-only", "upstream/main"]);
-  if (currentBranch !== "main") await git(["checkout", currentBranch]);
+  await updateFromRemoteMain("upstream");
+};
+
+/**
+ * Pulls the latest changes from the forked repository on local.
+ * @remarks This will checkout to main branch and merge the origin main branch into it.
+ */
+export const pullFork = async () => {
+  await updateFromRemoteMain("origin");
 };
 
 /**
@@ -266,6 +436,7 @@ export const sparseCheckoutAdd = async (pattern: string[]) => {
  * @param pattern The target pattern names.
  */
 export const sparseCheckoutRemove = async (pattern: string[]) => {
+  await resolveRepositoryPath();
   const sparseCheckoutInfoPath = path.join(repositoryPath, ".git", "info", "sparse-checkout");
   const sparseCheckoutInfo = await fs.readFile(sparseCheckoutInfoPath, "utf-8");
   const lines = sparseCheckoutInfo.split("\n");

--- a/extensions/forked-extensions/src/operation.ts
+++ b/extensions/forked-extensions/src/operation.ts
@@ -1,8 +1,14 @@
-import { Clipboard, Toast, confirmAlert, openExtensionPreferences, showToast } from "@raycast/api";
+import path from "node:path";
+import { Clipboard, LocalStorage, Toast, confirmAlert, openExtensionPreferences, showToast } from "@raycast/api";
 import * as api from "./api.js";
 import { catchError } from "./errors.js";
 import * as git from "./git.js";
-import { getCommitsText } from "./utils.js";
+import { getCloudSyncedPathRoot, getCommitsText, simplifyPath } from "./utils.js";
+
+/**
+ * The storage key prefix for acknowledged cloud-synced repository path warnings.
+ */
+const cloudSyncedRepositoryPathWarningStorageKey = "cloud-synced-repository-path-warning:";
 
 /**
  * Class to manage operations related to forked extensions.
@@ -45,11 +51,19 @@ class Operation {
         return;
       }
 
+      await git.resolveRepositoryPath();
+      const localForkedRepository = await git.getManagedForkedRepository();
+      const forkedRepository = localForkedRepository || (await api.getForkedRepository());
+      await git.resolveRepositoryPath(forkedRepository);
+
+      const shouldContinue = await this.confirmCloudSyncedRepositoryPath();
+      if (!shouldContinue) return;
+
       this.showToast({ title: "Initializing repository" });
-      const forkedRepository = await git.initRepository();
+      const initializedRepository = await git.initRepository(forkedRepository);
       await git.checkIfSparseCheckoutEnabled();
-      await git.setUpstream(forkedRepository);
-      return forkedRepository;
+      await git.setUpstream(initializedRepository);
+      return initializedRepository;
     } finally {
       this.isOperating = false;
       this.hideToast();
@@ -81,10 +95,47 @@ class Operation {
     );
 
   /**
+   * Warns once before initializing a repository inside a potentially cloud-synced location.
+   * @returns Whether the initialization should continue.
+   */
+  private confirmCloudSyncedRepositoryPath = async () => {
+    const cloudSyncedPathRoot = getCloudSyncedPathRoot(git.repositoryPath);
+    if (!cloudSyncedPathRoot) return true;
+
+    const hasRepository = await git.fileExists(path.join(git.repositoryPath, ".git"));
+    if (hasRepository) return true;
+
+    const warningKey = `${cloudSyncedRepositoryPathWarningStorageKey}${git.repositoryPath}`;
+    const acknowledgedWarning = await LocalStorage.getItem<string>(warningKey);
+    if (acknowledgedWarning === "true") return true;
+
+    return new Promise<boolean>((resolve, reject) => {
+      confirmAlert({
+        title: "Repository Path May Be Cloud-Synced",
+        message: `Your repository path ${simplifyPath(git.repositoryPath)} is inside ${cloudSyncedPathRoot}. If iCloud Drive or another cloud sync tool manages this folder, Git metadata may be duplicated or corrupted. We recommend choosing ~/Developer so the repository can be created at ~/Developer/forked-extensions instead.`,
+        primaryAction: {
+          title: "Open Preferences",
+          onAction: catchError(async () => {
+            await openExtensionPreferences();
+            resolve(false);
+          }),
+        },
+        dismissAction: {
+          title: "Continue Anyway",
+          onAction: catchError(async () => {
+            await LocalStorage.setItem(warningKey, "true");
+            resolve(true);
+          }),
+        },
+      }).catch(reject);
+    });
+  };
+
+  /**
    * Pulls the latest changes from the remote forked repository.
    * @remarks This will checkout to main branch and merge the forked main branch into it.
    */
-  pull = async () => this.spawn(async () => git.syncFork(), "Pulling changes", "Pulled successfully");
+  pull = async () => this.spawn(async () => git.pullFork(), "Pulling changes", "Pulled successfully");
 
   /**
    * Forks an extension by adding it to the sparse-checkout list.

--- a/extensions/forked-extensions/src/utils.ts
+++ b/extensions/forked-extensions/src/utils.ts
@@ -28,6 +28,15 @@ export const isMac = process.platform === "darwin";
 export const isWindows = process.platform === "win32";
 
 /**
+ * Resolves the path to the repository configuration.
+ * @remarks If the path starts with `~/`, it will be resolved to the user's home directory.
+ * @param input The input path to resolve.
+ * @returns The resolved path.
+ */
+export const resolvePath = (input: string) =>
+  input.startsWith("~/") ? path.join(process.env.HOME || "", input.slice(2)) : input;
+
+/**
  * Simplifies a file path by replacing the home directory with a tilde.
  * @param filePath The file path to simplify.
  * @returns The simplified file path.
@@ -36,6 +45,22 @@ export const simplifyPath = (filePath: string) => {
   const home = os.homedir();
   if (filePath.startsWith(home)) return filePath.replace(home, "~");
   return filePath;
+};
+
+/**
+ * Returns the cloud-synced root directory if the path is inside a risky location.
+ * @param input The file path to check.
+ * @returns The simplified risky root path, if any.
+ */
+export const getCloudSyncedPathRoot = (input: string) => {
+  const resolvedPath = resolvePath(input);
+  const riskyRoots = [
+    path.join(os.homedir(), "Desktop"),
+    path.join(os.homedir(), "Documents"),
+    path.join(os.homedir(), "Library", "Mobile Documents"),
+  ];
+  const riskyRoot = riskyRoots.find((root) => resolvedPath === root || resolvedPath.startsWith(`${root}${path.sep}`));
+  return riskyRoot ? simplifyPath(riskyRoot) : undefined;
 };
 
 /**

--- a/extensions/forked-extensions/src/utils.ts
+++ b/extensions/forked-extensions/src/utils.ts
@@ -34,7 +34,7 @@ export const isWindows = process.platform === "win32";
  * @returns The resolved path.
  */
 export const resolvePath = (input: string) =>
-  input.startsWith("~/") ? path.join(process.env.HOME || "", input.slice(2)) : input;
+  input.startsWith("~/") ? path.join(os.homedir(), input.slice(2)) : input;
 
 /**
  * Simplifies a file path by replacing the home directory with a tilde.


### PR DESCRIPTION
## Description

- Optimize clone and fetch behavior with the "tree:0" partial clone filter, "--no-tags", and "upstream/main"-only tracking
- Fix "Pull Changes" to update from "origin/main" instead of syncing "upstream/main"
- Change the default repository directory to "~/Developer", reuse an existing fork repository when selected directly, and warn before initializing inside potentially cloud-synced folders

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
