### PR TITLE
Update sap-logon extension

### DIFF
--- a/extensions/sap-logon/CHANGELOG.md
+++ b/extensions/sap-logon/CHANGELOG.md
@@ -1,6 +1,6 @@
 # SAP GUI Connector
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-04-23
 
 - Improved encoding for passwords
 - Added an error message when passwords with unsupported special characters are used

--- a/extensions/sap-logon/CHANGELOG.md
+++ b/extensions/sap-logon/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SAP GUI Connector
 
+## [Update] - {PR_MERGE_DATE}
+
+- Improved encoding for passwords
+- Added an error message when passwords with unsupported special characters are used
+
 ## [Update] - 2026-04-12
 
 - Added Turkish (TR) language option

--- a/extensions/sap-logon/src/add-system.tsx
+++ b/extensions/sap-logon/src/add-system.tsx
@@ -2,7 +2,14 @@ import { Action, ActionPanel, Form, showToast, Toast, useNavigation } from "@ray
 import { useForm, FormValidation } from "@raycast/utils";
 import { LanguageDropdown } from "./components";
 import { SAPSystemFormValues } from "./types";
-import { addSAPSystem, validateClient, validateInstanceNumber, validatePassword } from "./utils";
+import {
+  addSAPSystem,
+  validateApplicationServer,
+  validateClient,
+  validateInstanceNumber,
+  validatePassword,
+  validateUsername,
+} from "./utils";
 
 interface AddSystemFormProps {
   onSave?: () => void;
@@ -47,7 +54,10 @@ export function AddSystemForm({ onSave }: AddSystemFormProps) {
     },
     validation: {
       systemId: FormValidation.Required,
-      applicationServer: FormValidation.Required,
+      applicationServer: (value) => {
+        if (!value) return "Application server is required";
+        return validateApplicationServer(value);
+      },
       instanceNumber: (value) => {
         if (!value) return "Instance number is required";
         return validateInstanceNumber(value);
@@ -56,7 +66,10 @@ export function AddSystemForm({ onSave }: AddSystemFormProps) {
         if (!value) return "Client is required";
         return validateClient(value);
       },
-      username: FormValidation.Required,
+      username: (value) => {
+        if (!value) return "Username is required";
+        return validateUsername(value);
+      },
       password: (value) => {
         if (!value) return "Password is required";
         return validatePassword(value);

--- a/extensions/sap-logon/src/add-system.tsx
+++ b/extensions/sap-logon/src/add-system.tsx
@@ -2,7 +2,7 @@ import { Action, ActionPanel, Form, showToast, Toast, useNavigation } from "@ray
 import { useForm, FormValidation } from "@raycast/utils";
 import { LanguageDropdown } from "./components";
 import { SAPSystemFormValues } from "./types";
-import { addSAPSystem, validateClient, validateInstanceNumber } from "./utils";
+import { addSAPSystem, validateClient, validateInstanceNumber, validatePassword } from "./utils";
 
 interface AddSystemFormProps {
   onSave?: () => void;
@@ -57,7 +57,10 @@ export function AddSystemForm({ onSave }: AddSystemFormProps) {
         return validateClient(value);
       },
       username: FormValidation.Required,
-      password: FormValidation.Required,
+      password: (value) => {
+        if (!value) return "Password is required";
+        return validatePassword(value);
+      },
     },
   });
 

--- a/extensions/sap-logon/src/edit-system.tsx
+++ b/extensions/sap-logon/src/edit-system.tsx
@@ -3,7 +3,7 @@ import { useForm, FormValidation, usePromise } from "@raycast/utils";
 import { useCallback, useEffect } from "react";
 import { LanguageDropdown } from "./components";
 import { SAPSystem, SAPSystemFormValues } from "./types";
-import { getPassword, updateSAPSystem, validateClient, validateInstanceNumber } from "./utils";
+import { getPassword, updateSAPSystem, validateClient, validateInstanceNumber, validatePassword } from "./utils";
 
 interface EditSystemFormProps {
   system: SAPSystem;
@@ -67,7 +67,10 @@ export default function EditSystemForm({ system, onSave }: EditSystemFormProps) 
         return validateClient(value);
       },
       username: FormValidation.Required,
-      password: FormValidation.Required,
+      password: (value) => {
+        if (!value) return "Password is required";
+        return validatePassword(value);
+      },
     },
   });
 

--- a/extensions/sap-logon/src/edit-system.tsx
+++ b/extensions/sap-logon/src/edit-system.tsx
@@ -3,7 +3,15 @@ import { useForm, FormValidation, usePromise } from "@raycast/utils";
 import { useCallback, useEffect } from "react";
 import { LanguageDropdown } from "./components";
 import { SAPSystem, SAPSystemFormValues } from "./types";
