### PR TITLE
[Say] Use `native-say`

### DIFF
--- a/extensions/say/CHANGELOG.md
+++ b/extensions/say/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Say - Text to Speech Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-04-16
 
 - Replace deprecated `mac-say` and `@litomore/win-say` dependencies with `native-say`
 

--- a/extensions/say/CHANGELOG.md
+++ b/extensions/say/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Say - Text to Speech Changelog
 
+## [Maintenance] - {PR_MERGE_DATE}
+
+- Replace deprecated `mac-say` and `@litomore/win-say` dependencies with `native-say`
+
 ## [Enhancement] - 2026-04-12
 
 - Add Windows support with `@litomore/win-say`

--- a/extensions/say/README.md
+++ b/extensions/say/README.md
@@ -82,11 +82,11 @@ deeplink="raycast://extensions/litomore/say/typeToSay?launchType=background&argu
 open $deeplink
 ```
 
-### Use `mac-say` or `@litomore/win-say`
+### Use `native-say`
 
-Get them from https://github.com/LitoMore/mac-say and https://github.com/LitoMore/win-say.
+Get it from https://www.npmjs.com/package/native-say.
 
-They provide JavaScript interfaces for the built-in text-to-speech engines on macOS and Windows. You can use them if you want some advanced API usage.
+It provides JavaScript interfaces for the built-in text-to-speech engines on macOS and Windows. You can use it if you want some advanced API usage.
 
 ## FAQ
 

--- a/extensions/say/package-lock.json
+++ b/extensions/say/package-lock.json
@@ -7,12 +7,11 @@
       "name": "say",
       "license": "MIT",
       "dependencies": {
-        "@litomore/win-say": "^0.0.1",
         "@raycast/api": "^1.104.4",
         "@raycast/utils": "^2.2.2",
         "bplist-parser": "^0.3.2",
         "lodash": "^4.17.23",
-        "mac-say": "^0.3.3"
+        "native-say": "^0.0.2"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
@@ -1030,120 +1029,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@litomore/win-say": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@litomore/win-say/-/win-say-0.0.1.tgz",
-      "integrity": "sha512-HHJVznXERxg2lxeAj9uHQH6HQcdtmjbar08g3zAvXzWDvBthS0ZdxdgYIX0vsqZqrcP1lLU3NmSlJ2OFyB7YCA==",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^9.6.1",
-        "fkill": "^7.2.1",
-        "tasklist": "^6.0.0"
-      }
-    },
-    "node_modules/@litomore/win-say/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@litomore/win-say/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@litomore/win-say/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@litomore/win-say/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@litomore/win-say/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@litomore/win-say/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@litomore/win-say/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@oclif/core": {
@@ -2296,33 +2181,30 @@
       }
     },
     "node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
       "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^18.19.0 || >=20.5.0"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
-    },
-    "node_modules/execa/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2460,6 +2342,89 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fkill/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fkill/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fkill/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/fkill/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fkill/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fkill/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/fkill/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -2491,12 +2456,16 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2538,12 +2507,12 @@
       }
     },
     "node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=10.17.0"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -2668,12 +2637,12 @@
       }
     },
     "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2825,17 +2794,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/mac-say": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/mac-say/-/mac-say-0.3.3.tgz",
-      "integrity": "sha512-on6Yo244OsYpuGrXVh/oUFM8vse8+MVQPdFWD87JTBss4rpqtmdRQBmXd3aOFj0sqtgaNkkxVoUGa8BIjBg/rg==",
-      "license": "MIT",
-      "dependencies": {
-        "fkill": "^7.2.1",
-        "nano-spawn": "^1.0.2",
-        "ps-list": "^7.2.0"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2881,16 +2839,15 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/nano-spawn": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.3.tgz",
-      "integrity": "sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA==",
+    "node_modules/native-say": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/native-say/-/native-say-0.0.2.tgz",
+      "integrity": "sha512-L8VQ7ozslRkZ9JI+w5ul4kRr7bxI0Mdd1Yba3PStzEe8sg7xSToSfFl5rUwtoQG79ls4q+vcNCQ+x4vGXAVlKw==",
       "license": "MIT",
-      "engines": {
-        "node": ">=20.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
+      "dependencies": {
+        "execa": "^9.6.1",
+        "fkill": "^7.2.1",
+        "tasklist": "^6.0.0"
       }
     },
     "node_modules/natural-compare": {
@@ -2901,15 +2858,31 @@
       "license": "MIT"
     },
     "node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "license": "MIT",
       "dependencies": {
-        "path-key": "^3.0.0"
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/once": {
@@ -3079,6 +3052,89 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pid-port/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/pid-port/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pid-port/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/pid-port/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pid-port/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pid-port/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/pid-port/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3157,9 +3213,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -3291,12 +3347,15 @@
       }
     },
     "node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3385,11 +3444,44 @@
         "node": ">=8.12.0"
       }
     },
+    "node_modules/taskkill/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/taskkill/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/taskkill/node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/taskkill/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tasklist": {
       "version": "6.0.0",

--- a/extensions/say/package.json
+++ b/extensions/say/package.json
@@ -181,12 +181,11 @@
     ]
   },
   "dependencies": {
-    "@litomore/win-say": "^0.0.1",
     "@raycast/api": "^1.104.4",
     "@raycast/utils": "^2.2.2",
     "bplist-parser": "^0.3.2",
     "lodash": "^4.17.23",
-    "mac-say": "^0.3.3"
+    "native-say": "^0.0.2"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",

--- a/extensions/say/src/speech.ts
+++ b/extensions/say/src/speech.ts
@@ -1,15 +1,15 @@
-import { execFile } from "node:child_process";
 import process from "node:process";
-import { promisify } from "node:util";
-import * as winSay from "@litomore/win-say";
-import * as macSay from "mac-say";
+import {
+  checkIfSayIsRunning as nativeCheckIfSayIsRunning,
+  getAudioDevices as nativeGetAudioDevices,
+  getVoices as nativeGetVoices,
+  killRunningSay as nativeKillRunningSay,
+  say as nativeSay,
+} from "native-say";
+import type { SayOptions, Voice as NativeVoice, WindowsSayOptions, WindowsVoice } from "native-say";
 import { maxRate, minRate } from "./constants.js";
 
-type MacSayOptions = macSay.SayOptions;
-type WinSayOptions = winSay.SayOptions;
-type WinVoice = winSay.Voice;
-
-export type SayOptions = MacSayOptions & WinSayOptions;
+export type { Device, SayOptions } from "native-say";
 
 export type Voice = {
   name: string;
@@ -21,22 +21,12 @@ export type Voice = {
   enabled?: boolean;
 };
 
-export type Device = {
-  id: string;
-  name: string;
-};
-
 export const isMacOS = process.platform === "darwin";
 export const isWindows = process.platform === "win32";
 export const supportsAudioDeviceSelection = isMacOS;
 
 const windowsMinRate = -10;
 const windowsMaxRate = 10;
-const execFileAsync = promisify(execFile);
-const powershellArguments = ["-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command"];
-
-const runPowerShell = async (command: string) =>
-  execFileAsync("powershell.exe", [...powershellArguments, command], { encoding: "utf8" });
 
 const toWindowsRate = (rate?: number) => {
   if (rate === undefined) return undefined;
@@ -47,23 +37,11 @@ const toWindowsRate = (rate?: number) => {
   return Math.round((clampedRate - minRate) * scale + windowsMinRate);
 };
 
-const toWindowsSayOptions = (options: SayOptions = {}): WinSayOptions => ({
+const toWindowsSayOptions = (options: SayOptions = {}): WindowsSayOptions => ({
   voice: options.voice,
   rate: toWindowsRate(options.rate),
   volume: options.volume,
   outputFile: options.outputFile,
-  skipRunningCheck: options.skipRunningCheck,
-});
-
-const toMacSayOptions = (options: SayOptions = {}): MacSayOptions => ({
-  voice: options.voice,
-  rate: options.rate,
-  audioDevice: options.audioDevice,
-  quality: options.quality,
-  inputFile: options.inputFile,
-  outputFile: options.outputFile,
-  networkSend: options.networkSend,
-  channels: options.channels,
   skipRunningCheck: options.skipRunningCheck,
 });
 
@@ -72,7 +50,9 @@ const normalizeWindowsLanguageCode = (culture: string) => culture.replaceAll("-"
 const getWindowsVoiceExampleName = (voiceName: string) =>
   voiceName.replace(/^Microsoft\s+/i, "").replace(/\s+Desktop$/i, "");
 
-const normalizeWindowsVoice = (voice: WinVoice): Voice => ({
+const isWindowsVoice = (voice: NativeVoice): voice is WindowsVoice => "culture" in voice;
+
+const normalizeWindowsVoice = (voice: WindowsVoice): Voice => ({
   name: voice.name,
   languageCode: normalizeWindowsLanguageCode(voice.culture),
   example: `Hello! My name is ${getWindowsVoiceExampleName(voice.name)}.`,
@@ -82,101 +62,22 @@ const normalizeWindowsVoice = (voice: WinVoice): Voice => ({
   enabled: voice.enabled,
 });
 
-const getWindowsSayProcessIds = async () => {
-  try {
-    const { stdout } = await runPowerShell(`
-$marker = 'WIN_' + 'SAY_' + 'TTS_' + 'PROCESS'
-$processes = Get-CimInstance Win32_Process -Filter "Name = 'powershell.exe'" | Where-Object {
-  $_.ProcessId -ne $PID -and $_.CommandLine -like "*$marker*"
-} | Select-Object -ExpandProperty ProcessId
-$processes | ConvertTo-Json -Compress
-`);
-    const output = stdout.trim();
-    if (!output || output === "null") return [];
-
-    const parsedOutput: unknown = JSON.parse(output);
-    const processIds = Array.isArray(parsedOutput) ? parsedOutput : [parsedOutput];
-    return processIds.filter((processId): processId is number => typeof processId === "number");
-  } catch {
-    return [];
-  }
-};
-
-const checkIfWindowsSayIsRunning = async () => {
-  try {
-    const runningSay = await winSay.checkIfSayIsRunning();
-    if (runningSay) return runningSay;
-  } catch {
-    // Continue with the process marker fallback below.
-  }
-
-  const [processId] = await getWindowsSayProcessIds();
-  if (!processId) return undefined;
-
-  return {
-    imageName: "powershell.exe",
-    pid: processId,
-  };
-};
-
-const killWindowsRunningSay = async () => {
-  try {
-    await winSay.killRunningSay();
-  } catch {
-    // Continue with the process marker fallback below.
-  }
-
-  try {
-    await runPowerShell(`
-$marker = 'WIN_' + 'SAY_' + 'TTS_' + 'PROCESS'
-Get-CimInstance Win32_Process -Filter "Name = 'powershell.exe'" | Where-Object {
-  $_.ProcessId -ne $PID -and $_.CommandLine -like "*$marker*"
-} | ForEach-Object {
-  Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
-}
-`);
-  } catch {
-    // Stop commands should be best-effort.
-  }
-};
-
 export const say = async (text: string, options?: SayOptions) => {
   if (isWindows) {
-    if (!options?.skipRunningCheck) {
-      await killWindowsRunningSay();
-    }
-
-    await winSay.say(text, { ...toWindowsSayOptions(options), skipRunningCheck: true });
+    await nativeSay(text, toWindowsSayOptions(options));
     return;
   }
 
-  await macSay.say(text, toMacSayOptions(options));
+  await nativeSay(text, options);
 };
 
 export const getVoices = async (): Promise<Voice[]> => {
-  if (isWindows) {
-    const voices = await winSay.getVoices();
-    return voices.map((voice) => normalizeWindowsVoice(voice));
-  }
-
-  return macSay.getVoices();
+  const voices = await nativeGetVoices();
+  return voices.map((voice) => (isWindowsVoice(voice) ? normalizeWindowsVoice(voice) : voice));
 };
 
-export const getAudioDevices = async (): Promise<Device[]> => {
-  if (isWindows) return winSay.getAudioDevices();
-  return macSay.getAudioDevices();
-};
+export const getAudioDevices = nativeGetAudioDevices;
 
-export const checkIfSayIsRunning = async () => {
-  if (isWindows) return checkIfWindowsSayIsRunning();
-  return macSay.checkIfSayIsRunning();
-};
+export const checkIfSayIsRunning = nativeCheckIfSayIsRunning;
 
-export const killRunningSay = async () => {
-  if (isWindows) {
-    await killWindowsRunningSay();
-    return;
-  }
-
-  await macSay.killRunningSay();
-};
+export const killRunningSay = nativeKillRunningSay;


### PR DESCRIPTION
## Description

- Replace deprecated `mac-say` and `@litomore/win-say` dependencies with `native-say`

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
