### PR TITLE
ClaudeCast: Add permission mode and model preferences to Launch Project and Quick Continue

### DIFF
--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - **Launch Project Preferences**: Configurable Permission Mode and Model Override settings for the Launch Project command. All launch actions (New Session, Continue Last, Continue with Prompt) respect these preferences.
-- **Quick Continue Preferences**: Same Permission Mode and Model Override settings for the Quick Continue command, applied to both recent-session continuation and new-session fallback.
+- **Quick Continue Session Restore**: Quick Continue now restores the permission mode and model from the most recent session, so a session started with e.g. `fullAuto` or `haiku` continues with the same settings.
 
 ## [1.4.0] - 2026-04-13
 

--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ClaudeCast Changelog
 
-## [1.5.0] - {PR_MERGE_DATE}
+## [1.5.0] - 2026-04-30
 
 ### Added
 

--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -5,7 +5,10 @@
 ### Added
 
 - **Launch Project Preferences**: Configurable Permission Mode and Model Override settings for the Launch Project command. All launch actions (New Session, Continue Last, Continue with Prompt) respect these preferences.
-- **Quick Continue Session Restore**: Quick Continue now restores the permission mode and model from the most recent session, so a session started with e.g. `fullAuto` or `haiku` continues with the same settings.
+
+### Fixed
+
+- **Model Flag on Resume**: Removed explicit `--model` flag when resuming or continuing sessions. Claude Code remembers the model internally, and passing `--model` explicitly could disable features like extended context windows (1M). The `--model` flag is now only used for new sessions via the Launch Project model preference.
 
 ## [1.4.0] - 2026-04-13
 

--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **Launch Project Preferences**: Configurable Permission Mode and Model Override settings for the Launch Project command. All launch actions (New Session, Continue Last, Continue with Prompt) respect these preferences.
+- **Deep Search Permission Restore**: Sessions resumed or forked from Deep Search now restore the original permission mode.
 
 ### Fixed
 

--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ClaudeCast Changelog
 
+## [1.5.0] - 2026-04-13
+
+### Added
+
+- **Launch Project Preferences**: Configurable Permission Mode and Model Override settings for the Launch Project command. All launch actions (New Session, Continue Last, Continue with Prompt) respect these preferences.
+- **Quick Continue Preferences**: Same Permission Mode and Model Override settings for the Quick Continue command, applied to both recent-session continuation and new-session fallback.
+
 ## [1.4.0] - 2026-04-13
 
 ### Fixed

--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ClaudeCast Changelog
 
-## [1.5.0] - 2026-04-13
+## [1.5.0] - {PR_MERGE_DATE}
 
 ### Added
 

