### PR TITLE
✨ feat(espanso): add edit match action and search by replacement text

### DIFF
--- a/extensions/espanso/AGENTS.md
+++ b/extensions/espanso/AGENTS.md
@@ -9,6 +9,7 @@ The Espanso Raycast extension provides a search interface for Espanso text expan
 ### Core Components
 
 #### 1. Main Index (`src/index.tsx`)
+
 - **Purpose**: Primary search interface and state management
 - **Key Features**:
   - Fetches and displays Espanso matches
@@ -17,6 +18,7 @@ The Espanso Raycast extension provides a search interface for Espanso text expan
   - Organizes matches by folder structure
 
 #### 2. Match Item Component (`src/components/match-item/index.tsx`)
+
 - **Purpose**: Displays individual match entries
 - **Features**:
   - Shows triggers, labels, and replacement text
@@ -25,10 +27,12 @@ The Espanso Raycast extension provides a search interface for Espanso text expan
   - Handles multiple triggers per match
 
 #### 3. Dropdowns
+
 - **Category Dropdown** (`src/components/category-dropdown/index.tsx`): Filters matches by category
 - **Profile Dropdown** (`src/components/profile-dropdown/index.tsx`): Filters matches by profile context
 
 #### 4. Utilities (`src/lib/utils.ts`)
+
 - **`getMatches()`**: Main function that reads and parses Espanso YAML files
 - **`formatCategoryName()`**: Formats category names with proper acronym handling (AI, API, UI, UX, etc.)
 - **Import Resolution**: Handles Espanso's import system for YAML files
@@ -48,23 +52,27 @@ The Espanso Raycast extension provides a search interface for Espanso text expan
 ## Key Features Implemented
 
 ### 1. Profiles Support
+
 - Detects matches in `profiles/` folder structure
 - Extracts profile name from path (e.g., `profiles/work/` → "Work")
 - Provides profile dropdown for filtering
 - Matches outside profiles are accessible from all contexts
 
 ### 2. Smart Category System
+
 - **Full breadcrumb navigation**: Shows complete folder hierarchy
 - **Proper acronym formatting**: Uses `formatCategoryName()` for 50+ tech acronyms
 - **Index file handling**: Hides subcategory when filename is "index"
 - **Customizable separator**: User preference for breadcrumb separator character
 
 ### 3. Breadcrumb Customization
+
 - Setting in preferences to change separator (default: `·`)
 - Common alternatives: `/`, `>`, `→`, `›`, `»`
 - Applies consistently across all breadcrumb displays
 
 ### 4. Import Support
+
 - Handles Espanso's `imports` field in YAML files
 - Resolves relative paths and processes imported files
 - Maintains correct categorization for imported matches
@@ -72,6 +80,7 @@ The Espanso Raycast extension provides a search interface for Espanso text expan
 ## Folder Structure Patterns
 
 ### Standard Structure
+
 ```
 match/
   dev/
@@ -79,9 +88,11 @@ match/
   writing/
     templates.yml
 ```
+
 Result: Category = "Dev" or "Writing"
 
 ### Profiles Structure
+
 ```
 match/
   profiles/
@@ -92,15 +103,18 @@ match/
       personal/
         notes.yml
 ```
+
 Result: Profile = "Work"/"Home", Category = "Dev"/"Personal"
 
 ### Nested Structure
+
 ```
 match/
   dev/
     tools/
       git.yml
 ```
+
 Result: Category = "Dev · Tools" (with custom separator)
 
 ## Package.json Scripts
@@ -115,6 +129,7 @@ Result: Category = "Dev · Tools" (with custom separator)
 ## Dependencies
 
 ### Production
+
 - `@raycast/api`: Core Raycast API
 - `@raycast/utils`: Raycast utility functions
 - `change-case`: Text case conversion utilities
@@ -122,6 +137,7 @@ Result: Category = "Dev · Tools" (with custom separator)
 - `yaml`: YAML parsing
 
 ### Development
+
 - `@raycast/eslint-config`: Raycast ESLint configuration
 - `@types/*`: TypeScript type definitions
 - `eslint`: Linting
@@ -131,29 +147,34 @@ Result: Category = "Dev · Tools" (with custom separator)
 ## Raycast Store Requirements
 
 ### Code Quality Checklist
+
 - ✅ `npm run build` - Must complete successfully
 - ✅ `npm run lint` - Must pass without errors
 - ✅ `npm run typecheck` - Must pass without type errors
 - ✅ Extension opens correctly in Raycast
 
 ### Metadata Requirements (package.json)
+
 - ✅ `license`: Must be "MIT"
 - ✅ `author`: Raycast account username
 - ✅ `categories`: At least one, using Title Case
 - ✅ Latest `@raycast/api` version
 
 ### Documentation
