### PR TITLE
Update TypeWhisper dictation tracking and Windows support

### DIFF
--- a/extensions/typewhisper/CHANGELOG.md
+++ b/extensions/typewhisper/CHANGELOG.md
@@ -1,5 +1,11 @@
 # TypeWhisper Changelog
 
+## [Improved Dictation Session Tracking] - 2026-04-13
+
+- Updated Start Dictation and Show Last Transcription to use dictation session IDs for exact transcript lookup
+- Prefer session-specific transcript polling over guessing the latest history entry
+- Keep the existing history lookup as a fallback when no tracked session is available
+
 ## [Initial Version] - 2026-03-06
 
 - Added Start Dictation command to toggle voice dictation

--- a/extensions/typewhisper/CHANGELOG.md
+++ b/extensions/typewhisper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # TypeWhisper Changelog
 
-## [Improved Dictation Session Tracking] - 2026-04-13
+## [Improved Dictation Session Tracking] - {PR_MERGE_DATE}
 
 - Updated Start Dictation and Show Last Transcription to use dictation session IDs for exact transcript lookup
 - Prefer session-specific transcript polling over guessing the latest history entry

--- a/extensions/typewhisper/CHANGELOG.md
+++ b/extensions/typewhisper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # TypeWhisper Changelog
 
-## [Improved Dictation Session Tracking] - {PR_MERGE_DATE}
+## [Improved Dictation Session Tracking] - 2026-04-24
 
 - Updated Start Dictation and Show Last Transcription to use dictation session IDs for exact transcript lookup
 - Prefer session-specific transcript polling over guessing the latest history entry

--- a/extensions/typewhisper/package.json
+++ b/extensions/typewhisper/package.json
@@ -69,6 +69,7 @@
     "publish": "npx @raycast/api@latest publish"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ]
 }