--- a/extensions/claudecast/package.json
+++ b/extensions/claudecast/package.json
@@ -87,11 +87,11 @@
             },
             {
               "title": "Auto Edit",
-              "value": "autoEdit"
+              "value": "acceptEdits"
             },
             {
               "title": "Full Auto",
-              "value": "fullAuto"
+              "value": "auto"
             },
             {
               "title": "Bypass Permissions",

--- a/extensions/claudecast/package.json
+++ b/extensions/claudecast/package.json
@@ -137,64 +137,6 @@
         "continue",
         "resume",
         "last"
-      ],
-      "preferences": [
-        {
-          "name": "permissionMode",
-          "type": "dropdown",
-          "title": "Permission Mode",
-          "description": "Permission mode for the continued session",
-          "default": "default",
-          "required": false,
-          "data": [
-            {
-              "title": "Default (Interactive)",
-              "value": "default"
-            },
-            {
-              "title": "Plan Mode",
-              "value": "plan"
-            },
-            {
-              "title": "Auto Edit",
-              "value": "autoEdit"
-            },
-            {
-              "title": "Full Auto",
-              "value": "fullAuto"
-            },
-            {
-              "title": "Bypass Permissions",
-              "value": "bypassPermissions"
-            }
-          ]
-        },
-        {
-          "name": "model",
-          "type": "dropdown",
-          "title": "Model Override",
-          "description": "Override the extension's default model for the continued session",
-          "default": "",
-          "required": false,
-          "data": [
-            {
-              "title": "Use Extension Default",
-              "value": ""
-            },
-            {
-              "title": "Sonnet (Balanced)",
-              "value": "sonnet"
-            },
-            {
-              "title": "Opus (Most Capable)",
-              "value": "opus"
-            },
-            {
-              "title": "Haiku (Fastest)",
-              "value": "haiku"
-            }
-          ]
-        }
       ]
     },
     {

--- a/extensions/claudecast/package.json
+++ b/extensions/claudecast/package.json
@@ -67,6 +67,64 @@
         "open",
         "launch",
         "workspace"
+      ],
+      "preferences": [
+        {
+          "name": "permissionMode",
+          "type": "dropdown",
+          "title": "Permission Mode",
+          "description": "Default permission mode for new sessions launched from this command",
+          "default": "default",
+          "required": false,
+          "data": [
+            {
+              "title": "Default (Interactive)",
+              "value": "default"
+            },
+            {
+              "title": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "title": "Auto Edit",
+              "value": "autoEdit"
+            },
+            {
+              "title": "Full Auto",
+              "value": "fullAuto"
+            },
+            {
+              "title": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ]
+        },
+        {
+          "name": "model",
+          "type": "dropdown",
+          "title": "Model Override",
+          "description": "Override the extension's default model for sessions launched from this command",
+          "default": "",
+          "required": false,
+          "data": [
+            {
+              "title": "Use Extension Default",
+              "value": ""
+            },
+            {
+              "title": "Sonnet (Balanced)",
+              "value": "sonnet"
+            },
+            {
+              "title": "Opus (Most Capable)",
+              "value": "opus"
+            },
+            {
+              "title": "Haiku (Fastest)",
+              "value": "haiku"
+            }
+          ]
+        }
       ]
     },
     {
@@ -79,6 +137,64 @@
         "continue",
         "resume",
         "last"
+      ],
+      "preferences": [
+        {
+          "name": "permissionMode",
+          "type": "dropdown",
+          "title": "Permission Mode",
+          "description": "Permission mode for the continued session",
+          "default": "default",
+          "required": false,
+          "data": [
+            {
+              "title": "Default (Interactive)",
+              "value": "default"
+            },
+            {
+              "title": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "title": "Auto Edit",
+              "value": "autoEdit"
+            },
+            {
+              "title": "Full Auto",
+              "value": "fullAuto"
+            },
+            {
+              "title": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ]
+        },
+        {
+          "name": "model",
+          "type": "dropdown",
+          "title": "Model Override",
+          "description": "Override the extension's default model for the continued session",
+          "default": "",
+          "required": false,
+          "data": [
+            {
+              "title": "Use Extension Default",
+              "value": ""
+            },
+            {
+              "title": "Sonnet (Balanced)",
+              "value": "sonnet"
+            },
+            {
+              "title": "Opus (Most Capable)",
+              "value": "opus"
+            },
+            {
+              "title": "Haiku (Fastest)",
+              "value": "haiku"
+            }
+          ]
+        }
       ]
     },
     {

--- a/extensions/claudecast/src/browse-sessions.tsx
+++ b/extensions/claudecast/src/browse-sessions.tsx
@@ -164,7 +164,6 @@ function SessionItem({
       projectPath: session.projectPath,
       sessionId: session.id,
       permissionMode: session.permissionMode,
-      model: session.model,
     });
     await popToRoot();
   }
@@ -184,7 +183,6 @@ function SessionItem({
       sessionId: session.id,
       forkSession: true,
       permissionMode: session.permissionMode,
-      model: session.model,
     });
     await popToRoot();
   }
@@ -238,7 +236,6 @@ function SessionItem({
                   sessionId={session.id}
                   projectPath={session.projectPath}
                   permissionMode={session.permissionMode}
-                  model={session.model}
                 />
               }
             />
@@ -276,12 +273,10 @@ function SessionDetailView({
   sessionId,
   projectPath,
   permissionMode,
-  model,
 }: {
   sessionId: string;
   projectPath: string;
   permissionMode?: PermissionMode;
-  model?: string;
 }) {
   const [isLoading, setIsLoading] = useState(true);
   const [session, setSession] = useState<SessionDetail | null>(null);
@@ -354,7 +349,6 @@ function SessionDetailView({
                 projectPath,
                 sessionId,
                 permissionMode,
-                model,
               });
               await popToRoot();
             }}