+
 - ✅ `CHANGELOG.md`: Required at root with specific format
   - Use h2 headers: `## [Title] - {PR_MERGE_DATE}`
   - Include detailed bullet points
 - ✅ `README.md`: Required if setup needed (API keys, preferences)
 
 ### Assets
+
 - Icons: 512x512px PNG, works in light/dark themes
 - Screenshots: 2000×1250px, 16:10 ratio, PNG format
 - All assets in `media/` folder at extension root
 
 ### Best Practices
+
 - Use Preferences API for configuration
 - Apply Title Case to action panel items
 - Include icons in action lists
@@ -164,18 +185,21 @@ Result: Category = "Dev · Tools" (with custom separator)
 ## Development Tips
 
 ### Adding New Features
+
 1. Run `npm run typecheck` frequently during development
 2. Use `npm run lint` to ensure code style consistency
 3. Test with `npm run dev` before building
 4. Always update CHANGELOG.md with new features
 
 ### Category Handling
+
 - Categories are derived from folder structure automatically
 - Use `formatCategoryName()` for consistent display formatting
 - Breadcrumb separator comes from user preferences
 - Base categories are sorted first
 
 ### Working with Espanso Files
+
 - YAML files are read from Espanso's match directory
 - Imports are resolved recursively
 - File paths determine category structure
@@ -184,6 +208,7 @@ Result: Category = "Dev · Tools" (with custom separator)
 ## Testing Considerations
 
 Before submitting changes:
+
 1. Test with various folder structures
 2. Verify profile filtering works correctly
 3. Check breadcrumb display with different separators
@@ -195,6 +220,7 @@ Before submitting changes:
 ## Recent Improvements (Current PR)
 
 ### Features Added
+
 - Profiles support with automatic detection and filtering
 - Customizable breadcrumb separator preference
 - Proper acronym formatting across the UI
@@ -203,12 +229,14 @@ Before submitting changes:
 - TypeScript type checking script
 
 ### Refactoring
+
 - Separated folder and filename logic in category derivation
 - Centralized category name formatting
 - Improved breadcrumb path generation
 - Better state management for profiles and categories
 
 ### Technical Improvements
+
 - Added TypeScript type checking to development workflow
 - Upgraded dependencies to latest versions
 - Improved code quality and maintainability

--- a/extensions/espanso/CHANGELOG.md
+++ b/extensions/espanso/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Espanso Changelog
 
-## [1.1.0] - {PR_MERGE_DATE}
+## [1.1.0] - 2026-04-16
 
 ### What's Changed
 

--- a/extensions/espanso/CHANGELOG.md
+++ b/extensions/espanso/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Espanso Changelog
 
+## [1.1.0] - {PR_MERGE_DATE}
+
+### What's Changed
+
+- Added "Edit Match" action (⌘E) to edit existing matches directly from Search Matches via a pre-populated form
+- Replacement text is now searchable in addition to triggers and labels
+
 ## [Patch] - 2026-04-09
 
 ### Bug Fixes

--- a/extensions/espanso/package-lock.json
+++ b/extensions/espanso/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "espanso",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "espanso",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "1.104.11",
@@ -21,7 +23,42 @@
         "@types/yaml": "1.9.7",
         "eslint": "10.2.0",
         "prettier": "3.8.1",
-        "typescript": "6.0.2"
+        "typescript": "6.0.2",
+        "vitest": "4.1.4"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -947,6 +984,32 @@
         }
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@oclif/core": {
       "version": "4.10.5",
       "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.10.5.tgz",
@@ -1016,6 +1079,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@raycast/api": {
@@ -1129,6 +1202,324 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1446,6 +1837,119 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1534,6 +2038,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -1553,6 +2067,16 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/change-case": {
@@ -1621,6 +2145,13 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1674,6 +2205,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -1693,6 +2234,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -1932,6 +2480,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1940,6 +2498,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2075,6 +2643,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-package-type": {
@@ -2310,6 +2893,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -2336,6 +3192,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/minimatch": {
@@ -2389,11 +3255,41 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -2473,6 +3369,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2489,6 +3392,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -2536,6 +3468,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2577,6 +3543,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -2588,6 +3561,30 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2630,6 +3627,23 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2646,6 +3660,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -2658,6 +3682,14 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2747,6 +3779,174 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2761,6 +3961,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/extensions/espanso/package-lock.json
+++ b/extensions/espanso/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "espanso",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "espanso",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "1.104.11",
+        "@raycast/api": "1.104.12",
         "@raycast/utils": "2.2.3",
         "change-case": "5.4.4",
         "fs-extra": "11.3.4",
@@ -18,11 +18,11 @@
       "devDependencies": {
         "@raycast/eslint-config": "2.1.1",
         "@types/fs-extra": "11.0.4",
-        "@types/node": "25.5.2",
+        "@types/node": "25.6.0",
         "@types/react": "19.2.14",
         "@types/yaml": "1.9.7",
         "eslint": "10.2.0",
-        "prettier": "3.8.1",
+        "prettier": "3.8.3",
         "typescript": "6.0.2",
         "vitest": "4.1.4"
       }
