### PR TITLE
Update zen-browser extension

### DIFF
--- a/extensions/zen-browser/CHANGELOG.md
+++ b/extensions/zen-browser/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bumped `@raycast/utils` from `^2.2.0` to `^2.2.3` to pick up the fix for `useSQL` not falling back to a DB copy when `node:sqlite` reports `errcode: 5` ("database is locked"). Previously, searching bookmarks or history while Zen was running surfaced "Cannot query the data — database is locked" because the lock detector only matched error message text containing `(5)`/`(14)`, which the native `node:sqlite` path does not produce.
 
-## [Add Kagi Search Engine] - {PR_MERGE_DATE}
+## [Add Kagi Search Engine] - 2026-04-23
 
 - Added Kagi as a search engine option in the extension preferences.
 

--- a/extensions/zen-browser/CHANGELOG.md
+++ b/extensions/zen-browser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zen Changelog
 
+## [Fix Bookmark and History Search When Zen Is Running] - {PR-MERGE-DATE}
+
+- Bumped `@raycast/utils` from `^2.2.0` to `^2.2.3` to pick up the fix for `useSQL` not falling back to a DB copy when `node:sqlite` reports `errcode: 5` ("database is locked"). Previously, searching bookmarks or history while Zen was running surfaced "Cannot query the data — database is locked" because the lock detector only matched error message text containing `(5)`/`(14)`, which the native `node:sqlite` path does not produce.
+
 ## [Add Kagi Search Engine] - {PR-MERGE-DATE}
 
 - Added Kagi as a search engine option in the extension preferences.

--- a/extensions/zen-browser/CHANGELOG.md
+++ b/extensions/zen-browser/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bumped `@raycast/utils` from `^2.2.0` to `^2.2.3` to pick up the fix for `useSQL` not falling back to a DB copy when `node:sqlite` reports `errcode: 5` ("database is locked"). Previously, searching bookmarks or history while Zen was running surfaced "Cannot query the data — database is locked" because the lock detector only matched error message text containing `(5)`/`(14)`, which the native `node:sqlite` path does not produce.
 
-## [Add Kagi Search Engine] - {PR-MERGE-DATE}
+## [Add Kagi Search Engine] - {PR_MERGE_DATE}
 
 - Added Kagi as a search engine option in the extension preferences.
 

--- a/extensions/zen-browser/package-lock.json
+++ b/extensions/zen-browser/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.103.0",
-        "@raycast/utils": "^2.2.0"
+        "@raycast/utils": "^2.2.3"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
@@ -1142,6 +1142,7 @@
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.103.3.tgz",
       "integrity": "sha512-+lS8yOrqSP7++ZyomZnMkN0pzEZto/XOqag8MXt9SmTuJBZvfMV74f9wzXmJkRmynYxQHnpLqvs9otWrDd3Bvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.5.4",
         "@oclif/plugin-autocomplete": "^3.2.35",
@@ -1208,9 +1209,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.1.tgz",
-      "integrity": "sha512-MBOD3eccHTu1HVQstoqoJJsA5PubWv18EUq8Dxwg1PEJE+xVjEuslXpsNgR/2RtpTGeKgGiXePxUiVp5mILN5w==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.3.tgz",
+      "integrity": "sha512-YwqleVl0Wk/FOq+672gtvswuwMqjNqIr+c63FhouTEHc1LJ3zaohLSkW4+UcfBjPU8HySKQm+kJqZW1iOM9fnA==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1251,6 +1252,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1321,6 +1323,7 @@
       "integrity": "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.0",
         "@typescript-eslint/types": "8.46.0",
@@ -1526,6 +1529,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1890,6 +1894,7 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2747,6 +2752,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2987,6 +2993,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3051,6 +3058,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/zen-browser/package.json
+++ b/extensions/zen-browser/package.json
@@ -259,7 +259,7 @@
   },
   "dependencies": {
     "@raycast/api": "^1.103.0",
-    "@raycast/utils": "^2.2.0"
+    "@raycast/utils": "^2.2.3"
   },
   "devDependencies": {
     "@types/sql.js": "1.4.4",


### PR DESCRIPTION
## Description

Bumps `@raycast/utils` from `^2.2.0` (lockfile: `2.2.1`) to `^2.2.3`.

Search Bookmarks and Search History break with "Cannot query the data, database is locked" when Zen is running. Until recently, Raycast's Node runtime didn't expose `node:sqlite`, so `useSQL` in `@raycast/utils` fell through to the `sqlite3` CLI path. The CLI's error text contains `(5)`, which matches the existing lock detector and triggers the copy-to-temp fallback — so searches worked.

Raycast now bundles Node 22.22.2, which does expose `node:sqlite`. `useSQL` switches to the native path, and its error comes back as:

```
{ errcode: 5, message: "database is locked", code: "ERR_SQLITE_ERROR" }
```

No `(5)` in the message. The detector in `@raycast/utils` 2.2.1/2.2.2 only used `message.match("(5)") || message.match("(14)")`, so the lock went undetected, the fallback never ran, and the error bubbled up to the user.

[`@raycast/utils` 2.2.3 (PR #66)](https://github.com/raycast/utils/pull/66) added `error.errcode === 5 || error.errcode === 14` to the detector, which handles the native `node:sqlite` error shape. Bumping the pin fixes the regression.

No source changes — dependency bump only, plus lockfile and changelog entry.

## Screencast

Before (Zen running, installed store version):

> `Cannot query the data  database is locked`

After (Zen running, this branch via `npm run dev`):

> Bookmarks return as expected.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder