### PR TITLE
Add ability to move to bottom or hide target language that matches source language in quick translate

### DIFF
--- a/extensions/google-translate/CHANGELOG.md
+++ b/extensions/google-translate/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Google Translate Changelog
 
+## [Feature] - {PR_MERGE_DATE}
+
+ - In the quick translate command, if auto-detected source language is in target list, hide the matching target language or move it to bottom of the list
+ - Added extension preferences for above feature
+
 ## [Feature] - 2026-04-15
 
  - Added pronunciation text to quick translate command

--- a/extensions/google-translate/package.json
+++ b/extensions/google-translate/package.json
@@ -2117,7 +2117,7 @@
     },
     {
       "name": "outputMatchesInput",
-      "title": "If target language matches source",
+      "title": "Target Language Behavior",
       "description": "In the quick translate command, pick what happens when a target language in the list matches the source language",
       "type": "dropdown",
       "required": false,

--- a/extensions/google-translate/package.json
+++ b/extensions/google-translate/package.json
@@ -21,7 +21,9 @@
     "litomore",
     "ChanningKuo",
     "likid",
-    "xmok",
+    "xmok"
+  ],
+  "pastContributors": [
     "brucemakes012"
   ],
   "license": "MIT",
@@ -2110,6 +2112,28 @@
         {
           "title": "Paste to App",
           "value": "paste"
+        }
+      ]
+    },
+    {
+      "name": "outputMatchesInput",
+      "title": "If target language matches source",
+      "description": "In the quick translate command, pick what happens when a target language in the list matches the source language",
+      "type": "dropdown",
+      "required": false,
+      "default": "doNothing",
+      "data": [
+        {
+          "title": "Do nothing",
+          "value": "doNothing"
+        },
+        {
+          "title": "Move target language to bottom",
+          "value": "moveToBottom"
+        },
+        {
+          "title": "Hide target language",
+          "value": "hide"
         }
       ]
     },