--- a/extensions/typewhisper/src/dictation-session.ts
+++ b/extensions/typewhisper/src/dictation-session.ts
@@ -1,0 +1,42 @@
+import { LocalStorage } from "@raycast/api";
+import { TypeWhisperError, apiGet } from "./api";
+import type { DictationTranscriptionResponse } from "./types";
+
+const LAST_DICTATION_SESSION_ID_KEY = "last-dictation-session-id";
+const ACTIVE_DICTATION_SESSION_ID_KEY = "active-dictation-session-id";
+
+export async function setActiveDictationSessionId(id: string): Promise<void> {
+  await LocalStorage.setItem(ACTIVE_DICTATION_SESSION_ID_KEY, id);
+}
+
+export async function clearActiveDictationSessionId(): Promise<void> {
+  await LocalStorage.removeItem(ACTIVE_DICTATION_SESSION_ID_KEY);
+}
+
+export async function setLastDictationSessionId(id: string): Promise<void> {
+  await LocalStorage.setItem(LAST_DICTATION_SESSION_ID_KEY, id);
+}
+
+export async function getLastDictationSessionId(): Promise<string | undefined> {
+  const id = await LocalStorage.getItem<string>(LAST_DICTATION_SESSION_ID_KEY);
+  return id ?? undefined;
+}
+
+export async function fetchLastKnownDictationTranscription(): Promise<DictationTranscriptionResponse | null> {
+  const id = await getLastDictationSessionId();
+  if (!id) {
+    return null;
+  }
+
+  try {
+    return await apiGet<DictationTranscriptionResponse>(
+      "/v1/dictation/transcription",
+      { id },
+    );
+  } catch (error) {
+    if (error instanceof TypeWhisperError && error.statusCode === 404) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/extensions/typewhisper/src/dictation-session.ts
+++ b/extensions/typewhisper/src/dictation-session.ts
@@ -3,15 +3,6 @@ import { TypeWhisperError, apiGet } from "./api";
 import type { DictationTranscriptionResponse } from "./types";
 
 const LAST_DICTATION_SESSION_ID_KEY = "last-dictation-session-id";
-const ACTIVE_DICTATION_SESSION_ID_KEY = "active-dictation-session-id";
-
-export async function setActiveDictationSessionId(id: string): Promise<void> {
-  await LocalStorage.setItem(ACTIVE_DICTATION_SESSION_ID_KEY, id);
-}
-
-export async function clearActiveDictationSessionId(): Promise<void> {
-  await LocalStorage.removeItem(ACTIVE_DICTATION_SESSION_ID_KEY);
-}
 
 export async function setLastDictationSessionId(id: string): Promise<void> {
   await LocalStorage.setItem(LAST_DICTATION_SESSION_ID_KEY, id);

--- a/extensions/typewhisper/src/show-last-transcription.tsx
+++ b/extensions/typewhisper/src/show-last-transcription.tsx
@@ -1,10 +1,48 @@
 import { Clipboard, closeMainWindow, showHUD } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { apiGet, TypeWhisperError } from "./api";
+import { fetchLastKnownDictationTranscription } from "./dictation-session";
 import type { HistoryResponse } from "./types";
+
+async function copyAndPreview(text: string) {
+  await Clipboard.copy(text);
+  await closeMainWindow();
+
+  const preview = text.length > 60 ? text.substring(0, 60) + "..." : text;
+  await showHUD(`Copied: ${preview}`);
+}
 
 export default async function Command() {
   try {
+    const sessionResponse = await fetchLastKnownDictationTranscription();
+    if (sessionResponse) {
+      if (
+        sessionResponse.status === "completed" &&
+        sessionResponse.transcription?.text
+      ) {
+        await copyAndPreview(sessionResponse.transcription.text);
+        return;
+      }
+
+      if (sessionResponse.status === "processing") {
+        await showHUD("Last dictation is still processing");
+        return;
+      }
+
+      if (sessionResponse.status === "recording") {
+        await showHUD("Dictation is still recording");
+        return;
+      }
+
+      if (sessionResponse.status === "failed") {
+        await showFailureToast(
+          sessionResponse.error || "The last dictation failed",
+          { title: "TypeWhisper" },
+        );
+        return;
+      }
+    }
+
     const response = await apiGet<HistoryResponse>("/v1/history", {
       limit: "1",
     });
@@ -14,13 +52,7 @@ export default async function Command() {
       return;
     }
 
-    const entry = response.entries[0];
-    await Clipboard.copy(entry.text);
-    await closeMainWindow();
-
-    const preview =
-      entry.text.length > 60 ? entry.text.substring(0, 60) + "..." : entry.text;
-    await showHUD(`Copied: ${preview}`);
+    await copyAndPreview(response.entries[0].text);
   } catch (error) {
     if (error instanceof TypeWhisperError) {
       await showFailureToast(error.message, { title: "TypeWhisper" });

--- a/extensions/typewhisper/src/start-dictation.tsx
+++ b/extensions/typewhisper/src/start-dictation.tsx
@@ -1,11 +1,7 @@
 import { closeMainWindow, showHUD } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { apiGet, apiPost, TypeWhisperError } from "./api";
-import {
-  clearActiveDictationSessionId,
-  setActiveDictationSessionId,
-  setLastDictationSessionId,
-} from "./dictation-session";
+import { setLastDictationSessionId } from "./dictation-session";
 import type {
   DictationStartResponse,
   DictationStatusResponse,
@@ -22,15 +18,11 @@ export default async function Command() {
       const response =
         await apiPost<DictationStopResponse>("/v1/dictation/stop");
       await setLastDictationSessionId(response.id);
-      await clearActiveDictationSessionId();
       await closeMainWindow();
       await showHUD("Dictation stopped");
     } else {
       await closeMainWindow();
-      const response = await apiPost<DictationStartResponse>(
-        "/v1/dictation/start",
-      );
-      await setActiveDictationSessionId(response.id);
+      await apiPost<DictationStartResponse>("/v1/dictation/start");
       await showHUD("Dictation started");
     }
   } catch (error) {

--- a/extensions/typewhisper/src/start-dictation.tsx
+++ b/extensions/typewhisper/src/start-dictation.tsx
@@ -1,7 +1,16 @@
 import { closeMainWindow, showHUD } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { apiGet, apiPost, TypeWhisperError } from "./api";
-import type { DictationStatusResponse } from "./types";
+import {
+  clearActiveDictationSessionId,
+  setActiveDictationSessionId,
+  setLastDictationSessionId,
+} from "./dictation-session";
+import type {
+  DictationStartResponse,
+  DictationStatusResponse,
+  DictationStopResponse,
+} from "./types";
 
 export default async function Command() {
   try {
@@ -10,12 +19,18 @@ export default async function Command() {
     );
 
     if (status.is_recording) {
-      await apiPost("/v1/dictation/stop");
+      const response =
+        await apiPost<DictationStopResponse>("/v1/dictation/stop");
+      await setLastDictationSessionId(response.id);
+      await clearActiveDictationSessionId();
       await closeMainWindow();
       await showHUD("Dictation stopped");
     } else {
       await closeMainWindow();
-      await apiPost("/v1/dictation/start");
+      const response = await apiPost<DictationStartResponse>(
+        "/v1/dictation/start",
+      );
+      await setActiveDictationSessionId(response.id);
       await showHUD("Dictation started");
     }
   } catch (error) {

--- a/extensions/typewhisper/src/types.ts
+++ b/extensions/typewhisper/src/types.ts
@@ -47,6 +47,37 @@ export interface DictationStatusResponse {
   is_recording: boolean;
 }
 
+export interface DictationStartResponse {
+  id: string;
+  status: "recording";
+}
+
+export interface DictationStopResponse {
+  id: string;
+  status: "stopped";
+}
+
+export interface DictationTranscriptionPayload {
+  text: string;
+  raw_text: string;
+  timestamp: string;
+  app_name: string | null;
+  app_bundle_id: string | null;
+  app_url: string | null;
+  duration: number;
+  language: string | null;
+  engine: string;
+  model: string | null;
+  words_count: number;
+}
+
+export interface DictationTranscriptionResponse {
+  id: string;
+  status: "recording" | "processing" | "completed" | "failed";
+  transcription?: DictationTranscriptionPayload | null;
+  error?: string | null;
+}
+
 export interface TranscribeResponse {
   text: string;
   language: string | null;


### PR DESCRIPTION
## Description

This updates the TypeWhisper Raycast extension to use dictation session IDs for exact transcript lookup and marks the extension as available on Windows.

Previously, `Show Last Transcription` had to rely on the latest `/v1/history` entry, which could be ambiguous when multiple transcriptions or automations happened close together.

With this change:
- `Start Dictation` stores the session ID returned by the TypeWhisper API
- `Show Last Transcription` first checks `/v1/dictation/transcription?id=<uuid>` for the exact session result
- it falls back to `/v1/history?limit=1` when no tracked session is available
- the manifest metadata allows the extension on both macOS and Windows

This makes transcript retrieval deterministic and lets Raycast for Windows use the same local HTTP API integration.

## Screencast

No UI changes. This is an API integration and extension metadata update for the existing commands.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder