### PR TITLE
[Groq] Removed deprecated model

### DIFF
--- a/extensions/groq/CHANGELOG.md
+++ b/extensions/groq/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Groq Changelog
 
+## [Updated Models] - {PR_MERGE_DATE}
+
+- Removed deprecated `Kimi K2 0905 263k` from model selections and pricing metadata
+- Changed the global default model to `OpenAI GPT OSS 120B`
+
 ## [Updated Models] - 2025-11-17
 
 - Removed deprecated `DeepSeek R1 70B 128k`

--- a/extensions/groq/CHANGELOG.md
+++ b/extensions/groq/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Groq Changelog
 
-## [Updated Models] - {PR_MERGE_DATE}
+## [Updated Models] - 2026-04-20
 
 - Removed deprecated `Kimi K2 0905 263k` from model selections and pricing metadata
 - Changed the global default model to `OpenAI GPT OSS 120B`

--- a/extensions/groq/package.json
+++ b/extensions/groq/package.json
@@ -875,7 +875,7 @@
       "description": "LLM model to use for all your commands.",
       "type": "dropdown",
       "required": true,
-      "default": "llama-3.3-70b-versatile",
+      "default": "openai/gpt-oss-120b",
       "data": [
         {
           "value": "openai/gpt-oss-120b",

--- a/extensions/groq/package.json
+++ b/extensions/groq/package.json
@@ -43,10 +43,6 @@
               "title": "GPT OSS 20B 131k"
             },
             {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
-            },
-            {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
               "title": "Llama 4 Maverick 131k"
             },
@@ -103,10 +99,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
             },
             {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
@@ -167,10 +159,6 @@
               "title": "GPT OSS 20B 131k"
             },
             {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
-            },
-            {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
               "title": "Llama 4 Maverick 131k"
             },
@@ -227,10 +215,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
             },
             {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
@@ -291,10 +275,6 @@
               "title": "GPT OSS 20B 131k"
             },
             {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
-            },
-            {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
               "title": "Llama 4 Maverick 131k"
             },
@@ -351,10 +331,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
             },
             {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
@@ -429,10 +405,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
             },
             {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
@@ -510,10 +482,6 @@
               "title": "GPT OSS 20B 131k"
             },
             {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
-            },
-            {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
               "title": "Llama 4 Maverick 131k"
             },
@@ -571,10 +539,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
             },
             {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
@@ -636,10 +600,6 @@
               "title": "GPT OSS 20B 131k"
             },
             {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
-            },
-            {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
               "title": "Llama 4 Maverick 131k"
             },
@@ -697,10 +657,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
             },
             {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
@@ -762,10 +718,6 @@
               "title": "GPT OSS 20B 131k"
             },
             {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
-            },
-            {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
               "title": "Llama 4 Maverick 131k"
             },
@@ -823,10 +775,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
             },
             {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
@@ -888,10 +836,6 @@
               "title": "GPT OSS 20B 131k"
             },
             {
-              "value": "moonshotai/kimi-k2-instruct-0905",
-              "title": "Kimi K2 0905 263k"
-            },
-            {
               "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
               "title": "Llama 4 Maverick 131k"
             },
@@ -940,10 +884,6 @@
         {
           "value": "openai/gpt-oss-20b",
           "title": "GPT OSS 20B 131k"
-        },
-        {
-          "value": "moonshotai/kimi-k2-instruct-0905",
-          "title": "Kimi K2 0905 263k"
         },
         {
           "value": "meta-llama/llama-4-maverick-17b-128e-instruct",

--- a/extensions/groq/src/hook/utils.ts
+++ b/extensions/groq/src/hook/utils.ts
@@ -4,7 +4,6 @@ export const allModels = [
   { name: "Follow global model", id: "global" },
   { name: "GPT OSS 120B 131k", id: "openai/gpt-oss-120b" },
   { name: "GPT OSS 20B 131k", id: "openai/gpt-oss-20b" },
-  { name: "Kimi K2 0905 263k", id: "moonshotai/kimi-k2-instruct-0905" },
   { name: "Qwen 3 32B 128k", id: "qwen/qwen3-32b" },
   { name: "Llama 4 Maverick 131k", id: "meta-llama/llama-4-maverick-17b-128e-instruct" },
   { name: "Llama 4 Scout 131k", id: "meta-llama/llama-4-scout-17b-16e-instruct" },
@@ -20,7 +19,6 @@ const MODEL_RATES: Record<string, { input: number; output: number }> = {
   "llama-3.3-70b-versatile": { input: 0.59, output: 0.79 },
   "llama-3.1-8b-instant": { input: 0.05, output: 0.08 },
   "qwen/qwen3-32b": { input: 0.29, output: 0.59 },
-  "moonshotai/kimi-k2-instruct-0905": { input: 1.0, output: 3.0 },
 };
 
 export const THINKING_MODELS = ["openai/gpt-oss-120b", "openai/gpt-oss-20b", "qwen/qwen3-32b"] as const;


### PR DESCRIPTION
## Description

- Removed deprecated `Kimi K2 0905 263k` from model selections and pricing metadata
- Changed the global default model to `OpenAI GPT OSS 120B`

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
