### PR TITLE
fix(memos): restore memo listing for newer memos instances

### DIFF
--- a/extensions/memos/CHANGELOG.md
+++ b/extensions/memos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Send To Memos Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-04-20
 
 - fix: restore memo listing for newer Memos instances by resolving the current user via `/api/v1/auth/me` and listing memos with the authenticated user's `parent` resource name.
 - fix: remove the render loop in `MemosListCommand` by deriving filtered items from fetched data instead of storing a second derived list in component state.

--- a/extensions/memos/CHANGELOG.md
+++ b/extensions/memos/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Send To Memos Changelog
 
+## [Fix] - 2026-04-18
+
+- fix: restore memo listing for newer Memos instances by resolving the current user via `/api/v1/auth/me` and listing memos with the authenticated user's `parent` resource name.
+- fix: remove the render loop in `MemosListCommand` by deriving filtered items from fetched data instead of storing a second derived list in component state.
+
 ## [Update] - 2025-12-07
 
 - update dependencies and improve type safety.
@@ -8,7 +13,7 @@
 
 ## [Update & Breaking Change] - 2025-09-03
 
-- support memos@0.25.0. 
+- support memos@0.25.0.
 
 ## [Update] - 2025-03-31
 

--- a/extensions/memos/CHANGELOG.md
+++ b/extensions/memos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Send To Memos Changelog
 
-## [Fix] - 2026-04-18
+## [Fix] - {PR_MERGE_DATE}
 
 - fix: restore memo listing for newer Memos instances by resolving the current user via `/api/v1/auth/me` and listing memos with the authenticated user's `parent` resource name.
 - fix: remove the render loop in `MemosListCommand` by deriving filtered items from fetched data instead of storing a second derived list in component state.

--- a/extensions/memos/src/api.ts
+++ b/extensions/memos/src/api.ts
@@ -1,5 +1,5 @@
 import { getPreferenceValues, Cache, showToast, Toast } from "@raycast/api";
-import { useFetch } from "@raycast/utils";
+import { useFetch, usePromise } from "@raycast/utils";
 import parse from "url-parse";
 import FormData from "form-data";
 import fs from "fs";
@@ -11,6 +11,32 @@ import { Preferences, ResponseData, ROW_STATUS, AttachmentObj } from "./types";
 import { MeResponse, PostFileResponse, PostMemoParams, MemoInfoResponse } from "./types";
 
 const cache = new Cache();
+const CURRENT_USER_PATH = "/api/v1/auth/me";
+const LEGACY_CURRENT_USER_PATH = "/api/v1/auth/sessions/current";
+
+const buildMemoListUrl = ({
+  creatorName,
+  state,
+  pageSize,
+}: {
+  creatorName?: string;
+  state?: ROW_STATUS;
+  pageSize: number;
+}) => {
+  const params = new URLSearchParams({
+    pageSize: String(pageSize),
+  });
+
+  if (state) {
+    params.set("state", state);
+  }
+
+  if (creatorName) {
+    params.set("parent", creatorName);
+  }
+
+  return getRequestUrl(`/api/v1/memos?${params.toString()}`);
+};
 
 const parseResponse = async <T>(response: Response): Promise<T> => {
   const cookie = response.headers.get("Set-Cookie");
@@ -77,18 +103,6 @@ const getOpenId = () => {
   }
 };
 
