### PR TITLE
Update Mole extension stability

### DIFF
--- a/extensions/mole/CHANGELOG.md
+++ b/extensions/mole/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Mole Changelog
 
+## [Stability Improvements] - 2026-04-22
+
+- Fixed System Status crashes when Mole returns null values for optional status arrays
+- Improved Analyze Disk startup flow to avoid scanning the full home directory automatically
+- Added safer Analyze Disk error handling, process cancellation, timeouts, and result limits
+- Reduced Clean System preview memory usage by parsing only relevant scan output
+- Added Clean System timeout and non-zero exit handling for failed previews
+
 ## [Health Menu Bar] - 2026-04-12
 
 - Added Health Monitor menu bar command showing health score with color-coded heart icon (green ≥90, yellow ≥70, orange ≥50, red <50)

--- a/extensions/mole/CHANGELOG.md
+++ b/extensions/mole/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mole Changelog
 
-## [Stability Improvements] - 2026-04-22
+## [Stability Improvements] - {PR_MERGE_DATE}
 
 - Fixed System Status crashes when Mole returns null values for optional status arrays
 - Improved Analyze Disk startup flow to avoid scanning the full home directory automatically

--- a/extensions/mole/CHANGELOG.md
+++ b/extensions/mole/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mole Changelog
 
-## [Stability Improvements] - {PR_MERGE_DATE}
+## [Stability Improvements] - 2026-04-23
 
 - Fixed System Status crashes when Mole returns null values for optional status arrays
 - Improved Analyze Disk startup flow to avoid scanning the full home directory automatically

--- a/extensions/mole/src/analyze.tsx
+++ b/extensions/mole/src/analyze.tsx
@@ -1,10 +1,15 @@
 import { List, Icon, Color, ActionPanel, Action, getPreferenceValues, trash, showToast, Toast } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { execFile } from "child_process";
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { existsSync } from "fs";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { getMolePathSafe, MOLE_ENV } from "./utils/mole";
 import { formatBytes } from "./utils/parsers";
 import { MoleNotInstalled } from "./components/MoleNotInstalled";