@@ -377,7 +371,6 @@ function SessionDetailView({
                 sessionId,
                 forkSession: true,
                 permissionMode,
-                model,
               });
               await popToRoot();
             }}

--- a/extensions/claudecast/src/deep-search-sessions.tsx
+++ b/extensions/claudecast/src/deep-search-sessions.tsx
@@ -20,6 +20,7 @@ import {
   safeTruncate,
   SessionMetadata,
   SessionDetail,
+  PermissionMode,
 } from "./lib/session-parser";
 import { launchClaudeCode } from "./lib/terminal";
 import { ensureClaudeInstalled } from "./lib/claude-cli";
@@ -191,6 +192,7 @@ function SearchResultItem({
     await launchClaudeCode({
       projectPath: session.projectPath,
       sessionId: session.id,
+      permissionMode: session.permissionMode,
     });
     await popToRoot();
   }
@@ -209,6 +211,7 @@ function SearchResultItem({
       projectPath: session.projectPath,
       sessionId: session.id,
       forkSession: true,
+      permissionMode: session.permissionMode,
     });
     await popToRoot();
   }
@@ -275,6 +278,7 @@ function SearchResultItem({
                 <SessionDetailView
                   sessionId={session.id}
                   projectPath={session.projectPath}
+                  permissionMode={session.permissionMode}
                 />
               }
             />
@@ -311,9 +315,11 @@ function SearchResultItem({
 function SessionDetailView({
   sessionId,
   projectPath,
+  permissionMode,
 }: {
   sessionId: string;
   projectPath: string;
+  permissionMode?: PermissionMode;
 }) {
   const [isLoading, setIsLoading] = useState(true);
   const [session, setSession] = useState<SessionDetail | null>(null);
@@ -389,6 +395,7 @@ function SessionDetailView({
               await launchClaudeCode({
                 projectPath,
                 sessionId,
+                permissionMode,
               });
               await popToRoot();
             }}
@@ -410,6 +417,7 @@ function SessionDetailView({
                 projectPath,
                 sessionId,
                 forkSession: true,
+                permissionMode,
               });
               await popToRoot();
             }}

--- a/extensions/claudecast/src/launch-project.tsx
+++ b/extensions/claudecast/src/launch-project.tsx
@@ -8,6 +8,7 @@ import {
   Toast,
   Form,
   popToRoot,
+  getPreferenceValues,
 } from "@raycast/api";
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { existsSync } from "fs";
@@ -21,6 +22,7 @@ import {
   Project,
 } from "./lib/project-discovery";
 import { launchClaudeCode, openTerminalWithCommand } from "./lib/terminal";
+import type { PermissionMode } from "./lib/session-parser";
 
 // Type for batched git info
 type GitInfoMap = Record<
@@ -219,8 +221,16 @@ function ProjectItem({
       });
       return;
     }
+    const prefs = getPreferenceValues<Preferences.LaunchProject>();
+    const permissionMode = (prefs.permissionMode ||
+      "default") as PermissionMode;
+    const model = prefs.model || undefined;
     await addRecentProject(project.path);
-    await launchClaudeCode({ projectPath: project.path });
+    await launchClaudeCode({
+      projectPath: project.path,
+      permissionMode,
+      model,
+    });
     await popToRoot();
   }
 
@@ -234,10 +244,16 @@ function ProjectItem({
       });
       return;
     }
+    const prefs = getPreferenceValues<Preferences.LaunchProject>();
+    const permissionMode = (prefs.permissionMode ||
+      "default") as PermissionMode;
+    const model = prefs.model || undefined;
     await addRecentProject(project.path);
     await launchClaudeCode({
       projectPath: project.path,
       continueSession: true,
+      permissionMode,
+      model,
     });
     await popToRoot();
   }
@@ -343,12 +359,18 @@ function ContinueWithPromptForm({ project }: { project: Project }) {
       return;
     }
 
+    const prefs = getPreferenceValues<Preferences.LaunchProject>();
+    const permissionMode = (prefs.permissionMode ||
+      "default") as PermissionMode;
+    const model = prefs.model || undefined;
     setIsLoading(true);
     await addRecentProject(project.path);
     await launchClaudeCode({
       projectPath: project.path,
       continueSession: true,
       prompt: values.prompt,
+      permissionMode,
+      model,
     });
     await popToRoot();
   }

