### PR TITLE
App Store Connect: Add View App Status command

### DIFF
--- a/extensions/app-store-connect/CHANGELOG.md
+++ b/extensions/app-store-connect/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Release individual or all pending apps in `PENDING_DEVELOPER_RELEASE` state
 
 ## [Fix] - 2024-10-29
-- Add searchBarAccessory in SignIn 
+
+- Add searchBarAccessory in SignIn
 
 ## [Initial Version] - 2024-10-28

--- a/extensions/app-store-connect/CHANGELOG.md
+++ b/extensions/app-store-connect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # App Store Connect Changelog
 
+## [Add View App Status Command] - {PR_MERGE_DATE}
+
+- Add `View App Status` command to display app statuses and release versions pending developer release
+- Filter apps by platform (iOS, macOS, tvOS, visionOS) and by App Store state
+- Release individual or all pending apps in `PENDING_DEVELOPER_RELEASE` state
+
 ## [Fix] - 2024-10-29
 - Add searchBarAccessory in SignIn 
 

--- a/extensions/app-store-connect/CHANGELOG.md
+++ b/extensions/app-store-connect/CHANGELOG.md
@@ -1,6 +1,6 @@
 # App Store Connect Changelog
 
-## [Add View App Status Command] - {PR_MERGE_DATE}
+## [Add View App Status Command] - 2026-04-30
 
 - Add `View App Status` command to display app statuses and release versions pending developer release
 - Filter apps by platform (iOS, macOS, tvOS, visionOS) and by App Store state

--- a/extensions/app-store-connect/package-lock.json
+++ b/extensions/app-store-connect/package-lock.json
@@ -16,7 +16,7 @@
         "@raycast/eslint-config": "^1.0.8",
         "@types/node": "22.13.10",
         "@types/node-fetch": "^2.6.11",
-        "@types/react": "18.3.3",
+        "@types/react": "19.0.10",
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
         "typescript": "^5.9.3"
@@ -1166,15 +1166,6 @@
         }
       }
     },
-    "node_modules/@raycast/api/node_modules/@types/react": {
-      "version": "19.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
-      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@raycast/eslint-config": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-1.0.8.tgz",
@@ -1254,19 +1245,12 @@
         "form-data": "^4.0.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.12",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
-    },
     "node_modules/@types/react": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
+      "version": "19.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
+      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
+      "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },

--- a/extensions/app-store-connect/package.json
+++ b/extensions/app-store-connect/package.json
@@ -78,5 +78,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/app-store-connect/package.json
+++ b/extensions/app-store-connect/package.json
@@ -5,11 +5,21 @@
   "description": "Perform tasks from App Store Connect",
   "icon": "icon.png",
   "author": "johanthorell",
