### PR TITLE
docs(toggl-track): clarify Low Data Mode activation and sync expectations

### DIFF
--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Toggl Track Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Clarified Low Data Mode documentation in README — activation takes effect on next command launch, and framed sync behavior as a user contract (up to 1 hour delay) rather than implementation details
+
 ## [New Feature] - 2026-04-16
 
 - Add Low Data Mode for free-tier users: serves reads from local cache with hourly auto-sync (3 requests/hour), leaving 27 requests/hour for active use

--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Toggl Track Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-04-17
 
 - Clarified Low Data Mode documentation in README — activation takes effect on next command launch, and framed sync behavior as a user contract (up to 1 hour delay) rather than implementation details
 

--- a/extensions/toggl-track/README.md
+++ b/extensions/toggl-track/README.md
@@ -50,21 +50,13 @@ It is disabled by default, but can enabled from Raycast's extensions settings.
 
 An opt-in mode for users on Toggl's free tier (30 requests/hour). Enable it in **Raycast Settings > Extensions > Toggl Track > "Enable Low Data Mode"**.
 
+**Activation:** Takes effect on the next launch of any Toggl command.
+
 When enabled:
 
-- **Writes work normally** — starting and stopping timers hit the API (1 call each)
-- **Reads serve from local cache** — projects, clients, tags, workspaces, time entries, and running entry are all served from cached data without API calls
-- **Menu bar uses cached state** — no background API polling beyond the hourly auto-sync
-- **Auto-sync once per hour** — keeps data reasonably fresh (3 requests/hour) without manual intervention
-- **Manual sync** — press `Cmd+Shift+R` or select "Sync from Toggl" in the action menu to force a refresh at any time
-
-**First launch:** If no cached data exists, Low Data Mode automatically performs one sync to seed the cache. If you enable it while rate-limited and the cache is empty, you'll see a toast prompting you to sync later.
-
-**Known limitations:**
-
-- Timers started or stopped from the Toggl web/mobile app may take up to 1 hour to appear (or use manual sync)
-- Changes to projects, tags, or clients made outside Raycast require up to 1 hour or a manual sync to appear
-- Stale cache entries are automatically evicted after 24 hours
+- **Data isn't synced in real time** — expect up to 1 hour of delay between Raycast and Toggl's web or mobile apps
+- **Auto-sync once per hour** keeps cached data reasonably fresh
+- **Manual sync** — press `Cmd+Shift+R` to force a refresh at any time
 
 ### Menu Bar
 

--- a/extensions/toggl-track/README.md
+++ b/extensions/toggl-track/README.md
@@ -54,7 +54,7 @@ An opt-in mode for users on Toggl's free tier (30 requests/hour). Enable it in *
 
 When enabled:
 
-- **Data isn't synced in real time** — expect up to 1 hour of delay between Raycast and Toggl's web or mobile apps
+- **Data isn't synced in real time** — changes made in Toggl's web or mobile apps may take up to 1 hour to appear in Raycast
 - **Auto-sync once per hour** keeps cached data reasonably fresh
 - **Manual sync** — press `Cmd+Shift+R` to force a refresh at any time
 


### PR DESCRIPTION
## Summary

The README for the Low Data Mode feature (added in #26933) contained a few inaccuracies that could confuse users. This PR clarifies the documentation without changing any code.

### Changes

1. **Activation timing** — Previously the README implied Low Data Mode activates immediately when the checkbox is toggled. In fact, Raycast reads preferences via `getPreferenceValues()` once at module load time, so LDM takes effect on the next launch of a Toggl command.

2. **Sync expectations as a user contract** — Replaced the detailed bullet list of implementation details (read/write behavior, menu bar polling, cache eviction) with a simple user-facing statement: data may take up to 1 hour to sync between Raycast and Toggl's web/mobile apps. This framing is robust to future implementation changes (e.g., if write behavior evolves) and tells users what they actually need to know.

3. **Removed "Known limitations" section** — The bidirectional sync statement covers this more simply; 24h eviction is an internal detail that doesn't affect user-visible behavior.

## Test plan

- [ ] README renders cleanly on GitHub
- [ ] No code changes, so no build/functional testing needed