### PR TITLE
[Cloudflare] Add zone, tag & hostname cache purge; add ability to favorite sites

### DIFF
--- a/extensions/cloudflare/CHANGELOG.md
+++ b/extensions/cloudflare/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Cloudflare Changelog
 
-## [Custom Cache Purge & Favorite Sites] - {PR_MERGE_DATE}
+## [Custom Cache Purge & Favorite Sites] - 2026-04-27
 
 - Added support for purging cache by Hostname, Cache-Tag, and Prefix in addition to URL
 - New "Purge By" dropdown in the cache purge form with contextual hints and input validation (up to 100 tags)

--- a/extensions/cloudflare/CHANGELOG.md
+++ b/extensions/cloudflare/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Cloudflare Changelog
 
+## [Custom Cache Purge & Favorite Sites] - {PR_MERGE_DATE}
+
+- Added support for purging cache by Hostname, Cache-Tag, and Prefix in addition to URL
+- New "Purge By" dropdown in the cache purge form with contextual hints and input validation (up to 100 tags)
+- Remembers the last selected purge type and the last entered values per type and per site, with a "Purge Last Saved Values" action (`⌘⇧R`) for quick repeat purges
+- Purge history now tracks the purge type for each entry and lets you re-run previous purges
+- Added the ability to mark sites (zones) as favorites; favorites appear in a dedicated section at the top of the sites list (`⌘F` to toggle)
+
 ## [View Workers Command] - 2026-01-24
 
 - Added new "View Workers" command to list Cloudflare Workers across all accounts

--- a/extensions/cloudflare/src/service.ts
+++ b/extensions/cloudflare/src/service.ts
@@ -312,6 +312,48 @@ class Service {
     return { success, errors, messages, result };
   }
 
