### PR TITLE
[GitLab] Show purple merged icon for todos on merged MRs

### DIFF
--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitLab Changelog
 
-## [Merged MR icon in todos] - {PR_MERGE_DATE}
+## [Merged MR icon in todos] - 2026-04-15
 
 - Show purple merged icon for todos on merged merge requests
 

--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitLab Changelog
 
+## [Merged MR icon in todos] - {PR_MERGE_DATE}
+
+- Show purple merged icon for todos on merged merge requests
+
 ## [Fix "Mark All as Done" error] - 2026-03-19
 
 - Fix JSON parse error when marking all todos as done (HTTP 204 No Content)

--- a/extensions/gitlab/src/components/todo.tsx
+++ b/extensions/gitlab/src/components/todo.tsx
@@ -2,6 +2,7 @@ import { ActionPanel, Color, Image, launchCommand, LaunchType, List } from "@ray
 import { Project, Todo, User } from "../gitlabapi";
 import { GitLabIcons } from "../icons";
 import { CloseAllTodoAction, CloseTodoAction, ShowTodoDetailsAction } from "./todo_actions";
+import { MRState } from "./mr";
 import { GitLabOpenInBrowserAction } from "./actions";
 import { useTodos } from "./todo/utils";
 import { MyProjectsDropdown } from "./project";
@@ -56,10 +57,12 @@ function getTargetTypeSource(tt: string): string {
 }
 
 export function getTodoIcon(todo: Todo, overrideTintColor?: Color.ColorLike | null): Image.ImageLike {
-  const tt = todo.target_type;
+  if (todo.target_type === "MergeRequest" && todo.target?.state === MRState.merged) {
+    return { source: GitLabIcons.merged, tintColor: overrideTintColor ?? Color.Purple };
+  }
   return {
-    source: getTargetTypeSource(tt),
-    tintColor: overrideTintColor ? overrideTintColor : getActionColor(todo.action_name),
+    source: getTargetTypeSource(todo.target_type),
+    tintColor: overrideTintColor ?? getActionColor(todo.action_name),
   };
 }
 


### PR DESCRIPTION
## Description

Todos for merged merge requests now display a purple merged icon instead of the generic MR open icon. This matches the icon treatment already used in the MR list view.

## Screencast

<img width="91" height="195" alt="Screenshot 2026-04-14 at 11 44 13" src="https://github.com/user-attachments/assets/184ae9c6-1358-4252-b2a6-26063d4c3be2" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
