### PR TITLE
Update aerospace extension - Add Set to Tiling action

### DIFF
--- a/extensions/aerospace/CHANGELOG.md
+++ b/extensions/aerospace/CHANGELOG.md
@@ -1,5 +1,9 @@
 # aerospace Changelog
 
+## [Feature] - 2026-04-22
+
+- Add "Set to Tiling" action to window switcher (Cmd+T) — converts a floating window to tiling layout via `aerospace layout tiling`
+
 ## [Feature] - 2026-04-12
 
 - Add "Go to Workspace" command with searchable workspace list and shortcut display

--- a/extensions/aerospace/src/switchApps.tsx
+++ b/extensions/aerospace/src/switchApps.tsx
@@ -1,5 +1,5 @@
 import { Action, ActionPanel, Icon, LaunchProps, List, getPreferenceValues } from "@raycast/api";
-import { Windows, focusWindow, getWindows, pullWindowToCurrentWorkspace } from "./utils/appSwitcher";
+import { Windows, focusWindow, getWindows, pullWindowToCurrentWorkspace, setWindowTiling } from "./utils/appSwitcher";
 import { useEffect, useMemo, useState } from "react";
 import { useCachedState } from "@raycast/utils";
 
@@ -82,6 +82,14 @@ export default function Command(
                       shortcut={{ modifiers: ["shift"], key: "enter" }}
                       onAction={async () => {
                         await pullWindowToCurrentWorkspace(window["window-id"].toString());
+                      }}
+                    />
+                    <Action
+                      title="Set to Tiling"
+                      icon={Icon.AppWindowGrid3x3}
+                      shortcut={{ modifiers: ["cmd"], key: "t" }}
+                      onAction={async () => {
+                        await setWindowTiling(window["window-id"].toString());
                       }}
                     />
                   </ActionPanel>

--- a/extensions/aerospace/src/utils/appSwitcher.tsx
+++ b/extensions/aerospace/src/utils/appSwitcher.tsx
@@ -81,6 +81,23 @@ export function focusWindow(windowId: string) {
   closeMainWindow({ clearRootSearch: true });
 }
 
+export async function setWindowTiling(windowId: string) {
+  const result = spawnSync("aerospace", ["layout", "tiling", "--window-id", windowId], {
+    env: env(),
+    encoding: "utf8",
+    timeout: 15000,
+  });
+
+  if (result.status !== 0) {
+    await showToast({ style: Toast.Style.Failure, title: "Failed to set tiling layout", message: result.stderr });
+    return;
+  }
+
+  await showToast({ style: Toast.Style.Success, title: "Window set to tiling layout" });
+  popToRoot({ clearSearchBar: true });
+  closeMainWindow({ clearRootSearch: true });
+}
+
 export async function pullWindowToCurrentWorkspace(windowId: string) {
   const focused = spawnSync("aerospace", ["list-workspaces", "--focused"], {
     env: env(),


### PR DESCRIPTION
## Description

Adds a **"Set to Tiling"** action to the _Switch Apps in Workspace_ command in the Aerospace extension.

When browsing windows in the list, users can now press `Cmd+T` (or select it from the action panel) to convert the selected window from floating layout to tiling layout. This runs `aerospace layout tiling --window-id <id>` under the hood, mirroring what you'd do manually in the terminal.

The action shows a success toast on completion, or a failure toast with the aerospace error message if something goes wrong.

## Screencast

<!-- Paste screenshot here — drag and drop SCR-20260422-latz.png from ~/Downloads into this field -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)