+
+const ANALYZE_TIMEOUT_MS = 120000;
+const MAX_ANALYZE_OUTPUT_BYTES = 8 * 1024 * 1024;
+const MAX_VISIBLE_ENTRIES = 500;
 
 interface AnalyzeEntry {
   name: string;
@@ -18,35 +23,94 @@ interface AnalyzeResult {
   entries: AnalyzeEntry[];
 }
 
+function normalizeAnalyzeResult(value: unknown): AnalyzeResult {
+  const result = value as Partial<AnalyzeResult> | null;
+  const entries = Array.isArray(result?.entries)
+    ? result.entries.filter((entry): entry is AnalyzeEntry => {
+        const candidate = entry as Partial<AnalyzeEntry>;
+        return (
+          typeof candidate.name === "string" &&
+          typeof candidate.path === "string" &&
+          typeof candidate.size === "number" &&
+          typeof candidate.is_dir === "boolean"
+        );
+      })
+    : [];
+
+  return {
+    path: typeof result?.path === "string" ? result.path : "",
+    entries,
+  };
+}
+
+function getAnalyzeLocations(): { title: string; path: string; icon: Icon }[] {
+  const home = process.env.HOME;
+  const candidates = [
+    home ? { title: "Home", path: home, icon: Icon.House } : null,
+    home ? { title: "Downloads", path: `${home}/Downloads`, icon: Icon.Download } : null,
+    home ? { title: "Desktop", path: `${home}/Desktop`, icon: Icon.Desktop } : null,
+    home ? { title: "Documents", path: `${home}/Documents`, icon: Icon.Document } : null,
+    { title: "Applications", path: "/Applications", icon: Icon.AppWindow },
+    { title: "System Root", path: "/", icon: Icon.HardDrive },
+  ];
+
+  return candidates.filter((candidate): candidate is { title: string; path: string; icon: Icon } => {
+    return Boolean(candidate && existsSync(candidate.path));
+  });
+}
+
 function useAnalyze(molePath: string, dirPath: string) {
   const [data, setData] = useState<AnalyzeResult | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const processRef = useRef<ReturnType<typeof execFile> | null>(null);
 
   const scan = useCallback(() => {
+    processRef.current?.kill();
     setIsLoading(true);
     setData(null);
+    setError(null);
 
-    execFile(
+    const proc = execFile(
       molePath,
       ["analyze", "--json", dirPath],
-      { maxBuffer: 10 * 1024 * 1024, env: MOLE_ENV },
-      (_err, stdout, stderr) => {
-        const output = stdout || stderr || "";
+      { maxBuffer: MAX_ANALYZE_OUTPUT_BYTES, timeout: ANALYZE_TIMEOUT_MS, env: MOLE_ENV },
+      (err, stdout, stderr) => {
+        if (processRef.current !== proc) return;
+        processRef.current = null;
+
+        if (err) {
+          setError(new Error(stderr.trim() || err.message));
+          setIsLoading(false);
+          return;
+        }
+
+        const output = stdout.trim();
+        if (!output) {
+          setError(new Error("Mole did not return analysis data for this location."));
+          setIsLoading(false);
+          return;
+        }
+
         try {
-          setData(JSON.parse(output) as AnalyzeResult);
+          setData(normalizeAnalyzeResult(JSON.parse(output)));
         } catch {
-          setData(null);
+          setError(new Error("Mole returned invalid analysis data for this location."));
         }
         setIsLoading(false);
       },
     );
+    processRef.current = proc;
   }, [molePath, dirPath]);
 
   useEffect(() => {
     scan();
+    return () => {
+      processRef.current?.kill();
+    };
   }, [scan]);
 
-  return { data, isLoading, revalidate: scan };
+  return { data, error, isLoading, revalidate: scan };
 }
 
 export default function AnalyzeDisk() {
@@ -56,19 +120,52 @@ export default function AnalyzeDisk() {
     return <MoleNotInstalled />;
   }
 
-  const { analyzePath } = getPreferenceValues<Preferences.Analyze>();
-  const startPath = analyzePath || process.env.HOME || "/";
+  const { analyzePath } = getPreferenceValues<Preferences.Analyze>() ?? {};
 
-  return <AnalyzeList molePath={molePath} dirPath={startPath} />;
+  if (!analyzePath) {
+    return <AnalyzeStart molePath={molePath} />;
+  }
+
+  return <AnalyzeList molePath={molePath} dirPath={analyzePath} />;
+}
+
+function AnalyzeStart({ molePath }: { molePath: string }) {
+  return (
+    <List searchBarPlaceholder="Choose a location to analyze...">
+      <List.Section title="Locations">
+        {getAnalyzeLocations().map((location) => (
+          <List.Item
+            key={location.path}
+            title={location.title}
+            subtitle={location.path}
+            icon={location.icon}
+            actions={
+              <ActionPanel>
+                <Action.Push
+                  title="Analyze Location"
+                  icon={Icon.MagnifyingGlass}
+                  target={<AnalyzeList molePath={molePath} dirPath={location.path} />}
+                />
+                <Action.ShowInFinder path={location.path} />
+                <Action.CopyToClipboard title="Copy Path" content={location.path} />
+              </ActionPanel>
+            }
+          />
+        ))}
+      </List.Section>
+    </List>
+  );
 }
 
 function AnalyzeList({ molePath, dirPath }: { molePath: string; dirPath: string }) {
-  const { data, isLoading, revalidate } = useAnalyze(molePath, dirPath);
+  const { data, error, isLoading, revalidate } = useAnalyze(molePath, dirPath);
 
   const sorted = useMemo<AnalyzeEntry[]>(() => {
     if (!data?.entries) return [];
     return [...data.entries].sort((a, b) => b.size - a.size);
   }, [data]);
+  const visibleEntries = useMemo(() => sorted.slice(0, MAX_VISIBLE_ENTRIES), [sorted]);
+  const hiddenEntries = sorted.length - visibleEntries.length;
 
   const totalSize = useMemo<number>(() => sorted.reduce((sum: number, e: AnalyzeEntry) => sum + e.size, 0), [sorted]);
 
@@ -80,10 +177,28 @@ function AnalyzeList({ molePath, dirPath }: { molePath: string; dirPath: string 
     return Color.SecondaryText;
   };
 
+  if (error) {
+    return (
+      <List>
+        <List.EmptyView
+          title="Analysis Failed"
+          description={error.message}
+          icon={Icon.ExclamationMark}
+          actions={
+            <ActionPanel>
+              <Action title="Try Again" icon={Icon.ArrowClockwise} onAction={revalidate} />
+              <Action.ShowInFinder path={dirPath} />
+            </ActionPanel>
+          }
+        />
+      </List>
+    );
+  }
+
   return (
     <List isLoading={isLoading} searchBarPlaceholder={`Browsing ${dirPath}`} navigationTitle={dirPath.split("/").pop()}>
       {isLoading && !data && <List.Item title="Analyzing..." subtitle={dirPath} icon={Icon.MagnifyingGlass} />}
-      {sorted.map((entry: AnalyzeEntry) => (
+      {visibleEntries.map((entry: AnalyzeEntry) => (
         <List.Item
           key={entry.path}
           title={entry.name}
@@ -119,6 +234,19 @@ function AnalyzeList({ molePath, dirPath }: { molePath: string; dirPath: string 
           }
         />
       ))}
+      {hiddenEntries > 0 && (
+        <List.Item
+          title={`${hiddenEntries} smaller items hidden`}
+          subtitle={`Showing the largest ${MAX_VISIBLE_ENTRIES} entries to keep Raycast responsive`}
+          icon={Icon.EyeDisabled}
+          actions={
+            <ActionPanel>
+              <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={revalidate} />
+              <Action.ShowInFinder path={dirPath} />
+            </ActionPanel>
+          }
+        />
+      )}
     </List>
   );
 }

--- a/extensions/mole/src/clean.tsx
+++ b/extensions/mole/src/clean.tsx
@@ -6,12 +6,27 @@ import { getMolePathSafe, runMole, MOLE_ENV } from "./utils/mole";
 import { parseCleanDryRun, type CleanDryRunResult } from "./utils/parsers";
 import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
+const CLEAN_SCAN_TIMEOUT_MS = 180000;
+const CLEAN_PREVIEW_LINE_LIMIT = 2000;
+
+function isCleanPreviewLine(line: string): boolean {
+  return (
+    line.includes("➤") ||
+    line.includes("→") ||
+    line.includes("Potential space:") ||
+    line.includes("Items:") ||
+    line.includes("Nothing to clean") ||
+    line.includes("already clean")
+  );
+}
+
 function useStreamingClean(molePath: string) {
   const [data, setData] = useState<CleanDryRunResult>({ sections: [], totalSpace: "Scanning...", totalItems: 0 });
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const processRef = useRef<ChildProcess | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scanTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const startScan = useCallback(() => {
     if (processRef.current) {
@@ -22,6 +37,10 @@ function useStreamingClean(molePath: string) {
       clearTimeout(timerRef.current);
       timerRef.current = null;
     }
+    if (scanTimeoutRef.current) {
+      clearTimeout(scanTimeoutRef.current);
+      scanTimeoutRef.current = null;
+    }
 
     setIsLoading(true);
     setData({ sections: [], totalSpace: "Scanning...", totalItems: 0 });
@@ -30,31 +49,69 @@ function useStreamingClean(molePath: string) {
     const proc = spawn(molePath, ["clean", "--dry-run"], { env: MOLE_ENV });
     processRef.current = proc;
     let buffer = "";
+    let partialLine = "";
+
+    const appendPreviewLine = (line: string) => {
+      if (!isCleanPreviewLine(line)) return;
+      buffer += `${line}\n`;
+
+      const lines = buffer.split("\n");
+      if (lines.length > CLEAN_PREVIEW_LINE_LIMIT) {
+        buffer = lines.slice(-CLEAN_PREVIEW_LINE_LIMIT).join("\n");
+      }
+    };
+
+    const flushPreview = () => {
+      if (partialLine) {
+        appendPreviewLine(partialLine);
+        partialLine = "";
+      }
+      setData(parseCleanDryRun(buffer));
+    };
+
+    scanTimeoutRef.current = setTimeout(() => {
+      if (processRef.current !== proc) return;
+      setError(new Error("Mole clean preview timed out. Try again after validating sudo or reducing the scan scope."));
+      setIsLoading(false);
+      processRef.current = null;
+      proc.kill();
+    }, CLEAN_SCAN_TIMEOUT_MS);
 
     const handleChunk = (chunk: Buffer) => {
       if (processRef.current !== proc) return;
-      buffer += chunk.toString();
+      const lines = `${partialLine}${chunk.toString()}`.split(/\r?\n/);
+      partialLine = lines.pop() ?? "";
+      lines.forEach(appendPreviewLine);
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => {
-        if (processRef.current === proc) setData(parseCleanDryRun(buffer));
+        if (processRef.current === proc) flushPreview();
       }, 300);
     };
 
     proc.stdout.on("data", handleChunk);
     proc.stderr.on("data", handleChunk);
 
-    proc.on("close", () => {
+    proc.on("close", (code) => {
       if (processRef.current !== proc) return;
       if (timerRef.current) clearTimeout(timerRef.current);
+      if (scanTimeoutRef.current) clearTimeout(scanTimeoutRef.current);
+      flushPreview();
       const final = parseCleanDryRun(buffer);
       setData(final);
       setIsLoading(false);
       processRef.current = null;
+
+      if (code !== 0) {
+        setError(new Error(`Mole clean preview exited with code ${code ?? "unknown"}.`));
+        return;
+      }
+
       showToast({ style: Toast.Style.Success, title: "Scan complete", message: `${final.totalSpace} recoverable` });
     });
 
     proc.on("error", (err: Error) => {
       if (processRef.current !== proc) return;
+      if (scanTimeoutRef.current) clearTimeout(scanTimeoutRef.current);
       setError(err);
       setIsLoading(false);
       processRef.current = null;
@@ -66,6 +123,7 @@ function useStreamingClean(molePath: string) {
     return () => {
       processRef.current?.kill();
       if (timerRef.current) clearTimeout(timerRef.current);
+      if (scanTimeoutRef.current) clearTimeout(scanTimeoutRef.current);
     };
   }, [startScan]);
 

--- a/extensions/mole/src/clean.tsx
+++ b/extensions/mole/src/clean.tsx
@@ -95,7 +95,6 @@ function useStreamingClean(molePath: string) {
       if (processRef.current !== proc) return;
       if (timerRef.current) clearTimeout(timerRef.current);
       if (scanTimeoutRef.current) clearTimeout(scanTimeoutRef.current);
-      flushPreview();
       const final = parseCleanDryRun(buffer);
       setData(final);
       setIsLoading(false);

--- a/extensions/mole/src/system-status.tsx
+++ b/extensions/mole/src/system-status.tsx
@@ -6,6 +6,26 @@ import { type MoleStatus, formatBytes, formatPercent, formatRate } from "./utils
 import { getHealthIcon, getUsageColor, getBatteryIcon } from "./utils/icons";
 import { MoleNotInstalled } from "./components/MoleNotInstalled";
 
+function listOrEmpty<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeStatus(status: MoleStatus): MoleStatus {
+  return {
+    ...status,
+    batteries: listOrEmpty(status.batteries),
+    bluetooth: listOrEmpty(status.bluetooth),
+    disks: listOrEmpty(status.disks),
+    gpu: listOrEmpty(status.gpu),
+    network: listOrEmpty(status.network),
+    top_processes: listOrEmpty(status.top_processes),
+    cpu: {
+      ...status.cpu,
+      per_core: listOrEmpty(status.cpu?.per_core),
+    },
+  };
+}
+
 export default function SystemStatus() {
   const molePath = getMolePathSafe();
 
@@ -17,12 +37,15 @@ export default function SystemStatus() {
 }
 
 function StatusView({ molePath }: { molePath: string }) {
-  const { statusRefreshInterval } = getPreferenceValues<Preferences.SystemStatus>();
+  const { statusRefreshInterval } = getPreferenceValues<Preferences.SystemStatus>() ?? {};
   const refreshInterval = parseInt(statusRefreshInterval ?? "5", 10);
 
   const { data, error, isLoading, revalidate } = useExec(molePath, ["status", "--json"], {
-    parseOutput: ({ stdout }) => JSON.parse(stdout) as MoleStatus,
+    parseOutput: ({ stdout }) => normalizeStatus(JSON.parse(stdout) as MoleStatus),
     keepPreviousData: true,
+    failureToastOptions: {
+      title: "Failed to Get System Status",
+    },
   });
 
   useEffect(() => {
@@ -43,6 +66,7 @@ function StatusView({ molePath }: { molePath: string }) {
       <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={revalidate} />
     </ActionPanel>
   );
+  const activeNetwork = data?.network.filter((n) => n.ip) ?? [];
 
   return (
     <List isLoading={isLoading} isShowingDetail>
@@ -115,10 +139,10 @@ function StatusView({ molePath }: { molePath: string }) {
                           />
                         </List.Item.Detail.Metadata.TagList>
                       )}
-                      {data.network.filter((n) => n.ip).length > 0 && (
+                      {activeNetwork.length > 0 && (
                         <List.Item.Detail.Metadata.Label
                           title="Network"
-                          text={`${data.network.filter((n) => n.ip)[0].name} - ${data.network.filter((n) => n.ip)[0].ip}`}
+                          text={`${activeNetwork[0].name} - ${activeNetwork[0].ip}`}
                         />
                       )}
                       <List.Item.Detail.Metadata.Label title="Processes" text={String(data.procs)} />
@@ -327,46 +351,44 @@ function StatusView({ molePath }: { molePath: string }) {
           )}
 
           <List.Section title="Network">
-            {data.network
-              .filter((n) => n.ip)
-              .map((iface) => (
-                <List.Item
-                  key={iface.name}
-                  title={iface.name}
-                  subtitle={iface.ip}
-                  icon={Icon.Globe}
-                  accessories={[
-                    { text: `\u2193 ${formatRate(iface.rx_rate_mbs)}` },
-                    { text: `\u2191 ${formatRate(iface.tx_rate_mbs)}` },
-                  ]}
-                  detail={
-                    <List.Item.Detail
-                      metadata={
-                        <List.Item.Detail.Metadata>
-                          <List.Item.Detail.Metadata.Label title="Interface" text={iface.name} />
-                          <List.Item.Detail.Metadata.Label title="IP Address" text={iface.ip} />
-                          <List.Item.Detail.Metadata.Separator />
-                          <List.Item.Detail.Metadata.Label title="Download" text={formatRate(iface.rx_rate_mbs)} />
-                          <List.Item.Detail.Metadata.Label title="Upload" text={formatRate(iface.tx_rate_mbs)} />
-                          {data.proxy.enabled && (
-                            <>
-                              <List.Item.Detail.Metadata.Separator />
-                              <List.Item.Detail.Metadata.Label title="Proxy Type" text={data.proxy.type} />
-                              <List.Item.Detail.Metadata.Label title="Proxy Host" text={data.proxy.host} />
-                            </>
-                          )}
-                        </List.Item.Detail.Metadata>
-                      }
-                    />
-                  }
-                  actions={
-                    <ActionPanel>
-                      <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={revalidate} />
-                      <Action.CopyToClipboard title="Copy IP Address" content={iface.ip} />
-                    </ActionPanel>
-                  }
-                />
-              ))}
+            {activeNetwork.map((iface) => (
+              <List.Item
+                key={iface.name}
+                title={iface.name}
+                subtitle={iface.ip}
+                icon={Icon.Globe}
+                accessories={[
+                  { text: `\u2193 ${formatRate(iface.rx_rate_mbs)}` },
+                  { text: `\u2191 ${formatRate(iface.tx_rate_mbs)}` },
+                ]}
+                detail={
+                  <List.Item.Detail
+                    metadata={
+                      <List.Item.Detail.Metadata>
+                        <List.Item.Detail.Metadata.Label title="Interface" text={iface.name} />
+                        <List.Item.Detail.Metadata.Label title="IP Address" text={iface.ip} />
+                        <List.Item.Detail.Metadata.Separator />
+                        <List.Item.Detail.Metadata.Label title="Download" text={formatRate(iface.rx_rate_mbs)} />
+                        <List.Item.Detail.Metadata.Label title="Upload" text={formatRate(iface.tx_rate_mbs)} />
+                        {data.proxy.enabled && (
+                          <>
+                            <List.Item.Detail.Metadata.Separator />
+                            <List.Item.Detail.Metadata.Label title="Proxy Type" text={data.proxy.type} />
+                            <List.Item.Detail.Metadata.Label title="Proxy Host" text={data.proxy.host} />
+                          </>
+                        )}
+                      </List.Item.Detail.Metadata>
+                    }
+                  />
+                }
+                actions={
+                  <ActionPanel>
+                    <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={revalidate} />
+                    <Action.CopyToClipboard title="Copy IP Address" content={iface.ip} />
+                  </ActionPanel>
+                }
+              />
+            ))}
           </List.Section>
 
           <List.Section title="Top Processes">


### PR DESCRIPTION
## Description

This update improves Mole extension stability and integrates the latest pending contribution required by the Raycast publishing flow.

Changes included:

- Fixes `System Status` crashes when Mole returns `null` for optional status arrays such as batteries, network, disks, GPU, Bluetooth, top processes, or CPU cores.
- Improves `Analyze Disk` so it no longer scans the full home directory automatically when no default path is configured. It now starts from explicit locations, handles invalid output/errors, cancels stale processes, applies timeouts, and limits rendered results to keep Raycast responsive.
- Reduces `Clean System` preview memory usage by keeping only relevant scan output, and adds timeout/non-zero exit handling for failed previews.
- Pulls in the pending `Health Menu Bar` contribution, which adds a menu bar command for the system health score with configurable refresh intervals.
- Updates the changelog for the stability fixes and the pulled contribution.

## Screencast

No screencast attached. The primary changes are defensive runtime stability fixes for existing commands. The `Health Menu Bar` command was pulled in through `npx @raycast/api@latest pull-contributions` because Raycast required merging pending contributions before publishing this update.

## Validation

- `npm run lint`
- `npm run build`
- `npm run publish`

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