+  "contributors": [
+    "danilorequena"
+  ],
   "categories": [
     "Developer Tools"
   ],
   "license": "MIT",
   "commands": [
+    {
+      "name": "appStatus",
+      "title": "View App Status",
+      "subtitle": "App Store Connect",
+      "description": "Display app statuses and release versions pending developer release",
+      "mode": "view"
+    },
     {
       "name": "testFlightBuilds",
       "title": "Manage Builds",
@@ -56,7 +66,7 @@
     "@raycast/eslint-config": "^1.0.8",
     "@types/node": "22.13.10",
     "@types/node-fetch": "^2.6.11",
-    "@types/react": "18.3.3",
+    "@types/react": "19.0.10",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
     "typescript": "^5.9.3"

--- a/extensions/app-store-connect/src/Components/AppStatusDetail.tsx
+++ b/extensions/app-store-connect/src/Components/AppStatusDetail.tsx
@@ -1,13 +1,19 @@
 import { Action, ActionPanel, Color, Detail, Icon, useNavigation } from "@raycast/api";
 import { getPlatformIcon, getPlatformLabel, getStatusInfo } from "../Utils/statusHelpers";
-import { ProcessedApp } from "../appStatus";
+import { ProcessedApp, ProcessedAppVersion } from "../appStatus";
 import { ReleaseAppAction } from "./AppStatusListItem";
 
-export default function AppStatusDetail({ app }: { app: ProcessedApp }) {
+export default function AppStatusDetail({
+  app,
+  version,
+}: {
+  app: ProcessedApp;
+  version: ProcessedAppVersion | undefined;
+}) {
   const { pop } = useNavigation();
-  const statusInfo = app.latestVersion ? getStatusInfo(app.latestVersion.state) : null;
+  const statusInfo = version ? getStatusInfo(version.state) : null;
 
-  const markdown = buildMarkdown(app);
+  const markdown = buildMarkdown(app, version);
 
   return (
     <Detail
@@ -17,24 +23,22 @@ export default function AppStatusDetail({ app }: { app: ProcessedApp }) {
           <Detail.Metadata.Label title="App ID" text={app.id} />
           <Detail.Metadata.Label title="Bundle ID" text={app.bundleId} />
           <Detail.Metadata.Separator />
-          {app.latestVersion && (
+          {version && (
             <>
               <Detail.Metadata.TagList title="Status">
                 <Detail.Metadata.TagList.Item
-                  text={statusInfo?.label ?? app.latestVersion.state}
+                  text={statusInfo?.label ?? version.state}
                   color={statusInfo?.color ?? Color.SecondaryText}
                 />
               </Detail.Metadata.TagList>
-              <Detail.Metadata.Label title="Version" text={app.latestVersion.versionString} />
+              <Detail.Metadata.Label title="Version" text={version.versionString} />
               <Detail.Metadata.Label
                 title="Platform"
-                text={getPlatformLabel(app.latestVersion.platform)}
-                icon={getPlatformIcon(app.latestVersion.platform)}
+                text={getPlatformLabel(version.platform)}
+                icon={getPlatformIcon(version.platform)}
               />
-              <Detail.Metadata.Label title="Created" text={formatDate(app.latestVersion.createdDate)} />
-              {app.latestVersion.releaseType && (
-                <Detail.Metadata.Label title="Release Type" text={app.latestVersion.releaseType} />
-              )}
+              <Detail.Metadata.Label title="Created" text={formatDate(version.createdDate)} />
+              {version.releaseType && <Detail.Metadata.Label title="Release Type" text={version.releaseType} />}
             </>
           )}
           <Detail.Metadata.Separator />
@@ -43,7 +47,7 @@ export default function AppStatusDetail({ app }: { app: ProcessedApp }) {
       }
       actions={
         <ActionPanel>
-          <ReleaseAppAction app={app} onSuccess={pop} />
+          <ReleaseAppAction app={app} version={version} onSuccess={pop} />
           <Action.OpenInBrowser title="Open in App Store Connect" url={app.appStoreConnectUrl} icon={Icon.Globe} />
           <Action.CopyToClipboard
             title="Copy Bundle ID"
@@ -61,17 +65,17 @@ export default function AppStatusDetail({ app }: { app: ProcessedApp }) {
   );
 }
 
-function buildMarkdown(app: ProcessedApp): string {
-  const statusInfo = app.latestVersion ? getStatusInfo(app.latestVersion.state) : null;
-  const versionSection = app.latestVersion
+function buildMarkdown(app: ProcessedApp, version: ProcessedAppVersion | undefined): string {
+  const statusInfo = version ? getStatusInfo(version.state) : null;
+  const versionSection = version
     ? `
 | Field | Value |
 |-------|-------|
-| **Version** | ${app.latestVersion.versionString} |
-| **Status** | ${statusInfo?.label ?? app.latestVersion.state} |
-| **Platform** | ${getPlatformLabel(app.latestVersion.platform)} |
-| **Created** | ${formatDate(app.latestVersion.createdDate)} |
-| **Release Type** | ${app.latestVersion.releaseType ?? "N/A"} |
+| **Version** | ${version.versionString} |
+| **Status** | ${statusInfo?.label ?? version.state} |
+| **Platform** | ${getPlatformLabel(version.platform)} |
+| **Created** | ${formatDate(version.createdDate)} |
+| **Release Type** | ${version.releaseType ?? "N/A"} |
 `
     : "*No version available*";
 

--- a/extensions/app-store-connect/src/Components/AppStatusDetail.tsx
+++ b/extensions/app-store-connect/src/Components/AppStatusDetail.tsx
@@ -88,7 +88,7 @@ ${versionSection}
 
 function formatDate(dateString: string): string {
   const date = new Date(dateString);
-  return date.toLocaleDateString("en-US", {
+  return date.toLocaleDateString(undefined, {
     year: "numeric",
     month: "long",
     day: "numeric",

--- a/extensions/app-store-connect/src/Components/AppStatusDetail.tsx
+++ b/extensions/app-store-connect/src/Components/AppStatusDetail.tsx
@@ -1,0 +1,98 @@
+import { Action, ActionPanel, Color, Detail, Icon, useNavigation } from "@raycast/api";
+import { getPlatformIcon, getPlatformLabel, getStatusInfo } from "../Utils/statusHelpers";
+import { ProcessedApp } from "../appStatus";
+import { ReleaseAppAction } from "./AppStatusListItem";
+
+export default function AppStatusDetail({ app }: { app: ProcessedApp }) {
+  const { pop } = useNavigation();
+  const statusInfo = app.latestVersion ? getStatusInfo(app.latestVersion.state) : null;
+
+  const markdown = buildMarkdown(app);
+
+  return (
+    <Detail
+      markdown={markdown}
+      metadata={
+        <Detail.Metadata>
+          <Detail.Metadata.Label title="App ID" text={app.id} />
+          <Detail.Metadata.Label title="Bundle ID" text={app.bundleId} />
+          <Detail.Metadata.Separator />
+          {app.latestVersion && (
+            <>
+              <Detail.Metadata.TagList title="Status">
+                <Detail.Metadata.TagList.Item
+                  text={statusInfo?.label ?? app.latestVersion.state}
+                  color={statusInfo?.color ?? Color.SecondaryText}
+                />
+              </Detail.Metadata.TagList>
+              <Detail.Metadata.Label title="Version" text={app.latestVersion.versionString} />
+              <Detail.Metadata.Label
+                title="Platform"
+                text={getPlatformLabel(app.latestVersion.platform)}
+                icon={getPlatformIcon(app.latestVersion.platform)}
+              />
+              <Detail.Metadata.Label title="Created" text={formatDate(app.latestVersion.createdDate)} />
+              {app.latestVersion.releaseType && (
+                <Detail.Metadata.Label title="Release Type" text={app.latestVersion.releaseType} />
+              )}
+            </>
+          )}
+          <Detail.Metadata.Separator />
+          <Detail.Metadata.Link title="App Store Connect" target={app.appStoreConnectUrl} text="Open in Browser" />
+        </Detail.Metadata>
+      }
+      actions={
+        <ActionPanel>
+          <ReleaseAppAction app={app} onSuccess={pop} />
+          <Action.OpenInBrowser title="Open in App Store Connect" url={app.appStoreConnectUrl} icon={Icon.Globe} />
+          <Action.CopyToClipboard
+            title="Copy Bundle ID"
+            content={app.bundleId}
+            shortcut={{ modifiers: ["cmd"], key: "." }}
+          />
+          <Action.CopyToClipboard
+            title="Copy App ID"
+            content={app.id}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "." }}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+function buildMarkdown(app: ProcessedApp): string {
+  const statusInfo = app.latestVersion ? getStatusInfo(app.latestVersion.state) : null;
+  const versionSection = app.latestVersion
+    ? `
+| Field | Value |
+|-------|-------|
+| **Version** | ${app.latestVersion.versionString} |
+| **Status** | ${statusInfo?.label ?? app.latestVersion.state} |
+| **Platform** | ${getPlatformLabel(app.latestVersion.platform)} |
+| **Created** | ${formatDate(app.latestVersion.createdDate)} |
+| **Release Type** | ${app.latestVersion.releaseType ?? "N/A"} |
+`
+    : "*No version available*";
+
+  return `# ${app.name}
+
+**Bundle ID:** \`${app.bundleId}\`
+
+---
+
+## Latest Version
+${versionSection}
+`;
+}
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/extensions/app-store-connect/src/Components/AppStatusListItem.tsx
+++ b/extensions/app-store-connect/src/Components/AppStatusListItem.tsx
@@ -2,38 +2,40 @@ import { Action, ActionPanel, Alert, Color, Icon, List, Toast, confirmAlert, sho
 import { fetchAppStoreConnect } from "../Hooks/useAppStoreConnect";
 import { presentError } from "../Utils/utils";
 import { getCompactStatusLabel, getPlatformIcon, getPlatformLabel, getStatusInfo } from "../Utils/statusHelpers";
-import { PendingReleaseApp, ProcessedApp, STATUS_FILTERS, StatusFilter } from "../appStatus";
+import { PendingRelease, ProcessedApp, ProcessedAppVersion, STATUS_FILTERS, StatusFilter } from "../appStatus";
 import AppStatusDetail from "./AppStatusDetail";
 
 interface AppStatusListItemProps {
   app: ProcessedApp;
-  pendingReleaseApps: PendingReleaseApp[];
+  version: ProcessedAppVersion | undefined;
+  pendingReleaseApps: PendingRelease[];
   statusFilter: StatusFilter;
   onFilterChange: (filter: StatusFilter) => void;
 }
 
 export default function AppStatusListItem({
   app,
+  version,
   pendingReleaseApps,
   statusFilter,
   onFilterChange,
 }: AppStatusListItemProps) {
-  const statusInfo = app.latestVersion ? getStatusInfo(app.latestVersion.state) : null;
+  const statusInfo = version ? getStatusInfo(version.state) : null;
   const shortBundleId = compactTextMiddle(app.bundleId, 24, 8);
-  const compactStatus = app.latestVersion ? getCompactStatusLabel(app.latestVersion.state) : "No Version";
+  const compactStatus = version ? getCompactStatusLabel(version.state) : "No Version";
 
   const accessories: List.Item.Accessory[] = [];
-  if (app.latestVersion) {
+  if (version) {
     accessories.push({
       tag: {
         value: compactStatus,
         color: statusInfo?.color ?? Color.SecondaryText,
       },
-      tooltip: `Status: ${statusInfo?.label ?? app.latestVersion.state}`,
+      tooltip: `Status: ${statusInfo?.label ?? version.state}`,
     });
     accessories.push({
-      icon: getPlatformIcon(app.latestVersion.platform),
-      tooltip: getPlatformLabel(app.latestVersion.platform),
+      icon: getPlatformIcon(version.platform),
+      tooltip: getPlatformLabel(version.platform),
     });
   } else {
     accessories.push({
@@ -51,9 +53,13 @@ export default function AppStatusListItem({
       actions={
         <ActionPanel>
           <ActionPanel.Section>
-            <Action.Push title="View Details" icon={Icon.Eye} target={<AppStatusDetail app={app} />} />
-            <ReleaseAppAction app={app} />
-            <ReleaseAllAppsAction apps={pendingReleaseApps} />
+            <Action.Push
+              title="View Details"
+              icon={Icon.Eye}
+              target={<AppStatusDetail app={app} version={version} />}
+            />
+            <ReleaseAppAction app={app} version={version} />
+            <ReleaseAllAppsAction pending={pendingReleaseApps} />
             <Action.OpenInBrowser title="Open in App Store Connect" url={app.appStoreConnectUrl} icon={Icon.Globe} />
             <Action.CopyToClipboard
               title="Copy Bundle ID"
@@ -82,12 +88,18 @@ export default function AppStatusListItem({
   );
 }
 
-export function ReleaseAppAction({ app, onSuccess }: { app: ProcessedApp; onSuccess?: () => void }) {
-  if (!app.latestVersion || app.latestVersion.state !== "PENDING_DEVELOPER_RELEASE") {
+export function ReleaseAppAction({
+  app,
+  version,
+  onSuccess,
+}: {
+  app: ProcessedApp;
+  version: ProcessedAppVersion | undefined;
+  onSuccess?: () => void;
+}) {
+  if (!version || version.state !== "PENDING_DEVELOPER_RELEASE") {
     return null;
   }
-
-  const version = app.latestVersion;
 
   return (
     <Action
@@ -122,24 +134,24 @@ export function ReleaseAppAction({ app, onSuccess }: { app: ProcessedApp; onSucc
   );
 }
 
-function ReleaseAllAppsAction({ apps }: { apps: PendingReleaseApp[] }) {
-  if (apps.length === 0) return null;
+function ReleaseAllAppsAction({ pending }: { pending: PendingRelease[] }) {
+  if (pending.length === 0) return null;
 
   return (
     <Action
-      title={`Release All Pending Apps (${apps.length})`}
+      title={`Release All Pending Apps (${pending.length})`}
       icon={Icon.Rocket}
       shortcut={{ modifiers: ["cmd", "shift"], key: "enter" }}
       onAction={async () => {
-        const preview = apps
+        const preview = pending
           .slice(0, 3)
-          .map((a) => a.name)
+          .map(({ app }) => app.name)
           .join(", ");
-        const remaining = apps.length - Math.min(apps.length, 3);
+        const remaining = pending.length - Math.min(pending.length, 3);
         const summary = remaining > 0 ? `${preview} and ${remaining} more` : preview;
 
         const confirmed = await confirmAlert({
-          title: `Release ${apps.length} apps?`,
+          title: `Release ${pending.length} apps?`,
           message: `This will immediately release all versions pending developer release: ${summary}.`,
           primaryAction: { title: "Release All", style: Alert.ActionStyle.Default },
         });
@@ -148,20 +160,20 @@ function ReleaseAllAppsAction({ apps }: { apps: PendingReleaseApp[] }) {
         const toast = await showToast({
           style: Toast.Style.Animated,
           title: "Releasing apps…",
-          message: `0/${apps.length}`,
+          message: `0/${pending.length}`,
         });
 
         const failures: string[] = [];
-        for (const [index, app] of apps.entries()) {
-          toast.message = `${index + 1}/${apps.length} · ${app.name}`;
+        for (const [index, entry] of pending.entries()) {
+          toast.message = `${index + 1}/${pending.length} · ${entry.app.name}`;
           try {
-            await releaseAppVersion(app.latestVersion.id);
+            await releaseAppVersion(entry.version.id);
           } catch (error) {
-            failures.push(`${app.name}: ${errorMessage(error)}`);
+            failures.push(`${entry.app.name}: ${errorMessage(error)}`);
           }
         }
 
-        const releasedCount = apps.length - failures.length;
+        const releasedCount = pending.length - failures.length;
         if (failures.length === 0) {
           toast.style = Toast.Style.Success;
           toast.title = "Apps released";
@@ -172,7 +184,7 @@ function ReleaseAllAppsAction({ apps }: { apps: PendingReleaseApp[] }) {
         toast.style = Toast.Style.Failure;
         toast.title = "Bulk release finished with errors";
         toast.message =
-          failures.length === apps.length
+          failures.length === pending.length
             ? "No apps were released"
             : `${releasedCount} released, ${failures.length} failed`;
       }}

--- a/extensions/app-store-connect/src/Components/AppStatusListItem.tsx
+++ b/extensions/app-store-connect/src/Components/AppStatusListItem.tsx
@@ -109,7 +109,7 @@ export function ReleaseAppAction({
         const confirmed = await confirmAlert({
           title: `Release ${app.name}?`,
           message: `Version ${version.versionString} will be released on the App Store immediately.`,
-          primaryAction: { title: "Release Now", style: Alert.ActionStyle.Default },
+          primaryAction: { title: "Release Now", style: Alert.ActionStyle.Destructive },
         });
         if (!confirmed) return;
 
@@ -153,7 +153,7 @@ function ReleaseAllAppsAction({ pending }: { pending: PendingRelease[] }) {
         const confirmed = await confirmAlert({
           title: `Release ${pending.length} apps?`,
           message: `This will immediately release all versions pending developer release: ${summary}.`,
-          primaryAction: { title: "Release All", style: Alert.ActionStyle.Default },
+          primaryAction: { title: "Release All", style: Alert.ActionStyle.Destructive },
         });
         if (!confirmed) return;
 

--- a/extensions/app-store-connect/src/Components/AppStatusListItem.tsx
+++ b/extensions/app-store-connect/src/Components/AppStatusListItem.tsx
@@ -181,7 +181,7 @@ function ReleaseAllAppsAction({ apps }: { apps: PendingReleaseApp[] }) {
 }
 
 async function releaseAppVersion(appStoreVersionId: string) {
-  await fetchAppStoreConnect("/appStoreVersionReleaseRequests", "POST", {
+  const response = await fetchAppStoreConnect("/appStoreVersionReleaseRequests", "POST", {
     data: {
       type: "appStoreVersionReleaseRequests",
       relationships: {
@@ -191,6 +191,9 @@ async function releaseAppVersion(appStoreVersionId: string) {
       },
     },
   });
+  if (!response) {
+    throw new Error("Missing credentials – could not release app version");
+  }
 }
 
 function errorMessage(error: unknown): string {

--- a/extensions/app-store-connect/src/Components/AppStatusListItem.tsx
+++ b/extensions/app-store-connect/src/Components/AppStatusListItem.tsx
@@ -1,0 +1,204 @@
+import { Action, ActionPanel, Alert, Color, Icon, List, Toast, confirmAlert, showToast } from "@raycast/api";
+import { fetchAppStoreConnect } from "../Hooks/useAppStoreConnect";
+import { presentError } from "../Utils/utils";
+import { getCompactStatusLabel, getPlatformIcon, getPlatformLabel, getStatusInfo } from "../Utils/statusHelpers";
+import { PendingReleaseApp, ProcessedApp, STATUS_FILTERS, StatusFilter } from "../appStatus";
+import AppStatusDetail from "./AppStatusDetail";
+
+interface AppStatusListItemProps {
+  app: ProcessedApp;
+  pendingReleaseApps: PendingReleaseApp[];
+  statusFilter: StatusFilter;
+  onFilterChange: (filter: StatusFilter) => void;
+}
+
+export default function AppStatusListItem({
+  app,
+  pendingReleaseApps,
+  statusFilter,
+  onFilterChange,
+}: AppStatusListItemProps) {
+  const statusInfo = app.latestVersion ? getStatusInfo(app.latestVersion.state) : null;
+  const shortBundleId = compactTextMiddle(app.bundleId, 24, 8);
+  const compactStatus = app.latestVersion ? getCompactStatusLabel(app.latestVersion.state) : "No Version";
+
+  const accessories: List.Item.Accessory[] = [];
+  if (app.latestVersion) {
+    accessories.push({
+      tag: {
+        value: compactStatus,
+        color: statusInfo?.color ?? Color.SecondaryText,
+      },
+      tooltip: `Status: ${statusInfo?.label ?? app.latestVersion.state}`,
+    });
+    accessories.push({
+      icon: getPlatformIcon(app.latestVersion.platform),
+      tooltip: getPlatformLabel(app.latestVersion.platform),
+    });
+  } else {
+    accessories.push({
+      tag: { value: compactStatus, color: Color.SecondaryText },
+    });
+  }
+
+  return (
+    <List.Item
+      icon={statusInfo?.icon ?? Icon.AppWindow}
+      title={app.name}
+      subtitle={shortBundleId}
+      keywords={[app.bundleId, app.id, app.name]}
+      accessories={accessories}
+      actions={
+        <ActionPanel>
+          <ActionPanel.Section>
+            <Action.Push title="View Details" icon={Icon.Eye} target={<AppStatusDetail app={app} />} />
+            <ReleaseAppAction app={app} />
+            <ReleaseAllAppsAction apps={pendingReleaseApps} />
+            <Action.OpenInBrowser title="Open in App Store Connect" url={app.appStoreConnectUrl} icon={Icon.Globe} />
+            <Action.CopyToClipboard
+              title="Copy Bundle ID"
+              content={app.bundleId}
+              shortcut={{ modifiers: ["cmd"], key: "." }}
+            />
+            <Action.CopyToClipboard
+              title="Copy App ID"
+              content={app.id}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "." }}
+            />
+          </ActionPanel.Section>
+          <ActionPanel.Section title="Filter by Status">
+            {STATUS_FILTERS.map((filter) => (
+              <Action
+                key={filter.value}
+                title={filter.label}
+                icon={statusFilter === filter.value ? Icon.CheckCircle : filter.icon}
+                onAction={() => onFilterChange(filter.value)}
+              />
+            ))}
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+export function ReleaseAppAction({ app, onSuccess }: { app: ProcessedApp; onSuccess?: () => void }) {
+  if (!app.latestVersion || app.latestVersion.state !== "PENDING_DEVELOPER_RELEASE") {
+    return null;
+  }
+
+  const version = app.latestVersion;
+
+  return (
+    <Action
+      title="Release App Now"
+      icon={Icon.Upload}
+      onAction={async () => {
+        const confirmed = await confirmAlert({
+          title: `Release ${app.name}?`,
+          message: `Version ${version.versionString} will be released on the App Store immediately.`,
+          primaryAction: { title: "Release Now", style: Alert.ActionStyle.Default },
+        });
+        if (!confirmed) return;
+
+        const toast = await showToast({
+          style: Toast.Style.Animated,
+          title: "Releasing app…",
+          message: `${app.name} ${version.versionString}`,
+        });
+
+        try {
+          await releaseAppVersion(version.id);
+          toast.style = Toast.Style.Success;
+          toast.title = "App released";
+          toast.message = `${app.name} ${version.versionString}`;
+          onSuccess?.();
+        } catch (error) {
+          toast.hide();
+          presentError(error);
+        }
+      }}
+    />
+  );
+}
+
+function ReleaseAllAppsAction({ apps }: { apps: PendingReleaseApp[] }) {
+  if (apps.length === 0) return null;
+
+  return (
+    <Action
+      title={`Release All Pending Apps (${apps.length})`}
+      icon={Icon.Rocket}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "enter" }}
+      onAction={async () => {
+        const preview = apps
+          .slice(0, 3)
+          .map((a) => a.name)
+          .join(", ");
+        const remaining = apps.length - Math.min(apps.length, 3);
+        const summary = remaining > 0 ? `${preview} and ${remaining} more` : preview;
+
+        const confirmed = await confirmAlert({
+          title: `Release ${apps.length} apps?`,
+          message: `This will immediately release all versions pending developer release: ${summary}.`,
+          primaryAction: { title: "Release All", style: Alert.ActionStyle.Default },
+        });
+        if (!confirmed) return;
+
+        const toast = await showToast({
+          style: Toast.Style.Animated,
+          title: "Releasing apps…",
+          message: `0/${apps.length}`,
+        });
+
+        const failures: string[] = [];
+        for (const [index, app] of apps.entries()) {
+          toast.message = `${index + 1}/${apps.length} · ${app.name}`;
+          try {
+            await releaseAppVersion(app.latestVersion.id);
+          } catch (error) {
+            failures.push(`${app.name}: ${errorMessage(error)}`);
+          }
+        }
+
+        const releasedCount = apps.length - failures.length;
+        if (failures.length === 0) {
+          toast.style = Toast.Style.Success;
+          toast.title = "Apps released";
+          toast.message = `${releasedCount} apps released successfully`;
+          return;
+        }
+
+        toast.style = Toast.Style.Failure;
+        toast.title = "Bulk release finished with errors";
+        toast.message =
+          failures.length === apps.length
+            ? "No apps were released"
+            : `${releasedCount} released, ${failures.length} failed`;
+      }}
+    />
+  );
+}
+
+async function releaseAppVersion(appStoreVersionId: string) {
+  await fetchAppStoreConnect("/appStoreVersionReleaseRequests", "POST", {
+    data: {
+      type: "appStoreVersionReleaseRequests",
+      relationships: {
+        appStoreVersion: {
+          data: { type: "appStoreVersions", id: appStoreVersionId },
+        },
+      },
+    },
+  });
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return "Unknown error";
+}
+
+function compactTextMiddle(value: string, head: number, tail: number): string {
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}

--- a/extensions/app-store-connect/src/Model/schemas.ts
+++ b/extensions/app-store-connect/src/Model/schemas.ts
@@ -429,3 +429,43 @@ export const preReleaseVersionSchemas = z.array(preReleaseVersionSchema);
 export type AppStoreVersion = z.infer<typeof appStoreVersionSchema>;
 
 export type PreReleaseVersion = z.infer<typeof preReleaseVersionSchema>;
+
+// Lenient schema used by the `appStatus` command. Apple occasionally returns
+// states that are not in `appStoreVersionSchema`'s enum (e.g.
+// PROCESSING_FOR_APP_STORE, PREORDER_READY_FOR_SALE, PENDING_CONTRACT), so we
+// keep the state as a string here and let the UI map it to a fallback label.
+export const appStatusVersionSchema = z.object({
+  type: z.literal("appStoreVersions"),
+  id: z.string(),
+  attributes: z.object({
+    platform: z.string(),
+    versionString: z.string(),
+    appStoreState: z.string(),
+    releaseType: z.string().nullable().optional(),
+    createdDate: z.string(),
+  }),
+});
+
+export type AppStatusVersion = z.infer<typeof appStatusVersionSchema>;
+
+export const appWithVersionsSchema = appSchema.extend({
+  relationships: z.object({
+    appStoreVersions: z.object({
+      data: z.array(
+        z.object({
+          type: z.literal("appStoreVersions"),
+          id: z.string(),
+        }),
+      ),
+    }),
+  }),
+});
+
+export type AppWithVersions = z.infer<typeof appWithVersionsSchema>;
+
+export const appsWithVersionsResponseSchema = z.object({
+  data: z.array(appWithVersionsSchema),
+  included: z.array(appStatusVersionSchema).optional(),
+});
+
+export type AppsWithVersionsResponse = z.infer<typeof appsWithVersionsResponseSchema>;

--- a/extensions/app-store-connect/src/Utils/statusHelpers.ts
+++ b/extensions/app-store-connect/src/Utils/statusHelpers.ts
@@ -1,0 +1,118 @@
+import { Color, Icon } from "@raycast/api";
+
+interface StatusInfo {
+  color: Color;
+  icon: Icon;
+  label: string;
+}
+
+const STATUS_MAP: Record<string, StatusInfo> = {
+  // Active / positive
+  READY_FOR_SALE: { color: Color.Green, icon: Icon.CheckCircle, label: "✅ Ready for Sale" },
+  READY_FOR_DISTRIBUTION: { color: Color.Green, icon: Icon.CheckCircle, label: "✅ Ready for Distribution" },
+  PREORDER_READY_FOR_SALE: { color: Color.Green, icon: Icon.CheckCircle, label: "🛒 Pre-order Ready" },
+  PENDING_APPLE_RELEASE: { color: Color.Green, icon: Icon.Clock, label: "🍎 Pending Apple Release" },
+  PENDING_DEVELOPER_RELEASE: { color: Color.Blue, icon: Icon.Clock, label: "🚀 Pending Developer Release" },
+  ACCEPTED: { color: Color.Blue, icon: Icon.CheckCircle, label: "👍 Accepted" },
+
+  // In progress
+  IN_REVIEW: { color: Color.Orange, icon: Icon.Eye, label: "👀 In Review" },
+  WAITING_FOR_REVIEW: { color: Color.Yellow, icon: Icon.Clock, label: "⏳ Waiting for Review" },
+  READY_FOR_REVIEW: { color: Color.Yellow, icon: Icon.ArrowRight, label: "📤 Ready for Review" },
+  PROCESSING_FOR_APP_STORE: { color: Color.Yellow, icon: Icon.CircleProgress, label: "⚙️ Processing" },
+  PROCESSING_FOR_DISTRIBUTION: { color: Color.Yellow, icon: Icon.CircleProgress, label: "⚙️ Processing" },
+  WAITING_FOR_EXPORT_COMPLIANCE: { color: Color.Yellow, icon: Icon.Clock, label: "📋 Export Compliance" },
+
+  // Preparation
+  PREPARE_FOR_SUBMISSION: { color: Color.SecondaryText, icon: Icon.Pencil, label: "✏️ Prepare for Submission" },
+
+  // Negative / problem
+  REJECTED: { color: Color.Red, icon: Icon.XMarkCircle, label: "❌ Rejected" },
+  METADATA_REJECTED: { color: Color.Red, icon: Icon.XMarkCircle, label: "❌ Metadata Rejected" },
+  INVALID_BINARY: { color: Color.Red, icon: Icon.ExclamationMark, label: "⚠️ Invalid Binary" },
+  DEVELOPER_REJECTED: { color: Color.Orange, icon: Icon.XMarkCircle, label: "🚫 Developer Rejected" },
+
+  // Removed / inactive
+  REMOVED_FROM_SALE: { color: Color.SecondaryText, icon: Icon.Minus, label: "🗑️ Removed from Sale" },
+  DEVELOPER_REMOVED_FROM_SALE: { color: Color.SecondaryText, icon: Icon.Minus, label: "🗑️ Developer Removed" },
+  REPLACED_WITH_NEW_VERSION: { color: Color.SecondaryText, icon: Icon.ArrowClockwise, label: "🔄 Replaced" },
+
+  // Pending
+  PENDING_CONTRACT: { color: Color.Yellow, icon: Icon.Document, label: "📝 Pending Contract" },
+};
+
+const COMPACT_MAP: Record<string, string> = {
+  READY_FOR_SALE: "Ready",
+  READY_FOR_DISTRIBUTION: "Ready",
+  PREORDER_READY_FOR_SALE: "Pre-order",
+  PENDING_APPLE_RELEASE: "Apple Release",
+  PENDING_DEVELOPER_RELEASE: "Dev Release",
+  ACCEPTED: "Accepted",
+  IN_REVIEW: "In Review",
+  WAITING_FOR_REVIEW: "Waiting",
+  READY_FOR_REVIEW: "Ready Review",
+  PROCESSING_FOR_APP_STORE: "Processing",
+  PROCESSING_FOR_DISTRIBUTION: "Processing",
+  WAITING_FOR_EXPORT_COMPLIANCE: "Compliance",
+  PREPARE_FOR_SUBMISSION: "Prepare",
+  REJECTED: "Rejected",
+  METADATA_REJECTED: "Meta Rejected",
+  INVALID_BINARY: "Invalid Binary",
+  DEVELOPER_REJECTED: "Dev Rejected",
+  REMOVED_FROM_SALE: "Removed",
+  DEVELOPER_REMOVED_FROM_SALE: "Dev Removed",
+  REPLACED_WITH_NEW_VERSION: "Replaced",
+  PENDING_CONTRACT: "Contract",
+};
+
+export function getStatusInfo(state: string): StatusInfo {
+  return (
+    STATUS_MAP[state] || {
+      color: Color.SecondaryText,
+      icon: Icon.QuestionMark,
+      label: "❓ " + state.replace(/_/g, " "),
+    }
+  );
+}
+
+export function getCompactStatusLabel(state: string): string {
+  return COMPACT_MAP[state] || prettify(state);
+}
+
+export function getPlatformIcon(platform: string): Icon {
+  switch (platform) {
+    case "IOS":
+      return Icon.Mobile;
+    case "MAC_OS":
+      return Icon.Monitor;
+    case "TV_OS":
+      return Icon.Desktop;
+    case "VISION_OS":
+      return Icon.Eye;
+    default:
+      return Icon.AppWindow;
+  }
+}
+
+export function getPlatformLabel(platform: string): string {
+  switch (platform) {
+    case "IOS":
+      return "iOS";
+    case "MAC_OS":
+      return "macOS";
+    case "TV_OS":
+      return "tvOS";
+    case "VISION_OS":
+      return "visionOS";
+    default:
+      return platform;
+  }
+}
+
+function prettify(state: string): string {
+  return state
+    .toLowerCase()
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}

--- a/extensions/app-store-connect/src/appStatus.tsx
+++ b/extensions/app-store-connect/src/appStatus.tsx
@@ -1,0 +1,176 @@
+import { useMemo, useState } from "react";
+import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import { useAppStoreConnectApi } from "./Hooks/useAppStoreConnect";
+import { appsWithVersionsResponseSchema, AppStatusVersion, AppWithVersions } from "./Model/schemas";
+import SignIn from "./Components/SignIn";
+import AppStatusListItem from "./Components/AppStatusListItem";
+
+export interface ProcessedApp {
+  id: string;
+  name: string;
+  bundleId: string;
+  latestVersion?: {
+    id: string;
+    versionString: string;
+    state: string;
+    platform: string;
+    createdDate: string;
+    releaseType: string | null;
+  };
+  appStoreConnectUrl: string;
+}
+
+export interface PendingReleaseApp extends ProcessedApp {
+  latestVersion: NonNullable<ProcessedApp["latestVersion"]>;
+}
+
+export type StatusFilter = "all" | string;
+export type PlatformFilter = "all" | "IOS" | "MAC_OS" | "TV_OS" | "VISION_OS";
+
+export const STATUS_FILTERS: { value: StatusFilter; label: string; icon: Icon }[] = [
+  { value: "all", label: "All Apps", icon: Icon.List },
+  { value: "READY_FOR_SALE", label: "✅ Ready for Sale", icon: Icon.CheckCircle },
+  { value: "IN_REVIEW", label: "👀 In Review", icon: Icon.Eye },
+  { value: "WAITING_FOR_REVIEW", label: "⏳ Waiting for Review", icon: Icon.Clock },
+  { value: "PENDING_DEVELOPER_RELEASE", label: "🚀 Pending Developer Release", icon: Icon.Clock },
+  { value: "PREPARE_FOR_SUBMISSION", label: "✏️ Prepare for Submission", icon: Icon.Pencil },
+  { value: "REJECTED", label: "❌ Rejected", icon: Icon.XMarkCircle },
+];
+
+const PLATFORM_FILTERS: { value: PlatformFilter; label: string; icon: Icon }[] = [
+  { value: "all", label: "All Platforms", icon: Icon.List },
+  { value: "IOS", label: "iOS", icon: Icon.Mobile },
+  { value: "MAC_OS", label: "macOS", icon: Icon.Monitor },
+  { value: "TV_OS", label: "tvOS", icon: Icon.Desktop },
+  { value: "VISION_OS", label: "visionOS", icon: Icon.Eye },
+];
+
+export default function Command() {
+  const [path, setPath] = useState<string | undefined>(undefined);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [platformFilter, setPlatformFilter] = useState<PlatformFilter>("all");
+
+  const { data, isLoading } = useAppStoreConnectApi(
+    path,
+    (response) => {
+      const parsed = appsWithVersionsResponseSchema.safeParse(response);
+      if (!parsed.success) {
+        return [] as ProcessedApp[];
+      }
+      return processApps(parsed.data.data, parsed.data.included ?? []);
+    },
+    true,
+  );
+
+  const apps = data ?? [];
+  const pendingReleaseApps = useMemo(() => apps.filter(isPendingDeveloperRelease), [apps]);
+
+  const filteredApps = apps.filter((app) => {
+    const matchesStatus = statusFilter === "all" || app.latestVersion?.state === statusFilter;
+    const matchesPlatform = platformFilter === "all" || app.latestVersion?.platform === platformFilter;
+    return matchesStatus && matchesPlatform;
+  });
+
+  const statusFilterLabel = STATUS_FILTERS.find((f) => f.value === statusFilter)?.label ?? "All Apps";
+  const platformLabel = PLATFORM_FILTERS.find((f) => f.value === platformFilter)?.label ?? "All Platforms";
+  const hasFilter = statusFilter !== "all" || platformFilter !== "all";
+  const searchPlaceholder = hasFilter ? `Search in ${statusFilterLabel}…` : "Search apps…";
+
+  return (
+    <SignIn
+      didSignIn={() => {
+        setPath(
+          "/apps?include=appStoreVersions&fields[appStoreVersions]=platform,versionString,appStoreState,releaseType,createdDate&limit=200",
+        );
+      }}
+    >
+      <List
+        isLoading={isLoading}
+        searchBarPlaceholder={searchPlaceholder}
+        searchBarAccessory={
+          <List.Dropdown
+            tooltip="Filter by Platform"
+            value={platformFilter}
+            onChange={(newValue) => setPlatformFilter(newValue as PlatformFilter)}
+          >
+            {PLATFORM_FILTERS.map((filter) => (
+              <List.Dropdown.Item key={filter.value} title={filter.label} value={filter.value} icon={filter.icon} />
+            ))}
+          </List.Dropdown>
+        }
+      >
+        {filteredApps.length === 0 ? (
+          <List.EmptyView
+            icon={Icon.AppWindow}
+            title={hasFilter ? "No Apps Match Filter" : "No Apps Found"}
+            description={
+              hasFilter
+                ? `No apps for status "${statusFilterLabel}" and platform "${platformLabel}".`
+                : "No apps were found in your App Store Connect account."
+            }
+            actions={
+              hasFilter ? (
+                <ActionPanel>
+                  <Action
+                    title="Show All Apps"
+                    icon={Icon.List}
+                    onAction={() => {
+                      setStatusFilter("all");
+                      setPlatformFilter("all");
+                    }}
+                  />
+                </ActionPanel>
+              ) : undefined
+            }
+          />
+        ) : (
+          filteredApps.map((app) => (
+            <AppStatusListItem
+              key={app.id}
+              app={app}
+              pendingReleaseApps={pendingReleaseApps}
+              statusFilter={statusFilter}
+              onFilterChange={setStatusFilter}
+            />
+          ))
+        )}
+      </List>
+    </SignIn>
+  );
+}
+
+function processApps(apps: AppWithVersions[], includedVersions: AppStatusVersion[]): ProcessedApp[] {
+  const versionsById = new Map(includedVersions.map((v) => [v.id, v]));
+
+  return apps.map((app) => {
+    const versionRelationships = app.relationships.appStoreVersions.data;
+    const versions = versionRelationships
+      .map((ref) => versionsById.get(ref.id))
+      .filter((v): v is AppStatusVersion => v !== undefined);
+
+    const latest = versions.slice().sort((a, b) => {
+      return new Date(b.attributes.createdDate).getTime() - new Date(a.attributes.createdDate).getTime();
+    })[0];
+
+    return {
+      id: app.id,
+      name: app.attributes.name,
+      bundleId: app.attributes.bundleId,
+      latestVersion: latest
+        ? {
+            id: latest.id,
+            versionString: latest.attributes.versionString,
+            state: latest.attributes.appStoreState,
+            platform: latest.attributes.platform,
+            createdDate: latest.attributes.createdDate,
+            releaseType: latest.attributes.releaseType ?? null,
+          }
+        : undefined,
+      appStoreConnectUrl: `https://appstoreconnect.apple.com/apps/${app.id}`,
+    };
+  });
+}
+
+function isPendingDeveloperRelease(app: ProcessedApp): app is PendingReleaseApp {
+  return app.latestVersion?.state === "PENDING_DEVELOPER_RELEASE";
+}

--- a/extensions/app-store-connect/src/appStatus.tsx
+++ b/extensions/app-store-connect/src/appStatus.tsx
@@ -80,9 +80,8 @@ export default function Command() {
       apps
         .map((app) => ({ app, version: selectVersionForPlatform(app, platformFilter) }))
         .filter(({ version }) => {
-          const matchesStatus = statusFilter === "all" || version?.state === statusFilter;
-          const matchesPlatform = platformFilter === "all" || version !== undefined;
-          return matchesStatus && matchesPlatform;
+          if (!version) return false;
+          return statusFilter === "all" || version.state === statusFilter;
         }),
     [apps, statusFilter, platformFilter],
   );

--- a/extensions/app-store-connect/src/appStatus.tsx
+++ b/extensions/app-store-connect/src/appStatus.tsx
@@ -5,23 +5,26 @@ import { appsWithVersionsResponseSchema, AppStatusVersion, AppWithVersions } fro
 import SignIn from "./Components/SignIn";
 import AppStatusListItem from "./Components/AppStatusListItem";
 
+export interface ProcessedAppVersion {
+  id: string;
+  versionString: string;
+  state: string;
+  platform: string;
+  createdDate: string;
+  releaseType: string | null;
+}
+
 export interface ProcessedApp {
   id: string;
   name: string;
   bundleId: string;
-  latestVersion?: {
-    id: string;
-    versionString: string;
-    state: string;
-    platform: string;
-    createdDate: string;
-    releaseType: string | null;
-  };
+  versions: ProcessedAppVersion[];
   appStoreConnectUrl: string;
 }
 
-export interface PendingReleaseApp extends ProcessedApp {
-  latestVersion: NonNullable<ProcessedApp["latestVersion"]>;
+export interface PendingRelease {
+  app: ProcessedApp;
+  version: ProcessedAppVersion;
 }
 
 export type StatusFilter = "all" | string;
@@ -45,6 +48,14 @@ const PLATFORM_FILTERS: { value: PlatformFilter; label: string; icon: Icon }[] =
   { value: "VISION_OS", label: "visionOS", icon: Icon.Eye },
 ];
 
+export function selectVersionForPlatform(
+  app: ProcessedApp,
+  platformFilter: PlatformFilter,
+): ProcessedAppVersion | undefined {
+  if (platformFilter === "all") return app.versions[0];
+  return app.versions.find((v) => v.platform === platformFilter);
+}
+
 export default function Command() {
   const [path, setPath] = useState<string | undefined>(undefined);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
@@ -66,15 +77,26 @@ export default function Command() {
 
   const filteredApps = useMemo(
     () =>
-      apps.filter((app) => {
-        const matchesStatus = statusFilter === "all" || app.latestVersion?.state === statusFilter;
-        const matchesPlatform = platformFilter === "all" || app.latestVersion?.platform === platformFilter;
-        return matchesStatus && matchesPlatform;
-      }),
+      apps
+        .map((app) => ({ app, version: selectVersionForPlatform(app, platformFilter) }))
+        .filter(({ version }) => {
+          const matchesStatus = statusFilter === "all" || version?.state === statusFilter;
+          const matchesPlatform = platformFilter === "all" || version !== undefined;
+          return matchesStatus && matchesPlatform;
+        }),
     [apps, statusFilter, platformFilter],
   );
 
-  const pendingReleaseApps = useMemo(() => filteredApps.filter(isPendingDeveloperRelease), [filteredApps]);
+  const pendingReleaseApps = useMemo<PendingRelease[]>(
+    () =>
+      filteredApps
+        .filter(
+          (entry): entry is { app: ProcessedApp; version: ProcessedAppVersion } =>
+            entry.version?.state === "PENDING_DEVELOPER_RELEASE",
+        )
+        .map(({ app, version }) => ({ app, version })),
+    [filteredApps],
+  );
 
   const statusFilterLabel = STATUS_FILTERS.find((f) => f.value === statusFilter)?.label ?? "All Apps";
   const platformLabel = PLATFORM_FILTERS.find((f) => f.value === platformFilter)?.label ?? "All Platforms";
@@ -129,10 +151,11 @@ export default function Command() {
             }
           />
         ) : (
-          filteredApps.map((app) => (
+          filteredApps.map(({ app, version }) => (
             <AppStatusListItem
               key={app.id}
               app={app}
+              version={version}
               pendingReleaseApps={pendingReleaseApps}
               statusFilter={statusFilter}
               onFilterChange={setStatusFilter}
@@ -151,31 +174,23 @@ function processApps(apps: AppWithVersions[], includedVersions: AppStatusVersion
     const versionRelationships = app.relationships.appStoreVersions.data;
     const versions = versionRelationships
       .map((ref) => versionsById.get(ref.id))
-      .filter((v): v is AppStatusVersion => v !== undefined);
-
-    const latest = versions.slice().sort((a, b) => {
-      return new Date(b.attributes.createdDate).getTime() - new Date(a.attributes.createdDate).getTime();
-    })[0];
+      .filter((v): v is AppStatusVersion => v !== undefined)
+      .map<ProcessedAppVersion>((v) => ({
+        id: v.id,
+        versionString: v.attributes.versionString,
+        state: v.attributes.appStoreState,
+        platform: v.attributes.platform,
+        createdDate: v.attributes.createdDate,
+        releaseType: v.attributes.releaseType ?? null,
+      }))
+      .sort((a, b) => new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime());
 
     return {
       id: app.id,
       name: app.attributes.name,
       bundleId: app.attributes.bundleId,
-      latestVersion: latest
-        ? {
-            id: latest.id,
-            versionString: latest.attributes.versionString,
-            state: latest.attributes.appStoreState,
-            platform: latest.attributes.platform,
-            createdDate: latest.attributes.createdDate,
-            releaseType: latest.attributes.releaseType ?? null,
-          }
-        : undefined,
+      versions,
       appStoreConnectUrl: `https://appstoreconnect.apple.com/apps/${app.id}`,
     };
   });
-}
-
-function isPendingDeveloperRelease(app: ProcessedApp): app is PendingReleaseApp {
-  return app.latestVersion?.state === "PENDING_DEVELOPER_RELEASE";
 }

--- a/extensions/app-store-connect/src/appStatus.tsx
+++ b/extensions/app-store-connect/src/appStatus.tsx
@@ -63,13 +63,18 @@ export default function Command() {
   );
 
   const apps = data ?? [];
-  const pendingReleaseApps = useMemo(() => apps.filter(isPendingDeveloperRelease), [apps]);
 
-  const filteredApps = apps.filter((app) => {
-    const matchesStatus = statusFilter === "all" || app.latestVersion?.state === statusFilter;
-    const matchesPlatform = platformFilter === "all" || app.latestVersion?.platform === platformFilter;
-    return matchesStatus && matchesPlatform;
-  });
+  const filteredApps = useMemo(
+    () =>
+      apps.filter((app) => {
+        const matchesStatus = statusFilter === "all" || app.latestVersion?.state === statusFilter;
+        const matchesPlatform = platformFilter === "all" || app.latestVersion?.platform === platformFilter;
+        return matchesStatus && matchesPlatform;
+      }),
+    [apps, statusFilter, platformFilter],
+  );
+
+  const pendingReleaseApps = useMemo(() => filteredApps.filter(isPendingDeveloperRelease), [filteredApps]);
 
   const statusFilterLabel = STATUS_FILTERS.find((f) => f.value === statusFilter)?.label ?? "All Apps";
   const platformLabel = PLATFORM_FILTERS.find((f) => f.value === platformFilter)?.label ?? "All Platforms";


### PR DESCRIPTION
## Description

Adds a new `View App Status` command to the App Store Connect extension. It lists all apps with their latest version's App Store status and platform, lets you filter by platform and state, and can release versions that are pending developer release — individually or in bulk.

This extends the extension's TestFlight-focused commands with a view into production / App Store state, which is what maintainers reach for the moment their build is approved and waiting for the "Release" click.

## What's new

- `View App Status` command — lists apps via `GET /apps?include=appStoreVersions` and flattens each app's latest version into the list row.
- Status tag (color + compact label) + platform icon on each row.
- Platform filter dropdown (iOS, macOS, tvOS, visionOS) in the search bar.
- Status filter section in the item ActionPanel (Ready for Sale, In Review, Waiting for Review, Pending Developer Release, Prepare for Submission, Rejected).
- Detail view with markdown + `Detail.Metadata` (App ID, Bundle ID, status tag, version, platform, created date, release type) and a link to App Store Connect.
- `Release App Now` action — visible only when the latest version is in `PENDING_DEVELOPER_RELEASE`; confirms, then `POST /appStoreVersionReleaseRequests`.
- `Release All Pending Apps` action — bulk release with progress toast (`n/N · app name`) and partial-failure reporting.
- `Open in App Store Connect`, `Copy Bundle ID` (Cmd+.), `Copy App ID` (Cmd+Shift+.).

## Implementation notes

- **No new dependencies.** Reuses the existing `useAppStoreConnectApi` (with `loadAll=true` for pagination), `fetchAppStoreConnect` for the release POST, `SignIn` wrapper, `useTeams`, `presentError`, and `ATCError` patterns already in the extension.
- **Schemas:** adds `appStatusVersionSchema`, `appWithVersionsSchema`, and `appsWithVersionsResponseSchema` to `src/Model/schemas.ts`. `appStoreState` is kept as a `z.string()` in this schema path (with a UI fallback in `statusHelpers.ts`) because the API occasionally returns states outside the existing `appStoreVersionSchema` enum (e.g. `PROCESSING_FOR_APP_STORE`, `PREORDER_READY_FOR_SALE`, `PENDING_CONTRACT`). Kept the existing `appStoreVersionSchema` untouched to avoid affecting other commands.
- **`@types/react` bump (18.3.3 → 19.0.10):** `@raycast/api` now resolves to 1.104.1, which pulls in `@types/react@19`. Running `npm run build` on `main` as-is fails with `Type 'bigint' is not assignable to type 'ReactNode'` across every existing command, because the top-level `@types/react@18.3.3` conflicts with the nested one. Bumping to 19.0.10 aligns them and makes `ray build` green again — this change is needed regardless of this PR.
- No existing commands removed or modified; the 5 original commands (`testFlightBuilds`, `testInformation`, `showGroups`, `teamMembers`, `manageTeams`) are untouched.
- Added myself to `contributors`.

## Files

**New**
- `src/appStatus.tsx`
- `src/Components/AppStatusListItem.tsx`
- `src/Components/AppStatusDetail.tsx`
- `src/Utils/statusHelpers.ts`

**Modified**
- `package.json` — new command entry, `contributors`, `@types/react` bump
- `package-lock.json` — matches the `@types/react` bump
- `src/Model/schemas.ts` — appends the three new schemas
- `CHANGELOG.md` — new `{PR_MERGE_DATE}` entry at the top

## Verification

- `npm run lint` ✅
- `npm run build` ✅ (`ray build -e dist`)
- `npm run dev` — command appears alongside the existing five, shares credentials via `useTeams`, list/filter/detail/release flows all verified manually.