### PR TITLE
Update quick-git extension

### DIFF
--- a/extensions/quick-git/CHANGELOG.md
+++ b/extensions/quick-git/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 Added functionality to view and select submodules in a repo
 
-- View a list of submodules in a repo, and select a submodule as your working repo
+- View a list of submodules in a repo
+- Select a submodule as your working repo from the Git Status list
 - Open submodules remote repo
+- Include the repo name in the navigation title when you are in a repo.
 - Fix some bugs and cleanup some code
 
 ## [Working with worktrees] - 2026-02-12

--- a/extensions/quick-git/CHANGELOG.md
+++ b/extensions/quick-git/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quick Git Changelog
 
-## [Submodule Selection] - {PR_MERGE_DATE}
+## [Submodule Selection] - 2026-04-18
 
 Added functionality to view and select submodules in a repo
 

--- a/extensions/quick-git/CHANGELOG.md
+++ b/extensions/quick-git/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Quick Git Changelog
 
+## [Submodule Selection] - {PR_MERGE_DATE}
+
+Added functionality to view and select submodules in a repo
+
+- View a list of submodules in a repo, and select a submodule as your working repo
+- Open submodules remote repo
+- Fix some bugs and cleanup some code
+
 ## [Working with worktrees] - 2026-02-12
 
 Added support for navigating and managing worktrees.

--- a/extensions/quick-git/README.md
+++ b/extensions/quick-git/README.md
@@ -4,7 +4,7 @@ Quickly run git commands through Raycast, allows you to do common git tasks like
 - Check status
 - Stage and commit changes
 - Discard changes and restore a file to its previous state
-- Switch, create, delete, push and pull branches
+- Switch, create, delete, push and pull branches and worktrees
 
 ## Git Configuration
 

--- a/extensions/quick-git/package-lock.json
+++ b/extensions/quick-git/package-lock.json
@@ -8,10 +8,12 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.6",
-        "@raycast/utils": "^2.2.2"
+        "@raycast/utils": "^2.2.2",
+        "ini": "^6.0.0"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
+        "@types/ini": "^4.1.1",
         "@types/node": "22.14.0",
         "@types/react": "19.1.10",
         "eslint": "^9.39.2",
@@ -741,9 +743,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -752,9 +754,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -815,9 +817,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -839,9 +841,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1703,6 +1705,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1884,9 +1893,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1978,9 +1987,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2427,9 +2436,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2451,9 +2460,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2612,9 +2621,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -2655,9 +2664,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2792,6 +2801,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/is-docker": {
@@ -3014,12 +3032,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3154,9 +3172,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/extensions/quick-git/package.json
+++ b/extensions/quick-git/package.json
@@ -44,10 +44,12 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.104.6",
-    "@raycast/utils": "^2.2.2"
+    "@raycast/utils": "^2.2.2",
+    "ini": "^6.0.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",
+    "@types/ini": "^4.1.1",
     "@types/node": "22.14.0",
     "@types/react": "19.1.10",
     "eslint": "^9.39.2",

--- a/extensions/quick-git/src/components/GitBranches.tsx
+++ b/extensions/quick-git/src/components/GitBranches.tsx
@@ -5,15 +5,16 @@ import { Providers } from "./Providers.js";
 import { GitBranchItem } from "./GitBranches/GitBranchItem.js";
 import { CreateNewBranch } from "./actions/CreateNewBranch.js";
 import { SwitchToLastBranch } from "./actions/SwitchToLastBranch.js";
-import { useRepoStorage } from "../hooks/useRepo.js";
+import { useSelectedRepoStorage } from "../hooks/useRepo.js";
 import { parseBranches } from "../utils/git-branch/branch.js";
