### PR TITLE
fix(notion): add date divider to quick capture

### DIFF
--- a/extensions/notion/CHANGELOG.md
+++ b/extensions/notion/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Notion Changelog
 
-## [Add date divider to Quick Capture] - {PR_MERGE_DATE}
+## [Add date divider to Quick Capture] - 2026-04-30
 
 - Add an `Append with a date divider` checkbox to Notion Quick Capture so captured content can be prefixed with the current date ([#27345](https://github.com/raycast/extensions/pull/27345))
 

--- a/extensions/notion/CHANGELOG.md
+++ b/extensions/notion/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Notion Changelog
 
+## [Add date divider to Quick Capture] - {PR_MERGE_DATE}
+
+- Add an `Append with a date divider` checkbox to Notion Quick Capture so captured content can be prefixed with the current date ([#27345](https://github.com/raycast/extensions/pull/27345))
+
 ## [Fix database ID resolution for create/delete actions] - 2026-02-19
 
 - Fix `Create Database Page` failing for some shared databases with "Failed to create page" / `object_not_found` style errors caused by mixed `database_id` and `data_source_id` usage ([#25393](https://github.com/raycast/extensions/issues/25393))

--- a/extensions/notion/src/quick-capture.tsx
+++ b/extensions/notion/src/quick-capture.tsx
@@ -33,6 +33,7 @@ type QuickCaptureFormValues = {
   url: string;
   captureAs: string;
   page: string;
+  addDateDivider: boolean;
 };
 
 type LaunchContext = {
@@ -91,85 +92,110 @@ function QuickCapture({ launchContext }: QuickCaptureProps) {
 
   const searchPages = data?.pages;
 
-  const { itemProps, handleSubmit, setValue } = useForm<QuickCaptureFormValues>({
-    initialValues: {
-      captureAs: launchContext?.defaults?.captureAs,
-    },
-    async onSubmit(values) {
-      try {
-        await closeMainWindow();
+  const { itemProps, handleSubmit, setValue } = useForm<QuickCaptureFormValues>(
+    {
+      initialValues: {
+        captureAs: launchContext?.defaults?.captureAs,
+      },
+      async onSubmit(values) {
+        try {
+          await closeMainWindow();
 
-        await showToast({ style: Toast.Style.Animated, title: "Capturing content to page" });
+          await showToast({
+            style: Toast.Style.Animated,
+            title: "Capturing content to page",
+          });
 
-        const pageDetail = await getPageDetail(values.url);
-        const pageLink = pageDetail ? `[${pageDetail.title}](${values.url})` : values.url;
+          const pageDetail = await getPageDetail(values.url);
+          const pageLink = pageDetail
+            ? `[${pageDetail.title}](${values.url})`
+            : values.url;
 
-        let content: PageContent;
+          let content: PageContent;
 
-        switch (values.captureAs) {
-          case "url": {
-            content = [{ type: "bookmark", bookmark: { url: values.url } }];
-            break;
-          }
-
-          case "full": {
-            content = pageLink;
-            if (pageDetail) content += `\n\n${pageDetail.content}`;
-            break;
-          }
-
-          case "ai": {
-            content = pageLink;
-            if (pageDetail) {
-              const summary = await AI.ask(getSummaryPrompt(pageDetail.content));
-              content += `\n\n${summary}`;
+          switch (values.captureAs) {
+            case "url": {
+              content = [{ type: "bookmark", bookmark: { url: values.url } }];
+              break;
             }
-            break;
+
+            case "full": {
+              content = pageLink;
+              if (pageDetail) content += `\n\n${pageDetail.content}`;
+              break;
+            }
+
+            case "ai": {
+              content = pageLink;
+              if (pageDetail) {
+                const summary = await AI.ask(
+                  getSummaryPrompt(pageDetail.content),
+                );
+                content += `\n\n${summary}`;
+              }
+              break;
+            }
+
+            default: {
+              content = pageLink;
+            }
           }
 
-          default: {
-            content = pageLink;
+          let selectedPage: Page | undefined;
+
+          if (launchContext?.defaults?.pageId) {
+            const { pageId, objectType = "page" } = launchContext.defaults;
+            selectedPage =
+              objectType === "page"
+                ? await fetchPage(pageId)
+                : await fetchDatabase(pageId);
+          } else {
+            selectedPage = searchPages?.find((page) => page.id === values.page);
           }
-        }
 
-        let selectedPage: Page | undefined;
+          if (!selectedPage) {
+            await showToast({
+              style: Toast.Style.Failure,
+              title: "Could not find page",
+            });
+            return;
+          }
 
-        if (launchContext?.defaults?.pageId) {
-          const { pageId, objectType = "page" } = launchContext.defaults;
-          selectedPage = objectType === "page" ? await fetchPage(pageId) : await fetchDatabase(pageId);
-        } else {
-          selectedPage = searchPages?.find((page) => page.id === values.page);
-        }
+          if (selectedPage.object === "page") {
+            await appendToPage(selectedPage.id, {
+              content,
+              addDateDivider: values.addDateDivider,
+            });
+          }
 
-        if (!selectedPage) {
-          await showToast({ style: Toast.Style.Failure, title: "Could not find page" });
-          return;
-        }
+          if (selectedPage.object === "database") {
+            await createDatabasePage({
+              database: selectedPage.id,
+              content,
+              addDateDivider: values.addDateDivider,
+              "property::title::title": pageDetail?.title,
+            });
+          }
 
-        if (selectedPage.object === "page") {
-          await appendToPage(selectedPage.id, { content });
-        }
-
-        if (selectedPage.object === "database") {
-          await createDatabasePage({
-            database: selectedPage.id,
-            content,
-            "property::title::title": pageDetail?.title,
+          await showToast({
+            style: Toast.Style.Success,
+            title: "Captured content to page",
+          });
+        } catch {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Failed capturing content to page",
           });
         }
-
-        await showToast({ style: Toast.Style.Success, title: "Captured content to page" });
-      } catch {
-        await showToast({ style: Toast.Style.Failure, title: "Failed capturing content to page" });
-      }
-    },
-    validation: {
-      url: (input) => {
-        if (!input) return "The URL is required";
-        if (!validateUrl(input)) return "The URL is not valid";
+      },
+      validation: {
+        url: (input) => {
+          if (!input) return "The URL is required";
+          if (!validateUrl(input)) return "The URL is not valid";
+        },
       },
     },
-  });
+  );
 
   useEffect(() => {
     async function getText() {
@@ -210,7 +236,10 @@ function QuickCapture({ launchContext }: QuickCaptureProps) {
 
     return {
       name: page ? `Quick capture to ${getPageName(page)}` : "Quick capture",
-      link: url + "?launchContext=" + encodeURIComponent(JSON.stringify(launchContext)),
+      link:
+        url +
+        "?launchContext=" +
+        encodeURIComponent(JSON.stringify(launchContext)),
     };
   }
 
@@ -218,8 +247,15 @@ function QuickCapture({ launchContext }: QuickCaptureProps) {
     <Form
       actions={
         <ActionPanel>
-          <Action.SubmitForm onSubmit={handleSubmit} title="Capture" icon={Icon.SaveDocument} />
-          <Action.CreateQuicklink title="Create Quicklink" quicklink={getQuicklink()} />
+          <Action.SubmitForm
+            onSubmit={handleSubmit}
+            title="Capture"
+            icon={Icon.SaveDocument}
+          />
+          <Action.CreateQuicklink
+            title="Create Quicklink"
+            quicklink={getQuicklink()}
+          />
         </ActionPanel>
       }
     >
@@ -231,9 +267,24 @@ function QuickCapture({ launchContext }: QuickCaptureProps) {
 
       <Form.Dropdown {...itemProps.captureAs} title="Capture As" storeValue>
         <Form.Dropdown.Item title="Bookmark" value="url" icon={Icon.Link} />
-        <Form.Dropdown.Item title="Full Page" value="full" icon={Icon.Paragraph} />
-        <Form.Dropdown.Item title="Summarize Page with AI" value="ai" icon={Icon.Stars} />
+        <Form.Dropdown.Item
+          title="Full Page"
+          value="full"
+          icon={Icon.Paragraph}
+        />
+        <Form.Dropdown.Item
+          title="Summarize Page with AI"
+          value="ai"
+          icon={Icon.Stars}
+        />
       </Form.Dropdown>
+
+      <Form.Checkbox
+        {...itemProps.addDateDivider}
+        label="Append with a date divider"
+        info="Add a divider with the current date before the captured content"
+        storeValue
+      />
 
       {/*
         When a default page/database is specified in the LaunchContext, we will fetch it directly instead

--- a/extensions/notion/src/quick-capture.tsx
+++ b/extensions/notion/src/quick-capture.tsx
@@ -92,110 +92,101 @@ function QuickCapture({ launchContext }: QuickCaptureProps) {
 
   const searchPages = data?.pages;
 
-  const { itemProps, handleSubmit, setValue } = useForm<QuickCaptureFormValues>(
-    {
-      initialValues: {
-        captureAs: launchContext?.defaults?.captureAs,
-      },
-      async onSubmit(values) {
-        try {
-          await closeMainWindow();
+  const { itemProps, handleSubmit, setValue } = useForm<QuickCaptureFormValues>({
+    initialValues: {
+      captureAs: launchContext?.defaults?.captureAs,
+    },
+    async onSubmit(values) {
+      try {
+        await closeMainWindow();
 
-          await showToast({
-            style: Toast.Style.Animated,
-            title: "Capturing content to page",
-          });
+        await showToast({
+          style: Toast.Style.Animated,
+          title: "Capturing content to page",
+        });
 
-          const pageDetail = await getPageDetail(values.url);
-          const pageLink = pageDetail
-            ? `[${pageDetail.title}](${values.url})`
-            : values.url;
+        const pageDetail = await getPageDetail(values.url);
+        const pageLink = pageDetail ? `[${pageDetail.title}](${values.url})` : values.url;
 
-          let content: PageContent;
+        let content: PageContent;
 
-          switch (values.captureAs) {
-            case "url": {
-              content = [{ type: "bookmark", bookmark: { url: values.url } }];
-              break;
+        switch (values.captureAs) {
+          case "url": {
+            content = [{ type: "bookmark", bookmark: { url: values.url } }];
+            break;
+          }
+
+          case "full": {
+            content = pageLink;
+            if (pageDetail) content += `\n\n${pageDetail.content}`;
+            break;
+          }
+
+          case "ai": {
+            content = pageLink;
+            if (pageDetail) {
+              const summary = await AI.ask(getSummaryPrompt(pageDetail.content));
+              content += `\n\n${summary}`;
             }
-
-            case "full": {
-              content = pageLink;
-              if (pageDetail) content += `\n\n${pageDetail.content}`;
-              break;
-            }
-
-            case "ai": {
-              content = pageLink;
-              if (pageDetail) {
-                const summary = await AI.ask(
-                  getSummaryPrompt(pageDetail.content),
-                );
-                content += `\n\n${summary}`;
-              }
-              break;
-            }
-
-            default: {
-              content = pageLink;
-            }
+            break;
           }
 
-          let selectedPage: Page | undefined;
-
-          if (launchContext?.defaults?.pageId) {
-            const { pageId, objectType = "page" } = launchContext.defaults;
-            selectedPage =
-              objectType === "page"
-                ? await fetchPage(pageId)
-                : await fetchDatabase(pageId);
-          } else {
-            selectedPage = searchPages?.find((page) => page.id === values.page);
+          default: {
+            content = pageLink;
           }
+        }
 
-          if (!selectedPage) {
-            await showToast({
-              style: Toast.Style.Failure,
-              title: "Could not find page",
-            });
-            return;
-          }
+        let selectedPage: Page | undefined;
 
-          if (selectedPage.object === "page") {
-            await appendToPage(selectedPage.id, {
-              content,
-              addDateDivider: values.addDateDivider,
-            });
-          }
+        if (launchContext?.defaults?.pageId) {
+          const { pageId, objectType = "page" } = launchContext.defaults;
+          selectedPage = objectType === "page" ? await fetchPage(pageId) : await fetchDatabase(pageId);
+        } else {
+          selectedPage = searchPages?.find((page) => page.id === values.page);
+        }
 
-          if (selectedPage.object === "database") {
-            await createDatabasePage({
-              database: selectedPage.id,
-              content,
-              addDateDivider: values.addDateDivider,
-              "property::title::title": pageDetail?.title,
-            });
-          }
-
-          await showToast({
-            style: Toast.Style.Success,
-            title: "Captured content to page",
-          });
-        } catch {
+        if (!selectedPage) {
           await showToast({
             style: Toast.Style.Failure,
-            title: "Failed capturing content to page",
+            title: "Could not find page",
+          });
+          return;
+        }
+
+        if (selectedPage.object === "page") {
+          await appendToPage(selectedPage.id, {
+            content,
+            addDateDivider: values.addDateDivider,
           });
         }
-      },
-      validation: {
-        url: (input) => {
-          if (!input) return "The URL is required";
-          if (!validateUrl(input)) return "The URL is not valid";
-        },
+
+        if (selectedPage.object === "database") {
+          await createDatabasePage({
+            database: selectedPage.id,
+            content,
+            addDateDivider: values.addDateDivider,
+            "property::title::title": pageDetail?.title,
+          });
+        }
+
+        await showToast({
+          style: Toast.Style.Success,
+          title: "Captured content to page",
+        });
+      } catch {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Failed capturing content to page",
+        });
+      }
+    },
+    validation: {
+      url: (input) => {
+        if (!input) return "The URL is required";
+        if (!validateUrl(input)) return "The URL is not valid";
       },
     },
-  );
+  });
 
   useEffect(() => {
     async function getText() {
@@ -236,10 +227,7 @@ function QuickCapture({ launchContext }: QuickCaptureProps) {
 
     return {
       name: page ? `Quick capture to ${getPageName(page)}` : "Quick capture",
-      link:
-        url +
-        "?launchContext=" +
-        encodeURIComponent(JSON.stringify(launchContext)),
+      link: url + "?launchContext=" + encodeURIComponent(JSON.stringify(launchContext)),
     };
   }
 
@@ -247,15 +235,8 @@ function QuickCapture({ launchContext }: QuickCaptureProps) {
     <Form
       actions={
         <ActionPanel>
-          <Action.SubmitForm
-            onSubmit={handleSubmit}
-            title="Capture"
-            icon={Icon.SaveDocument}
-          />
-          <Action.CreateQuicklink
-            title="Create Quicklink"
-            quicklink={getQuicklink()}
-          />
+          <Action.SubmitForm onSubmit={handleSubmit} title="Capture" icon={Icon.SaveDocument} />
+          <Action.CreateQuicklink title="Create Quicklink" quicklink={getQuicklink()} />
         </ActionPanel>
       }
     >
@@ -267,16 +248,8 @@ function QuickCapture({ launchContext }: QuickCaptureProps) {
 
       <Form.Dropdown {...itemProps.captureAs} title="Capture As" storeValue>
         <Form.Dropdown.Item title="Bookmark" value="url" icon={Icon.Link} />
-        <Form.Dropdown.Item
-          title="Full Page"
-          value="full"
-          icon={Icon.Paragraph}
-        />
-        <Form.Dropdown.Item
-          title="Summarize Page with AI"
-          value="ai"
-          icon={Icon.Stars}
-        />
+        <Form.Dropdown.Item title="Full Page" value="full" icon={Icon.Paragraph} />
+        <Form.Dropdown.Item title="Summarize Page with AI" value="ai" icon={Icon.Stars} />
       </Form.Dropdown>
 
       <Form.Checkbox

--- a/extensions/notion/src/utils/notion/block.ts
+++ b/extensions/notion/src/utils/notion/block.ts
@@ -21,3 +21,7 @@ export function getDateMention(date: Date = new Date()): BlockObjectRequest {
     },
   };
 }
+
+export function prependDateDivider(children: BlockObjectRequest[]) {
+  return [{ divider: {} }, getDateMention(), ...children];
+}

--- a/extensions/notion/src/utils/notion/database/index.ts
+++ b/extensions/notion/src/utils/notion/database/index.ts
@@ -4,7 +4,7 @@ import { type Form, showToast, Toast } from "@raycast/api";
 import { markdownToBlocks } from "@tryfabric/martian";
 
 import { isMarkdownPageContent, isReadableProperty } from "..";
-import { getDateMention } from "../block";
+import { prependDateDivider } from "../block";
 import { handleError, isNotNullOrUndefined, pageMapper } from "../global";
 import { getNotionClient } from "../oauth";
 import { formValueToPropertyValue } from "../page/property";
@@ -15,10 +15,7 @@ import { DatabaseProperty } from "./property";
 export type { PropertyConfig } from "./property";
 export type { DatabaseProperty };
 
-async function resolveDataSourceId(
-  notion: Client,
-  databaseOrDataSourceId: string,
-): Promise<string> {
+async function resolveDataSourceId(notion: Client, databaseOrDataSourceId: string): Promise<string> {
   try {
     await notion.dataSources.retrieve({
       data_source_id: databaseOrDataSourceId,
@@ -68,9 +65,7 @@ export async function fetchDatabases() {
       filter: { property: "object", value: "data_source" },
     });
     return databases.results
-      .map((x) =>
-        x.object === "data_source" && "last_edited_time" in x ? x : undefined,
-      )
+      .map((x) => (x.object === "data_source" && "last_edited_time" in x ? x : undefined))
       .filter(isNotNullOrUndefined)
       .map(
         (x) =>
@@ -80,8 +75,7 @@ export async function fetchDatabases() {
             title: x.title[0]?.plain_text,
             icon_emoji: x.icon?.type === "emoji" ? x.icon.emoji : null,
             icon_file: x.icon?.type === "file" ? x.icon.file.url : null,
-            icon_external:
-              x.icon?.type === "external" ? x.icon.external.url : null,
+            icon_external: x.icon?.type === "external" ? x.icon.external.url : null,
           }) as Database,
       );
   } catch (err) {
@@ -163,10 +157,7 @@ export async function queryDatabase(
 
 type CreateRequest = Parameters<Client["pages"]["create"]>[0];
 
-async function resolveParentDatabaseId(
-  notion: Client,
-  databaseOrDataSourceId: string,
-): Promise<string> {
+async function resolveParentDatabaseId(notion: Client, databaseOrDataSourceId: string): Promise<string> {
   try {
     const dataSource = await notion.dataSources.retrieve({
       data_source_id: databaseOrDataSourceId,
@@ -223,19 +214,13 @@ export async function createDatabasePage(values: Form.Values) {
         ? // casting because converting from the `Block` type in martian to the `BlockObjectRequest` type in notion
           (markdownToBlocks(content) as BlockObjectRequest[])
         : content;
-      arg.children = addDateDivider
-        ? [{ divider: {} }, getDateMention(), ...children]
-        : children;
+      arg.children = addDateDivider ? prependDateDivider(children) : children;
     }
 
     Object.keys(props).forEach((formId) => {
-      const type = formId.match(/(?<=property::).*(?=::)/g)?.[0] as
-        | DatabaseProperty["type"]
-        | null;
+      const type = formId.match(/(?<=property::).*(?=::)/g)?.[0] as DatabaseProperty["type"] | null;
       if (!type) return;
-      const propId = formId.match(
-        new RegExp("(?<=property::" + type + "::).*", "g"),
-      )?.[0];
+      const propId = formId.match(new RegExp("(?<=property::" + type + "::).*", "g"))?.[0];
       const value = values[formId];
       if (value == "_select_null_") return;
       if (!propId || !value) return;

--- a/extensions/notion/src/utils/notion/database/index.ts
+++ b/extensions/notion/src/utils/notion/database/index.ts
@@ -4,6 +4,7 @@ import { type Form, showToast, Toast } from "@raycast/api";
 import { markdownToBlocks } from "@tryfabric/martian";
 
 import { isMarkdownPageContent, isReadableProperty } from "..";
+import { getDateMention } from "../block";
 import { handleError, isNotNullOrUndefined, pageMapper } from "../global";
 import { getNotionClient } from "../oauth";
 import { formValueToPropertyValue } from "../page/property";
@@ -14,7 +15,10 @@ import { DatabaseProperty } from "./property";
 export type { PropertyConfig } from "./property";
 export type { DatabaseProperty };
 
-async function resolveDataSourceId(notion: Client, databaseOrDataSourceId: string): Promise<string> {
+async function resolveDataSourceId(
+  notion: Client,
+  databaseOrDataSourceId: string,
+): Promise<string> {
   try {
     await notion.dataSources.retrieve({
       data_source_id: databaseOrDataSourceId,
@@ -64,7 +68,9 @@ export async function fetchDatabases() {
       filter: { property: "object", value: "data_source" },
     });
     return databases.results
-      .map((x) => (x.object === "data_source" && "last_edited_time" in x ? x : undefined))
+      .map((x) =>
+        x.object === "data_source" && "last_edited_time" in x ? x : undefined,
+      )
       .filter(isNotNullOrUndefined)
       .map(
         (x) =>
@@ -74,7 +80,8 @@ export async function fetchDatabases() {
             title: x.title[0]?.plain_text,
             icon_emoji: x.icon?.type === "emoji" ? x.icon.emoji : null,
             icon_file: x.icon?.type === "file" ? x.icon.file.url : null,
-            icon_external: x.icon?.type === "external" ? x.icon.external.url : null,
+            icon_external:
+              x.icon?.type === "external" ? x.icon.external.url : null,
           }) as Database,
       );
   } catch (err) {
@@ -86,7 +93,9 @@ export async function fetchDatabaseProperties(databaseId: string) {
   try {
     const notion = getNotionClient();
     const dataSourceId = await resolveDataSourceId(notion, databaseId);
-    const dataSource = await notion.dataSources.retrieve({ data_source_id: dataSourceId });
+    const dataSource = await notion.dataSources.retrieve({
+      data_source_id: dataSourceId,
+    });
 
     if (!("properties" in dataSource)) return [];
 
@@ -154,7 +163,10 @@ export async function queryDatabase(
 
 type CreateRequest = Parameters<Client["pages"]["create"]>[0];
 
-async function resolveParentDatabaseId(notion: Client, databaseOrDataSourceId: string): Promise<string> {
+async function resolveParentDatabaseId(
+  notion: Client,
+  databaseOrDataSourceId: string,
+): Promise<string> {
   try {
     const dataSource = await notion.dataSources.retrieve({
       data_source_id: databaseOrDataSourceId,
@@ -198,7 +210,7 @@ async function resolveParentDatabaseId(notion: Client, databaseOrDataSourceId: s
 export async function createDatabasePage(values: Form.Values) {
   try {
     const notion = getNotionClient();
-    const { database, content, ...props } = values;
+    const { database, content, addDateDivider = false, ...props } = values;
     const parentDatabaseId = await resolveParentDatabaseId(notion, database);
 
     const arg: CreateRequest = {
@@ -207,16 +219,23 @@ export async function createDatabasePage(values: Form.Values) {
     };
 
     if (content) {
-      arg.children = isMarkdownPageContent(content)
+      const children = isMarkdownPageContent(content)
         ? // casting because converting from the `Block` type in martian to the `BlockObjectRequest` type in notion
           (markdownToBlocks(content) as BlockObjectRequest[])
         : content;
+      arg.children = addDateDivider
+        ? [{ divider: {} }, getDateMention(), ...children]
+        : children;
     }
 
     Object.keys(props).forEach((formId) => {
-      const type = formId.match(/(?<=property::).*(?=::)/g)?.[0] as DatabaseProperty["type"] | null;
+      const type = formId.match(/(?<=property::).*(?=::)/g)?.[0] as
+        | DatabaseProperty["type"]
+        | null;
       if (!type) return;
-      const propId = formId.match(new RegExp("(?<=property::" + type + "::).*", "g"))?.[0];
+      const propId = formId.match(
+        new RegExp("(?<=property::" + type + "::).*", "g"),
+      )?.[0];
       const value = values[formId];
       if (value == "_select_null_") return;
       if (!propId || !value) return;

--- a/extensions/notion/src/utils/notion/page/index.ts
+++ b/extensions/notion/src/utils/notion/page/index.ts
@@ -1,4 +1,7 @@
-import { BlockObjectRequest, UpdatePageParameters } from "@notionhq/client/build/src/api-endpoints";
+import {
+  BlockObjectRequest,
+  UpdatePageParameters,
+} from "@notionhq/client/build/src/api-endpoints";
 import { showToast, Toast, Image, Icon } from "@raycast/api";
 import { markdownToBlocks } from "@tryfabric/martian";
 import { NotionToMarkdown } from "notion-to-md";
@@ -48,7 +51,10 @@ export async function deletePage(pageId: string) {
   }
 }
 
-export async function patchPage(pageId: string, properties: UpdatePageParameters["properties"]) {
+export async function patchPage(
+  pageId: string,
+  properties: UpdatePageParameters["properties"],
+) {
   try {
     const notion = getNotionClient();
     const page = await notion.pages.update({
@@ -62,7 +68,11 @@ export async function patchPage(pageId: string, properties: UpdatePageParameters
   }
 }
 
-export async function search(query?: string, nextCursor?: string, pageSize: number = 25) {
+export async function search(
+  query?: string,
+  nextCursor?: string,
+  pageSize: number = 25,
+) {
   const notion = getNotionClient();
   const database = await notion.search({
     sort: {
@@ -74,7 +84,11 @@ export async function search(query?: string, nextCursor?: string, pageSize: numb
     ...(nextCursor && { start_cursor: nextCursor }),
   });
 
-  return { pages: database.results.map(pageMapper), hasMore: database.has_more, nextCursor: database.next_cursor };
+  return {
+    pages: database.results.map(pageMapper),
+    hasMore: database.has_more,
+    nextCursor: database.next_cursor,
+  };
 }
 
 export async function fetchPageContent(pageId: string) {
@@ -88,7 +102,9 @@ export async function fetchPageContent(pageId: string) {
 
     return {
       markdown:
-        results.length === 0 ? "*Page is empty*" : n2m.toMarkdownString(await n2m.blocksToMarkdown(results)).parent,
+        results.length === 0
+          ? "*Page is empty*"
+          : n2m.toMarkdownString(await n2m.blocksToMarkdown(results)).parent,
     };
   } catch (err) {
     return handleError(err, "Failed to fetch page content", undefined);
@@ -114,6 +130,10 @@ type AppendBlockToPageParams = {
   addDateDivider?: boolean;
 };
 
+function prependDateDivider(children: BlockObjectRequest[]) {
+  return [{ divider: {} }, getDateMention(), ...children];
+}
+
 export async function appendBlockToPage({
   pageId,
   children,
@@ -123,8 +143,12 @@ export async function appendBlockToPage({
   try {
     const notion = getNotionClient();
 
-    const childrenToInsert = addDateDivider ? [{ divider: {} }, getDateMention(), ...children] : children;
-    const insertAfter = prepend ? await fetchPageFirstBlockId(pageId) : undefined;
+    const childrenToInsert = addDateDivider
+      ? prependDateDivider(children)
+      : children;
+    const insertAfter = prepend
+      ? await fetchPageFirstBlockId(pageId)
+      : undefined;
 
     const { results } = await notion.blocks.children.append({
       block_id: pageId,
@@ -138,26 +162,36 @@ export async function appendBlockToPage({
   }
 }
 
-export async function appendToPage(pageId: string, params: { content: PageContent }) {
+export async function appendToPage(
+  pageId: string,
+  params: { content: PageContent; addDateDivider?: boolean },
+) {
   try {
     const notion = getNotionClient();
-    const { content } = params;
+    const { content, addDateDivider = false } = params;
+
+    const children = isMarkdownPageContent(content)
+      ? // casting because converting from the `Block` type in martian to the `BlockObjectRequest` type in notion
+        (markdownToBlocks(content) as BlockObjectRequest[])
+      : content;
 
     const { results } = await notion.blocks.children.append({
       block_id: pageId,
-      children: isMarkdownPageContent(content)
-        ? // casting because converting from the `Block` type in martian to the `BlockObjectRequest` type in notion
-          (markdownToBlocks(content) as BlockObjectRequest[])
-        : content,
+      children: addDateDivider ? prependDateDivider(children) : children,
     });
 
     const n2m = new NotionToMarkdown({ notionClient: notion });
 
     return {
-      markdown: results.length === 0 ? "" : "\n\n" + n2m.toMarkdownString(await n2m.blocksToMarkdown(results)),
+      markdown:
+        results.length === 0
+          ? ""
+          : "\n\n" + n2m.toMarkdownString(await n2m.blocksToMarkdown(results)),
     };
   } catch (err) {
-    return handleError(err, "Failed to add content to the page", { markdown: "" });
+    return handleError(err, "Failed to add content to the page", {
+      markdown: "",
+    });
   }
 }
 
@@ -174,7 +208,10 @@ export function getPageIcon(page: Page): Image.ImageLike {
 }
 
 export function getPageName(page: Page): string {
-  return (page.icon_emoji ? page.icon_emoji + " " : "") + (page.title ? page.title : "Untitled");
+  return (
+    (page.icon_emoji ? page.icon_emoji + " " : "") +
+    (page.title ? page.title : "Untitled")
+  );
 }
 export interface Page {
   object: "page" | "database";

--- a/extensions/notion/src/utils/notion/page/index.ts
+++ b/extensions/notion/src/utils/notion/page/index.ts
@@ -1,13 +1,10 @@
-import {
-  BlockObjectRequest,
-  UpdatePageParameters,
-} from "@notionhq/client/build/src/api-endpoints";
+import { BlockObjectRequest, UpdatePageParameters } from "@notionhq/client/build/src/api-endpoints";
 import { showToast, Toast, Image, Icon } from "@raycast/api";
 import { markdownToBlocks } from "@tryfabric/martian";
 import { NotionToMarkdown } from "notion-to-md";
 
 import { isMarkdownPageContent, PageContent } from "..";
-import { getDateMention } from "../block";
+import { prependDateDivider } from "../block";
 import { handleError, pageMapper } from "../global";
 import { getNotionClient } from "../oauth";
 
@@ -51,10 +48,7 @@ export async function deletePage(pageId: string) {
   }
 }
 
-export async function patchPage(
-  pageId: string,
-  properties: UpdatePageParameters["properties"],
-) {
+export async function patchPage(pageId: string, properties: UpdatePageParameters["properties"]) {
   try {
     const notion = getNotionClient();
     const page = await notion.pages.update({
@@ -68,11 +62,7 @@ export async function patchPage(
   }
 }
 
-export async function search(
-  query?: string,
-  nextCursor?: string,
-  pageSize: number = 25,
-) {
+export async function search(query?: string, nextCursor?: string, pageSize: number = 25) {
   const notion = getNotionClient();
   const database = await notion.search({
     sort: {
@@ -102,9 +92,7 @@ export async function fetchPageContent(pageId: string) {
 
     return {
       markdown:
-        results.length === 0
-          ? "*Page is empty*"
-          : n2m.toMarkdownString(await n2m.blocksToMarkdown(results)).parent,
+        results.length === 0 ? "*Page is empty*" : n2m.toMarkdownString(await n2m.blocksToMarkdown(results)).parent,
     };
   } catch (err) {
     return handleError(err, "Failed to fetch page content", undefined);
@@ -130,10 +118,6 @@ type AppendBlockToPageParams = {
   addDateDivider?: boolean;
 };
 
-function prependDateDivider(children: BlockObjectRequest[]) {
-  return [{ divider: {} }, getDateMention(), ...children];
-}
-
 export async function appendBlockToPage({
   pageId,
   children,
@@ -143,12 +127,8 @@ export async function appendBlockToPage({
   try {
     const notion = getNotionClient();
 
-    const childrenToInsert = addDateDivider
-      ? prependDateDivider(children)
-      : children;
-    const insertAfter = prepend
-      ? await fetchPageFirstBlockId(pageId)
-      : undefined;
+    const childrenToInsert = addDateDivider ? prependDateDivider(children) : children;
+    const insertAfter = prepend ? await fetchPageFirstBlockId(pageId) : undefined;
 
     const { results } = await notion.blocks.children.append({
       block_id: pageId,
@@ -162,10 +142,7 @@ export async function appendBlockToPage({
   }
 }
 
-export async function appendToPage(
-  pageId: string,
-  params: { content: PageContent; addDateDivider?: boolean },
-) {
+export async function appendToPage(pageId: string, params: { content: PageContent; addDateDivider?: boolean }) {
   try {
     const notion = getNotionClient();
     const { content, addDateDivider = false } = params;
@@ -183,10 +160,7 @@ export async function appendToPage(
     const n2m = new NotionToMarkdown({ notionClient: notion });
 
     return {
-      markdown:
-        results.length === 0
-          ? ""
-          : "\n\n" + n2m.toMarkdownString(await n2m.blocksToMarkdown(results)),
+      markdown: results.length === 0 ? "" : "\n\n" + n2m.toMarkdownString(await n2m.blocksToMarkdown(results)),
     };
   } catch (err) {
     return handleError(err, "Failed to add content to the page", {
@@ -208,10 +182,7 @@ export function getPageIcon(page: Page): Image.ImageLike {
 }
 
 export function getPageName(page: Page): string {
-  return (
-    (page.icon_emoji ? page.icon_emoji + " " : "") +
-    (page.title ? page.title : "Untitled")
-  );
+  return (page.icon_emoji ? page.icon_emoji + " " : "") + (page.title ? page.title : "Untitled");
 }
 export interface Page {
   object: "page" | "database";


### PR DESCRIPTION
## Summary
- add an `Append with a date divider` option to Notion Quick Capture
- thread the divider flag through the existing Notion append/create helpers
- reuse the same divider + date mention behavior already used by Add Text to Page

## Validation
- `npx --yes prettier --check` on the 3 touched files
- `git diff --check --no-index` against the upstream versions of the touched files
- read back the final diffs locally to confirm the checkbox wiring and helper flow are consistent