### PR TITLE
Add pronunciation text to quick translate command in google translate extension

### DIFF
--- a/extensions/google-translate/CHANGELOG.md
+++ b/extensions/google-translate/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Translate Changelog
 
+## [Feature] - {PR_MERGE_DATE}
+
+ - Added pronunciation text to quick translate command
+
 ## [Cross Platform Shortcuts + Modernize] - 2025-12-24
 
 - Make `Shortcut`s cross-platform

--- a/extensions/google-translate/CHANGELOG.md
+++ b/extensions/google-translate/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Translate Changelog
 
-## [Feature] - {PR_MERGE_DATE}
+## [Feature] - 2026-04-15
 
  - Added pronunciation text to quick translate command
 

--- a/extensions/google-translate/package.json
+++ b/extensions/google-translate/package.json
@@ -21,7 +21,8 @@
     "litomore",
     "ChanningKuo",
     "likid",
-    "xmok"
+    "xmok",
+    "brucemakes012"
   ],
   "license": "MIT",
   "commands": [

--- a/extensions/google-translate/src/QuickTranslate/QuickTranslateListItem.tsx
+++ b/extensions/google-translate/src/QuickTranslate/QuickTranslateListItem.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { ActionPanel, List, Toast, showToast } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
 import { supportedLanguagesByCode } from "../languages";
@@ -53,6 +54,8 @@ export function QuickTranslateListItem(props: {
   // Reassigning langFrom to the detected language in case it was auto-detected
   langFrom = supportedLanguagesByCode[result.langFrom];
 
+  const pronunciationMarkdown = result.pronunciationText ? `\`\`\`\n${result.pronunciationText}\n\`\`\`\n\n` : "";
+
   return (
     <List.Item
       key={langTo.code}
@@ -65,7 +68,7 @@ export function QuickTranslateListItem(props: {
       ]}
       detail={
         <List.Item.Detail
-          markdown={result.translatedText}
+          markdown={result.translatedText + "\n\n\n" + pronunciationMarkdown}
           metadata={
             <List.Item.Detail.Metadata>
               <List.Item.Detail.Metadata.TagList title="Source Language">


### PR DESCRIPTION
## Description

I added pronunciation text that was previously only displayed in the simple translate command to the quick translate command as well. 

P.S. I am fairly new to software development/git so if I did something incorrect please let me know and I'll fix it, thank you!

## Screencast

From this to → this
![Image](https://github.com/user-attachments/assets/f138bf8c-4327-47e2-b6b7-2798cab2b147)


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
