### PR TITLE
[Raindrop.io] Improve add command behavior and collection state

### DIFF
--- a/extensions/raindrop-io/CHANGELOG.md
+++ b/extensions/raindrop-io/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Raindrop.io Extension Changelog
 
+## [Enhancements] - {PR_MERGE_DATE}
+
+- Focus the Collection field first in the bookmark form.
+- Close the Add Bookmark command after a successful save while keeping the window open on errors.
+- Unify last used collection storage and migrate the legacy key.
+
 ## [Fixes] - 2026-03-31
 
 - Fix loading collections in the Save Browser Tab form by building the dropdown options directly from the collections API response.

--- a/extensions/raindrop-io/package.json
+++ b/extensions/raindrop-io/package.json
@@ -20,7 +20,8 @@
     "xmok",
     "luiscarlospando",
     "janrokita",
-    "lemikeone"
+    "lemikeone",
+    "timseriakov"
   ],
   "pastContributors": [
     "sh-cho"

--- a/extensions/raindrop-io/src/add.tsx
+++ b/extensions/raindrop-io/src/add.tsx
@@ -1,5 +1,5 @@
 import { BookmarkForm } from "./components/BookmarkForm";
-import { showToast, Toast, LaunchProps } from "@raycast/api";
+import { closeMainWindow, showHUD, showToast, Toast, LaunchProps } from "@raycast/api";
 
 function AddBookmarks(props: LaunchProps<{ launchContext?: { url?: string; title?: string } }>) {
   const defaultLink = props.launchContext?.url;
@@ -12,8 +12,9 @@ function AddBookmarks(props: LaunchProps<{ launchContext?: { url?: string; title
       onWillSave={() => {
         showToast(Toast.Style.Animated, "Adding Link...");
       }}
-      onSaved={() => {
-        showToast(Toast.Style.Success, "Link Added");
+      onSaved={async () => {
+        await closeMainWindow({ clearRootSearch: true });
+        await showHUD("Link added");
       }}
       onError={() => {
         showToast(Toast.Style.Failure, "Error Adding Link");

--- a/extensions/raindrop-io/src/add.tsx
+++ b/extensions/raindrop-io/src/add.tsx
@@ -1,23 +1,34 @@
 import { BookmarkForm } from "./components/BookmarkForm";
-import { closeMainWindow, showHUD, showToast, Toast, LaunchProps } from "@raycast/api";
-
+import { closeMainWindow, PopToRootType, showToast, Toast, LaunchProps } from "@raycast/api";
+import { useRef } from "react";
 function AddBookmarks(props: LaunchProps<{ launchContext?: { url?: string; title?: string } }>) {
   const defaultLink = props.launchContext?.url;
   const defaultValues = props.launchContext?.title ? { title: props.launchContext.title } : undefined;
+  const toastRef = useRef<Toast | null>(null);
 
   return (
     <BookmarkForm
       defaultLink={defaultLink}
       defaultValues={defaultValues}
       onWillSave={() => {
-        showToast(Toast.Style.Animated, "Adding Link...");
+        const toast = new Toast({ style: Toast.Style.Animated, title: "Adding Link..." });
+        toastRef.current = toast;
+        void toast.show();
       }}
       onSaved={async () => {
-        await closeMainWindow({ clearRootSearch: true });
-        await showHUD("Link added");
+        await toastRef.current?.hide();
+        toastRef.current = null;
+        await closeMainWindow({ clearRootSearch: true, popToRootType: PopToRootType.Immediate });
+        await showToast(Toast.Style.Success, "Link added");
       }}
-      onError={() => {
-        showToast(Toast.Style.Failure, "Error Adding Link");
+      onError={(error) => {
+        if (toastRef.current) {
+          toastRef.current.style = Toast.Style.Failure;
+          toastRef.current.title = "Error Adding Link";
+          toastRef.current.message = error.message;
+          return;
+        }
+        showToast(Toast.Style.Failure, "Error Adding Link", error.message);
       }}
     />
   );

--- a/extensions/raindrop-io/src/components/BookmarkForm.tsx
+++ b/extensions/raindrop-io/src/components/BookmarkForm.tsx
@@ -72,30 +72,29 @@ export const BookmarkForm = (props: BookmarkFormProps) => {
       props.onWillSave?.();
 
       try {
-        const response =
+        if (
           mode === "edit" && props.bookmarkId
-            ? await updateBookmark({
+            ? !(await updateBookmark({
                 preferences,
                 values,
                 bookmarkId: props.bookmarkId,
                 showCollectionCreation,
-              })
-            : await createBookmark({
+              })).ok
+            : !(await createBookmark({
                 preferences,
                 values,
                 showCollectionCreation,
-              });
+              }))
+        ) {
+          throw new Error("Failed to save bookmark");
+        }
 
-        if (response.status === 200) {
-          await props.onSaved?.();
-          if (mode !== "edit" && !props.onSaved) {
-            reset({ link: "", collection: "-1", tags: [] });
-            setDropdownValue("-1");
-            setShowCollectionCreation(false);
-            focus("collection");
-          }
-        } else {
-          throw new Error(response.statusText);
+        await props.onSaved?.();
+        if (mode !== "edit" && !props.onSaved) {
+          reset({ link: "", collection: "-1", tags: [] });
+          setDropdownValue("-1");
+          setShowCollectionCreation(false);
+          focus("collection");
         }
       } catch (error) {
         if (error instanceof Error) {

--- a/extensions/raindrop-io/src/components/BookmarkForm.tsx
+++ b/extensions/raindrop-io/src/components/BookmarkForm.tsx
@@ -49,7 +49,7 @@ type BookmarkFormProps = {
   isLoading?: boolean;
   defaultLink?: string;
   onWillSave?: () => void;
-  onSaved?: () => void;
+  onSaved?: () => void | Promise<void>;
   onError?: (error: Error) => void;
   mode?: "create" | "edit";
   bookmarkId?: number;
@@ -87,11 +87,13 @@ export const BookmarkForm = (props: BookmarkFormProps) => {
               });
 
         if (response.status === 200) {
-          if (mode !== "edit") {
+          await props.onSaved?.();
+          if (mode !== "edit" && !props.onSaved) {
             reset({ link: "", collection: "-1", tags: [] });
-            focus("link");
+            setDropdownValue("-1");
+            setShowCollectionCreation(false);
+            focus("collection");
           }
-          props.onSaved?.();
         } else {
           throw new Error(response.statusText);
         }

--- a/extensions/raindrop-io/src/components/BookmarkForm.tsx
+++ b/extensions/raindrop-io/src/components/BookmarkForm.tsx
@@ -149,7 +149,6 @@ export const BookmarkForm = (props: BookmarkFormProps) => {
         title="Link"
         placeholder="https://example.com"
         info={mode === "edit" ? undefined : "You can add multiple links separated by commas, spaces, or semicolons."}
-        autoFocus
         onBlur={(event) => {
           const link = event.target.value;
           if (link && link !== linkRef.current) {
@@ -167,6 +166,7 @@ export const BookmarkForm = (props: BookmarkFormProps) => {
         {...itemProps.collection}
         title="Collection"
         isLoading={isLoadingCollections}
+        autoFocus
         value={dropdownValue}
         onChange={(newValue: string) => {
           setShowCollectionCreation(newValue === "-2");

--- a/extensions/raindrop-io/src/components/CreateForm.tsx
+++ b/extensions/raindrop-io/src/components/CreateForm.tsx
@@ -27,19 +27,15 @@ export const CreateForm = (props: CreateFormProps) => {
       props.onWillCreate?.();
 
       try {
-        const response = await createBookmark({
+        await createBookmark({
           preferences,
           values,
           showCollectionCreation,
         });
 
-        if (response.status === 200) {
-          reset({ link: "", collection: "-1", tags: [] });
-          focus("link");
-          props.onCreated?.();
-        } else {
-          throw new Error(response.statusText);
-        }
+        reset({ link: "", collection: "-1", tags: [] });
+        focus("link");
+        props.onCreated?.();
       } catch (error) {
         if (error instanceof Error) {
           props.onError?.(error);

--- a/extensions/raindrop-io/src/helpers/utils.ts
+++ b/extensions/raindrop-io/src/helpers/utils.ts
@@ -1,3 +1,4 @@
+import { CreateBookmarksResponse } from "../types";
 import { BrowserExtension, environment } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { CollectionCreationResponse, FormValues } from "../types";
@@ -32,7 +33,7 @@ export async function createBookmark({
   preferences: Preferences;
   values: FormValues;
   showCollectionCreation: boolean;
-}) {
+}): Promise<CreateBookmarksResponse> {
   let collectionId = values.collection;
 
   if (showCollectionCreation && values.newCollection) {
@@ -42,7 +43,7 @@ export async function createBookmark({
     }).then((data) => data.item._id.toString());
   }
 
-  return fetch("https://api.raindrop.io/rest/v1/raindrops", {
+  const response = await fetch("https://api.raindrop.io/rest/v1/raindrops", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -59,6 +60,18 @@ export async function createBookmark({
       })),
     }),
   });
+
+  if (!response.ok) {
+    throw new Error(`Failed to save bookmark: ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as CreateBookmarksResponse;
+
+  if (!data.result || !data.items?.length) {
+    throw new Error("Failed to save bookmark");
+  }
+
+  return data;
 }
 
 /**

--- a/extensions/raindrop-io/src/hooks/useLastUsedCollection.ts
+++ b/extensions/raindrop-io/src/hooks/useLastUsedCollection.ts
@@ -13,6 +13,7 @@ export function useLastUsedCollection() {
     const legacyCollectionId = await LocalStorage.getItem<string>(LEGACY_LAST_USED_COLLECTION_KEY);
     if (legacyCollectionId) {
       await LocalStorage.setItem(LAST_USED_COLLECTION_KEY, legacyCollectionId);
+      await LocalStorage.removeItem(LEGACY_LAST_USED_COLLECTION_KEY);
       return legacyCollectionId;
     }
 

--- a/extensions/raindrop-io/src/hooks/useLastUsedCollection.ts
+++ b/extensions/raindrop-io/src/hooks/useLastUsedCollection.ts
@@ -1,8 +1,7 @@
+import { LocalStorage } from "@raycast/api";
+
 export const LAST_USED_COLLECTION_KEY = "last-used-collection";
 const LEGACY_LAST_USED_COLLECTION_KEY = "lastUsedCollection";
-
-
-import { LocalStorage } from "@raycast/api";
 
 export function useLastUsedCollection() {
   const getLastUsedCollection = async () => {

--- a/extensions/raindrop-io/src/hooks/useLastUsedCollection.ts
+++ b/extensions/raindrop-io/src/hooks/useLastUsedCollection.ts
@@ -1,12 +1,27 @@
+export const LAST_USED_COLLECTION_KEY = "last-used-collection";
+const LEGACY_LAST_USED_COLLECTION_KEY = "lastUsedCollection";
+
+
 import { LocalStorage } from "@raycast/api";
 
 export function useLastUsedCollection() {
   const getLastUsedCollection = async () => {
-    return await LocalStorage.getItem<string>("lastUsedCollection");
+    const collectionId = await LocalStorage.getItem<string>(LAST_USED_COLLECTION_KEY);
+    if (collectionId) {
+      return collectionId;
+    }
+
+    const legacyCollectionId = await LocalStorage.getItem<string>(LEGACY_LAST_USED_COLLECTION_KEY);
+    if (legacyCollectionId) {
+      await LocalStorage.setItem(LAST_USED_COLLECTION_KEY, legacyCollectionId);
+      return legacyCollectionId;
+    }
+
+    return null;
   };
 
   const setLastUsedCollection = async (collectionId: string) => {
-    await LocalStorage.setItem("lastUsedCollection", collectionId);
+    await LocalStorage.setItem(LAST_USED_COLLECTION_KEY, collectionId);
   };
 
   return { getLastUsedCollection, setLastUsedCollection };

--- a/extensions/raindrop-io/src/latest_bookmarks.tsx
+++ b/extensions/raindrop-io/src/latest_bookmarks.tsx
@@ -5,11 +5,11 @@ import BookmarkItem from "./components/BookmarkItem";
 import CollectionsDropdown from "./components/CollectionsDropdown";
 import { Bookmark } from "./types";
 import { useRequest } from "./hooks/useRequest";
-import { useLastUsedCollection } from "./hooks/useLastUsedCollection";
+import { LAST_USED_COLLECTION_KEY, useLastUsedCollection } from "./hooks/useLastUsedCollection";
 
 export default function LatestBookmarks() {
   const preferences: Preferences = getPreferenceValues();
-  const [lastUsedCollection, setLastUsedCollection] = useCachedState<string>("last-used-collection", "0");
+  const [lastUsedCollection, setLastUsedCollection] = useCachedState<string>(LAST_USED_COLLECTION_KEY, "0");
 
   const { getLastUsedCollection, setLastUsedCollection: setNextCollectionToUse } = useLastUsedCollection();
 

--- a/extensions/raindrop-io/src/quick_add.tsx
+++ b/extensions/raindrop-io/src/quick_add.tsx
@@ -25,7 +25,7 @@ export default async function QuickAddBookmark(props: LaunchProps<{ arguments: A
     const title = await getLinkTitle(url);
 
     // Create bookmark in Unsorted collection (-1)
-    const response = await createBookmark({
+    await createBookmark({
       preferences,
       values: {
         link: url,
@@ -35,10 +35,6 @@ export default async function QuickAddBookmark(props: LaunchProps<{ arguments: A
       },
       showCollectionCreation: false,
     });
-
-    if (!response.ok) {
-      throw new Error("Failed to save bookmark");
-    }
 
     toast.style = Toast.Style.Success;
     toast.title = "Bookmark saved";

--- a/extensions/raindrop-io/src/save_browser_tab.tsx
+++ b/extensions/raindrop-io/src/save_browser_tab.tsx
@@ -1,23 +1,35 @@
-import { Toast, closeMainWindow, showHUD, showToast } from "@raycast/api";
+import { Toast, closeMainWindow, PopToRootType, showToast } from "@raycast/api";
+import { useRef } from "react";
 import { BookmarkForm } from "./components/BookmarkForm";
 import { useBrowserLink } from "./hooks/useBrowserLink";
 
 const AddBrowserTab = () => {
   const { isLoading, data: link } = useBrowserLink();
+  const toastRef = useRef<Toast | null>(null);
 
   return (
     <BookmarkForm
       isLoading={isLoading}
       defaultLink={link}
       onWillSave={() => {
-        showToast(Toast.Style.Animated, "Adding Link...");
+        const toast = new Toast({ style: Toast.Style.Animated, title: "Adding Link..." });
+        toastRef.current = toast;
+        void toast.show();
       }}
       onSaved={async () => {
-        await closeMainWindow({ clearRootSearch: true });
-        await showHUD("Link added");
+        await toastRef.current?.hide();
+        toastRef.current = null;
+        await closeMainWindow({ clearRootSearch: true, popToRootType: PopToRootType.Immediate });
+        await showToast(Toast.Style.Success, "Link added");
       }}
-      onError={() => {
-        showToast(Toast.Style.Failure, "Error Adding Link");
+      onError={(error) => {
+        if (toastRef.current) {
+          toastRef.current.style = Toast.Style.Failure;
+          toastRef.current.title = "Error Adding Link";
+          toastRef.current.message = error.message;
+          return;
+        }
+        showToast(Toast.Style.Failure, "Error Adding Link", error.message);
       }}
     />
   );

--- a/extensions/raindrop-io/src/search.tsx
+++ b/extensions/raindrop-io/src/search.tsx
@@ -6,11 +6,11 @@ import BookmarkItem from "./components/BookmarkItem";
 import CollectionsDropdown from "./components/CollectionsDropdown";
 import { Bookmark } from "./types";
 import { useRequest } from "./hooks/useRequest";
-import { useLastUsedCollection } from "./hooks/useLastUsedCollection";
+import { LAST_USED_COLLECTION_KEY, useLastUsedCollection } from "./hooks/useLastUsedCollection";
 
 export default function Main(): ReactElement {
   const preferences = getPreferenceValues();
-  const [lastUsedCollection, setLastUsedCollection] = useCachedState<string>("last-used-collection", "0");
+  const [lastUsedCollection, setLastUsedCollection] = useCachedState<string>(LAST_USED_COLLECTION_KEY, "0");
 
   const { getLastUsedCollection, setLastUsedCollection: setNextCollectionToUse } = useLastUsedCollection();
 


### PR DESCRIPTION
## Description
- focus the `Collection` field first in the Add Bookmark flow to reduce input friction
- immediately dismiss the Add Bookmark view after submit while preventing Raycast from restoring it on the next open
- validate bookmark creation against the Raindrop API response body so success is shown only when items were actually created
- improve Add Bookmark and Save Browser Tab feedback so success and failure are surfaced after the view closes
- unify last used collection storage under a single key and migrate the legacy key
- add changelog and contributor metadata updates required for upstream review

## Screencast
- existing extension/commands, no new UI surface

<img width="2992" height="1868" alt="SCR-20260421-qona" src="https://github.com/user-attachments/assets/6eff006c-70f9-4fbc-934e-410281cb86c6" />

## Validation
- `npm run build` in `extensions/raindrop-io` ✅
- `npm run lint` in `extensions/raindrop-io` ✅
- manual Raycast dev-flow verification for collection focus, close-after-submit, real-create validation, and post-close success feedback ✅

## Checklist
- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)