@@ -1092,9 +1092,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.11",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.11.tgz",
-      "integrity": "sha512-UaLyWDlgtgyruTVclcJ1RAJjRWKc/ISw+WQAzTHui4qpY3olaaXWrE/dox6/7Cd3mFZtkQ6grhdUiYTBsUUfuw==",
+      "version": "1.104.12",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.12.tgz",
+      "integrity": "sha512-DdrtoksnzLw4q60BgFr/H+PIvIObOfJrW15duTFH7QXVx/0Vxzw9fY7wo+H2gQ2JDDAh9sEMCpc5akP3UxKjTw==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
@@ -1564,13 +1564,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/react": {
@@ -3434,9 +3434,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3755,9 +3755,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/extensions/espanso/package.json
+++ b/extensions/espanso/package.json
@@ -14,7 +14,7 @@
     "System",
     "Productivity"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "commands": [
     {

--- a/extensions/espanso/package.json
+++ b/extensions/espanso/package.json
@@ -54,7 +54,7 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "1.104.11",
+    "@raycast/api": "1.104.12",
     "@raycast/utils": "2.2.3",
     "change-case": "5.4.4",
     "fs-extra": "11.3.4",
@@ -63,11 +63,11 @@
   "devDependencies": {
     "@raycast/eslint-config": "2.1.1",
     "@types/fs-extra": "11.0.4",
-    "@types/node": "25.5.2",
+    "@types/node": "25.6.0",
     "@types/react": "19.2.14",
     "@types/yaml": "1.9.7",
     "eslint": "10.2.0",
-    "prettier": "3.8.1",
+    "prettier": "3.8.3",
     "typescript": "6.0.2",
     "vitest": "4.1.4"
   },

--- a/extensions/espanso/package.json
+++ b/extensions/espanso/package.json
@@ -68,7 +68,8 @@
     "@types/yaml": "1.9.7",
     "eslint": "10.2.0",
     "prettier": "3.8.1",
-    "typescript": "6.0.2"
+    "typescript": "6.0.2",
+    "vitest": "4.1.4"
   },
   "preferences": [
     {
@@ -93,7 +94,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "platforms": [
     "macOS"

--- a/extensions/espanso/src/add-match.tsx
+++ b/extensions/espanso/src/add-match.tsx
@@ -87,7 +87,7 @@ export default function Command() {
         {...itemProps.label}
       />
 
-      <Form.TextField
+      <Form.TextArea
         title="Replace"
         placeholder="Enter replacement"
         info="The replacement text"

--- a/extensions/espanso/src/components/edit-match-form/index.tsx
+++ b/extensions/espanso/src/components/edit-match-form/index.tsx
@@ -1,0 +1,82 @@
+import { Action, ActionPanel, Form, Toast, showToast, useNavigation } from "@raycast/api";
+import { FormValidation, useForm } from "@raycast/utils";
+import { updateMatchInFile } from "../../lib/utils";
+
+interface EditMatchFormProps {
+  filePath: string;
+  originalTriggers: string[];
+  initialTrigger: string;
+  initialLabel?: string;
+  initialReplace: string;
+  onEdited: () => void;
+}
+
+interface Values {
+  trigger: string;
+  label?: string;
+  replace: string;
+}
+
+export default function EditMatchForm({
+  filePath,
+  originalTriggers,
+  initialTrigger,
+  initialLabel,
+  initialReplace,
+  onEdited,
+}: EditMatchFormProps) {
+  const { pop } = useNavigation();
+
+  const { handleSubmit, itemProps } = useForm<Values>({
+    initialValues: { trigger: initialTrigger, label: initialLabel ?? "", replace: initialReplace },
+    onSubmit(values) {
+      const triggers = values.trigger
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean);
+      try {
+        updateMatchInFile(filePath, originalTriggers, { triggers, label: values.label, replace: values.replace });
+        showToast({ style: Toast.Style.Success, title: "Match updated" });
+        onEdited();
+        pop();
+      } catch (err) {
+        showToast({
+          style: Toast.Style.Failure,
+          title: "Failed to update match",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    validation: { trigger: FormValidation.Required, replace: FormValidation.Required },
+  });
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Save" onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField
+        title="Trigger(s)"
+        info="A trigger or comma-separated list of triggers"
+        placeholder="Enter trigger"
+        {...itemProps.trigger}
+      />
+      <Form.TextField
+        title="Label"
+        info="A human-readable text of the trigger"
+        placeholder="Enter label"
+        {...itemProps.label}
+      />
+      <Form.TextField
+        title="Replace"
+        info="The replacement text"
+        placeholder="Enter replacement"
+        {...itemProps.replace}
+      />
+      <Form.Description title="File" text={filePath} />
+    </Form>
+  );
+}

--- a/extensions/espanso/src/components/edit-match-form/index.tsx
+++ b/extensions/espanso/src/components/edit-match-form/index.tsx
@@ -76,7 +76,7 @@ export default function EditMatchForm({
         placeholder="Enter replacement"
         {...itemProps.replace}
       />
-      <Form.Description title="File" text={filePath} />
+      <Form.Description title="File" text={filePath.replace(process.env.HOME ?? "", "~")} />
     </Form>
   );
 }

--- a/extensions/espanso/src/components/edit-match-form/index.tsx
+++ b/extensions/espanso/src/components/edit-match-form/index.tsx
@@ -70,7 +70,7 @@ export default function EditMatchForm({
         placeholder="Enter label"
         {...itemProps.label}
       />
-      <Form.TextField
+      <Form.TextArea
         title="Replace"
         info="The replacement text"
         placeholder="Enter replacement"

--- a/extensions/espanso/src/components/edit-match-form/index.tsx
+++ b/extensions/espanso/src/components/edit-match-form/index.tsx
@@ -34,6 +34,10 @@ export default function EditMatchForm({
         .split(",")
         .map((t) => t.trim())
         .filter(Boolean);
+      if (!triggers.length) {
+        showToast({ style: Toast.Style.Failure, title: "At least one trigger is required" });
+        return;
+      }
       try {
         updateMatchInFile(filePath, originalTriggers, { triggers, label: values.label, replace: values.replace });
         showToast({ style: Toast.Style.Success, title: "Match updated" });

--- a/extensions/espanso/src/components/match-item/index.tsx
+++ b/extensions/espanso/src/components/match-item/index.tsx
@@ -109,29 +109,29 @@ export default function MatchItem({
                   />
                   <Action.CopyToClipboard title="Copy Content" content={expandedReplace} />
                   {isDynamic && <Action icon={Icon.ArrowClockwise} title="Re-Evaluate" onAction={refresh} />}
-                  {canEdit && (
-                    <Action.Push
-                      icon={Icon.Pencil}
-                      title="Edit Match"
-                      shortcut={{ modifiers: ["cmd"], key: "e" }}
-                      target={
-                        <EditMatchForm
-                          filePath={filePath}
-                          originalTriggers={triggers}
-                          initialTrigger={triggers.join(", ")}
-                          initialLabel={label}
-                          initialReplace={replace ?? ""}
-                          onEdited={onEdited}
-                        />
-                      }
-                    />
-                  )}
                 </>
               )}
             </>
           )}
           <Action.CopyToClipboard title="Copy Triggers" content={triggers.join(", ")} />
           {label && <Action.CopyToClipboard title="Copy Label" content={label} />}
+          {canEdit && (
+            <Action.Push
+              icon={Icon.Pencil}
+              title="Edit Match"
+              shortcut={{ modifiers: ["cmd"], key: "e" }}
+              target={
+                <EditMatchForm
+                  filePath={filePath}
+                  originalTriggers={triggers}
+                  initialTrigger={triggers.join(", ")}
+                  initialLabel={label}
+                  initialReplace={replace ?? ""}
+                  onEdited={onEdited}
+                />
+              }
+            />
+          )}
           <Action.OpenWith path={filePath} />
           <Action.ShowInFinder path={filePath} />
           <Action.Trash title="Move the Whole File to Trash" paths={filePath} />

--- a/extensions/espanso/src/components/match-item/index.tsx
+++ b/extensions/espanso/src/components/match-item/index.tsx
@@ -115,6 +115,8 @@ export default function MatchItem({
           )}
           <Action.CopyToClipboard title="Copy Triggers" content={triggers.join(", ")} />
           {label && <Action.CopyToClipboard title="Copy Label" content={label} />}
+          <Action.OpenWith path={filePath} />
+          <Action.ShowInFinder path={filePath} />
           {canEdit && (
             <Action.Push
               icon={Icon.Pencil}
@@ -132,8 +134,6 @@ export default function MatchItem({
               }
             />
           )}
-          <Action.OpenWith path={filePath} />
-          <Action.ShowInFinder path={filePath} />
           <Action.Trash title="Move the Whole File to Trash" paths={filePath} />
         </ActionPanel>
       }

--- a/extensions/espanso/src/components/match-item/index.tsx
+++ b/extensions/espanso/src/components/match-item/index.tsx
@@ -52,6 +52,7 @@ export default function MatchItem({
     <List.Item
       id={id}
       title={label ?? triggers.join(", ")}
+      keywords={replace ? [replace] : undefined}
       subtitle={profile ? formatCategoryName(profile, separator) : ""}
       detail={
         <List.Item.Detail

--- a/extensions/espanso/src/components/match-item/index.tsx
+++ b/extensions/espanso/src/components/match-item/index.tsx
@@ -3,6 +3,7 @@ import { pathToFileURL } from "node:url";
 import { Application, Action, ActionPanel, Clipboard, Icon, List } from "@raycast/api";
 import { FormattedMatch } from "../../lib/types";
 import { formatCategoryName, expandMatch, resolveImagePath } from "../../lib/utils";
+import EditMatchForm from "../edit-match-form";
 
 interface MatchItemProps {
   id: string;
@@ -12,6 +13,7 @@ interface MatchItemProps {
   separator: string;
   isSelected: boolean;
   configPath: string;
+  onEdited: () => void;
 }
 
 export default function MatchItem({
@@ -22,13 +24,15 @@ export default function MatchItem({
   separator,
   isSelected,
   configPath,
+  onEdited,
 }: MatchItemProps) {
-  const { triggers, replace, image_path, form, label, filePath, profile, vars } = match;
+  const { triggers, replace, image_path, form, label, filePath, profile, vars, isRegex } = match;
   const [expandedReplace, setExpandedReplace] = useState(replace ?? "");
   const [resolvedImagePath, setResolvedImagePath] = useState<string | undefined>(undefined);
 
   const isDynamic = !!vars?.length;
   const isImage = !!image_path;
+  const canEdit = !form && !image_path && !isRegex && !filePath.includes("/packages/");
 
   const refresh = () => expandMatch(replace, vars).then(setExpandedReplace);
 
@@ -104,6 +108,23 @@ export default function MatchItem({
                   />
                   <Action.CopyToClipboard title="Copy Content" content={expandedReplace} />
                   {isDynamic && <Action icon={Icon.ArrowClockwise} title="Re-Evaluate" onAction={refresh} />}
+                  {canEdit && (
+                    <Action.Push
+                      icon={Icon.Pencil}
+                      title="Edit Match"
+                      shortcut={{ modifiers: ["cmd"], key: "e" }}
+                      target={
+                        <EditMatchForm
+                          filePath={filePath}
+                          originalTriggers={triggers}
+                          initialTrigger={triggers.join(", ")}
+                          initialLabel={label}
+                          initialReplace={replace ?? ""}
+                          onEdited={onEdited}
+                        />
+                      }
+                    />
+                  )}
                 </>
               )}
             </>

--- a/extensions/espanso/src/index.tsx
+++ b/extensions/espanso/src/index.tsx
@@ -13,6 +13,7 @@ export default function Command() {
   const { breadcrumbSeparator = "·" } = getPreferenceValues<{ breadcrumbSeparator?: string }>();
   const separator = ` ${breadcrumbSeparator.trim()} `;
 
+  const [refreshKey, setRefreshKey] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [items, setItems] = useState<FormattedMatch[]>([]);
   const [filteredItems, setFilteredItems] = useState<FormattedMatch[]>([]);
@@ -31,6 +32,7 @@ export default function Command() {
 
   useEffect(() => {
     const fetchData = async () => {
+      setIsLoading(true);
       try {
         const { config, packages: packageFilesDirectory, match: matchFilesDirectory } = getEspansoConfig();
         setConfigPath(config);
@@ -128,7 +130,7 @@ export default function Command() {
       }
     };
     fetchData();
-  }, []);
+  }, [refreshKey]);
 
   useEffect(() => {
     let filtered = items;
@@ -216,6 +218,7 @@ export default function Command() {
                   separator={separator}
                   isSelected={selectedItemId === id}
                   configPath={configPath}
+                  onEdited={() => setRefreshKey((k) => k + 1)}
                 />
               );
             })}

--- a/extensions/espanso/src/lib/types.ts
+++ b/extensions/espanso/src/lib/types.ts
@@ -46,7 +46,12 @@ type BaseMatch = Replacement & (SingleTrigger | MultiTrigger | RegexTrigger);
 
 export type EspansoMatch = BaseMatch & Label & Form & { vars?: EspansoVar[] };
 
-export type NormalizedEspansoMatch = EspansoMatch & MultiTrigger & FilePath & { category?: string };
+export type NormalizedEspansoMatch = EspansoMatch &
+  MultiTrigger &
+  FilePath & {
+    category?: string;
+    isRegex?: boolean;
+  };
 
 export type EspansoConfig = {
   config: string;

--- a/extensions/espanso/src/lib/utils.test.ts
+++ b/extensions/espanso/src/lib/utils.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import YAML from "yaml";
+
+// Mock Raycast API — unavailable outside the Raycast runtime
+vi.mock("@raycast/api", () => ({
+  Clipboard: { readText: vi.fn() },
+  getPreferenceValues: vi.fn(() => ({})),
+}));
+
+// Mock change-case — not under test here
+vi.mock("change-case", () => ({ capitalCase: (s: string) => s }));
+
+// We intercept fs-extra so tests never touch the real filesystem.
+// Each test seeds `mockFiles` with the YAML it wants to expose.
+const mockFiles: Record<string, string> = {};
+let lastWritten: { path: string; content: string } | null = null;
+
+vi.mock("fs-extra", () => ({
+  default: {
+    readFileSync: (p: string) => {
+      if (!(p in mockFiles)) throw new Error(`File not found: ${p}`);
+      return mockFiles[p];
+    },
+    writeFileSync: (p: string, content: string) => {
+      lastWritten = { path: p, content };
+    },
+    // stubs used by other parts of utils.ts (not under test)
+    readdirSync: vi.fn(() => []),
+    existsSync: vi.fn(() => false),
+    statSync: vi.fn(() => ({ mtime: new Date(), isFile: () => false })),
+    appendFileSync: vi.fn(),
+  },
+}));
+
+// Import after mocks are in place
+import { updateMatchInFile } from "./utils";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const seedFile = (filePath: string, yaml: string) => {
+  mockFiles[filePath] = yaml;
+  lastWritten = null;
+};
+
+const writtenDoc = () => {
+  if (!lastWritten) throw new Error("writeFileSync was never called");
+  return YAML.parse(lastWritten.content);
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("updateMatchInFile", () => {
+  beforeEach(() => {
+    lastWritten = null;
+    for (const k of Object.keys(mockFiles)) delete mockFiles[k];
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path — single trigger
+  // -------------------------------------------------------------------------
+
+  it("updates trigger, replace, and label when the match uses a single trigger key", () => {
+    const filePath = "/fake/match.yml";
+    seedFile(
+      filePath,
+      `matches:
+  - trigger: ":hello"
+    replace: "Hello world"
+`,
+    );
+
+    updateMatchInFile(filePath, [":hello"], {
+      triggers: [":hi"],
+      label: "Greeting",
+      replace: "Hi there",
+    });
+
+    const doc = writtenDoc();
+    expect(doc.matches).toHaveLength(1);
+    expect(doc.matches[0].trigger).toBe(":hi");
+    expect(doc.matches[0].triggers).toBeUndefined();
+    expect(doc.matches[0].replace).toBe("Hi there");
+    expect(doc.matches[0].label).toBe("Greeting");
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path — multi trigger
+  // -------------------------------------------------------------------------
+
+  it("updates a match that uses a triggers array (multi-trigger format)", () => {
+    const filePath = "/fake/match.yml";
+    seedFile(
+      filePath,
+      `matches:
+  - triggers: [":a", ":b"]
+    replace: "alpha"
+`,
+    );
+
+    updateMatchInFile(filePath, [":a", ":b"], {
+      triggers: [":x", ":y", ":z"],
+      replace: "xyz",
+    });
+
+    const doc = writtenDoc();
+    expect(doc.matches[0].triggers).toEqual([":x", ":y", ":z"]);
+    expect(doc.matches[0].trigger).toBeUndefined();
+    expect(doc.matches[0].replace).toBe("xyz");
+  });
+
+  // -------------------------------------------------------------------------
+  // Single → multi promotion
+  // -------------------------------------------------------------------------
+
+  it("promotes a single-trigger entry to triggers array when given multiple new triggers", () => {
+    const filePath = "/fake/match.yml";
+    seedFile(
+      filePath,
+      `matches:
+  - trigger: ":one"
+    replace: "one"
+`,
+    );
+
+    updateMatchInFile(filePath, [":one"], {
+      triggers: [":one", ":1"],
+      replace: "one",
+    });
+
+    const doc = writtenDoc();
+    expect(doc.matches[0].triggers).toEqual([":one", ":1"]);
+    expect(doc.matches[0].trigger).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Multi → single demotion
+  // -------------------------------------------------------------------------
+
+  it("demotes a multi-trigger entry to a single trigger key when given one new trigger", () => {
+    const filePath = "/fake/match.yml";
+    seedFile(
+      filePath,
+      `matches:
+  - triggers: [":foo", ":bar"]
+    replace: "foobar"
+`,
+    );
+
+    updateMatchInFile(filePath, [":foo", ":bar"], {
+      triggers: [":foo"],
+      replace: "foobar",
+    });
+
+    const doc = writtenDoc();
+    expect(doc.matches[0].trigger).toBe(":foo");
+    expect(doc.matches[0].triggers).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Label deletion — empty string
+  // -------------------------------------------------------------------------
+
+  it("removes the label field when the update passes an empty label", () => {
+    const filePath = "/fake/match.yml";
+    seedFile(
+      filePath,
+      `matches:
+  - trigger: ":greet"
+    label: "Old label"
+    replace: "Hello"
+`,
+    );
+
+    updateMatchInFile(filePath, [":greet"], {
+      triggers: [":greet"],
+      label: "",
+      replace: "Hello",
+    });
+
+    const doc = writtenDoc();
+    expect(doc.matches[0].label).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Label deletion — whitespace-only string
+  // -------------------------------------------------------------------------
+
+  it("removes the label field when the update passes a whitespace-only label", () => {
+    const filePath = "/fake/match.yml";
+    seedFile(
+      filePath,
+      `matches:
+  - trigger: ":greet"
+    label: "Old label"
+    replace: "Hello"
+`,
+    );
+
+    updateMatchInFile(filePath, [":greet"], {
+      triggers: [":greet"],
+      label: "   ",
+      replace: "Hello",
+    });
+
+    const doc = writtenDoc();
+    expect(doc.matches[0].label).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown-field preservation (vars, image_path, etc.)
+  // -------------------------------------------------------------------------
+
+  it("preserves unrelated fields like vars when updating a match", () => {
+    const filePath = "/fake/match.yml";
+    seedFile(
+      filePath,
+      `matches:
+  - trigger: ":date"
+    replace: "{{mydate}}"
+    vars:
+      - name: mydate
+        type: date
+        params:
+          format: "%Y-%m-%d"
+`,
+    );
+
+    updateMatchInFile(filePath, [":date"], {
+      triggers: [":today"],
+      replace: "{{mydate}}",
+    });
+
+    const doc = writtenDoc();
+    expect(doc.matches[0].trigger).toBe(":today");
+    expect(doc.matches[0].vars).toBeDefined();
+    expect(doc.matches[0].vars[0].name).toBe("mydate");
+  });
+
+  // -------------------------------------------------------------------------
+  // Multiple matches in file — only the target is mutated
+  // -------------------------------------------------------------------------
+
+  it("leaves other matches untouched when only one match is updated", () => {
+    const filePath = "/fake/match.yml";
+    seedFile(
+      filePath,
+      `matches:
+  - trigger: ":aaa"
+    replace: "AAA"
+  - trigger: ":bbb"
+    replace: "BBB"
+  - trigger: ":ccc"
+    replace: "CCC"
+`,
+    );
+
+    updateMatchInFile(filePath, [":bbb"], {
+      triggers: [":bbb"],
+      replace: "Updated BBB",
+    });
+
+    const doc = writtenDoc();
+    expect(doc.matches).toHaveLength(3);
+    expect(doc.matches[0].replace).toBe("AAA");
+    expect(doc.matches[1].replace).toBe("Updated BBB");
+    expect(doc.matches[2].replace).toBe("CCC");
+  });
+
+  // -------------------------------------------------------------------------
+  // Error path — match not found
+  // -------------------------------------------------------------------------
+
+  it("throws when the original triggers do not match any entry in the file", () => {
+    const filePath = "/fake/match.yml";
+    seedFile(
+      filePath,
+      `matches:
+  - trigger: ":real"
+    replace: "real"
+`,
+    );
+
+    expect(() =>
+      updateMatchInFile(filePath, [":ghost"], {
+        triggers: [":ghost"],
+        replace: "boo",
+      }),
+    ).toThrow(/not found/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // Error path — multi-trigger array order matters (exact match required)
+  // -------------------------------------------------------------------------
+
+  it("throws when the trigger array order differs from the stored order", () => {
+    const filePath = "/fake/match.yml";
+    seedFile(
+      filePath,
+      `matches:
+  - triggers: [":a", ":b"]
+    replace: "ab"
+`,
+    );
+
+    expect(() =>
+      updateMatchInFile(filePath, [":b", ":a"], {
+        triggers: [":b", ":a"],
+        replace: "ba",
+      }),
+    ).toThrow(/not found/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // Error path — no matches sequence in file
+  // -------------------------------------------------------------------------
+
+  it("throws when the YAML file has no top-level matches key", () => {
+    const filePath = "/fake/match.yml";
+    seedFile(filePath, `something: else\n`);
+
+    expect(() =>
+      updateMatchInFile(filePath, [":foo"], {
+        triggers: [":foo"],
+        replace: "bar",
+      }),
+    ).toThrow(/No 'matches' sequence/i);
+  });
+});

--- a/extensions/espanso/src/lib/utils.ts
+++ b/extensions/espanso/src/lib/utils.ts
@@ -128,6 +128,53 @@ export function appendMatchToFile(fileContent: string, fileName: string, espanso
   return { fileName, filePath };
 }
 
+export function updateMatchInFile(
+  filePath: string,
+  originalTriggers: string[],
+  updates: { triggers: string[]; label?: string; replace: string },
+): void {
+  const raw = fse.readFileSync(filePath, "utf-8");
+  const doc = YAML.parseDocument(raw);
+  const matches = doc.get("matches");
+  if (!YAML.isSeq(matches)) throw new Error(`No 'matches' sequence found in ${filePath}`);
+
+  const target = matches.items.find((item) => {
+    if (!YAML.isMap(item)) return false;
+    const trigger = item.get("trigger");
+    const triggers = item.get("triggers");
+    if (typeof trigger === "string" && originalTriggers.length === 1 && trigger === originalTriggers[0]) return true;
+    if (YAML.isSeq(triggers)) {
+      const arr = triggers.toJSON() as unknown[];
+      return (
+        Array.isArray(arr) && arr.length === originalTriggers.length && arr.every((v, i) => v === originalTriggers[i])
+      );
+    }
+    return false;
+  });
+
+  if (!target || !YAML.isMap(target)) {
+    throw new Error(`Match with triggers [${originalTriggers.join(", ")}] not found in ${filePath}`);
+  }
+
+  target.delete("trigger");
+  target.delete("triggers");
+  if (updates.triggers.length === 1) {
+    target.set("trigger", updates.triggers[0]);
+  } else {
+    target.set("triggers", updates.triggers);
+  }
+
+  if (updates.label && updates.label.trim()) {
+    target.set("label", updates.label);
+  } else {
+    target.delete("label");
+  }
+
+  target.set("replace", updates.replace);
+
+  fse.writeFileSync(filePath, doc.toString());
+}
+
 export function getMatches(espansoMatchDir: string, options?: { packagePath: boolean }): NormalizedEspansoMatch[] {
   const finalMatches: NormalizedEspansoMatch[] = [];
   const loadedFiles = new Set<string>();
@@ -176,13 +223,13 @@ export function getMatches(espansoMatchDir: string, options?: { packagePath: boo
       ...matches.flatMap((obj: EspansoMatch) => {
         if ("trigger" in obj) {
           const { trigger, replace, image_path, form, label, vars } = obj;
-          return [{ triggers: [trigger], replace, image_path, form, label, vars, filePath, category }];
+          return [{ triggers: [trigger], replace, image_path, form, label, vars, filePath, category, isRegex: false }];
         } else if ("triggers" in obj) {
           const { triggers, replace, image_path, form, label, vars } = obj;
-          return [{ triggers, replace, image_path, form, label, vars, filePath, category }];
+          return [{ triggers, replace, image_path, form, label, vars, filePath, category, isRegex: false }];
         } else if ("regex" in obj) {
           const { regex, replace, image_path, form, label, vars } = obj;
-          return [{ triggers: [regex], replace, image_path, form, label, vars, filePath, category }];
+          return [{ triggers: [regex], replace, image_path, form, label, vars, filePath, category, isRegex: true }];
         } else {
           return [];
         }
@@ -284,7 +331,6 @@ const evaluateVar = async (v: EspansoVar): Promise<string> => {
         const interactive = shellBase === "zsh" || shellBase === "bash";
         const shellArgs = interactive ? [rawShell, "-i", "-c", v.params.cmd] : [rawShell, "-c", v.params.cmd];
         const { stdout } = await execFilePromise("/usr/bin/env", shellArgs);
-        // eslint-disable-next-line no-control-regex
         return (
           stdout
             // eslint-disable-next-line no-control-regex

--- a/extensions/espanso/tsconfig.json
+++ b/extensions/espanso/tsconfig.json
@@ -1,14 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node 16",
-  "include": [
-    "src/**/*",
-    "raycast-env.d.ts"
-  ],
+  "include": ["src/**/*", "raycast-env.d.ts"],
   "compilerOptions": {
-    "lib": [
-      "es2021"
-    ],
+    "lib": ["es2021"],
     "module": "commonjs",
     "target": "es2021",
     "strict": true,

--- a/extensions/espanso/vitest.config.ts
+++ b/extensions/espanso/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Description

Closes #22967.

Two improvements to the Espanso extension:

**Edit Match action**

Each match in the Search Matches list now has an "Edit Match" action (shortcut: `⌘E`) for matches that are editable (i.e. plain text replacements — regex, image, and package matches are excluded). Activating it opens a pre-populated form with the match's current trigger(s), label, and replacement text. On save, the YAML file is updated in-place using the YAML Document API, which preserves comments and unsupported fields such as `vars`. The list auto-refreshes after a successful edit.

A Vitest test suite with 11 cases covers the `updateMatchInFile` utility across scenarios including multi-trigger matches, matches with labels, and edge cases where the match is not found.

**Search by replacement text**

The replacement text is now included as a `keywords` prop on `List.Item`, so users can find matches by their replacement text in addition to their triggers and labels.

## Screencast

No visual changes for the search-by-replacement improvement.

The Edit Match action opens a form pre-populated with the match's current data and writes the updated values back to the YAML file on save — a screencast is not included but the flow is straightforward and can be validated using the steps below.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the assets folder are used by the extension itself
- [x] I checked that assets used in the README are located outside the metadata folder if they were not generated with our metadata tool
