### PR TITLE
[Cal.com Share Meeting Links] Migrate to API v2

### DIFF
--- a/extensions/cal-com-share-meeting-links/CHANGELOG.md
+++ b/extensions/cal-com-share-meeting-links/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Cal.com Share Meeting Links Changelog
 
+## [Fix: Migrate to Cal.com API v2] - {PR_MERGE_DATE}
+
+- Migrate all API calls from Cal.com API v1 to v2 (v1 was permanently shut down on April 8, 2026)
+- Update authentication from query parameter to Bearer token header
+- Add required `cal-api-version` headers for all endpoints
+- Replace booking status update with separate confirm/decline endpoints (removes "Pending" option which is no longer supported)
+- Update cancel booking from DELETE to POST with request body
+- Use v2 field names (`meetingUrl`, `location`, `lengthInMinutes`, `recurrence`, etc.)
+
 ## [Generate private links] - 2025-10-28
 
 - Adds an action inside "Share Meeting Link" to generate and copy a one-time use private link (⌘ + S).

--- a/extensions/cal-com-share-meeting-links/package.json
+++ b/extensions/cal-com-share-meeting-links/package.json
@@ -17,7 +17,8 @@
     "pernielsentikaer",
     "alexs",
     "stelo",
-    "runofthemilgeek"
+    "runofthemilgeek",
+    "andrewbenson"
   ],
   "commands": [
     {

--- a/extensions/cal-com-share-meeting-links/src/api/cal.com.ts
+++ b/extensions/cal-com-share-meeting-links/src/api/cal.com.ts
@@ -109,7 +109,7 @@ async function calAPI<T>({ method = "GET", ...props }: AxiosRequestConfig) {
 export function useCurrentUser() {
   return useCachedPromise(
     async () => {
-      return await calAPI<CalUser>({ url: "/me", headers: { "cal-api-version": "2024-08-13" } });
+      return await calAPI<CalUser>({ url: "/me" });
     },
     [],
     { failureToastOptions: { title: "Unable to load current user" } },
@@ -173,7 +173,7 @@ export function createPrivateLinkForEventType(eventTypeId: number, signal: Abort
   return calAPI<CreatePrivateLinkResponse>({
     method: "POST",
     url: `/event-types/${eventTypeId}/private-links`,
-    headers: { "cal-api-version": "2024-06-14" },
+    headers: { "cal-api-version": "2024-09-04" },
     data: {
       maxUsageCount: 1,
     },

--- a/extensions/cal-com-share-meeting-links/src/api/cal.com.ts
+++ b/extensions/cal-com-share-meeting-links/src/api/cal.com.ts
@@ -6,30 +6,20 @@ import moment from "moment";
 export interface CalUser {
   id: number;
   username: string;
-  name: string;
+  name: string | null;
   email: string;
-  emailVerified: string;
-  bio: string;
-  avatar: string;
+  avatarUrl: string | null;
+  bio: string | null;
   timeZone: string;
   weekStart: string;
-  endTime: number;
-  bufferTime: number;
-  theme: null;
-  defaultScheduleId: number;
-  locale: string;
   timeFormat: number;
-  brandColor: string;
-  darkBrandColor: string;
-  allowDynamicBooking: true;
-  away: false;
-  createdDate: string;
-  verified: false;
-  invitedTo: null;
-}
-
-interface CalUserResp {
-  user: CalUser;
+  defaultScheduleId: number | null;
+  locale: string | null;
+  organizationId: number | null;
+  organization: {
+    isPlatform: boolean;
+    id: number;
+  } | null;
 }
 
 export interface CalEventType {
@@ -37,86 +27,61 @@ export interface CalEventType {
   title: string;
   slug: string;
   description: string;
-  position: number;
   locations: Array<unknown>;
-  length: number;
-  hidden: false;
-  userId: null;
-  teamId: null;
-  eventName: null;
-  timeZone: null;
-  periodType: string;
-  periodStartDate: string;
-  periodEndDate: string;
-  periodDays: null;
-  periodCountCalendarDays: false;
-  requiresConfirmation: false;
-  recurringEvent: null | recurringEvent;
-  disableGuests: false;
-  hideCalendarNotes: false;
+  lengthInMinutes: number;
+  hidden: boolean;
+  ownerId: number | null;
+  teamId: number | null;
+  recurrence: null | Recurrence;
+  confirmationPolicy: object | null;
+  disableGuests: boolean;
+  hideCalendarNotes: boolean;
   minimumBookingNotice: number;
   beforeEventBuffer: number;
   afterEventBuffer: number;
-  seatsPerTimeSlot: null;
-  schedulingType: null;
-  scheduleId: null;
   price: number;
   currency: string;
-  slotInterval: null;
   metadata: object;
-  successRedirectUrl: null;
-  link: string;
+  bookingUrl: string;
 }
 
-interface recurringEvent {
-  freq: number;
-  count: number;
+interface Recurrence {
+  frequency: string;
+  occurrences: number;
   interval: number;
 }
 
-interface CalEventTypeResp {
-  event_types: CalEventType[];
-}
-
-export interface CalBookingResp {
-  bookings: {
+export interface CalBooking {
+  id: number;
+  uid: string;
+  title: string;
+  description: string;
+  start: string;
+  end: string;
+  duration: number;
+  createdAt: string;
+  status: string;
+  meetingUrl: string | null;
+  location: string | null;
+  hosts: {
     id: number;
-    userId: number;
-    description: string;
-    eventTypeId: number;
-    uid: string;
-    title: string;
-    startTime: string;
-    endTime: string;
-    createdAt: string;
-    attendees: {
-      email: string;
-      name: string;
-      timeZone: string;
-      locale: string;
-    }[];
-    user: {
-      email: string;
-      name: string;
-      timeZone: string;
-      locale: string;
-    };
-    payment: {
-      id: number;
-      success: boolean;
-      paymentOption: string;
-    }[];
-    metadata: Record<string, unknown>;
-    status: string;
-    responses: {
-      email: string;
-      name: string;
-      location: {
-        optionValue: string;
-        value: string;
-      };
-    };
+    name: string;
+    email: string;
+    username: string;
+    timeZone: string;
   }[];
+  attendees: {
+    email: string;
+    name: string;
+    timeZone: string;
+    locale: string;
+  }[];
+  eventType: {
+    id: number;
+    slug: string;
+  } | null;
+  bookingFieldsResponses: Record<string, unknown> | null;
+  metadata: Record<string, unknown> | null;
 }
 
 interface CreatePrivateLinkResponse {
@@ -127,41 +92,24 @@ interface CreatePrivateLinkResponse {
   expiresAt: string;
 }
 
-export interface updateBookingContent {
-  status: string;
-}
-
-const defaultBaseUrl = "https://api.cal.com/v1/";
-const apiV2BaseUrl = "https://api.cal.com/v2/";
 const { token } = getPreferenceValues<Preferences>();
 
 const api = axios.create({
-  baseURL: defaultBaseUrl,
-  params: { apiKey: token },
-});
-
-const apiV2 = axios.create({
-  baseURL: apiV2BaseUrl,
+  baseURL: "https://api.cal.com/v2/",
   headers: {
     Authorization: `Bearer ${token}`,
   },
 });
 
 async function calAPI<T>({ method = "GET", ...props }: AxiosRequestConfig) {
-  const resp = await api.request<T>({ method, ...props });
-  return resp.data;
-}
-
-async function calAPIV2<T>({ method = "GET", ...props }: AxiosRequestConfig) {
-  const resp = await apiV2.request<{ data: T }>({ method, ...props });
+  const resp = await api.request<{ status: string; data: T }>({ method, ...props });
   return resp.data.data;
 }
 
 export function useCurrentUser() {
   return useCachedPromise(
     async () => {
-      const data = await calAPI<CalUserResp>({ url: "/me" });
-      return data.user;
+      return await calAPI<CalUser>({ url: "/me" });
     },
     [],
     { failureToastOptions: { title: "Unable to load current user" } },
@@ -171,8 +119,10 @@ export function useCurrentUser() {
 export function useEventTypes() {
   return useCachedPromise(
     async () => {
-      const data = await calAPI<CalEventTypeResp>({ url: "/event-types" });
-      return data.event_types.sort((a, b) => b.position - a.position);
+      return await calAPI<CalEventType[]>({
+        url: "/event-types",
+        headers: { "cal-api-version": "2024-06-14" },
+      });
     },
     [],
     { failureToastOptions: { title: "Unable to load event types" } },
@@ -182,34 +132,45 @@ export function useEventTypes() {
 export function useBookings() {
   return useCachedPromise(
     async () => {
-      const data = await calAPI<CalBookingResp>({ url: "/bookings" });
-      return data.bookings.sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
+      const data = await calAPI<CalBooking[]>({
+        url: "/bookings",
+        headers: { "cal-api-version": "2026-02-25" },
+      });
+      return data.sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime());
     },
     [],
     { failureToastOptions: { title: "Unable to load bookings" } },
   );
 }
 
-export function updateBooking(bookingId: number, data: updateBookingContent) {
+export function confirmBooking(bookingUid: string) {
   return calAPI({
-    method: "PATCH",
-    url: `/bookings/${bookingId}`,
-    data,
+    method: "POST",
+    url: `/bookings/${bookingUid}/confirm`,
+    headers: { "cal-api-version": "2026-02-25" },
   });
 }
 
-export function cancelBooking(bookingId: number, reason: string) {
+export function declineBooking(bookingUid: string, reason?: string) {
   return calAPI({
-    method: "DELETE",
-    url: `/bookings/${bookingId}/cancel`,
-    params: {
-      cancellationReason: reason,
-    },
+    method: "POST",
+    url: `/bookings/${bookingUid}/decline`,
+    headers: { "cal-api-version": "2026-02-25" },
+    data: reason ? { reason } : undefined,
+  });
+}
+
+export function cancelBooking(bookingUid: string, reason: string) {
+  return calAPI({
+    method: "POST",
+    url: `/bookings/${bookingUid}/cancel`,
+    headers: { "cal-api-version": "2026-02-25" },
+    data: { cancellationReason: reason },
   });
 }
 
 export function createPrivateLinkForEventType(eventTypeId: number, signal: AbortSignal) {
-  return calAPIV2<CreatePrivateLinkResponse>({
+  return calAPI<CreatePrivateLinkResponse>({
     method: "POST",
     url: `/event-types/${eventTypeId}/private-links`,
     data: {

--- a/extensions/cal-com-share-meeting-links/src/api/cal.com.ts
+++ b/extensions/cal-com-share-meeting-links/src/api/cal.com.ts
@@ -109,7 +109,7 @@ async function calAPI<T>({ method = "GET", ...props }: AxiosRequestConfig) {
 export function useCurrentUser() {
   return useCachedPromise(
     async () => {
-      return await calAPI<CalUser>({ url: "/me" });
+      return await calAPI<CalUser>({ url: "/me", headers: { "cal-api-version": "2024-08-13" } });
     },
     [],
     { failureToastOptions: { title: "Unable to load current user" } },
@@ -173,6 +173,7 @@ export function createPrivateLinkForEventType(eventTypeId: number, signal: Abort
   return calAPI<CreatePrivateLinkResponse>({
     method: "POST",
     url: `/event-types/${eventTypeId}/private-links`,
+    headers: { "cal-api-version": "2024-06-14" },
     data: {
       maxUsageCount: 1,
     },

--- a/extensions/cal-com-share-meeting-links/src/components/cancel-booking.tsx
+++ b/extensions/cal-com-share-meeting-links/src/components/cancel-booking.tsx
@@ -1,5 +1,5 @@
 import { Action, ActionPanel, Color, confirmAlert, Form, Icon, showToast, Toast, useNavigation } from "@raycast/api";
-import { CalBookingResp, cancelBooking } from "@api/cal.com";
+import { CalBooking, cancelBooking } from "@api/cal.com";
 import { FormValidation, MutatePromise, showFailureToast, useForm } from "@raycast/utils";
 
 export interface CancelBookingFormValues {
@@ -7,17 +7,17 @@ export interface CancelBookingFormValues {
 }
 
 interface CancelBookingProps {
-  bookingId: number;
-  mutate: MutatePromise<CalBookingResp["bookings"] | undefined>;
+  bookingUid: string;
+  mutate: MutatePromise<CalBooking[] | undefined>;
 }
 
-export function CancelBooking({ bookingId, mutate }: CancelBookingProps) {
+export function CancelBooking({ bookingUid, mutate }: CancelBookingProps) {
   const { pop } = useNavigation();
 
   const handleCancelBooking = async (reason: string) => {
     const toast = await showToast({ style: Toast.Style.Animated, title: "Cancelling booking" });
     try {
-      await cancelBooking(bookingId, reason);
+      await cancelBooking(bookingUid, reason);
       toast.style = Toast.Style.Success;
       toast.title = "Booking Cancelled";
       toast.message = "Booking has been successfully cancelled";
@@ -36,7 +36,7 @@ export function CancelBooking({ bookingId, mutate }: CancelBookingProps) {
           return;
         }
 
-        return bookings.map((b) => (b.id === bookingId ? { ...b, status: "CANCELLED" } : b));
+        return bookings.map((b) => (b.uid === bookingUid ? { ...b, status: "cancelled" } : b));
       },
     });
   };

--- a/extensions/cal-com-share-meeting-links/src/index.tsx
+++ b/extensions/cal-com-share-meeting-links/src/index.tsx
@@ -57,16 +57,16 @@ export default function Command() {
             ...(item.hidden
               ? [{ icon: { source: Icon.EyeDisabled, tintColor: Color.Orange }, tooltip: "Hidden" }]
               : []),
-            ...(item.recurringEvent
+            ...(item.recurrence
               ? [
                   {
                     icon: { source: Icon.Repeat, tintColor: Color.Purple },
-                    text: String(item.recurringEvent.count),
-                    tooltip: `Repeats up to ${item.recurringEvent.count} times`,
+                    text: String(item.recurrence.occurrences),
+                    tooltip: `Repeats up to ${item.recurrence.occurrences} times`,
                   },
                 ]
               : []),
-            ...(item.requiresConfirmation
+            ...(item.confirmationPolicy
               ? [
                   {
                     icon: { source: Icon.QuestionMarkCircle, tintColor: Color.Yellow },
@@ -74,13 +74,13 @@ export default function Command() {
                   },
                 ]
               : []),
-            { icon: { source: Icon.Clock, tintColor: Color.Blue }, text: `${item.length} min` },
+            { icon: { source: Icon.Clock, tintColor: Color.Blue }, text: `${item.lengthInMinutes} min` },
           ]}
-          keywords={item.length ? [item.length.toString()] : []}
+          keywords={item.lengthInMinutes ? [item.lengthInMinutes.toString()] : []}
           actions={
             <ActionPanel>
-              <Action.CopyToClipboard content={item.link} icon={Icon.Link} />
-              <Action.OpenInBrowser url={item.link} title="Preview URL" />
+              <Action.CopyToClipboard content={item.bookingUrl} icon={Icon.Link} />
+              <Action.OpenInBrowser url={item.bookingUrl} title="Preview URL" />
               <ActionPanel.Section title="Quick Links">
                 <Action.OpenInBrowser
                   title="Open Dashboard"

--- a/extensions/cal-com-share-meeting-links/src/view-bookings.tsx
+++ b/extensions/cal-com-share-meeting-links/src/view-bookings.tsx
@@ -1,34 +1,56 @@
 import { Action, ActionPanel, Color, Icon, List, openCommandPreferences, showToast, Toast } from "@raycast/api";
 import { showFailureToast, useCachedState } from "@raycast/utils";
-import { formatDateTime, formatTime, updateBooking, useBookings } from "@api/cal.com";
+import { CalBooking, confirmBooking, declineBooking, formatDateTime, formatTime, useBookings } from "@api/cal.com";
 import { CancelBooking } from "@components/cancel-booking";
 
 export default function viewBookings() {
   const { data: items, isLoading, error, mutate } = useBookings();
   const [isShowingDetail, setIsShowingDetail] = useCachedState("show-details", false);
 
-  const handleUpdateBookingStatus = async (bookingId: number, status: string) => {
-    const data = { status };
-    const toast = await showToast({ style: Toast.Style.Animated, title: "Updating booking status" });
+  const handleConfirmBooking = async (bookingUid: string) => {
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Confirming booking" });
     try {
-      await updateBooking(bookingId, data);
+      await confirmBooking(bookingUid);
       toast.style = Toast.Style.Success;
-      toast.title = "Booking Status Updated";
-      toast.message = `Booking status has been successfully updated to ${status.toLowerCase()}`;
+      toast.title = "Booking Confirmed";
+      toast.message = "Booking has been successfully accepted";
     } catch (error) {
-      await showFailureToast(error, { title: "Failed to update booking status" });
+      await showFailureToast(error, { title: "Failed to confirm booking" });
       throw error;
     }
   };
 
-  const handleUpdateAndMutate = async (bookingId: number, status: string) => {
-    await mutate(handleUpdateBookingStatus(bookingId, status), {
+  const handleDeclineBooking = async (bookingUid: string) => {
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Declining booking" });
+    try {
+      await declineBooking(bookingUid);
+      toast.style = Toast.Style.Success;
+      toast.title = "Booking Declined";
+      toast.message = "Booking has been successfully declined";
+    } catch (error) {
+      await showFailureToast(error, { title: "Failed to decline booking" });
+      throw error;
+    }
+  };
+
+  const handleConfirmAndMutate = async (item: CalBooking) => {
+    await mutate(handleConfirmBooking(item.uid), {
       optimisticUpdate: (bookings) => {
         if (!bookings) {
           return;
         }
+        return bookings.map((b) => (b.id === item.id ? { ...b, status: "accepted" } : b));
+      },
+    });
+  };
 
-        return bookings.map((b) => (b.id === bookingId ? { ...b, status } : b));
+  const handleDeclineAndMutate = async (item: CalBooking) => {
+    await mutate(handleDeclineBooking(item.uid), {
+      optimisticUpdate: (bookings) => {
+        if (!bookings) {
+          return;
+        }
+        return bookings.map((b) => (b.id === item.id ? { ...b, status: "rejected" } : b));
       },
     });
   };
@@ -60,10 +82,10 @@ export default function viewBookings() {
                 onAction={() => setIsShowingDetail(!isShowingDetail)}
               />
               <Action.OpenInBrowser title="Open Booking in Browser" url={`https://cal.com/booking/${item.uid}`} />
-              {item.metadata && (item.metadata["videoCallUrl"] as string | undefined) && (
+              {item.meetingUrl && (
                 <Action.OpenInBrowser
                   title="Open Video Call"
-                  url={item.metadata["videoCallUrl"] as string}
+                  url={item.meetingUrl}
                   icon={Icon.Video}
                   shortcut={{ modifiers: ["cmd"], key: "v" }}
                 />
@@ -72,24 +94,19 @@ export default function viewBookings() {
                 <Action
                   title="Accept"
                   icon={{ source: Icon.CheckCircle, tintColor: Color.Green }}
-                  onAction={() => handleUpdateAndMutate(item.id, "ACCEPTED")}
+                  onAction={() => handleConfirmAndMutate(item)}
                 />
                 <Action
-                  title="Reject"
+                  title="Decline"
                   icon={{ source: Icon.XMarkCircle, tintColor: Color.Red }}
-                  onAction={() => handleUpdateAndMutate(item.id, "REJECTED")}
-                />
-                <Action
-                  title="Pending"
-                  icon={{ source: Icon.Clock, tintColor: Color.Orange }}
-                  onAction={() => handleUpdateAndMutate(item.id, "PENDING")}
+                  onAction={() => handleDeclineAndMutate(item)}
                 />
               </ActionPanel.Submenu>
               <Action.Push
                 title="Cancel Booking"
                 icon={{ source: Icon.XMarkCircle, tintColor: Color.Red }}
                 shortcut={{ modifiers: ["cmd"], key: "c" }}
-                target={<CancelBooking bookingId={item.id} mutate={mutate} />}
+                target={<CancelBooking bookingUid={item.uid} mutate={mutate} />}
               />
               <Action.OpenInBrowser
                 title="Open All Bookings in Browser"
@@ -102,7 +119,7 @@ export default function viewBookings() {
             ...(isShowingDetail
               ? []
               : [
-                  ...(item.metadata && (item.metadata["videoCallUrl"] as string | undefined)
+                  ...(item.meetingUrl
                     ? [
                         {
                           icon: { source: Icon.Video, tintColor: Color.Yellow },
@@ -110,7 +127,7 @@ export default function viewBookings() {
                         },
                       ]
                     : []),
-                  ...(item.responses?.location?.optionValue
+                  ...(item.location
                     ? [
                         {
                           icon: { source: Icon.Pin, tintColor: Color.Yellow },
@@ -119,9 +136,9 @@ export default function viewBookings() {
                       ]
                     : []),
                   {
-                    date: new Date(item.startTime),
+                    date: new Date(item.start),
                     icon: { source: Icon.Calendar, tintColor: Color.Blue },
-                    tooltip: `${formatDateTime(item.startTime) + " - " + formatTime(item.endTime)}`,
+                    tooltip: `${formatDateTime(item.start) + " - " + formatTime(item.end)}`,
                   },
                 ]),
             {
@@ -138,31 +155,27 @@ export default function viewBookings() {
                   <List.Item.Detail.Metadata.Label title="Title" text={item.title} />
                   <List.Item.Detail.Metadata.Label
                     title="Status"
-                    text={item.status.charAt(0).toUpperCase() + item.status.slice(1).toLowerCase()}
+                    text={item.status.charAt(0).toUpperCase() + item.status.slice(1)}
                     icon={getIconForStatus(item.status)}
                   />
                   <List.Item.Detail.Metadata.Label
                     title="Start"
-                    text={formatDateTime(item.startTime)}
+                    text={formatDateTime(item.start)}
                     icon={{ source: Icon.Calendar, tintColor: Color.Blue }}
                   />
                   <List.Item.Detail.Metadata.Label
                     title="End"
-                    text={formatDateTime(item.endTime)}
+                    text={formatDateTime(item.end)}
                     icon={{ source: Icon.Calendar, tintColor: Color.Blue }}
                   />
-                  {item.metadata && (item.metadata["videoCallUrl"] as string | undefined) && (
-                    <List.Item.Detail.Metadata.Link
-                      title="Video Call"
-                      target={item.metadata["videoCallUrl"] as string}
-                      text={"Link"}
-                    />
+                  {item.meetingUrl && (
+                    <List.Item.Detail.Metadata.Link title="Video Call" target={item.meetingUrl} text={"Link"} />
                   )}
-                  {item.responses?.location?.optionValue && (
+                  {item.location && (
                     <List.Item.Detail.Metadata.Label
                       title={"Location"}
                       icon={{ source: Icon.Pin, tintColor: Color.Yellow }}
-                      text={item.responses?.location?.optionValue}
+                      text={item.location}
                     />
                   )}
                   <List.Item.Detail.Metadata.Separator />
@@ -191,12 +204,12 @@ export default function viewBookings() {
 
 function getIconForStatus(status: string) {
   switch (status) {
-    case "ACCEPTED":
+    case "accepted":
       return { source: Icon.CheckCircle, tintColor: Color.Green };
-    case "REJECTED":
-    case "CANCELLED":
+    case "rejected":
+    case "cancelled":
       return { source: Icon.XMarkCircle, tintColor: Color.Red };
-    case "PENDING":
+    case "pending":
       return { source: Icon.Clock, tintColor: Color.Orange };
     default:
       return { source: Icon.Circle, tintColor: Color.Purple };


### PR DESCRIPTION
## Description

Cal.com permanently shut down API v1 on April 8, 2026, breaking this extension completely (HTTP 410 on all requests). This migrates all endpoints to v2.

- Replace v1 query-param auth with v2 Bearer token auth
- Add required `cal-api-version` headers per endpoint family
- Update all types to match v2 response shapes
- Replace single PATCH booking update with separate confirm/decline endpoints
- Change cancel booking from DELETE to POST with request body
- Use v2 field names throughout (`start`/`end`, `lengthInMinutes`, `meetingUrl`, etc.)
- Remove "Pending" status option (no longer supported in v2)

Fixes #27030

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)