+  async purgeByHostnames(
+    zoneId: string,
+    hosts: string[],
+  ): Promise<CachePurgeResult> {
+    const response = await this.client.post<CachePurgeResult>(
+      `zones/${zoneId}/purge_cache`,
+      {
+        hosts,
+      },
+    );
+    const { success, errors, messages, result } = response.data;
+    return { success, errors, messages, result };
+  }
+
+  async purgeByTags(
+    zoneId: string,
+    tags: string[],
+  ): Promise<CachePurgeResult> {
+    const response = await this.client.post<CachePurgeResult>(
+      `zones/${zoneId}/purge_cache`,
+      {
+        tags,
+      },
+    );
+    const { success, errors, messages, result } = response.data;
+    return { success, errors, messages, result };
+  }
+
+  async purgeByPrefixes(
+    zoneId: string,
+    prefixes: string[],
+  ): Promise<CachePurgeResult> {
+    const response = await this.client.post<CachePurgeResult>(
+      `zones/${zoneId}/purge_cache`,
+      {
+        prefixes,
+      },
+    );
+    const { success, errors, messages, result } = response.data;
+    return { success, errors, messages, result };
+  }
+
   async purgeEverything(zoneId: string): Promise<CachePurgeResult> {
     const response = await this.client.post<CachePurgeResult>(
       `zones/${zoneId}/purge_cache`,

--- a/extensions/cloudflare/src/service.ts
+++ b/extensions/cloudflare/src/service.ts
@@ -326,10 +326,7 @@ class Service {
     return { success, errors, messages, result };
   }
 
-  async purgeByTags(
-    zoneId: string,
-    tags: string[],
-  ): Promise<CachePurgeResult> {
+  async purgeByTags(zoneId: string, tags: string[]): Promise<CachePurgeResult> {
     const response = await this.client.post<CachePurgeResult>(
       `zones/${zoneId}/purge_cache`,
       {
@@ -506,6 +503,7 @@ function formatWorker(item: WorkerItem): Worker {
 export default Service;
 export type {
   Account,
+  CachePurgeResult,
   Deployment,
   DeploymentStatus,
   DnsRecord,

--- a/extensions/cloudflare/src/view-cache-purge.tsx
+++ b/extensions/cloudflare/src/view-cache-purge.tsx
@@ -10,7 +10,7 @@ import {
   showToast,
   Toast,
 } from '@raycast/api';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Service, { CachePurgeResult, Zone } from './service';
 import { getToken } from './utils';
 import { SiteProps } from './view-sites';
@@ -68,6 +68,7 @@ export function CachePurgeView(props: SiteProps) {
   const [purgeType, setPurgeType] = useState<PurgeType>('url');
   const [entries, setEntries] = useState<string>('');
   const [loaded, setLoaded] = useState(false);
+  const currentTypeRef = useRef<PurgeType>('url');
   const field = PURGE_FIELD_CONFIG[purgeType];
 
   // Restore last selected purge type and its last entries on mount
@@ -82,6 +83,7 @@ export function CachePurgeView(props: SiteProps) {
         : 'url';
       const lastEntries =
         (await LocalStorage.getItem<string>(LAST_ENTRIES_KEY(id, type))) ?? '';
+      currentTypeRef.current = type;
       setPurgeType(type);
       setEntries(lastEntries);
       setLoaded(true);
@@ -91,11 +93,15 @@ export function CachePurgeView(props: SiteProps) {
   // Load remembered entries whenever the type changes (after initial load)
   const handleTypeChange = async (value: string) => {
     const type = value as PurgeType;
+    currentTypeRef.current = type;
     setPurgeType(type);
     await LocalStorage.setItem(LAST_TYPE_KEY(id), type);
     const remembered =
       (await LocalStorage.getItem<string>(LAST_ENTRIES_KEY(id, type))) ?? '';
-    setEntries(remembered);
+    // Guard against stale resolution when the user switches types rapidly.
+    if (currentTypeRef.current === type) {
+      setEntries(remembered);
+    }
   };
 
   const handleSubmit = async (values: { entries: string }) => {

--- a/extensions/cloudflare/src/view-cache-purge.tsx
+++ b/extensions/cloudflare/src/view-cache-purge.tsx
@@ -10,7 +10,7 @@ import {
   showToast,
   Toast,
 } from '@raycast/api';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Service, { CachePurgeResult, Zone } from './service';
 import { getToken } from './utils';
 import { SiteProps } from './view-sites';
@@ -18,6 +18,19 @@ import { SiteProps } from './view-sites';
 const service = new Service(getToken());
 
 type PurgeType = 'url' | 'hostname' | 'tag' | 'prefix';
+const PURGE_TYPES: readonly PurgeType[] = [
+  'url',
+  'hostname',
+  'tag',
+  'prefix',
+] as const;
+
+function isPurgeType(value: unknown): value is PurgeType {
+  return (
+    typeof value === 'string' &&
+    (PURGE_TYPES as readonly string[]).includes(value)
+  );
+}
 
 interface CachePurgeHistoryItem {
   url: string;
@@ -63,60 +76,86 @@ const LAST_TYPE_KEY = (zoneId: string) => `cache-purge-last-type-${zoneId}`;
 const LAST_ENTRIES_KEY = (zoneId: string, type: PurgeType) =>
   `cache-purge-last-entries-${zoneId}-${type}`;
 
+type RememberedEntries = Record<PurgeType, string>;
+
+interface InitialState {
+  type: PurgeType;
+  entriesByType: RememberedEntries;
+}
+
+async function loadInitialState(zoneId: string): Promise<InitialState> {
+  const [storedType, ...storedEntries] = await Promise.all([
+    LocalStorage.getItem<string>(LAST_TYPE_KEY(zoneId)),
+    ...PURGE_TYPES.map((type) =>
+      LocalStorage.getItem<string>(LAST_ENTRIES_KEY(zoneId, type)),
+    ),
+  ]);
+  const type = isPurgeType(storedType) ? storedType : 'url';
+  const entriesByType = PURGE_TYPES.reduce((acc, t, i) => {
+    acc[t] = storedEntries[i] ?? '';
+    return acc;
+  }, {} as RememberedEntries);
+  return { type, entriesByType };
+}
+
 export function CachePurgeView(props: SiteProps) {
   const { id } = props;
-  const [purgeType, setPurgeType] = useState<PurgeType>('url');
-  const [entries, setEntries] = useState<string>('');
-  const [loaded, setLoaded] = useState(false);
-  const currentTypeRef = useRef<PurgeType>('url');
-  const field = PURGE_FIELD_CONFIG[purgeType];
+  const [initialState, setInitialState] = useState<InitialState | null>(null);
 
-  // Restore last selected purge type and its last entries on mount
   useEffect(() => {
-    (async () => {
-      const lastType =
-        (await LocalStorage.getItem<string>(LAST_TYPE_KEY(id))) ?? 'url';
-      const type = (
-        ['url', 'hostname', 'tag', 'prefix'] as PurgeType[]
-      ).includes(lastType as PurgeType)
-        ? (lastType as PurgeType)
-        : 'url';
-      const lastEntries =
-        (await LocalStorage.getItem<string>(LAST_ENTRIES_KEY(id, type))) ?? '';
-      currentTypeRef.current = type;
-      setPurgeType(type);
-      setEntries(lastEntries);
-      setLoaded(true);
-    })();
+    let cancelled = false;
+    loadInitialState(id).then((state) => {
+      if (!cancelled) setInitialState(state);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
-  // Load remembered entries whenever the type changes (after initial load)
-  const handleTypeChange = async (value: string) => {
-    const type = value as PurgeType;
-    currentTypeRef.current = type;
-    setPurgeType(type);
-    await LocalStorage.setItem(LAST_TYPE_KEY(id), type);
-    const remembered =
-      (await LocalStorage.getItem<string>(LAST_ENTRIES_KEY(id, type))) ?? '';
-    // Guard against stale resolution when the user switches types rapidly.
-    if (currentTypeRef.current === type) {
-      setEntries(remembered);
-    }
+  if (!initialState) {
+    return <Form isLoading />;
+  }
+
+  return <CachePurgeForm zoneId={id} initialState={initialState} />;
+}
+
+interface CachePurgeFormProps {
+  zoneId: string;
+  initialState: InitialState;
+}
+
+function CachePurgeForm({ zoneId, initialState }: CachePurgeFormProps) {
+  const [purgeType, setPurgeType] = useState<PurgeType>(initialState.type);
+  const [entriesByType, setEntriesByType] = useState<RememberedEntries>(
+    initialState.entriesByType,
+  );
+  const field = PURGE_FIELD_CONFIG[purgeType];
+  const entries = entriesByType[purgeType];
+
+  const handleTypeChange = (value: string) => {
+    if (!isPurgeType(value) || value === purgeType) return;
+    setPurgeType(value);
+    void LocalStorage.setItem(LAST_TYPE_KEY(zoneId), value);
+  };
+
+  const handleEntriesChange = (value: string) => {
+    setEntriesByType((prev) => ({ ...prev, [purgeType]: value }));
   };
 
   const handleSubmit = async (values: { entries: string }) => {
     const rawValue = values.entries ?? '';
-    const initiated = await submitPurge(id, purgeType, rawValue);
+    const initiated = await submitPurge(zoneId, purgeType, rawValue);
     if (initiated) {
-      await LocalStorage.setItem(LAST_TYPE_KEY(id), purgeType);
-      await LocalStorage.setItem(LAST_ENTRIES_KEY(id, purgeType), rawValue);
+      await Promise.all([
+        LocalStorage.setItem(LAST_TYPE_KEY(zoneId), purgeType),
+        LocalStorage.setItem(LAST_ENTRIES_KEY(zoneId, purgeType), rawValue),
+      ]);
+      setEntriesByType((prev) => ({ ...prev, [purgeType]: rawValue }));
     }
   };
 
   const handlePurgeLast = async () => {
-    const remembered =
-      (await LocalStorage.getItem<string>(LAST_ENTRIES_KEY(id, purgeType))) ??
-      '';
+    const remembered = entriesByType[purgeType];
     if (!remembered.trim()) {
       await showToast({
         style: Toast.Style.Failure,
@@ -125,12 +164,11 @@ export function CachePurgeView(props: SiteProps) {
       });
       return;
     }
-    await submitPurge(id, purgeType, remembered);
+    await submitPurge(zoneId, purgeType, remembered);
   };
 
   return (
     <Form
-      isLoading={!loaded}
       actions={
         <ActionPanel>
           <Action.SubmitForm
@@ -147,7 +185,7 @@ export function CachePurgeView(props: SiteProps) {
           <Action.Push
             icon={Icon.List}
             title="Purge History"
-            target={<CachePurgeHistory id={id} accountId={''} />}
+            target={<CachePurgeHistory id={zoneId} accountId={''} />}
             shortcut={{ modifiers: ['cmd'], key: 'h' }}
           />
         </ActionPanel>
@@ -174,7 +212,7 @@ export function CachePurgeView(props: SiteProps) {
         placeholder={field.placeholder}
         info={field.info}
         value={entries}
-        onChange={setEntries}
+        onChange={handleEntriesChange}
       />
     </Form>
   );

--- a/extensions/cloudflare/src/view-cache-purge.tsx
+++ b/extensions/cloudflare/src/view-cache-purge.tsx
@@ -17,104 +17,308 @@ import { SiteProps } from './view-sites';
 
 const service = new Service(getToken());
 
+type PurgeType = 'url' | 'hostname' | 'tag' | 'prefix';
+
 interface CachePurgeHistoryItem {
   url: string;
   lastPurged: string;
   count: number;
+  type?: PurgeType;
 }
+
+const PURGE_FIELD_CONFIG: Record<
+  PurgeType,
+  { title: string; placeholder: string; info: string }
+> = {
+  url: {
+    title: 'List of URL(s)',
+    placeholder: 'https://example.com/foo\nhttps://example.com/bar',
+    info: 'Separate URL(s) one per line or with commas. Purges assets in the cache that match the URL(s) exactly.',
+  },
+  hostname: {
+    title: 'List of Hostname(s)',
+    placeholder: 'www.example.com\nimages.example.com',
+    info: 'Any assets at URLs with a host that matches one of the provided values will be purged from the cache. Separate one per line or with commas.',
+  },
+  tag: {
+    title: 'List of Cache Tag(s)',
+    placeholder: 'dog, cat, foobar',
+    info: 'Any assets served with a Cache-Tag response header that matches one of the provided values will be purged. Up to 100 tags at a time. Separate with commas or one per line.',
+  },
+  prefix: {
+    title: 'List of Prefix(es)',
+    placeholder: 'example.com/foo\nexample.com/bar/',
+    info: 'Any assets in the directory will be purged from cache. Separate one per line or with commas.',
+  },
+};
+
+function parseEntries(value: string): string[] {
+  return value
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+const LAST_TYPE_KEY = (zoneId: string) => `cache-purge-last-type-${zoneId}`;
+const LAST_ENTRIES_KEY = (zoneId: string, type: PurgeType) =>
+  `cache-purge-last-entries-${zoneId}-${type}`;
 
 export function CachePurgeView(props: SiteProps) {
   const { id } = props;
+  const [purgeType, setPurgeType] = useState<PurgeType>('url');
+  const [entries, setEntries] = useState<string>('');
+  const [loaded, setLoaded] = useState(false);
+  const field = PURGE_FIELD_CONFIG[purgeType];
+
+  // Restore last selected purge type and its last entries on mount
+  useEffect(() => {
+    (async () => {
+      const lastType =
+        (await LocalStorage.getItem<string>(LAST_TYPE_KEY(id))) ?? 'url';
+      const type = (['url', 'hostname', 'tag', 'prefix'] as PurgeType[]).includes(
+        lastType as PurgeType,
+      )
+        ? (lastType as PurgeType)
+        : 'url';
+      const lastEntries =
+        (await LocalStorage.getItem<string>(LAST_ENTRIES_KEY(id, type))) ?? '';
+      setPurgeType(type);
+      setEntries(lastEntries);
+      setLoaded(true);
+    })();
+  }, [id]);
+
+  // Load remembered entries whenever the type changes (after initial load)
+  const handleTypeChange = async (value: string) => {
+    const type = value as PurgeType;
+    setPurgeType(type);
+    await LocalStorage.setItem(LAST_TYPE_KEY(id), type);
+    const remembered =
+      (await LocalStorage.getItem<string>(LAST_ENTRIES_KEY(id, type))) ?? '';
+    setEntries(remembered);
+  };
+
+  const handleSubmit = async (values: { entries: string }) => {
+    await LocalStorage.setItem(LAST_TYPE_KEY(id), purgeType);
+    await LocalStorage.setItem(
+      LAST_ENTRIES_KEY(id, purgeType),
+      values.entries ?? '',
+    );
+    await submitPurge(id, purgeType, values.entries ?? '');
+  };
+
+  const handlePurgeLast = async () => {
+    const remembered =
+      (await LocalStorage.getItem<string>(LAST_ENTRIES_KEY(id, purgeType))) ??
+      '';
+    if (!remembered.trim()) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: 'No previous purge',
+        message: `No remembered ${purgeType} values for this site.`,
+      });
+      return;
+    }
+    await submitPurge(id, purgeType, remembered);
+  };
 
   return (
     <Form
+      isLoading={!loaded}
       actions={
         <ActionPanel>
           <Action.SubmitForm
             icon={Icon.Hammer}
-            title="Purge Files"
-            onSubmit={(values) => clearUrlsFromCache(id, values.urls)}
+            title="Purge Cache"
+            onSubmit={handleSubmit}
+          />
+          <Action
+            icon={Icon.Repeat}
+            title="Purge Last Saved Values"
+            shortcut={{ modifiers: ['cmd', 'shift'], key: 'r' }}
+            onAction={handlePurgeLast}
           />
           <Action.Push
             icon={Icon.List}
-            title="File Purge History"
+            title="Purge History"
             target={<CachePurgeHistory id={id} accountId={''} />}
             shortcut={{ modifiers: ['cmd'], key: 'h' }}
           />
         </ActionPanel>
       }
     >
+      <Form.Dropdown
+        id="purgeType"
+        title="Purge By"
+        value={purgeType}
+        onChange={handleTypeChange}
+      >
+        <Form.Dropdown.Item value="url" title="URL" icon={Icon.Link} />
+        <Form.Dropdown.Item
+          value="hostname"
+          title="Hostname"
+          icon={Icon.Globe}
+        />
+        <Form.Dropdown.Item value="tag" title="Tag" icon={Icon.Tag} />
+        <Form.Dropdown.Item value="prefix" title="Prefix" icon={Icon.Folder} />
+      </Form.Dropdown>
       <Form.TextArea
-        id="urls"
-        title="List of URL(s)"
-        placeholder="Separate URL(s) one per line"
+        id="entries"
+        title={field.title}
+        placeholder={field.placeholder}
+        info={field.info}
+        value={entries}
+        onChange={setEntries}
       />
     </Form>
   );
 }
 
+async function submitPurge(
+  zoneId: string,
+  type: PurgeType,
+  rawValue: string,
+) {
+  const entries = parseEntries(rawValue);
+  if (entries.length === 0) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: 'No values provided',
+      message: 'Please enter at least one value to purge.',
+    });
+    return;
+  }
+  if (type === 'tag' && entries.length > 100) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: 'Too many tags',
+      message: 'You can purge up to 100 tags at a time.',
+    });
+    return;
+  }
+  await purgeFromCache(zoneId, type, entries);
+}
+
 function CachePurgeHistory(props: SiteProps) {
   const { id } = props;
 
-  const [state, setState] = useState({ items: [] });
+  const [state, setState] = useState<{ items: CachePurgeHistoryItem[] }>({
+    items: [],
+  });
+  const [sortBy, setSortBy] = useState<'latest' | 'count' | 'oldest'>(
+    'latest',
+  );
 
   useEffect(() => {
+    LocalStorage.getItem<string>(`cache-purge-sort-${id}`).then((value) => {
+      if (value === 'latest' || value === 'count' || value === 'oldest') {
+        setSortBy(value);
+      }
+    });
     LocalStorage.getItem<string>(`cache-purge-history-${id}`).then((items) => {
       if (items) {
         setState({ items: JSON.parse(items) });
       }
     });
+  }, [id]);
+
+  const sortedItems = [...state.items].sort((a, b) => {
+    switch (sortBy) {
+      case 'count':
+        return b.count - a.count;
+      case 'oldest':
+        return (
+          new Date(a.lastPurged).getTime() - new Date(b.lastPurged).getTime()
+        );
+      case 'latest':
+      default:
+        return (
+          new Date(b.lastPurged).getTime() - new Date(a.lastPurged).getTime()
+        );
+    }
   });
 
   return (
-    <List>
-      {state.items.map((entry: CachePurgeHistoryItem, index) => (
-        <List.Item
-          key={index}
-          title={entry.url}
-          accessories={[
-            { text: `${entry.count} time(s) purged` },
-            {
-              text: `Last purged at ${new Date(
-                entry.lastPurged,
-              ).toLocaleString()}`,
-            },
-          ]}
-          actions={
-            <ActionPanel>
-              <Action
-                icon={Icon.Hammer}
-                title="Purge URL"
-                shortcut={{ modifiers: ['cmd', 'shift'], key: 'p' }}
-                onAction={() => clearUrlsFromCache(id, entry.url)}
-              />
-              <Action
-                icon={Icon.Trash}
-                title="Remove from History"
-                shortcut={{ modifiers: ['cmd'], key: 'd' }}
-                onAction={() => {
-                  const items = state.items.filter(
-                    (item: CachePurgeHistoryItem) => item.url !== entry.url,
-                  );
-                  LocalStorage.setItem(
-                    `cache-purge-history-${id}`,
-                    JSON.stringify(items),
-                  );
-                  setState({ items });
-                }}
-              />
-            </ActionPanel>
-          }
-        />
-      ))}
+    <List
+      searchBarAccessory={
+        <List.Dropdown
+          tooltip="Sort By"
+          value={sortBy}
+          onChange={(value) => {
+            setSortBy(value as 'latest' | 'count' | 'oldest');
+            LocalStorage.setItem(`cache-purge-sort-${id}`, value);
+          }}
+        >
+          <List.Dropdown.Item title="Latest First" value="latest" />
+          <List.Dropdown.Item title="Oldest First" value="oldest" />
+          <List.Dropdown.Item title="Most Purged" value="count" />
+        </List.Dropdown>
+      }
+    >
+      {sortedItems.map((entry: CachePurgeHistoryItem, index) => {
+        const type: PurgeType = entry.type ?? 'url';
+        return (
+          <List.Item
+            key={index}
+            title={entry.url}
+            accessories={[
+              { tag: type.toUpperCase() },
+              { text: `${entry.count} time(s) purged` },
+              {
+                text: `Last purged at ${new Date(
+                  entry.lastPurged,
+                ).toLocaleString()}`,
+              },
+            ]}
+            actions={
+              <ActionPanel>
+                <Action
+                  icon={Icon.Hammer}
+                  title="Purge Again"
+                  shortcut={{ modifiers: ['cmd', 'shift'], key: 'p' }}
+                  onAction={() => purgeFromCache(id, type, [entry.url])}
+                />
+                <Action
+                  icon={Icon.Trash}
+                  title="Remove from History"
+                  shortcut={{ modifiers: ['cmd'], key: 'd' }}
+                  onAction={() => {
+                    const items = state.items.filter(
+                      (item: CachePurgeHistoryItem) =>
+                        !(item.url === entry.url && (item.type ?? 'url') === type),
+                    );
+                    LocalStorage.setItem(
+                      `cache-purge-history-${id}`,
+                      JSON.stringify(items),
+                    );
+                    setState({ items });
+                  }}
+                />
+              </ActionPanel>
+            }
+          />
+        );
+      })}
     </List>
   );
 }
 
-async function clearUrlsFromCache(zoneId: string, urls: string) {
+async function purgeFromCache(
+  zoneId: string,
+  type: PurgeType,
+  entries: string[],
+) {
+  const typeLabel = {
+    url: 'URL(s)',
+    hostname: 'hostname(s)',
+    tag: 'tag(s)',
+    prefix: 'prefix(es)',
+  }[type];
+
   if (
     !(await confirmAlert({
-      title: 'Do you really want to purge the files from cache?',
+      title: `Do you really want to purge these ${typeLabel} from cache?`,
+      message: entries.join('\n'),
       primaryAction: { title: 'Purge', style: Alert.ActionStyle.Destructive },
     }))
   ) {
@@ -123,56 +327,53 @@ async function clearUrlsFromCache(zoneId: string, urls: string) {
 
   const toast = await showToast({
     style: Toast.Style.Animated,
-    title: 'Purging URL(s)',
+    title: `Purging ${typeLabel}`,
   });
 
-  // Split URLs by newline
-  const urlList = urls.split('\n');
-
-  const result = await service.purgeFilesbyURL(zoneId, urlList);
+  let result;
+  switch (type) {
+    case 'url':
+      result = await service.purgeFilesbyURL(zoneId, entries);
+      break;
+    case 'hostname':
+      result = await service.purgeByHostnames(zoneId, entries);
+      break;
+    case 'tag':
+      result = await service.purgeByTags(zoneId, entries);
+      break;
+    case 'prefix':
+      result = await service.purgeByPrefixes(zoneId, entries);
+      break;
+  }
 
   if (result.success) {
     toast.style = Toast.Style.Success;
-    toast.title = 'URL(s) purged';
+    toast.title = `${typeLabel} purged`;
 
-    // Add purged URLs as CachePurgeHistoryItem to history
     LocalStorage.getItem<string>(`cache-purge-history-${zoneId}`).then(
       (items) => {
-        if (items) {
-          const history = JSON.parse(items);
-          urlList.forEach((url) => {
-            // If in history, update lastPurged and count
-            const index = history.findIndex(
-              (entry: CachePurgeHistoryItem) => entry.url === url,
-            );
-            if (index !== -1) {
-              history[index].lastPurged = new Date().toISOString();
-              history[index].count++;
-            } else {
-              // If not in history, add new entry
-              history.push({
-                url,
-                lastPurged: new Date().toISOString(),
-                count: 1,
-              });
-            }
-          });
-          // Save last 100 items in local storage
-          LocalStorage.setItem(
-            `cache-purge-history-${zoneId}`,
-            JSON.stringify(history.slice(-100)),
+        const history: CachePurgeHistoryItem[] = items ? JSON.parse(items) : [];
+        entries.forEach((entry) => {
+          const index = history.findIndex(
+            (item) => item.url === entry && (item.type ?? 'url') === type,
           );
-        } else {
-          const history = urlList.map((url) => ({
-            url,
-            lastPurged: new Date().toISOString(),
-            count: 1,
-          }));
-          LocalStorage.setItem(
-            `cache-purge-history-${zoneId}`,
-            JSON.stringify(history),
-          );
-        }
+          if (index !== -1) {
+            history[index].lastPurged = new Date().toISOString();
+            history[index].count++;
+            history[index].type = type;
+          } else {
+            history.push({
+              url: entry,
+              lastPurged: new Date().toISOString(),
+              count: 1,
+              type,
+            });
+          }
+        });
+        LocalStorage.setItem(
+          `cache-purge-history-${zoneId}`,
+          JSON.stringify(history.slice(-100)),
+        );
       },
     );
 
@@ -180,7 +381,7 @@ async function clearUrlsFromCache(zoneId: string, urls: string) {
   }
 
   toast.style = Toast.Style.Failure;
-  toast.title = 'Failed to purge URL(s)';
+  toast.title = `Failed to purge ${typeLabel}`;
   if (result.errors.length > 0) {
     toast.message = result.errors[0].message;
   }

--- a/extensions/cloudflare/src/view-cache-purge.tsx
+++ b/extensions/cloudflare/src/view-cache-purge.tsx
@@ -11,7 +11,7 @@ import {
   Toast,
 } from '@raycast/api';
 import { useEffect, useState } from 'react';
-import Service, { Zone } from './service';
+import Service, { CachePurgeResult, Zone } from './service';
 import { getToken } from './utils';
 import { SiteProps } from './view-sites';
 
@@ -75,9 +75,9 @@ export function CachePurgeView(props: SiteProps) {
     (async () => {
       const lastType =
         (await LocalStorage.getItem<string>(LAST_TYPE_KEY(id))) ?? 'url';
-      const type = (['url', 'hostname', 'tag', 'prefix'] as PurgeType[]).includes(
-        lastType as PurgeType,
-      )
+      const type = (
+        ['url', 'hostname', 'tag', 'prefix'] as PurgeType[]
+      ).includes(lastType as PurgeType)
         ? (lastType as PurgeType)
         : 'url';
       const lastEntries =
@@ -99,12 +99,12 @@ export function CachePurgeView(props: SiteProps) {
   };
 
   const handleSubmit = async (values: { entries: string }) => {
-    await LocalStorage.setItem(LAST_TYPE_KEY(id), purgeType);
-    await LocalStorage.setItem(
-      LAST_ENTRIES_KEY(id, purgeType),
-      values.entries ?? '',
-    );
-    await submitPurge(id, purgeType, values.entries ?? '');
+    const rawValue = values.entries ?? '';
+    const initiated = await submitPurge(id, purgeType, rawValue);
+    if (initiated) {
+      await LocalStorage.setItem(LAST_TYPE_KEY(id), purgeType);
+      await LocalStorage.setItem(LAST_ENTRIES_KEY(id, purgeType), rawValue);
+    }
   };
 
   const handlePurgeLast = async () => {
@@ -178,7 +178,7 @@ async function submitPurge(
   zoneId: string,
   type: PurgeType,
   rawValue: string,
-) {
+): Promise<boolean> {
   const entries = parseEntries(rawValue);
   if (entries.length === 0) {
     await showToast({
@@ -186,7 +186,7 @@ async function submitPurge(
       title: 'No values provided',
       message: 'Please enter at least one value to purge.',
     });
-    return;
+    return false;
   }
   if (type === 'tag' && entries.length > 100) {
     await showToast({
@@ -194,9 +194,9 @@ async function submitPurge(
       title: 'Too many tags',
       message: 'You can purge up to 100 tags at a time.',
     });
-    return;
+    return false;
   }
-  await purgeFromCache(zoneId, type, entries);
+  return await purgeFromCache(zoneId, type, entries);
 }
 
 function CachePurgeHistory(props: SiteProps) {
@@ -205,9 +205,7 @@ function CachePurgeHistory(props: SiteProps) {
   const [state, setState] = useState<{ items: CachePurgeHistoryItem[] }>({
     items: [],
   });
-  const [sortBy, setSortBy] = useState<'latest' | 'count' | 'oldest'>(
-    'latest',
-  );
+  const [sortBy, setSortBy] = useState<'latest' | 'count' | 'oldest'>('latest');
 
   useEffect(() => {
     LocalStorage.getItem<string>(`cache-purge-sort-${id}`).then((value) => {
@@ -285,7 +283,10 @@ function CachePurgeHistory(props: SiteProps) {
                   onAction={() => {
                     const items = state.items.filter(
                       (item: CachePurgeHistoryItem) =>
-                        !(item.url === entry.url && (item.type ?? 'url') === type),
+                        !(
+                          item.url === entry.url &&
+                          (item.type ?? 'url') === type
+                        ),
                     );
                     LocalStorage.setItem(
                       `cache-purge-history-${id}`,
@@ -307,7 +308,7 @@ async function purgeFromCache(
   zoneId: string,
   type: PurgeType,
   entries: string[],
-) {
+): Promise<boolean> {
   const typeLabel = {
     url: 'URL(s)',
     hostname: 'hostname(s)',
@@ -322,7 +323,7 @@ async function purgeFromCache(
       primaryAction: { title: 'Purge', style: Alert.ActionStyle.Destructive },
     }))
   ) {
-    return;
+    return false;
   }
 
   const toast = await showToast({
@@ -330,7 +331,7 @@ async function purgeFromCache(
     title: `Purging ${typeLabel}`,
   });
 
-  let result;
+  let result: CachePurgeResult;
   switch (type) {
     case 'url':
       result = await service.purgeFilesbyURL(zoneId, entries);
@@ -344,6 +345,10 @@ async function purgeFromCache(
     case 'prefix':
       result = await service.purgeByPrefixes(zoneId, entries);
       break;
+    default: {
+      const _exhaustive: never = type;
+      throw new Error(`Unhandled purge type: ${_exhaustive}`);
+    }
   }
 
   if (result.success) {
@@ -377,7 +382,7 @@ async function purgeFromCache(
       },
     );
 
-    return;
+    return true;
   }
 
   toast.style = Toast.Style.Failure;
@@ -385,6 +390,7 @@ async function purgeFromCache(
   if (result.errors.length > 0) {
     toast.message = result.errors[0].message;
   }
+  return false;
 }
 
 export async function purgeEverything(zone: Zone) {

--- a/extensions/cloudflare/src/view-sites.tsx
+++ b/extensions/cloudflare/src/view-sites.tsx
@@ -22,9 +22,16 @@ import {
   handleNetworkError,
 } from './utils';
 import { CachePurgeView, purgeEverything } from './view-cache-purge';
-import { FormValidation, useCachedPromise, useForm } from '@raycast/utils';
+import {
+  FormValidation,
+  useCachedPromise,
+  useForm,
+  useLocalStorage,
+} from '@raycast/utils';
 
 const service = new Service(getToken());
+
+const FAVORITES_STORAGE_KEY = 'favorite-zone-ids';
 
 function Command() {
   const {
@@ -55,8 +62,109 @@ function Command() {
     },
   );
 
+  const {
+    value: favoriteIds = [],
+    setValue: setFavoriteIds,
+    isLoading: isLoadingFavorites,
+  } = useLocalStorage<string[]>(FAVORITES_STORAGE_KEY, []);
+  const favoriteSet = new Set(favoriteIds);
+
+  const toggleFavorite = async (zoneId: string) => {
+    const next = favoriteSet.has(zoneId)
+      ? favoriteIds.filter((id) => id !== zoneId)
+      : [...favoriteIds, zoneId];
+    await setFavoriteIds(next);
+    await showToast({
+      style: Toast.Style.Success,
+      title: favoriteSet.has(zoneId)
+        ? 'Removed from favorites'
+        : 'Added to favorites',
+    });
+  };
+
+  const favoriteSites: { accountId: string; site: Zone }[] = [];
+  Object.entries(sites).forEach(([accountId, accountSites]) => {
+    accountSites.forEach((site) => {
+      if (favoriteSet.has(site.id)) {
+        favoriteSites.push({ accountId, site });
+      }
+    });
+  });
+
+  const renderSiteItem = (accountId: string, site: Zone) => {
+    const isFavorite = favoriteSet.has(site.id);
+    return (
+      <List.Item
+        actions={
+          <ActionPanel>
+            <ActionPanel.Section>
+              <Action.Push
+                icon={Icon.Document}
+                title="Show Details"
+                target={<SiteView accountId={accountId} id={site.id} />}
+              />
+              <Action.Push
+                icon={Icon.List}
+                // eslint-disable-next-line @raycast/prefer-title-case
+                title="Show DNS Records"
+                target={<DnsRecordView siteId={site.id} />}
+              />
+              <Action.OpenInBrowser
+                title="Open on Cloudflare"
+                url={getSiteUrl(accountId, site.name)}
+                shortcut={{ modifiers: ['cmd'], key: 'o' }}
+              />
+              <Action
+                icon={isFavorite ? Icon.StarDisabled : Icon.Star}
+                title={
+                  isFavorite ? 'Remove from Favorites' : 'Add to Favorites'
+                }
+                shortcut={{ modifiers: ['cmd'], key: 'f' }}
+                onAction={() => toggleFavorite(site.id)}
+              />
+            </ActionPanel.Section>
+            <ActionPanel.Section>
+              <Action.Push
+                icon={Icon.Hammer}
+                title="Purge Cache"
+                target={<CachePurgeView accountId={accountId} id={site.id} />}
+                shortcut={{ modifiers: ['cmd', 'shift'], key: 'e' }}
+              />
+              <Action
+                icon={Icon.Hammer}
+                title="Purge Everything from Cache"
+                shortcut={{ modifiers: ['cmd'], key: 'e' }}
+                onAction={async () => {
+                  purgeEverything(site);
+                }}
+              />
+              <Action
+                icon={Icon.ArrowClockwise}
+                title="Reload Sites from Cloudflare"
+                onAction={clearSiteCache}
+                shortcut={{ modifiers: ['cmd'], key: 'r' }}
+              />
+            </ActionPanel.Section>
+            <ActionPanel.Section>
+              <Action.CopyToClipboard
+                icon={Icon.CopyClipboard}
+                content={site.name}
+                title="Copy Site URL"
+                shortcut={{ modifiers: ['cmd'], key: '.' }}
+              />
+            </ActionPanel.Section>
+          </ActionPanel>
+        }
+        icon={getSiteStatusIcon(site.status)}
+        key={site.id}
+        title={site.name}
+        accessories={isFavorite ? [{ icon: Icon.Star }] : undefined}
+      />
+    );
+  };
+
   return (
-    <List isLoading={isLoading}>
+    <List isLoading={isLoading || isLoadingFavorites}>
       {!isLoading && !Object.keys(sites).length && (
         <List.EmptyView
           icon="no-sites.svg"
@@ -69,83 +177,28 @@ function Command() {
           }
         />
       )}
-      {Object.entries(sites)
-        .filter((entry) => entry[1].length > 0)
-        .map((entry) => {
-          const [accountId, accountSites] = entry;
-          const account = accounts.find((account) => account.id === accountId);
-          const name = account?.name || '';
-          return (
-            <List.Section title={name} key={accountId}>
-              {accountSites.map((site) => (
-                <List.Item
-                  actions={
-                    <ActionPanel>
-                      <ActionPanel.Section>
-                        <Action.Push
-                          icon={Icon.Document}
-                          title="Show Details"
-                          target={
-                            <SiteView accountId={accountId} id={site.id} />
-                          }
-                        />
-                        <Action.Push
-                          icon={Icon.List}
-                          // eslint-disable-next-line @raycast/prefer-title-case
-                          title="Show DNS Records"
-                          target={<DnsRecordView siteId={site.id} />}
-                        />
-                        <Action.OpenInBrowser
-                          title="Open on Cloudflare"
-                          url={getSiteUrl(accountId, site.name)}
-                          shortcut={{ modifiers: ['cmd'], key: 'o' }}
-                        />
-                      </ActionPanel.Section>
-                      <ActionPanel.Section>
-                        <Action.Push
-                          icon={Icon.Hammer}
-                          title="Purge Files from Cache by URL"
-                          target={
-                            <CachePurgeView
-                              accountId={accountId}
-                              id={site.id}
-                            />
-                          }
-                          shortcut={{ modifiers: ['cmd', 'shift'], key: 'e' }}
-                        />
-                        <Action
-                          icon={Icon.Hammer}
-                          title="Purge Everything from Cache"
-                          shortcut={{ modifiers: ['cmd'], key: 'e' }}
-                          onAction={async () => {
-                            purgeEverything(site);
-                          }}
-                        />
-                        <Action
-                          icon={Icon.ArrowClockwise}
-                          title="Reload Sites from Cloudflare"
-                          onAction={clearSiteCache}
-                          shortcut={{ modifiers: ['cmd'], key: 'r' }}
-                        />
-                      </ActionPanel.Section>
-                      <ActionPanel.Section>
-                        <Action.CopyToClipboard
-                          icon={Icon.CopyClipboard}
-                          content={site.name}
-                          title="Copy Site URL"
-                          shortcut={{ modifiers: ['cmd'], key: '.' }}
-                        />
-                      </ActionPanel.Section>
-                    </ActionPanel>
-                  }
-                  icon={getSiteStatusIcon(site.status)}
-                  key={site.id}
-                  title={site.name}
-                />
-              ))}
-            </List.Section>
-          );
-        })}
+      {favoriteSites.length > 0 && (
+        <List.Section title="Favorites" key="favorites">
+          {favoriteSites.map(({ accountId, site }) =>
+            renderSiteItem(accountId, site),
+          )}
+        </List.Section>
+      )}
+      {!isLoadingFavorites &&
+        Object.entries(sites)
+          .filter((entry) => entry[1].length > 0)
+          .map((entry) => {
+            const [accountId, accountSites] = entry;
+            const account = accounts.find(
+              (account) => account.id === accountId,
+            );
+            const name = account?.name || '';
+            return (
+              <List.Section title={name} key={accountId}>
+                {accountSites.map((site) => renderSiteItem(accountId, site))}
+              </List.Section>
+            );
+          })}
     </List>
   );
 }


### PR DESCRIPTION
## Description

- Added support for purging cache by Hostname, Cache-Tag, and Prefix in addition to URL
- New "Purge By" dropdown in the cache purge form with contextual hints and input validation (up to 100 tags)
- Remembers the last selected purge type and the last entered values per type and per site, with a "Purge Last Saved Values" action (`⌘⇧R`) for quick repeat purges
- Purge history now tracks the purge type for each entry and lets you re-run previous purges
- Added the ability to mark sites (zones) as favorites; favorites appear in a dedicated section at the top of the sites list (`⌘F` to toggle)

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

https://github.com/user-attachments/assets/296fd113-e519-4ec4-9a6d-5aba5cd4eb87

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