--- a/extensions/google-translate/src/QuickTranslate/QuickTranslateListItem.tsx
+++ b/extensions/google-translate/src/QuickTranslate/QuickTranslateListItem.tsx
@@ -36,6 +36,7 @@ export function QuickTranslateListItem(props: {
   if (isLoading) {
     return (
       <List.Item
+        id={langTo.code}
         title={`Translating to ${langTo.name}...`}
         accessories={[
           {
@@ -58,6 +59,7 @@ export function QuickTranslateListItem(props: {
 
   return (
     <List.Item
+      id={langTo.code}
       key={langTo.code}
       title={result.translatedText}
       accessories={[

--- a/extensions/google-translate/src/QuickTranslate/QuickTranslateListItem.tsx
+++ b/extensions/google-translate/src/QuickTranslate/QuickTranslateListItem.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { ActionPanel, List, Toast, showToast } from "@raycast/api";
+import { useEffect } from "react";
 import { usePromise } from "@raycast/utils";
-import { supportedLanguagesByCode } from "../languages";
+import { supportedLanguagesByCode, LanguageCode } from "../languages";
 import { simpleTranslate } from "../simple-translate";
 import { LanguageCodeSet } from "../types";
 import { ConfigurableCopyPasteActions, OpenOnGoogleTranslateWebsiteAction, ToggleFullTextAction } from "../actions";
@@ -12,6 +13,7 @@ export function QuickTranslateListItem(props: {
   isShowingDetail: boolean;
   setIsShowingDetail: (isShowingDetail: boolean) => void;
   setIsLoading: (isLoading: boolean) => void;
+  onDetectedSourceLanguage: (language: LanguageCode) => void;
 }) {
   let langFrom = supportedLanguagesByCode[props.languageSet.langFrom];
   const langTo = supportedLanguagesByCode[props.languageSet.langTo[0]];
@@ -32,6 +34,16 @@ export function QuickTranslateListItem(props: {
       });
     },
   });
+
+  useEffect(() => {
+    if (!result) {
+      return;
+    }
+
+    if (props.languageSet.langFrom === "auto") {
+      props.onDetectedSourceLanguage(result.langFrom);
+    }
+  }, [result, props.languageSet.langFrom, props.onDetectedSourceLanguage]);
 
   if (isLoading) {
     return (

--- a/extensions/google-translate/src/quick-translate.tsx
+++ b/extensions/google-translate/src/quick-translate.tsx
@@ -1,21 +1,64 @@
 import { List } from "@raycast/api";
-import { ReactElement, useState } from "react";
+import { ReactElement, useEffect, useState } from "react";
 import { LanguageDropdown } from "./QuickTranslate/LanguageDropdown";
 import { QuickTranslateListItem } from "./QuickTranslate/QuickTranslateListItem";
 import { useDebouncedValue, usePreferences, useSourceLanguage, useTargetLanguages, useTextState } from "./hooks";
 import { LanguageCode } from "./languages";
+import { AUTO_DETECT, detectLanguage } from "./simple-translate";
 
 export default function QuickTranslate(): ReactElement {
   const [sourceLanguage] = useSourceLanguage();
   const [targetLanguages] = useTargetLanguages();
-  const { proxy } = usePreferences();
+  const { proxy, outputMatchesInput } = usePreferences();
   const [isShowingDetail, setIsShowingDetail] = useState(true);
   const [text, setText] = useTextState();
   const debouncedText = useDebouncedValue(text, 500).trim();
 
-  const [loadingStates, setLoadingStates] = useState(new Map(targetLanguages.map((lang) => [lang, false])));
+  const [detectedSourceLanguage, setDetectedSourceLanguage] = useState<LanguageCode | null>(null);
+
+  useEffect(() => {
+    if (sourceLanguage === AUTO_DETECT && debouncedText) {
+      detectLanguage(debouncedText, proxy).then(setDetectedSourceLanguage);
+    } else {
+      setDetectedSourceLanguage(null);
+    }
+  }, [sourceLanguage, debouncedText, proxy]);
+
+  const effectiveSourceLanguage = sourceLanguage === AUTO_DETECT ? detectedSourceLanguage : sourceLanguage;
+
+  let processedTargetLanguages = targetLanguages;
+  if (effectiveSourceLanguage && targetLanguages.includes(effectiveSourceLanguage)) {
+    if (outputMatchesInput === "hide" && targetLanguages.length > 1) {
+      processedTargetLanguages = targetLanguages.filter((lang) => lang !== effectiveSourceLanguage);
+    } else if (outputMatchesInput === "moveToBottom") {
+      processedTargetLanguages = [
+        ...targetLanguages.filter((lang) => lang !== effectiveSourceLanguage),
+        effectiveSourceLanguage,
+      ];
+    }
+  }
+
+  const [loadingStates, setLoadingStates] = useState(new Map(processedTargetLanguages.map((lang) => [lang, false])));
+
+  useEffect(() => {
+    setLoadingStates(new Map(processedTargetLanguages.map((lang) => [lang, false])));
+  }, [processedTargetLanguages]);
 
   const isAnyLoading = Array.from(loadingStates.values()).some((isLoading) => isLoading);
+
+  const [selectedItemId, setSelectedItemId] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (processedTargetLanguages.length > 0 && outputMatchesInput === "moveToBottom") {
+      setSelectedItemId(processedTargetLanguages[0]);
+    } else {
+      setSelectedItemId(undefined);
+    }
+  }, [processedTargetLanguages, outputMatchesInput]);
+
+  useEffect(() => {
+    setSelectedItemId(undefined);
+  }, [debouncedText]);
 
   function setIsLoading(lang: LanguageCode, isLoading: boolean) {
     setLoadingStates((prev) => new Map(prev).set(lang, isLoading));
@@ -29,9 +72,10 @@ export default function QuickTranslate(): ReactElement {
       isLoading={isAnyLoading}
       isShowingDetail={isShowingDetail}
       searchBarAccessory={<LanguageDropdown />}
+      selectedItemId={selectedItemId}
     >
       {debouncedText
-        ? targetLanguages.map((targetLanguage) => (
+        ? processedTargetLanguages.map((targetLanguage) => (
             <QuickTranslateListItem
               key={targetLanguage}
               debouncedText={debouncedText}

--- a/extensions/google-translate/src/quick-translate.tsx
+++ b/extensions/google-translate/src/quick-translate.tsx
@@ -1,10 +1,10 @@
 import { List } from "@raycast/api";
-import { ReactElement, useEffect, useState } from "react";
+import { ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 import { LanguageDropdown } from "./QuickTranslate/LanguageDropdown";
 import { QuickTranslateListItem } from "./QuickTranslate/QuickTranslateListItem";
 import { useDebouncedValue, usePreferences, useSourceLanguage, useTargetLanguages, useTextState } from "./hooks";
 import { LanguageCode } from "./languages";
-import { AUTO_DETECT, detectLanguage } from "./simple-translate";
+import { AUTO_DETECT } from "./simple-translate";
 
 export default function QuickTranslate(): ReactElement {
   const [sourceLanguage] = useSourceLanguage();
@@ -16,27 +16,31 @@ export default function QuickTranslate(): ReactElement {
 
   const [detectedSourceLanguage, setDetectedSourceLanguage] = useState<LanguageCode | null>(null);
 
+  const handleDetectedSourceLanguage = useCallback((language: LanguageCode) => {
+    setDetectedSourceLanguage((prev) => (prev === language ? prev : language));
+  }, []);
+
   useEffect(() => {
-    if (sourceLanguage === AUTO_DETECT && debouncedText) {
-      detectLanguage(debouncedText, proxy).then(setDetectedSourceLanguage);
-    } else {
+    if (sourceLanguage !== AUTO_DETECT || !debouncedText) {
       setDetectedSourceLanguage(null);
     }
-  }, [sourceLanguage, debouncedText, proxy]);
+  }, [sourceLanguage, debouncedText]);
 
   const effectiveSourceLanguage = sourceLanguage === AUTO_DETECT ? detectedSourceLanguage : sourceLanguage;
 
-  let processedTargetLanguages = targetLanguages;
-  if (effectiveSourceLanguage && targetLanguages.includes(effectiveSourceLanguage)) {
-    if (outputMatchesInput === "hide" && targetLanguages.length > 1) {
-      processedTargetLanguages = targetLanguages.filter((lang) => lang !== effectiveSourceLanguage);
-    } else if (outputMatchesInput === "moveToBottom") {
-      processedTargetLanguages = [
-        ...targetLanguages.filter((lang) => lang !== effectiveSourceLanguage),
-        effectiveSourceLanguage,
-      ];
+  const processedTargetLanguages = useMemo(() => {
+    if (effectiveSourceLanguage && targetLanguages.includes(effectiveSourceLanguage)) {
+      if (outputMatchesInput === "hide" && targetLanguages.length > 1) {
+        return targetLanguages.filter((lang) => lang !== effectiveSourceLanguage);
+      }
+
+      if (outputMatchesInput === "moveToBottom") {
+        return [...targetLanguages.filter((lang) => lang !== effectiveSourceLanguage), effectiveSourceLanguage];
+      }
     }
-  }
+
+    return targetLanguages;
+  }, [targetLanguages, effectiveSourceLanguage, outputMatchesInput]);
 
   const [loadingStates, setLoadingStates] = useState(new Map(processedTargetLanguages.map((lang) => [lang, false])));
 
@@ -83,6 +87,7 @@ export default function QuickTranslate(): ReactElement {
               isShowingDetail={isShowingDetail}
               setIsShowingDetail={setIsShowingDetail}
               setIsLoading={(isLoading) => setIsLoading(targetLanguage, isLoading)}
+              onDetectedSourceLanguage={handleDetectedSourceLanguage}
             />
           ))
         : null}

--- a/extensions/google-translate/src/simple-translate.ts
+++ b/extensions/google-translate/src/simple-translate.ts
@@ -20,7 +20,20 @@ export type SimpleTranslateResult = {
   proxy?: string;
 };
 
-export class TranslateError extends Error {}
+export async function detectLanguage(text: string, proxy?: string): Promise<LanguageCode | null> {
+  try {
+    if (!text) return null;
+    const translated = await translate(text, {
+      from: AUTO_DETECT,
+      to: "en", // dummy
+      raw: true,
+      proxy,
+    });
+    return translated?.from?.language?.iso as LanguageCode;
+  } catch {
+    return null;
+  }
+}
 
 const extractPronounceTextFromRaw = (raw: string) => {
   return raw?.[0]?.[1]?.[2];

--- a/extensions/google-translate/src/simple-translate.ts
+++ b/extensions/google-translate/src/simple-translate.ts
@@ -22,21 +22,6 @@ export type SimpleTranslateResult = {
 
 export class TranslateError extends Error {}
 
-export async function detectLanguage(text: string, proxy?: string): Promise<LanguageCode | null> {
-  try {
-    if (!text) return null;
-    const translated = await translate(text, {
-      from: AUTO_DETECT,
-      to: "en", // dummy
-      raw: true,
-      proxy,
-    });
-    return translated?.from?.language?.iso as LanguageCode;
-  } catch {
-    return null;
-  }
-}
-
 const extractPronounceTextFromRaw = (raw: string) => {
   return raw?.[0]?.[1]?.[2];
 };

--- a/extensions/google-translate/src/simple-translate.ts
+++ b/extensions/google-translate/src/simple-translate.ts
@@ -20,6 +20,8 @@ export type SimpleTranslateResult = {
   proxy?: string;
 };
 
+export class TranslateError extends Error {}
+
 export async function detectLanguage(text: string, proxy?: string): Promise<LanguageCode | null> {
   try {
     if (!text) return null;


### PR DESCRIPTION
## Description

### Problem
As I'm studying Japanese right now, I often use the Quick Translate command to convert from English to Japanese and vice versa. I have English set as the first language in my quick translate output list as I usually want to see what something means in Japanese, but I often want to see how to say something in Japanese as well, and when I type in English I don't want to see it translated into English again. 

### Solution
I added an extension preference for "when target language matches source language", which defaults to "do nothing" so existing users would not be affected unintentionally. The other two options are "move target language to bottom" and "hide target language". In the former, if a target language matches the source language, then that language will be moved to the bottom of the list so the user can browse the other target languages first. The latter option hides the matching target language completely. 

### Coding changes
Changes were made to package.json to add the extension preferences. Changes to simple-translate.tx were necessary in order to get the auto-detected language before the translated text are all loaded. The remaining changes are for implementing the functionality, as well as other minor fixes like resetting the item selection to the first item in "move to bottom" mode, and preventing blank output if target list only has one language in "hide" mode. 

## Screencast

https://github.com/user-attachments/assets/805ddaab-1ea2-4517-a6a3-773702311317

Here's a demo of 1. "do nothing" with current functionality, 2. "move to bottom" mode where english and japanese were moved to the bottom depending on the source language, and 3. "hide" mode with similar test case. Thanks for reviewing this and let me know if anything needs to be changed!

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
