### PR TITLE
Update gif-search extension

### DIFF
--- a/extensions/gif-search/CHANGELOG.md
+++ b/extensions/gif-search/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GIF Search Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Sort Recents by most recently visited first, and move an already-recent GIF back to the top when it's visited again
+
 ## [Add Klipy support] - 2026-02-05
 
 - Add Klipy support

--- a/extensions/gif-search/CHANGELOG.md
+++ b/extensions/gif-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GIF Search Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-04-23
 
 - Sort Recents by most recently visited first, and move an already-recent GIF back to the top when it's visited again
 

--- a/extensions/gif-search/src/lib/localGifs.ts
+++ b/extensions/gif-search/src/lib/localGifs.ts
@@ -27,9 +27,10 @@ export async function getAll(type: LocalType) {
 }
 
 export async function save(gif: IGif, service: ServiceName, type: LocalType) {
-  const gifs = new Set(await get(service, type));
-  gifs.add(gif.id.toString());
-  return LocalStorage.setItem(getKey(service, type), JSON.stringify(Array.from(gifs)));
+  const id = gif.id.toString();
+  const existing = (await get(service, type)).filter((existingId) => existingId !== id);
+  const updated = type === "recent" ? [id, ...existing] : [...existing, id];
+  return LocalStorage.setItem(getKey(service, type), JSON.stringify(updated));
 }
 
 export async function remove(gif: IGif, service: ServiceName, type: LocalType) {


### PR DESCRIPTION
## Description

Closes #27346.

Fix Recents ordering in the GIF Search extension. Previously Recents were rendered oldest-first, and re-visiting an already-recent GIF did not move it back to the top because `save()` used a `Set` (no-op on re-add).

Now `save()` removes any prior occurrence of the GIF id, then prepends for `"recent"` (newest first) and appends for `"favs"` (preserves existing insertion-order, no-dupes semantics). No API, schema, or storage-key changes — existing LocalStorage entries keep working and naturally re-sort as users visit GIFs.

### Changed files

- `extensions/gif-search/src/lib/localGifs.ts` — rewrite `save()` body (3 → 4 lines)
- `extensions/gif-search/CHANGELOG.md` — add entry

## Screencast

<!-- N/A — ordering-only change. Happy to add a before/after clip on request. -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` (clean) and `npm run lint` (clean)
- [x] I tested this distribution build in Raycast — new GIFs land at the top of Recents and re-visiting an existing GIF moves it back to the front
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder