### PR TITLE
Update microsoft-teams-calling extension

### DIFF
--- a/extensions/microsoft-teams-calling/CHANGELOG.md
+++ b/extensions/microsoft-teams-calling/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Microsoft Teams Changelog
 
+## [Fix Teams API 2.0 Permissions] - {PR_MERGE_DATE}
+
+- Stops Teams seeking user permission every time the extension performs an action.
+
 ## [Fix Notifications] - 2024-04-04
 
 - Fix inverted notifications for quick actions toggle mute and toggle camera.

--- a/extensions/microsoft-teams-calling/CHANGELOG.md
+++ b/extensions/microsoft-teams-calling/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Microsoft Teams Changelog
 
-## [Fix Teams API 2.0 Permissions] - {PR_MERGE_DATE}
+## [Fix Teams API 2.0 Permissions] - 2026-04-22
 
 - Stops Teams seeking user permission every time the extension performs an action.
 

--- a/extensions/microsoft-teams-calling/package.json
+++ b/extensions/microsoft-teams-calling/package.json
@@ -5,6 +5,9 @@
   "description": "Control your meeting with the keyboard, even when Microsoft Teams is in the background. Toggle microphone, camera and background blur and send reactions.",
   "icon": "teams.png",
   "author": "sven",
+  "contributors": [
+    "leec-666"
+  ],
   "categories": [
     "Applications",
     "Communication"

--- a/extensions/microsoft-teams-calling/package.json
+++ b/extensions/microsoft-teams-calling/package.json
@@ -49,8 +49,14 @@
       "description": "Classic Teams or New Teams",
       "type": "dropdown",
       "data": [
-        {"title": "Classic Teams", "value": "classic"}, 
-        {"title": "New Teams", "value": "new"}
+        {
+          "title": "Classic Teams",
+          "value": "classic"
+        },
+        {
+          "title": "New Teams",
+          "value": "new"
+        }
       ],
       "default": "new",
       "required": true
@@ -83,5 +89,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/microsoft-teams-calling/src/teams/meetingClientV2.ts
+++ b/extensions/microsoft-teams-calling/src/teams/meetingClientV2.ts
@@ -25,6 +25,7 @@ const manufacturer = "Sven Wiegand";
 const device = "Raycast";
 const app = "Raycast";
 const appVersion = "1.0.0";
+const tokenRefreshTimeoutMs = 5000;
 
 type MeetingActionV2 =
   | ToggleMuteAction
@@ -76,6 +77,9 @@ export class MeetingClientV2 implements MeetingClient {
   private ws: WebSocket | undefined;
   private readonly updateMessageDeferred: Deferred<UpdateMessage>[] = [];
   private readonly messageCallback: ((msg: UpdateMessage) => void) | undefined;
+  private tokenRefreshDeferred = new Deferred<void>();
+  private tokenSave: Promise<void> = Promise.resolve();
+  private connectedWithToken = false;
   private lastCommandFinished = false;
   private lastUpdate = {} as UpdateMessage;
 
@@ -94,16 +98,18 @@ export class MeetingClientV2 implements MeetingClient {
   }
 
   private connectWS(token: string | undefined, props: MeetingClientProps) {
-    const queryParams = {
+    this.connectedWithToken = Boolean(token);
+    const queryParams = new URLSearchParams({
       "protocol-version": apiVersion,
       manufacturer,
       device,
       app,
       "app-version": appVersion,
-    };
-    const paramNames = Object.keys(queryParams) as (keyof typeof queryParams)[];
-    const params = paramNames.map((key) => `${key}=${encodeURI(queryParams[key])}`).join("&");
-    const url = `ws://${host}:${port}?${token ? "token=" + token : ""}&${params}`;
+    });
+    if (token) {
+      queryParams.set("token", token);
+    }
+    const url = `ws://${host}:${port}?${queryParams.toString()}`;
 
     console.debug(`Connecting to ${url} …`);
     this.ws = new WebSocket(url);
@@ -140,7 +146,8 @@ export class MeetingClientV2 implements MeetingClient {
       this.messageCallback?.(statusMessageV1);
     } else if (this.isTokenRefreshMessage(msg)) {
       console.debug("Refresh token message. Updating local storage.");
-      setToken(msg.tokenRefresh);
+      this.tokenSave = setToken(msg.tokenRefresh);
+      this.tokenRefreshDeferred.resolve();
     } else if (this.isResponseMessage(msg)) {
       if (msg.requestId === 0) {
         // only for responses to our requests
@@ -200,7 +207,23 @@ export class MeetingClientV2 implements MeetingClient {
     const deferredUpdateMessage = new Deferred<UpdateMessage>();
     this.updateMessageDeferred.push(deferredUpdateMessage);
     this.sendAction(action);
-    return deferredUpdateMessage.promise;
+    const updateMessage = await deferredUpdateMessage.promise;
+    await this.waitForTokenRefreshIfPairing(updateMessage);
+    return updateMessage;
+  }
+
+  private async waitForTokenRefreshIfPairing(updateMessage: UpdateMessage) {
+    const mightBePairing = !this.connectedWithToken || updateMessage.meetingUpdate.meetingPermissions.canPair;
+    if (!mightBePairing) {
+      await this.tokenSave;
+      return;
+    }
+
+    await Promise.race([
+      this.tokenRefreshDeferred.promise,
+      new Promise<void>((resolve) => setTimeout(resolve, tokenRefreshTimeoutMs)),
+    ]);
+    await this.tokenSave;
   }
 
   public async requestMeetingState(): Promise<UpdateMessage> {

--- a/extensions/microsoft-teams-calling/src/teams/meetingClientV2.ts
+++ b/extensions/microsoft-teams-calling/src/teams/meetingClientV2.ts
@@ -147,6 +147,7 @@ export class MeetingClientV2 implements MeetingClient {
     } else if (this.isTokenRefreshMessage(msg)) {
       console.debug("Refresh token message. Updating local storage.");
       this.tokenSave = setToken(msg.tokenRefresh);
+      this.connectedWithToken = true;
       this.tokenRefreshDeferred.resolve();
     } else if (this.isResponseMessage(msg)) {
       if (msg.requestId === 0) {


### PR DESCRIPTION
## Description

Prevents Teams prompting for permission every time the extension performs an action.  

- Resolves #25453
- Resolves #23710
- Resolves #21743
- Resolves #24585

Updated the New Teams API client to persist the refreshed pairing token before no-view commands exit.

The fix tracks the tokenRefresh save operation from Teams and waits for it during pairing, with a short timeout so already-paired commands stay responsive. This prevents Teams from treating every Raycast command as a new connection request after the first approval. The websocket connection URL now also uses URLSearchParams so the auth token and app identity query parameters are encoded consistently.

Also closes the websocket after direct no-view commands complete, giving those commands a cleaner lifecycle.
 
## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