+import { navigationTitle } from "../utils/navigationTitle.js";
 
 interface Props {
   checkStatus: () => void;
 }
 
 export function GitBranches({ checkStatus }: Props) {
-  const repo = useRepoStorage();
+  const repo = useSelectedRepoStorage();
   const { data, isLoading, revalidate } = useExec("git", ["branch", "--sort=-committerdate", "--no-color"], {
     cwd: repo.value,
     parseOutput: ({ stdout }) => {
@@ -39,10 +40,10 @@ export function GitBranches({ checkStatus }: Props) {
   }, [data, repo.setValue, revalidate]);
 
   return (
-    <Providers repo={repo.value} checkStatus={checkStatus}>
+    <Providers repo={repo} checkStatus={checkStatus}>
       <List
         searchBarPlaceholder="Search branches…"
-        navigationTitle="Change Branches"
+        navigationTitle={navigationTitle("Change Branches", repo.value)}
         isLoading={isLoading}
         actions={
           <ActionPanel>

--- a/extensions/quick-git/src/components/GitBranches/GitBranchItem.tsx
+++ b/extensions/quick-git/src/components/GitBranches/GitBranchItem.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { memo } from "react";
 import { Color, List } from "@raycast/api";
 import { GitBranchItemActions } from "./GitBranchItemActions.js";
 import { BranchInfo } from "../../utils/git-branch/branch.js";
@@ -9,8 +9,8 @@ interface Props {
   updateRepo: (value: string) => Promise<void>;
 }
 
-export function GitBranchItem({ branch, checkBranches, updateRepo }: Props) {
-  const accessories = useMemo(() => {
+export const GitBranchItem = memo(function GitBranchItem({ branch, checkBranches, updateRepo }: Props) {
+  const accessories = () => {
     if (branch.isCurrentBranch) {
       return [{ tag: { value: "Current branch", color: Color.PrimaryText } }];
     }
@@ -18,12 +18,12 @@ export function GitBranchItem({ branch, checkBranches, updateRepo }: Props) {
     if (branch.isWorktree) {
       return [{ tag: { value: "Worktree" } }];
     }
-  }, [branch.isCurrentBranch, branch.isWorktree]);
+  };
 
   return (
     <List.Item
       title={branch.name}
-      accessories={accessories}
+      accessories={accessories()}
       actions={
         <GitBranchItemActions
           branch={branch.name}
@@ -35,4 +35,4 @@ export function GitBranchItem({ branch, checkBranches, updateRepo }: Props) {
       }
     />
   );
-}
+});

--- a/extensions/quick-git/src/components/GitBranches/GitBranchItemActions.tsx
+++ b/extensions/quick-git/src/components/GitBranches/GitBranchItemActions.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { memo } from "react";
 import { ActionPanel } from "@raycast/api";
 import { SwitchToBranch } from "../actions/SwitchToBranch.js";
 import { DeleteBranch } from "../actions/DeleteBranch.js";
@@ -17,10 +17,16 @@ interface Props {
   updateRepo: (value: string) => Promise<void>;
 }
 
-export function GitBranchItemActions({ branch, isCurrentBranch, isWorktree, checkBranches, updateRepo }: Props) {
+export const GitBranchItemActions = memo(function GitBranchItemActions({
+  branch,
+  isCurrentBranch,
+  isWorktree,
+  checkBranches,
+  updateRepo,
+}: Props) {
   const { data: worktreeDir } = useWorktreeDir(branch);
 
-  const actions = useMemo(() => {
+  const actions = () => {
     if (isWorktree) {
       return (
         <>
@@ -40,14 +46,14 @@ export function GitBranchItemActions({ branch, isCurrentBranch, isWorktree, chec
     }
 
     return null;
-  }, [branch, checkBranches, isCurrentBranch, isWorktree, updateRepo, worktreeDir]);
+  };
 
   return (
     <ActionPanel>
-      {actions}
+      {actions()}
       <CreateNewBranch checkBranches={checkBranches} />
       <CreateNewWorkTree checkBranches={checkBranches} />
       <SwitchToLastBranch checkBranches={checkBranches} />
     </ActionPanel>
   );
-}
+});

--- a/extensions/quick-git/src/components/GitRepos.tsx
+++ b/extensions/quick-git/src/components/GitRepos.tsx
@@ -2,13 +2,13 @@ import { useCallback, useMemo } from "react";
 import { ActionPanel, getPreferenceValues, List, showToast, Toast } from "@raycast/api";
 import { showFailureToast, useExec, useFrecencySorting } from "@raycast/utils";
 import { parseRepoDirectoryName, RepoDir } from "../utils/repos.js";
-import { RepoContext, useRepoStorage } from "../hooks/useRepo.js";
+import { RepoContext, useSelectedRepoStorage } from "../hooks/useRepo.js";
 import { GitRepoItem } from "./GitRepos/GitRepoItem.js";
 import { launchQuickGit } from "../utils/launchCommands.js";
 import { ChooseSpecificRepo } from "./actions/ChooseSpecificRepo.js";
 
 export function GitRepos() {
-  const currentRepo = useRepoStorage();
+  const currentRepo = useSelectedRepoStorage();
   const repoLocation = getPreferenceValues<Preferences>()["repo-locations"];
   const { data, isLoading } = useExec(
     "find",
@@ -53,7 +53,7 @@ export function GitRepos() {
   }, [changeRepo, currentRepo.value, sortedData]);
 
   return (
-    <RepoContext value={currentRepo.value ?? ""}>
+    <RepoContext value={currentRepo}>
       <List
         searchBarPlaceholder="Search git repos…"
         navigationTitle="Change Git Repo"

--- a/extensions/quick-git/src/components/GitRepos/GitRepoItem.tsx
+++ b/extensions/quick-git/src/components/GitRepos/GitRepoItem.tsx
@@ -1,5 +1,5 @@
 import { ActionPanel, List } from "@raycast/api";
-import { useCallback, useMemo } from "react";
+import { memo } from "react";
 import { RepoDir } from "../../utils/repos.js";
 import { SelectCurrentRepo } from "../actions/ChangeCurrentRepo.js";
 import { ChooseSpecificRepo } from "../actions/ChooseSpecificRepo.js";
@@ -12,23 +12,14 @@ interface Props {
   changeRepo: (item: RepoDir) => void;
 }
 
-export function GitRepoItem({ repoDir, isSelected, changeRepo }: Props) {
-  const accessories = useMemo(() => {
-    if (isSelected) {
-      return [{ text: "Current Repo" }];
-    }
-  }, [isSelected]);
+export const GitRepoItem = memo(function GitRepoItem({ repoDir, isSelected, changeRepo }: Props) {
+  const accessories = isSelected ? [{ text: "Current Repo" }] : null;
 
-  const selectRepo = useCallback(() => {
+  const selectRepo = () => {
     changeRepo(repoDir);
-  }, [changeRepo, repoDir]);
+  };
 
-  const selectedActions = useMemo(() => {
-    if (isSelected) {
-      return <CheckStatus />;
-    }
-    return <SelectCurrentRepo selectRepo={selectRepo} />;
-  }, [isSelected, selectRepo]);
+  const selectedActions = isSelected ? <CheckStatus /> : <SelectCurrentRepo selectRepo={selectRepo} />;
 
   return (
     <List.Item
@@ -43,4 +34,4 @@ export function GitRepoItem({ repoDir, isSelected, changeRepo }: Props) {
       }
     />
   );
-}
+});

--- a/extensions/quick-git/src/components/GitStatus.tsx
+++ b/extensions/quick-git/src/components/GitStatus.tsx
@@ -7,14 +7,14 @@ import { GitStatusEmpty } from "./GitStatus/GitStatusEmpty.js";
 import { ChangeCurrentBranch } from "./actions/ChangeCurrentBranch.js";
 import { SetRepo } from "./actions/SetRepo.js";
 import { Providers } from "./Providers.js";
-import { useHasSubmodles } from "../hooks/useHasSubmodules.js";
+import { useHasSubmodules } from "../hooks/useHasSubmodules.js";
 import { ChangeSubmodules } from "./actions/ChangeSubmodules.js";
 import { navigationTitle } from "../utils/navigationTitle.js";
 import { useGitStatus } from "../hooks/useGitStatus.js";
 
 export function GitStatus() {
   const repo = useSelectedRepoStorage();
-  const { data: hasSubmodule, isLoading: checkingSubmodules } = useHasSubmodles(repo.value);
+  const { data: hasSubmodule, isLoading: checkingSubmodules } = useHasSubmodules(repo.value);
   const { data, isLoading, revalidate } = useGitStatus(repo.value);
 
   const showDetails = !!repo.value && !!data?.files.length;

--- a/extensions/quick-git/src/components/GitStatus.tsx
+++ b/extensions/quick-git/src/components/GitStatus.tsx
@@ -1,42 +1,34 @@
 import { useMemo } from "react";
 import { ActionPanel, List } from "@raycast/api";
-import { showFailureToast, useExec } from "@raycast/utils";
-import { parseGitStatusPorcelain } from "../utils/git-status/porcelain.js";
-import { useRepoStorage } from "../hooks/useRepo.js";
+import { useSelectedRepoStorage } from "../hooks/useRepo.js";
 import { GitStatusItem } from "./GitStatus/GitStatusItem.js";
 import { RemoteGitActions } from "./GitStatus/RemoteGitActions.js";
 import { GitStatusEmpty } from "./GitStatus/GitStatusEmpty.js";
 import { ChangeCurrentBranch } from "./actions/ChangeCurrentBranch.js";
 import { SetRepo } from "./actions/SetRepo.js";
 import { Providers } from "./Providers.js";
+import { useHasSubmodles } from "../hooks/useHasSubmodules.js";
+import { ChangeSubmodules } from "./actions/ChangeSubmodules.js";
+import { navigationTitle } from "../utils/navigationTitle.js";
+import { useGitStatus } from "../hooks/useGitStatus.js";
 
 export function GitStatus() {
-  const repo = useRepoStorage();
-  const { data, isLoading, revalidate } = useExec("git", ["status", "--porcelain=2", "--branch"], {
-    cwd: repo.value,
-    execute: !!repo.value,
-    keepPreviousData: false,
-    onError: (error) => {
-      showFailureToast(error, { title: "Could not fetch git status" });
-    },
-    parseOutput: ({ stdout }) => parseGitStatusPorcelain(stdout),
-  });
+  const repo = useSelectedRepoStorage();
+  const { data: hasSubmodule, isLoading: checkingSubmodules } = useHasSubmodles(repo.value);
+  const { data, isLoading, revalidate } = useGitStatus(repo.value);
 
-  const showDetails = useMemo(() => !!repo.value && !!data?.files.length, [data?.files.length, repo.value]);
+  const showDetails = !!repo.value && !!data?.files.length;
 
-  const actions = useMemo(() => {
-    if (!repo.value) {
-      return <SetRepo />;
-    }
-
-    return (
-      <>
-        <ChangeCurrentBranch />
-        <RemoteGitActions />
-        <SetRepo title="Change Current Repo" />
-      </>
-    );
-  }, [repo.value]);
+  const statusActions = repo.value ? (
+    <>
+      <ChangeCurrentBranch />
+      {hasSubmodule && <ChangeSubmodules changeRepo={repo.setValue} />}
+      <RemoteGitActions />
+      <SetRepo title="Change Current Repo" />
+    </>
+  ) : (
+    <SetRepo />
+  );
 
   const statusItems = useMemo(() => {
     if (!data?.files.length) {
@@ -54,13 +46,13 @@ export function GitStatus() {
   }, [data]);
 
   return (
-    <Providers repo={repo.value} checkStatus={revalidate}>
+    <Providers repo={repo} checkStatus={revalidate}>
       <List
         searchBarPlaceholder="Search modified files…"
-        navigationTitle="Git Status"
+        navigationTitle={navigationTitle("Git Status", repo.value)}
         isShowingDetail={showDetails}
-        isLoading={repo.isLoading || isLoading}
-        actions={<ActionPanel>{actions}</ActionPanel>}
+        isLoading={repo.isLoading || isLoading || checkingSubmodules}
+        actions={<ActionPanel>{statusActions}</ActionPanel>}
       >
         {statusItems}
       </List>

--- a/extensions/quick-git/src/components/GitStatus/GitStatusEmpty.tsx
+++ b/extensions/quick-git/src/components/GitStatus/GitStatusEmpty.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { List } from "@raycast/api";
 import { useRepo } from "../../hooks/useRepo.js";
 
@@ -11,36 +10,29 @@ interface Props {
 
 export function GitStatusEmpty({ name, ahead, behind, upstream }: Props) {
   const repo = useRepo();
+  if (!repo) {
+    return <List.EmptyView title="Please select a repo" />;
+  }
 
-  const title = useMemo(() => {
-    if (repo && name) {
-      return `On branch ${name}`;
-    }
+  return <List.EmptyView title={`On branch ${name}`} description={description(ahead, behind, upstream)} />;
+}
 
-    return "Please select a repo";
-  }, [name, repo]);
+function description(ahead?: number, behind?: number, upstream?: string): string {
+  if (ahead && behind) {
+    return `Ahead of '${upstream}' by ${ahead}, and behind by ${behind} commits`;
+  }
 
-  const description = useMemo(() => {
-    if (!repo) {
-      return;
-    }
+  if (ahead && !behind) {
+    return `Ahead of '${upstream}' by ${ahead} commits.`;
+  }
 
-    if (ahead && behind) {
-      return `Ahead of '${upstream}' by ${ahead}, and behind by ${behind} commits`;
-    }
+  if (!ahead && behind) {
+    return `Behind '${upstream}' by ${behind} commits.`;
+  }
 
-    if (ahead && !behind) {
-      return `Ahead of '${upstream}' by ${ahead} commits.`;
-    }
-
-    if (!ahead && behind) {
-      return `Behind '${upstream}' by ${behind} commits.`;
-    }
-
+  if (upstream) {
     return `Up to date with ${upstream}`;
+  }
 
-    return "Nothing to commit, working tree clean";
-  }, [ahead, behind, repo, upstream]);
-
-  return <List.EmptyView title={title} description={description} />;
+  return "Nothing to commit, working tree clean";
 }

--- a/extensions/quick-git/src/components/GitStatus/GitStatusItem.tsx
+++ b/extensions/quick-git/src/components/GitStatus/GitStatusItem.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from "react";
-import { Icon, List } from "@raycast/api";
+import { useState } from "react";
+import { Icon, Image, List } from "@raycast/api";
 import type { StatusInfo } from "../../utils/git-status/porcelain.js";
 import type { BranchInfo } from "../../utils/git-status/branch.js";
 import { GitStatusItemDetail } from "./GitStatusItemDetail.js";
@@ -13,34 +13,16 @@ interface Props {
 export function GitStatusItem({ status, branch }: Props) {
   const [diff, setDiff] = useState("");
 
-  const title = useMemo(() => {
-    if (status.origPath) {
-      return `${status.origPath} -> ${status.fileName}`;
-    }
-    return status.fileName;
-  }, [status.fileName, status.origPath]);
-
-  const icon = useMemo(() => {
-    if (status.changes.hasStagedChanges && status.changes.hasUnstagedChanges) {
-      return Icon.CircleProgress50;
-    }
-
-    if (status.changes.hasStagedChanges && !status.changes.hasUnstagedChanges) {
-      return Icon.CheckCircle;
-    }
-
-    return Icon.Circle;
-  }, [status.changes.hasStagedChanges, status.changes.hasUnstagedChanges]);
-
   return (
     <List.Item
-      icon={icon}
-      title={title}
+      icon={statusIcon(status)}
+      title={status.origPath ? `${status.origPath} -> ${status.fileName}` : status.fileName}
       actions={
         <GitStatusItemActions
           isNotStaged={status.changes.hasUnstagedChanges}
           isCommittedFile={status.changes.isTracked}
           isShowingDiff={!!diff}
+          isSubmodule={status.submodule.isSubmodule}
           fileName={status.fileName}
           updateDiff={setDiff}
         />
@@ -48,4 +30,16 @@ export function GitStatusItem({ status, branch }: Props) {
       detail={<GitStatusItemDetail branch={branch} status={status} diff={diff} />}
     />
   );
+}
+
+function statusIcon(status: StatusInfo): Image.ImageLike {
+  if (status.changes.hasStagedChanges && status.changes.hasUnstagedChanges) {
+    return Icon.CircleProgress50;
+  }
+
+  if (status.changes.hasStagedChanges && !status.changes.hasUnstagedChanges) {
+    return Icon.CheckCircle;
+  }
+
+  return Icon.Circle;
 }

--- a/extensions/quick-git/src/components/GitStatus/GitStatusItemActions.tsx
+++ b/extensions/quick-git/src/components/GitStatus/GitStatusItemActions.tsx
@@ -17,7 +17,7 @@ import { ResetAllUnstagedFiles } from "../actions/ResetAllFiles.js";
 import { useSelectedRepo } from "../../hooks/useRepo.js";
 import { SwitchToSubmodule } from "../actions/SwitchToSubmodule.js";
 import { ChangeSubmodules } from "../actions/ChangeSubmodules.js";
-import { useHasSubmodles } from "../../hooks/useHasSubmodules.js";
+import { useHasSubmodules } from "../../hooks/useHasSubmodules.js";
 
 interface Props {
   isNotStaged: boolean;
@@ -37,7 +37,7 @@ export const GitStatusItemActions = memo(function GitStatusItemActions({
   updateDiff,
 }: Props) {
   const repo = useSelectedRepo();
-  const { data: hasSubmodule } = useHasSubmodles(repo.value);
+  const { data: hasSubmodule } = useHasSubmodules(repo.value);
   const mainAction = isNotStaged ? <AddFile fileName={fileName} /> : <UnstageFile fileName={fileName} />;
 
   const restoreFile = () => {

--- a/extensions/quick-git/src/components/GitStatus/GitStatusItemActions.tsx
+++ b/extensions/quick-git/src/components/GitStatus/GitStatusItemActions.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { memo } from "react";
 import { ActionPanel } from "@raycast/api";
 import { RemoteGitActions } from "./RemoteGitActions.js";
 import { AddFile } from "../actions/AddFile.js";
@@ -14,21 +14,33 @@ import { UnstageAllFiles } from "../actions/UnstageAllFiles.js";
 import { StashAllFiles } from "../actions/StashAllFiles.js";
 import { FileDiff } from "../actions/FileDiff.js";
 import { ResetAllUnstagedFiles } from "../actions/ResetAllFiles.js";
+import { useSelectedRepo } from "../../hooks/useRepo.js";
+import { SwitchToSubmodule } from "../actions/SwitchToSubmodule.js";
+import { ChangeSubmodules } from "../actions/ChangeSubmodules.js";
+import { useHasSubmodles } from "../../hooks/useHasSubmodules.js";
 
 interface Props {
   isNotStaged: boolean;
   isCommittedFile: boolean;
   isShowingDiff: boolean;
+  isSubmodule: boolean;
   fileName: string;
   updateDiff: (data: string) => void;
 }
 
-export function GitStatusItemActions({ isNotStaged, isCommittedFile, isShowingDiff, fileName, updateDiff }: Props) {
-  const mainAction = useMemo(() => {
-    return isNotStaged ? <AddFile fileName={fileName} /> : <UnstageFile fileName={fileName} />;
-  }, [fileName, isNotStaged]);
+export const GitStatusItemActions = memo(function GitStatusItemActions({
+  isNotStaged,
+  isCommittedFile,
+  isShowingDiff,
+  isSubmodule,
+  fileName,
+  updateDiff,
+}: Props) {
+  const repo = useSelectedRepo();
+  const { data: hasSubmodule } = useHasSubmodles(repo.value);
+  const mainAction = isNotStaged ? <AddFile fileName={fileName} /> : <UnstageFile fileName={fileName} />;
 
-  const restoreFile = useMemo(() => {
+  const restoreFile = () => {
     if (!isNotStaged || !isCommittedFile) {
       return null;
     }
@@ -39,17 +51,29 @@ export function GitStatusItemActions({ isNotStaged, isCommittedFile, isShowingDi
         <ResetFile fileName={fileName} />
       </>
     );
-  }, [fileName, isCommittedFile, isNotStaged, isShowingDiff, updateDiff]);
+  };
+
+  const submoduleActions = () => {
+    if (!repo.value || (!hasSubmodule && !isSubmodule)) return null;
+    if (hasSubmodule && !isSubmodule) return <ChangeSubmodules changeRepo={repo.setValue} />;
+    return (
+      <ActionPanel.Section title="Submodules">
+        <SwitchToSubmodule submodulePath={fileName} updateRepo={repo.setValue} />
+        <ChangeSubmodules changeRepo={repo.setValue} />
+      </ActionPanel.Section>
+    );
+  };
 
   return (
     <ActionPanel>
       <ActionPanel.Section>
         {mainAction}
         <CommitMessage />
-        {restoreFile}
+        {restoreFile()}
       </ActionPanel.Section>
 
       <ChangeCurrentBranch />
+      {submoduleActions()}
 
       <ActionPanel.Section title="Bulk Actions">
         <AddAllFiles />
@@ -67,4 +91,4 @@ export function GitStatusItemActions({ isNotStaged, isCommittedFile, isShowingDi
       </ActionPanel.Section>
     </ActionPanel>
   );
-}
+});

--- a/extensions/quick-git/src/components/GitStatus/GitStatusItemDetail.tsx
+++ b/extensions/quick-git/src/components/GitStatus/GitStatusItemDetail.tsx
@@ -1,8 +1,8 @@
+import { memo } from "react";
 import { Color, List } from "@raycast/api";
 import type { BranchInfo } from "../../utils/git-status/branch.js";
 import type { StatusInfo } from "../../utils/git-status/porcelain.js";
 import { GitStatusTags } from "./GitStatusTags.js";
-import { useMemo } from "react";
 import { getProgressIcon } from "@raycast/utils";
 
 interface Props {
@@ -11,8 +11,8 @@ interface Props {
   diff: string;
 }
 
-export function GitStatusItemDetail({ branch, status, diff }: Props) {
-  const upstreamData = useMemo(() => {
+export const GitStatusItemDetail = memo(function GitStatusItemDetail({ branch, status, diff }: Props) {
+  const upstreamData = () => {
     if (!branch.upstream) {
       return null;
     }
@@ -24,14 +24,14 @@ export function GitStatusItemDetail({ branch, status, diff }: Props) {
         <List.Item.Detail.Metadata.Label title="Behind" text={`${branch.behind} commits`} />
       </>
     );
-  }, [branch.ahead, branch.behind, branch.upstream]);
+  };
 
-  const renamedFile = useMemo(() => {
+  const renamedFile = () => {
     if (!status.changes.changeScore && !status.origPath) {
       return null;
     }
 
-    const progressIcon = getProgressIcon(status.changes.changeScore ?? 0 / 100, Color.Magenta);
+    const progressIcon = getProgressIcon((status.changes.changeScore ?? 0) / 100, Color.Magenta);
     return (
       <>
         <List.Item.Detail.Metadata.Label title="Original path" text={status.origPath} />
@@ -42,15 +42,9 @@ export function GitStatusItemDetail({ branch, status, diff }: Props) {
         />
       </>
     );
-  }, [status.changes.changeScore, status.origPath]);
+  };
 
-  const diffMarkdown = useMemo(() => {
-    if (!diff) {
-      return null;
-    }
-
-    return "```diff\n" + diff;
-  }, [diff]);
+  const diffMarkdown = diff ? "```diff\n" + diff : null;
 
   return (
     <List.Item.Detail
@@ -58,13 +52,13 @@ export function GitStatusItemDetail({ branch, status, diff }: Props) {
       metadata={
         <List.Item.Detail.Metadata>
           <List.Item.Detail.Metadata.Label title="File path" text={status.fileName} />
-          {renamedFile}
+          {renamedFile()}
           <GitStatusTags changes={status.changes} />
           <List.Item.Detail.Metadata.Separator />
           <List.Item.Detail.Metadata.Label title="Branch" text={branch.name} />
-          {upstreamData}
+          {upstreamData()}
         </List.Item.Detail.Metadata>
       }
     />
   );
-}
+});

--- a/extensions/quick-git/src/components/GitStatus/GitStatusTags.tsx
+++ b/extensions/quick-git/src/components/GitStatus/GitStatusTags.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { memo } from "react";
 import { Color, List } from "@raycast/api";
 import type { StatusValue } from "../../utils/git-status/changes.js";
 import { ChangeStatus, parseStatusValueName } from "../../utils/git-status/changes.js";
@@ -34,14 +34,31 @@ function colorForStatus(stagedStatus: StatusValue) {
   }
 }
 
-export function GitStatusTags({ changes }: Props) {
-  const tags = useMemo(() => {
-    const tags = [];
+export const GitStatusTags = memo(function GitStatusTags({ changes }: Props) {
+  const tags = [];
 
-    if (changes.hasStagedChanges) {
-      tags.push(<List.Item.Detail.Metadata.TagList.Item key={tags.length} text={"Staged"} color={Color.PrimaryText} />);
+  if (changes.hasStagedChanges) {
+    tags.push(<List.Item.Detail.Metadata.TagList.Item key={tags.length} text={"Staged"} color={Color.PrimaryText} />);
 
-      const status = parseStatusValueName(changes.stagedChanges);
+    const status = parseStatusValueName(changes.stagedChanges);
+    if (status) {
+      tags.push(
+        <List.Item.Detail.Metadata.TagList.Item
+          key={tags.length}
+          text={status}
+          color={colorForStatus(changes.stagedChanges)}
+        />,
+      );
+    }
+  }
+
+  if (changes.hasUnstagedChanges) {
+    tags.push(
+      <List.Item.Detail.Metadata.TagList.Item key={tags.length} text={"Unstaged"} color={Color.SecondaryText} />,
+    );
+
+    if (changes.unstagedChanges !== changes.stagedChanges) {
+      const status = parseStatusValueName(changes.unstagedChanges);
       if (status) {
         tags.push(
           <List.Item.Detail.Metadata.TagList.Item
@@ -52,28 +69,7 @@ export function GitStatusTags({ changes }: Props) {
         );
       }
     }
-
-    if (changes.hasUnstagedChanges) {
-      tags.push(
-        <List.Item.Detail.Metadata.TagList.Item key={tags.length} text={"Unstaged"} color={Color.SecondaryText} />,
-      );
-
-      if (changes.unstagedChanges !== changes.stagedChanges) {
-        const status = parseStatusValueName(changes.unstagedChanges);
-        if (status) {
-          tags.push(
-            <List.Item.Detail.Metadata.TagList.Item
-              key={tags.length}
-              text={status}
-              color={colorForStatus(changes.stagedChanges)}
-            />,
-          );
-        }
-      }
-    }
-
-    return tags;
-  }, [changes.hasStagedChanges, changes.stagedChanges, changes.hasUnstagedChanges, changes.unstagedChanges]);
+  }
 
   return <List.Item.Detail.Metadata.TagList title="Status">{tags}</List.Item.Detail.Metadata.TagList>;
-}
+});

--- a/extensions/quick-git/src/components/GitSubmodules.tsx
+++ b/extensions/quick-git/src/components/GitSubmodules.tsx
@@ -1,0 +1,52 @@
+import { useCachedPromise } from "@raycast/utils";
+import { parseSubmoduleKey, submodulesConfig } from "../utils/submodules.js";
+import { ReactElement, useMemo } from "react";
+import { List } from "@raycast/api";
+import { GitSubmoduleItem } from "./GitSubmodules/GitSubmoduleItem.js";
+import { GitSubmodulesEmpty } from "./GitSubmodules/GitSubmodulesEmpty.js";
+import { Providers } from "./Providers.js";
+import { navigationTitle } from "../utils/navigationTitle.js";
+import { useSelectedRepoStorage } from "../hooks/useRepo.js";
+
+interface Props {
+  changeRepo: (repoDir: string) => Promise<void>;
+  checkStatus: () => void;
+}
+
+export function GitSubmodules({ changeRepo, checkStatus }: Props) {
+  const repo = useSelectedRepoStorage();
+  const submodules = useCachedPromise(submodulesConfig, [repo.value], { execute: !!repo.value });
+
+  const submoduleList = useMemo(() => {
+    if (!submodules.data) {
+      return <GitSubmodulesEmpty />;
+    }
+
+    return (
+      <>
+        {Object.entries(submodules.data).reduce<ReactElement[]>((list, [key, value]) => {
+          const keyName = parseSubmoduleKey(key);
+          if (!keyName) {
+            return list;
+          }
+
+          list.push(
+            <GitSubmoduleItem key={key} dir={keyName} path={value.path} url={value.url} updateRepo={changeRepo} />,
+          );
+          return list;
+        }, [])}
+      </>
+    );
+  }, [changeRepo, submodules.data]);
+
+  return (
+    <Providers repo={{ ...repo, setValue: changeRepo }} checkStatus={checkStatus}>
+      <List
+        navigationTitle={navigationTitle("Submodules", repo.value)}
+        isLoading={repo.isLoading || submodules.isLoading}
+      >
+        {submoduleList}
+      </List>
+    </Providers>
+  );
+}

--- a/extensions/quick-git/src/components/GitSubmodules/GitSubmoduleItem.tsx
+++ b/extensions/quick-git/src/components/GitSubmodules/GitSubmoduleItem.tsx
@@ -1,0 +1,14 @@
+import { memo } from "react";
+import { List } from "@raycast/api";
+import { GitSubmoduleItemActions } from "./GitSubmoduleItemActions.js";
+
+interface Props {
+  dir: string;
+  path: string;
+  url: string;
+  updateRepo: (repoDir: string) => Promise<void>;
+}
+
+export const GitSubmoduleItem = memo(function GitSubmoduleItem({ dir, url, path, updateRepo }: Props) {
+  return <List.Item title={dir} actions={<GitSubmoduleItemActions url={url} path={path} updateRepo={updateRepo} />} />;
+});

--- a/extensions/quick-git/src/components/GitSubmodules/GitSubmoduleItemActions.tsx
+++ b/extensions/quick-git/src/components/GitSubmodules/GitSubmoduleItemActions.tsx
@@ -1,0 +1,29 @@
+import { memo } from "react";
+import { ActionPanel, useNavigation } from "@raycast/api";
+import { ViewRemote } from "../actions/ViewRemote.js";
+import { SwitchToSubmodule } from "../actions/SwitchToSubmodule.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
+
+interface Props {
+  url: string;
+  path: string;
+  updateRepo: (repoDir: string) => Promise<void>;
+}
+
+export const GitSubmoduleItemActions = memo(function GitSubmoduleItemActions({ url, path, updateRepo }: Props) {
+  const checkStatus = useCheckStatus();
+  const { pop } = useNavigation();
+
+  const updateRepoAndNavigate = (repoDir: string) =>
+    updateRepo(repoDir).then(() => {
+      checkStatus();
+      pop();
+    });
+
+  return (
+    <ActionPanel>
+      <SwitchToSubmodule submodulePath={path} updateRepo={updateRepoAndNavigate} />
+      <ViewRemote url={url} />
+    </ActionPanel>
+  );
+});

--- a/extensions/quick-git/src/components/GitSubmodules/GitSubmodulesEmpty.tsx
+++ b/extensions/quick-git/src/components/GitSubmodules/GitSubmodulesEmpty.tsx
@@ -1,0 +1,5 @@
+import { List } from "@raycast/api";
+
+export function GitSubmodulesEmpty() {
+  return <List.EmptyView title="There are no submodules in this repo" />;
+}

--- a/extensions/quick-git/src/components/Providers.tsx
+++ b/extensions/quick-git/src/components/Providers.tsx
@@ -1,15 +1,15 @@
 import { PropsWithChildren } from "react";
-import { CheckStatusContext } from "../hooks/useCheckStatus.js";
-import { RepoContext } from "../hooks/useRepo.js";
+import { CheckStatusContext } from "../hooks/useGitStatus.js";
+import { RepoContext, SelectedRepo } from "../hooks/useRepo.js";
 
 interface Props {
-  repo?: string;
+  repo: SelectedRepo;
   checkStatus: () => void;
 }
 
 export function Providers({ repo, checkStatus, children }: PropsWithChildren<Props>) {
   return (
-    <RepoContext value={repo ?? ""}>
+    <RepoContext value={repo}>
       <CheckStatusContext value={checkStatus}>{children}</CheckStatusContext>
     </RepoContext>
   );

--- a/extensions/quick-git/src/components/actions/AddAllFiles.tsx
+++ b/extensions/quick-git/src/components/actions/AddAllFiles.tsx
@@ -1,7 +1,7 @@
 import { Action, Icon, showToast } from "@raycast/api";
 import { showFailureToast, useExec } from "@raycast/utils";
 import { useRepo } from "../../hooks/useRepo.js";
-import { useCheckStatus } from "../../hooks/useCheckStatus.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
 
 export function AddAllFiles() {
   const repo = useRepo();

--- a/extensions/quick-git/src/components/actions/AddFile.tsx
+++ b/extensions/quick-git/src/components/actions/AddFile.tsx
@@ -1,7 +1,7 @@
 import { Action, Icon, showToast } from "@raycast/api";
 import { showFailureToast, useExec } from "@raycast/utils";
 import { useRepo } from "../../hooks/useRepo.js";
-import { useCheckStatus } from "../../hooks/useCheckStatus.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
 
 interface Props {
   fileName: string;

--- a/extensions/quick-git/src/components/actions/ChangeCurrentBranch.tsx
+++ b/extensions/quick-git/src/components/actions/ChangeCurrentBranch.tsx
@@ -1,6 +1,6 @@
 import { Action, Icon } from "@raycast/api";
 import { GitBranches } from "../GitBranches.js";
-import { useCheckStatus } from "../../hooks/useCheckStatus.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
 
 export function ChangeCurrentBranch() {
   const checkStatus = useCheckStatus();

--- a/extensions/quick-git/src/components/actions/ChangeSubmodules.tsx
+++ b/extensions/quick-git/src/components/actions/ChangeSubmodules.tsx
@@ -1,0 +1,23 @@
+import { Action, Icon } from "@raycast/api";
+import { GitSubmodules } from "../GitSubmodules.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
+
+interface Props {
+  changeRepo: (repoDir: string) => Promise<void>;
+}
+
+export function ChangeSubmodules({ changeRepo }: Props) {
+  const checkStatus = useCheckStatus();
+
+  return (
+    <Action.Push
+      title="View Submodules"
+      icon={Icon.ArrowsExpand}
+      target={<GitSubmodules changeRepo={changeRepo} checkStatus={checkStatus} />}
+      shortcut={{
+        macOS: { key: "s", modifiers: ["cmd", "shift"] },
+        Windows: { key: "s", modifiers: ["ctrl", "shift"] },
+      }}
+    />
+  );
+}

--- a/extensions/quick-git/src/components/actions/CommitMessage.tsx
+++ b/extensions/quick-git/src/components/actions/CommitMessage.tsx
@@ -1,6 +1,6 @@
 import { Action, Icon } from "@raycast/api";
 import { GitCommit } from "../forms/GitCommit.js";
-import { useCheckStatus } from "../../hooks/useCheckStatus.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
 
 export function CommitMessage() {
   const checkStatus = useCheckStatus();

--- a/extensions/quick-git/src/components/actions/DeleteBranch.tsx
+++ b/extensions/quick-git/src/components/actions/DeleteBranch.tsx
@@ -1,4 +1,4 @@
-import { Action, Icon, showToast } from "@raycast/api";
+import { Action, Icon, showToast, Toast } from "@raycast/api";
 import { showFailureToast, useExec } from "@raycast/utils";
 import { useRepo } from "../../hooks/useRepo.js";
 
@@ -17,7 +17,7 @@ export function DeleteBranch({ branch, checkBranches }: Props) {
       checkBranches();
     },
     onError: (error) => {
-      showFailureToast(error, { title: `Could not delete branch ${branch}` });
+      showFailureToast(error, { title: `Could not delete branch: ${branch}` });
     },
   });
   const { revalidate: deleteBranch } = useExec("git", ["branch", "-d", branch], {
@@ -27,13 +27,14 @@ export function DeleteBranch({ branch, checkBranches }: Props) {
       showToast({ title: `Deleted branch ${branch}` });
       checkBranches();
     },
-    onError: (error) => {
-      showFailureToast(error, {
+    onError: () => {
+      showToast({
         title: `Could not delete ${branch}`,
         primaryAction: {
           title: "Force Delete Branch?",
           onAction: hardDeleteBranch,
         },
+        style: Toast.Style.Failure,
       });
     },
   });

--- a/extensions/quick-git/src/components/actions/DeleteWorktree.tsx
+++ b/extensions/quick-git/src/components/actions/DeleteWorktree.tsx
@@ -1,4 +1,4 @@
-import { Action, Icon, showToast } from "@raycast/api";
+import { Action, Icon, showToast, Toast } from "@raycast/api";
 import { showFailureToast, useExec } from "@raycast/utils";
 import { useRepo } from "../../hooks/useRepo.js";
 
@@ -18,7 +18,7 @@ export function DeleteWorktree({ worktreeName, worktreePath, checkBranches }: Pr
       checkBranches();
     },
     onError: (error) => {
-      showFailureToast(error, { title: `Could not delete worktree ${worktreeName}` });
+      showFailureToast(error, { title: `Could not delete worktree: ${worktreeName}` });
     },
   });
   const { revalidate: deleteWorktree } = useExec("git", ["worktree", "remove", worktreePath], {
@@ -28,13 +28,14 @@ export function DeleteWorktree({ worktreeName, worktreePath, checkBranches }: Pr
       showToast({ title: `Deleted worktree ${worktreeName}` });
       checkBranches();
     },
-    onError: (error) => {
-      showFailureToast(error, {
+    onError: () => {
+      showToast({
         title: `Could not delete ${worktreeName}`,
         primaryAction: {
           title: "Force Delete Worktree?",
           onAction: hardDeleteWorktree,
         },
+        style: Toast.Style.Failure,
       });
     },
   });

--- a/extensions/quick-git/src/components/actions/FetchBranch.tsx
+++ b/extensions/quick-git/src/components/actions/FetchBranch.tsx
@@ -1,7 +1,7 @@
 import { Action, Icon, showToast, Toast } from "@raycast/api";
 import { showFailureToast, useExec } from "@raycast/utils";
 import { useRepo } from "../../hooks/useRepo.js";
-import { useCheckStatus } from "../../hooks/useCheckStatus.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
 
 export function FetchBranch() {
   const repo = useRepo();

--- a/extensions/quick-git/src/components/actions/OpenPreferences.tsx
+++ b/extensions/quick-git/src/components/actions/OpenPreferences.tsx
@@ -1,5 +1,5 @@
 import { Action, openExtensionPreferences } from "@raycast/api";
 
-export const OpenPreferences = () => {
+export function OpenPreferences() {
   return <Action title="Open Preferences" onAction={openExtensionPreferences} />;
-};
+}

--- a/extensions/quick-git/src/components/actions/PullBranch.tsx
+++ b/extensions/quick-git/src/components/actions/PullBranch.tsx
@@ -1,7 +1,7 @@
 import { Action, Icon, Keyboard, showToast, Toast } from "@raycast/api";
 import { showFailureToast, useExec } from "@raycast/utils";
 import { useRepo } from "../../hooks/useRepo.js";
-import { useCheckStatus } from "../../hooks/useCheckStatus.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
 
 export function PullBranch() {
   const repo = useRepo();

--- a/extensions/quick-git/src/components/actions/PushBranch.tsx
+++ b/extensions/quick-git/src/components/actions/PushBranch.tsx
@@ -1,7 +1,7 @@
 import { Action, Icon, Keyboard, showToast, Toast } from "@raycast/api";
 import { showFailureToast, useExec } from "@raycast/utils";
 import { useRepo } from "../../hooks/useRepo.js";
-import { useCheckStatus } from "../../hooks/useCheckStatus.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
 
 export function PushBranch() {
   const repo = useRepo();
@@ -32,13 +32,14 @@ export function PushBranch() {
       checkStatus();
       showToast({ title: "Remote up to date" });
     },
-    onError: (error) => {
-      showFailureToast(error, {
+    onError: () => {
+      showToast({
         title: "Could not push this branch",
         primaryAction: {
           onAction: forcePush,
           title: "Force Push Branch?",
         },
+        style: Toast.Style.Failure,
       });
     },
   });

--- a/extensions/quick-git/src/components/actions/ResetAllFiles.tsx
+++ b/extensions/quick-git/src/components/actions/ResetAllFiles.tsx
@@ -1,7 +1,7 @@
 import { Action, Icon, showToast } from "@raycast/api";
 import { showFailureToast, useExec } from "@raycast/utils";
 import { useRepo } from "../../hooks/useRepo.js";
-import { useCheckStatus } from "../../hooks/useCheckStatus.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
 
 export function ResetAllUnstagedFiles() {
   const repo = useRepo();

--- a/extensions/quick-git/src/components/actions/ResetFile.tsx
+++ b/extensions/quick-git/src/components/actions/ResetFile.tsx
@@ -1,7 +1,7 @@
 import { Action, Icon, Keyboard, showToast } from "@raycast/api";
 import { showFailureToast, useExec } from "@raycast/utils";
 import { useRepo } from "../../hooks/useRepo.js";
-import { useCheckStatus } from "../../hooks/useCheckStatus.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
 
 interface Props {
   fileName: string;

--- a/extensions/quick-git/src/components/actions/StashAllFiles.tsx
+++ b/extensions/quick-git/src/components/actions/StashAllFiles.tsx
@@ -1,7 +1,7 @@
 import { Action, Icon, showToast } from "@raycast/api";
 import { showFailureToast, useExec } from "@raycast/utils";
 import { useRepo } from "../../hooks/useRepo.js";
-import { useCheckStatus } from "../../hooks/useCheckStatus.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
 
 export function StashAllFiles() {
   const repo = useRepo();

--- a/extensions/quick-git/src/components/actions/SwitchToSubmodule.tsx
+++ b/extensions/quick-git/src/components/actions/SwitchToSubmodule.tsx
@@ -1,0 +1,35 @@
+import { Action, Icon, showToast } from "@raycast/api";
+import { useRepo } from "../../hooks/useRepo.js";
+import { join } from "node:path";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
+import { showFailureToast } from "@raycast/utils";
+
+interface Props {
+  submodulePath: string;
+  updateRepo: (repoDir: string) => Promise<void>;
+}
+
+export function SwitchToSubmodule({ submodulePath, updateRepo }: Props) {
+  const repo = useRepo();
+  const checkStatus = useCheckStatus();
+  const updateCurrentRepo = () => {
+    const path = join(repo, submodulePath);
+    updateRepo(path)
+      .then(() => {
+        checkStatus();
+        showToast({ title: `Updated repo to be ${path}` });
+      })
+      .catch((error) => {
+        showFailureToast(error, { title: "Could not update repo" });
+      });
+  };
+
+  return (
+    <Action
+      title="Switch to Submodule"
+      icon={Icon.Reply}
+      onAction={updateCurrentRepo}
+      shortcut={{ macOS: { key: "s", modifiers: ["cmd"] }, Windows: { key: "s", modifiers: ["ctrl"] } }}
+    />
+  );
+}

--- a/extensions/quick-git/src/components/actions/SwitchToWorktree.tsx
+++ b/extensions/quick-git/src/components/actions/SwitchToWorktree.tsx
@@ -1,5 +1,4 @@
 import { Action, Icon, useNavigation } from "@raycast/api";
-import { useCallback } from "react";
 import { useWorktreeDir } from "../../hooks/useWorktreeDir.js";
 
 interface Props {
@@ -11,11 +10,11 @@ export function SwitchToWorkTree({ worktree, updateRepo }: Props) {
   const { data: worktreeDir } = useWorktreeDir(worktree);
   const { pop } = useNavigation();
 
-  const switchToWorktree = useCallback(() => {
+  const switchToWorktree = () => {
     if (worktreeDir) {
       updateRepo(worktreeDir).then(pop);
     }
-  }, [pop, updateRepo, worktreeDir]);
+  };
 
   return <Action title="Switch to This Worktree" icon={Icon.Replace} onAction={switchToWorktree} />;
 }

--- a/extensions/quick-git/src/components/actions/UnstageAllFiles.tsx
+++ b/extensions/quick-git/src/components/actions/UnstageAllFiles.tsx
@@ -1,7 +1,7 @@
 import { Action, Icon, Keyboard, showToast } from "@raycast/api";
 import { showFailureToast, useExec } from "@raycast/utils";
 import { useRepo } from "../../hooks/useRepo.js";
-import { useCheckStatus } from "../../hooks/useCheckStatus.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
 
 export function UnstageAllFiles() {
   const repo = useRepo();

--- a/extensions/quick-git/src/components/actions/UnstageFile.tsx
+++ b/extensions/quick-git/src/components/actions/UnstageFile.tsx
@@ -1,7 +1,7 @@
 import { Action, Icon, showToast } from "@raycast/api";
 import { showFailureToast, useExec } from "@raycast/utils";
 import { useRepo } from "../../hooks/useRepo.js";
-import { useCheckStatus } from "../../hooks/useCheckStatus.js";
+import { useCheckStatus } from "../../hooks/useGitStatus.js";
 
 interface Props {
   fileName: string;

--- a/extensions/quick-git/src/components/actions/ViewRemote.tsx
+++ b/extensions/quick-git/src/components/actions/ViewRemote.tsx
@@ -1,0 +1,9 @@
+import { Action } from "@raycast/api";
+
+interface Props {
+  url: string;
+}
+
+export function ViewRemote({ url }: Props) {
+  return <Action.OpenInBrowser title="View Remote Repo" url={url} />;
+}

--- a/extensions/quick-git/src/components/actions/ViewRemote.tsx
+++ b/extensions/quick-git/src/components/actions/ViewRemote.tsx
@@ -1,9 +1,11 @@
 import { Action } from "@raycast/api";
+import { convertSSHtoHTTP } from "../../utils/url.js";
+import { memo } from "react";
 
 interface Props {
   url: string;
 }
 
-export function ViewRemote({ url }: Props) {
-  return <Action.OpenInBrowser title="View Remote Repo" url={url} />;
-}
+export const ViewRemote = memo(function ViewRemote({ url }: Props) {
+  return <Action.OpenInBrowser title="View Remote Repo" url={convertSSHtoHTTP(url)} />;
+});

--- a/extensions/quick-git/src/components/forms/ChooseDirectory.tsx
+++ b/extensions/quick-git/src/components/forms/ChooseDirectory.tsx
@@ -1,11 +1,11 @@
 import { Action, ActionPanel, Form, Icon, showToast, Toast } from "@raycast/api";
 import { FormValidation, showFailureToast, useForm } from "@raycast/utils";
-import { useRepoStorage } from "../../hooks/useRepo.js";
+import { useSelectedRepo } from "../../hooks/useRepo.js";
 import { OpenPreferences } from "../actions/OpenPreferences.js";
 import { launchQuickGit } from "../../utils/launchCommands.js";
 
 export function ChooseDirectory() {
-  const repo = useRepoStorage();
+  const repo = useSelectedRepo();
 
   const { handleSubmit, itemProps } = useForm({
     onSubmit({ newRepo }: { newRepo: string[] }) {

--- a/extensions/quick-git/src/components/forms/CreateBranch.tsx
+++ b/extensions/quick-git/src/components/forms/CreateBranch.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Action, ActionPanel, Form, Icon, showToast, useNavigation } from "@raycast/api";
 import { showFailureToast, useExec, useForm } from "@raycast/utils";
-import { useRepoStorage } from "../../hooks/useRepo.js";
+import { useSelectedRepo } from "../../hooks/useRepo.js";
 import { validateBranchName } from "../../utils/validators.js";
 
 interface Props {
@@ -9,7 +9,7 @@ interface Props {
 }
 
 export function CreateBranch({ checkBranches }: Props) {
-  const repo = useRepoStorage();
+  const repo = useSelectedRepo();
   const { pop } = useNavigation();
   const [branchName, setBranchName] = useState("");
   const { revalidate, isLoading } = useExec("git", ["switch", "-c", branchName], {

--- a/extensions/quick-git/src/components/forms/CreateWorktree.tsx
+++ b/extensions/quick-git/src/components/forms/CreateWorktree.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Action, ActionPanel, Form, Icon, showToast, useNavigation } from "@raycast/api";
 import { showFailureToast, useExec, useForm } from "@raycast/utils";
-import { useRepoStorage } from "../../hooks/useRepo.js";
+import { useSelectedRepo } from "../../hooks/useRepo.js";
 import path from "node:path";
 import { validateBranchName } from "../../utils/validators.js";
 
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export function CreateWorktree({ checkBranches }: Props) {
-  const repo = useRepoStorage();
+  const repo = useSelectedRepo();
   const { pop } = useNavigation();
   const [worktreeName, setWorktreeName] = useState("");
   const [worktreeDir, setWorktreeDir] = useState("");

--- a/extensions/quick-git/src/components/forms/GitCommit.tsx
+++ b/extensions/quick-git/src/components/forms/GitCommit.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
 import { Action, ActionPanel, Form, Icon, showToast, useNavigation } from "@raycast/api";
 import { FormValidation, showFailureToast, useExec, useForm } from "@raycast/utils";
-import { useRepoStorage } from "../../hooks/useRepo.js";
+import { useSelectedRepo } from "../../hooks/useRepo.js";
 
 interface Props {
   checkStatus: () => void;
 }
 
 export function GitCommit({ checkStatus }: Props) {
-  const repo = useRepoStorage();
+  const repo = useSelectedRepo();
   const { pop } = useNavigation();
   const [commitMsg, setCommitMsg] = useState("");
   const { revalidate } = useExec("git", ["commit", "-m", commitMsg], {

--- a/extensions/quick-git/src/hooks/useCheckStatus.ts
+++ b/extensions/quick-git/src/hooks/useCheckStatus.ts
@@ -1,9 +1,0 @@
-import { createContext, useContext } from "react";
-
-export const CheckStatusContext = createContext<() => void>(() => {
-  throw Error("Cannot check status: CheckStatusContext was not initialized");
-});
-
-export function useCheckStatus() {
-  return useContext(CheckStatusContext);
-}

--- a/extensions/quick-git/src/hooks/useGitStatus.ts
+++ b/extensions/quick-git/src/hooks/useGitStatus.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from "react";
+import { showFailureToast, useExec } from "@raycast/utils";
+import { parseGitStatusPorcelain } from "../utils/git-status/porcelain.js";
+
+export function useGitStatus(repo?: string) {
+  return useExec("git", ["status", "--porcelain=2", "--branch"], {
+    cwd: repo,
+    execute: !!repo,
+    keepPreviousData: false,
+    onError: (error) => {
+      showFailureToast(error, { title: "Could not fetch git status" });
+    },
+    parseOutput: ({ stdout }) => parseGitStatusPorcelain(stdout),
+  });
+}
+
+export const CheckStatusContext = createContext<() => void>(() => {
+  throw Error("Cannot check status: CheckStatusContext was not initialized");
+});
+
+export function useCheckStatus() {
+  return useContext(CheckStatusContext);
+}

--- a/extensions/quick-git/src/hooks/useHasSubmodules.ts
+++ b/extensions/quick-git/src/hooks/useHasSubmodules.ts
@@ -1,0 +1,6 @@
+import { useCachedPromise } from "@raycast/utils";
+import { hasSubmodules } from "../utils/submodules.js";
+
+export function useHasSubmodles(repo?: string) {
+  return useCachedPromise(hasSubmodules, [repo], { execute: !!repo });
+}

--- a/extensions/quick-git/src/hooks/useHasSubmodules.ts
+++ b/extensions/quick-git/src/hooks/useHasSubmodules.ts
@@ -1,6 +1,6 @@
 import { useCachedPromise } from "@raycast/utils";
 import { hasSubmodules } from "../utils/submodules.js";
 
-export function useHasSubmodles(repo?: string) {
+export function useHasSubmodules(repo?: string) {
   return useCachedPromise(hasSubmodules, [repo], { execute: !!repo });
 }

--- a/extensions/quick-git/src/hooks/useRepo.ts
+++ b/extensions/quick-git/src/hooks/useRepo.ts
@@ -1,12 +1,23 @@
 import { useLocalStorage } from "@raycast/utils";
 import { createContext, useContext } from "react";
 
-export const RepoContext = createContext("");
+export type SelectedRepo = ReturnType<typeof useLocalStorage<string>>;
 
-export function useRepoStorage() {
+export const RepoContext = createContext<SelectedRepo>({
+  value: undefined,
+  setValue: async () => {},
+  removeValue: async () => {},
+  isLoading: false,
+});
+
+export function useSelectedRepoStorage(): SelectedRepo {
   return useLocalStorage<string>("selectedRepo");
 }
 
-export function useRepo() {
+export function useRepo(): string {
+  return useContext(RepoContext).value ?? "";
+}
+
+export function useSelectedRepo(): SelectedRepo {
   return useContext(RepoContext);
 }

--- a/extensions/quick-git/src/utils/navigationTitle.ts
+++ b/extensions/quick-git/src/utils/navigationTitle.ts
@@ -1,0 +1,13 @@
+import path from "node:path";
+
+export function navigationTitle(actionName: string, repo?: string): string {
+  if (!repo) {
+    return actionName;
+  }
+  try {
+    const dir = path.parse(repo);
+    return `${actionName} | ${dir.name}`;
+  } catch {
+    return actionName;
+  }
+}

--- a/extensions/quick-git/src/utils/submodules.ts
+++ b/extensions/quick-git/src/utils/submodules.ts
@@ -1,0 +1,42 @@
+import { join } from "node:path";
+import { readFile, stat } from "node:fs/promises";
+import { parse } from "ini";
+
+interface Submodule {
+  path: string;
+  url: string;
+}
+
+export type SubmoduleConfig = Record<string, Submodule>;
+
+export async function hasSubmodules(currentDir?: string): Promise<boolean> {
+  if (!currentDir) {
+    return false;
+  }
+
+  const gitModules = join(currentDir, ".gitmodules");
+  return stat(gitModules)
+    .then((res) => res.isFile())
+    .catch(() => false);
+}
+
+export async function submodulesConfig(currentDir?: string): Promise<SubmoduleConfig | null> {
+  if (!currentDir) {
+    return null;
+  }
+
+  const gitModules = join(currentDir, ".gitmodules");
+  let submodules: SubmoduleConfig;
+  try {
+    const contents = await readFile(gitModules, "utf-8");
+    submodules = parse(contents);
+  } catch {
+    return null;
+  }
+
+  return submodules;
+}
+
+export function parseSubmoduleKey(key: string): string | undefined {
+  return key.match(/submodule "(?<keyName>.*)"/)?.groups?.["keyName"];
+}

--- a/extensions/quick-git/src/utils/url.ts
+++ b/extensions/quick-git/src/utils/url.ts
@@ -1,0 +1,12 @@
+export function convertSSHtoHTTP(url: string): string {
+  if (url.startsWith("https")) {
+    return url;
+  }
+
+  const matches = url.match(/^git@([^:]+):(.+?)\.git?$/);
+  if (!matches || matches.length < 3) {
+    return url;
+  }
+
+  return `https://${matches[1]}/${matches[2]}`;
+}

--- a/extensions/quick-git/src/utils/url.ts
+++ b/extensions/quick-git/src/utils/url.ts
@@ -3,7 +3,7 @@ export function convertSSHtoHTTP(url: string): string {
     return url;
   }
 
-  const matches = url.match(/^git@([^:]+):(.+?)\.git?$/);
+  const matches = url.match(/^git@([^:]+):(.+?)(\.git)?$/);
   if (!matches || matches.length < 3) {
     return url;
   }


### PR DESCRIPTION
## Description

Added selected support for git submodules, if you have a repo that has them you can now open that repo directly, or select that as the repo that you want quick-git to operate it.

Also makes some other small QOL updates and fixes some bugs.

## Screencast

https://github.com/user-attachments/assets/e38bbdc7-c361-4a65-8c17-6178dbf5ff65


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
