### PR TITLE
ClaudeCast: Fix underscore path resolution, restore permission mode and model on resume

### DIFF
--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -1,5 +1,16 @@
 # ClaudeCast Changelog
 
+## [1.4.0] - 2026-04-13
+
+### Fixed
+
+- **Underscore Path Resolution**: Projects with underscores in their path (e.g. `my_project`) now resolve correctly when browsing sessions. Claude Code encodes underscores as dashes in directory names, and the filesystem walk now probes underscore variants alongside dash variants.
+- **encodeProjectPath**: Updated to replace `_` with `-` alongside `/` and `.`, matching Claude Code's actual encoding behavior.
+
+### Added
+
+- **Permission Mode Restore on Resume**: Sessions started with non-default permission modes (e.g. `bypassPermissions`, `auto`, `plan`) now resume with the same mode. The `permissionMode` is parsed from session JSONL and passed as `--permission-mode` flag to Claude Code.
+
 ## [1.3.0] - 2026-04-06
 
 ### Added

--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 
 - **Permission Mode Restore on Resume**: Sessions started with non-default permission modes (e.g. `bypassPermissions`, `auto`, `plan`) now resume with the same mode. The `permissionMode` is parsed from session JSONL and passed as `--permission-mode` flag to Claude Code.
+- **Model Restore on Resume**: Sessions now resume with the same model they were started with (e.g. a Haiku session won't unexpectedly resume with Opus). The model is passed as `--model` flag to Claude Code.
 
 ## [1.3.0] - 2026-04-06
 

--- a/extensions/claudecast/src/browse-sessions.tsx
+++ b/extensions/claudecast/src/browse-sessions.tsx
@@ -20,6 +20,7 @@ import {
   safeTruncate,
   SessionMetadata,
   SessionDetail,
+  PermissionMode,
 } from "./lib/session-parser";
 import { launchClaudeCode } from "./lib/terminal";
 import { ensureClaudeInstalled } from "./lib/claude-cli";
@@ -162,6 +163,7 @@ function SessionItem({
     await launchClaudeCode({
       projectPath: session.projectPath,
       sessionId: session.id,
+      permissionMode: session.permissionMode,
     });
     await popToRoot();
   }
@@ -180,6 +182,7 @@ function SessionItem({
       projectPath: session.projectPath,
       sessionId: session.id,
       forkSession: true,
+      permissionMode: session.permissionMode,
     });
     await popToRoot();
   }
@@ -232,6 +235,7 @@ function SessionItem({
                 <SessionDetailView
                   sessionId={session.id}
                   projectPath={session.projectPath}
+                  permissionMode={session.permissionMode}
                 />
               }
             />
@@ -268,9 +272,11 @@ function SessionItem({
 function SessionDetailView({
   sessionId,
   projectPath,
+  permissionMode,
 }: {
   sessionId: string;
   projectPath: string;
+  permissionMode?: PermissionMode;
 }) {
   const [isLoading, setIsLoading] = useState(true);
   const [session, setSession] = useState<SessionDetail | null>(null);
@@ -342,6 +348,7 @@ function SessionDetailView({
               await launchClaudeCode({
                 projectPath,
                 sessionId,
+                permissionMode,
               });
               await popToRoot();
             }}
@@ -363,6 +370,7 @@ function SessionDetailView({
                 projectPath,
                 sessionId,
                 forkSession: true,
+                permissionMode,
               });
               await popToRoot();
             }}

--- a/extensions/claudecast/src/browse-sessions.tsx
+++ b/extensions/claudecast/src/browse-sessions.tsx
@@ -164,6 +164,7 @@ function SessionItem({
       projectPath: session.projectPath,
       sessionId: session.id,
       permissionMode: session.permissionMode,
+      model: session.model,
     });
     await popToRoot();
   }
@@ -183,6 +184,7 @@ function SessionItem({
       sessionId: session.id,
       forkSession: true,
       permissionMode: session.permissionMode,
+      model: session.model,
     });
     await popToRoot();
   }
@@ -236,6 +238,7 @@ function SessionItem({
                   sessionId={session.id}
                   projectPath={session.projectPath}
                   permissionMode={session.permissionMode}
+                  model={session.model}
                 />
               }
             />
@@ -273,10 +276,12 @@ function SessionDetailView({
   sessionId,
   projectPath,
   permissionMode,
+  model,
 }: {
   sessionId: string;
   projectPath: string;
   permissionMode?: PermissionMode;
+  model?: string;
 }) {
   const [isLoading, setIsLoading] = useState(true);
   const [session, setSession] = useState<SessionDetail | null>(null);
@@ -349,6 +354,7 @@ function SessionDetailView({
                 projectPath,
                 sessionId,
                 permissionMode,
+                model,
               });
               await popToRoot();
             }}
@@ -371,6 +377,7 @@ function SessionDetailView({
                 sessionId,
                 forkSession: true,
                 permissionMode,
+                model,
               });
               await popToRoot();
             }}