--- a/extensions/claudecast/src/lib/terminal.ts
+++ b/extensions/claudecast/src/lib/terminal.ts
@@ -199,9 +199,11 @@ export async function launchClaudeCode(options: {
     args.push("--permission-mode", options.permissionMode);
   }
 
-  // Restore the session's model so a Haiku session doesn't resume with Opus.
-  // Normalize to short names so Claude Code enables features like extended context.
-  if (options.model) {
+  // Only pass --model for new sessions (not resume/continue). Claude Code
+  // remembers the model from the session and passing --model explicitly can
+  // disable features like extended context windows.
+  const isResumingSession = options.sessionId || options.continueSession;
+  if (options.model && !isResumingSession) {
     args.push("--model", normalizeModelName(options.model));
   }
 

--- a/extensions/claudecast/src/lib/terminal.ts
+++ b/extensions/claudecast/src/lib/terminal.ts
@@ -21,6 +21,19 @@ export function expandTilde(inputPath: string): string {
   return trimmed;
 }
 
+/**
+ * Normalize a full model ID (e.g. "claude-opus-4-6") to the short name
+ * ("opus") that Claude Code expects for proper feature enablement like
+ * extended context windows.
+ */
+function normalizeModelName(model: string): string {
+  if (["opus", "sonnet", "haiku"].includes(model)) return model;
+  if (model.includes("opus")) return "opus";
+  if (model.includes("sonnet")) return "sonnet";
+  if (model.includes("haiku")) return "haiku";
+  return model;
+}
+
 type TerminalApp = "Terminal" | "iTerm" | "Warp" | "kitty" | "Ghostty";
 
 /**
@@ -186,9 +199,10 @@ export async function launchClaudeCode(options: {
     args.push("--permission-mode", options.permissionMode);
   }
 
-  // Restore the session's model so a Haiku session doesn't resume with Opus
+  // Restore the session's model so a Haiku session doesn't resume with Opus.
+  // Normalize to short names so Claude Code enables features like extended context.
   if (options.model) {
-    args.push("--model", options.model);
+    args.push("--model", normalizeModelName(options.model));
   }
 
   if (options.prompt) {

--- a/extensions/claudecast/src/quick-continue.tsx
+++ b/extensions/claudecast/src/quick-continue.tsx
@@ -1,8 +1,7 @@
-import { showToast, Toast, showHUD, getPreferenceValues } from "@raycast/api";
+import { showToast, Toast, showHUD } from "@raycast/api";
 import { existsSync } from "fs";
 import { getMostRecentProject } from "./lib/project-discovery";
 import { getMostRecentSession } from "./lib/session-parser";
-import type { PermissionMode } from "./lib/session-parser";
 import { launchClaudeCode } from "./lib/terminal";
 import { ensureClaudeInstalled } from "./lib/claude-cli";
 
@@ -10,11 +9,6 @@ export default async function QuickContinue() {
   try {
     // Check if Claude is installed first
     if (!(await ensureClaudeInstalled())) return;
-
-    const prefs = getPreferenceValues<Preferences.QuickContinue>();
-    const permissionMode = (prefs.permissionMode ||
-      "default") as PermissionMode;
-    const model = prefs.model || undefined;
 
     // First try to get the most recent session
     const recentSession = await getMostRecentSession();
@@ -24,21 +18,19 @@ export default async function QuickContinue() {
       await launchClaudeCode({
         projectPath: recentSession.projectPath,
         continueSession: true,
-        permissionMode,
-        model,
+        permissionMode: recentSession.permissionMode,
+        model: recentSession.model,
       });
       return;
     }
 
-    // Fall back to most recent project
+    // Fall back to most recent project (no session to restore settings from)
     const recentProject = await getMostRecentProject();
 
     if (recentProject && existsSync(recentProject.path)) {
       await showHUD(`Starting new session in ${recentProject.name}...`);
       await launchClaudeCode({
         projectPath: recentProject.path,
-        permissionMode,
-        model,
       });
       return;
     }

--- a/extensions/claudecast/src/quick-continue.tsx
+++ b/extensions/claudecast/src/quick-continue.tsx
@@ -19,7 +19,6 @@ export default async function QuickContinue() {
         projectPath: recentSession.projectPath,
         continueSession: true,
         permissionMode: recentSession.permissionMode,
-        model: recentSession.model,
       });
       return;
     }

--- a/extensions/claudecast/src/quick-continue.tsx
+++ b/extensions/claudecast/src/quick-continue.tsx
@@ -1,7 +1,8 @@
-import { showToast, Toast, showHUD } from "@raycast/api";
+import { showToast, Toast, showHUD, getPreferenceValues } from "@raycast/api";
 import { existsSync } from "fs";
 import { getMostRecentProject } from "./lib/project-discovery";
 import { getMostRecentSession } from "./lib/session-parser";
+import type { PermissionMode } from "./lib/session-parser";
 import { launchClaudeCode } from "./lib/terminal";
 import { ensureClaudeInstalled } from "./lib/claude-cli";
 
@@ -9,6 +10,11 @@ export default async function QuickContinue() {
   try {
     // Check if Claude is installed first
     if (!(await ensureClaudeInstalled())) return;
+
+    const prefs = getPreferenceValues<Preferences.QuickContinue>();
+    const permissionMode = (prefs.permissionMode ||
+      "default") as PermissionMode;
+    const model = prefs.model || undefined;
 
     // First try to get the most recent session
     const recentSession = await getMostRecentSession();
@@ -18,6 +24,8 @@ export default async function QuickContinue() {
       await launchClaudeCode({
         projectPath: recentSession.projectPath,
         continueSession: true,
+        permissionMode,
+        model,
       });
       return;
     }
@@ -29,6 +37,8 @@ export default async function QuickContinue() {
       await showHUD(`Starting new session in ${recentProject.name}...`);
       await launchClaudeCode({
         projectPath: recentProject.path,
+        permissionMode,
+        model,
       });
       return;
     }


### PR DESCRIPTION
## Summary

Follow-up to #27137. This PR adds launch preferences, extends permission mode restore to all session commands, and fixes a model flag issue that could disable extended context windows.

### Launch Project — Configurable Preferences
Adds command-level preferences for Permission Mode and Model Override:
- **Permission Mode**: Default (Interactive), Plan Mode, Auto Edit, Full Auto, Bypass Permissions
- **Model Override**: Use Extension Default, Sonnet, Opus, Haiku

All three launch actions (New Session, Continue Last Session, Continue with Prompt) respect these preferences. The model flag is only passed for **new sessions** — not for resume or continue.

### Deep Search — Permission Mode Restore
Sessions resumed or forked from Deep Search Sessions now restore the original permission mode, matching the existing behavior in Browse Sessions.

### Model Flag Fix — Preserve Extended Context
Removed explicit `--model` flag when resuming or continuing sessions (Browse Sessions, Quick Continue, Deep Search). Claude Code remembers the model internally, and passing `--model` explicitly disables features like extended context windows (1M tokens). This also reverts the `--model` passing from #27137 for resume scenarios.

A `normalizeModelName()` helper maps full model IDs (e.g. `claude-opus-4-6`) to short names (`opus`) for new sessions launched via preferences, ensuring proper feature enablement.

### Changes

- `package.json`: Added `permissionMode` and `model` dropdown preferences to `launch-project`
- `launch-project.tsx`: Reads preferences and passes them to `launchClaudeCode` for new sessions
- `terminal.ts`: Added `normalizeModelName()`, guard to skip `--model` on resume/continue
- `browse-sessions.tsx`: Removed `model` from resume/fork calls
- `deep-search-sessions.tsx`: Added `permissionMode` to all resume/fork calls and detail view
- `quick-continue.tsx`: Removed `model` from continue call
- `CHANGELOG.md`: Added v1.5.0 entry

## Test plan

- [ ] Open Launch Project settings → verify Permission Mode and Model Override dropdowns
- [ ] Set Model Override to "Opus" → New Session → verify `--model opus` flag is passed
- [ ] Resume a session from Browse Sessions → verify NO `--model` flag, extended context (1M) active
- [ ] Resume a `bypassPermissions` session from Deep Search → verify `--permission-mode bypassPermissions` is passed
- [ ] Fork a session from Deep Search → verify permission mode is restored
- [ ] Quick Continue → verify no `--model` flag, session resumes with original model
- [ ] Leave both preferences at defaults → verify no extra flags are added

🤖 Generated with [Claude Code](https://claude.com/claude-code)