### PR TITLE
[Skills] Add support for updating individual skills

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Update Individual Skills] - {PR_MERGE_DATE}
+## [Update Individual Skills] - 2026-04-17
 
 - Add per-skill update action using `skills update <name>` (requires `skills` CLI 1.5.0+), so a single outdated skill can be updated without touching the others
 

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Update Individual Skills] - {PR_MERGE_DATE}
+
+- Add per-skill update action using `skills update <name>` (requires `skills` CLI 1.5.0+), so a single outdated skill can be updated without touching the others
+
 ## [Reduce Complexity] - 2026-04-11
 
 - Remove test infrastructure (vitest, test stubs, all test files) that added maintenance burden without meaningful coverage

--- a/extensions/skills/src/components/InstalledSkillListItem.tsx
+++ b/extensions/skills/src/components/InstalledSkillListItem.tsx
@@ -82,7 +82,6 @@ interface InstalledSkillListItemProps {
   isShowingDetail: boolean;
   mutate: MutateSkills;
   onToggleDetail: () => void;
-  onUpdate: () => void;
 }
 
 export function InstalledSkillListItem({
@@ -91,7 +90,6 @@ export function InstalledSkillListItem({
   isShowingDetail,
   mutate,
   onToggleDetail,
-  onUpdate,
 }: InstalledSkillListItemProps) {
   const extraAgents = skill.agentCount - skill.agents.length;
   const agentsText = extraAgents > 0 ? `${skill.agents.join(", ")} +${extraAgents} more` : skill.agents.join(", ");
@@ -146,7 +144,7 @@ export function InstalledSkillListItem({
             {skill.sourceUrl && <Action.CopyToClipboard title="Copy Source URL" content={skill.sourceUrl} />}
           </ActionPanel.Section>
           <ActionPanel.Section>
-            {skill.hasUpdate && <UpdateSkillAction onUpdate={onUpdate} />}
+            {skill.hasUpdate && <UpdateSkillAction skillName={skill.name} mutate={mutate} />}
             <RemoveSkillAction skill={skill} mutate={mutate} />
           </ActionPanel.Section>
           <Action

--- a/extensions/skills/src/components/actions/UpdateSkillAction.tsx
+++ b/extensions/skills/src/components/actions/UpdateSkillAction.tsx
@@ -1,34 +1,50 @@
 import { Action, Icon, confirmAlert, Alert, showToast, Toast } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
-import { updateAllSkills } from "../../utils/skills-cli";
+import { updateAllSkills, updateSkill } from "../../utils/skills-cli";
+import type { MutateSkills } from "../../hooks/useInstalledSkills";
 
 interface UpdateSkillActionProps {
-  onUpdate: () => void;
+  /** When provided, updates just this skill. Otherwise, updates all installed skills. */
+  skillName?: string;
+  mutate: MutateSkills;
 }
 
-export function UpdateSkillAction({ onUpdate }: UpdateSkillActionProps) {
+export function UpdateSkillAction({ skillName, mutate }: UpdateSkillActionProps) {
+  const isSingle = skillName !== undefined;
+
   return (
     <Action
-      title="Update All Skills"
+      title={isSingle ? "Update Skill" : "Update All Skills"}
       icon={Icon.ArrowClockwise}
       shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
       onAction={async () => {
         const confirmed = await confirmAlert({
-          title: "Update All Skills?",
-          message: "This will update all installed skills to the latest version.",
+          title: isSingle ? `Update "${skillName}"?` : "Update All Skills?",
+          message: isSingle
+            ? `This will update "${skillName}" to the latest version.`
+            : "This will update all installed skills to the latest version.",
           primaryAction: { title: "Update", style: Alert.ActionStyle.Default },
         });
         if (!confirmed) return;
 
-        const toast = await showToast({ style: Toast.Style.Animated, title: "Updating skills..." });
+        const toast = await showToast({
+          style: Toast.Style.Animated,
+          title: isSingle ? "Updating skill..." : "Updating skills...",
+        });
         try {
-          await updateAllSkills();
+          await mutate(isSingle ? updateSkill(skillName) : updateAllSkills(), {
+            optimisticUpdate: (skills) => {
+              if (!skills) return [];
+              return skills.map((s) => (!isSingle || s.name === skillName ? { ...s, hasUpdate: false } : s));
+            },
+          });
           toast.style = Toast.Style.Success;
-          toast.title = "All skills updated";
-          onUpdate();
+          toast.title = isSingle ? "Skill updated" : "All skills updated";
         } catch (error) {
           await toast.hide();
-          await showFailureToast(error, { title: "Failed to update skills" });
+          await showFailureToast(error, {
+            title: isSingle ? "Failed to update skill" : "Failed to update skills",
+          });
         }
       }}
     />

--- a/extensions/skills/src/manage-skills.tsx
+++ b/extensions/skills/src/manage-skills.tsx
@@ -101,7 +101,7 @@ export default function Command() {
                 }
                 actions={
                   <ActionPanel>
-                    <UpdateSkillAction onUpdate={revalidate} />
+                    <UpdateSkillAction mutate={mutate} />
                   </ActionPanel>
                 }
               />
@@ -116,7 +116,6 @@ export default function Command() {
                 isShowingDetail={isShowingDetail}
                 mutate={mutate}
                 onToggleDetail={toggleDetail}
-                onUpdate={revalidate}
               />
             ))}
           </List.Section>

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -253,6 +253,14 @@ export async function updateAllSkills(): Promise<void> {
   await runSkillsCli(["update", "-y"]);
 }
 
+/**
+ * Update a single installed skill by name.
+ * Runs `npx -y skills@latest update <skill-name> -y`.
+ */
+export async function updateSkill(skillName: string): Promise<void> {
+  await runSkillsCli(["update", skillName, "-y"]);
+}
+
 const LOCK_FILE = ".skill-lock.json";
 const AGENTS_DIR = ".agents";
 


### PR DESCRIPTION
## Description

Follow-up to #26234, which added the outdated-skill highlight but deferred the per-skill update action because `skills update` only supported updating all installed skills at once.

The skills CLI now accepts a skill name argument (https://github.com/vercel-labs/skills/issues/528), so this PR wires it up to the extension. When a user presses the update action on a single outdated skill, only that skill is updated instead of all of them.

## Screencast

<img width="1492" height="946" alt="2026-04-16 at 16 02 41" src="https://github.com/user-attachments/assets/dad8f58d-1398-4b7a-8b5f-cd4fbc143f71" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension's commands
- [x] I checked that assets used by the extension itself are placed outside of the `assets` folder