--- a/extensions/claudecast/src/lib/session-parser.ts
+++ b/extensions/claudecast/src/lib/session-parser.ts
@@ -4,6 +4,14 @@ import os from "os";
 import readline from "readline";
 import { trash } from "@raycast/api";
 
+export type PermissionMode =
+  | "acceptEdits"
+  | "auto"
+  | "bypassPermissions"
+  | "default"
+  | "dontAsk"
+  | "plan";
+
 export interface SessionMetadata {
   id: string;
   filePath: string;
@@ -16,6 +24,7 @@ export interface SessionMetadata {
   cost: number;
   model?: string;
   matchSnippet?: string;
+  permissionMode?: PermissionMode;
 }
 
 export interface SessionMessage {
@@ -47,6 +56,7 @@ interface JSONLEntry {
   };
   model?: string;
   timestamp?: string;
+  permissionMode?: PermissionMode;
 }
 
 /**
@@ -229,6 +239,9 @@ async function resolveByFilesystemWalk(
  * At each level, tries taking the longest possible run of parts as a single
  * path component (joined with literal "-"), checking if it exists on disk.
  * An empty part signals a dot-prefix (from Claude's encoding of "/." → "--").
+ *
+ * Claude Code encodes `_` as `-` in project directory names, so each candidate
+ * component is also probed with all dashes replaced by underscores.
  */
 async function walkPathSegments(
   basePath: string,
@@ -253,24 +266,33 @@ async function walkPathSegments(
       continue;
     }
 
-    const candidatePath = path.join(basePath, component);
+    // Claude Code also encodes underscores as dashes, so try both variants.
+    // Original (with dashes) is tried first to prefer literal dash names.
+    const variants = [component];
+    if (component.includes("-")) {
+      variants.push(component.replace(/-/g, "_"));
+    }
 
-    try {
-      const stat = await fs.promises.stat(candidatePath);
+    for (const variant of variants) {
+      const candidatePath = path.join(basePath, variant);
 
-      if (remaining.length === 0) {
-        // Last component — any file type is fine
-        return candidatePath;
-      }
+      try {
+        const stat = await fs.promises.stat(candidatePath);
 
-      if (stat.isDirectory()) {
-        const resolved = await walkPathSegments(candidatePath, remaining);
-        if (resolved) return resolved;
-      }
-    } catch (error: unknown) {
-      const code = (error as NodeJS.ErrnoException)?.code;
-      if (code !== "ENOENT" && code !== "ENOTDIR") {
-        console.warn(`Unexpected error probing ${candidatePath}:`, error);
+        if (remaining.length === 0) {
+          // Last component — any file type is fine
+          return candidatePath;
+        }
+
+        if (stat.isDirectory()) {
+          const resolved = await walkPathSegments(candidatePath, remaining);
+          if (resolved) return resolved;
+        }
+      } catch (error: unknown) {
+        const code = (error as NodeJS.ErrnoException)?.code;
+        if (code !== "ENOENT" && code !== "ENOTDIR") {
+          console.warn(`Unexpected error probing ${candidatePath}:`, error);
+        }
       }
     }
   }
@@ -280,12 +302,12 @@ async function walkPathSegments(
 
 /**
  * Encode a project path to Claude's directory naming format.
- * Claude Code (verified as of v1.x) replaces both / and . with -.
+ * Claude Code replaces /, ., and _ with -.
  * Confirmed empirically by inspecting ~/.claude/projects/ directory names
  * against their corresponding originalPath values in sessions-index.json.
  */
 export function encodeProjectPath(projectPath: string): string {
-  return projectPath.replace(/[/.]/g, "-");
+  return projectPath.replace(/[/._]/g, "-");
 }
 
 /**
@@ -375,6 +397,9 @@ async function parseSessionMetadataFast(
 
         if (entry.type === "user" || entry.type === "human") {
           turnCount++;
+          if (!result.permissionMode && entry.permissionMode) {
+            result.permissionMode = entry.permissionMode;
+          }
           if (!result.firstMessage && entry.message?.content) {
             const content = entry.message.content;
             if (typeof content === "string") {
@@ -632,6 +657,7 @@ export async function listAllSessions(options?: {
         turnCount: metadata.turnCount || 0,
         cost: metadata.cost || 0,
         model: metadata.model,
+        permissionMode: metadata.permissionMode,
       });
     } catch {
       // Skip files we can't read
@@ -672,6 +698,7 @@ export async function listProjectSessions(
           turnCount: metadata.turnCount || 0,
           cost: metadata.cost || 0,
           model: metadata.model,
+          permissionMode: metadata.permissionMode,
         });
       } catch {
         // Skip files we can't read
@@ -758,6 +785,7 @@ export async function searchSessionContent(
         cost: match.cost,
         model: match.model,
         matchSnippet: match.matchSnippet,
+        permissionMode: match.permissionMode,
       });
     }
   }
@@ -781,6 +809,7 @@ async function searchSingleSession(
   cost: number;
   model?: string;
   matchSnippet?: string;
+  permissionMode?: PermissionMode;
 } | null> {
   type MatchResult = {
     id: string;
@@ -790,6 +819,7 @@ async function searchSingleSession(
     cost: number;
     model?: string;
     matchSnippet?: string;
+    permissionMode?: PermissionMode;
   };
 
   return new Promise<MatchResult | null>((resolve) => {
@@ -800,6 +830,7 @@ async function searchSingleSession(
     let firstMessage = "";
     let turnCount = 0;
     let model: string | undefined;
+    let permissionMode: PermissionMode | undefined;
     let resolved = false;
 
     const safeResolve = (value: MatchResult | null) => {
@@ -864,6 +895,9 @@ async function searchSingleSession(
 
         if (entry.type === "user" || entry.type === "human") {
           turnCount++;
+          if (!permissionMode && entry.permissionMode) {
+            permissionMode = entry.permissionMode;
+          }
           if (!firstMessage && content) {
             firstMessage = safeTruncate(content, 200);
           }
@@ -906,6 +940,7 @@ async function searchSingleSession(
               cost: 0,
               model,
               matchSnippet,
+              permissionMode,
             }
           : null,
       );

--- a/extensions/claudecast/src/lib/session-parser.ts
+++ b/extensions/claudecast/src/lib/session-parser.ts
@@ -268,6 +268,12 @@ async function walkPathSegments(
 
     // Claude Code also encodes underscores as dashes, so try both variants.
     // Original (with dashes) is tried first to prefer literal dash names.
+    // Note: mixed dash/underscore names within a single component (e.g.
+    // "helm-charts_v2") are not attempted — the encoding is inherently lossy
+    // and trying all 2^n combinations per component is impractical. In
+    // practice, the outer `take` loop handles this by splitting the encoded
+    // string at different points, so "helm-charts" and "my_service" are
+    // resolved as separate components rather than one mixed component.
     const variants = [component];
     if (component.includes("-")) {
       variants.push(component.replace(/-/g, "_"));

--- a/extensions/claudecast/src/lib/terminal.ts
+++ b/extensions/claudecast/src/lib/terminal.ts
@@ -156,6 +156,7 @@ export async function launchClaudeCode(options: {
   prompt?: string;
   printMode?: boolean; // Use -p flag for non-interactive output
   dangerouslySkipPermissions?: boolean; // Skip permission prompts for autonomous workflows
+  permissionMode?: string; // Restore the session's original permission mode on resume
 }): Promise<void> {
   const args: string[] = ["claude"];
 
@@ -171,6 +172,12 @@ export async function launchClaudeCode(options: {
     }
   } else if (options.continueSession) {
     args.push("-c");
+  }
+
+  // Restore the session's permission mode (unless dangerouslySkipPermissions
+  // was already set explicitly, which implies bypassPermissions)
+  if (options.permissionMode && options.permissionMode !== "default" && !options.dangerouslySkipPermissions) {
+    args.push("--permission-mode", options.permissionMode);
   }
 
   if (options.prompt) {

--- a/extensions/claudecast/src/lib/terminal.ts
+++ b/extensions/claudecast/src/lib/terminal.ts
@@ -158,6 +158,7 @@ export async function launchClaudeCode(options: {
   printMode?: boolean; // Use -p flag for non-interactive output
   dangerouslySkipPermissions?: boolean; // Skip permission prompts for autonomous workflows
   permissionMode?: PermissionMode; // Restore the session's original permission mode on resume
+  model?: string; // Restore the session's original model on resume
 }): Promise<void> {
   const args: string[] = ["claude"];
 
@@ -183,6 +184,11 @@ export async function launchClaudeCode(options: {
     !options.dangerouslySkipPermissions
   ) {
     args.push("--permission-mode", options.permissionMode);
+  }
+
+  // Restore the session's model so a Haiku session doesn't resume with Opus
+  if (options.model) {
+    args.push("--model", options.model);
   }
 
   if (options.prompt) {

--- a/extensions/claudecast/src/lib/terminal.ts
+++ b/extensions/claudecast/src/lib/terminal.ts
@@ -4,6 +4,7 @@ import { promisify } from "util";
 import { writeFileSync } from "fs";
 import { tmpdir, homedir } from "os";
 import { join } from "path";
+import type { PermissionMode } from "./session-parser";
 
 const execFilePromise = promisify(execFile);
 
@@ -156,7 +157,7 @@ export async function launchClaudeCode(options: {
   prompt?: string;
   printMode?: boolean; // Use -p flag for non-interactive output
   dangerouslySkipPermissions?: boolean; // Skip permission prompts for autonomous workflows
-  permissionMode?: string; // Restore the session's original permission mode on resume
+  permissionMode?: PermissionMode; // Restore the session's original permission mode on resume
 }): Promise<void> {
   const args: string[] = ["claude"];
 

--- a/extensions/claudecast/src/lib/terminal.ts
+++ b/extensions/claudecast/src/lib/terminal.ts
@@ -176,7 +176,11 @@ export async function launchClaudeCode(options: {
 
   // Restore the session's permission mode (unless dangerouslySkipPermissions
   // was already set explicitly, which implies bypassPermissions)
-  if (options.permissionMode && options.permissionMode !== "default" && !options.dangerouslySkipPermissions) {
+  if (
+    options.permissionMode &&
+    options.permissionMode !== "default" &&
+    !options.dangerouslySkipPermissions
+  ) {
     args.push("--permission-mode", options.permissionMode);
   }
 


### PR DESCRIPTION
## Summary

Three improvements to ClaudeCast's session handling:

### 1. Fix project path resolution for directories containing underscores

Claude Code encodes underscores (`_`) as dashes (`-`) in `~/.claude/projects/` directory names, but ClaudeCast's filesystem walk only probed dash-joined variants. This caused **"Project path no longer exists"** errors for any project path containing underscores.

**Example:** A project at `/home/user/my_projects/api_server` gets encoded as `-home-user-my-projects-api-server`. When resolving back, the walk tried `my-projects` and `api-server` on disk but never `my_projects` or `api_server`, so resolution failed.

**Fix:**
- `walkPathSegments` now also probes underscore variants of each candidate component (dash variant is tried first to preserve preference for literal dashes in directory names like `helm-charts`)
- `encodeProjectPath` updated regex from `/[/.]/g` to `/[/._]/g` to match Claude Code's actual encoding behavior

### 2. Restore permission mode when resuming sessions

Sessions started with non-default permission modes (e.g. `bypassPermissions`, `auto`, `plan`) previously lost that setting on resume — Claude Code would fall back to `default` mode.

**Fix:**
- `permissionMode` is now parsed from the first user entry in session JSONL files
- Added to `SessionMetadata` and propagated through all session listing and search flows
- Passed as `--permission-mode` flag when launching Claude Code for resume or fork

### 3. Restore model when resuming sessions

Sessions started with a specific model (e.g. Haiku or Sonnet) would resume with the user's default model instead. This could lead to unexpected cost changes or capability differences.

**Fix:**
- The session's `model` (already parsed into `SessionMetadata`) is now passed as `--model` flag when launching Claude Code for resume or fork

## Testing

**Path resolution** — verified against filesystem with various patterns:

| Path pattern | Result |
|---|---|
| `group_name/repo-name` (underscore group, hyphen repo) | Correctly resolved |
| `group_name/repo_name` (both underscored) | Correctly resolved |
| `group/repo-name` (no underscores) | Correctly resolved |
| `group_name/repo` (underscore group, plain repo) | Correctly resolved |

All existing behavior preserved — the dash variant is always tried first, so paths with real dashes continue to resolve correctly.

**Permission mode & model** — verified that both fields are correctly extracted from session JSONL and included in all `SessionMetadata` construction sites (`listAllSessions`, `listProjectSessions`, `searchSessionContent`), and passed through to `launchClaudeCode`.