### PR TITLE
[Beeper Desktop] Add Windows platform support

### DIFF
--- a/extensions/beeper/CHANGELOG.md
+++ b/extensions/beeper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Beeper Changelog
 
+## [Windows Support] - 2026-04-13
+
+### Added
+
+- Windows platform support
+- Windows-compatible Beeper app detection in `getBeeperAppPath()`
+
 ## [Initial Release] - 2026-04-13
 
 ### Added

--- a/extensions/beeper/package.json
+++ b/extensions/beeper/package.json
@@ -14,7 +14,8 @@
   ],
   "license": "MIT",
   "platforms": [
-    "macOS"
+    "macOS",
+    "windows"
   ],
   "keywords": [
     "beeper",

--- a/extensions/beeper/package.json
+++ b/extensions/beeper/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "platforms": [
     "macOS",
-    "windows"
+    "Windows"
   ],
   "keywords": [
     "beeper",

--- a/extensions/beeper/src/utils/helpers.ts
+++ b/extensions/beeper/src/utils/helpers.ts
@@ -1,6 +1,6 @@
 import BeeperDesktop from "@beeper/desktop-api";
 import { existsSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, platform } from "node:os";
 import { join } from "node:path";
 
 export const parseDate = (value?: string) => {
@@ -15,7 +15,13 @@ export const getMessageID = (message: BeeperDesktop.Message & { messageID?: stri
   message.messageID ?? message.id;
 
 export const getBeeperAppPath = () => {
-  const candidates = ["/Applications/Beeper Desktop.app", join(homedir(), "Applications", "Beeper Desktop.app")];
+  const candidates =
+    platform() === "win32"
+      ? [
+          join(process.env.LOCALAPPDATA || "", "Programs", "Beeper", "Beeper.exe"),
+          join(homedir(), "AppData", "Local", "Programs", "Beeper", "Beeper.exe"),
+        ]
+      : ["/Applications/Beeper Desktop.app", join(homedir(), "Applications", "Beeper Desktop.app")];
   return candidates.find((path) => existsSync(path));
 };
 


### PR DESCRIPTION
## Summary
- Adds `windows` to the supported platforms in package.json
- Updates `getBeeperAppPath()` to detect Beeper's install location on Windows (`%LOCALAPPDATA%\Programs\Beeper\Beeper.exe`)

## Test plan
- [x] Tested on Windows 11 with Raycast Windows — extension loads, onboarding works, Recent Chats works
- [x] Build succeeds (`npx ray build`)
- [ ] Verify macOS behavior is unchanged (no code paths modified for macOS)