### PR TITLE
Remove tracking query parameter from Notion URL in copy-notion-markdown-link

### DIFF
--- a/extensions/copy-notion-markdown-link/CHANGELOG.md
+++ b/extensions/copy-notion-markdown-link/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Copy Notion Markdown Link Changelog
 
+## [Remove tracking query parameter] - 2026-04-23
+
+- Remove `source=copy_link` tracking query parameter from copied Notion URLs to produce cleaner markdown links.
+
 ## [Initial Version] - 2025-11-04

--- a/extensions/copy-notion-markdown-link/src/get-notion-page-as-markdown-link.ts
+++ b/extensions/copy-notion-markdown-link/src/get-notion-page-as-markdown-link.ts
@@ -77,8 +77,11 @@ export default async function main() {
     const windowTitle = parts[0];
     const linkUrl = parts[1];
 
+    // Remove tracking query parameter
+    const cleanedUrl = linkUrl?.replace(/[?&]source=copy_link/, "");
+
     // URL validation
-    if (!linkUrl || !linkUrl.includes("notion.so")) {
+    if (!cleanedUrl || !cleanedUrl.includes("notion.so")) {
       await showHUD("Failed to copy Notion link. Please try again.");
       if (previousClipboard) {
         await Clipboard.copy(previousClipboard);
@@ -94,7 +97,7 @@ export default async function main() {
       cleanedTitle = windowTitle.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
     }
 
-    const markdownLink = `[${cleanedTitle}](${linkUrl})`;
+    const markdownLink = `[${cleanedTitle}](${cleanedUrl})`;
 
     await Clipboard.copy(markdownLink);
 

--- a/extensions/copy-notion-markdown-link/src/get-notion-page-as-markdown-link.ts
+++ b/extensions/copy-notion-markdown-link/src/get-notion-page-as-markdown-link.ts
@@ -77,19 +77,19 @@ export default async function main() {
     const windowTitle = parts[0];
     const linkUrl = parts[1];
 
-    // Remove tracking query parameter
-    const url = new URL(linkUrl);
-    url.searchParams.delete("source");
-    const cleanedUrl = url.toString();
-
     // URL validation
-    if (!cleanedUrl || !cleanedUrl.includes("notion.so")) {
+    if (!linkUrl || !linkUrl.includes("notion.so")) {
       await showHUD("Failed to copy Notion link. Please try again.");
       if (previousClipboard) {
         await Clipboard.copy(previousClipboard);
       }
       return;
     }
+
+    // Remove tracking query parameter
+    const url = new URL(linkUrl);
+    url.searchParams.delete("source");
+    const cleanedUrl = url.toString();
 
     // Process title - check if empty first, then escape square brackets
     let cleanedTitle: string;

--- a/extensions/copy-notion-markdown-link/src/get-notion-page-as-markdown-link.ts
+++ b/extensions/copy-notion-markdown-link/src/get-notion-page-as-markdown-link.ts
@@ -78,7 +78,9 @@ export default async function main() {
     const linkUrl = parts[1];
 
     // Remove tracking query parameter
-    const cleanedUrl = linkUrl?.replace(/[?&]source=copy_link/, "");
+    const url = new URL(linkUrl);
+    url.searchParams.delete("source");
+    const cleanedUrl = url.toString();
 
     // URL validation
     if (!cleanedUrl || !cleanedUrl.includes("notion.so")) {


### PR DESCRIPTION
## Description

Remove the `?source=copy_link` tracking query parameter from the Notion page URL when generating markdown links.

### Why

When copying a page link in Notion, the `source=copy_link` parameter is automatically appended for Notion's internal analytics. This parameter is not needed for accessing the page and clutters the generated markdown links. Since this extension's purpose is to produce clean markdown links, removing it improves the output.

### How

Uses the `URL` API to safely delete only the `source` parameter, preserving any other query parameters and avoiding malformed URLs.

## Screencast

N/A (no visual change — the copied markdown link simply no longer includes `?source=copy_link`)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)