### PR TITLE
Add Alai MCP Server to Model Context Protocol Registry

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add Alai MCP Server] - {PR_MERGE_DATE}
+## [Add Alai MCP Server] - 2026-04-30
 
 Add community Alai MCP Server to registry for AI-powered presentation generation (text-to-slides, exports to PDF, PPTX, or shareable link).
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add Alai MCP Server] - 2026-04-18
+## [Add Alai MCP Server] - {PR_MERGE_DATE}
 
 Add community Alai MCP Server to registry for AI-powered presentation generation (text-to-slides, exports to PDF, PPTX, or shareable link).
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Add Alai MCP Server] - 2026-04-18
+
+Add community Alai MCP Server to registry for AI-powered presentation generation (text-to-slides, exports to PDF, PPTX, or shareable link).
+
 ## [Add Sanity MCP Server] - 2026-03-07
 
 Add official Sanity MCP Server to registry for direct access to Sanity projects.

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -734,7 +734,7 @@ export const COMMUNITY_ENTRIES: RegistryEntry[] = [
     title: "Alai",
     description:
       "Generate, edit, and export high-quality AI presentations to PDF, PPTX, or a shareable link. Supports themes, vibes, and creative slide variants.",
-    icon: "https://framerusercontent.com/images/FN6bUXoDO3VHXWV9aucdRQZGBkU.png",
+    icon: "https://storage.getalai.com/Alai%20Logo%20-%20Gradient%20BG.png",
     homepage: "https://getalai.com",
     configuration: {
       command: "npx",

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -730,6 +730,18 @@ export const COMMUNITY_ENTRIES: RegistryEntry[] = [
     },
   },
   {
+    name: "alai",
+    title: "Alai",
+    description:
+      "Generate, edit, and export high-quality AI presentations to PDF, PPTX, or a shareable link. Supports themes, vibes, and creative slide variants.",
+    icon: "https://framerusercontent.com/images/FN6bUXoDO3VHXWV9aucdRQZGBkU.png",
+    homepage: "https://getalai.com",
+    configuration: {
+      command: "npx",
+      args: ["-y", "mcp-remote", "https://slides-api.getalai.com/mcp/"],
+    },
+  },
+  {
     name: "apple-script",
     title: "Apple Script",
     description:


### PR DESCRIPTION
## Description

Adds **Alai** — an AI presentation generator — to the Model Context Protocol Registry extension under `COMMUNITY_ENTRIES`.

Alai is a hosted, remote streamable-HTTP MCP server available at `https://slides-api.getalai.com/mcp/`. It exposes 11 tools for generating, editing, and exporting presentations (PDF / PPTX / shareable link). It is also listed in the official MCP Registry as `com.getalai/presentations` (DNS-verified).

The entry uses `mcp-remote` to bridge to the hosted endpoint, matching the pattern used by other remote community/official entries in this file (Linear, Sentry, Sanity, Prisma, Razuna, Gen-PDF).

- **Homepage:** https://getalai.com
- **Repo:** https://github.com/getalai/alai-mcp-server
- **Official MCP Registry:** `com.getalai/presentations`

## Screencast / Testing

Extension dev server launched with the modified `entries.ts`; Alai shows under the Community list in the MCP Registry view, and the suggested config (`npx -y mcp-remote https://slides-api.getalai.com/mcp/`) connects successfully to the hosted endpoint and lists all 11 tools.

## Checklist

- [x] New `COMMUNITY_ENTRIES` entry inserted alphabetically (after `airtable`, before `apple-script`)
- [x] `CHANGELOG.md` updated with dated entry at the top
- [x] `entries.ts` passes `prettier --check`
- [x] Icon served over HTTPS
- [x] No other files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)