### PR TITLE
fix: update cli and logout on invalid session token

### DIFF
--- a/extensions/bitwarden/CHANGELOG.md
+++ b/extensions/bitwarden/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bitwarden Changelog
 
+## [CLI update & Fix] - {PR_MERGE_DATE}
+
+- Logout whenever there is a "Invalid session token" error
+
 ## [Fix] - 2026-04-20
 
 - 🐛 Fix infinite retry loop when unlocking vault with invalid session token
@@ -8,6 +12,7 @@
 
 - Update bundled Bitwarden CLI from v2025.11.0 to v2026.2.0 to fix "Invalid session token" error caused by server-side KDF upgrades
 - Fix incorrect vault status saved after API key login
+
 ## [Fix] - 2026-04-02
 
 - Catch Invalid session token error

--- a/extensions/bitwarden/CHANGELOG.md
+++ b/extensions/bitwarden/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Bitwarden Changelog
 
-## [CLI update & Fix] - {PR_MERGE_DATE}
+## [CLI update & Fix] - 2026-04-23
 
 - Logout whenever there is a "Invalid session token" error
 

--- a/extensions/bitwarden/src/api/bitwarden.ts
+++ b/extensions/bitwarden/src/api/bitwarden.ts
@@ -102,11 +102,11 @@ const BinDownloadLogger = (() => {
 })();
 
 export const cliInfo = {
-  version: "2026.2.0",
+  version: "2026.3.0",
   get sha256() {
-    if (platform === "windows") return "6e7fe65ef0d0401af20bb739cb81469a0c001d9ee249ceea4a86974ae27a4c46";
-    if (process.arch === "arm64") return "63c736b74620280e422ce238bdbcbc267689a0ff831168959ef2124588fcc1e5";
-    return "60cc5109b1cdad560231e02098f1ab2d16efa821d51c6ec089cb5c3cc351b2e5";
+    if (platform === "windows") return "3f129e6d15ae950b5840d20ce9bcf99c2248ce5330f4d4c70e859512d5992371";
+    if (process.arch === "arm64") return "d935e9885ed215ecb0de9a7e7251487012b007a74fedbaaec6074d299fef3e02";
+    return "015ed86b1f9e23a366e0c7937a5b5cfcd26348505608e5e446890cd83a00b1d2";
   },
   downloadPage: "https://github.com/bitwarden/clients/releases",
   path: {
@@ -772,13 +772,7 @@ export class Bitwarden {
     }
     if (/Invalid session token/i.test(errorContent)) {
       if (!skipInvalidSessionTokenLogout) {
-        // Avoid running the full logout lifecycle here (which fires logout listeners).
-        // Clear the session token and mark the vault as unauthenticated so callers
-        // can perform an explicit `bitwarden.logout()` when they want the full
-        // logout side-effects (listeners, storage updates, etc.). This prevents
-        // duplicate listener invocations.
-        this.clearSessionToken();
-        await this.saveLastVaultStatus("handleCommonErrors:InvalidSessionToken", "unauthenticated");
+        await this.logout({ reason: "Invalid session token", immediate: true });
       }
       return { error: new InvalidSessionTokenError() };
     }

--- a/extensions/bitwarden/src/components/UnlockForm.tsx
+++ b/extensions/bitwarden/src/components/UnlockForm.tsx
@@ -63,7 +63,6 @@ const UnlockForm = ({ pendingAction = Promise.resolve() }: UnlockFormProps) => {
       const { error: unlockError } = await bitwarden.unlock(password);
       if (unlockError) {
         if (unlockError instanceof InvalidSessionTokenError && !args?.retryInvalidSessionToken) {
-          await bitwarden.logout({ reason: "Invalid session token" });
           return await onSubmit({ retryInvalidSessionToken: true });
         }
         return handleUnlockError(unlockError, {


### PR DESCRIPTION
## Description

#27340 #27294

- Update the CLI to the latest version.
- Apply a change made previously that was supposed to be done in https://github.com/raycast/extensions/pull/26997/changes#r3096607214

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
