### PR TITLE
fix: Google Contacts AI tool timeout on empty query

### DIFF
--- a/extensions/google-contacts/CHANGELOG.md
+++ b/extensions/google-contacts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Contacts Changelog
 
-## [1.0.1] - {PR_MERGE_DATE}
+## [1.0.1] - 2026-04-13
 
 - Fix `search` operation timing out (600s max) when the AI tool is called without a query — now returns a single page of contacts instead of paginating the entire address book
 

--- a/extensions/google-contacts/CHANGELOG.md
+++ b/extensions/google-contacts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Contacts Changelog
 
+## [1.0.1] - {PR_MERGE_DATE}
+
+- Fix `search` operation timing out (600s max) when the AI tool is called without a query — now returns a single page of contacts instead of paginating the entire address book
+
 ## [Initial Release] - 2026-04-03
 
 - Search Contacts with List, Detail, and Grid view modes

--- a/extensions/google-contacts/package-lock.json
+++ b/extensions/google-contacts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "google-contacts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "google-contacts",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.11",

--- a/extensions/google-contacts/package.json
+++ b/extensions/google-contacts/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "google-contacts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "Google Contacts",
   "description": "Browse, search, and manage your Google Contacts directly from Raycast — create, edit, delete, and action contacts without leaving your keyboard.",
   "icon": "extension-icon.png",

--- a/extensions/google-contacts/src/api.ts
+++ b/extensions/google-contacts/src/api.ts
@@ -47,6 +47,16 @@ export async function fetchAllContacts(
   return all;
 }
 
+export async function fetchContactsFirstPage(token: string, pageSize = 30): Promise<Person[]> {
+  const params = new URLSearchParams({
+    personFields: PERSON_FIELDS,
+    pageSize: String(pageSize),
+    sortOrder: "FIRST_NAME_ASCENDING",
+  });
+  const res = await fetchApi<ConnectionsListResponse>(`${BASE_URL}/people/me/connections?${params}`, token);
+  return res.connections ?? [];
+}
+
 export async function searchContacts(token: string, query: string): Promise<Person[]> {
   // Warmup request required by Google before real searches return results
   await fetchApi<SearchResponse>(`${BASE_URL}/people:searchContacts?query=&readMask=names`, token);

--- a/extensions/google-contacts/src/tools/google-contacts.ts
+++ b/extensions/google-contacts/src/tools/google-contacts.ts
@@ -1,4 +1,11 @@
-import { createContact, deleteContact, fetchAllContacts, getContact, searchContacts, updateContact } from "../api";
+import {
+  createContact,
+  deleteContact,
+  fetchContactsFirstPage,
+  getContact,
+  searchContacts,
+  updateContact,
+} from "../api";
 import { google } from "../oauth";
 
 type Input = {
@@ -97,8 +104,7 @@ export default async function tool(input: Input) {
   switch (input.operation) {
     case "search": {
       if (!input.query) {
-        const contacts = await fetchAllContacts(token);
-        return contacts.slice(0, 30);
+        return await fetchContactsFirstPage(token);
       }
       const results = await searchContacts(token, input.query);
       if (results.length === 0) {


### PR DESCRIPTION
## Description

Fixes `tools/google-contacts` timing out at Raycast's 600s hard limit when the AI tool is called without a query.

The `search` operation previously fell through to `fetchAllContacts`, which paginates the entire address book at `pageSize: 1000` with a heavy `personFields` set, then threw away everything past the first 30. For users with many contacts or slow Google API round-trips, this reliably exceeded the 600s tool execution budget.

Now, the no-query branch calls a new `fetchContactsFirstPage` helper that does a single API request for the first page (30 contacts). This matches the pattern in `google-calendar` (`list-calendars.ts`, `search-events.ts`) where AI tools return safe small defaults when called without filters.

`fetchAllContacts` is retained for the UI hook in `src/hooks.ts` where full enumeration + caching is appropriate.

## Screencast

_N/A — behaviour change is internal to an AI tool. Before: `Error: The execution of tools/google-contacts timed out (600s max).` After: single page returns in ~1-2s._

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder