### PR TITLE
Add HDMI 3 / Alt DP 2 to source options

### DIFF
--- a/extensions/display-input-switcher/CHANGELOG.md
+++ b/extensions/display-input-switcher/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Display Input Switcher Changelog
 
-## [Added HDMI 3 source option] - {PR_MERGE_DATE}
+## [Added HDMI 3 source option] - 2026-04-13
 
 - Added HDMI 3 / Alt DP 2 to the list of available display input sources
 

--- a/extensions/display-input-switcher/CHANGELOG.md
+++ b/extensions/display-input-switcher/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Display Input Switcher Changelog
 
+## [Added HDMI 3 source option] - {PR_MERGE_DATE}
+
+- Added HDMI 3 / Alt DP 2 to the list of available display input sources
+
 ## [Initial Version] - 2026-04-10
 
 - Switch Input Source command with dropdown selection (HDMI 1/2, DisplayPort 1/2, USB-C)

--- a/extensions/display-input-switcher/src/utils/sources.ts
+++ b/extensions/display-input-switcher/src/utils/sources.ts
@@ -11,6 +11,7 @@ const VALUE_TO_NAME: Record<number, string> = {
   16: "DisplayPort 2",
   17: "HDMI 1",
   18: "HDMI 2",
+  19: "HDMI 3 / Alt DP 2",
   27: "USB-C",
 };
 


### PR DESCRIPTION
#27123 

Adds HDMI 3 (which works as Alt DP 2 on some LG monitors) 
## Description

Adds an additional option (HDMI 3) to the display choices
- [X ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ X] I checked that files in the `assets` folder are used by the extension itself
- [ X] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