-const getUseFetch = <T>(url: string, options: Record<string, unknown>) => {
-  return useFetch<T, T>(url, {
-    headers: {
-      "Content-Type": "application/json",
-      // Cookie: getCookie(),
-      Authorization: `Bearer ${getToken()}`,
-    },
-    parseResponse,
-    ...options,
-  });
-};
-
 const getFetch = <T>(options: AxiosRequestConfig) => {
   return axios<T>({
     headers: {
@@ -109,10 +123,26 @@ const getFetch = <T>(options: AxiosRequestConfig) => {
   });
 };
 
+const getCurrentUserRequest = async () => {
+  try {
+    return await getFetch<MeResponse>({
+      url: getRequestUrl(CURRENT_USER_PATH),
+      method: "GET",
+    });
+  } catch (error) {
+    if (!axios.isAxiosError(error) || error.response?.status !== 404) {
+      throw error;
+    }
+
+    return getFetch<MeResponse>({
+      url: getRequestUrl(LEGACY_CURRENT_USER_PATH),
+      method: "GET",
+    });
+  }
+};
+
 export const getMe = () => {
-  return getUseFetch<MeResponse>(getRequestUrl(`/api/v1/auth/sessions/current`), {
-    method: "GET",
-  });
+  return usePromise(getCurrentUserRequest, []);
 };
 
 export const sendMemo = (data: PostMemoParams) => {
@@ -126,15 +156,15 @@ export const sendMemo = (data: PostMemoParams) => {
 };
 
 export const getRecentTags = async (): Promise<string[]> => {
-  const { user: me } = await getFetch<MeResponse>({
-    url: getRequestUrl(`/api/v1/auth/sessions/current`),
-    method: "GET",
-  });
+  const { user: me } = await getCurrentUserRequest();
 
   const memos = await getFetch<{
     memos: MemoInfoResponse[];
   }>({
-    url: getRequestUrl(`/api/v1/memos?pageSize=50&parent=${encodeURIComponent(me.name)}`),
+    url: buildMemoListUrl({
+      creatorName: me.name,
+      pageSize: 50,
+    }),
     method: "GET",
   });
 
@@ -185,14 +215,12 @@ export const postMemoAttachments = (memoName: string, attachments: Partial<Attac
   });
 };
 
-export const getAllMemos = (currentUserId?: number, { state = ROW_STATUS.NORMAL } = {}) => {
-  let parent = "";
-
-  if (currentUserId) {
-    parent = encodeURIComponent(`users/${currentUserId}`);
-  }
-
-  const url = getRequestUrl(`/api/v1/memos?parent=${parent}&state=${state}&pageSize=20`);
+export const getAllMemos = (currentUserName?: string, { state = ROW_STATUS.NORMAL } = {}) => {
+  const url = buildMemoListUrl({
+    creatorName: currentUserName,
+    state,
+    pageSize: 20,
+  });
 
   const { isLoading, data, revalidate, pagination } = useFetch<
     {
@@ -206,6 +234,7 @@ export const getAllMemos = (currentUserId?: number, { state = ROW_STATUS.NORMAL 
       "Content-Type": "application/json",
       Authorization: `Bearer ${getToken()}`,
     },
+    execute: Boolean(currentUserName),
     parseResponse,
     mapResult(result) {
       return {
@@ -218,7 +247,7 @@ export const getAllMemos = (currentUserId?: number, { state = ROW_STATUS.NORMAL 
     initialData: [],
   });
 
-  return { isLoading, data: currentUserId ? data : [], revalidate, pagination };
+  return { isLoading, data: currentUserName ? data : [], revalidate, pagination };
 };
 
 export const patchMemo = (memoName: string, { state = ROW_STATUS.NORMAL } = {}) => {

--- a/extensions/memos/src/memosList.tsx
+++ b/extensions/memos/src/memosList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { List, ActionPanel, Action, Icon, confirmAlert, Alert, showToast, Toast } from "@raycast/api";
 import {
   archiveMemo,
@@ -13,58 +13,48 @@ import { MemoInfoResponse, MeResponse, ROW_STATUS } from "./types";
 
 export default function MemosListCommand() {
   const [searchText, setSearchText] = useState("");
-  const [currentUserId, setCurrentUserId] = useState<number>();
+  const [currentUserName, setCurrentUserName] = useState<string>();
   const [state, setState] = useState(ROW_STATUS.NORMAL);
-  const { isLoading, data, revalidate, pagination } = getAllMemos(currentUserId, { state });
+  const { isLoading, data, revalidate, pagination } = getAllMemos(currentUserName, { state });
   const { isLoading: isLoadingUser, data: userData } = getMe();
-  const [filterList, setFilterList] = useState<MemoInfoResponse[]>([]);
+  const [markdownByMemoName, setMarkdownByMemoName] = useState<Record<string, string>>({});
+  const loadingMarkdownMemoNames = useRef(new Set<string>());
 
   useEffect(() => {
     if (!isLoadingUser && userData && "user" in userData) {
       const user = (userData as MeResponse).user;
       if (user && user.name) {
-        const userId = +user.name.split("/")[1];
-        setCurrentUserId(userId);
+        setCurrentUserName(user.name);
       }
     }
   }, [isLoadingUser, userData]);
 
   useEffect(() => {
-    if (currentUserId) {
-      revalidate();
+    const dataList = data || [];
+    for (const item of dataList) {
+      if (
+        item.attachments.length === 0 ||
+        markdownByMemoName[item.name] ||
+        loadingMarkdownMemoNames.current.has(item.name)
+      ) {
+        continue;
+      }
+
+      loadingMarkdownMemoNames.current.add(item.name);
+      void getItemMarkdown(item).finally(() => {
+        loadingMarkdownMemoNames.current.delete(item.name);
+      });
     }
-  }, [currentUserId]);
+  }, [data, markdownByMemoName]);
 
-  useEffect(() => {
-    const dataList = data || [];
-
-    setFilterList(
-      dataList
-        .filter((item) => item.content.includes(searchText))
-        .map((item) => {
-          item.markdown = item.content;
-          if (item.attachments.length > 0) {
-            getItemMarkdown(item);
-          }
-          return item;
-        }) || [],
-    );
-  }, [searchText]);
-
-  useEffect(() => {
-    const dataList = data || [];
-    setFilterList(
-      dataList.map((item) => {
-        item.markdown = item.content;
-
-        if (item.attachments.length > 0) {
-          getItemMarkdown(item);
-        }
-
-        return item;
-      }),
-    );
-  }, [data]);
+  const filterList = useMemo(() => {
+    return (data || [])
+      .filter((item) => item.content.includes(searchText))
+      .map((item) => ({
+        ...item,
+        markdown: markdownByMemoName[item.name] ?? item.content,
+      }));
+  }, [data, markdownByMemoName, searchText]);
 
   function getItemUrl(item: MemoInfoResponse) {
     const url = getRequestUrl(`/${item.name}`);
@@ -85,14 +75,15 @@ export default function MemosListCommand() {
 
     markdown += attachmentMarkdowns.join("");
 
-    setFilterList((prevList) => {
-      const updatedList = prevList.map((prevItem) => {
-        if (prevItem.name === item.name) {
-          return { ...prevItem, markdown };
-        }
-        return prevItem;
-      });
-      return updatedList;
+    setMarkdownByMemoName((prev) => {
+      if (prev[item.name] === markdown) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        [item.name]: markdown,
+      };
     });
   }
 
@@ -197,7 +188,7 @@ export default function MemosListCommand() {
 
   return (
     <List
-      isLoading={isLoading}
+      isLoading={isLoading || isLoadingUser}
       filtering={false}
       onSearchTextChange={setSearchText}
       navigationTitle="Search Memos"

--- a/extensions/memos/tests/compatibility.test.mjs
+++ b/extensions/memos/tests/compatibility.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const readSource = (relativePath) => fs.readFileSync(path.join(__dirname, "..", relativePath), "utf8");
+
+test("current user request uses the new auth endpoint with a legacy fallback", () => {
+  const apiSource = readSource("src/api.ts");
+
+  assert.match(apiSource, /\/api\/v1\/auth\/me/);
+  assert.match(apiSource, /\/api\/v1\/auth\/sessions\/current/);
+});
+
+test("memo listing does not parse a numeric user id from the resource name", () => {
+  const listSource = readSource("src/memosList.tsx");
+
+  assert.doesNotMatch(listSource, /split\("\/"\)\[1\]/);
+});
+
+test("memo listing scopes requests with the parent query parameter", () => {
+  const apiSource = readSource("src/api.ts");
+
+  assert.match(apiSource, /params\.set\("parent", creatorName\)/);
+});
+
+test("memo listing does not send a creator filter expression", () => {
+  const apiSource = readSource("src/api.ts");
+
+  assert.doesNotMatch(apiSource, /creator ==/);
+});
+
+test("memo listing does not manually revalidate when the current user changes", () => {
+  const listSource = readSource("src/memosList.tsx");
+
+  assert.doesNotMatch(listSource, /if \(currentUserName\) \{\s*revalidate\(\);/s);
+});
+
+test("memo listing does not keep a derived filter list in local state", () => {
+  const listSource = readSource("src/memosList.tsx");
+
+  assert.doesNotMatch(listSource, /const \[filterList, setFilterList\]/);
+});


### PR DESCRIPTION
## Summary

This PR restores memo listing for newer Memos instances.

It updates the extension to:
- resolve the current user via `/api/v1/auth/me`, with a fallback to the legacy `/api/v1/auth/sessions/current` endpoint for older deployments;
- list memos with the authenticated user's resource name as the `parent` query parameter instead of parsing a numeric ID from `user.name` or using a `creator == ...` filter expression;
- remove the render loop in `MemosListCommand` by deriving the filtered list from fetched data and caching attachment markdown separately.

## Why listing failed before

The previous implementation assumed an older Memos API shape in two places:
- it fetched the current user from `/api/v1/auth/sessions/current`, which newer Memos deployments no longer expose;
- it parsed `user.name` as if it always contained a numeric row id and then rebuilt `parent=users/<id>` from that parsed value.

While investigating this against a current Memos instance, I also found that using a `creator == ...` filter expression for list requests returned an error payload instead of a memo list, whereas `parent=<authenticated user resource name>` returned the expected results. That meant the extension could silently render an empty list even with valid credentials.

On top of that, once list data was available, `MemosListCommand` kept a second derived `filterList` state and updated it from effects, which could trigger a render loop.

## What changed

- Added a compatibility wrapper for the current-user request that prefers `/api/v1/auth/me` and falls back to the legacy endpoint on 404.
- Switched memo list and recent-tag requests to use the authenticated user's resource name directly as `parent`.
- Stopped parsing a numeric user id from `user.name`.
- Removed the extra derived list state from `MemosListCommand` and replaced it with a small markdown cache keyed by memo name.
- Added compatibility tests covering:
  - auth endpoint fallback;
  - resource-name based user handling;
  - `parent`-based memo listing;
  - the absence of the render-loop pattern.

## Verification

- `node --test extensions/memos/tests/compatibility.test.mjs`
- `npm run type-check` in `extensions/memos`
- `npm run lint` in `extensions/memos`
- verified against a live Memos instance that:
  - `/api/v1/auth/me` returns the authenticated user resource name;
  - `/api/v1/memos?parent=<user resource name>` returns memo history;
  - `creator == ...` filtering does not return the expected memo list on that instance.
