### PR TITLE
Update freeagent extension

### DIFF
--- a/extensions/freeagent/CHANGELOG.md
+++ b/extensions/freeagent/CHANGELOG.md
@@ -1,5 +1,10 @@
 # FreeAgent Changelog
 
+## [Fix timeslip date display] - {PR_MERGE_DATE}
+
+- Changed timeslip list to show day-level relative dates (Today, Yesterday, 3 days ago) instead of hour-level (14 hours ago)
+- Timeslips in FreeAgent are day-level, so hour-level precision was misleading
+
 ## [Fix time parsing in Create Timeslip] - 2026-01-08
 
 - Fixed bug where entering time in HH:MM format (e.g., `4:30`) would only record the hours portion

--- a/extensions/freeagent/CHANGELOG.md
+++ b/extensions/freeagent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # FreeAgent Changelog
 
-## [Fix timeslip date display] - {PR_MERGE_DATE}
+## [Fix timeslip date display] - 2026-04-15
 
 - Changed timeslip list to show day-level relative dates (Today, Yesterday, 3 days ago) instead of hour-level (14 hours ago)
 - Timeslips in FreeAgent are day-level, so hour-level precision was misleading

--- a/extensions/freeagent/CLAUDE.md
+++ b/extensions/freeagent/CLAUDE.md
@@ -95,6 +95,9 @@ All commands use the `authorizedWithFreeAgent` HOC from `oauth.ts` plus the `use
 - `useEffect` for data fetching when authentication is ready
 - All error states handled through the custom hook
 
+### Changelog
+When updating `CHANGELOG.md`, use `{PR_MERGE_DATE}` as the date placeholder instead of a real date. The actual date will be filled in when the PR is merged.
+
 ### Preferences
 The extension supports user preferences defined in package.json:
 - `default_payment_terms_in_days` - Default payment terms for new invoices

--- a/extensions/freeagent/src/list-timeslips.tsx
+++ b/extensions/freeagent/src/list-timeslips.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { authorizedWithFreeAgent } from "./oauth";
 import { Timeslip } from "./types";
 import { fetchTimeslips } from "./services/freeagent";
-import { parseDate, getProjectDisplayName, getTaskDisplayName, getUserDisplayName } from "./utils/formatting";
+import { formatRelativeDay, getProjectDisplayName, getTaskDisplayName, getUserDisplayName } from "./utils/formatting";
 import { useFreeAgent } from "./hooks/useFreeAgent";
 
 const ListTimeslips = function Command() {
@@ -44,7 +44,7 @@ const ListTimeslips = function Command() {
               icon={Icon.Clock}
               title={taskName}
               subtitle={`${projectName} • ${userName}${timeslip.comment ? ` • ${timeslip.comment}` : ""}`}
-              accessories={[{ text: `${timeslip.hours}h` }, { date: parseDate(timeslip.dated_on) }]}
+              accessories={[{ text: `${timeslip.hours}h` }, { text: formatRelativeDay(timeslip.dated_on) }]}
               actions={
                 <ActionPanel>
                   <Action.CopyToClipboard title="Copy Project Uri" content={projectUrl} />

--- a/extensions/freeagent/src/utils/formatting.ts
+++ b/extensions/freeagent/src/utils/formatting.ts
@@ -88,6 +88,21 @@ export function getTaskDisplayName(task: string | Task): string {
   return task.name || "Unknown Task";
 }
 
+export function formatRelativeDay(dateString: string): string {
+  const date = new Date(dateString + "T00:00:00");
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const diffTime = today.getTime() - date.getTime();
+  const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays > 1 && diffDays <= 7) return `${diffDays} days ago`;
+
+  return date.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+}
+
 export function formatDateForAPI(date: Date): string {
   // Format date as YYYY-MM-DD in local timezone to avoid timezone conversion issues
   const year = date.getFullYear();

--- a/extensions/freeagent/src/utils/formatting.ts
+++ b/extensions/freeagent/src/utils/formatting.ts
@@ -89,18 +89,19 @@ export function getTaskDisplayName(task: string | Task): string {
 }
 
 export function formatRelativeDay(dateString: string): string {
-  const date = new Date(dateString + "T00:00:00");
+  const [year, month, day] = dateString.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
   const today = new Date();
-  today.setHours(0, 0, 0, 0);
 
-  const diffTime = today.getTime() - date.getTime();
-  const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24));
+  const dateUtc = Date.UTC(year, month - 1, day);
+  const todayUtc = Date.UTC(today.getFullYear(), today.getMonth(), today.getDate());
+  const diffDays = Math.floor((todayUtc - dateUtc) / (1000 * 60 * 60 * 24));
 
   if (diffDays === 0) return "Today";
   if (diffDays === 1) return "Yesterday";
   if (diffDays > 1 && diffDays <= 7) return `${diffDays} days ago`;
 
-  return date.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+  return date.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" });
 }
 
 export function formatDateForAPI(date: Date): string {


### PR DESCRIPTION
## Description

Show day-level relative dates for timeslips instead of hours

Timeslips in FreeAgent are assigned at a day level, so showing hour-level precision (e.g. "14 hours ago") was misleading. Now shows Today, Yesterday, N days ago, or a formatted date.
## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
