### PR TITLE
[Skills] Fix node homebrew versioned formula resolution

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Fix Homebrew `node@` Resolution and add Custom `npx` Validation] - {PR_MERGE_DATE}
+## [Fix Homebrew `node@` Resolution and add Custom `npx` Validation] - 2026-04-23
 
 - Detect versioned Homebrew Node formula bins like `/opt/homebrew/opt/node@24/bin` so the Skills CLI can find `node` when `npx` comes from Homebrew, while still preferring Node installs from version managers first
 - Validate the optional "Custom npx Path" override before running the CLI and show a clearer error detail when the configured path is incorrect

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Skills Changelog
 
+## [Fix Homebrew `node@` Resolution and add Custom `npx` Validation] - {PR_MERGE_DATE}
+
+- Detect versioned Homebrew Node formula bins like `/opt/homebrew/opt/node@24/bin` so the Skills CLI can find `node` when `npx` comes from Homebrew
+- Validate the optional "Custom npx Path" override before running the CLI and show a clearer error detail when the configured path is incorrect
+
 ## [Fix Silent Auto-Update on Load] - 2026-04-21
 
 - Stop silently auto-updating outdated skills when opening Manage Skills

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Fix Homebrew `node@` Resolution and add Custom `npx` Validation] - {PR_MERGE_DATE}
 
-- Detect versioned Homebrew Node formula bins like `/opt/homebrew/opt/node@24/bin` so the Skills CLI can find `node` when `npx` comes from Homebrew
+- Detect versioned Homebrew Node formula bins like `/opt/homebrew/opt/node@24/bin` so the Skills CLI can find `node` when `npx` comes from Homebrew, while still preferring Node installs from version managers first
 - Validate the optional "Custom npx Path" override before running the CLI and show a clearer error detail when the configured path is incorrect
 
 ## [Fix Silent Auto-Update on Load] - 2026-04-21

