### PR TITLE
Update wakatime extension

### DIFF
--- a/extensions/wakatime/.gitignore
+++ b/extensions/wakatime/.gitignore
@@ -1,0 +1,14 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# Raycast specific files
+raycast-env.d.ts
+.raycast-swift-build
+.swiftpm
+compiled_raycast_swift
+compiled_raycast_rust
+
+# misc
+.DS_Store

--- a/extensions/wakatime/CHANGELOG.md
+++ b/extensions/wakatime/CHANGELOG.md
@@ -1,6 +1,6 @@
 # WakaTime Changelog
 
-## [Fixes Avatar Images] - {PR_MERGE_DATE}
+## [Fixes Avatar Images] - 2026-04-20
 
 ### Fixed
 

--- a/extensions/wakatime/CHANGELOG.md
+++ b/extensions/wakatime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # WakaTime Changelog
 
+## [Fixes Avatar Images] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Replaced the non-working `photo_public` field with `is_photo_public` from the WakaTime API when rendering user avatars.
+
 ## [Summary Command Fixes] - 2025-04-17
 
 - Upgrade to `@raycast/api` - v1.96.0

--- a/extensions/wakatime/package-lock.json
+++ b/extensions/wakatime/package-lock.json
@@ -1304,6 +1304,7 @@
       "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1438,6 +1439,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1857,6 +1859,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2754,6 +2757,7 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3039,6 +3043,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3106,6 +3111,7 @@
       "integrity": "sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.30.1",
         "@typescript-eslint/types": "8.30.1",

--- a/extensions/wakatime/package.json
+++ b/extensions/wakatime/package.json
@@ -84,5 +84,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/wakatime/package.json
+++ b/extensions/wakatime/package.json
@@ -5,6 +5,9 @@
   "description": "Show your Wakatime Activity Stats, Projects and Leaderboards",
   "icon": "icon.png",
   "author": "iammola",
+  "contributors": [
+    "olafvanmidden"
+  ],
   "categories": [
     "Productivity",
     "Developer Tools"

--- a/extensions/wakatime/src/components/Leaderboard.tsx
+++ b/extensions/wakatime/src/components/Leaderboard.tsx
@@ -44,7 +44,7 @@ export const LeaderBoardItem: React.FC<LeaderBoardItemProps> = ({
       id={user.id}
       subtitle={`#${rank}`}
       title={user.display_name}
-      icon={user.photo_public ? { source: user.photo, mask: Image.Mask.Circle } : getAvatarIcon(user.display_name)}
+      icon={user.is_photo_public ? { source: user.photo, mask: Image.Mask.Circle } : getAvatarIcon(user.display_name)}
       actions={
         <ActionPanel>
           <ActionPanel.Section title="Item">

--- a/extensions/wakatime/src/summary.tsx
+++ b/extensions/wakatime/src/summary.tsx
@@ -27,7 +27,7 @@ export default function SummaryCommand() {
             title={data.display_name}
             accessories={accessories}
             icon={
-              data.photo_public ? { source: data.photo, mask: Image.Mask.Circle } : getAvatarIcon(data.display_name)
+              data.is_photo_public ? { source: data.photo, mask: Image.Mask.Circle } : getAvatarIcon(data.display_name)
             }
             actions={
               <ActionPanel>

--- a/extensions/wakatime/src/types.ts
+++ b/extensions/wakatime/src/types.ts
@@ -28,7 +28,7 @@ declare global {
         /** email address for public profile. Nullable. */
         public_email: string;
         /** whether this user's photo should be shown on the public leader board */
-        photo_public: boolean;
+        is_photo_public: boolean;
         /** user's timezone in Country/Region format */
         timezone: string | null;
         /** time of most recent heartbeat received in ISO 8601 format */
@@ -297,7 +297,7 @@ declare global {
       /** whether this user's email should be shown publicly on leader boards */
       is_email_public: boolean;
       /** whether this user's photo should be shown publicly on leader boards */
-      photo_public: boolean;
+      is_photo_public: boolean;
       /** user's public photo */
       photo: string;
     }


### PR DESCRIPTION
## Description

- Fix avatar rendering by using WakaTime's correct is_photo_public field
- Update the related WakaTime TypeScript types to match the API response

https://wakatime.com/developers#users

## Screencast

<img width="739" height="64" alt="FixScreenshot" src="https://github.com/user-attachments/assets/caf8acb3-a768-4b0c-92eb-b7209f1b1ed0" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
