### PR TITLE
fix(ccusage): add auto-refresh polling to CLI hooks using usageLimitsRefreshInterval preference

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [v2.3.1] - {PR_MERGE_DATE}
+
+### Fixed
+
+- CLI data (daily, monthly, total, session) now auto-refreshes on the configured interval instead of only updating on manual revalidation
+
 ## [v2.3.0] - 2026-03-23
 
 ### Added

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [v2.3.1] - {PR_MERGE_DATE}
+## [v2.3.1] - 2026-04-23
 
 ### Fixed
 

--- a/extensions/ccusage/src/hooks/useCCUsageBlocksCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageBlocksCli.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Cache } from "@raycast/api";
 import { useExec } from "@raycast/utils";
 import { BlocksCommandResponse, BlocksCommandResponseSchema } from "../types/usage-types";
@@ -49,6 +49,12 @@ export const useCCUsageBlocksCli = () => {
       },
     },
   });
+
+  const intervalMs = parseInt(preferences.usageLimitsRefreshInterval || "60", 10) * 1000;
+  useEffect(() => {
+    const id = setInterval(() => result.revalidate(), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs, result.revalidate]);
 
   return result;
 };

--- a/extensions/ccusage/src/hooks/useCCUsageDailyCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageDailyCli.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Cache } from "@raycast/api";
 import { useExec } from "@raycast/utils";
 import { DailyUsageCommandResponse, DailyUsageCommandResponseSchema } from "../types/usage-types";
@@ -48,6 +48,12 @@ export const useCCUsageDailyCli = () => {
       },
     },
   });
+
+  const intervalMs = parseInt(preferences.usageLimitsRefreshInterval || "60", 10) * 1000;
+  useEffect(() => {
+    const id = setInterval(() => result.revalidate(), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
 
   return result;
 };

--- a/extensions/ccusage/src/hooks/useCCUsageDailyCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageDailyCli.ts
@@ -53,7 +53,7 @@ export const useCCUsageDailyCli = () => {
   useEffect(() => {
     const id = setInterval(() => result.revalidate(), intervalMs);
     return () => clearInterval(id);
-  }, [intervalMs]);
+  }, [intervalMs, result.revalidate]);
 
   return result;
 };

--- a/extensions/ccusage/src/hooks/useCCUsageMonthlyCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageMonthlyCli.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Cache } from "@raycast/api";
 import { useExec } from "@raycast/utils";
 import { MonthlyUsageCommandResponse, MonthlyUsageCommandResponseSchema } from "../types/usage-types";
@@ -49,6 +49,12 @@ export const useCCUsageMonthlyCli = () => {
       },
     },
   });
+
+  const intervalMs = parseInt(preferences.usageLimitsRefreshInterval || "60", 10) * 1000;
+  useEffect(() => {
+    const id = setInterval(() => result.revalidate(), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
 
   return result;
 };

--- a/extensions/ccusage/src/hooks/useCCUsageMonthlyCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageMonthlyCli.ts
@@ -54,7 +54,7 @@ export const useCCUsageMonthlyCli = () => {
   useEffect(() => {
     const id = setInterval(() => result.revalidate(), intervalMs);
     return () => clearInterval(id);
-  }, [intervalMs]);
+  }, [intervalMs, result.revalidate]);
 
   return result;
 };

--- a/extensions/ccusage/src/hooks/useCCUsageSessionCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageSessionCli.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Cache } from "@raycast/api";
 import { useExec } from "@raycast/utils";
 import { SessionUsageCommandResponse, SessionUsageCommandResponseSchema } from "../types/usage-types";
@@ -49,6 +49,12 @@ export const useCCUsageSessionCli = () => {
       },
     },
   });
+
+  const intervalMs = parseInt(preferences.usageLimitsRefreshInterval || "60", 10) * 1000;
+  useEffect(() => {
+    const id = setInterval(() => result.revalidate(), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
 
   return result;
 };

--- a/extensions/ccusage/src/hooks/useCCUsageSessionCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageSessionCli.ts
@@ -54,7 +54,7 @@ export const useCCUsageSessionCli = () => {
   useEffect(() => {
     const id = setInterval(() => result.revalidate(), intervalMs);
     return () => clearInterval(id);
-  }, [intervalMs]);
+  }, [intervalMs, result.revalidate]);
 
   return result;
 };

--- a/extensions/ccusage/src/hooks/useCCUsageTotalCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageTotalCli.ts
@@ -54,7 +54,7 @@ export const useCCUsageTotalCli = () => {
   useEffect(() => {
     const id = setInterval(() => result.revalidate(), intervalMs);
     return () => clearInterval(id);
-  }, [intervalMs]);
+  }, [intervalMs, result.revalidate]);
 
   return result;
 };

--- a/extensions/ccusage/src/hooks/useCCUsageTotalCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageTotalCli.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Cache } from "@raycast/api";
 import { useExec } from "@raycast/utils";
 import { TotalUsageResponse, TotalUsageResponseSchema } from "../types/usage-types";
@@ -49,6 +49,12 @@ export const useCCUsageTotalCli = () => {
       },
     },
   });
+
+  const intervalMs = parseInt(preferences.usageLimitsRefreshInterval || "60", 10) * 1000;
+  useEffect(() => {
+    const id = setInterval(() => result.revalidate(), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
 
   return result;
 };


### PR DESCRIPTION
## Description

The four CLI hooks in the `ccusage` extension (`useCCUsageDailyCli`, `useCCUsageMonthlyCli`, `useCCUsageTotalCli`, `useCCUsageSessionCli`) were not auto-refreshing. `useExec` from `@raycast/utils` is a one-shot hook — it fetches once on mount and never polls again. As a result, usage data (today's cost, monthly total, session list) would only update when the user triggered a manual revalidation.

The fix adds a `setInterval` inside each CLI hook that calls `result.revalidate()` on the interval configured by the existing `usageLimitsRefreshInterval` preference (default 60 s). This wires up the refresh cadence that was already exposed as a user preference but had no effect on the CLI hooks.

## Screencast

No visual changes — this is a background data-refresh fix. The displayed figures now update automatically at the configured interval instead of remaining stale until a manual refresh.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
