### PR TITLE
Document rate limits for Raycast AI usage

### DIFF
--- a/docs/api-reference/ai.md
+++ b/docs/api-reference/ai.md
@@ -221,3 +221,11 @@ If a model isn't available to the user (or has been disabled by the user), Rayca
 #### Properties
 
 <InterfaceTableFromJSDoc name="AI.AskOptions" />
+
+## Rate limit
+
+Defines the rate limits that apply to Raycast AI usage within extensions. These values specify how many AI requests can be made per minute and per hour.
+
+| Limit per minute | Limit per hour |
+|---|---|
+| 10/minute | 100/hour |


### PR DESCRIPTION
Added rate limit section to AI usage documentation.

## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