-import { getPassword, updateSAPSystem, validateClient, validateInstanceNumber, validatePassword } from "./utils";
+import {
+  getPassword,
+  updateSAPSystem,
+  validateApplicationServer,
+  validateClient,
+  validateInstanceNumber,
+  validatePassword,
+  validateUsername,
+} from "./utils";
 
 interface EditSystemFormProps {
   system: SAPSystem;
@@ -57,7 +65,10 @@ export default function EditSystemForm({ system, onSave }: EditSystemFormProps) 
     },
     validation: {
       systemId: FormValidation.Required,
-      applicationServer: FormValidation.Required,
+      applicationServer: (value) => {
+        if (!value) return "Application server is required";
+        return validateApplicationServer(value);
+      },
       instanceNumber: (value) => {
         if (!value) return "Instance number is required";
         return validateInstanceNumber(value);
@@ -66,7 +77,10 @@ export default function EditSystemForm({ system, onSave }: EditSystemFormProps) 
         if (!value) return "Client is required";
         return validateClient(value);
       },
-      username: FormValidation.Required,
+      username: (value) => {
+        if (!value) return "Username is required";
+        return validateUsername(value);
+      },
       password: (value) => {
         if (!value) return "Password is required";
         return validatePassword(value);

--- a/extensions/sap-logon/src/utils.ts
+++ b/extensions/sap-logon/src/utils.ts
@@ -283,9 +283,21 @@ export function validateClient(value: string): string | undefined {
   return undefined;
 }
 
-export function validatePassword(value: string): string | undefined {
+export function validateNoReservedChars(value: string, fieldLabel: string): string | undefined {
   if (/[/&]/.test(value)) {
-    return "Password must not contain '/' or '&'";
+    return `${fieldLabel} must not contain '/' or '&'`;
   }
   return undefined;
+}
+
+export function validatePassword(value: string): string | undefined {
+  return validateNoReservedChars(value, "Password");
+}
+
+export function validateApplicationServer(value: string): string | undefined {
+  return validateNoReservedChars(value, "Application server");
+}
+
+export function validateUsername(value: string): string | undefined {
+  return validateNoReservedChars(value, "Username");
 }

--- a/extensions/sap-logon/src/utils.ts
+++ b/extensions/sap-logon/src/utils.ts
@@ -219,24 +219,11 @@ function sanitizeFilename(name: string): string {
   return name.replace(/[^a-zA-Z0-9_-]/g, "_");
 }
 
-// Encode value for SAP connection string (avoid breaking on special chars)
-function encodeSAPValue(value: string): string {
-  // Encode all characters that could break the SAP connection string parsing
-  return value
-    .replace(/%/g, "%25") // Must be first to avoid double-encoding
-    .replace(/&/g, "%26")
-    .replace(/=/g, "%3D")
-    .replace(/\+/g, "%2B")
-    .replace(/#/g, "%23")
-    .replace(/\s/g, "%20");
-}
-
 export async function createAndOpenSAPCFile(system: SAPSystem): Promise<string> {
   const password = await getPassword(system.id);
 
-  // Build the connection string with encoded values
   // Format: conn=/H/{application server}/S/32{instance number}&user={username}&lang={language}&client={client}&pass={password}
-  const connectionString = `conn=/H/${encodeSAPValue(system.applicationServer)}/S/32${encodeSAPValue(system.instanceNumber)}&user=${encodeSAPValue(system.username)}&lang=${encodeSAPValue(system.language)}&clnt=${encodeSAPValue(system.client)}&pass=${encodeSAPValue(password)}`;
+  const connectionString = `conn=/H/${system.applicationServer}/S/32${system.instanceNumber}&user=${system.username}&lang=${system.language}&clnt=${system.client}&pass=${password}`;
 
   // Use Raycast's support path for temp files (more appropriate than os.tmpdir)
   const tempDir = path.join(environment.supportPath, "sapc-files");
@@ -292,6 +279,13 @@ export function validateInstanceNumber(value: string): string | undefined {
 export function validateClient(value: string): string | undefined {
   if (!/^\d{3}$/.test(value)) {
     return "Client must be exactly 3 digits (e.g., 100, 800)";
+  }
+  return undefined;
+}
+
+export function validatePassword(value: string): string | undefined {
+  if (/[/&]/.test(value)) {
+    return "Password must not contain '/' or '&'";
   }
   return undefined;
 }


### PR DESCRIPTION
## Description

Due to a technical restriction from the SAP GUI, passwords containing '/' or '&' cannot be used here. 
I have added a validation for that special case and removed the encoding of other special characters. 

## Screencast

<img width="1730" height="1172" alt="CleanShot 2026-04-22 at 11 14 43@2x" src="https://github.com/user-attachments/assets/864b3016-db74-4df5-bd5f-03c7ff402901" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