--- a/extensions/skills/package.json
+++ b/extensions/skills/package.json
@@ -40,7 +40,7 @@
     {
       "name": "customNpxPath",
       "title": "Custom npx Path",
-      "description": "Optional custom `npx` path override for cases when the extension cannot detect it automatically.",
+      "description": "Optional override for the `npx` executable when automatic detection does not work.",
       "placeholder": "e.g., /opt/homebrew/bin/npx or ~/.local/bin/npx",
       "type": "textfield",
       "required": false

--- a/extensions/skills/src/manage-skills.tsx
+++ b/extensions/skills/src/manage-skills.tsx
@@ -1,7 +1,7 @@
 import { List, Detail, Icon, ActionPanel, Action, Color, openExtensionPreferences } from "@raycast/api";
 import { useState } from "react";
 import { useInstalledSkills } from "./hooks/useInstalledSkills";
-import { isNpxResolutionError } from "./utils/skills-cli";
+import { isInvalidCustomNpxPathError, isNpxResolutionError } from "./utils/skills-cli";
 import { InstalledSkillListItem } from "./components/InstalledSkillListItem";
 import { UpdateSkillAction } from "./components/actions/UpdateSkillAction";
 
@@ -11,16 +11,31 @@ export default function Command() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [isShowingDetail, setIsShowingDetail] = useState(true);
   const toggleDetail = () => setIsShowingDetail((prev) => !prev);
+  const hasInvalidCustomNpxPathError = error ? isInvalidCustomNpxPathError(error) : false;
   const hasNpxResolutionError = error ? isNpxResolutionError(error) : false;
 
   if (error && skills.length === 0) {
-    const errorDetails = hasNpxResolutionError
-      ? "This is an `npx` resolution issue in the local CLI runtime.\n\n1. Run `which npx` in Terminal.\n2. Open Extension Preferences (`Cmd+Shift+,`).\n3. Set **Custom npx Path** to the path from step 1, then retry."
-      : "This is a local Skills CLI execution failure.\n\n1. Retry the command.\n2. Open Extension Preferences and verify **Custom npx Path** if you use a non-standard Node.js setup.\n3. Run `npx -y skills@latest list -g` in Terminal to inspect the underlying CLI error.";
+    const { errorTitle, errorDetails } = hasInvalidCustomNpxPathError
+      ? {
+          errorTitle: "Invalid Custom npx Path",
+          errorDetails:
+            "The configured **Custom npx Path** does not point to a valid `npx` executable.\n\n1. Open Extension Preferences (`Cmd+Shift+,`).\n2. Fix or clear **Custom npx Path**.\n3. If unsure, run `which npx` in Terminal and use that value.",
+        }
+      : hasNpxResolutionError
+        ? {
+            errorTitle: "Unable to Load Installed Skills",
+            errorDetails:
+              "This is an `npx` resolution issue in the local CLI runtime.\n\n1. Run `which npx` in Terminal.\n2. Open Extension Preferences (`Cmd+Shift+,`).\n3. Set **Custom npx Path** to the path from step 1, then retry.",
+          }
+        : {
+            errorTitle: "Unable to Load Installed Skills",
+            errorDetails:
+              "This is a local Skills CLI execution failure.\n\n1. Retry the command.\n2. Open Extension Preferences and verify **Custom npx Path** if you use a non-standard Node.js setup.\n3. Run `npx -y skills@latest list -g` in Terminal to inspect the underlying CLI error.",
+          };
 
     return (
       <Detail
-        markdown={`# Unable to Load Installed Skills\n\n**Error:** ${error.message}\n\n---\n\n${errorDetails}`}
+        markdown={`# ${errorTitle}\n\n**Error:** ${error.message}\n\n---\n\n${errorDetails}`}
         actions={
           <ActionPanel>
             <Action title="Retry" onAction={revalidate} icon={Icon.RotateClockwise} />

--- a/extensions/skills/src/utils/node-path-resolver.ts
+++ b/extensions/skills/src/utils/node-path-resolver.ts
@@ -3,30 +3,17 @@ import { cpus } from "node:os";
 import { join } from "node:path";
 import semver from "semver";
 
+type VersionedPath = {
+  path: string;
+  version: string;
+};
+
 const isWindows = process.platform === "win32";
 const isMacOS = process.platform === "darwin";
 
-let cachedPaths: string | null = null;
-let cachedPathsPromise: Promise<string> | null = null;
 let cachedIsAppleSilicon: boolean | null = null;
-
-const getAppleSiliconStatus = (): boolean => {
-  if (cachedIsAppleSilicon !== null) return cachedIsAppleSilicon;
-  cachedIsAppleSilicon = cpus()[0]?.model?.includes("Apple") ?? false;
-  return cachedIsAppleSilicon;
-};
-
-const parseVersion = (version: string): number => {
-  const coerced = semver.coerce(version);
-  if (!coerced) return 0;
-
-  // Convert semver to a sortable number so directory names can be ordered newest-first
-  return coerced.major * 1000000 + coerced.minor * 1000 + coerced.patch;
-};
-
-const sortPathsByVersion = (paths: Array<{ path: string; version: string }>): string[] => {
-  return paths.sort((a, b) => parseVersion(b.version) - parseVersion(a.version)).map((item) => item.path);
-};
+let cachedPathsPromise: Promise<string> | null = null;
+let cachedPaths: string | null = null;
 
 export const pathExists = async (path: string): Promise<boolean> => {
   try {
@@ -37,13 +24,29 @@ export const pathExists = async (path: string): Promise<boolean> => {
   }
 };
 
-const resolveExistingVersionedPaths = async (
-  versionedPaths: Array<{ path: string; version: string }>,
-): Promise<Array<{ path: string; version: string }>> => {
+const isAppleSilicon = (): boolean => {
+  if (cachedIsAppleSilicon !== null) return cachedIsAppleSilicon;
+  cachedIsAppleSilicon = cpus()[0]?.model?.includes("Apple") ?? false;
+  return cachedIsAppleSilicon;
+};
+
+const getVersionSortKey = (version: string): number => {
+  const coerced = semver.coerce(version);
+  if (!coerced) return 0;
+
+  // Convert semver to a sortable number so directory names can be ordered newest-first
+  return coerced.major * 1000000 + coerced.minor * 1000 + coerced.patch;
+};
+
+const sortPathsByVersion = (paths: VersionedPath[]): string[] => {
+  return paths.sort((a, b) => getVersionSortKey(b.version) - getVersionSortKey(a.version)).map((item) => item.path);
+};
+
+const resolveExistingVersionedPaths = async (versionedPaths: VersionedPath[]): Promise<VersionedPath[]> => {
   const results = await Promise.all(
     versionedPaths.map(async (versionedPath) => ((await pathExists(versionedPath.path)) ? versionedPath : null)),
   );
-  return results.filter((item): item is { path: string; version: string } => item !== null);
+  return results.filter((item): item is VersionedPath => item !== null);
 };
 
 const resolveExistingPaths = async (paths: string[]): Promise<string[]> => {
@@ -51,13 +54,45 @@ const resolveExistingPaths = async (paths: string[]): Promise<string[]> => {
   return results.filter((path): path is string => path !== null);
 };
 
+const resolveExistingVersionedExecutablePaths = async (
+  versionedPaths: VersionedPath[],
+  executableName: string,
+): Promise<VersionedPath[]> => {
+  const results = await Promise.all(
+    versionedPaths.map(async (versionedPath) =>
+      (await pathExists(join(versionedPath.path, executableName))) ? versionedPath : null,
+    ),
+  );
+
+  return results.filter((item): item is VersionedPath => item !== null);
+};
+
 const scanVersionedNodePaths = async (
   versionsDir: string,
   getBinPath: (version: string) => string,
-): Promise<Array<{ path: string; version: string }>> => {
+): Promise<VersionedPath[]> => {
   try {
     const nodeVersions = await readdir(versionsDir);
     return resolveExistingVersionedPaths(nodeVersions.map((version) => ({ path: getBinPath(version), version })));
+  } catch {
+    return [];
+  }
+};
+
+const resolveHomebrewVersionedNodePaths = async (homebrewPrefix: string): Promise<string[]> => {
+  const homebrewOptDir = join(homebrewPrefix, "opt");
+
+  try {
+    const formulas = await readdir(homebrewOptDir);
+    const versionedPaths: VersionedPath[] = formulas
+      .filter((formula) => /^node@.+$/.test(formula))
+      .map((formula) => ({
+        path: join(homebrewOptDir, formula, "bin"),
+        version: formula.slice("node@".length),
+      }));
+
+    const existingVersionedPaths = await resolveExistingVersionedExecutablePaths(versionedPaths, "node");
+    return sortPathsByVersion(existingVersionedPaths);
   } catch {
     return [];
   }
@@ -107,13 +142,14 @@ export const resolveVersionManagerPaths = async (): Promise<string[]> => {
 };
 
 const buildEnhancedNodePaths = async (): Promise<string> => {
-  const isAppleSilicon = getAppleSiliconStatus();
+  const homebrewPrefix = isAppleSilicon() ? "/opt/homebrew" : "/usr/local";
 
-  const platformPaths = isAppleSilicon
-    ? ["/opt/homebrew/bin", "/opt/homebrew/lib/node_modules/.bin"]
-    : ["/usr/local/bin", "/usr/local/lib/node_modules/.bin"];
+  const homebrewPaths = [join(homebrewPrefix, "bin"), join(homebrewPrefix, "lib", "node_modules", ".bin")];
 
-  const versionManagerPaths = await resolveVersionManagerPaths();
+  const [homebrewVersionedNodePaths, versionManagerPaths] = await Promise.all([
+    resolveHomebrewVersionedNodePaths(homebrewPrefix),
+    resolveVersionManagerPaths(),
+  ]);
 
   const systemPaths = ["/usr/bin", "/bin"];
 
@@ -121,7 +157,13 @@ const buildEnhancedNodePaths = async (): Promise<string> => {
     systemPaths.push(`${process.env.HOME}/.npm/bin`, `${process.env.HOME}/.yarn/bin`);
   }
 
-  const allPaths = [...platformPaths, ...versionManagerPaths, ...systemPaths, process.env.PATH || ""];
+  const allPaths = [
+    ...homebrewPaths,
+    ...homebrewVersionedNodePaths,
+    ...versionManagerPaths,
+    ...systemPaths,
+    process.env.PATH || "",
+  ];
 
   cachedPaths = allPaths.filter((path) => path).join(":");
   return cachedPaths;

--- a/extensions/skills/src/utils/node-path-resolver.ts
+++ b/extensions/skills/src/utils/node-path-resolver.ts
@@ -158,9 +158,9 @@ const buildEnhancedNodePaths = async (): Promise<string> => {
   }
 
   const allPaths = [
-    ...homebrewPaths,
-    ...homebrewVersionedNodePaths,
     ...versionManagerPaths,
+    ...homebrewVersionedNodePaths,
+    ...homebrewPaths,
     ...systemPaths,
     process.env.PATH || "",
   ];

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -10,6 +10,9 @@ import { getExecOptions } from "./exec-options";
 const home = homedir();
 const isWindows = process.platform === "win32";
 
+let validatedCustomNpxPath: string | null = null;
+let pendingCustomNpxValidation: { path: string; promise: Promise<void> } | null = null;
+
 type ExecFailure = Error & {
   code?: string | number;
   stderr?: string;
@@ -80,6 +83,28 @@ function normalizeCliError(error: unknown, npxCommand: string): Error {
 }
 
 async function validateCustomNpxPath(customNpxPath: string): Promise<void> {
+  if (validatedCustomNpxPath === customNpxPath) {
+    return;
+  }
+
+  if (pendingCustomNpxValidation?.path === customNpxPath) {
+    return pendingCustomNpxValidation.promise;
+  }
+
+  const validationPromise = assertValidCustomNpxPath(customNpxPath);
+  pendingCustomNpxValidation = { path: customNpxPath, promise: validationPromise };
+
+  try {
+    await validationPromise;
+    validatedCustomNpxPath = customNpxPath;
+  } finally {
+    if (pendingCustomNpxValidation?.path === customNpxPath) {
+      pendingCustomNpxValidation = null;
+    }
+  }
+}
+
+async function assertValidCustomNpxPath(customNpxPath: string): Promise<void> {
   const invalidPathMessage =
     "The configured Custom npx Path is incorrect. It must point to the `npx` executable. Update the path in the extension configuration or clear it to use automatic detection.";
 
@@ -88,16 +113,13 @@ async function validateCustomNpxPath(customNpxPath: string): Promise<void> {
     throw new InvalidCustomNpxPathError(invalidPathMessage);
   }
 
+  let fileStats;
   try {
-    const fileStats = await stat(customNpxPath);
-    if (fileStats.isDirectory()) {
-      throw new InvalidCustomNpxPathError(invalidPathMessage);
-    }
-  } catch (error) {
-    if (error instanceof InvalidCustomNpxPathError) {
-      throw error;
-    }
-
+    fileStats = await stat(customNpxPath);
+  } catch {
+    throw new InvalidCustomNpxPathError(invalidPathMessage);
+  }
+  if (fileStats.isDirectory()) {
     throw new InvalidCustomNpxPathError(invalidPathMessage);
   }
 

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -49,7 +49,8 @@ async function runSkillsCli(args: string[]): Promise<string> {
 
   const npxCommand = customNpxPath ?? "npx";
   try {
-    const { stdout } = await execAsync(buildSkillsCliCommand(npxCommand, args), await getExecOptions());
+    const execOptions = await getExecOptions();
+    const { stdout } = await execAsync(buildSkillsCliCommand(npxCommand, args), execOptions);
     return stdout;
   } catch (error) {
     throw normalizeCliError(error, npxCommand);
@@ -67,7 +68,7 @@ function shellEscape(arg: string): string {
 function normalizeCliError(error: unknown, npxCommand: string): Error {
   if (isNpxCommandResolutionFailure(error, npxCommand)) {
     return new NpxResolutionError(
-      "Unable to find a working npx command. Run `which npx` in Terminal, then set that path in Extension Preferences under 'Custom npx Path'.",
+      "Unable to find a working npx command. Run `which npx` in Terminal, then set that path in the extension configuration under 'Custom npx Path'.",
     );
   }
 
@@ -80,7 +81,7 @@ function normalizeCliError(error: unknown, npxCommand: string): Error {
 
 async function validateCustomNpxPath(customNpxPath: string): Promise<void> {
   const invalidPathMessage =
-    "The configured Custom npx Path is incorrect. It must point to the `npx` executable. Update the path in Extension Preferences or clear it to use automatic detection.";
+    "The configured Custom npx Path is incorrect. It must point to the `npx` executable. Update the path in the extension configuration or clear it to use automatic detection.";
 
   const executableNames = isWindows ? new Set(["npx", "npx.cmd", "npx.exe"]) : new Set(["npx"]);
   if (!executableNames.has(basename(customNpxPath).toLowerCase())) {

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -1,4 +1,5 @@
-import { readFile } from "node:fs/promises";
+import { access, readFile, stat } from "node:fs/promises";
+import { constants } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import { getCustomNpxPath, preferences } from "../preferences";
@@ -25,12 +26,28 @@ export function isNpxResolutionError(error: unknown): boolean {
   return error instanceof NpxResolutionError;
 }
 
+export class InvalidCustomNpxPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidCustomNpxPathError";
+  }
+}
+
+export function isInvalidCustomNpxPathError(error: unknown): boolean {
+  return error instanceof InvalidCustomNpxPathError;
+}
+
 function buildSkillsCliCommand(npxCommand: string, args: string[]): string {
   return [npxCommand, "-y", "skills@latest", ...args].map(shellEscape).join(" ");
 }
 
 async function runSkillsCli(args: string[]): Promise<string> {
-  const npxCommand = getCustomNpxPath() ?? "npx";
+  const customNpxPath = getCustomNpxPath();
+  if (customNpxPath) {
+    await validateCustomNpxPath(customNpxPath);
+  }
+
+  const npxCommand = customNpxPath ?? "npx";
   try {
     const { stdout } = await execAsync(buildSkillsCliCommand(npxCommand, args), await getExecOptions());
     return stdout;
@@ -59,6 +76,37 @@ function normalizeCliError(error: unknown, npxCommand: string): Error {
   }
 
   return new Error("Failed to execute the skills CLI command.");
+}
+
+async function validateCustomNpxPath(customNpxPath: string): Promise<void> {
+  const invalidPathMessage =
+    "The configured Custom npx Path is incorrect. It must point to the `npx` executable. Update the path in Extension Preferences or clear it to use automatic detection.";
+
+  const executableNames = isWindows ? new Set(["npx", "npx.cmd", "npx.exe"]) : new Set(["npx"]);
+  if (!executableNames.has(basename(customNpxPath).toLowerCase())) {
+    throw new InvalidCustomNpxPathError(invalidPathMessage);
+  }
+
+  try {
+    const fileStats = await stat(customNpxPath);
+    if (fileStats.isDirectory()) {
+      throw new InvalidCustomNpxPathError(invalidPathMessage);
+    }
+  } catch (error) {
+    if (error instanceof InvalidCustomNpxPathError) {
+      throw error;
+    }
+
+    throw new InvalidCustomNpxPathError(invalidPathMessage);
+  }
+
+  if (!isWindows) {
+    try {
+      await access(customNpxPath, constants.X_OK);
+    } catch {
+      throw new InvalidCustomNpxPathError(invalidPathMessage);
+    }
+  }
 }
 
 function isNpxCommandResolutionFailure(error: unknown, npxCommand: string): boolean {


### PR DESCRIPTION
## Description

Fixes #27297

Fix two related `skills` extension issues around local Node.js path resolution.

- Add support for versioned Homebrew Node formula paths such as `/opt/homebrew/opt/node@24/bin` when building the CLI `PATH`. This fixes cases where Raycast can find Homebrew `npx` but not the matching `node` binary.
- Validate the optional `Custom npx Path` before spawning the CLI and show a clearer error when the configured path is incorrect, instead of surfacing a misleading downstream command failure.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
