### PR TITLE
Update media-converter extension

### DIFF
--- a/extensions/media-converter/CHANGELOG.md
+++ b/extensions/media-converter/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Media Converter Changelog
 
+## [1.6.0] - {PR_MERGE_DATE}
+
+### Added
+
+- New command **Merge Media** to concatenate multiple video or audio files into a single file. Automatically uses fast FFmpeg stream-copy when all inputs share codec/resolution/fps/sample-rate; falls back to a full re-encode via the concat filter otherwise. A "Force re-encode" toggle is available.
+- New command **View Conversion History** showing your recent conversions grouped by day, with actions: Open file, Show in Finder, Re-run with same settings, Copy FFmpeg command, Remove, Clear all.
+- New command **Manage Presets** for browsing/creating/editing/deleting conversion presets. Ships with curated built-in presets: Web Image (WebP 80), Web Image (JPG 80), Email-friendly Video (MP4), WhatsApp Video (MP4), Podcast (MP3 192 VBR), Lossless Audio (FLAC), Twitter/X GIF, Voice Memo (M4A 96k).
+- In the Convert Media form:
+  - **Preset** dropdown (built-in + user presets filtered to the current file type) with a "Save Settings as Preset…" action (⌘S) that captures the current form state.
+  - **Trim** fields (Start / End) accepting `HH:MM:SS[.mmm]` or bare seconds, with validation and live preview of the resulting duration.
+  - **Save to** dropdown: same folder as input (default), preferences custom folder, or a per-run override folder.
+  - **Strip metadata** checkbox that wires `-map_metadata -1` through for video/audio/image (and a best-effort strip for HEIC via `sips`).
+  - Live progress percentage and ETA in the toast while converting videos or GIFs.
+  - Success toast now reports size savings, e.g. "saved 42.3 MB (58%)".
+- **Video → GIF** output. Select `.gif` when converting a video and choose fps, width, and loop behaviour. Uses FFmpeg's `palettegen` + `paletteuse` pipeline for clean, low-size GIFs.
+- New AI tool **Merge Media** (`merge-media`) and extended `convert-media` tool with `outputDir`, `stripMetadata`, `trimStart`, `trimEnd`, `presetId`, `gifFps`, `gifWidth`, `gifLoop` parameters.
+- New extension preferences:
+  - `Default GIF FPS`
+  - `Default GIF Width`
+  - `Default Output Location` (`Same folder as input` / `Custom folder`)
+  - `Custom Output Folder`
+  - `Strip Metadata By Default`
+
+### API Changes
+
+- `convertMedia` now takes an options bag as its fourth argument (`{ returnCommandString?, outputDir?, stripMetadata?, trim?, onProgress? }`) instead of a boolean. The simple 3-argument form still works with the same defaults.
+- Added `src/utils/ffmpegRun.ts` with `runFFmpegWithProgress` (spawns FFmpeg and streams `-progress pipe:1` updates back) and `probeDurationSec` (parses `ffmpeg -i` stderr).
+- Added `src/utils/convertBatch.ts` — shared batch orchestrator that owns history logging, size tracking, progress reporting, and the success summary toast. Consumed by both the Convert Media form and future programmatic callers.
+- Added `src/utils/history.ts`, `src/utils/presets.ts`, `src/utils/merge.ts`, `src/utils/time.ts`, `src/utils/format.ts`.
+- Extended `types/media.ts` with `GifQuality`, `TrimOptions`, `Preset`, `OutputGifExtension`, `OutputCategory`, and `getOutputCategory()`.
+- Built-in presets live in `src/config/built-in-presets.json`.
+
+### Fixed
+
+- **Audio-only merges** via the concat filter failed with `Stream specifier ':v:0' matches no streams` because the filter graph always requested a video stream, even for WAV/MP3/FLAC inputs. The re-encode merge now emits an audio-only filter graph when the output format is audio.
+
+### Tests
+
+- Added unit tests (Node's built-in test runner via `tsx`) covering time parsing, byte/size formatting, FFmpeg stdout/stderr parsers, merge stream-info helpers, media type helpers, and built-in preset validation.
+- Added `npm run test:smoke` — generates tiny fixtures with FFmpeg itself and exercises `convertMedia`/`mergeMedia` end-to-end (webm, GIF, trim, strip-metadata, stream-copy merge, re-encode merge, audio merge, progress callbacks).
+- Added `TESTING.md` with the manual UI checklist for every command.
+- Extended `ai.evals` with cases covering GIF parameters, trim, strip-metadata, audio merge, video merge, and the `forceReencode` flag.
+
 ## [1.5.4] - 2026-03-05
 
 ### Added

--- a/extensions/media-converter/CHANGELOG.md
+++ b/extensions/media-converter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Media Converter Changelog
 
-## [1.6.0] - {PR_MERGE_DATE}
+## [1.6.0] - 2026-04-27
 
 ### Added
 

--- a/extensions/media-converter/README.md
+++ b/extensions/media-converter/README.md
@@ -7,6 +7,15 @@
 
 - Convert videos, images, and audio files with a simple interface
 - Support for all popular media formats
+- **Video → Animated GIF** with quality palette generation
+- **Trim** videos and audio via Start / End fields
+- **Strip metadata** (EXIF, GPS, tags) for privacy — per-run toggle or a default preference
+- **Custom output folder** — save converted files anywhere (per-run or as a preference)
+- **Before/After size comparison** in the success toast (e.g. "saved 42 MB (58%)")
+- **Live progress %** and ETA for video and GIF conversions
+- **Conversion history** — browse, re-run, open, or copy the FFmpeg command for any past conversion
+- **Presets** — built-in presets (Web WebP, Email MP4, Podcast MP3, Twitter GIF, …) plus save-your-own
+- **Merge / concatenate** multiple video or audio files with automatic fast stream-copy or re-encode fallback
 - Simple customization of the quality of the output file; precise control by enabling it in extension preferences
 - Smart file naming to prevent conflicts
 - Automatic FFmpeg installation and management
@@ -16,7 +25,7 @@
 
 | Media Type | Supported Input Formats                                                                                                                            | Supported Output Formats                 |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| Video      | MOV, MP4, AVI, MKV, MPG, WEBM, TS, MPEG, VOB, M2TS, MTS, M4V, FLV, 3GP, ASF, WMV, RMVB, OGV, MXF, NUT, DV, GXF, RM, CDXL, WTV, M3U8, MPD, SEG, TXD | MP4, AVI, MKV, MOV, MPG, WEBM            |
+| Video      | MOV, MP4, AVI, MKV, MPG, WEBM, TS, MPEG, VOB, M2TS, MTS, M4V, FLV, 3GP, ASF, WMV, RMVB, OGV, MXF, NUT, DV, GXF, RM, CDXL, WTV, M3U8, MPD, SEG, TXD | MP4, AVI, MKV, MOV, MPG, WEBM, **GIF**   |
 | Image      | JPG, JPEG, PNG, WEBP, HEIC (MacOS), TIFF, TIF, AVIF, BMP, PCX, TGA, RAS, SGI, PPM, PGM, PBM, PNM, XBM, XPM, ICO, JP2, J2K, PCD, CIN, WBMP, XFACE   | JPG, PNG, WEBP, HEIC (MacOS), TIFF, AVIF |
 | Audio      | MP3, AAC, WAV, M4A, FLAC, AIF, AIFF, OGG, OGA, ALAC, WMA, OPUS, AMR, CAF, AU, SND, APE, DSF, DFF, MPC, WV, SPX, XA, RA                             | MP3, AAC, WAV, FLAC, M4A                 |
 
@@ -26,8 +35,32 @@
 
 1. Open Raycast and search for "Convert Media"
 2. Select files to convert (⌘ + click for multiple) OR select files in Finder before opening the extension
-3. Choose your desired output format and quality settings (defaults are fine)
-4. Press &#8984;↵ to start conversion
+3. (Optional) Pick a **Preset**, adjust **Trim**, toggle **Strip metadata**, or change the **Save to** folder
+4. Choose your desired output format and quality settings (defaults are fine)
+5. Press &#8984;↵ to start conversion
+6. After conversion, a toast shows the size savings (e.g. "saved 42 MB (58%)"). Press &#8984;O to open the new file.
+
+#### Converting video to GIF
+
+Select any video file, pick `.gif` as the output format, then choose frame rate (10/15/24/30 fps), width, and whether the GIF should loop. The extension uses FFmpeg's `palettegen` + `paletteuse` pipeline for high-quality GIF output.
+
+### Merge Media
+
+1. Search for "Merge Media" in Raycast
+2. Select 2+ video files OR 2+ audio files (all must be the same type)
+3. Pick an output format and filename
+4. Turn on "Always re-encode" if your inputs have different codecs/resolutions; otherwise the extension tries fast stream-copy first.
+
+### View Conversion History
+
+- Open "View Conversion History" to see your recent conversions grouped by day.
+- For each entry: Open the file, show in Finder, re-run with the exact same settings (great after re-saving a source file), copy the FFmpeg command, or remove from history.
+
+### Manage Presets
+
+- "Manage Presets" lets you browse built-in presets (WebP 80, Podcast MP3, Twitter GIF, etc.) and create/edit/delete your own.
+- Built-in presets can be duplicated to "My Presets" and then customized.
+- From the Convert Media form, use "Save Settings as Preset…" (⌘S) to capture the current format, quality, trim, metadata and output folder as a reusable preset.
 
 ### Preferences
 
@@ -44,6 +77,11 @@ You can also set defaults in extension preferences:
 - **Default Audio Quality Preset**: preset used in simple mode (`lowest`, `low`, `medium`, `high`, `highest`).
 - **Default Video Output Format**: default output format for video conversions.
 - **Default Video Quality Preset**: preset used in simple mode (`lowest`, `low`, `medium`, `high`, `highest`).
+- **Default GIF FPS**: default frame rate for video → GIF conversions (`10`, `15`, `24`, `30`).
+- **Default GIF Width**: default output width for GIFs (`original`, `480`, `720`, `1080`).
+- **Default Output Location**: `Same folder as input` or `Custom folder` (see next).
+- **Custom Output Folder**: absolute path used when `Default Output Location` is set to `Custom folder`.
+- **Strip Metadata By Default**: when on, converted files get `-map_metadata -1` applied so EXIF/GPS/tags are removed.
 
 You can still override all values in the Convert Media form every time you run a conversion.
 
@@ -55,6 +93,10 @@ You can still override all values in the Convert Media form every time you run a
    - Convert all png files on my @finder desktop to webp
    - Convert my last screen recording in @finder downloads to webm
    - Convert the heic photos in @finder desktop to png
+   - Turn my last video in @finder downloads into a 15fps 720px looping gif
+   - Trim the first 3 seconds off my last mp4 and save to Desktop
+   - Merge the three mp3s on my @finder desktop into one file called interview.mp3
+   - Compress my last mp4 without metadata
 
 ### Advanced usage
 

--- a/extensions/media-converter/TESTING.md
+++ b/extensions/media-converter/TESTING.md
@@ -1,0 +1,160 @@
+# Testing the Media Converter extension
+
+This extension has three automated test layers plus a manual UI checklist you
+should walk through before shipping a release that touches the converter,
+merge, history, or presets code paths.
+
+## 1. Unit tests
+
+Fast, headless, no FFmpeg required. Covers pure helpers: time parsing,
+byte-size formatting, FFmpeg stderr/stdout parsers, merge stream-info logic,
+and built-in preset validation.
+
+```bash
+npm test
+```
+
+All unit tests live under `test/unit/*.test.ts` and run via Node's built-in
+test runner plus `tsx`. `@raycast/api` is stubbed via `test/register.mjs`
+(which redirects both ESM and CJS resolutions to `test/stubs/raycast-api.js`),
+so the tests can import real source files that transitively depend on Raycast
+runtime APIs.
+
+## 2. FFmpeg smoke test
+
+Generates tiny fixtures with FFmpeg itself (via `testsrc`, `sine`, `color`
+filters — no binary fixtures checked into the repo), then exercises the real
+`convertMedia` and `mergeMedia` code paths end-to-end.
+
+```bash
+npm run test:smoke
+```
+
+What it covers:
+
+- `.mp4 -> .webm` (libvpx-vp9 + opus with CRF)
+- `.mp4 -> .gif` (palettegen / paletteuse pipeline)
+- `.mp4` conversion with trim (`-ss` / `-to`)
+- `.mp4` conversion with `stripMetadata` (verifies metadata is gone)
+- `.wav -> .mp3`
+- `.png -> .jpg`
+- Merge two compatible `.mp4` files via stream-copy (fastest path)
+- Merge two `.mp4` files with `forceReencode` (concat filter with video+audio)
+- Merge two `.wav` files into `.mp3` via concat filter (audio-only path)
+- Video conversion emits at least one progress callback
+
+Requires FFmpeg ≥ 6 on PATH (Homebrew’s `/opt/homebrew/bin/ffmpeg` is picked
+up automatically).
+
+## 3. AI tool evals
+
+Lightweight natural-language regression suite for the Raycast AI tools. Run
+via the Raycast CLI:
+
+```bash
+npx ray evals
+```
+
+Evals live under `package.json` → `ai.evals` and cover:
+
+- `convert-media` with simple prompts, presets, trim, strip-metadata, and
+  GIF-specific parameters (`gifFps`, `gifWidth`, `gifLoop`)
+- `merge-media` with newline-separated input paths and the `forceReencode`
+  flag
+
+## 4. Manual UI checklist
+
+Walk through each Raycast command with a sample file open in Finder. The
+checklist is intentionally exhaustive — it takes ~15 minutes end to end and
+is the surest way to catch regressions the automated layers can't see
+(Raycast forms, toasts, navigation, file pickers).
+
+### Convert Media — images
+
+- [ ] Opens with selected Finder image prefilled
+- [ ] Output format dropdown only shows image + `.gif` options for animated PNGs? (no — images have image-only outputs)
+- [ ] Change JPG quality slider — preview updates, submit produces a file next to the input
+- [ ] WebP lossless variant is selectable and produces a visibly identical file
+- [ ] HEIC → JPG works on macOS (uses `sips`, falls back gracefully on Windows with a clear toast)
+- [ ] PNG with "strip metadata" enabled removes EXIF (verify with `exiftool` or similar)
+- [ ] Custom output location override (pick a different folder) writes there
+- [ ] Success toast shows the before/after size delta
+
+### Convert Media — audio
+
+- [ ] `.wav → .mp3` with VBR on produces a smaller file than CBR
+- [ ] `.mp3 → .m4a` works (`-c:a aac`)
+- [ ] `.flac → .wav` produces a larger file (lossless blow-up)
+- [ ] Trim start/end fields accept `1:30`, `90`, `00:01:30.500` — invalid input shows an inline validation error
+- [ ] Trimming an audio file produces the expected duration (±0.2s)
+
+### Convert Media — video
+
+- [ ] `.mov → .mp4` re-encodes with progress toast updating (percent + ETA)
+- [ ] `.mp4 → .webm` shows progress and produces a smaller file at same quality
+- [ ] `.mp4 → .mkv` with HEVC (`libx265`) works
+- [ ] `.mp4 → .gif` with fps=15/width=720/loop=on produces a looping GIF
+- [ ] Trim 0:01..0:05 produces a 4-second output (probe with `ffmpeg -i`)
+- [ ] "Strip metadata" strips title/comment/creation-time
+- [ ] Progress toast stays responsive (no UI freeze) for a 30s+ input
+
+### Convert Media — presets
+
+- [ ] Preset dropdown lists all built-in presets and any user presets
+- [ ] Picking a preset fills outputFormat + quality + trim + stripMetadata
+- [ ] "Save as preset…" form appears, persists under `LocalStorage`, and re-appears on reopen
+- [ ] Deleting a user preset from the Manage Presets command removes it here next open
+
+### Merge Media
+
+- [ ] Launched via command: file picker shows selected Finder files prefilled
+- [ ] Adding a 2nd, 3rd, 4th file works via the picker
+- [ ] `Cmd+Up` / `Cmd+Down` shortcuts rotate the file order
+- [ ] Merging 2 compatible `.mp4`s reports "stream-copy" strategy (fast, no re-encode) in the toast
+- [ ] Merging files with different resolution/codec automatically falls back to re-encode
+- [ ] `forceReencode` checkbox forces the slow path
+- [ ] Custom output filename is honoured (no double extension)
+- [ ] Merging 3 audio files (`.wav` + `.mp3` + `.m4a`) into `.mp3` works
+- [ ] Strip metadata option applies to the merged output
+
+### View Conversion History
+
+- [ ] Runs after at least one conversion is logged
+- [ ] Entries are grouped by date (Today / Yesterday / older)
+- [ ] Selecting an entry shows size delta, format, duration
+- [ ] "Open" action launches the file with the default app
+- [ ] "Show in Finder" reveals the output file
+- [ ] "Re-run" opens the convert form pre-filled with the entry's inputs
+- [ ] "Copy FFmpeg Command" copies a shell-runnable command
+- [ ] "Remove" deletes a single entry; list refreshes
+- [ ] "Clear All" requires confirmation and empties the list
+
+### Manage Presets
+
+- [ ] Built-in presets are listed with a badge indicating they're built-in
+- [ ] User presets appear in a separate section
+- [ ] "Duplicate" a built-in preset produces a user-editable copy
+- [ ] "Edit" a user preset updates it in LocalStorage
+- [ ] "Delete" a user preset removes it; built-in presets can't be deleted
+- [ ] Newly created preset immediately appears in the Convert form's preset dropdown
+
+### AI tools (from the Raycast AI side panel)
+
+- [ ] `Convert this image to webp` prompt succeeds on a selected image
+- [ ] `Convert this video using the Email-friendly preset` applies the preset
+- [ ] `Make this into a 15fps 720p GIF` maps to `.gif` with matching params
+- [ ] `Merge these files into merged.mp4` with multiple selected files succeeds
+- [ ] Merging audio-only selection produces an audio file (no "Invalid filtergraph" error)
+- [ ] Trim + strip-metadata prompts round-trip correctly
+
+## 5. Before shipping a release
+
+- [ ] `npm test` — green
+- [ ] `npm run test:smoke` — green
+- [ ] `npx ray build` — green (no type errors)
+- [ ] `npx ray lint` — no warnings or errors
+- [ ] Manual checklist above walked end-to-end on a real file in Raycast
+
+If any automated layer is red, treat it as a blocker; the bugs they catch
+(codec arg shapes, filter graph mismatches, timestamp rounding) are the
+exact class of regressions users will hit first.

--- a/extensions/media-converter/package-lock.json
+++ b/extensions/media-converter/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react": "^19.0.10",
         "eslint": "^9.0.0",
         "prettier": "^3.3.3",
+        "tsx": "^4.21.0",
         "typescript": "^5.4.5"
       }
     },
@@ -2457,6 +2458,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -2510,6 +2526,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob-parent": {
@@ -3133,6 +3162,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -3344,6 +3383,510 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/type-check": {

--- a/extensions/media-converter/package.json
+++ b/extensions/media-converter/package.json
@@ -28,6 +28,27 @@
       "subtitle": "Media Converter",
       "description": "Converts a media file to a different file format",
       "mode": "view"
+    },
+    {
+      "name": "merge",
+      "title": "Merge Media",
+      "subtitle": "Media Converter",
+      "description": "Concatenate multiple video or audio files into a single output file",
+      "mode": "view"
+    },
+    {
+      "name": "history",
+      "title": "View Conversion History",
+      "subtitle": "Media Converter",
+      "description": "Browse, re-run or clear your recent conversions",
+      "mode": "view"
+    },
+    {
+      "name": "presets",
+      "title": "Manage Presets",
+      "subtitle": "Media Converter",
+      "description": "Create, edit and delete conversion presets",
+      "mode": "view"
     }
   ],
   "tools": [
@@ -35,6 +56,11 @@
       "name": "convert-media",
       "title": "Convert Media",
       "description": "Convert an image, video or audio file to a different file format"
+    },
+    {
+      "name": "merge-media",
+      "title": "Merge Media",
+      "description": "Concatenate multiple video or audio files into a single output file"
     }
   ],
   "ai": {
@@ -83,6 +109,103 @@
             "callsTool": "convert-media"
           }
         ]
+      },
+      {
+        "input": "@media-converter convert @finder video.mp4 to a GIF at 15 fps and 720 wide",
+        "mocks": {
+          "convert-media": {}
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "convert-media",
+              "arguments": {
+                "outputFileType": ".gif"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "input": "@media-converter trim @finder clip.mp4 from 0:10 to 0:30 and save as mp4",
+        "mocks": {
+          "convert-media": {}
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "convert-media",
+              "arguments": {
+                "outputFileType": ".mp4"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "input": "@media-converter convert @finder photo.jpg to webp and strip all the EXIF and GPS metadata",
+        "mocks": {
+          "convert-media": {}
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "convert-media",
+              "arguments": {
+                "outputFileType": ".webp",
+                "stripMetadata": true
+              }
+            }
+          }
+        ]
+      },
+      {
+        "input": "@media-converter merge @finder clip1.mp4 and @finder clip2.mp4 into merged.mp4",
+        "mocks": {
+          "merge-media": {}
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "merge-media",
+              "arguments": {
+                "outputFileType": ".mp4"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "input": "@media-converter concatenate these three audio files @finder intro.mp3 @finder body.mp3 @finder outro.mp3 into one mp3",
+        "mocks": {
+          "merge-media": {}
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "merge-media",
+              "arguments": {
+                "outputFileType": ".mp3"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "input": "@media-converter merge @finder a.mov and @finder b.mov and always re-encode them",
+        "mocks": {
+          "merge-media": {}
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "merge-media",
+              "arguments": {
+                "forceReencode": true
+              }
+            }
+          }
+        ]
       }
     ]
   },
@@ -99,6 +222,7 @@
     "@types/react": "^19.0.10",
     "eslint": "^9.0.0",
     "prettier": "^3.3.3",
+    "tsx": "^4.21.0",
     "typescript": "^5.4.5"
   },
   "scripts": {
@@ -108,6 +232,8 @@
     "generate:image-preferences": "node scripts/generate-image-preferences.mjs --write",
     "check:image-preferences": "node scripts/generate-image-preferences.mjs --check",
     "lint": "ray lint",
+    "test": "node --import tsx --import ./test/register.mjs --test \"test/unit/**/*.test.ts\"",
+    "test:smoke": "node --import tsx --import ./test/register.mjs test/smoke/run-smoke.ts",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
   },
@@ -685,6 +811,93 @@
         }
       ],
       "description": "Default quality preset used only when 'More Conversion Settings (Advanced)' is OFF."
+    },
+    {
+      "name": "defaultGifFps",
+      "type": "dropdown",
+      "title": "Default GIF FPS",
+      "default": "15",
+      "required": false,
+      "data": [
+        {
+          "title": "10 fps",
+          "value": "10"
+        },
+        {
+          "title": "15 fps (Default)",
+          "value": "15"
+        },
+        {
+          "title": "24 fps",
+          "value": "24"
+        },
+        {
+          "title": "30 fps",
+          "value": "30"
+        }
+      ],
+      "description": "Default frame rate for GIF conversions."
+    },
+    {
+      "name": "defaultGifWidth",
+      "type": "dropdown",
+      "title": "Default GIF Width",
+      "default": "original",
+      "required": false,
+      "data": [
+        {
+          "title": "Original (no resize)",
+          "value": "original"
+        },
+        {
+          "title": "480 px",
+          "value": "480"
+        },
+        {
+          "title": "720 px",
+          "value": "720"
+        },
+        {
+          "title": "1080 px",
+          "value": "1080"
+        }
+      ],
+      "description": "Default horizontal resolution for GIF conversions."
+    },
+    {
+      "name": "defaultOutputLocation",
+      "type": "dropdown",
+      "title": "Default Output Location",
+      "default": "sameAsInput",
+      "required": false,
+      "data": [
+        {
+          "title": "Same folder as input (Default)",
+          "value": "sameAsInput"
+        },
+        {
+          "title": "Custom folder",
+          "value": "customFolder"
+        }
+      ],
+      "description": "Where converted files are written by default."
+    },
+    {
+      "name": "customOutputFolder",
+      "type": "textfield",
+      "title": "Custom Output Folder",
+      "placeholder": "/path/to/output/folder",
+      "required": false,
+      "description": "Used when 'Default Output Location' is set to 'Custom folder'. Must be an existing folder you can write to."
+    },
+    {
+      "name": "defaultStripMetadata",
+      "type": "checkbox",
+      "title": "Strip Metadata By Default",
+      "label": "Remove EXIF/GPS/tags from converted files by default",
+      "default": false,
+      "required": false,
+      "description": "When on, converted files will have their metadata removed unless you override in the form."
     },
     {
       "name": "ffmpeg_path",

--- a/extensions/media-converter/src/components/ConverterForm.tsx
+++ b/extensions/media-converter/src/components/ConverterForm.tsx
@@ -4,26 +4,39 @@ import {
   Action,
   showToast,
   Toast,
-  showInFinder,
   Icon,
-  openCommandPreferences,
   getPreferenceValues,
   Clipboard,
+  useNavigation,
 } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
+import fs from "fs";
+import path from "path";
 import { convertMedia } from "../utils/converter";
+import { runConversionBatch } from "../utils/convertBatch";
+import { parseTimeString, formatTimeString } from "../utils/time";
+import { getAllPresets, findPreset, saveUserPreset } from "../utils/presets";
+import { execPromise } from "../utils/exec";
 import {
   OUTPUT_VIDEO_EXTENSIONS,
   OUTPUT_AUDIO_EXTENSIONS,
   OUTPUT_IMAGE_EXTENSIONS,
+  OUTPUT_GIF_EXTENSIONS,
   type MediaType,
   type AllOutputExtension,
   type OutputVideoExtension,
   type OutputImageExtension,
   type OutputAudioExtension,
   type QualitySettings,
+  type Preset,
+  type TrimOptions,
+  type GifFps,
+  type GifWidth,
+  GIF_FPS,
+  GIF_WIDTH,
   getMediaType,
+  getOutputCategory,
   AUDIO_BITRATES,
   type AudioBitrate,
   AUDIO_SAMPLE_RATES,
@@ -55,27 +68,69 @@ import {
   DEFAULT_SIMPLE_QUALITY,
   getDefaultQuality,
 } from "../types/media";
-import path from "path";
-import { execPromise } from "../utils/exec";
 
-export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }) {
+type LaunchContext = {
+  prefill?: {
+    inputs?: string[];
+    outputFormat?: AllOutputExtension;
+    quality?: QualitySettings;
+    trim?: TrimOptions;
+    stripMetadata?: boolean;
+    outputDir?: string;
+  };
+};
+
+export function ConverterForm({
+  initialFiles = [],
+  launchContext,
+}: {
+  initialFiles?: string[];
+  launchContext?: LaunchContext;
+} = {}) {
   const preferences = getPreferenceValues();
+  const prefill = launchContext?.prefill;
+
   const [selectedFileType, setSelectedFileType] = useState<MediaType | null>(null);
-  const [currentFiles, setCurrentFiles] = useState<string[]>(initialFiles || []);
-  const [outputFormat, setOutputFormat] = useState<AllOutputExtension | null>(null);
-  const [currentQualitySetting, setCurrentQualitySetting] = useState<QualitySettings | null>(null);
+  const [currentFiles, setCurrentFiles] = useState<string[]>(prefill?.inputs ?? initialFiles ?? []);
+  const [outputFormat, setOutputFormat] = useState<AllOutputExtension | null>(prefill?.outputFormat ?? null);
+  const [currentQualitySetting, setCurrentQualitySetting] = useState<QualitySettings | null>(prefill?.quality ?? null);
   const [simpleQuality, setSimpleQuality] = useState<QualityLevel>(DEFAULT_SIMPLE_QUALITY);
+  const [presetId, setPresetId] = useState<string>("");
+  const [presets, setPresets] = useState<Preset[]>([]);
+  const [trimStart, setTrimStart] = useState<string>(prefill?.trim?.start ?? "");
+  const [trimEnd, setTrimEnd] = useState<string>(prefill?.trim?.end ?? "");
+  const [stripMetadata, setStripMetadata] = useState<boolean>(
+    prefill?.stripMetadata ?? Boolean(preferences.defaultStripMetadata),
+  );
+  const [outputLocationMode, setOutputLocationMode] = useState<"sameAsInput" | "customFolder" | "thisRun">(
+    prefill?.outputDir
+      ? "thisRun"
+      : ((preferences.defaultOutputLocation as "sameAsInput" | "customFolder") ?? "sameAsInput"),
+  );
+  const [customOutputFolderOverride, setCustomOutputFolderOverride] = useState<string>(prefill?.outputDir ?? "");
 
   const [isLoading, setIsLoading] = useState(true);
+  const { push } = useNavigation();
 
   useEffect(() => {
-    if (initialFiles && initialFiles.length > 0) {
-      handleFileSelect(initialFiles);
+    (async () => {
+      try {
+        const all = await getAllPresets();
+        setPresets(all);
+      } catch (err) {
+        console.warn("Failed to load presets:", err);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (currentFiles.length > 0) {
+      handleFileSelect(currentFiles);
     } else {
-      // TODO: fix this
       setIsLoading(false);
     }
-  }, [initialFiles]);
+    // Intentionally run only on mount to process initial files once.
+  }, []);
 
   const handleFileSelect = (files: string[]) => {
     if (files.length === 0) {
@@ -88,13 +143,12 @@ export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }
       let primaryFileType: MediaType | null = null;
       for (const file of files) {
         if (path.extname(file) === ".heic" && process.platform !== "darwin") {
-          continue; // Skip .heic files when not on macOS.
-          // TODO: implement SharpJS, solve this state.
+          continue;
         }
         const type = getMediaType(path.extname(file));
         if (type) {
           primaryFileType = type as MediaType;
-          break; // Found the first valid file type
+          break;
         }
       }
 
@@ -127,20 +181,19 @@ export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }
           style: Toast.Style.Failure,
           title: "Invalid files in selection",
           message: `Kept ${processedFiles.length} ${primaryFileType} file${processedFiles.length > 1 ? "s" : ""}. ${files.length - processedFiles.length} other file${files.length - processedFiles.length > 1 ? "s" : ""} from your selection were invalid or of a different type and have been discarded.`,
-          secondaryAction: {
-            title: "See supported formats",
-            shortcut: { modifiers: ["cmd"], key: "o" },
-            onAction: () => {
-              execPromise(
-                "open https://www.raycast.com/leandro.maia/media-converter#:~:text=supported%20input%20formats",
-              );
-            },
-          },
         });
       }
 
       setCurrentFiles(processedFiles);
       setSelectedFileType(primaryFileType);
+
+      // If a prefill provided output format, respect it and skip default reset.
+      if (prefill?.outputFormat && prefill?.quality) {
+        setOutputFormat(prefill.outputFormat);
+        setCurrentQualitySetting(prefill.quality);
+        setIsLoading(false);
+        return;
+      }
 
       const preferredImageFormat = preferences.defaultImageOutputFormat as OutputImageExtension | undefined;
       const sanitizedImageFormat =
@@ -162,7 +215,6 @@ export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }
           ? preferredAudioFormat
           : (".mp3" as const);
 
-      // Initialize default output format and quality based on file type
       const defaultFormat =
         primaryFileType === "image"
           ? defaultImageFormat
@@ -192,11 +244,7 @@ export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }
       }
     } catch (error) {
       const errorMessage = String(error);
-      showToast({
-        style: Toast.Style.Failure,
-        title: "Error processing files",
-        message: errorMessage,
-      });
+      showToast({ style: Toast.Style.Failure, title: "Error processing files", message: errorMessage });
       console.error("Error processing files:", errorMessage);
       setCurrentFiles([]);
       setSelectedFileType(null);
@@ -205,64 +253,130 @@ export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }
     setIsLoading(false);
   };
 
+  const resolvedOutputDir = useMemo<string | undefined>(() => {
+    if (outputLocationMode === "thisRun") {
+      return customOutputFolderOverride.trim() || undefined;
+    }
+    if (outputLocationMode === "customFolder") {
+      const configured = (preferences.customOutputFolder as string | undefined)?.trim();
+      return configured || undefined;
+    }
+    return undefined; // same as input
+  }, [outputLocationMode, customOutputFolderOverride, preferences.customOutputFolder]);
+
+  const parsedTrim = useMemo<TrimOptions | undefined>(() => {
+    const startSec = parseTimeString(trimStart);
+    const endSec = parseTimeString(trimEnd);
+    if (startSec === null && endSec === null) return undefined;
+    return { start: trimStart, end: trimEnd };
+  }, [trimStart, trimEnd]);
+
+  const trimValidationHint = useMemo<string>(() => {
+    if (!trimStart && !trimEnd) return "";
+    const startOk = trimStart === "" || parseTimeString(trimStart) !== null;
+    const endOk = trimEnd === "" || parseTimeString(trimEnd) !== null;
+    if (!startOk) return "Start time is not a valid HH:MM:SS or seconds value";
+    if (!endOk) return "End time is not a valid HH:MM:SS or seconds value";
+    const s = parseTimeString(trimStart);
+    const e = parseTimeString(trimEnd);
+    if (s !== null && e !== null && s >= e) return "End time must be after start time";
+    if (s !== null && e !== null) return `Will keep ${formatTimeString(e - s)} of video`;
+    if (s !== null) return `Will skip the first ${formatTimeString(s)}`;
+    if (e !== null) return `Will keep only the first ${formatTimeString(e)}`;
+    return "";
+  }, [trimStart, trimEnd]);
+
   const handleSubmit = async () => {
-    setIsLoading(true);
-    const toast = await showToast({
-      style: Toast.Style.Animated,
-      // TODO: When converting video, we could show the progress percentage. This would require to find a solution when multiple files are being converted.
-      // I don't think it is possible to show the progress of images. Unsure about audio.
-      title: `Converting ${currentFiles.length} file${currentFiles.length > 1 ? "s" : ""}...`,
-    });
+    if (!outputFormat || !currentQualitySetting) return;
 
-    for (const item of currentFiles) {
+    // Validate trim
+    const startOk = trimStart === "" || parseTimeString(trimStart) !== null;
+    const endOk = trimEnd === "" || parseTimeString(trimEnd) !== null;
+    if (!startOk || !endOk) {
+      await showToast({ style: Toast.Style.Failure, title: "Invalid trim values", message: trimValidationHint });
+      return;
+    }
+
+    // Validate output folder if custom
+    if (resolvedOutputDir) {
       try {
-        if (!outputFormat || !currentQualitySetting) {
-          throw new Error("Output format and quality settings must be configured");
-        }
-
-        const outputPath = await convertMedia(item, outputFormat, currentQualitySetting);
-
-        await toast.hide();
-        // TODO: Add proper toast success when having multiple files being converted, like "successfully converted 1 file out of 5", etc.
-        // Should also handle edge cases, such as when the user is converting a file to something, then converts it again to another:
-        // like a queue system for handling multiple files.
-        await showToast({
-          style: Toast.Style.Success,
-          title: "File converted successfully!",
-          message: "⌘O to open the file",
-          primaryAction: {
-            title: "Open File",
-            shortcut: { modifiers: ["cmd"], key: "o" },
-            onAction: () => {
-              showInFinder(outputPath);
-            },
-          },
-        });
-      } catch (error) {
-        await toast.hide();
-        const errorMessage = String(error);
-
-        // In theory, this should never happen
-        // Check if the error is related to FFmpeg not being installed
-        if (errorMessage.includes("FFmpeg is not installed or configured")) {
-          showFailureToast(new Error("FFmpeg needs to be configured to convert files"), {
-            title: "FFmpeg not found",
-            primaryAction: {
-              title: "Configure FFmpeg",
-              onAction: () => {
-                // Open command preferences to set FFmpeg path
-                openCommandPreferences();
-              },
-            },
+        const stat = fs.statSync(resolvedOutputDir);
+        if (!stat.isDirectory()) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Output folder is not a directory",
+            message: resolvedOutputDir,
           });
-        } else {
-          await showToast({ style: Toast.Style.Failure, title: "Conversion failed", message: errorMessage });
-          console.error(`Conversion failed:`, errorMessage);
+          return;
         }
+      } catch {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Output folder does not exist",
+          message: resolvedOutputDir,
+        });
+        return;
       }
     }
-    setIsLoading(false);
+
+    setIsLoading(true);
+    try {
+      await runConversionBatch(currentFiles, {
+        outputFormat,
+        quality: currentQualitySetting,
+        outputDir: resolvedOutputDir,
+        stripMetadata,
+        trim: parsedTrim,
+        showProgress: true,
+      });
+    } finally {
+      setIsLoading(false);
+    }
   };
+
+  const onPresetChange = async (id: string) => {
+    setPresetId(id);
+    if (!id) return;
+    const preset = await findPreset(id);
+    if (!preset) return;
+    setOutputFormat(preset.outputFormat);
+    setCurrentQualitySetting(preset.quality);
+    if (preset.trim) {
+      setTrimStart(preset.trim.start ?? "");
+      setTrimEnd(preset.trim.end ?? "");
+    }
+    if (typeof preset.stripMetadata === "boolean") setStripMetadata(preset.stripMetadata);
+    if (preset.outputDir) {
+      setOutputLocationMode("thisRun");
+      setCustomOutputFolderOverride(preset.outputDir);
+    }
+  };
+
+  const saveAsPresetAction = (
+    <Action
+      title="Save Settings as Preset…"
+      icon={Icon.Stars}
+      shortcut={{ modifiers: ["cmd"], key: "s" }}
+      onAction={() => {
+        if (!outputFormat || !currentQualitySetting || !selectedFileType) return;
+        push(
+          <SavePresetForm
+            initialName=""
+            mediaType={getOutputCategory(outputFormat) === "gif" ? "gif" : selectedFileType}
+            outputFormat={outputFormat}
+            quality={currentQualitySetting}
+            trim={parsedTrim}
+            stripMetadata={stripMetadata}
+            outputDir={resolvedOutputDir}
+            onSaved={async () => {
+              const refreshed = await getAllPresets();
+              setPresets(refreshed);
+            }}
+          />,
+        );
+      }}
+    />
+  );
 
   return (
     <Form
@@ -271,13 +385,8 @@ export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }
         <ActionPanel>
           {currentFiles && currentFiles.length > 0 && selectedFileType && (
             <>
-              <Action.SubmitForm
-                title="Convert"
-                onSubmit={handleSubmit}
-                icon={Icon.NewDocument}
-                // For some reason, this still shows up as cmd+return instead of just return, so no use for now
-                /* shortcut={{ modifiers: [], key: "return" }} */
-              />
+              <Action.SubmitForm title="Convert" onSubmit={handleSubmit} icon={Icon.NewDocument} />
+              {saveAsPresetAction}
               <Action
                 title="Copy FFmpeg Command"
                 icon={Icon.Clipboard}
@@ -286,16 +395,14 @@ export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }
                   windows: { modifiers: ["ctrl", "shift"], key: "c" },
                 }}
                 onAction={async () => {
-                  if (!outputFormat || !currentQualitySetting) {
-                    await showToast({
-                      style: Toast.Style.Failure,
-                      title: "Configuration incomplete",
-                      message: "Output format and quality settings must be configured",
-                    });
-                    return;
-                  }
+                  if (!outputFormat || !currentQualitySetting) return;
                   try {
-                    const command = await convertMedia(currentFiles[0], outputFormat, currentQualitySetting, true);
+                    const command = await convertMedia(currentFiles[0], outputFormat, currentQualitySetting, {
+                      returnCommandString: true,
+                      outputDir: resolvedOutputDir,
+                      stripMetadata,
+                      trim: parsedTrim,
+                    });
                     await Clipboard.copy(command);
                     await showToast({
                       style: Toast.Style.Success,
@@ -303,11 +410,7 @@ export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }
                       message: currentFiles.length > 1 ? "Command for the first file copied" : "FFmpeg command copied",
                     });
                   } catch (error) {
-                    await showToast({
-                      style: Toast.Style.Failure,
-                      title: "Failed to generate command",
-                      message: String(error),
-                    });
+                    showFailureToast(error, { title: "Failed to generate command" });
                   }
                 }}
               />
@@ -321,10 +424,29 @@ export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }
         title="Select files"
         allowMultipleSelection={true}
         value={currentFiles}
-        onChange={(newFiles) => {
-          handleFileSelect(newFiles);
-        }}
+        onChange={(newFiles) => handleFileSelect(newFiles)}
       />
+
+      {selectedFileType && presets.length > 0 && (
+        <Form.Dropdown id="preset" title="Preset" value={presetId} onChange={onPresetChange}>
+          <Form.Dropdown.Item value="" title="— None —" />
+          <Form.Dropdown.Section title="Built-in">
+            {presets
+              .filter((p) => p.builtIn && presetMatchesFileType(p, selectedFileType))
+              .map((p) => (
+                <Form.Dropdown.Item key={p.id} value={p.id} title={p.name} />
+              ))}
+          </Form.Dropdown.Section>
+          <Form.Dropdown.Section title="My Presets">
+            {presets
+              .filter((p) => !p.builtIn && presetMatchesFileType(p, selectedFileType))
+              .map((p) => (
+                <Form.Dropdown.Item key={p.id} value={p.id} title={p.name} />
+              ))}
+          </Form.Dropdown.Section>
+        </Form.Dropdown>
+      )}
+
       {selectedFileType && (
         <Form.Dropdown
           id="format"
@@ -333,24 +455,22 @@ export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }
           onChange={(newFormat) => {
             const format = newFormat as AllOutputExtension;
             setOutputFormat(format);
-            if (preferences.moreConversionSettings || selectedFileType === "image") {
+            if (preferences.moreConversionSettings || selectedFileType === "image" || format === ".gif") {
               setCurrentQualitySetting(getDefaultQuality(format, preferences));
             } else {
-              // Update quality settings based on current simple quality level
               setCurrentQualitySetting(getDefaultQuality(format, preferences, simpleQuality));
             }
           }}
         >
           <Form.Dropdown.Section>
             {(() => {
-              const availableExtensions =
+              const availableExtensions: readonly AllOutputExtension[] =
                 selectedFileType === "image"
                   ? OUTPUT_IMAGE_EXTENSIONS
                   : selectedFileType === "audio"
                     ? OUTPUT_AUDIO_EXTENSIONS
-                    : OUTPUT_VIDEO_EXTENSIONS;
+                    : ([...OUTPUT_VIDEO_EXTENSIONS, ...OUTPUT_GIF_EXTENSIONS] as const);
 
-              /* HEIC is only supported on macOS with SIPS, so we filter it out on other platforms. */
               return availableExtensions
                 .filter((format) => process.platform === "darwin" || format !== ".heic")
                 .map((format) => <Form.Dropdown.Item key={format} value={format} title={format} />);
@@ -358,10 +478,16 @@ export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }
           </Form.Dropdown.Section>
         </Form.Dropdown>
       )}
+
       {/* Quality Settings */}
       {selectedFileType && outputFormat && currentQualitySetting && (
         <>
-          {preferences.moreConversionSettings || selectedFileType === "image" ? (
+          {outputFormat === ".gif" ? (
+            <GifQualityControls
+              settings={currentQualitySetting as { ".gif": { fps: GifFps; width: GifWidth; loop: boolean } }}
+              onChange={(s) => setCurrentQualitySetting(s)}
+            />
+          ) : preferences.moreConversionSettings || selectedFileType === "image" ? (
             <QualitySettingsComponent
               outputFormat={outputFormat}
               currentQuality={currentQualitySetting}
@@ -388,6 +514,190 @@ export function ConverterForm({ initialFiles = [] }: { initialFiles?: string[] }
           )}
         </>
       )}
+
+      {/* Trim (video/audio/gif only) */}
+      {selectedFileType && (selectedFileType === "video" || selectedFileType === "audio") && (
+        <>
+          <Form.Separator />
+          <Form.Description title="Trim (optional)" text="Leave empty to keep the full duration." />
+          <Form.TextField
+            id="trimStart"
+            title="Start"
+            placeholder="e.g. 0:10 or 10.5"
+            value={trimStart}
+            onChange={setTrimStart}
+          />
+          <Form.TextField
+            id="trimEnd"
+            title="End"
+            placeholder="e.g. 1:30 or 90"
+            value={trimEnd}
+            onChange={setTrimEnd}
+          />
+          {trimValidationHint && <Form.Description text={trimValidationHint} />}
+          {currentFiles.length > 1 && parsedTrim && (
+            <Form.Description text={`Trim will be applied to all ${currentFiles.length} files.`} />
+          )}
+        </>
+      )}
+
+      {/* Output location + metadata */}
+      {selectedFileType && (
+        <>
+          <Form.Separator />
+          <Form.Dropdown
+            id="outputLocation"
+            title="Save to"
+            value={outputLocationMode}
+            onChange={(v) => setOutputLocationMode(v as typeof outputLocationMode)}
+          >
+            <Form.Dropdown.Item value="sameAsInput" title="Same folder as input" />
+            <Form.Dropdown.Item
+              value="customFolder"
+              title={
+                preferences.customOutputFolder
+                  ? `Preference folder (${preferences.customOutputFolder})`
+                  : "Preference folder (not set)"
+              }
+            />
+            <Form.Dropdown.Item value="thisRun" title="Choose for this run…" />
+          </Form.Dropdown>
+          {outputLocationMode === "thisRun" && (
+            <Form.TextField
+              id="customOutputFolderOverride"
+              title="Output folder"
+              placeholder="/absolute/path/to/folder"
+              value={customOutputFolderOverride}
+              onChange={setCustomOutputFolderOverride}
+            />
+          )}
+          <Form.Checkbox
+            id="stripMetadata"
+            title="Privacy"
+            label="Strip metadata (EXIF, GPS, tags)"
+            value={stripMetadata}
+            onChange={setStripMetadata}
+          />
+        </>
+      )}
+    </Form>
+  );
+}
+
+function presetMatchesFileType(preset: Preset, fileType: MediaType): boolean {
+  if (fileType === "video") return preset.mediaType === "video" || preset.mediaType === "gif";
+  return preset.mediaType === fileType;
+}
+
+function GifQualityControls({
+  settings,
+  onChange,
+}: {
+  settings: { ".gif": { fps: GifFps; width: GifWidth; loop: boolean } };
+  onChange: (next: QualitySettings) => void;
+}) {
+  const gif = settings[".gif"];
+  return (
+    <>
+      <Form.Dropdown
+        id="gifFps"
+        title="FPS"
+        value={gif.fps}
+        onChange={(v) => onChange({ ".gif": { ...gif, fps: v as GifFps } } as QualitySettings)}
+        info="Higher frame rates look smoother but produce larger files"
+      >
+        {GIF_FPS.map((fps) => (
+          <Form.Dropdown.Item key={fps} value={fps} title={`${fps} fps`} />
+        ))}
+      </Form.Dropdown>
+      <Form.Dropdown
+        id="gifWidth"
+        title="Width"
+        value={gif.width}
+        onChange={(v) => onChange({ ".gif": { ...gif, width: v as GifWidth } } as QualitySettings)}
+        info="Smaller widths produce smaller GIFs. Height scales proportionally."
+      >
+        {GIF_WIDTH.map((w) => (
+          <Form.Dropdown.Item key={w} value={w} title={w === "original" ? "Original" : `${w}px`} />
+        ))}
+      </Form.Dropdown>
+      <Form.Checkbox
+        id="gifLoop"
+        title="Loop"
+        label="Play forever (loop)"
+        value={gif.loop}
+        onChange={(v) => onChange({ ".gif": { ...gif, loop: v } } as QualitySettings)}
+      />
+    </>
+  );
+}
+
+function SavePresetForm({
+  initialName,
+  mediaType,
+  outputFormat,
+  quality,
+  trim,
+  stripMetadata,
+  outputDir,
+  onSaved,
+}: {
+  initialName: string;
+  mediaType: MediaType | "gif";
+  outputFormat: AllOutputExtension;
+  quality: QualitySettings;
+  trim?: TrimOptions;
+  stripMetadata?: boolean;
+  outputDir?: string;
+  onSaved: () => Promise<void> | void;
+}) {
+  const [name, setName] = useState(initialName);
+  const [description, setDescription] = useState("");
+  const { pop } = useNavigation();
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm
+            title="Save Preset"
+            icon={Icon.Stars}
+            onSubmit={async () => {
+              if (!name.trim()) {
+                await showToast({ style: Toast.Style.Failure, title: "Name required" });
+                return;
+              }
+              try {
+                await saveUserPreset({
+                  name: name.trim(),
+                  mediaType,
+                  outputFormat,
+                  quality,
+                  trim,
+                  stripMetadata,
+                  outputDir,
+                  description: description.trim() || undefined,
+                });
+                await onSaved();
+                await showToast({ style: Toast.Style.Success, title: "Preset saved" });
+                pop();
+              } catch (error) {
+                showFailureToast(error, { title: "Failed to save preset" });
+              }
+            }}
+          />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField id="name" title="Name" placeholder="e.g. My Video Compression" value={name} onChange={setName} />
+      <Form.TextArea
+        id="description"
+        title="Description"
+        placeholder="Optional notes"
+        value={description}
+        onChange={setDescription}
+      />
+      <Form.Description text={`Format: ${outputFormat}`} />
     </Form>
   );
 }
@@ -428,7 +738,6 @@ function QualitySettingsComponent({
       );
     }
     case "audio": {
-      // Derive controls from the AudioQuality type structure dynamically
       const audioSettings = getCurrentSettings() as Record<string, unknown>;
       const audioControls = Object.keys(audioSettings || {});
       return (
@@ -442,7 +751,6 @@ function QualitySettingsComponent({
       );
     }
     case "video": {
-      // Derive controls from the VideoQuality type structure dynamically
       const videoSettings = getCurrentSettings() as Record<string, unknown>;
       const videoControls = Object.keys(videoSettings || {});
       return (
@@ -470,7 +778,6 @@ function QualitySettingsComponent({
     settings: unknown;
     onSettingsChange: (settings: unknown) => void;
   }) {
-    // Handle image quality settings (simpler, non-object based)
     if (mediaType === "image") {
       const handleImageChange = (value: string | number) => {
         onSettingsChange(value);
@@ -510,7 +817,6 @@ function QualitySettingsComponent({
         );
       }
 
-      // For .jpg, .heic, .avif, .webp - use percentage quality
       return (
         <Form.Dropdown
           id="qualitySetting"
@@ -539,14 +845,10 @@ function QualitySettingsComponent({
       );
     }
 
-    // Handle audio and video quality settings (object-based)
-
     const renderControl = (controlType: AllControlType) => {
-      // Type-safe access to current value
       const settingsObj = settings as Record<string, unknown>;
       const currentValue = settingsObj?.[controlType];
 
-      // Audio controls
       if (mediaType === "audio") {
         controlType = controlType as AudioControlType;
         switch (controlType) {
@@ -689,7 +991,6 @@ function QualitySettingsComponent({
         }
       }
 
-      // Video controls
       if (mediaType === "video") {
         controlType = controlType as VideoControlType;
         switch (controlType) {
@@ -703,16 +1004,12 @@ function QualitySettingsComponent({
                 onChange={(mode: string) => {
                   const newMode = mode as VideoEncodingMode;
 
-                  // Reset settings based on new encoding mode and format
                   if (outputFormat === ".mov") {
-                    // MOV only has variant, no encoding mode
                     return;
                   } else if (newMode === "crf") {
-                    // Use CRF defaults from DEFAULT_QUALITIES
-                    const newSettings = DEFAULT_QUALITIES[outputFormat];
+                    const newSettings = DEFAULT_QUALITIES[outputFormat as keyof typeof DEFAULT_QUALITIES];
                     onSettingsChange(newSettings);
                   } else {
-                    // Use VBR defaults from DEFAULT_VBR_QUALITIES, but update encoding mode
                     const vbrDefault = DEFAULT_VBR_QUALITIES[outputFormat as keyof typeof DEFAULT_VBR_QUALITIES];
                     const newSettings = { ...vbrDefault, encodingMode: newMode };
                     onSettingsChange(newSettings);
@@ -786,10 +1083,8 @@ function QualitySettingsComponent({
               >
                 {VIDEO_MAX_BITRATE.filter((rate) => {
                   if (rate === "") return true;
-
                   const currentBitrate = settingsObj?.bitrate as VideoBitrate;
                   if (!currentBitrate) return true;
-
                   return parseInt(rate) >= parseInt(currentBitrate);
                 }).map((rate) => (
                   <Form.Dropdown.Item key={rate} value={rate} title={`${rate === "" ? "No limit" : rate + " kbps"}`} />

--- a/extensions/media-converter/src/components/ConverterForm.tsx
+++ b/extensions/media-converter/src/components/ConverterForm.tsx
@@ -16,7 +16,8 @@ import path from "path";
 import { convertMedia } from "../utils/converter";
 import { runConversionBatch } from "../utils/convertBatch";
 import { parseTimeString, formatTimeString } from "../utils/time";
-import { getAllPresets, findPreset, saveUserPreset } from "../utils/presets";
+import { getAllPresets, findPreset } from "../utils/presets";
+import { PresetEditorForm } from "./PresetEditorForm";
 import { execPromise } from "../utils/exec";
 import {
   OUTPUT_VIDEO_EXTENSIONS,
@@ -360,14 +361,16 @@ export function ConverterForm({
       onAction={() => {
         if (!outputFormat || !currentQualitySetting || !selectedFileType) return;
         push(
-          <SavePresetForm
-            initialName=""
-            mediaType={getOutputCategory(outputFormat) === "gif" ? "gif" : selectedFileType}
-            outputFormat={outputFormat}
-            quality={currentQualitySetting}
-            trim={parsedTrim}
-            stripMetadata={stripMetadata}
-            outputDir={resolvedOutputDir}
+          <PresetEditorForm
+            mode="create"
+            seed={{
+              mediaType: getOutputCategory(outputFormat) === "gif" ? "gif" : selectedFileType,
+              outputFormat,
+              quality: currentQualitySetting,
+              trim: parsedTrim,
+              stripMetadata,
+              outputDir: resolvedOutputDir,
+            }}
             onSaved={async () => {
               const refreshed = await getAllPresets();
               setPresets(refreshed);
@@ -629,76 +632,6 @@ export function GifQualityControls({
         onChange={(v) => onChange({ ".gif": { ...gif, loop: v } } as QualitySettings)}
       />
     </>
-  );
-}
-
-function SavePresetForm({
-  initialName,
-  mediaType,
-  outputFormat,
-  quality,
-  trim,
-  stripMetadata,
-  outputDir,
-  onSaved,
-}: {
-  initialName: string;
-  mediaType: MediaType | "gif";
-  outputFormat: AllOutputExtension;
-  quality: QualitySettings;
-  trim?: TrimOptions;
-  stripMetadata?: boolean;
-  outputDir?: string;
-  onSaved: () => Promise<void> | void;
-}) {
-  const [name, setName] = useState(initialName);
-  const [description, setDescription] = useState("");
-  const { pop } = useNavigation();
-
-  return (
-    <Form
-      actions={
-        <ActionPanel>
-          <Action.SubmitForm
-            title="Save Preset"
-            icon={Icon.Stars}
-            onSubmit={async () => {
-              if (!name.trim()) {
-                await showToast({ style: Toast.Style.Failure, title: "Name required" });
-                return;
-              }
-              try {
-                await saveUserPreset({
-                  name: name.trim(),
-                  mediaType,
-                  outputFormat,
-                  quality,
-                  trim,
-                  stripMetadata,
-                  outputDir,
-                  description: description.trim() || undefined,
-                });
-                await onSaved();
-                await showToast({ style: Toast.Style.Success, title: "Preset saved" });
-                pop();
-              } catch (error) {
-                showFailureToast(error, { title: "Failed to save preset" });
-              }
-            }}
-          />
-        </ActionPanel>
-      }
-    >
-      <Form.TextField id="name" title="Name" placeholder="e.g. My Video Compression" value={name} onChange={setName} />
-      <Form.TextArea
-        id="description"
-        title="Description"
-        placeholder="Optional notes"
-        value={description}
-        onChange={setDescription}
-      />
-      <Form.Description text={`Format: ${outputFormat}`} />
-    </Form>
   );
 }
 
@@ -1096,7 +1029,7 @@ export function QualitySettingsComponent({
             return (
               <Form.Dropdown
                 key="preset"
-                id="preset"
+                id="videoEncodingPreset"
                 title="Encoding Preset"
                 value={currentValue as VideoPreset}
                 onChange={(preset: string) =>

--- a/extensions/media-converter/src/components/ConverterForm.tsx
+++ b/extensions/media-converter/src/components/ConverterForm.tsx
@@ -589,7 +589,7 @@ function presetMatchesFileType(preset: Preset, fileType: MediaType): boolean {
   return preset.mediaType === fileType;
 }
 
-function GifQualityControls({
+export function GifQualityControls({
   settings,
   onChange,
 }: {
@@ -705,7 +705,7 @@ function SavePresetForm({
 // TODO: If the selected output setting surpasses the quality of the original file, show the input audio's bitrate/profile/sample, which file is that.
 // Just a warning, letting the user know that the output file will not be better than the input file.
 
-function QualitySettingsComponent({
+export function QualitySettingsComponent({
   outputFormat,
   currentQuality,
   onQualityChange,

--- a/extensions/media-converter/src/components/ConverterForm.tsx
+++ b/extensions/media-converter/src/components/ConverterForm.tsx
@@ -88,7 +88,7 @@ export function ConverterForm({
   initialFiles?: string[];
   launchContext?: LaunchContext;
 } = {}) {
-  const preferences = getPreferenceValues();
+  const preferences = getPreferenceValues<Preferences>();
   const prefill = launchContext?.prefill;
 
   const [selectedFileType, setSelectedFileType] = useState<MediaType | null>(null);

--- a/extensions/media-converter/src/components/MergeForm.tsx
+++ b/extensions/media-converter/src/components/MergeForm.tsx
@@ -1,0 +1,249 @@
+import { Form, ActionPanel, Action, Icon, showToast, Toast, showInFinder, getPreferenceValues } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { useState, useEffect, useMemo } from "react";
+import fs from "fs";
+import path from "path";
+import { mergeMedia } from "../utils/merge";
+import { formatTimeString } from "../utils/time";
+import {
+  OUTPUT_VIDEO_EXTENSIONS,
+  OUTPUT_AUDIO_EXTENSIONS,
+  type AllOutputExtension,
+  type MediaType,
+  getMediaType,
+} from "../types/media";
+
+export function MergeForm({ initialFiles = [] }: { initialFiles?: string[] }) {
+  const preferences = getPreferenceValues();
+  const [files, setFiles] = useState<string[]>(initialFiles);
+  const [outputFormat, setOutputFormat] = useState<AllOutputExtension>(".mp4");
+  const [outputFileName, setOutputFileName] = useState<string>("merged");
+  const [outputLocationMode, setOutputLocationMode] = useState<"sameAsFirst" | "customFolder" | "thisRun">(
+    (preferences.defaultOutputLocation as "sameAsInput" | "customFolder") === "customFolder"
+      ? "customFolder"
+      : "sameAsFirst",
+  );
+  const [customOutputFolderOverride, setCustomOutputFolderOverride] = useState<string>("");
+  const [stripMetadata, setStripMetadata] = useState<boolean>(Boolean(preferences.defaultStripMetadata));
+  const [forceReencode, setForceReencode] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const mediaType: MediaType | null = useMemo(() => {
+    if (files.length === 0) return null;
+    const t = getMediaType(path.extname(files[0]));
+    return t === "image" ? null : t; // merging images doesn't really make sense
+  }, [files]);
+
+  useEffect(() => {
+    if (
+      mediaType === "audio" &&
+      !OUTPUT_AUDIO_EXTENSIONS.includes(outputFormat as (typeof OUTPUT_AUDIO_EXTENSIONS)[number])
+    ) {
+      setOutputFormat(".mp3");
+    } else if (
+      mediaType === "video" &&
+      !OUTPUT_VIDEO_EXTENSIONS.includes(outputFormat as (typeof OUTPUT_VIDEO_EXTENSIONS)[number])
+    ) {
+      setOutputFormat(".mp4");
+    }
+  }, [mediaType]);
+
+  const resolvedOutputDir = useMemo<string | undefined>(() => {
+    if (outputLocationMode === "thisRun") return customOutputFolderOverride.trim() || undefined;
+    if (outputLocationMode === "customFolder") {
+      const configured = (preferences.customOutputFolder as string | undefined)?.trim();
+      return configured || undefined;
+    }
+    return files[0] ? path.dirname(files[0]) : undefined;
+  }, [outputLocationMode, customOutputFolderOverride, preferences.customOutputFolder, files]);
+
+  const validationHint = useMemo(() => {
+    if (files.length === 0) return "Select at least 2 files of the same type (video or audio).";
+    if (files.length === 1) return "Select at least one more file to merge.";
+    const types = new Set(files.map((f) => getMediaType(path.extname(f))));
+    types.delete(null as unknown as MediaType);
+    if (types.has("image")) return "Image files cannot be merged. Please select only video or audio files.";
+    if (types.size > 1) return "All files must be the same type (all video or all audio).";
+    return "";
+  }, [files]);
+
+  const handleSubmit = async () => {
+    if (validationHint) {
+      await showToast({ style: Toast.Style.Failure, title: "Cannot merge", message: validationHint });
+      return;
+    }
+    if (!outputFileName.trim()) {
+      await showToast({ style: Toast.Style.Failure, title: "Output filename is required" });
+      return;
+    }
+
+    if (resolvedOutputDir) {
+      try {
+        const stat = fs.statSync(resolvedOutputDir);
+        if (!stat.isDirectory()) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Output folder is not a directory",
+            message: resolvedOutputDir,
+          });
+          return;
+        }
+      } catch {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Output folder does not exist",
+          message: resolvedOutputDir,
+        });
+        return;
+      }
+    }
+
+    setIsLoading(true);
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: `Merging ${files.length} files…`,
+    });
+    try {
+      const result = await mergeMedia(files, outputFormat, {
+        outputDir: resolvedOutputDir,
+        stripMetadata,
+        outputFileName: outputFileName.trim(),
+        forceReencode,
+        onProgress: (p) => {
+          const pct = Math.floor(p.percent);
+          const eta = p.etaSec !== undefined ? ` · ETA ${formatTimeString(p.etaSec)}` : "";
+          toast.title = `Merging · ${pct}%${eta}`;
+        },
+      });
+      await toast.hide();
+      await showToast({
+        style: Toast.Style.Success,
+        title: "Merged successfully!",
+        message: `${path.basename(result.outputPath)} · ${result.strategy === "stream-copy" ? "stream copy" : "re-encoded"}`,
+        primaryAction: {
+          title: "Open File",
+          shortcut: { modifiers: ["cmd"], key: "o" },
+          onAction: () => showInFinder(result.outputPath),
+        },
+      });
+    } catch (error) {
+      await toast.hide();
+      showFailureToast(error, { title: "Merge failed" });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const availableFormats: readonly AllOutputExtension[] =
+    mediaType === "audio" ? OUTPUT_AUDIO_EXTENSIONS : OUTPUT_VIDEO_EXTENSIONS;
+
+  return (
+    <Form
+      isLoading={isLoading}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Merge" icon={Icon.Link} onSubmit={handleSubmit} />
+          <Action
+            title="Reorder: Move First Selected File up"
+            icon={Icon.ArrowUp}
+            shortcut={{ modifiers: ["cmd"], key: "arrowUp" }}
+            onAction={() => {
+              if (files.length < 2) return;
+              setFiles([files[files.length - 1], ...files.slice(0, -1)]);
+            }}
+          />
+          <Action
+            title="Reorder: Move First File Down"
+            icon={Icon.ArrowDown}
+            shortcut={{ modifiers: ["cmd"], key: "arrowDown" }}
+            onAction={() => {
+              if (files.length < 2) return;
+              setFiles([...files.slice(1), files[0]]);
+            }}
+          />
+        </ActionPanel>
+      }
+    >
+      <Form.Description
+        title="Merge Media"
+        text="Concatenate multiple video OR multiple audio files into a single output. Inputs are concatenated in the order shown below."
+      />
+      <Form.FilePicker
+        id="files"
+        title="Select files to merge"
+        allowMultipleSelection={true}
+        value={files}
+        onChange={setFiles}
+      />
+      {files.length > 0 && (
+        <Form.Description
+          text={
+            "Merge order:\n" +
+            files.map((f, i) => `  ${i + 1}. ${path.basename(f)}`).join("\n") +
+            "\n\nTip: Cmd+↑ / Cmd+↓ in Actions rotates the order."
+          }
+        />
+      )}
+      {validationHint && <Form.Description text={validationHint} />}
+      <Form.Dropdown
+        id="outputFormat"
+        title="Output Format"
+        value={outputFormat}
+        onChange={(v) => setOutputFormat(v as AllOutputExtension)}
+      >
+        {availableFormats.map((f) => (
+          <Form.Dropdown.Item key={f} value={f} title={f} />
+        ))}
+      </Form.Dropdown>
+      <Form.TextField
+        id="outputFileName"
+        title="Output Filename"
+        value={outputFileName}
+        onChange={setOutputFileName}
+        placeholder="merged"
+      />
+      <Form.Checkbox
+        id="forceReencode"
+        title="Encoding"
+        label="Always re-encode (skip stream-copy detection)"
+        value={forceReencode}
+        onChange={setForceReencode}
+        info="Stream-copy is much faster but only works when all inputs share codec, resolution, fps, etc. Turn this on for slower-but-guaranteed compatibility."
+      />
+      <Form.Separator />
+      <Form.Dropdown
+        id="outputLocation"
+        title="Save to"
+        value={outputLocationMode}
+        onChange={(v) => setOutputLocationMode(v as typeof outputLocationMode)}
+      >
+        <Form.Dropdown.Item value="sameAsFirst" title="Same folder as first input" />
+        <Form.Dropdown.Item
+          value="customFolder"
+          title={
+            preferences.customOutputFolder
+              ? `Preference folder (${preferences.customOutputFolder})`
+              : "Preference folder (not set)"
+          }
+        />
+        <Form.Dropdown.Item value="thisRun" title="Choose for this run…" />
+      </Form.Dropdown>
+      {outputLocationMode === "thisRun" && (
+        <Form.TextField
+          id="customOutputFolderOverride"
+          title="Output folder"
+          placeholder="/absolute/path/to/folder"
+          value={customOutputFolderOverride}
+          onChange={setCustomOutputFolderOverride}
+        />
+      )}
+      <Form.Checkbox
+        id="stripMetadata"
+        title="Privacy"
+        label="Strip metadata (EXIF, GPS, tags)"
+        value={stripMetadata}
+        onChange={setStripMetadata}
+      />
+    </Form>
+  );
+}

--- a/extensions/media-converter/src/components/MergeForm.tsx
+++ b/extensions/media-converter/src/components/MergeForm.tsx
@@ -14,7 +14,7 @@ import {
 } from "../types/media";
 
 export function MergeForm({ initialFiles = [] }: { initialFiles?: string[] }) {
-  const preferences = getPreferenceValues();
+  const preferences = getPreferenceValues<Preferences>();
   const [files, setFiles] = useState<string[]>(initialFiles);
   const [outputFormat, setOutputFormat] = useState<AllOutputExtension>(".mp4");
   const [outputFileName, setOutputFileName] = useState<string>("merged");

--- a/extensions/media-converter/src/components/PresetEditorForm.tsx
+++ b/extensions/media-converter/src/components/PresetEditorForm.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useState } from "react";
+import { Form, ActionPanel, Action, showToast, Toast, useNavigation, getPreferenceValues } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { saveUserPreset } from "../utils/presets";
+import {
+  Preset,
+  AllOutputExtension,
+  QualitySettings,
+  MediaType,
+  TrimOptions,
+  OUTPUT_IMAGE_EXTENSIONS,
+  OUTPUT_AUDIO_EXTENSIONS,
+  OUTPUT_VIDEO_EXTENSIONS,
+  OUTPUT_GIF_EXTENSIONS,
+  getDefaultQuality,
+  getOutputCategory,
+  GifFps,
+  GifWidth,
+} from "../types/media";
+import { parseTimeString, formatTimeString } from "../utils/time";
+import { GifQualityControls, QualitySettingsComponent } from "./ConverterForm";
+
+export type PresetEditorSeed = {
+  name?: string;
+  description?: string;
+  mediaType?: MediaType | "gif";
+  outputFormat?: AllOutputExtension;
+  quality?: QualitySettings;
+  stripMetadata?: boolean;
+  trim?: TrimOptions;
+  outputDir?: string;
+};
+
+export type PresetEditorMode = { mode: "create"; seed?: PresetEditorSeed } | { mode: "edit"; preset: Preset };
+
+export function PresetEditorForm({ onSaved, ...rest }: { onSaved: () => Promise<void> | void } & PresetEditorMode) {
+  const preferences = getPreferenceValues();
+  const { pop } = useNavigation();
+
+  const editing = rest.mode === "edit" ? rest.preset : null;
+  const seed = rest.mode === "create" ? rest.seed : undefined;
+
+  const initialMediaType = editing?.mediaType ?? seed?.mediaType ?? "video";
+  const initialOutputFormat = editing?.outputFormat ?? seed?.outputFormat ?? ".mp4";
+  const initialQuality =
+    editing?.quality ?? seed?.quality ?? getDefaultQuality(initialOutputFormat, preferences, "high");
+
+  const [name, setName] = useState(editing?.name ?? seed?.name ?? "");
+  const [description, setDescription] = useState(editing?.description ?? seed?.description ?? "");
+  const [mediaType, setMediaType] = useState<MediaType | "gif">(initialMediaType);
+  const [outputFormat, setOutputFormat] = useState<AllOutputExtension>(initialOutputFormat);
+  const [quality, setQuality] = useState<QualitySettings>(initialQuality);
+  const [stripMetadata, setStripMetadata] = useState<boolean>(editing?.stripMetadata ?? seed?.stripMetadata ?? false);
+  const [trimStart, setTrimStart] = useState(editing?.trim?.start ?? seed?.trim?.start ?? "");
+  const [trimEnd, setTrimEnd] = useState(editing?.trim?.end ?? seed?.trim?.end ?? "");
+  const [outputDir, setOutputDir] = useState(editing?.outputDir ?? seed?.outputDir ?? "");
+
+  const formats = formatsForMediaType(mediaType);
+  const outputCategory = getOutputCategory(outputFormat);
+  const supportsTrim = outputCategory === "video" || outputCategory === "audio" || outputCategory === "gif";
+
+  useEffect(() => {
+    const first = formats[0];
+    if (first && !formats.includes(outputFormat)) {
+      setOutputFormat(first);
+      setQuality(getDefaultQuality(first, preferences, "high"));
+    }
+  }, [mediaType]);
+
+  useEffect(() => {
+    const q = (quality as Record<string, unknown>)[outputFormat];
+    if (q === undefined) {
+      setQuality(getDefaultQuality(outputFormat, preferences, "high"));
+    }
+  }, [outputFormat]);
+
+  const trimStartError = trimStart && parseTimeString(trimStart) === null ? "Invalid time format" : undefined;
+  const trimEndError = trimEnd && parseTimeString(trimEnd) === null ? "Invalid time format" : undefined;
+
+  const trimPreviewText = (() => {
+    if (!supportsTrim) return undefined;
+    const s = parseTimeString(trimStart);
+    const e = parseTimeString(trimEnd);
+    if (s === null && e === null) return undefined;
+    if (s !== null && e !== null && e <= s) return "End must be after start";
+    const startLabel = s !== null ? formatTimeString(s) : "start";
+    const endLabel = e !== null ? formatTimeString(e) : "end";
+    const duration = s !== null && e !== null ? ` · ${formatTimeString(e - s)} long` : "";
+    return `Trim ${startLabel} → ${endLabel}${duration}`;
+  })();
+
+  const submit = async () => {
+    if (!name.trim()) {
+      await showToast({ style: Toast.Style.Failure, title: "Name required" });
+      return;
+    }
+    if (trimStartError || trimEndError) {
+      await showToast({ style: Toast.Style.Failure, title: "Invalid trim time" });
+      return;
+    }
+    try {
+      await saveUserPreset({
+        id: editing?.id,
+        name: name.trim(),
+        mediaType,
+        outputFormat,
+        quality,
+        stripMetadata,
+        trim: trimStart.trim() || trimEnd.trim() ? { start: trimStart.trim(), end: trimEnd.trim() } : undefined,
+        outputDir: outputDir.trim() || undefined,
+        description: description.trim() || undefined,
+      });
+      await onSaved();
+      await showToast({
+        style: Toast.Style.Success,
+        title: editing ? "Preset updated" : "Preset saved",
+      });
+      pop();
+    } catch (error) {
+      showFailureToast(error, { title: "Failed to save preset" });
+    }
+  };
+
+  return (
+    <Form
+      navigationTitle={editing ? `Edit ${editing.name}` : "New Preset"}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title={editing ? "Save Changes" : "Save Preset"} onSubmit={submit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField
+        id="name"
+        title="Name"
+        placeholder="e.g. My Video Compression"
+        value={name}
+        onChange={setName}
+        autoFocus={!editing}
+      />
+      <Form.TextArea
+        id="description"
+        title="Description"
+        placeholder="Optional notes"
+        value={description}
+        onChange={setDescription}
+      />
+
+      <Form.Separator />
+
+      <Form.Dropdown
+        id="mediaType"
+        title="Media Type"
+        value={mediaType}
+        onChange={(v) => setMediaType(v as typeof mediaType)}
+      >
+        <Form.Dropdown.Item value="video" title="Video" />
+        <Form.Dropdown.Item value="audio" title="Audio" />
+        <Form.Dropdown.Item value="image" title="Image" />
+        <Form.Dropdown.Item value="gif" title="GIF (from video)" />
+      </Form.Dropdown>
+
+      <Form.Dropdown
+        id="outputFormat"
+        title="Output Format"
+        value={outputFormat}
+        onChange={(v) => setOutputFormat(v as AllOutputExtension)}
+      >
+        {formats.map((f) => (
+          <Form.Dropdown.Item key={f} value={f} title={f} />
+        ))}
+      </Form.Dropdown>
+
+      <Form.Separator />
+
+      {outputCategory === "gif" ? (
+        <GifQualityControls
+          settings={quality as { ".gif": { fps: GifFps; width: GifWidth; loop: boolean } }}
+          onChange={setQuality}
+        />
+      ) : (
+        <QualitySettingsComponent outputFormat={outputFormat} currentQuality={quality} onQualityChange={setQuality} />
+      )}
+
+      <Form.Separator />
+
+      <Form.Checkbox
+        id="stripMetadata"
+        title="Privacy"
+        label="Strip metadata (EXIF, GPS, tags)"
+        value={stripMetadata}
+        onChange={setStripMetadata}
+      />
+
+      {supportsTrim && (
+        <>
+          <Form.TextField
+            id="trimStart"
+            title="Trim Start"
+            placeholder="0:30 or 30 or 00:00:30.000"
+            value={trimStart}
+            onChange={setTrimStart}
+            error={trimStartError}
+          />
+          <Form.TextField
+            id="trimEnd"
+            title="Trim End"
+            placeholder="1:30 or 90 or 00:01:30.000"
+            value={trimEnd}
+            onChange={setTrimEnd}
+            error={trimEndError}
+          />
+          {trimPreviewText && <Form.Description text={trimPreviewText} />}
+        </>
+      )}
+
+      <Form.TextField
+        id="outputDir"
+        title="Output Folder"
+        placeholder="Leave blank to save alongside input"
+        value={outputDir}
+        onChange={setOutputDir}
+        info="Absolute path. Applied when this preset is used."
+      />
+    </Form>
+  );
+}
+
+function formatsForMediaType(m: MediaType | "gif"): AllOutputExtension[] {
+  if (m === "image")
+    return OUTPUT_IMAGE_EXTENSIONS.filter(
+      (f) => process.platform === "darwin" || f !== ".heic",
+    ) as AllOutputExtension[];
+  if (m === "audio") return [...OUTPUT_AUDIO_EXTENSIONS];
+  if (m === "gif") return [...OUTPUT_GIF_EXTENSIONS];
+  return [...OUTPUT_VIDEO_EXTENSIONS];
+}

--- a/extensions/media-converter/src/config/built-in-presets.json
+++ b/extensions/media-converter/src/config/built-in-presets.json
@@ -1,0 +1,73 @@
+{
+  "v": 1,
+  "presets": [
+    {
+      "id": "builtin-web-webp",
+      "name": "Web Image (WebP 80)",
+      "mediaType": "image",
+      "outputFormat": ".webp",
+      "quality": { ".webp": 80 },
+      "description": "Great balance of quality and size for websites"
+    },
+    {
+      "id": "builtin-web-jpg",
+      "name": "Web Image (JPG 80)",
+      "mediaType": "image",
+      "outputFormat": ".jpg",
+      "quality": { ".jpg": 80 },
+      "description": "Widely compatible web-friendly JPG"
+    },
+    {
+      "id": "builtin-email-video",
+      "name": "Email-friendly Video (MP4)",
+      "mediaType": "video",
+      "outputFormat": ".mp4",
+      "quality": { ".mp4": { "encodingMode": "crf", "crf": 60, "preset": "medium" } },
+      "stripMetadata": true,
+      "description": "Smaller H.264 MP4, good for email attachments"
+    },
+    {
+      "id": "builtin-whatsapp-video",
+      "name": "WhatsApp Video (MP4)",
+      "mediaType": "video",
+      "outputFormat": ".mp4",
+      "quality": { ".mp4": { "encodingMode": "crf", "crf": 55, "preset": "fast" } },
+      "stripMetadata": true,
+      "description": "Compressed MP4 suitable for WhatsApp"
+    },
+    {
+      "id": "builtin-podcast-mp3",
+      "name": "Podcast (MP3 192 VBR)",
+      "mediaType": "audio",
+      "outputFormat": ".mp3",
+      "quality": { ".mp3": { "bitrate": "192", "vbr": true } },
+      "description": "Standard podcast-quality MP3"
+    },
+    {
+      "id": "builtin-lossless-flac",
+      "name": "Lossless Audio (FLAC)",
+      "mediaType": "audio",
+      "outputFormat": ".flac",
+      "quality": {
+        ".flac": { "compressionLevel": "5", "sampleRate": "48000", "bitDepth": "24" }
+      },
+      "description": "High-quality FLAC archive"
+    },
+    {
+      "id": "builtin-twitter-gif",
+      "name": "Twitter/X GIF (15 fps, 720w)",
+      "mediaType": "gif",
+      "outputFormat": ".gif",
+      "quality": { ".gif": { "fps": "15", "width": "720", "loop": true } },
+      "description": "Small looping GIF for social posts"
+    },
+    {
+      "id": "builtin-voice-memo-m4a",
+      "name": "Voice Memo (M4A 96k)",
+      "mediaType": "audio",
+      "outputFormat": ".m4a",
+      "quality": { ".m4a": { "bitrate": "96", "profile": "aac_low" } },
+      "description": "Tiny M4A for voice recordings"
+    }
+  ]
+}

--- a/extensions/media-converter/src/convert.tsx
+++ b/extensions/media-converter/src/convert.tsx
@@ -1,10 +1,22 @@
 import { useState, useEffect } from "react";
-import { LocalStorage, getSelectedFinderItems, showToast, Toast } from "@raycast/api";
+import { LocalStorage, getSelectedFinderItems, showToast, Toast, LaunchProps } from "@raycast/api";
 import { HelloPage } from "./components/HelloPage";
 import { ConverterForm } from "./components/ConverterForm";
 import { findFFmpegPath } from "./utils/ffmpeg";
+import type { AllOutputExtension, QualitySettings, TrimOptions } from "./types/media";
 
-export default function Command() {
+type LaunchContext = {
+  prefill?: {
+    inputs?: string[];
+    outputFormat?: AllOutputExtension;
+    quality?: QualitySettings;
+    trim?: TrimOptions;
+    stripMetadata?: boolean;
+    outputDir?: string;
+  };
+};
+
+export default function Command(props: LaunchProps<{ launchContext?: LaunchContext }>) {
   // For some reason, limiting this to boolean only (and setting it to false) will show HelloPage.tsx during loading, so that's a no no... There's probably an easy workaround though
   const [hasSeenHelloPage, setHasSeenHelloPage] = useState<boolean | null>(null);
   const [initialFinderFiles, setInitialFinderFiles] = useState<string[]>([]);
@@ -95,5 +107,5 @@ export default function Command() {
     return <HelloPage onContinue={() => setHasSeenHelloPage(true)} lostFFmpegMessage={ffmpegLostMessage} />;
   }
 
-  return <ConverterForm initialFiles={initialFinderFiles} />;
+  return <ConverterForm initialFiles={initialFinderFiles} launchContext={props.launchContext} />;
 }

--- a/extensions/media-converter/src/history.tsx
+++ b/extensions/media-converter/src/history.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useState } from "react";
+import fs from "fs";
+import path from "path";
+import {
+  List,
+  ActionPanel,
+  Action,
+  Icon,
+  Color,
+  showToast,
+  Toast,
+  showInFinder,
+  confirmAlert,
+  Alert,
+  Clipboard,
+  launchCommand,
+  LaunchType,
+} from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { listHistory, removeHistory, clearHistory, HistoryEntry } from "./utils/history";
+import { formatBytes, formatSavings } from "./utils/format";
+import { convertMedia } from "./utils/converter";
+
+export default function Command() {
+  const [entries, setEntries] = useState<HistoryEntry[] | null>(null);
+
+  const reload = async () => {
+    try {
+      const list = await listHistory();
+      setEntries(list);
+    } catch (error) {
+      showFailureToast(error, { title: "Failed to load history" });
+      setEntries([]);
+    }
+  };
+
+  useEffect(() => {
+    reload();
+  }, []);
+
+  if (entries === null) {
+    return <List isLoading={true} />;
+  }
+
+  if (entries.length === 0) {
+    return (
+      <List>
+        <List.EmptyView
+          icon={Icon.Clock}
+          title="No conversions yet"
+          description="Your converted files will appear here. Run a conversion from Convert Media to get started."
+        />
+      </List>
+    );
+  }
+
+  const grouped = groupByDate(entries);
+
+  return (
+    <List
+      searchBarPlaceholder="Search by filename or format"
+      actions={
+        <ActionPanel>
+          <Action
+            title="Clear All History"
+            icon={Icon.Trash}
+            style={Action.Style.Destructive}
+            onAction={async () => {
+              if (
+                await confirmAlert({
+                  title: "Clear all conversion history?",
+                  message: "This only deletes the history entries. Your converted files are not affected.",
+                  primaryAction: { title: "Clear", style: Alert.ActionStyle.Destructive },
+                })
+              ) {
+                await clearHistory();
+                await reload();
+              }
+            }}
+          />
+        </ActionPanel>
+      }
+    >
+      {grouped.map(({ label, items }) => (
+        <List.Section key={label} title={label}>
+          {items.map((entry) => (
+            <HistoryItem key={entry.id} entry={entry} onChange={reload} />
+          ))}
+        </List.Section>
+      ))}
+    </List>
+  );
+}
+
+function HistoryItem({ entry, onChange }: { entry: HistoryEntry; onChange: () => Promise<void> }) {
+  const primaryOutput = entry.outputs[0];
+  const title = primaryOutput ? path.basename(primaryOutput) : "Conversion";
+  const outputExists = primaryOutput ? fs.existsSync(primaryOutput) : false;
+
+  const savingsText =
+    entry.inputBytes > 0 && entry.outputBytes > 0
+      ? formatSavings(entry.inputBytes, entry.outputBytes)
+      : formatBytes(entry.outputBytes);
+
+  const time = new Date(entry.timestampMs);
+  const timeStr = time.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+
+  return (
+    <List.Item
+      icon={{
+        source: outputExists ? Icon.Document : Icon.Warning,
+        tintColor: outputExists ? Color.PrimaryText : Color.Orange,
+      }}
+      title={title}
+      subtitle={entry.outputFormat}
+      accessories={[
+        { text: savingsText },
+        { text: timeStr },
+        ...(outputExists ? [] : [{ icon: Icon.Warning, tooltip: "Output file no longer exists" }]),
+      ]}
+      actions={
+        <ActionPanel>
+          <ActionPanel.Section>
+            {outputExists && primaryOutput && (
+              <>
+                <Action.Open title="Open File" target={primaryOutput} icon={Icon.Eye} />
+                <Action title="Show in Finder" icon={Icon.Finder} onAction={() => showInFinder(primaryOutput)} />
+              </>
+            )}
+            <Action
+              title="Re-Run with Same Settings"
+              icon={Icon.ArrowClockwise}
+              shortcut={{ modifiers: ["cmd"], key: "r" }}
+              onAction={() => rerunEntry(entry)}
+            />
+            <Action
+              title="Copy FFmpeg Command"
+              icon={Icon.Clipboard}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+              onAction={async () => {
+                try {
+                  if (entry.inputs.length === 0) return;
+                  const cmd = await convertMedia(entry.inputs[0], entry.outputFormat, entry.quality, {
+                    returnCommandString: true,
+                    outputDir: entry.outputDir,
+                    stripMetadata: entry.stripMetadata,
+                    trim: entry.trim,
+                  });
+                  await Clipboard.copy(cmd);
+                  await showToast({ style: Toast.Style.Success, title: "Command copied" });
+                } catch (error) {
+                  showFailureToast(error, { title: "Failed to generate command" });
+                }
+              }}
+            />
+          </ActionPanel.Section>
+          <ActionPanel.Section>
+            <Action
+              title="Remove from History"
+              icon={Icon.Trash}
+              style={Action.Style.Destructive}
+              shortcut={{ modifiers: ["ctrl"], key: "x" }}
+              onAction={async () => {
+                await removeHistory(entry.id);
+                await onChange();
+              }}
+            />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+async function rerunEntry(entry: HistoryEntry): Promise<void> {
+  // Only pass inputs that still exist
+  const stillExisting = entry.inputs.filter((p) => {
+    try {
+      return fs.statSync(p).isFile();
+    } catch {
+      return false;
+    }
+  });
+  if (stillExisting.length === 0) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Source files not found",
+      message: "The original input files no longer exist at the recorded paths.",
+    });
+    return;
+  }
+  try {
+    await launchCommand({
+      name: "convert",
+      type: LaunchType.UserInitiated,
+      context: {
+        prefill: {
+          inputs: stillExisting,
+          outputFormat: entry.outputFormat,
+          quality: entry.quality,
+          trim: entry.trim,
+          stripMetadata: entry.stripMetadata,
+          outputDir: entry.outputDir,
+        },
+      },
+    });
+  } catch (error) {
+    showFailureToast(error, { title: "Failed to launch Convert Media" });
+  }
+}
+
+function groupByDate(entries: HistoryEntry[]): { label: string; items: HistoryEntry[] }[] {
+  const now = new Date();
+  const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  const todayStart = startOfDay(now);
+  const yesterdayStart = todayStart - 24 * 60 * 60 * 1000;
+  const weekStart = todayStart - 7 * 24 * 60 * 60 * 1000;
+
+  const groups = new Map<string, HistoryEntry[]>();
+  const order: string[] = [];
+  const push = (label: string, entry: HistoryEntry) => {
+    if (!groups.has(label)) {
+      groups.set(label, []);
+      order.push(label);
+    }
+    groups.get(label)!.push(entry);
+  };
+
+  for (const e of entries) {
+    if (e.timestampMs >= todayStart) push("Today", e);
+    else if (e.timestampMs >= yesterdayStart) push("Yesterday", e);
+    else if (e.timestampMs >= weekStart) push("This week", e);
+    else {
+      const d = new Date(e.timestampMs);
+      push(d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" }), e);
+    }
+  }
+
+  return order.map((label) => ({ label, items: groups.get(label)! }));
+}

--- a/extensions/media-converter/src/history.tsx
+++ b/extensions/media-converter/src/history.tsx
@@ -95,7 +95,10 @@ export default function Command() {
 function HistoryItem({ entry, onChange }: { entry: HistoryEntry; onChange: () => Promise<void> }) {
   const primaryOutput = entry.outputs[0];
   const title = primaryOutput ? path.basename(primaryOutput) : "Conversion";
-  const outputExists = primaryOutput ? fs.existsSync(primaryOutput) : false;
+  const [outputExists, setOutputExists] = useState(false);
+  useEffect(() => {
+    setOutputExists(primaryOutput ? fs.existsSync(primaryOutput) : false);
+  }, [primaryOutput]);
 
   const savingsText =
     entry.inputBytes > 0 && entry.outputBytes > 0

--- a/extensions/media-converter/src/merge.tsx
+++ b/extensions/media-converter/src/merge.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+import { getSelectedFinderItems } from "@raycast/api";
+import { MergeForm } from "./components/MergeForm";
+
+export default function Command() {
+  const [initialFiles, setInitialFiles] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const items = await getSelectedFinderItems();
+        setInitialFiles(items.map((i) => i.path));
+      } catch {
+        setInitialFiles([]);
+      }
+    })();
+  }, []);
+
+  if (initialFiles === null) {
+    return <MergeForm initialFiles={[]} />;
+  }
+
+  return <MergeForm initialFiles={initialFiles} />;
+}

--- a/extensions/media-converter/src/presets.tsx
+++ b/extensions/media-converter/src/presets.tsx
@@ -1,0 +1,335 @@
+import { useEffect, useState } from "react";
+import {
+  List,
+  ActionPanel,
+  Action,
+  Icon,
+  Color,
+  showToast,
+  Toast,
+  confirmAlert,
+  Alert,
+  useNavigation,
+  Form,
+  getPreferenceValues,
+} from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { getAllPresets, deleteUserPreset, duplicatePreset, saveUserPreset } from "./utils/presets";
+import {
+  Preset,
+  AllOutputExtension,
+  QualitySettings,
+  MediaType,
+  OUTPUT_IMAGE_EXTENSIONS,
+  OUTPUT_AUDIO_EXTENSIONS,
+  OUTPUT_VIDEO_EXTENSIONS,
+  OUTPUT_GIF_EXTENSIONS,
+  getDefaultQuality,
+} from "./types/media";
+
+export default function Command() {
+  const [presets, setPresets] = useState<Preset[] | null>(null);
+
+  const reload = async () => {
+    try {
+      const all = await getAllPresets();
+      setPresets(all);
+    } catch (error) {
+      showFailureToast(error, { title: "Failed to load presets" });
+      setPresets([]);
+    }
+  };
+
+  useEffect(() => {
+    reload();
+  }, []);
+
+  if (presets === null) return <List isLoading={true} />;
+
+  const builtIns = presets.filter((p) => p.builtIn);
+  const userPresets = presets.filter((p) => !p.builtIn);
+
+  return (
+    <List
+      searchBarPlaceholder="Search presets"
+      actions={
+        <ActionPanel>
+          <CreatePresetAction onChange={reload} />
+        </ActionPanel>
+      }
+    >
+      {builtIns.length > 0 && (
+        <List.Section title="Built-in">
+          {builtIns.map((p) => (
+            <PresetItem key={p.id} preset={p} onChange={reload} />
+          ))}
+        </List.Section>
+      )}
+      <List.Section title="My Presets">
+        {userPresets.length === 0 ? (
+          <List.Item
+            title="No user presets yet"
+            subtitle="Save current form settings via 'Save Settings as Preset…' in the Convert Media form, or use the action below."
+            icon={Icon.Stars}
+            actions={
+              <ActionPanel>
+                <CreatePresetAction onChange={reload} />
+              </ActionPanel>
+            }
+          />
+        ) : (
+          userPresets.map((p) => <PresetItem key={p.id} preset={p} onChange={reload} />)
+        )}
+      </List.Section>
+    </List>
+  );
+}
+
+function PresetItem({ preset, onChange }: { preset: Preset; onChange: () => Promise<void> }) {
+  const subtitle = preset.description ?? describePreset(preset);
+  const accessories: List.Item.Accessory[] = [
+    { tag: { value: preset.outputFormat, color: Color.Blue } },
+    { text: preset.mediaType },
+  ];
+  if (preset.stripMetadata) accessories.push({ icon: Icon.EyeDisabled, tooltip: "Strips metadata" });
+  if (preset.trim) accessories.push({ icon: Icon.FilmStrip, tooltip: "Includes trim settings" });
+
+  return (
+    <List.Item
+      title={preset.name}
+      subtitle={subtitle}
+      icon={preset.builtIn ? Icon.Star : Icon.StarCircle}
+      accessories={accessories}
+      actions={
+        <ActionPanel>
+          <ActionPanel.Section>
+            <Action
+              title="Duplicate to My Presets"
+              icon={Icon.Duplicate}
+              onAction={async () => {
+                try {
+                  await duplicatePreset(preset.id);
+                  await onChange();
+                  await showToast({ style: Toast.Style.Success, title: "Preset duplicated" });
+                } catch (error) {
+                  showFailureToast(error, { title: "Failed to duplicate preset" });
+                }
+              }}
+            />
+            {!preset.builtIn && <RenamePresetAction preset={preset} onChange={onChange} />}
+          </ActionPanel.Section>
+          {!preset.builtIn && (
+            <ActionPanel.Section>
+              <Action
+                title="Delete Preset"
+                icon={Icon.Trash}
+                style={Action.Style.Destructive}
+                shortcut={{ modifiers: ["ctrl"], key: "x" }}
+                onAction={async () => {
+                  if (
+                    await confirmAlert({
+                      title: `Delete "${preset.name}"?`,
+                      primaryAction: { title: "Delete", style: Alert.ActionStyle.Destructive },
+                    })
+                  ) {
+                    await deleteUserPreset(preset.id);
+                    await onChange();
+                  }
+                }}
+              />
+            </ActionPanel.Section>
+          )}
+          <ActionPanel.Section>
+            <CreatePresetAction onChange={onChange} />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+function CreatePresetAction({ onChange }: { onChange: () => Promise<void> }) {
+  const { push } = useNavigation();
+  return (
+    <Action
+      title="Create New Preset…"
+      icon={Icon.Plus}
+      shortcut={{ modifiers: ["cmd"], key: "n" }}
+      onAction={() => push(<CreatePresetForm onSaved={onChange} />)}
+    />
+  );
+}
+
+function RenamePresetAction({ preset, onChange }: { preset: Preset; onChange: () => Promise<void> }) {
+  const { push } = useNavigation();
+  return (
+    <Action
+      title="Rename"
+      icon={Icon.Pencil}
+      shortcut={{ modifiers: ["cmd"], key: "e" }}
+      onAction={() => push(<RenamePresetForm preset={preset} onSaved={onChange} />)}
+    />
+  );
+}
+
+function RenamePresetForm({ preset, onSaved }: { preset: Preset; onSaved: () => Promise<void> }) {
+  const [name, setName] = useState(preset.name);
+  const [description, setDescription] = useState(preset.description ?? "");
+  const { pop } = useNavigation();
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm
+            title="Save"
+            onSubmit={async () => {
+              if (!name.trim()) {
+                await showToast({ style: Toast.Style.Failure, title: "Name required" });
+                return;
+              }
+              try {
+                await saveUserPreset({
+                  id: preset.id,
+                  name: name.trim(),
+                  mediaType: preset.mediaType,
+                  outputFormat: preset.outputFormat,
+                  quality: preset.quality,
+                  trim: preset.trim,
+                  stripMetadata: preset.stripMetadata,
+                  outputDir: preset.outputDir,
+                  description: description.trim() || undefined,
+                });
+                await onSaved();
+                pop();
+              } catch (error) {
+                showFailureToast(error, { title: "Failed to save preset" });
+              }
+            }}
+          />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField id="name" title="Name" value={name} onChange={setName} />
+      <Form.TextArea id="description" title="Description" value={description} onChange={setDescription} />
+    </Form>
+  );
+}
+
+function CreatePresetForm({ onSaved }: { onSaved: () => Promise<void> }) {
+  const preferences = getPreferenceValues();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [mediaType, setMediaType] = useState<MediaType | "gif">("video");
+  const [outputFormat, setOutputFormat] = useState<AllOutputExtension>(".mp4");
+  const [stripMetadata, setStripMetadata] = useState(false);
+  const { pop } = useNavigation();
+
+  const formats = formatsForMediaType(mediaType);
+
+  useEffect(() => {
+    // Reset output format to first valid one when media type changes
+    const first = formats[0];
+    if (first && !formats.includes(outputFormat)) {
+      setOutputFormat(first);
+    }
+  }, [mediaType]);
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm
+            title="Create Preset"
+            onSubmit={async () => {
+              if (!name.trim()) {
+                await showToast({ style: Toast.Style.Failure, title: "Name required" });
+                return;
+              }
+              try {
+                const quality: QualitySettings = getDefaultQuality(outputFormat, preferences, "high");
+                await saveUserPreset({
+                  name: name.trim(),
+                  mediaType,
+                  outputFormat,
+                  quality,
+                  stripMetadata,
+                  description: description.trim() || undefined,
+                });
+                await onSaved();
+                await showToast({ style: Toast.Style.Success, title: "Preset created" });
+                pop();
+              } catch (error) {
+                showFailureToast(error, { title: "Failed to create preset" });
+              }
+            }}
+          />
+        </ActionPanel>
+      }
+    >
+      <Form.Description text="Presets store a default output format, quality and privacy option. To save more detailed settings (advanced quality controls, trim, custom output folder), use 'Save Settings as Preset…' from the Convert Media form." />
+      <Form.TextField id="name" title="Name" value={name} onChange={setName} autoFocus={true} />
+      <Form.TextArea
+        id="description"
+        title="Description"
+        placeholder="Optional notes"
+        value={description}
+        onChange={setDescription}
+      />
+      <Form.Dropdown
+        id="mediaType"
+        title="Media Type"
+        value={mediaType}
+        onChange={(v) => setMediaType(v as typeof mediaType)}
+      >
+        <Form.Dropdown.Item value="video" title="Video" />
+        <Form.Dropdown.Item value="audio" title="Audio" />
+        <Form.Dropdown.Item value="image" title="Image" />
+        <Form.Dropdown.Item value="gif" title="GIF (from video)" />
+      </Form.Dropdown>
+      <Form.Dropdown
+        id="outputFormat"
+        title="Output Format"
+        value={outputFormat}
+        onChange={(v) => setOutputFormat(v as AllOutputExtension)}
+      >
+        {formats.map((f) => (
+          <Form.Dropdown.Item key={f} value={f} title={f} />
+        ))}
+      </Form.Dropdown>
+      <Form.Checkbox
+        id="stripMetadata"
+        title="Privacy"
+        label="Strip metadata (EXIF, GPS, tags)"
+        value={stripMetadata}
+        onChange={setStripMetadata}
+      />
+    </Form>
+  );
+}
+
+function formatsForMediaType(m: MediaType | "gif"): AllOutputExtension[] {
+  if (m === "image")
+    return OUTPUT_IMAGE_EXTENSIONS.filter(
+      (f) => process.platform === "darwin" || f !== ".heic",
+    ) as AllOutputExtension[];
+  if (m === "audio") return [...OUTPUT_AUDIO_EXTENSIONS];
+  if (m === "gif") return [...OUTPUT_GIF_EXTENSIONS];
+  return [...OUTPUT_VIDEO_EXTENSIONS];
+}
+
+function describePreset(p: Preset): string {
+  const parts: string[] = [p.outputFormat];
+  const q = (p.quality as Record<string, unknown>)[p.outputFormat];
+  if (typeof q === "number") parts.push(`quality ${q}`);
+  else if (typeof q === "string") parts.push(q);
+  else if (q && typeof q === "object") {
+    const obj = q as Record<string, unknown>;
+    if (obj.bitrate) parts.push(`${obj.bitrate}kbps`);
+    if (obj.crf !== undefined) parts.push(`CRF ${obj.crf}`);
+    if (obj.variant) parts.push(`ProRes ${obj.variant}`);
+    if (obj.fps) parts.push(`${obj.fps}fps`);
+  }
+  if (p.stripMetadata) parts.push("strip metadata");
+  return parts.join(" · ");
+}

--- a/extensions/media-converter/src/presets.tsx
+++ b/extensions/media-converter/src/presets.tsx
@@ -10,27 +10,11 @@ import {
   confirmAlert,
   Alert,
   useNavigation,
-  Form,
-  getPreferenceValues,
 } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
-import { getAllPresets, deleteUserPreset, duplicatePreset, saveUserPreset } from "./utils/presets";
-import {
-  Preset,
-  AllOutputExtension,
-  QualitySettings,
-  MediaType,
-  OUTPUT_IMAGE_EXTENSIONS,
-  OUTPUT_AUDIO_EXTENSIONS,
-  OUTPUT_VIDEO_EXTENSIONS,
-  OUTPUT_GIF_EXTENSIONS,
-  getDefaultQuality,
-  getOutputCategory,
-  GifFps,
-  GifWidth,
-} from "./types/media";
-import { parseTimeString, formatTimeString } from "./utils/time";
-import { GifQualityControls, QualitySettingsComponent } from "./components/ConverterForm";
+import { getAllPresets, deleteUserPreset, duplicatePreset } from "./utils/presets";
+import { Preset } from "./types/media";
+import { PresetEditorForm } from "./components/PresetEditorForm";
 
 export default function Command() {
   const [presets, setPresets] = useState<Preset[] | null>(null);
@@ -108,9 +92,11 @@ function PresetItem({ preset, onChange }: { preset: Preset; onChange: () => Prom
       actions={
         <ActionPanel>
           <ActionPanel.Section>
+            {!preset.builtIn && <EditPresetAction preset={preset} onChange={onChange} />}
             <Action
               title="Duplicate to My Presets"
               icon={Icon.Duplicate}
+              shortcut={{ modifiers: ["cmd"], key: "d" }}
               onAction={async () => {
                 try {
                   await duplicatePreset(preset.id);
@@ -121,7 +107,6 @@ function PresetItem({ preset, onChange }: { preset: Preset; onChange: () => Prom
                 }
               }}
             />
-            {!preset.builtIn && <EditPresetAction preset={preset} onChange={onChange} />}
           </ActionPanel.Section>
           {!preset.builtIn && (
             <ActionPanel.Section>
@@ -175,202 +160,6 @@ function EditPresetAction({ preset, onChange }: { preset: Preset; onChange: () =
       onAction={() => push(<PresetEditorForm mode="edit" preset={preset} onSaved={onChange} />)}
     />
   );
-}
-
-type EditorMode = { mode: "create" } | { mode: "edit"; preset: Preset };
-
-function PresetEditorForm({ onSaved, ...rest }: { onSaved: () => Promise<void> } & EditorMode) {
-  const preferences = getPreferenceValues();
-  const { pop } = useNavigation();
-  const editing = rest.mode === "edit" ? rest.preset : null;
-
-  const [name, setName] = useState(editing?.name ?? "");
-  const [description, setDescription] = useState(editing?.description ?? "");
-  const [mediaType, setMediaType] = useState<MediaType | "gif">(editing?.mediaType ?? "video");
-  const [outputFormat, setOutputFormat] = useState<AllOutputExtension>(editing?.outputFormat ?? ".mp4");
-  const [quality, setQuality] = useState<QualitySettings>(
-    editing?.quality ?? getDefaultQuality(editing?.outputFormat ?? ".mp4", preferences, "high"),
-  );
-  const [stripMetadata, setStripMetadata] = useState<boolean>(editing?.stripMetadata ?? false);
-  const [trimStart, setTrimStart] = useState(editing?.trim?.start ?? "");
-  const [trimEnd, setTrimEnd] = useState(editing?.trim?.end ?? "");
-  const [outputDir, setOutputDir] = useState(editing?.outputDir ?? "");
-
-  const formats = formatsForMediaType(mediaType);
-  const outputCategory = getOutputCategory(outputFormat);
-  const supportsTrim = outputCategory === "video" || outputCategory === "audio" || outputCategory === "gif";
-
-  // When media type changes, reset the output format + quality so they stay consistent.
-  useEffect(() => {
-    const first = formats[0];
-    if (first && !formats.includes(outputFormat)) {
-      setOutputFormat(first);
-      setQuality(getDefaultQuality(first, preferences, "high"));
-    }
-  }, [mediaType]);
-
-  // When output format changes within the same media type, reset quality to sensible defaults.
-  useEffect(() => {
-    // Only reset if the current quality doesn't have an entry for the new format.
-    const q = (quality as Record<string, unknown>)[outputFormat];
-    if (q === undefined) {
-      setQuality(getDefaultQuality(outputFormat, preferences, "high"));
-    }
-  }, [outputFormat]);
-
-  const trimStartError = trimStart && parseTimeString(trimStart) === null ? "Invalid time format" : undefined;
-  const trimEndError = trimEnd && parseTimeString(trimEnd) === null ? "Invalid time format" : undefined;
-
-  const trimPreviewText = (() => {
-    if (!supportsTrim) return undefined;
-    const s = parseTimeString(trimStart);
-    const e = parseTimeString(trimEnd);
-    if (s === null && e === null) return undefined;
-    if (s !== null && e !== null && e <= s) return "End must be after start";
-    const startLabel = s !== null ? formatTimeString(s) : "start";
-    const endLabel = e !== null ? formatTimeString(e) : "end";
-    const duration = s !== null && e !== null ? ` · ${formatTimeString(e - s)} long` : "";
-    return `Trim ${startLabel} → ${endLabel}${duration}`;
-  })();
-
-  const submit = async () => {
-    if (!name.trim()) {
-      await showToast({ style: Toast.Style.Failure, title: "Name required" });
-      return;
-    }
-    if (trimStartError || trimEndError) {
-      await showToast({ style: Toast.Style.Failure, title: "Invalid trim time" });
-      return;
-    }
-    try {
-      await saveUserPreset({
-        id: editing?.id,
-        name: name.trim(),
-        mediaType,
-        outputFormat,
-        quality,
-        stripMetadata,
-        trim: trimStart.trim() || trimEnd.trim() ? { start: trimStart.trim(), end: trimEnd.trim() } : undefined,
-        outputDir: outputDir.trim() || undefined,
-        description: description.trim() || undefined,
-      });
-      await onSaved();
-      await showToast({
-        style: Toast.Style.Success,
-        title: editing ? "Preset updated" : "Preset created",
-      });
-      pop();
-    } catch (error) {
-      showFailureToast(error, { title: "Failed to save preset" });
-    }
-  };
-
-  return (
-    <Form
-      navigationTitle={editing ? `Edit ${editing.name}` : "New Preset"}
-      actions={
-        <ActionPanel>
-          <Action.SubmitForm title={editing ? "Save Changes" : "Create Preset"} onSubmit={submit} />
-        </ActionPanel>
-      }
-    >
-      <Form.TextField id="name" title="Name" value={name} onChange={setName} autoFocus={!editing} />
-      <Form.TextArea
-        id="description"
-        title="Description"
-        placeholder="Optional notes"
-        value={description}
-        onChange={setDescription}
-      />
-
-      <Form.Separator />
-
-      <Form.Dropdown
-        id="mediaType"
-        title="Media Type"
-        value={mediaType}
-        onChange={(v) => setMediaType(v as typeof mediaType)}
-      >
-        <Form.Dropdown.Item value="video" title="Video" />
-        <Form.Dropdown.Item value="audio" title="Audio" />
-        <Form.Dropdown.Item value="image" title="Image" />
-        <Form.Dropdown.Item value="gif" title="GIF (from video)" />
-      </Form.Dropdown>
-
-      <Form.Dropdown
-        id="outputFormat"
-        title="Output Format"
-        value={outputFormat}
-        onChange={(v) => setOutputFormat(v as AllOutputExtension)}
-      >
-        {formats.map((f) => (
-          <Form.Dropdown.Item key={f} value={f} title={f} />
-        ))}
-      </Form.Dropdown>
-
-      <Form.Separator />
-
-      {outputCategory === "gif" ? (
-        <GifQualityControls
-          settings={quality as { ".gif": { fps: GifFps; width: GifWidth; loop: boolean } }}
-          onChange={setQuality}
-        />
-      ) : (
-        <QualitySettingsComponent outputFormat={outputFormat} currentQuality={quality} onQualityChange={setQuality} />
-      )}
-
-      <Form.Separator />
-
-      <Form.Checkbox
-        id="stripMetadata"
-        title="Privacy"
-        label="Strip metadata (EXIF, GPS, tags)"
-        value={stripMetadata}
-        onChange={setStripMetadata}
-      />
-
-      {supportsTrim && (
-        <>
-          <Form.TextField
-            id="trimStart"
-            title="Trim Start"
-            placeholder="0:30 or 30 or 00:00:30.000"
-            value={trimStart}
-            onChange={setTrimStart}
-            error={trimStartError}
-          />
-          <Form.TextField
-            id="trimEnd"
-            title="Trim End"
-            placeholder="1:30 or 90 or 00:01:30.000"
-            value={trimEnd}
-            onChange={setTrimEnd}
-            error={trimEndError}
-          />
-          {trimPreviewText && <Form.Description text={trimPreviewText} />}
-        </>
-      )}
-
-      <Form.TextField
-        id="outputDir"
-        title="Output Folder"
-        placeholder="Leave blank to save alongside input"
-        value={outputDir}
-        onChange={setOutputDir}
-        info="Absolute path. Applied when this preset is used."
-      />
-    </Form>
-  );
-}
-
-function formatsForMediaType(m: MediaType | "gif"): AllOutputExtension[] {
-  if (m === "image")
-    return OUTPUT_IMAGE_EXTENSIONS.filter(
-      (f) => process.platform === "darwin" || f !== ".heic",
-    ) as AllOutputExtension[];
-  if (m === "audio") return [...OUTPUT_AUDIO_EXTENSIONS];
-  if (m === "gif") return [...OUTPUT_GIF_EXTENSIONS];
-  return [...OUTPUT_VIDEO_EXTENSIONS];
 }
 
 function describePreset(p: Preset): string {

--- a/extensions/media-converter/src/presets.tsx
+++ b/extensions/media-converter/src/presets.tsx
@@ -25,7 +25,12 @@ import {
   OUTPUT_VIDEO_EXTENSIONS,
   OUTPUT_GIF_EXTENSIONS,
   getDefaultQuality,
+  getOutputCategory,
+  GifFps,
+  GifWidth,
 } from "./types/media";
+import { parseTimeString, formatTimeString } from "./utils/time";
+import { GifQualityControls, QualitySettingsComponent } from "./components/ConverterForm";
 
 export default function Command() {
   const [presets, setPresets] = useState<Preset[] | null>(null);
@@ -116,7 +121,7 @@ function PresetItem({ preset, onChange }: { preset: Preset; onChange: () => Prom
                 }
               }}
             />
-            {!preset.builtIn && <RenamePresetAction preset={preset} onChange={onChange} />}
+            {!preset.builtIn && <EditPresetAction preset={preset} onChange={onChange} />}
           </ActionPanel.Section>
           {!preset.builtIn && (
             <ActionPanel.Section>
@@ -155,120 +160,121 @@ function CreatePresetAction({ onChange }: { onChange: () => Promise<void> }) {
       title="Create New Preset…"
       icon={Icon.Plus}
       shortcut={{ modifiers: ["cmd"], key: "n" }}
-      onAction={() => push(<CreatePresetForm onSaved={onChange} />)}
+      onAction={() => push(<PresetEditorForm mode="create" onSaved={onChange} />)}
     />
   );
 }
 
-function RenamePresetAction({ preset, onChange }: { preset: Preset; onChange: () => Promise<void> }) {
+function EditPresetAction({ preset, onChange }: { preset: Preset; onChange: () => Promise<void> }) {
   const { push } = useNavigation();
   return (
     <Action
-      title="Rename"
+      title="Edit Preset…"
       icon={Icon.Pencil}
       shortcut={{ modifiers: ["cmd"], key: "e" }}
-      onAction={() => push(<RenamePresetForm preset={preset} onSaved={onChange} />)}
+      onAction={() => push(<PresetEditorForm mode="edit" preset={preset} onSaved={onChange} />)}
     />
   );
 }
 
-function RenamePresetForm({ preset, onSaved }: { preset: Preset; onSaved: () => Promise<void> }) {
-  const [name, setName] = useState(preset.name);
-  const [description, setDescription] = useState(preset.description ?? "");
-  const { pop } = useNavigation();
+type EditorMode = { mode: "create" } | { mode: "edit"; preset: Preset };
 
-  return (
-    <Form
-      actions={
-        <ActionPanel>
-          <Action.SubmitForm
-            title="Save"
-            onSubmit={async () => {
-              if (!name.trim()) {
-                await showToast({ style: Toast.Style.Failure, title: "Name required" });
-                return;
-              }
-              try {
-                await saveUserPreset({
-                  id: preset.id,
-                  name: name.trim(),
-                  mediaType: preset.mediaType,
-                  outputFormat: preset.outputFormat,
-                  quality: preset.quality,
-                  trim: preset.trim,
-                  stripMetadata: preset.stripMetadata,
-                  outputDir: preset.outputDir,
-                  description: description.trim() || undefined,
-                });
-                await onSaved();
-                pop();
-              } catch (error) {
-                showFailureToast(error, { title: "Failed to save preset" });
-              }
-            }}
-          />
-        </ActionPanel>
-      }
-    >
-      <Form.TextField id="name" title="Name" value={name} onChange={setName} />
-      <Form.TextArea id="description" title="Description" value={description} onChange={setDescription} />
-    </Form>
-  );
-}
-
-function CreatePresetForm({ onSaved }: { onSaved: () => Promise<void> }) {
+function PresetEditorForm({ onSaved, ...rest }: { onSaved: () => Promise<void> } & EditorMode) {
   const preferences = getPreferenceValues();
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [mediaType, setMediaType] = useState<MediaType | "gif">("video");
-  const [outputFormat, setOutputFormat] = useState<AllOutputExtension>(".mp4");
-  const [stripMetadata, setStripMetadata] = useState(false);
   const { pop } = useNavigation();
+  const editing = rest.mode === "edit" ? rest.preset : null;
+
+  const [name, setName] = useState(editing?.name ?? "");
+  const [description, setDescription] = useState(editing?.description ?? "");
+  const [mediaType, setMediaType] = useState<MediaType | "gif">(editing?.mediaType ?? "video");
+  const [outputFormat, setOutputFormat] = useState<AllOutputExtension>(editing?.outputFormat ?? ".mp4");
+  const [quality, setQuality] = useState<QualitySettings>(
+    editing?.quality ?? getDefaultQuality(editing?.outputFormat ?? ".mp4", preferences, "high"),
+  );
+  const [stripMetadata, setStripMetadata] = useState<boolean>(editing?.stripMetadata ?? false);
+  const [trimStart, setTrimStart] = useState(editing?.trim?.start ?? "");
+  const [trimEnd, setTrimEnd] = useState(editing?.trim?.end ?? "");
+  const [outputDir, setOutputDir] = useState(editing?.outputDir ?? "");
 
   const formats = formatsForMediaType(mediaType);
+  const outputCategory = getOutputCategory(outputFormat);
+  const supportsTrim = outputCategory === "video" || outputCategory === "audio" || outputCategory === "gif";
 
+  // When media type changes, reset the output format + quality so they stay consistent.
   useEffect(() => {
-    // Reset output format to first valid one when media type changes
     const first = formats[0];
     if (first && !formats.includes(outputFormat)) {
       setOutputFormat(first);
+      setQuality(getDefaultQuality(first, preferences, "high"));
     }
   }, [mediaType]);
 
+  // When output format changes within the same media type, reset quality to sensible defaults.
+  useEffect(() => {
+    // Only reset if the current quality doesn't have an entry for the new format.
+    const q = (quality as Record<string, unknown>)[outputFormat];
+    if (q === undefined) {
+      setQuality(getDefaultQuality(outputFormat, preferences, "high"));
+    }
+  }, [outputFormat]);
+
+  const trimStartError = trimStart && parseTimeString(trimStart) === null ? "Invalid time format" : undefined;
+  const trimEndError = trimEnd && parseTimeString(trimEnd) === null ? "Invalid time format" : undefined;
+
+  const trimPreviewText = (() => {
+    if (!supportsTrim) return undefined;
+    const s = parseTimeString(trimStart);
+    const e = parseTimeString(trimEnd);
+    if (s === null && e === null) return undefined;
+    if (s !== null && e !== null && e <= s) return "End must be after start";
+    const startLabel = s !== null ? formatTimeString(s) : "start";
+    const endLabel = e !== null ? formatTimeString(e) : "end";
+    const duration = s !== null && e !== null ? ` · ${formatTimeString(e - s)} long` : "";
+    return `Trim ${startLabel} → ${endLabel}${duration}`;
+  })();
+
+  const submit = async () => {
+    if (!name.trim()) {
+      await showToast({ style: Toast.Style.Failure, title: "Name required" });
+      return;
+    }
+    if (trimStartError || trimEndError) {
+      await showToast({ style: Toast.Style.Failure, title: "Invalid trim time" });
+      return;
+    }
+    try {
+      await saveUserPreset({
+        id: editing?.id,
+        name: name.trim(),
+        mediaType,
+        outputFormat,
+        quality,
+        stripMetadata,
+        trim: trimStart.trim() || trimEnd.trim() ? { start: trimStart.trim(), end: trimEnd.trim() } : undefined,
+        outputDir: outputDir.trim() || undefined,
+        description: description.trim() || undefined,
+      });
+      await onSaved();
+      await showToast({
+        style: Toast.Style.Success,
+        title: editing ? "Preset updated" : "Preset created",
+      });
+      pop();
+    } catch (error) {
+      showFailureToast(error, { title: "Failed to save preset" });
+    }
+  };
+
   return (
     <Form
+      navigationTitle={editing ? `Edit ${editing.name}` : "New Preset"}
       actions={
         <ActionPanel>
-          <Action.SubmitForm
-            title="Create Preset"
-            onSubmit={async () => {
-              if (!name.trim()) {
-                await showToast({ style: Toast.Style.Failure, title: "Name required" });
-                return;
-              }
-              try {
-                const quality: QualitySettings = getDefaultQuality(outputFormat, preferences, "high");
-                await saveUserPreset({
-                  name: name.trim(),
-                  mediaType,
-                  outputFormat,
-                  quality,
-                  stripMetadata,
-                  description: description.trim() || undefined,
-                });
-                await onSaved();
-                await showToast({ style: Toast.Style.Success, title: "Preset created" });
-                pop();
-              } catch (error) {
-                showFailureToast(error, { title: "Failed to create preset" });
-              }
-            }}
-          />
+          <Action.SubmitForm title={editing ? "Save Changes" : "Create Preset"} onSubmit={submit} />
         </ActionPanel>
       }
     >
-      <Form.Description text="Presets store a default output format, quality and privacy option. To save more detailed settings (advanced quality controls, trim, custom output folder), use 'Save Settings as Preset…' from the Convert Media form." />
-      <Form.TextField id="name" title="Name" value={name} onChange={setName} autoFocus={true} />
+      <Form.TextField id="name" title="Name" value={name} onChange={setName} autoFocus={!editing} />
       <Form.TextArea
         id="description"
         title="Description"
@@ -276,6 +282,9 @@ function CreatePresetForm({ onSaved }: { onSaved: () => Promise<void> }) {
         value={description}
         onChange={setDescription}
       />
+
+      <Form.Separator />
+
       <Form.Dropdown
         id="mediaType"
         title="Media Type"
@@ -287,6 +296,7 @@ function CreatePresetForm({ onSaved }: { onSaved: () => Promise<void> }) {
         <Form.Dropdown.Item value="image" title="Image" />
         <Form.Dropdown.Item value="gif" title="GIF (from video)" />
       </Form.Dropdown>
+
       <Form.Dropdown
         id="outputFormat"
         title="Output Format"
@@ -297,12 +307,57 @@ function CreatePresetForm({ onSaved }: { onSaved: () => Promise<void> }) {
           <Form.Dropdown.Item key={f} value={f} title={f} />
         ))}
       </Form.Dropdown>
+
+      <Form.Separator />
+
+      {outputCategory === "gif" ? (
+        <GifQualityControls
+          settings={quality as { ".gif": { fps: GifFps; width: GifWidth; loop: boolean } }}
+          onChange={setQuality}
+        />
+      ) : (
+        <QualitySettingsComponent outputFormat={outputFormat} currentQuality={quality} onQualityChange={setQuality} />
+      )}
+
+      <Form.Separator />
+
       <Form.Checkbox
         id="stripMetadata"
         title="Privacy"
         label="Strip metadata (EXIF, GPS, tags)"
         value={stripMetadata}
         onChange={setStripMetadata}
+      />
+
+      {supportsTrim && (
+        <>
+          <Form.TextField
+            id="trimStart"
+            title="Trim Start"
+            placeholder="0:30 or 30 or 00:00:30.000"
+            value={trimStart}
+            onChange={setTrimStart}
+            error={trimStartError}
+          />
+          <Form.TextField
+            id="trimEnd"
+            title="Trim End"
+            placeholder="1:30 or 90 or 00:01:30.000"
+            value={trimEnd}
+            onChange={setTrimEnd}
+            error={trimEndError}
+          />
+          {trimPreviewText && <Form.Description text={trimPreviewText} />}
+        </>
+      )}
+
+      <Form.TextField
+        id="outputDir"
+        title="Output Folder"
+        placeholder="Leave blank to save alongside input"
+        value={outputDir}
+        onChange={setOutputDir}
+        info="Absolute path. Applied when this preset is used."
       />
     </Form>
   );

--- a/extensions/media-converter/src/tools/convert-media.ts
+++ b/extensions/media-converter/src/tools/convert-media.ts
@@ -1,15 +1,20 @@
-import { convertMedia } from "../utils/converter";
+import { convertMedia, ConvertOptions } from "../utils/converter";
 import {
   type QualitySettings,
   type QualityLevel,
   type OutputImageExtension,
   type OutputAudioExtension,
   type OutputVideoExtension,
-  /* type AllOutputExtension, */
+  type AllOutputExtension,
   type ImageQuality,
   type AudioQuality,
   type VideoQuality,
+  type GifQuality,
+  type GifFps,
+  type GifWidth,
+  type TrimOptions,
   getMediaType,
+  getOutputCategory,
   DEFAULT_QUALITIES,
   // Advanced controls & helpers
   AUDIO_BITRATES,
@@ -24,6 +29,8 @@ import {
   buildVideoQuality,
 } from "../types/media";
 import { findFFmpegPath } from "../utils/ffmpeg";
+import { findPreset } from "../utils/presets";
+import { parseTimeString } from "../utils/time";
 import type { Tool } from "@raycast/api";
 import path from "path";
 import os from "os";
@@ -71,9 +78,28 @@ type Input = {
     | ".webp"
     | ".heic"
     | ".tiff"
-    | ".avif";
+    | ".avif"
+    // GIF (from video input)
+    | ".gif";
   // Simple mode quality (optional). If omitted, sensible defaults apply.
   quality?: QualityLevel;
+
+  // --- Optional cross-cutting controls ---
+  /** Absolute path to output folder. Must exist. */
+  outputDir?: string;
+  /** Remove EXIF/GPS/tags from output. */
+  stripMetadata?: boolean;
+  /** Trim start time, e.g. "0:10" or "10.5" (seconds). */
+  trimStart?: string;
+  /** Trim end time, e.g. "1:30" or "90" (seconds). */
+  trimEnd?: string;
+  /** Preset ID to apply. If set, overrides most other params. */
+  presetId?: string;
+
+  // --- Optional GIF controls (apply when outputFileType === ".gif") ---
+  gifFps?: "10" | "15" | "24" | "30";
+  gifWidth?: "original" | "480" | "720" | "1080";
+  gifLoop?: boolean;
 
   // --- Optional advanced image controls (apply when relevant) ---
   // Generic percentage for JPG/WEBP/HEIC/AVIF (0-100)
@@ -139,10 +165,46 @@ type Input = {
 };
 
 export default async function ConvertMedia(input: Input) {
+  const installed = await findFFmpegPath();
+  if (!installed) {
+    return {
+      type: "error",
+      message: "FFmpeg is not installed. Please install FFmpeg to use this tool.",
+    };
+  }
+
+  // If a preset is specified, apply its settings on top of `input` before any processing.
+  let effectiveInput: Input = input;
+  if (input.presetId) {
+    try {
+      const preset = await findPreset(input.presetId);
+      if (!preset) {
+        return { type: "error", message: `Preset not found: ${input.presetId}` };
+      }
+      effectiveInput = {
+        ...input,
+        outputFileType: preset.outputFormat as Input["outputFileType"],
+        outputDir: input.outputDir ?? preset.outputDir,
+        stripMetadata: input.stripMetadata ?? preset.stripMetadata,
+        trimStart: input.trimStart ?? preset.trim?.start,
+        trimEnd: input.trimEnd ?? preset.trim?.end,
+      };
+    } catch (error) {
+      return { type: "error", message: `Failed to load preset: ${String(error)}` };
+    }
+  }
+
   const {
     inputPath,
     outputFileType,
     quality,
+    outputDir,
+    stripMetadata,
+    trimStart,
+    trimEnd,
+    gifFps,
+    gifWidth,
+    gifLoop,
     // image
     imageQualityPercent,
     webpLossless,
@@ -163,14 +225,7 @@ export default async function ConvertMedia(input: Input) {
     videoPreset,
     proresVariant,
     vp9Quality,
-  } = input;
-  const installed = await findFFmpegPath();
-  if (!installed) {
-    return {
-      type: "error",
-      message: "FFmpeg is not installed. Please install FFmpeg to use this tool.",
-    };
-  }
+  } = effectiveInput;
 
   let fullPath: string;
   let mediaType: "image" | "audio" | "video" | null;
@@ -192,6 +247,65 @@ export default async function ConvertMedia(input: Input) {
       message: String(error),
     };
   }
+
+  // Validate optional output directory & load preset if given.
+  let resolvedOutputDir: string | undefined;
+  if (outputDir) {
+    resolvedOutputDir = path.resolve(path.normalize(outputDir.replace(/^~/, os.homedir())));
+    try {
+      const stat = fs.statSync(resolvedOutputDir);
+      if (!stat.isDirectory()) {
+        return { type: "error", message: `Output path is not a directory: ${resolvedOutputDir}` };
+      }
+    } catch {
+      return { type: "error", message: `Output directory does not exist: ${resolvedOutputDir}` };
+    }
+  }
+
+  // Validate trim values.
+  if (trimStart && parseTimeString(trimStart) === null) {
+    return { type: "error", message: `Invalid trimStart value: ${trimStart}` };
+  }
+  if (trimEnd && parseTimeString(trimEnd) === null) {
+    return { type: "error", message: `Invalid trimEnd value: ${trimEnd}` };
+  }
+  const trim: TrimOptions | undefined = trimStart || trimEnd ? { start: trimStart, end: trimEnd } : undefined;
+
+  // GIF output path: build GifQuality and bypass the normal quality builder.
+  if (getOutputCategory(outputFileType as AllOutputExtension) === "gif") {
+    if (mediaType !== "video") {
+      return {
+        type: "error",
+        message: `GIF output requires a video input. Got ${mediaType} file: ${fullPath}`,
+      };
+    }
+    const fpsChoice = (gifFps ?? "15") as GifFps;
+    const widthChoice = (gifWidth ?? "original") as GifWidth;
+    const loopChoice = typeof gifLoop === "boolean" ? gifLoop : true;
+    const gifQuality: GifQuality = {
+      ".gif": { fps: fpsChoice, width: widthChoice, loop: loopChoice },
+    };
+    try {
+      const outputPath = await convertMedia(fullPath, ".gif", gifQuality, {
+        outputDir: resolvedOutputDir,
+        stripMetadata,
+        trim,
+      });
+      return {
+        type: "success",
+        message: `✅ Converted video to GIF\n- Input: ${fullPath}\n- Output: ${outputPath}\n- Settings: ${fpsChoice}fps, width ${widthChoice}, loop=${loopChoice}`,
+      };
+    } catch (error) {
+      console.error(error);
+      return { type: "error", message: `❌ GIF conversion failed. Error: ${error}` };
+    }
+  }
+
+  const convertOpts: ConvertOptions = {
+    outputDir: resolvedOutputDir,
+    stripMetadata,
+    trim,
+  };
 
   try {
     let outputPath: string;
@@ -388,18 +502,21 @@ export default async function ConvertMedia(input: Input) {
         fullPath,
         outputFileType as OutputImageExtension,
         qualitySettings as ImageQuality,
+        convertOpts,
       );
     } else if (mediaType === "audio") {
       outputPath = await convertMedia(
         fullPath,
         outputFileType as OutputAudioExtension,
         qualitySettings as AudioQuality,
+        convertOpts,
       );
     } else if (mediaType === "video") {
       outputPath = await convertMedia(
         fullPath,
         outputFileType as OutputVideoExtension,
         qualitySettings as VideoQuality,
+        convertOpts,
       );
     } else {
       return {

--- a/extensions/media-converter/src/tools/convert-media.ts
+++ b/extensions/media-converter/src/tools/convert-media.ts
@@ -269,6 +269,14 @@ export default async function ConvertMedia(input: Input) {
   if (trimEnd && parseTimeString(trimEnd) === null) {
     return { type: "error", message: `Invalid trimEnd value: ${trimEnd}` };
   }
+  // Ensure end is after start when both provided (prevents FFmpeg producing empty output)
+  if (trimStart && trimEnd) {
+    const s = parseTimeString(trimStart);
+    const e = parseTimeString(trimEnd);
+    if (s !== null && e !== null && e <= s) {
+      return { type: "error", message: "End time must be after start time" };
+    }
+  }
   const trim: TrimOptions | undefined = trimStart || trimEnd ? { start: trimStart, end: trimEnd } : undefined;
 
   // GIF output path: build GifQuality and bypass the normal quality builder.

--- a/extensions/media-converter/src/tools/merge-media.ts
+++ b/extensions/media-converter/src/tools/merge-media.ts
@@ -1,0 +1,94 @@
+import type { Tool } from "@raycast/api";
+import path from "path";
+import os from "os";
+import fs from "fs";
+import { mergeMedia } from "../utils/merge";
+import { findFFmpegPath } from "../utils/ffmpeg";
+import { AllOutputExtension, getOutputCategory } from "../types/media";
+
+type Input = {
+  /**
+   * Absolute paths of the files to merge, separated by newlines ("\n"). Must contain at least 2 paths.
+   * Inputs are concatenated in the order provided.
+   */
+  inputPaths: string;
+  outputFileType: ".mp4" | ".avi" | ".mov" | ".mkv" | ".mpg" | ".webm" | ".mp3" | ".aac" | ".wav" | ".flac" | ".m4a";
+  /** Absolute path to output folder. Defaults to the folder of the first input. */
+  outputDir?: string;
+  /** Bare filename without extension. Defaults to "merged". */
+  outputFileName?: string;
+  /** Remove EXIF/GPS/tags from the merged output. */
+  stripMetadata?: boolean;
+  /** When true, always re-encode instead of trying fast stream-copy. */
+  forceReencode?: boolean;
+};
+
+function resolvePath(p: string): string {
+  return path.resolve(path.normalize(p.replace(/^~/, os.homedir())));
+}
+
+function parseInputPaths(raw: string): string[] {
+  return raw
+    .split(/\r?\n|\|{2,}/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+export default async function MergeMediaTool(input: Input) {
+  const ffmpeg = await findFFmpegPath();
+  if (!ffmpeg) {
+    return { type: "error", message: "FFmpeg is not installed or configured." };
+  }
+
+  const rawPaths = parseInputPaths(input.inputPaths ?? "");
+  if (rawPaths.length < 2) {
+    return { type: "error", message: "At least 2 input paths are required to merge. Separate paths with newlines." };
+  }
+
+  const absoluteInputs = rawPaths.map(resolvePath);
+  for (const p of absoluteInputs) {
+    if (!fs.existsSync(p)) {
+      return { type: "error", message: `File does not exist: ${p}` };
+    }
+  }
+
+  const outputCategory = getOutputCategory(input.outputFileType as AllOutputExtension);
+  if (outputCategory !== "video" && outputCategory !== "audio") {
+    return { type: "error", message: `Output format ${input.outputFileType} is not valid for merging.` };
+  }
+
+  try {
+    const result = await mergeMedia(absoluteInputs, input.outputFileType as AllOutputExtension, {
+      outputDir: input.outputDir ? resolvePath(input.outputDir) : undefined,
+      outputFileName: input.outputFileName,
+      stripMetadata: input.stripMetadata,
+      forceReencode: input.forceReencode,
+    });
+    return {
+      type: "success",
+      message: `Merged ${absoluteInputs.length} files into ${result.outputPath} (${result.strategy})`,
+    };
+  } catch (error) {
+    return { type: "error", message: `Merge failed: ${String(error)}` };
+  }
+}
+
+export const confirmation: Tool.Confirmation<Input> = async (params: Input) => {
+  const paths = parseInputPaths(params.inputPaths ?? "");
+  const info: { name: string; value: string }[] = [
+    { name: "Files", value: `${paths.length} inputs` },
+    { name: "Output Format", value: params.outputFileType },
+  ];
+  if (paths.length > 0) {
+    info.push({ name: "First file", value: paths[0] });
+    info.push({ name: "Last file", value: paths[paths.length - 1] });
+  }
+  if (params.outputFileName) info.push({ name: "Output Name", value: params.outputFileName });
+  if (params.outputDir) info.push({ name: "Output Folder", value: params.outputDir });
+  if (params.stripMetadata) info.push({ name: "Strip Metadata", value: "yes" });
+  if (params.forceReencode) info.push({ name: "Force Re-encode", value: "yes" });
+  return {
+    message: "This will create a new merged file from the inputs in the given order.",
+    info,
+  };
+};

--- a/extensions/media-converter/src/tools/merge-media.ts
+++ b/extensions/media-converter/src/tools/merge-media.ts
@@ -57,9 +57,23 @@ export default async function MergeMediaTool(input: Input) {
     return { type: "error", message: `Output format ${input.outputFileType} is not valid for merging.` };
   }
 
+  // Validate optional output directory to provide a clear error message early
+  let resolvedOutputDir: string | undefined;
+  if (input.outputDir) {
+    resolvedOutputDir = resolvePath(input.outputDir);
+    try {
+      const stat = fs.statSync(resolvedOutputDir);
+      if (!stat.isDirectory()) {
+        return { type: "error", message: `Output path is not a directory: ${resolvedOutputDir}` };
+      }
+    } catch {
+      return { type: "error", message: `Output directory does not exist: ${resolvedOutputDir}` };
+    }
+  }
+
   try {
     const result = await mergeMedia(absoluteInputs, input.outputFileType as AllOutputExtension, {
-      outputDir: input.outputDir ? resolvePath(input.outputDir) : undefined,
+      outputDir: resolvedOutputDir,
       outputFileName: input.outputFileName,
       stripMetadata: input.stripMetadata,
       forceReencode: input.forceReencode,

--- a/extensions/media-converter/src/types/media.ts
+++ b/extensions/media-converter/src/types/media.ts
@@ -110,6 +110,7 @@ export const INPUT_AUDIO_EXTENSIONS = [
 export const OUTPUT_VIDEO_EXTENSIONS = [".mp4", ".avi", ".mov", ".mkv", ".mpg", ".webm"] as const;
 export const OUTPUT_AUDIO_EXTENSIONS = [".mp3", ".aac", ".wav", ".flac", ".m4a"] as const;
 export const OUTPUT_IMAGE_EXTENSIONS = [".jpg", ".png", ".webp", ".heic", ".tiff", ".avif"] as const;
+export const OUTPUT_GIF_EXTENSIONS = [".gif"] as const;
 
 export const INPUT_ALL_EXTENSIONS = [
   ...INPUT_VIDEO_EXTENSIONS,
@@ -121,6 +122,7 @@ export const OUTPUT_ALL_EXTENSIONS = [
   ...OUTPUT_VIDEO_EXTENSIONS,
   ...OUTPUT_AUDIO_EXTENSIONS,
   ...OUTPUT_IMAGE_EXTENSIONS,
+  ...OUTPUT_GIF_EXTENSIONS,
 ] as const;
 
 // =============================================================================
@@ -136,8 +138,13 @@ export type InputAudioExtension = (typeof INPUT_AUDIO_EXTENSIONS)[number];
 export type OutputVideoExtension = (typeof OUTPUT_VIDEO_EXTENSIONS)[number];
 export type OutputImageExtension = (typeof OUTPUT_IMAGE_EXTENSIONS)[number];
 export type OutputAudioExtension = (typeof OUTPUT_AUDIO_EXTENSIONS)[number];
+export type OutputGifExtension = (typeof OUTPUT_GIF_EXTENSIONS)[number];
 
-export type AllOutputExtension = OutputVideoExtension | OutputAudioExtension | OutputImageExtension;
+export type AllOutputExtension =
+  | OutputVideoExtension
+  | OutputAudioExtension
+  | OutputImageExtension
+  | OutputGifExtension;
 // =============================================================================
 
 export type ImageQuality = {
@@ -279,11 +286,52 @@ export type VideoControlType =
   | "variant";
 
 // =============================================================================
+// GIF Quality Settings
+// =============================================================================
+
+export const GIF_FPS = ["10", "15", "24", "30"] as const;
+export type GifFps = (typeof GIF_FPS)[number];
+export const GIF_WIDTH = ["original", "480", "720", "1080"] as const;
+export type GifWidth = (typeof GIF_WIDTH)[number];
+
+export type GifQuality = {
+  ".gif": { fps: GifFps; width: GifWidth; loop: boolean };
+};
+
+// =============================================================================
 // Universal Quality Type
 // =============================================================================
 
-export type QualitySettings = ImageQuality | AudioQuality | VideoQuality;
+export type QualitySettings = ImageQuality | AudioQuality | VideoQuality | GifQuality;
 export type AllControlType = VideoControlType | AudioControlType | "qualityLevel";
+
+// =============================================================================
+// Trim Options
+// =============================================================================
+
+export type TrimOptions = {
+  /** Start time string in HH:MM:SS[.mmm] or bare seconds. Empty/undefined = no trim at start. */
+  start?: string;
+  /** End time string in HH:MM:SS[.mmm] or bare seconds. Empty/undefined = no trim at end. */
+  end?: string;
+};
+
+// =============================================================================
+// Preset Type (built-in + user-defined)
+// =============================================================================
+
+export type Preset = {
+  id: string;
+  name: string;
+  builtIn?: boolean;
+  mediaType: MediaType | "gif";
+  outputFormat: AllOutputExtension;
+  quality: QualitySettings;
+  trim?: TrimOptions;
+  stripMetadata?: boolean;
+  outputDir?: string;
+  description?: string;
+};
 
 // ---------------- Video builder factory ----------------
 
@@ -497,6 +545,9 @@ export const DEFAULT_QUALITIES = {
   ".mkv": { encodingMode: "crf", crf: 75, preset: "medium" },
   ".mpg": { encodingMode: "crf", crf: 75 },
   ".webm": { encodingMode: "crf", crf: 60, quality: "good" },
+
+  // GIF default
+  ".gif": { fps: "15", width: "original", loop: true },
 } as const;
 
 // Video VBR defaults (for when switching to VBR modes)
@@ -584,6 +635,19 @@ export function getMediaType(extension: string): MediaType | null {
   return null;
 }
 
+/**
+ * Return the "category" of an output extension, including GIF as its own bucket.
+ * Used by the converter form to choose the right UI controls.
+ */
+export type OutputCategory = "image" | "audio" | "video" | "gif";
+
+export function getOutputCategory(extension: AllOutputExtension): OutputCategory {
+  if (OUTPUT_GIF_EXTENSIONS.includes(extension as OutputGifExtension)) return "gif";
+  if (OUTPUT_IMAGE_EXTENSIONS.includes(extension as OutputImageExtension)) return "image";
+  if (OUTPUT_AUDIO_EXTENSIONS.includes(extension as OutputAudioExtension)) return "audio";
+  return "video";
+}
+
 type SimpleQualityMappingExtension = keyof typeof SIMPLE_QUALITY_MAPPINGS;
 
 function isOutputImageExtension(format: AllOutputExtension): format is OutputImageExtension {
@@ -604,9 +668,19 @@ export function getDefaultQuality(
     return getDefaultImageQuality(format, preferences);
   }
 
+  if (format === ".gif") {
+    const fpsPref = typeof preferences.defaultGifFps === "string" ? preferences.defaultGifFps : "";
+    const widthPref = typeof preferences.defaultGifWidth === "string" ? preferences.defaultGifWidth : "";
+    const fps = (GIF_FPS as readonly string[]).includes(fpsPref) ? (fpsPref as GifFps) : DEFAULT_QUALITIES[".gif"].fps;
+    const width = (GIF_WIDTH as readonly string[]).includes(widthPref)
+      ? (widthPref as GifWidth)
+      : DEFAULT_QUALITIES[".gif"].width;
+    return { ".gif": { fps, width, loop: true } } as QualitySettings;
+  }
+
   if (preferences.moreConversionSettings) {
     return {
-      [format]: DEFAULT_QUALITIES[format],
+      [format]: DEFAULT_QUALITIES[format as Exclude<AllOutputExtension, ".gif">],
     } as QualitySettings;
   }
 

--- a/extensions/media-converter/src/utils/convertBatch.ts
+++ b/extensions/media-converter/src/utils/convertBatch.ts
@@ -1,0 +1,163 @@
+import fs from "fs";
+import path from "path";
+import { showToast, Toast, showInFinder, openCommandPreferences } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { convertMedia, ConvertOptions } from "./converter";
+import { appendHistory } from "./history";
+import { formatBytes, formatSavings } from "./format";
+import { formatTimeString } from "./time";
+import { AllOutputExtension, QualitySettings, TrimOptions, getMediaType, getOutputCategory } from "../types/media";
+
+export type BatchOptions = {
+  outputFormat: AllOutputExtension;
+  quality: QualitySettings;
+  outputDir?: string;
+  stripMetadata?: boolean;
+  trim?: TrimOptions;
+  /** When true, individual video conversions show live progress in the toast. */
+  showProgress?: boolean;
+};
+
+export type BatchResult = {
+  successes: { input: string; output: string; inputBytes: number; outputBytes: number }[];
+  failures: { input: string; error: string }[];
+};
+
+function safeStatSize(p: string): number {
+  try {
+    return fs.statSync(p).size;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Orchestrates converting an array of files with shared settings. Handles:
+ *  - Animated progress toast (with ETA/percent for videos & gifs)
+ *  - Size tracking and savings message
+ *  - History logging
+ *  - Success/failure summary toast
+ */
+export async function runConversionBatch(files: string[], opts: BatchOptions): Promise<BatchResult> {
+  const result: BatchResult = { successes: [], failures: [] };
+  if (files.length === 0) return result;
+
+  const outputCategory = getOutputCategory(opts.outputFormat);
+  const canShowProgress = opts.showProgress !== false && (outputCategory === "video" || outputCategory === "gif");
+
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: buildInitialTitle(files.length, outputCategory),
+  });
+
+  for (let i = 0; i < files.length; i++) {
+    const input = files[i];
+    const position = `${i + 1}/${files.length}`;
+    toast.title = `Converting ${position}…`;
+    toast.message = path.basename(input);
+
+    const started = Date.now();
+    const inputBytes = safeStatSize(input);
+
+    try {
+      const convertOpts: ConvertOptions = {
+        outputDir: opts.outputDir,
+        stripMetadata: opts.stripMetadata,
+        trim: opts.trim,
+      };
+
+      if (canShowProgress) {
+        convertOpts.onProgress = (p) => {
+          const pct = Math.floor(p.percent);
+          const eta = p.etaSec !== undefined ? ` · ETA ${formatTimeString(p.etaSec)}` : "";
+          toast.title = `Converting ${position} · ${pct}%${eta}`;
+        };
+      }
+
+      const output = await convertMedia(input, opts.outputFormat, opts.quality, convertOpts);
+      const outputBytes = safeStatSize(output);
+      result.successes.push({ input, output, inputBytes, outputBytes });
+
+      // Log to history (non-blocking failures here shouldn't break the batch)
+      try {
+        const mediaType = outputCategory === "gif" ? "gif" : (getMediaType(path.extname(input)) ?? "video");
+        await appendHistory({
+          inputs: [input],
+          outputs: [output],
+          outputFormat: opts.outputFormat,
+          quality: opts.quality,
+          mediaType,
+          trim: opts.trim,
+          stripMetadata: opts.stripMetadata,
+          outputDir: opts.outputDir,
+          durationMs: Date.now() - started,
+          inputBytes,
+          outputBytes,
+        });
+      } catch (historyErr) {
+        console.warn("Failed to write history entry:", historyErr);
+      }
+    } catch (error) {
+      const errorMessage = String(error);
+      result.failures.push({ input, error: errorMessage });
+      console.error(`Conversion failed for ${input}:`, errorMessage);
+
+      if (errorMessage.includes("FFmpeg is not installed or configured")) {
+        await toast.hide();
+        showFailureToast(new Error("FFmpeg needs to be configured to convert files"), {
+          title: "FFmpeg not found",
+          primaryAction: {
+            title: "Configure FFmpeg",
+            onAction: () => openCommandPreferences(),
+          },
+        });
+        return result;
+      }
+    }
+  }
+
+  await toast.hide();
+  await presentSummary(result);
+  return result;
+}
+
+function buildInitialTitle(count: number, category: "video" | "audio" | "image" | "gif"): string {
+  const suffix = count > 1 ? "s" : "";
+  const noun = category === "gif" ? "GIF" : category;
+  return `Converting ${count} ${noun}${suffix}…`;
+}
+
+async function presentSummary(result: BatchResult): Promise<void> {
+  const okCount = result.successes.length;
+  const failCount = result.failures.length;
+  const totalIn = result.successes.reduce((sum, s) => sum + s.inputBytes, 0);
+  const totalOut = result.successes.reduce((sum, s) => sum + s.outputBytes, 0);
+
+  if (okCount === 0 && failCount > 0) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Conversion failed",
+      message: result.failures[0]?.error ?? "Unknown error",
+    });
+    return;
+  }
+
+  const savingsLabel = totalIn > 0 ? formatSavings(totalIn, totalOut) : formatBytes(totalOut);
+  const titleBase = okCount === 1 ? "File converted successfully!" : `${okCount} files converted`;
+  const title = failCount > 0 ? `${titleBase} (${failCount} failed)` : titleBase;
+  const singleOutput = okCount === 1 ? result.successes[0].output : null;
+  const message = singleOutput ? `${path.basename(singleOutput)} · ${savingsLabel}` : savingsLabel;
+
+  await showToast({
+    style: Toast.Style.Success,
+    title,
+    message,
+    primaryAction: singleOutput
+      ? {
+          title: "Open File",
+          shortcut: { modifiers: ["cmd"], key: "o" },
+          onAction: () => showInFinder(singleOutput),
+        }
+      : undefined,
+  });
+}

--- a/extensions/media-converter/src/utils/converter.ts
+++ b/extensions/media-converter/src/utils/converter.ts
@@ -3,6 +3,8 @@ import fs from "fs";
 import os from "os";
 import { findFFmpegPath } from "./ffmpeg";
 import { execPromise } from "./exec";
+import { runFFmpegWithProgress, probeDurationSec, type ProgressInfo } from "./ffmpegRun";
+import { parseTimeString, toFfmpegTime } from "./time";
 import {
   AllOutputExtension,
   OutputImageExtension,
@@ -12,8 +14,11 @@ import {
   ImageQuality,
   AudioQuality,
   VideoQuality,
+  GifQuality,
   getMediaType,
+  getOutputCategory,
   Percentage,
+  TrimOptions,
 } from "../types/media";
 
 function convertQualityToCrf(qualityPercentage: Percentage): number {
@@ -22,26 +27,50 @@ function convertQualityToCrf(qualityPercentage: Percentage): number {
   return Math.round(51 - (qualityPercentage / 100) * 51);
 }
 
-function getUniqueOutputPath(filePath: string, extension: string): string {
-  const outputFilePath = filePath.replace(path.extname(filePath), extension);
+function getUniqueOutputPath(filePath: string, extension: string, outputDir?: string): string {
+  const baseName = path.basename(filePath, path.extname(filePath));
+  const dir = outputDir && outputDir.length > 0 ? outputDir : path.dirname(filePath);
+  const outputFilePath = path.join(dir, `${baseName}${extension}`);
   let finalOutputPath = outputFilePath;
   let counter = 1;
 
   while (fs.existsSync(finalOutputPath)) {
-    const fileName = path.basename(outputFilePath, extension);
-    const dirName = path.dirname(outputFilePath);
-    finalOutputPath = path.join(dirName, `${fileName}(${counter})${extension}`);
+    finalOutputPath = path.join(dir, `${baseName}(${counter})${extension}`);
     counter++;
   }
 
   return finalOutputPath;
 }
 
+export type ConvertOptions = {
+  returnCommandString?: boolean;
+  outputDir?: string;
+  stripMetadata?: boolean;
+  trim?: TrimOptions;
+  onProgress?: (p: ProgressInfo) => void;
+};
+
+/**
+ * Build the `-ss <start>` / `-to <end>` flags string for FFmpeg.
+ * Both flags are input-side (placed before `-i`) for speed; FFmpeg seeks to
+ * the nearest keyframe which is accurate enough for most use cases.
+ * Returns an empty string if no valid trim is requested.
+ */
+function buildTrimFlags(trim: TrimOptions | undefined): string {
+  if (!trim) return "";
+  const parts: string[] = [];
+  const start = parseTimeString(trim.start ?? "");
+  const end = parseTimeString(trim.end ?? "");
+  if (start !== null && start > 0) parts.push(`-ss ${toFfmpegTime(start)}`);
+  if (end !== null && end > 0) parts.push(`-to ${toFfmpegTime(end)}`);
+  return parts.length > 0 ? ` ${parts.join(" ")}` : "";
+}
+
 export async function convertMedia<T extends AllOutputExtension>(
   filePath: string,
   outputFormat: T,
   quality: QualitySettings,
-  returnCommandString = false,
+  opts: ConvertOptions = {},
 ): Promise<string> {
   const ffmpegPath = await findFFmpegPath();
 
@@ -50,13 +79,65 @@ export async function convertMedia<T extends AllOutputExtension>(
     throw new Error("FFmpeg is not installed or configured. Please install FFmpeg to use this converter.");
   }
 
-  let ffmpegCmd = `"${ffmpegPath.path}" -i`;
+  const { returnCommandString = false, outputDir, stripMetadata, trim, onProgress } = opts;
+  const trimFlags = buildTrimFlags(trim);
+  const metadataFlag = stripMetadata ? " -map_metadata -1" : "";
+
+  let ffmpegCmd = `"${ffmpegPath.path}"${trimFlags} -i`;
+  const outputCategory = getOutputCategory(outputFormat);
   const currentMediaType = getMediaType(path.extname(filePath))!;
+
+  // Helper to execute the final single-shot command, optionally with progress.
+  const execWithOptionalProgress = async (cmd: string): Promise<void> => {
+    if (onProgress && (currentMediaType === "video" || outputCategory === "gif")) {
+      const total = (await probeDurationSec(ffmpegPath.path, filePath)) ?? undefined;
+      await runFFmpegWithProgress(cmd, { totalDurationSec: total, onProgress });
+    } else {
+      await execPromise(cmd);
+    }
+  };
+
+  // Special handling: GIF output from a video input.
+  if (outputCategory === "gif") {
+    const gifQuality = quality as GifQuality;
+    const gifSettings = gifQuality[".gif"];
+    const finalOutputPath = getUniqueOutputPath(filePath, ".gif", outputDir);
+
+    const fps = gifSettings.fps;
+    const scale = gifSettings.width === "original" ? "iw" : gifSettings.width;
+    const filterBase = `fps=${fps},scale=${scale}:-1:flags=lanczos`;
+    const loopArg = gifSettings.loop ? "0" : "-1"; // 0 = infinite loop, -1 = no loop
+
+    const tempPaletteFile = path.join(os.tmpdir(), `gif_palette_${Date.now()}.png`);
+    const paletteCmd = `"${ffmpegPath.path}"${trimFlags} -i "${filePath}" -vf "${filterBase},palettegen=stats_mode=diff" -y "${tempPaletteFile}"`;
+    const finalCmd = `"${ffmpegPath.path}"${trimFlags} -i "${filePath}" -i "${tempPaletteFile}" -lavfi "${filterBase} [x]; [x][1:v] paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle" -loop ${loopArg}${metadataFlag} -y "${finalOutputPath}"`;
+
+    if (returnCommandString) {
+      return `${paletteCmd}\n${finalCmd}`;
+    }
+
+    try {
+      console.log(`Executing FFmpeg palette command: ${paletteCmd}`);
+      await execPromise(paletteCmd);
+      console.log(`Executing FFmpeg GIF command: ${finalCmd}`);
+      await execWithOptionalProgress(finalCmd);
+      return finalOutputPath;
+    } finally {
+      if (fs.existsSync(tempPaletteFile)) {
+        try {
+          fs.unlinkSync(tempPaletteFile);
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  }
+
   switch (currentMediaType) {
     case "image": {
       const currentOutputFormat = outputFormat as OutputImageExtension;
       const imageQuality = quality as ImageQuality;
-      const finalOutputPath = getUniqueOutputPath(filePath, currentOutputFormat);
+      const finalOutputPath = getUniqueOutputPath(filePath, currentOutputFormat, outputDir);
 
       let tempHeicFile: string | null = null;
       let tempPaletteFile: string | null = null;
@@ -73,6 +154,14 @@ export async function convertMedia<T extends AllOutputExtension>(
           try {
             // Attempt HEIC conversion using SIPS directly
             await execPromise(sipsCmd);
+            if (stripMetadata) {
+              // Best-effort metadata strip on macOS
+              try {
+                await execPromise(`sips -d all "${finalOutputPath}"`);
+              } catch (stripErr) {
+                console.warn("SIPS metadata strip failed:", stripErr);
+              }
+            }
           } catch (error) {
             // Parse error to provide more specific feedback
             const errorMessage = String(error);
@@ -132,7 +221,7 @@ export async function convertMedia<T extends AllOutputExtension>(
                   const tempPaletteFileName = `${path.basename(filePath, path.extname(filePath))}_palette.png`;
                   tempPaletteFile = path.join(os.tmpdir(), tempPaletteFileName);
                   const paletteCmd = `"${ffmpegPath.path}" -i "${processedInputPath}" -vf "palettegen=max_colors=256" -y "${tempPaletteFile}"`;
-                  ffmpegCmd = `"${ffmpegPath.path}" -i "${processedInputPath}" -i "${tempPaletteFile}" -lavfi "paletteuse=dither=bayer:bayer_scale=5" -compression_level 100 -y "${finalOutputPath}"`;
+                  ffmpegCmd = `"${ffmpegPath.path}" -i "${processedInputPath}" -i "${tempPaletteFile}" -lavfi "paletteuse=dither=bayer:bayer_scale=5" -compression_level 100${metadataFlag} -y "${finalOutputPath}"`;
                   return `${paletteCmd}\n${ffmpegCmd}`;
                 } else {
                   const tempPaletteFileName = `${path.basename(filePath, path.extname(filePath))}_palette_${Date.now()}.png`;
@@ -166,6 +255,7 @@ export async function convertMedia<T extends AllOutputExtension>(
               ffmpegCmd += ` -c:v libaom-av1 -crf ${Math.round(63 - (Number(imageQuality[".avif"]) / 100) * 63)} -still-picture 1`;
               break;
           }
+          ffmpegCmd += metadataFlag;
           if (currentOutputFormat !== ".png" || imageQuality[".png"] !== "png-8") {
             ffmpegCmd += ` -y "${finalOutputPath}"`;
           } else {
@@ -195,7 +285,7 @@ export async function convertMedia<T extends AllOutputExtension>(
     case "audio": {
       const currentOutputFormat = outputFormat as OutputAudioExtension;
       const audioQuality = quality as AudioQuality;
-      const finalOutputPath = getUniqueOutputPath(filePath, currentOutputFormat);
+      const finalOutputPath = getUniqueOutputPath(filePath, currentOutputFormat, outputDir);
 
       ffmpegCmd += ` "${filePath}"`;
 
@@ -243,12 +333,13 @@ export async function convertMedia<T extends AllOutputExtension>(
           throw new Error(`Unknown audio output format: ${currentOutputFormat}`);
       }
 
+      ffmpegCmd += metadataFlag;
       ffmpegCmd += ` -y "${finalOutputPath}"`;
       if (returnCommandString) {
         return ffmpegCmd;
       }
       console.log(`Executing FFmpeg audio command: ${ffmpegCmd}`);
-      await execPromise(ffmpegCmd);
+      await execWithOptionalProgress(ffmpegCmd);
       return finalOutputPath;
     }
 
@@ -306,7 +397,7 @@ export async function convertMedia<T extends AllOutputExtension>(
       }
 
       // Handle encoding mode (unified for all formats except .mov)
-      const finalOutputPath = getUniqueOutputPath(filePath, currentOutputFormat);
+      const finalOutputPath = getUniqueOutputPath(filePath, currentOutputFormat, outputDir);
       let logFilePrefix: string | null = null;
 
       if (currentOutputFormat !== ".mov") {
@@ -329,7 +420,8 @@ export async function convertMedia<T extends AllOutputExtension>(
                 logFilePrefix = path.join(os.tmpdir(), `ffmpeg2pass_${Date.now()}`);
                 const nullDevice = process.platform === "win32" ? "NUL" : "/dev/null";
                 const firstPassCmd = ffmpegCmd + ` -pass 1 -passlogfile "${logFilePrefix}" -f null ${nullDevice}`;
-                const secondPassCmd = ffmpegCmd + ` -pass 2 -passlogfile "${logFilePrefix}" -y "${finalOutputPath}"`;
+                const secondPassCmd =
+                  ffmpegCmd + `${metadataFlag} -pass 2 -passlogfile "${logFilePrefix}" -y "${finalOutputPath}"`;
                 return `${firstPassCmd}\n${secondPassCmd}`;
               } else {
                 // First pass - need to specify log file prefix for 2-pass encoding
@@ -350,12 +442,13 @@ export async function convertMedia<T extends AllOutputExtension>(
       }
 
       try {
+        ffmpegCmd += metadataFlag;
         ffmpegCmd += ` -y "${finalOutputPath}"`;
         if (returnCommandString) {
           return ffmpegCmd;
         }
         console.log(`Executing FFmpeg video command: ${ffmpegCmd}`);
-        await execPromise(ffmpegCmd);
+        await execWithOptionalProgress(ffmpegCmd);
         return finalOutputPath;
       } finally {
         // Clean up 2-pass log files if they exist

--- a/extensions/media-converter/src/utils/converter.ts
+++ b/extensions/media-converter/src/utils/converter.ts
@@ -51,10 +51,9 @@ export type ConvertOptions = {
 };
 
 /**
- * Build the `-ss <start>` / `-to <end>` flags string for FFmpeg.
- * Both flags are input-side (placed before `-i`) for speed; FFmpeg seeks to
- * the nearest keyframe which is accurate enough for most use cases.
- * Returns an empty string if no valid trim is requested.
+ * Build input-side trim flags for FFmpeg.
+ * When both start and end are present, use `-ss <start> -t <duration>` to avoid
+ * ambiguity from input-side `-to` (which is absolute in the source timeline).
  */
 function buildTrimFlags(trim: TrimOptions | undefined): string {
   if (!trim) return "";
@@ -62,8 +61,25 @@ function buildTrimFlags(trim: TrimOptions | undefined): string {
   const start = parseTimeString(trim.start ?? "");
   const end = parseTimeString(trim.end ?? "");
   if (start !== null && start > 0) parts.push(`-ss ${toFfmpegTime(start)}`);
-  if (end !== null && end > 0) parts.push(`-to ${toFfmpegTime(end)}`);
+  if (start !== null && start > 0 && end !== null && end > start) {
+    parts.push(`-t ${toFfmpegTime(end - start)}`);
+  } else if (end !== null && end > 0) {
+    parts.push(`-to ${toFfmpegTime(end)}`);
+  }
   return parts.length > 0 ? ` ${parts.join(" ")}` : "";
+}
+
+function appendMetadataBeforeOutput(cmd: string, metadataFlag: string, outputPath: string): string {
+  if (!metadataFlag || cmd.includes(metadataFlag)) return cmd;
+  const quotedOutput = `"${outputPath}"`;
+  const yOutput = `-y ${quotedOutput}`;
+  if (cmd.includes(yOutput)) {
+    return cmd.replace(yOutput, `${metadataFlag} ${yOutput}`);
+  }
+  if (cmd.includes(quotedOutput)) {
+    return cmd.replace(quotedOutput, `${metadataFlag} ${quotedOutput}`);
+  }
+  return cmd + metadataFlag;
 }
 
 export async function convertMedia<T extends AllOutputExtension>(
@@ -255,7 +271,7 @@ export async function convertMedia<T extends AllOutputExtension>(
               ffmpegCmd += ` -c:v libaom-av1 -crf ${Math.round(63 - (Number(imageQuality[".avif"]) / 100) * 63)} -still-picture 1`;
               break;
           }
-          ffmpegCmd += metadataFlag;
+          ffmpegCmd = appendMetadataBeforeOutput(ffmpegCmd, metadataFlag, finalOutputPath);
           if (currentOutputFormat !== ".png" || imageQuality[".png"] !== "png-8") {
             ffmpegCmd += ` -y "${finalOutputPath}"`;
           } else {

--- a/extensions/media-converter/src/utils/ffmpegRun.ts
+++ b/extensions/media-converter/src/utils/ffmpegRun.ts
@@ -1,0 +1,210 @@
+import { spawn } from "child_process";
+import { execPromise } from "./exec";
+
+export type ProgressInfo = {
+  percent: number; // 0-100
+  processedSec: number;
+  totalSec: number;
+  etaSec?: number;
+  fps?: number;
+  speed?: number; // e.g. 1.2 means 1.2x realtime
+};
+
+/**
+ * Spawn an FFmpeg process with `-progress pipe:1 -nostats` and stream progress
+ * updates back to the caller. `cmd` must be a full command string that begins
+ * with the quoted ffmpeg path and ends with the output target. We append the
+ * progress flags just before the final output argument by prepending them to
+ * the already-built command (FFmpeg is tolerant of global options anywhere
+ * before the next `-i`, but for robustness we wrap the command via `sh -c`).
+ *
+ * This is intentionally simple: we rely on the shell to parse the command
+ * (matching how `execPromise(cmd)` works today), and we just inject the
+ * progress flags at the very end, which FFmpeg accepts as per-output options
+ * but also honors at the global level.
+ */
+export async function runFFmpegWithProgress(
+  cmd: string,
+  opts: {
+    totalDurationSec?: number;
+    onProgress?: (p: ProgressInfo) => void;
+    signal?: AbortSignal;
+  } = {},
+): Promise<{ stdout: string; stderr: string }> {
+  const { totalDurationSec, onProgress, signal } = opts;
+  // Insert `-progress pipe:1 -nostats` immediately after the ffmpeg binary path
+  // so they're global options. The command starts with `"<path>" -i ...`.
+  // Find the first space after the (possibly quoted) binary.
+  const injected = injectGlobalFlags(cmd, "-progress pipe:1 -nostats");
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(injected, {
+      shell: true,
+      windowsHide: true,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let buffer = "";
+    const started = Date.now();
+
+    const abortHandler = () => {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* ignore */
+      }
+    };
+    if (signal) {
+      if (signal.aborted) {
+        abortHandler();
+      } else {
+        signal.addEventListener("abort", abortHandler, { once: true });
+      }
+    }
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      stdout += text;
+      buffer += text;
+
+      // FFmpeg emits progress as key=value lines terminated by `progress=continue|end`.
+      let idx: number;
+      while ((idx = buffer.indexOf("progress=")) !== -1) {
+        const nl = buffer.indexOf("\n", idx);
+        if (nl === -1) break;
+        const block = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        if (onProgress) {
+          const info = parseProgressBlock(block, totalDurationSec, started);
+          if (info) onProgress(info);
+        }
+      }
+    });
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    child.on("error", (err) => {
+      if (signal) signal.removeEventListener("abort", abortHandler);
+      reject(err);
+    });
+
+    child.on("close", (code) => {
+      if (signal) signal.removeEventListener("abort", abortHandler);
+      if (code === 0) {
+        if (onProgress && totalDurationSec && totalDurationSec > 0) {
+          onProgress({ percent: 100, processedSec: totalDurationSec, totalSec: totalDurationSec });
+        }
+        resolve({ stdout, stderr });
+      } else {
+        reject(new Error(`FFmpeg exited with code ${code}: ${stderr.trim() || stdout.trim()}`));
+      }
+    });
+  });
+}
+
+export function injectGlobalFlags(cmd: string, flags: string): string {
+  // Binary path may be quoted with spaces (e.g. `"/path/to/ffmpeg" -i ...`).
+  if (cmd.startsWith('"')) {
+    const closingQuote = cmd.indexOf('"', 1);
+    if (closingQuote !== -1) {
+      return cmd.slice(0, closingQuote + 1) + " " + flags + cmd.slice(closingQuote + 1);
+    }
+  }
+  const firstSpace = cmd.indexOf(" ");
+  if (firstSpace === -1) return cmd + " " + flags;
+  return cmd.slice(0, firstSpace) + " " + flags + cmd.slice(firstSpace);
+}
+
+export function parseProgressBlock(
+  block: string,
+  totalDurationSec: number | undefined,
+  startedAt: number,
+): ProgressInfo | null {
+  const lines = block.split("\n");
+  const kv = new Map<string, string>();
+  for (const line of lines) {
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    kv.set(line.slice(0, eq).trim(), line.slice(eq + 1).trim());
+  }
+  const outTimeMs = kv.get("out_time_ms");
+  const outTimeUs = kv.get("out_time_us");
+  const outTime = kv.get("out_time");
+  let processedSec = NaN;
+  if (outTimeMs && !Number.isNaN(Number(outTimeMs))) {
+    processedSec = Number(outTimeMs) / 1_000_000; // FFmpeg reports microseconds as out_time_ms (historical bug/quirk)
+  } else if (outTimeUs && !Number.isNaN(Number(outTimeUs))) {
+    processedSec = Number(outTimeUs) / 1_000_000;
+  } else if (outTime) {
+    processedSec = parseFfmpegTimestamp(outTime);
+  }
+  if (!Number.isFinite(processedSec) || processedSec < 0) return null;
+
+  const total = totalDurationSec && totalDurationSec > 0 ? totalDurationSec : undefined;
+  const percent = total ? Math.max(0, Math.min(100, (processedSec / total) * 100)) : 0;
+
+  const fps = Number(kv.get("fps"));
+  const speedStr = kv.get("speed"); // e.g. "1.23x"
+  const speed = speedStr ? Number(speedStr.replace("x", "")) : undefined;
+
+  let etaSec: number | undefined;
+  if (total && processedSec > 0.1) {
+    const remaining = total - processedSec;
+    const elapsed = (Date.now() - startedAt) / 1000;
+    const effectiveSpeed =
+      speed && Number.isFinite(speed) && speed > 0 ? speed : processedSec / Math.max(elapsed, 0.001);
+    if (effectiveSpeed > 0) etaSec = remaining / effectiveSpeed;
+  }
+
+  return {
+    percent,
+    processedSec,
+    totalSec: total ?? 0,
+    etaSec,
+    fps: Number.isFinite(fps) ? fps : undefined,
+    speed: Number.isFinite(speed as number) ? speed : undefined,
+  };
+}
+
+function parseFfmpegTimestamp(ts: string): number {
+  // "HH:MM:SS.mmm"
+  const parts = ts.split(":");
+  if (parts.length !== 3) return NaN;
+  const [h, m, s] = parts.map(Number);
+  if ([h, m, s].some((n) => Number.isNaN(n))) return NaN;
+  return h * 3600 + m * 60 + s;
+}
+
+/**
+ * Probe the duration of a media file in seconds by parsing `ffmpeg -i` stderr.
+ * Returns null if the duration line is missing or unparseable (e.g. image inputs).
+ * We intentionally don't rely on `ffprobe` since the bundled static binary
+ * may ship without it.
+ */
+export async function probeDurationSec(ffmpegPath: string, filePath: string): Promise<number | null> {
+  try {
+    await execPromise(`"${ffmpegPath}" -hide_banner -i "${filePath}" -f null -`);
+  } catch (err: unknown) {
+    // `ffmpeg -f null -` will exit non-zero when used this way on some platforms;
+    // the stderr still contains the metadata we need.
+    const stderr =
+      typeof err === "object" && err !== null && "stderr" in err ? String((err as { stderr: unknown }).stderr) : "";
+    const msg =
+      typeof err === "object" && err !== null && "message" in err ? String((err as { message: unknown }).message) : "";
+    return parseDurationFromStderr(stderr || msg);
+  }
+  return null;
+}
+
+export function parseDurationFromStderr(stderr: string): number | null {
+  const match = stderr.match(/Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)/);
+  if (!match) return null;
+  const h = Number(match[1]);
+  const m = Number(match[2]);
+  const s = Number(match[3]);
+  if ([h, m, s].some((n) => Number.isNaN(n))) return null;
+  return h * 3600 + m * 60 + s;
+}

--- a/extensions/media-converter/src/utils/ffmpegRun.ts
+++ b/extensions/media-converter/src/utils/ffmpegRun.ts
@@ -186,10 +186,9 @@ function parseFfmpegTimestamp(ts: string): number {
  */
 export async function probeDurationSec(ffmpegPath: string, filePath: string): Promise<number | null> {
   try {
-    await execPromise(`"${ffmpegPath}" -hide_banner -i "${filePath}" -f null -`);
+    await execPromise(`"${ffmpegPath}" -hide_banner -i "${filePath}"`);
   } catch (err: unknown) {
-    // `ffmpeg -f null -` will exit non-zero when used this way on some platforms;
-    // the stderr still contains the metadata we need.
+    // `ffmpeg -i` with no output exits non-zero after printing metadata.
     const stderr =
       typeof err === "object" && err !== null && "stderr" in err ? String((err as { stderr: unknown }).stderr) : "";
     const msg =

--- a/extensions/media-converter/src/utils/format.ts
+++ b/extensions/media-converter/src/utils/format.ts
@@ -1,0 +1,30 @@
+/**
+ * Human-friendly byte formatter: 1536 -> "1.5 KB".
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes)) return "0 B";
+  const abs = Math.abs(bytes);
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let i = 0;
+  let value = abs;
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024;
+    i++;
+  }
+  const rounded = value >= 100 || i === 0 ? Math.round(value).toString() : value.toFixed(1);
+  const sign = bytes < 0 ? "-" : "";
+  return `${sign}${rounded} ${units[i]}`;
+}
+
+/**
+ * Format a delta like "-42.3 MB (58%)" or "+3.2 MB (larger)" for size comparisons.
+ */
+export function formatSavings(inputBytes: number, outputBytes: number): string {
+  const delta = outputBytes - inputBytes;
+  if (inputBytes <= 0) return formatBytes(outputBytes);
+  const pct = Math.round((Math.abs(delta) / inputBytes) * 100);
+  if (delta <= 0) {
+    return `saved ${formatBytes(-delta)} (${pct}%)`;
+  }
+  return `+${formatBytes(delta)} larger (${pct}%)`;
+}

--- a/extensions/media-converter/src/utils/history.ts
+++ b/extensions/media-converter/src/utils/history.ts
@@ -1,0 +1,78 @@
+import { LocalStorage } from "@raycast/api";
+import { AllOutputExtension, QualitySettings, TrimOptions, MediaType } from "../types/media";
+
+const STORAGE_KEY = "conversion-history";
+const MAX_ENTRIES = 200;
+const SCHEMA_VERSION = 1;
+
+export type HistoryEntry = {
+  id: string;
+  timestampMs: number;
+  inputs: string[];
+  outputs: string[];
+  outputFormat: AllOutputExtension;
+  quality: QualitySettings;
+  mediaType: MediaType | "gif";
+  trim?: TrimOptions;
+  stripMetadata?: boolean;
+  outputDir?: string;
+  durationMs: number;
+  inputBytes: number;
+  outputBytes: number;
+};
+
+type StoredShape = {
+  v: number;
+  entries: HistoryEntry[];
+};
+
+function newId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function readAll(): Promise<StoredShape> {
+  const raw = (await LocalStorage.getItem<string>(STORAGE_KEY)) ?? "";
+  if (!raw) return { v: SCHEMA_VERSION, entries: [] };
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && Array.isArray(parsed.entries)) {
+      return { v: parsed.v ?? SCHEMA_VERSION, entries: parsed.entries };
+    }
+  } catch (err) {
+    console.warn("Failed to parse conversion history, resetting:", err);
+  }
+  return { v: SCHEMA_VERSION, entries: [] };
+}
+
+async function writeAll(data: StoredShape): Promise<void> {
+  await LocalStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+export async function appendHistory(entry: Omit<HistoryEntry, "id" | "timestampMs">): Promise<HistoryEntry> {
+  const full: HistoryEntry = { id: newId(), timestampMs: Date.now(), ...entry };
+  const data = await readAll();
+  data.entries.unshift(full);
+  if (data.entries.length > MAX_ENTRIES) data.entries.length = MAX_ENTRIES;
+  await writeAll(data);
+  return full;
+}
+
+export async function listHistory(): Promise<HistoryEntry[]> {
+  const data = await readAll();
+  return data.entries;
+}
+
+export async function removeHistory(id: string): Promise<void> {
+  const data = await readAll();
+  data.entries = data.entries.filter((e) => e.id !== id);
+  await writeAll(data);
+}
+
+export async function clearHistory(): Promise<void> {
+  await writeAll({ v: SCHEMA_VERSION, entries: [] });
+}
+
+export async function getHistoryEntry(id: string): Promise<HistoryEntry | null> {
+  const data = await readAll();
+  return data.entries.find((e) => e.id === id) ?? null;
+}

--- a/extensions/media-converter/src/utils/merge.ts
+++ b/extensions/media-converter/src/utils/merge.ts
@@ -106,7 +106,7 @@ export function canStreamCopy(streams: StreamInfo[]): boolean {
     }
     if (!!s.audioCodec !== !!first.audioCodec) return false;
     if (s.audioCodec && s.audioCodec !== first.audioCodec) return false;
-    if (s.audioSampleRate && s.audioSampleRate !== first.audioSampleRate) return false;
+    if (s.audioSampleRate && first.audioSampleRate && s.audioSampleRate !== first.audioSampleRate) return false;
     if (s.audioChannels && s.audioChannels !== first.audioChannels) return false;
   }
   return true;

--- a/extensions/media-converter/src/utils/merge.ts
+++ b/extensions/media-converter/src/utils/merge.ts
@@ -95,10 +95,15 @@ export function canStreamCopy(streams: StreamInfo[]): boolean {
   if (streams.length < 2) return false;
   const first = streams[0];
   for (const s of streams) {
-    if (!s.videoCodec || s.videoCodec !== first.videoCodec) return false;
-    if (!s.videoWidth || s.videoWidth !== first.videoWidth) return false;
-    if (!s.videoHeight || s.videoHeight !== first.videoHeight) return false;
-    if (!s.videoFps || Math.abs(s.videoFps - (first.videoFps ?? 0)) > 0.1) return false;
+    if (first.videoCodec) {
+      if (!s.videoCodec || s.videoCodec !== first.videoCodec) return false;
+      if (!s.videoWidth || s.videoWidth !== first.videoWidth) return false;
+      if (!s.videoHeight || s.videoHeight !== first.videoHeight) return false;
+      if (!s.videoFps || Math.abs(s.videoFps - (first.videoFps ?? 0)) > 0.1) return false;
+    } else if (s.videoCodec) {
+      // First input has no video but this one does — incompatible.
+      return false;
+    }
     if (!!s.audioCodec !== !!first.audioCodec) return false;
     if (s.audioCodec && s.audioCodec !== first.audioCodec) return false;
     if (s.audioSampleRate && s.audioSampleRate !== first.audioSampleRate) return false;
@@ -199,7 +204,9 @@ export async function mergeMedia(
   if (strategy === "stream-copy") {
     // Build a concat list file for ffmpeg's concat demuxer
     const listFile = path.join(os.tmpdir(), `media-converter-concat-${Date.now()}.txt`);
-    const listContents = inputs.map((p) => `file '${p.replace(/'/g, "'\\''")}'`).join("\n");
+    // FFmpeg concat demuxer uses `\` as the escape char inside single-quoted
+    // strings (NOT shell-style `'\''`). Escape backslashes first, then quotes.
+    const listContents = inputs.map((p) => `file '${p.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`).join("\n");
     try {
       fs.writeFileSync(listFile, listContents);
       const cmd = `"${ffmpegPath.path}" -f concat -safe 0 -i "${listFile}" -c copy${metadataFlag} -y "${outputPath}"`;

--- a/extensions/media-converter/src/utils/merge.ts
+++ b/extensions/media-converter/src/utils/merge.ts
@@ -1,0 +1,262 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { findFFmpegPath } from "./ffmpeg";
+import { execPromise } from "./exec";
+import { runFFmpegWithProgress, probeDurationSec, type ProgressInfo } from "./ffmpegRun";
+import { AllOutputExtension, OutputVideoExtension, OutputAudioExtension, getOutputCategory } from "../types/media";
+
+export type MergeOptions = {
+  outputDir?: string;
+  stripMetadata?: boolean;
+  onProgress?: (p: ProgressInfo) => void;
+  /** If provided, used as the bare filename (without ext) for the merged output. */
+  outputFileName?: string;
+  /** When true, skip stream-copy detection and always re-encode. */
+  forceReencode?: boolean;
+};
+
+export type StreamInfo = {
+  videoCodec?: string;
+  videoWidth?: number;
+  videoHeight?: number;
+  videoFps?: number;
+  audioCodec?: string;
+  audioSampleRate?: number;
+  audioChannels?: number;
+  durationSec?: number;
+};
+
+/**
+ * Probe a file by parsing `ffmpeg -i` stderr output. Intentionally tolerant —
+ * returns whatever it could extract.
+ */
+export async function probeStreamInfo(ffmpegPath: string, filePath: string): Promise<StreamInfo> {
+  let stderr = "";
+  try {
+    await execPromise(`"${ffmpegPath}" -hide_banner -i "${filePath}"`);
+  } catch (err: unknown) {
+    // ffmpeg with only -i exits non-zero; the useful info is in stderr
+    const s =
+      typeof err === "object" && err !== null && "stderr" in err ? String((err as { stderr: unknown }).stderr) : "";
+    const m =
+      typeof err === "object" && err !== null && "message" in err ? String((err as { message: unknown }).message) : "";
+    stderr = s || m;
+  }
+
+  return parseStreamInfo(stderr);
+}
+
+export function parseStreamInfo(stderr: string): StreamInfo {
+  const info: StreamInfo = {};
+
+  const durMatch = stderr.match(/Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)/);
+  if (durMatch) {
+    info.durationSec = Number(durMatch[1]) * 3600 + Number(durMatch[2]) * 60 + Number(durMatch[3]);
+  }
+
+  // Video line: "Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(tv, bt709), 1920x1080 [...], 2396 kb/s, 30 fps, ..."
+  const vMatch = stderr.match(
+    /Stream #\d+:\d+(?:\[[^\]]+\])?(?:\(\w+\))?: Video:\s*(\w+)[^,]*,[^,]*,\s*(\d+)x(\d+)[^\n]*?(\d+(?:\.\d+)?)\s*fps/,
+  );
+  if (vMatch) {
+    info.videoCodec = vMatch[1];
+    info.videoWidth = Number(vMatch[2]);
+    info.videoHeight = Number(vMatch[3]);
+    info.videoFps = Number(vMatch[4]);
+  } else {
+    const vCodec = stderr.match(/Stream #\d+:\d+[^:]*: Video:\s*(\w+)/);
+    if (vCodec) info.videoCodec = vCodec[1];
+  }
+
+  // Audio line: "Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 128 kb/s"
+  const aMatch = stderr.match(/Stream #\d+:\d+(?:\[[^\]]+\])?(?:\(\w+\))?: Audio:\s*(\w+)[^,]*,\s*(\d+)\s*Hz,\s*(\w+)/);
+  if (aMatch) {
+    info.audioCodec = aMatch[1];
+    info.audioSampleRate = Number(aMatch[2]);
+    const layout = aMatch[3];
+    info.audioChannels = layout === "mono" ? 1 : layout === "stereo" ? 2 : layout.startsWith("5.1") ? 6 : undefined;
+  } else {
+    const aCodec = stderr.match(/Stream #\d+:\d+[^:]*: Audio:\s*(\w+)/);
+    if (aCodec) info.audioCodec = aCodec[1];
+  }
+
+  return info;
+}
+
+/**
+ * Determine whether a list of files can be merged via the FFmpeg concat
+ * demuxer with `-c copy` (no re-encode). Returns true only if all inputs
+ * share the same video codec/resolution/fps AND audio codec/sample rate/
+ * channels. Missing values are treated as "unknown" and disqualify stream
+ * copy as a safety measure.
+ */
+export function canStreamCopy(streams: StreamInfo[]): boolean {
+  if (streams.length < 2) return false;
+  const first = streams[0];
+  for (const s of streams) {
+    if (!s.videoCodec || s.videoCodec !== first.videoCodec) return false;
+    if (!s.videoWidth || s.videoWidth !== first.videoWidth) return false;
+    if (!s.videoHeight || s.videoHeight !== first.videoHeight) return false;
+    if (!s.videoFps || Math.abs(s.videoFps - (first.videoFps ?? 0)) > 0.1) return false;
+    if (!!s.audioCodec !== !!first.audioCodec) return false;
+    if (s.audioCodec && s.audioCodec !== first.audioCodec) return false;
+    if (s.audioSampleRate && s.audioSampleRate !== first.audioSampleRate) return false;
+    if (s.audioChannels && s.audioChannels !== first.audioChannels) return false;
+  }
+  return true;
+}
+
+function getUniqueMergePath(dir: string, baseName: string, ext: string): string {
+  let candidate = path.join(dir, `${baseName}${ext}`);
+  let counter = 1;
+  while (fs.existsSync(candidate)) {
+    candidate = path.join(dir, `${baseName}(${counter})${ext}`);
+    counter++;
+  }
+  return candidate;
+}
+
+function buildCodecArgs(outputFormat: AllOutputExtension): string {
+  const category = getOutputCategory(outputFormat);
+  if (category === "audio") {
+    switch (outputFormat as OutputAudioExtension) {
+      case ".mp3":
+        return " -c:a libmp3lame -b:a 192k";
+      case ".aac":
+      case ".m4a":
+        return " -c:a aac -b:a 192k";
+      case ".wav":
+        return " -c:a pcm_s16le -ar 44100";
+      case ".flac":
+        return " -c:a flac";
+    }
+  }
+  if (category === "video") {
+    switch (outputFormat as OutputVideoExtension) {
+      case ".mp4":
+        return " -c:v libx264 -preset medium -crf 23 -c:a aac -b:a 192k -pix_fmt yuv420p";
+      case ".mkv":
+        return " -c:v libx265 -preset medium -crf 28 -c:a aac -b:a 192k -pix_fmt yuv420p";
+      case ".mov":
+        return " -c:v prores -profile:v 2 -c:a pcm_s16le";
+      case ".webm":
+        return " -c:v libvpx-vp9 -b:v 0 -crf 30 -c:a libopus -b:a 128k";
+      case ".avi":
+        return " -c:v libxvid -q:v 6 -c:a mp3";
+      case ".mpg":
+        return " -c:v mpeg2video -q:v 6 -c:a mp3";
+    }
+  }
+  return "";
+}
+
+export type MergeStrategy = "stream-copy" | "reencode";
+
+export type MergeResult = {
+  outputPath: string;
+  strategy: MergeStrategy;
+};
+
+/**
+ * Merge multiple media files into a single output. Automatically tries
+ * stream-copy via the concat demuxer when inputs are compatible, and
+ * falls back to full re-encode via the concat filter otherwise.
+ */
+export async function mergeMedia(
+  inputs: string[],
+  outputFormat: AllOutputExtension,
+  opts: MergeOptions = {},
+): Promise<MergeResult> {
+  if (inputs.length < 2) {
+    throw new Error("At least 2 files are required to merge.");
+  }
+
+  const ffmpegPath = await findFFmpegPath();
+  if (!ffmpegPath) {
+    throw new Error("FFmpeg is not installed or configured.");
+  }
+
+  const outputDir = opts.outputDir && opts.outputDir.length > 0 ? opts.outputDir : path.dirname(inputs[0]);
+  const baseName = (opts.outputFileName && opts.outputFileName.trim()) || "merged";
+  const outputPath = getUniqueMergePath(outputDir, baseName, outputFormat);
+  const metadataFlag = opts.stripMetadata ? " -map_metadata -1" : "";
+
+  // Decide strategy
+  let strategy: MergeStrategy = "reencode";
+  if (!opts.forceReencode) {
+    try {
+      const streams = await Promise.all(inputs.map((p) => probeStreamInfo(ffmpegPath.path, p)));
+      if (canStreamCopy(streams)) {
+        strategy = "stream-copy";
+      }
+    } catch (err) {
+      console.warn("Stream probing failed, falling back to re-encode:", err);
+      strategy = "reencode";
+    }
+  }
+
+  if (strategy === "stream-copy") {
+    // Build a concat list file for ffmpeg's concat demuxer
+    const listFile = path.join(os.tmpdir(), `media-converter-concat-${Date.now()}.txt`);
+    const listContents = inputs.map((p) => `file '${p.replace(/'/g, "'\\''")}'`).join("\n");
+    try {
+      fs.writeFileSync(listFile, listContents);
+      const cmd = `"${ffmpegPath.path}" -f concat -safe 0 -i "${listFile}" -c copy${metadataFlag} -y "${outputPath}"`;
+      const total = await sumDurations(ffmpegPath.path, inputs);
+      console.log(`Executing FFmpeg stream-copy merge: ${cmd}`);
+      if (opts.onProgress) {
+        await runFFmpegWithProgress(cmd, { totalDurationSec: total, onProgress: opts.onProgress });
+      } else {
+        await execPromise(cmd);
+      }
+    } finally {
+      try {
+        fs.unlinkSync(listFile);
+      } catch {
+        /* ignore */
+      }
+    }
+    return { outputPath, strategy };
+  }
+
+  // Re-encode via concat filter. The concat filter is picky: every input
+  // listed in its pattern must actually have a stream of that type, so we
+  // tailor the graph to the output category (audio-only vs video+audio).
+  const n = inputs.length;
+  const inputsArg = inputs.map((p) => `-i "${p}"`).join(" ");
+  const outCategory = getOutputCategory(outputFormat);
+  let filter: string;
+  let mapArgs: string;
+  if (outCategory === "audio") {
+    const filterParts: string[] = [];
+    for (let i = 0; i < n; i++) filterParts.push(`[${i}:a:0]`);
+    filter = `${filterParts.join("")}concat=n=${n}:v=0:a=1[a]`;
+    mapArgs = ` -map "[a]"`;
+  } else {
+    const filterParts: string[] = [];
+    for (let i = 0; i < n; i++) filterParts.push(`[${i}:v:0][${i}:a:0?]`);
+    filter = `${filterParts.join("")}concat=n=${n}:v=1:a=1[v][a]`;
+    mapArgs = ` -map "[v]" -map "[a]"`;
+  }
+  const codecArgs = buildCodecArgs(outputFormat);
+  const cmd = `"${ffmpegPath.path}" ${inputsArg} -filter_complex "${filter}"${mapArgs}${codecArgs}${metadataFlag} -y "${outputPath}"`;
+  const total = await sumDurations(ffmpegPath.path, inputs);
+  console.log(`Executing FFmpeg re-encode merge: ${cmd}`);
+  if (opts.onProgress) {
+    await runFFmpegWithProgress(cmd, { totalDurationSec: total, onProgress: opts.onProgress });
+  } else {
+    await execPromise(cmd);
+  }
+  return { outputPath, strategy };
+}
+
+async function sumDurations(ffmpegPath: string, inputs: string[]): Promise<number | undefined> {
+  let total = 0;
+  for (const p of inputs) {
+    const d = await probeDurationSec(ffmpegPath, p);
+    if (d === null) return undefined;
+    total += d;
+  }
+  return total;
+}

--- a/extensions/media-converter/src/utils/merge.ts
+++ b/extensions/media-converter/src/utils/merge.ts
@@ -112,6 +112,36 @@ export function canStreamCopy(streams: StreamInfo[]): boolean {
   return true;
 }
 
+export function buildReencodeConcatGraph(
+  inputCount: number,
+  outCategory: ReturnType<typeof getOutputCategory>,
+  streams: StreamInfo[] = [],
+): { filter: string; mapArgs: string } {
+  if (outCategory === "audio") {
+    const filterParts: string[] = [];
+    for (let i = 0; i < inputCount; i++) filterParts.push(`[${i}:a:0]`);
+    return {
+      filter: `${filterParts.join("")}concat=n=${inputCount}:v=0:a=1[a]`,
+      mapArgs: ` -map "[a]"`,
+    };
+  }
+
+  const includeAudio = streams.length === inputCount && streams.every((s) => Boolean(s.audioCodec));
+  const filterParts: string[] = [];
+  for (let i = 0; i < inputCount; i++) {
+    filterParts.push(includeAudio ? `[${i}:v:0][${i}:a:0]` : `[${i}:v:0]`);
+  }
+
+  return {
+    filter: `${filterParts.join("")}concat=n=${inputCount}:v=1:a=${includeAudio ? 1 : 0}${includeAudio ? "[v][a]" : "[v]"}`,
+    mapArgs: includeAudio ? ` -map "[v]" -map "[a]"` : ` -map "[v]"`,
+  };
+}
+
+function inputsMatchOutputFormat(inputs: string[], outputFormat: AllOutputExtension): boolean {
+  return inputs.every((p) => path.extname(p).toLowerCase() === outputFormat.toLowerCase());
+}
+
 function getUniqueMergePath(dir: string, baseName: string, ext: string): string {
   let candidate = path.join(dir, `${baseName}${ext}`);
   let counter = 1;
@@ -189,16 +219,15 @@ export async function mergeMedia(
 
   // Decide strategy
   let strategy: MergeStrategy = "reencode";
-  if (!opts.forceReencode) {
-    try {
-      const streams = await Promise.all(inputs.map((p) => probeStreamInfo(ffmpegPath.path, p)));
-      if (canStreamCopy(streams)) {
-        strategy = "stream-copy";
-      }
-    } catch (err) {
-      console.warn("Stream probing failed, falling back to re-encode:", err);
-      strategy = "reencode";
+  let streams: StreamInfo[] = [];
+  try {
+    streams = await Promise.all(inputs.map((p) => probeStreamInfo(ffmpegPath.path, p)));
+    if (!opts.forceReencode && inputsMatchOutputFormat(inputs, outputFormat) && canStreamCopy(streams)) {
+      strategy = "stream-copy";
     }
+  } catch (err) {
+    console.warn("Stream probing failed, falling back to re-encode:", err);
+    strategy = "reencode";
   }
 
   if (strategy === "stream-copy") {
@@ -233,19 +262,7 @@ export async function mergeMedia(
   const n = inputs.length;
   const inputsArg = inputs.map((p) => `-i "${p}"`).join(" ");
   const outCategory = getOutputCategory(outputFormat);
-  let filter: string;
-  let mapArgs: string;
-  if (outCategory === "audio") {
-    const filterParts: string[] = [];
-    for (let i = 0; i < n; i++) filterParts.push(`[${i}:a:0]`);
-    filter = `${filterParts.join("")}concat=n=${n}:v=0:a=1[a]`;
-    mapArgs = ` -map "[a]"`;
-  } else {
-    const filterParts: string[] = [];
-    for (let i = 0; i < n; i++) filterParts.push(`[${i}:v:0][${i}:a:0?]`);
-    filter = `${filterParts.join("")}concat=n=${n}:v=1:a=1[v][a]`;
-    mapArgs = ` -map "[v]" -map "[a]"`;
-  }
+  const { filter, mapArgs } = buildReencodeConcatGraph(n, outCategory, streams);
   const codecArgs = buildCodecArgs(outputFormat);
   const cmd = `"${ffmpegPath.path}" ${inputsArg} -filter_complex "${filter}"${mapArgs}${codecArgs}${metadataFlag} -y "${outputPath}"`;
   const total = await sumDurations(ffmpegPath.path, inputs);

--- a/extensions/media-converter/src/utils/presets.ts
+++ b/extensions/media-converter/src/utils/presets.ts
@@ -1,0 +1,123 @@
+import { LocalStorage } from "@raycast/api";
+import builtInPresetsFile from "../config/built-in-presets.json";
+import {
+  Preset,
+  AllOutputExtension,
+  QualitySettings,
+  TrimOptions,
+  MediaType,
+  OUTPUT_ALL_EXTENSIONS,
+} from "../types/media";
+
+const USER_PRESETS_KEY = "user-presets";
+const SCHEMA_VERSION = 1;
+
+type StoredShape = { v: number; presets: Preset[] };
+
+type RawPreset = {
+  id: string;
+  name: string;
+  builtIn?: boolean;
+  mediaType: MediaType | "gif";
+  outputFormat: string;
+  quality: unknown;
+  trim?: TrimOptions;
+  stripMetadata?: boolean;
+  outputDir?: string;
+  description?: string;
+};
+
+function normaliseRaw(raw: RawPreset, markBuiltIn: boolean): Preset | null {
+  if (!OUTPUT_ALL_EXTENSIONS.includes(raw.outputFormat as (typeof OUTPUT_ALL_EXTENSIONS)[number])) {
+    return null;
+  }
+  return {
+    id: raw.id,
+    name: raw.name,
+    builtIn: markBuiltIn || raw.builtIn === true,
+    mediaType: raw.mediaType,
+    outputFormat: raw.outputFormat as AllOutputExtension,
+    quality: raw.quality as QualitySettings,
+    trim: raw.trim,
+    stripMetadata: raw.stripMetadata,
+    outputDir: raw.outputDir,
+    description: raw.description,
+  };
+}
+
+export function getBuiltInPresets(): Preset[] {
+  const raw = builtInPresetsFile as { presets: RawPreset[] };
+  return raw.presets.map((p) => normaliseRaw(p, true)).filter((p): p is Preset => p !== null);
+}
+
+async function readUser(): Promise<StoredShape> {
+  const raw = (await LocalStorage.getItem<string>(USER_PRESETS_KEY)) ?? "";
+  if (!raw) return { v: SCHEMA_VERSION, presets: [] };
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && Array.isArray(parsed.presets)) {
+      const presets = parsed.presets
+        .map((p: RawPreset) => normaliseRaw(p, false))
+        .filter((p: Preset | null): p is Preset => p !== null);
+      return { v: parsed.v ?? SCHEMA_VERSION, presets };
+    }
+  } catch (err) {
+    console.warn("Failed to parse user presets, resetting:", err);
+  }
+  return { v: SCHEMA_VERSION, presets: [] };
+}
+
+async function writeUser(data: StoredShape): Promise<void> {
+  await LocalStorage.setItem(USER_PRESETS_KEY, JSON.stringify(data));
+}
+
+export async function getUserPresets(): Promise<Preset[]> {
+  const data = await readUser();
+  return data.presets;
+}
+
+export async function getAllPresets(): Promise<Preset[]> {
+  const user = await getUserPresets();
+  return [...getBuiltInPresets(), ...user];
+}
+
+export async function findPreset(id: string): Promise<Preset | null> {
+  const all = await getAllPresets();
+  return all.find((p) => p.id === id) ?? null;
+}
+
+function newId(): string {
+  return `user-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export async function saveUserPreset(preset: Omit<Preset, "id" | "builtIn"> & { id?: string }): Promise<Preset> {
+  const data = await readUser();
+  const id = preset.id ?? newId();
+  const existing = data.presets.findIndex((p) => p.id === id);
+  const toStore: Preset = { ...preset, id, builtIn: false };
+  if (existing >= 0) data.presets[existing] = toStore;
+  else data.presets.unshift(toStore);
+  await writeUser(data);
+  return toStore;
+}
+
+export async function deleteUserPreset(id: string): Promise<void> {
+  const data = await readUser();
+  data.presets = data.presets.filter((p) => p.id !== id);
+  await writeUser(data);
+}
+
+export async function duplicatePreset(id: string, newName?: string): Promise<Preset | null> {
+  const source = await findPreset(id);
+  if (!source) return null;
+  return saveUserPreset({
+    name: newName ?? `${source.name} (copy)`,
+    mediaType: source.mediaType,
+    outputFormat: source.outputFormat,
+    quality: source.quality,
+    trim: source.trim,
+    stripMetadata: source.stripMetadata,
+    outputDir: source.outputDir,
+    description: source.description,
+  });
+}

--- a/extensions/media-converter/src/utils/time.ts
+++ b/extensions/media-converter/src/utils/time.ts
@@ -1,0 +1,58 @@
+/**
+ * Parse a user-provided time string into seconds.
+ *
+ * Accepted formats:
+ *   - "SS" or "SS.mmm" (e.g. "90", "12.5")
+ *   - "MM:SS[.mmm]" (e.g. "1:30", "01:30.250")
+ *   - "HH:MM:SS[.mmm]" (e.g. "00:01:30")
+ *
+ * Returns null for invalid input (including empty/whitespace).
+ */
+export function parseTimeString(input: string | undefined | null): number | null {
+  if (input === undefined || input === null) return null;
+  const trimmed = String(input).trim();
+  if (trimmed.length === 0) return null;
+
+  const parts = trimmed.split(":");
+  if (parts.length > 3) return null;
+
+  const nums = parts.map((p) => (p === "" ? NaN : Number(p)));
+  if (nums.some((n) => Number.isNaN(n) || n < 0)) return null;
+
+  let seconds: number;
+  if (nums.length === 1) {
+    seconds = nums[0];
+  } else if (nums.length === 2) {
+    if (nums[1] >= 60) return null;
+    seconds = nums[0] * 60 + nums[1];
+  } else {
+    if (nums[1] >= 60 || nums[2] >= 60) return null;
+    seconds = nums[0] * 3600 + nums[1] * 60 + nums[2];
+  }
+
+  return Number.isFinite(seconds) ? seconds : null;
+}
+
+/**
+ * Format a number of seconds as "H:MM:SS" or "M:SS" if under an hour.
+ */
+export function formatTimeString(totalSec: number): string {
+  if (!Number.isFinite(totalSec) || totalSec < 0) return "0:00";
+  const sec = Math.floor(totalSec % 60);
+  const min = Math.floor((totalSec / 60) % 60);
+  const hr = Math.floor(totalSec / 3600);
+  const pad2 = (n: number) => n.toString().padStart(2, "0");
+  return hr > 0 ? `${hr}:${pad2(min)}:${pad2(sec)}` : `${min}:${pad2(sec)}`;
+}
+
+/**
+ * Format as FFmpeg-compatible "HH:MM:SS.mmm" for use with -ss / -to.
+ */
+export function toFfmpegTime(totalSec: number): string {
+  const clamped = Math.max(0, totalSec);
+  const hr = Math.floor(clamped / 3600);
+  const min = Math.floor((clamped / 60) % 60);
+  const sec = clamped - hr * 3600 - min * 60;
+  const pad2 = (n: number) => n.toString().padStart(2, "0");
+  return `${pad2(hr)}:${pad2(min)}:${sec.toFixed(3).padStart(6, "0")}`;
+}

--- a/extensions/media-converter/test/loader.mjs
+++ b/extensions/media-converter/test/loader.mjs
@@ -1,0 +1,15 @@
+// Minimal Node ESM resolve hook that redirects `@raycast/api` imports to
+// a local test stub. Used for unit tests; never loaded in production.
+import { pathToFileURL } from "node:url";
+import { resolve as resolvePath, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const stubUrl = pathToFileURL(resolvePath(here, "stubs/raycast-api.js")).href;
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "@raycast/api") {
+    return { url: stubUrl, format: "module", shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}

--- a/extensions/media-converter/test/register.mjs
+++ b/extensions/media-converter/test/register.mjs
@@ -1,0 +1,21 @@
+// Pre-test bootstrap: chain our @raycast/api stub loader after tsx.
+import { register, createRequire } from "node:module";
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// 1. Intercept ESM imports of `@raycast/api`.
+register("./loader.mjs", import.meta.url);
+
+// 2. Also intercept CJS `require("@raycast/api")` by monkey-patching
+//    Module._resolveFilename. tsx's TS-aware CJS loader uses the CJS
+//    resolution path and bypasses the ESM resolve hook entirely.
+const here = dirname(fileURLToPath(import.meta.url));
+const stubPath = resolvePath(here, "stubs/raycast-api.js");
+
+const require = createRequire(import.meta.url);
+const Module = require("node:module");
+const originalResolveFilename = Module._resolveFilename;
+Module._resolveFilename = function (request, parent, ...rest) {
+  if (request === "@raycast/api") return stubPath;
+  return originalResolveFilename.call(this, request, parent, ...rest);
+};

--- a/extensions/media-converter/test/smoke/run-smoke.ts
+++ b/extensions/media-converter/test/smoke/run-smoke.ts
@@ -1,0 +1,259 @@
+/**
+ * Smoke test harness: exercises convertMedia + mergeMedia end-to-end against
+ * auto-generated tiny fixtures so we know the wiring actually works.
+ *
+ * We intentionally don't ship real binary fixtures — FFmpeg is perfectly
+ * capable of generating tiny test inputs from its built-in sources
+ * (`testsrc`, `sine`, `color` filters).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { convertMedia } from "../../src/utils/converter";
+import { mergeMedia } from "../../src/utils/merge";
+import type { QualitySettings } from "../../src/types/media";
+
+// `QualitySettings` is derived from `VIDEO_QUALITY_OBJECT as const`, so it
+// narrows fields like `crf` to a single literal value (e.g. `75`) and
+// requires every format key to be present. At runtime only the one matching
+// key is read, but TypeScript has no way to know that here — we use a
+// helper cast so each smoke check reads clearly.
+function q(partial: Record<string, unknown>): QualitySettings {
+  return partial as unknown as QualitySettings;
+}
+
+const execP = promisify(exec);
+
+const TMP = path.join(os.tmpdir(), `media-converter-smoke-${Date.now()}`);
+fs.mkdirSync(TMP, { recursive: true });
+
+type Check = { name: string; ok: boolean; info?: string };
+const results: Check[] = [];
+
+function log(step: string) {
+  process.stdout.write(`\x1b[36m→ ${step}\x1b[0m\n`);
+}
+
+function pass(name: string, info?: string) {
+  results.push({ name, ok: true, info });
+  process.stdout.write(`  \x1b[32m✓ ${name}${info ? ` (${info})` : ""}\x1b[0m\n`);
+}
+
+function fail(name: string, info: string) {
+  results.push({ name, ok: false, info });
+  process.stdout.write(`  \x1b[31m✗ ${name} — ${info}\x1b[0m\n`);
+}
+
+async function findFFmpegBinary(): Promise<string> {
+  const candidates = ["/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg", "/usr/bin/ffmpeg"];
+  for (const c of candidates) if (fs.existsSync(c)) return c;
+  try {
+    const { stdout } = await execP("which ffmpeg");
+    const p = stdout.trim();
+    if (p && fs.existsSync(p)) return p;
+  } catch {
+    /* ignore */
+  }
+  throw new Error("FFmpeg not found on PATH — install it before running smoke tests.");
+}
+
+async function genVideoFixture(ffmpeg: string, out: string, durationSec = 2): Promise<void> {
+  // 160x120 test pattern + 440Hz sine at 30fps — tiny but valid mp4.
+  const cmd =
+    `"${ffmpeg}" -y -hide_banner -loglevel error ` +
+    `-f lavfi -i testsrc=duration=${durationSec}:size=160x120:rate=30 ` +
+    `-f lavfi -i sine=frequency=440:duration=${durationSec} ` +
+    `-c:v libx264 -preset ultrafast -pix_fmt yuv420p -tune stillimage ` +
+    `-c:a aac -shortest "${out}"`;
+  await execP(cmd);
+}
+
+async function genAudioFixture(ffmpeg: string, out: string, durationSec = 2): Promise<void> {
+  const cmd = `"${ffmpeg}" -y -hide_banner -loglevel error -f lavfi -i sine=frequency=440:duration=${durationSec} "${out}"`;
+  await execP(cmd);
+}
+
+async function genImageFixture(ffmpeg: string, out: string): Promise<void> {
+  const cmd = `"${ffmpeg}" -y -hide_banner -loglevel error -f lavfi -i color=red:size=160x120 -frames:v 1 "${out}"`;
+  await execP(cmd);
+}
+
+function sizeOf(p: string): number {
+  try {
+    return fs.statSync(p).size;
+  } catch {
+    return 0;
+  }
+}
+
+async function probeDuration(ffmpeg: string, p: string): Promise<number | null> {
+  try {
+    await execP(`"${ffmpeg}" -hide_banner -i "${p}"`);
+  } catch (err: unknown) {
+    const stderr = typeof err === "object" && err !== null && "stderr" in err ? String((err as { stderr: unknown }).stderr) : "";
+    const m = stderr.match(/Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)/);
+    if (!m) return null;
+    return Number(m[1]) * 3600 + Number(m[2]) * 60 + Number(m[3]);
+  }
+  return null;
+}
+
+async function check(name: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+  } catch (err) {
+    fail(name, err instanceof Error ? err.message : String(err));
+  }
+}
+
+async function main() {
+  log(`Using workspace: ${TMP}`);
+  const ffmpeg = await findFFmpegBinary();
+  log(`Using ffmpeg: ${ffmpeg}`);
+
+  // ---- Generate fixtures ----
+  log("Generating fixtures");
+  const vid1 = path.join(TMP, "a.mp4");
+  const vid2 = path.join(TMP, "b.mp4");
+  const aud1 = path.join(TMP, "a.wav");
+  const aud2 = path.join(TMP, "b.wav");
+  const img1 = path.join(TMP, "a.png");
+  await genVideoFixture(ffmpeg, vid1, 2);
+  await genVideoFixture(ffmpeg, vid2, 2);
+  await genAudioFixture(ffmpeg, aud1, 2);
+  await genAudioFixture(ffmpeg, aud2, 2);
+  await genImageFixture(ffmpeg, img1);
+  pass("fixtures generated", `${fs.readdirSync(TMP).length} files`);
+
+  // ---- Video: mp4 -> webm ----
+  await check("convert mp4 -> webm", async () => {
+    const out = await convertMedia(
+      vid1,
+      ".webm",
+      q({ ".webm": { encodingMode: "crf", crf: 50, quality: "good" } }),
+      { outputDir: TMP },
+    );
+    if (!fs.existsSync(out) || sizeOf(out) < 500) throw new Error(`output missing or too small: ${out}`);
+    pass("convert mp4 -> webm", `${sizeOf(out)} bytes`);
+  });
+
+  // ---- Video: mp4 -> gif (palette pipeline) ----
+  await check("convert mp4 -> gif", async () => {
+    const out = await convertMedia(
+      vid1,
+      ".gif",
+      q({ ".gif": { fps: "10", width: "original", loop: true } }),
+      { outputDir: TMP },
+    );
+    if (!fs.existsSync(out) || sizeOf(out) < 500) throw new Error(`output missing or too small: ${out}`);
+    pass("convert mp4 -> gif", `${sizeOf(out)} bytes`);
+  });
+
+  // ---- Video with trim ----
+  await check("convert mp4 with trim 0:00..0:01", async () => {
+    const out = await convertMedia(
+      vid1,
+      ".mp4",
+      q({ ".mp4": { encodingMode: "crf", crf: 28, preset: "ultrafast" } }),
+      { outputDir: TMP, trim: { start: "0", end: "1" } },
+    );
+    const dur = await probeDuration(ffmpeg, out);
+    if (dur === null) throw new Error("could not probe trimmed duration");
+    if (dur > 1.5) throw new Error(`expected duration <=1.5s, got ${dur}`);
+    pass("convert mp4 with trim 0:00..0:01", `duration=${dur.toFixed(2)}s`);
+  });
+
+  // ---- Video strip metadata ----
+  await check("convert mp4 with stripMetadata", async () => {
+    const out = await convertMedia(
+      vid1,
+      ".mp4",
+      q({ ".mp4": { encodingMode: "crf", crf: 28, preset: "ultrafast" } }),
+      { outputDir: TMP, stripMetadata: true },
+    );
+    const { stdout } = await execP(`"${ffmpeg}" -hide_banner -i "${out}" -f ffmetadata - 2>&1 || true`);
+    if (/title=|artist=|comment=/i.test(stdout)) throw new Error(`metadata not stripped: ${stdout.slice(0, 200)}`);
+    pass("convert mp4 with stripMetadata");
+  });
+
+  // ---- Audio: wav -> mp3 ----
+  await check("convert wav -> mp3", async () => {
+    const out = await convertMedia(aud1, ".mp3", q({ ".mp3": { bitrate: "128", vbr: false } }), { outputDir: TMP });
+    if (!fs.existsSync(out) || sizeOf(out) < 500) throw new Error(`output missing or too small: ${out}`);
+    pass("convert wav -> mp3", `${sizeOf(out)} bytes`);
+  });
+
+  // ---- Image: png -> jpg ----
+  await check("convert png -> jpg", async () => {
+    const out = await convertMedia(img1, ".jpg", q({ ".jpg": 80 }), { outputDir: TMP });
+    if (!fs.existsSync(out) || sizeOf(out) < 200) throw new Error(`output missing or too small: ${out}`);
+    pass("convert png -> jpg", `${sizeOf(out)} bytes`);
+  });
+
+  // ---- Merge: 2 compatible mp4s (should stream-copy) ----
+  await check("merge 2 compatible mp4s (stream-copy)", async () => {
+    const result = await mergeMedia([vid1, vid2], ".mp4", { outputDir: TMP, outputFileName: "merged-sc" });
+    if (!fs.existsSync(result.outputPath)) throw new Error(`merged file missing: ${result.outputPath}`);
+    const dur = await probeDuration(ffmpeg, result.outputPath);
+    if (dur === null || dur < 3.5) throw new Error(`merged duration looks wrong: ${dur}`);
+    if (result.strategy !== "stream-copy") throw new Error(`expected stream-copy, got ${result.strategy}`);
+    pass("merge 2 compatible mp4s", `strategy=${result.strategy}, dur=${dur.toFixed(2)}s`);
+  });
+
+  // ---- Merge: 2 mp4s forced re-encode ----
+  await check("merge 2 mp4s with forceReencode", async () => {
+    const result = await mergeMedia([vid1, vid2], ".mp4", {
+      outputDir: TMP,
+      outputFileName: "merged-re",
+      forceReencode: true,
+    });
+    if (result.strategy !== "reencode") throw new Error(`expected reencode, got ${result.strategy}`);
+    const dur = await probeDuration(ffmpeg, result.outputPath);
+    if (dur === null || dur < 3.5) throw new Error(`merged (re-encode) duration looks wrong: ${dur}`);
+    pass("merge 2 mp4s with forceReencode", `dur=${dur.toFixed(2)}s`);
+  });
+
+  // ---- Merge: 2 audio files ----
+  await check("merge 2 wav -> mp3 (re-encode)", async () => {
+    const result = await mergeMedia([aud1, aud2], ".mp3", { outputDir: TMP, outputFileName: "merged-audio" });
+    if (!fs.existsSync(result.outputPath)) throw new Error(`merged audio missing: ${result.outputPath}`);
+    const dur = await probeDuration(ffmpeg, result.outputPath);
+    if (dur === null || dur < 3.5) throw new Error(`merged audio duration looks wrong: ${dur}`);
+    pass("merge 2 wav -> mp3", `strategy=${result.strategy}, dur=${dur.toFixed(2)}s`);
+  });
+
+  // ---- Progress callback fires at least once for a video conversion ----
+  await check("convert mp4 emits progress events", async () => {
+    let gotProgress = false;
+    await convertMedia(
+      vid1,
+      ".mkv",
+      q({ ".mkv": { encodingMode: "crf", crf: 35, preset: "ultrafast" } }),
+      {
+        outputDir: TMP,
+        onProgress: () => {
+          gotProgress = true;
+        },
+      },
+    );
+    if (!gotProgress) throw new Error("no progress events were emitted");
+    pass("convert mp4 emits progress events");
+  });
+
+  // ---- Summary ----
+  const passed = results.filter((r) => r.ok).length;
+  const failed = results.filter((r) => !r.ok).length;
+  process.stdout.write(`\n\x1b[1mSmoke results:\x1b[0m ${passed} passed, ${failed} failed\n`);
+  process.stdout.write(`Workspace: ${TMP}\n`);
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Smoke script crashed:", err);
+  process.exit(2);
+});

--- a/extensions/media-converter/test/smoke/run-smoke.ts
+++ b/extensions/media-converter/test/smoke/run-smoke.ts
@@ -92,7 +92,8 @@ async function probeDuration(ffmpeg: string, p: string): Promise<number | null> 
   try {
     await execP(`"${ffmpeg}" -hide_banner -i "${p}"`);
   } catch (err: unknown) {
-    const stderr = typeof err === "object" && err !== null && "stderr" in err ? String((err as { stderr: unknown }).stderr) : "";
+    const stderr =
+      typeof err === "object" && err !== null && "stderr" in err ? String((err as { stderr: unknown }).stderr) : "";
     const m = stderr.match(/Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)/);
     if (!m) return null;
     return Number(m[1]) * 3600 + Number(m[2]) * 60 + Number(m[3]);
@@ -129,36 +130,28 @@ async function main() {
 
   // ---- Video: mp4 -> webm ----
   await check("convert mp4 -> webm", async () => {
-    const out = await convertMedia(
-      vid1,
-      ".webm",
-      q({ ".webm": { encodingMode: "crf", crf: 50, quality: "good" } }),
-      { outputDir: TMP },
-    );
+    const out = await convertMedia(vid1, ".webm", q({ ".webm": { encodingMode: "crf", crf: 50, quality: "good" } }), {
+      outputDir: TMP,
+    });
     if (!fs.existsSync(out) || sizeOf(out) < 500) throw new Error(`output missing or too small: ${out}`);
     pass("convert mp4 -> webm", `${sizeOf(out)} bytes`);
   });
 
   // ---- Video: mp4 -> gif (palette pipeline) ----
   await check("convert mp4 -> gif", async () => {
-    const out = await convertMedia(
-      vid1,
-      ".gif",
-      q({ ".gif": { fps: "10", width: "original", loop: true } }),
-      { outputDir: TMP },
-    );
+    const out = await convertMedia(vid1, ".gif", q({ ".gif": { fps: "10", width: "original", loop: true } }), {
+      outputDir: TMP,
+    });
     if (!fs.existsSync(out) || sizeOf(out) < 500) throw new Error(`output missing or too small: ${out}`);
     pass("convert mp4 -> gif", `${sizeOf(out)} bytes`);
   });
 
   // ---- Video with trim ----
   await check("convert mp4 with trim 0:00..0:01", async () => {
-    const out = await convertMedia(
-      vid1,
-      ".mp4",
-      q({ ".mp4": { encodingMode: "crf", crf: 28, preset: "ultrafast" } }),
-      { outputDir: TMP, trim: { start: "0", end: "1" } },
-    );
+    const out = await convertMedia(vid1, ".mp4", q({ ".mp4": { encodingMode: "crf", crf: 28, preset: "ultrafast" } }), {
+      outputDir: TMP,
+      trim: { start: "0", end: "1" },
+    });
     const dur = await probeDuration(ffmpeg, out);
     if (dur === null) throw new Error("could not probe trimmed duration");
     if (dur > 1.5) throw new Error(`expected duration <=1.5s, got ${dur}`);
@@ -167,12 +160,10 @@ async function main() {
 
   // ---- Video strip metadata ----
   await check("convert mp4 with stripMetadata", async () => {
-    const out = await convertMedia(
-      vid1,
-      ".mp4",
-      q({ ".mp4": { encodingMode: "crf", crf: 28, preset: "ultrafast" } }),
-      { outputDir: TMP, stripMetadata: true },
-    );
+    const out = await convertMedia(vid1, ".mp4", q({ ".mp4": { encodingMode: "crf", crf: 28, preset: "ultrafast" } }), {
+      outputDir: TMP,
+      stripMetadata: true,
+    });
     const { stdout } = await execP(`"${ffmpeg}" -hide_banner -i "${out}" -f ffmetadata - 2>&1 || true`);
     if (/title=|artist=|comment=/i.test(stdout)) throw new Error(`metadata not stripped: ${stdout.slice(0, 200)}`);
     pass("convert mp4 with stripMetadata");
@@ -227,17 +218,12 @@ async function main() {
   // ---- Progress callback fires at least once for a video conversion ----
   await check("convert mp4 emits progress events", async () => {
     let gotProgress = false;
-    await convertMedia(
-      vid1,
-      ".mkv",
-      q({ ".mkv": { encodingMode: "crf", crf: 35, preset: "ultrafast" } }),
-      {
-        outputDir: TMP,
-        onProgress: () => {
-          gotProgress = true;
-        },
+    await convertMedia(vid1, ".mkv", q({ ".mkv": { encodingMode: "crf", crf: 35, preset: "ultrafast" } }), {
+      outputDir: TMP,
+      onProgress: () => {
+        gotProgress = true;
       },
-    );
+    });
     if (!gotProgress) throw new Error("no progress events were emitted");
     pass("convert mp4 emits progress events");
   });

--- a/extensions/media-converter/test/stubs/raycast-api.js
+++ b/extensions/media-converter/test/stubs/raycast-api.js
@@ -1,0 +1,45 @@
+// Runtime stub for `@raycast/api`. Only covers the surface we touch during
+// unit tests (LocalStorage + a few enum-ish exports). Anything else will
+// throw, making it obvious if a test accidentally depends on Raycast runtime.
+
+const storage = new Map();
+
+export const LocalStorage = {
+  getItem: async (key) => storage.get(key),
+  setItem: async (key, value) => {
+    storage.set(key, value);
+  },
+  removeItem: async (key) => {
+    storage.delete(key);
+  },
+  allItems: async () => Object.fromEntries(storage),
+  clear: async () => {
+    storage.clear();
+  },
+};
+
+export const Toast = { Style: { Success: "SUCCESS", Failure: "FAILURE", Animated: "ANIMATED" } };
+export const Icon = new Proxy({}, { get: (_t, prop) => String(prop) });
+export const Color = new Proxy({}, { get: (_t, prop) => String(prop) });
+export const environment = { supportPath: "/tmp", assetsPath: "/tmp", commandName: "test" };
+
+export async function showToast() {}
+export async function showInFinder() {}
+export async function showHUD() {}
+export async function getPreferenceValues() {
+  return {};
+}
+export function openCommandPreferences() {}
+export async function launchCommand() {}
+export const Clipboard = { copy: async () => {} };
+
+export function getSelectedFinderItems() {
+  return Promise.resolve([]);
+}
+
+// Tool schema helpers used by AI tools (not invoked at runtime in tests).
+export const Tool = {
+  Confirmation: () => null,
+};
+
+export default {};

--- a/extensions/media-converter/test/unit/ffmpegRun.test.ts
+++ b/extensions/media-converter/test/unit/ffmpegRun.test.ts
@@ -1,10 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import {
-  parseProgressBlock,
-  parseDurationFromStderr,
-  injectGlobalFlags,
-} from "../../src/utils/ffmpegRun";
+import { parseProgressBlock, parseDurationFromStderr, injectGlobalFlags } from "../../src/utils/ffmpegRun";
 
 describe("parseProgressBlock", () => {
   const sampleBlock = [

--- a/extensions/media-converter/test/unit/ffmpegRun.test.ts
+++ b/extensions/media-converter/test/unit/ffmpegRun.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseProgressBlock,
+  parseDurationFromStderr,
+  injectGlobalFlags,
+} from "../../src/utils/ffmpegRun";
+
+describe("parseProgressBlock", () => {
+  const sampleBlock = [
+    "bitrate=1234.5kbits/s",
+    "total_size=100000",
+    "out_time_us=15000000",
+    "out_time_ms=15000000",
+    "out_time=00:00:15.000000",
+    "dup_frames=0",
+    "drop_frames=0",
+    "speed=1.25x",
+    "fps=30.0",
+    "progress=continue",
+  ].join("\n");
+
+  it("returns null for blocks without a parseable out_time", () => {
+    const block = "bitrate=1234.5\nprogress=continue";
+    assert.equal(parseProgressBlock(block, 60, Date.now()), null);
+  });
+
+  it("computes percent from processed / total seconds", () => {
+    const info = parseProgressBlock(sampleBlock, 60, Date.now());
+    assert.ok(info);
+    assert.equal(info!.processedSec, 15);
+    assert.equal(info!.totalSec, 60);
+    assert.equal(info!.percent, 25);
+  });
+
+  it("reports 0% when total duration is unknown", () => {
+    const info = parseProgressBlock(sampleBlock, undefined, Date.now());
+    assert.ok(info);
+    assert.equal(info!.percent, 0);
+  });
+
+  it("clamps percent to [0, 100] when processed exceeds total", () => {
+    const block = "out_time_ms=70000000\nspeed=1x\nprogress=continue";
+    const info = parseProgressBlock(block, 60, Date.now());
+    assert.ok(info);
+    assert.equal(info!.percent, 100);
+  });
+
+  it("extracts fps and speed", () => {
+    const info = parseProgressBlock(sampleBlock, 60, Date.now());
+    assert.ok(info);
+    assert.equal(info!.fps, 30);
+    assert.equal(info!.speed, 1.25);
+  });
+
+  it("derives an ETA using reported speed when available", () => {
+    // 15s processed of 60s total at 1.25x => remaining=45s, ETA = 45/1.25 = 36s
+    const info = parseProgressBlock(sampleBlock, 60, Date.now());
+    assert.ok(info);
+    assert.ok(info!.etaSec !== undefined);
+    assert.ok(Math.abs(info!.etaSec! - 36) < 0.1);
+  });
+
+  it("falls back to out_time timestamp when out_time_ms is absent", () => {
+    const block = "out_time=00:01:00.000\nspeed=1x\nprogress=continue";
+    const info = parseProgressBlock(block, 300, Date.now());
+    assert.ok(info);
+    assert.equal(info!.processedSec, 60);
+    assert.equal(info!.percent, 20);
+  });
+});
+
+describe("parseDurationFromStderr", () => {
+  it("extracts duration from a standard FFmpeg Duration line", () => {
+    const stderr = "  Duration: 00:01:23.45, start: 0.000000, bitrate: 5000 kb/s\n";
+    assert.equal(parseDurationFromStderr(stderr), 83.45);
+  });
+
+  it("handles integer-second durations", () => {
+    const stderr = "Duration: 01:02:03, ...";
+    assert.equal(parseDurationFromStderr(stderr), 3723);
+  });
+
+  it("returns null when no Duration line is present", () => {
+    assert.equal(parseDurationFromStderr("totally unrelated output"), null);
+  });
+
+  it("returns null for malformed duration values", () => {
+    assert.equal(parseDurationFromStderr("Duration: ab:cd:ef, ..."), null);
+  });
+});
+
+describe("injectGlobalFlags", () => {
+  it("injects after a quoted binary path", () => {
+    const cmd = `"/path/with spaces/ffmpeg" -i "in.mp4" out.mp4`;
+    const out = injectGlobalFlags(cmd, "-progress pipe:1 -nostats");
+    assert.equal(out, `"/path/with spaces/ffmpeg" -progress pipe:1 -nostats -i "in.mp4" out.mp4`);
+  });
+
+  it("injects after an unquoted binary path", () => {
+    const cmd = `ffmpeg -i in.mp4 out.mp4`;
+    const out = injectGlobalFlags(cmd, "-progress pipe:1 -nostats");
+    assert.equal(out, `ffmpeg -progress pipe:1 -nostats -i in.mp4 out.mp4`);
+  });
+
+  it("appends flags when command has no spaces (degenerate case)", () => {
+    assert.equal(injectGlobalFlags("ffmpeg", "-nostats"), "ffmpeg -nostats");
+  });
+});

--- a/extensions/media-converter/test/unit/format.test.ts
+++ b/extensions/media-converter/test/unit/format.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatBytes, formatSavings } from "../../src/utils/format";
+
+describe("formatBytes", () => {
+  it("formats small byte values in B", () => {
+    assert.equal(formatBytes(0), "0 B");
+    assert.equal(formatBytes(512), "512 B");
+  });
+
+  it("formats KB with 1 decimal under 100", () => {
+    assert.equal(formatBytes(1536), "1.5 KB");
+  });
+
+  it("formats KB without decimal at or above 100", () => {
+    assert.equal(formatBytes(1024 * 150), "150 KB");
+  });
+
+  it("formats MB with 1 decimal under 100", () => {
+    assert.equal(formatBytes(1024 * 1024 * 2), "2.0 MB");
+    assert.equal(formatBytes(1024 * 1024 * 2.5), "2.5 MB");
+  });
+
+  it("formats GB with 1 decimal under 100", () => {
+    assert.equal(formatBytes(1024 ** 3 * 3), "3.0 GB");
+  });
+
+  it("handles non-finite as 0 B", () => {
+    assert.equal(formatBytes(Number.NaN), "0 B");
+    assert.equal(formatBytes(Number.POSITIVE_INFINITY), "0 B");
+  });
+
+  it("formats negative values with a leading minus", () => {
+    assert.equal(formatBytes(-1536), "-1.5 KB");
+  });
+});
+
+describe("formatSavings", () => {
+  it("reports saved bytes and percent when output is smaller", () => {
+    // 10 MB -> 4 MB, saved 6 MB (60%)
+    const saved = formatSavings(10 * 1024 * 1024, 4 * 1024 * 1024);
+    assert.match(saved, /^saved 6\.0 MB \(60%\)$/);
+  });
+
+  it("reports size increase when output is larger", () => {
+    // 1 MB -> 1.5 MB, +0.5 MB larger (50%)
+    const larger = formatSavings(1 * 1024 * 1024, 1.5 * 1024 * 1024);
+    assert.match(larger, /^\+512 KB larger \(50%\)$/);
+  });
+
+  it("reports 0% when sizes are equal", () => {
+    const equal = formatSavings(2048, 2048);
+    assert.equal(equal, "saved 0 B (0%)");
+  });
+
+  it("falls back to raw output size when input size is 0", () => {
+    // No meaningful percentage — just show the output.
+    assert.equal(formatSavings(0, 1024), "1.0 KB");
+  });
+});

--- a/extensions/media-converter/test/unit/media-types.test.ts
+++ b/extensions/media-converter/test/unit/media-types.test.ts
@@ -83,7 +83,9 @@ describe("getDefaultQuality", () => {
   };
 
   it("returns a GIF quality shape for .gif", () => {
-    const q = getDefaultQuality(".gif", { ...basePrefs }, "high") as { ".gif": { fps: string; width: string; loop: boolean } };
+    const q = getDefaultQuality(".gif", { ...basePrefs }, "high") as {
+      ".gif": { fps: string; width: string; loop: boolean };
+    };
     assert.ok(q[".gif"]);
     assert.ok(["10", "15", "24", "30"].includes(q[".gif"].fps));
     assert.ok(["original", "480", "720", "1080"].includes(q[".gif"].width));
@@ -91,11 +93,9 @@ describe("getDefaultQuality", () => {
   });
 
   it("honours defaultGifFps and defaultGifWidth preferences for .gif", () => {
-    const q = getDefaultQuality(
-      ".gif",
-      { ...basePrefs, defaultGifFps: "24", defaultGifWidth: "720" },
-      "high",
-    ) as { ".gif": { fps: string; width: string } };
+    const q = getDefaultQuality(".gif", { ...basePrefs, defaultGifFps: "24", defaultGifWidth: "720" }, "high") as {
+      ".gif": { fps: string; width: string };
+    };
     assert.equal(q[".gif"].fps, "24");
     assert.equal(q[".gif"].width, "720");
   });

--- a/extensions/media-converter/test/unit/media-types.test.ts
+++ b/extensions/media-converter/test/unit/media-types.test.ts
@@ -1,0 +1,169 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  getMediaType,
+  getOutputCategory,
+  getDefaultQuality,
+  OUTPUT_ALL_EXTENSIONS,
+  type AllOutputExtension,
+} from "../../src/types/media";
+// We intentionally don't import `../../src/utils/presets` here — it imports
+// `@raycast/api` at module load, which is only available inside Raycast.
+// Instead we validate the built-in presets JSON directly against the
+// schema contracts exposed by `../../src/types/media`.
+import builtInPresetsFile from "../../src/config/built-in-presets.json";
+
+type RawBuiltInPreset = {
+  id: string;
+  name: string;
+  mediaType: "image" | "video" | "audio" | "gif";
+  outputFormat: string;
+  quality: Record<string, unknown>;
+  stripMetadata?: boolean;
+  description?: string;
+};
+const builtInPresets = (builtInPresetsFile as { presets: RawBuiltInPreset[] }).presets;
+
+describe("getMediaType", () => {
+  it("detects common video extensions", () => {
+    assert.equal(getMediaType(".mp4"), "video");
+    assert.equal(getMediaType(".MOV"), "video");
+    assert.equal(getMediaType(".webm"), "video");
+  });
+
+  it("detects common audio extensions", () => {
+    assert.equal(getMediaType(".mp3"), "audio");
+    assert.equal(getMediaType(".flac"), "audio");
+  });
+
+  it("detects common image extensions", () => {
+    assert.equal(getMediaType(".jpg"), "image");
+    assert.equal(getMediaType(".png"), "image");
+    assert.equal(getMediaType(".heic"), "image");
+  });
+
+  it("returns null for unknown extensions", () => {
+    assert.equal(getMediaType(".xyz"), null);
+    assert.equal(getMediaType(""), null);
+  });
+});
+
+describe("getOutputCategory", () => {
+  it("puts .gif in its own category (not image)", () => {
+    assert.equal(getOutputCategory(".gif"), "gif");
+  });
+
+  it("recognises image outputs", () => {
+    assert.equal(getOutputCategory(".jpg"), "image");
+    assert.equal(getOutputCategory(".png"), "image");
+    assert.equal(getOutputCategory(".webp"), "image");
+  });
+
+  it("recognises audio outputs", () => {
+    assert.equal(getOutputCategory(".mp3"), "audio");
+    assert.equal(getOutputCategory(".flac"), "audio");
+  });
+
+  it("recognises video outputs", () => {
+    assert.equal(getOutputCategory(".mp4"), "video");
+    assert.equal(getOutputCategory(".mkv"), "video");
+  });
+});
+
+describe("getDefaultQuality", () => {
+  // Minimal preferences object for simple-mode defaults.
+  const basePrefs = {
+    moreConversionSettings: false,
+    defaultJpgQuality: "80",
+    defaultWebpQuality: "80",
+    defaultPngVariant: "png-24",
+    defaultHeicQuality: "80",
+    defaultTiffCompression: "deflate",
+    defaultAvifQuality: "80",
+  };
+
+  it("returns a GIF quality shape for .gif", () => {
+    const q = getDefaultQuality(".gif", { ...basePrefs }, "high") as { ".gif": { fps: string; width: string; loop: boolean } };
+    assert.ok(q[".gif"]);
+    assert.ok(["10", "15", "24", "30"].includes(q[".gif"].fps));
+    assert.ok(["original", "480", "720", "1080"].includes(q[".gif"].width));
+    assert.equal(typeof q[".gif"].loop, "boolean");
+  });
+
+  it("honours defaultGifFps and defaultGifWidth preferences for .gif", () => {
+    const q = getDefaultQuality(
+      ".gif",
+      { ...basePrefs, defaultGifFps: "24", defaultGifWidth: "720" },
+      "high",
+    ) as { ".gif": { fps: string; width: string } };
+    assert.equal(q[".gif"].fps, "24");
+    assert.equal(q[".gif"].width, "720");
+  });
+
+  it("returns image quality based on preferences", () => {
+    const q = getDefaultQuality(".jpg", { ...basePrefs, defaultJpgQuality: "70" }) as { ".jpg": number };
+    assert.equal(q[".jpg"], 70);
+  });
+
+  it("returns simple-mode audio quality for .mp3", () => {
+    const q = getDefaultQuality(".mp3", { ...basePrefs }, "high") as { ".mp3": { bitrate: string; vbr: boolean } };
+    assert.ok(q[".mp3"]);
+    assert.equal(typeof q[".mp3"].bitrate, "string");
+    assert.equal(typeof q[".mp3"].vbr, "boolean");
+  });
+
+  it("returns simple-mode video quality for .mp4", () => {
+    const q = getDefaultQuality(".mp4", { ...basePrefs }, "high") as { ".mp4": Record<string, unknown> };
+    assert.ok(q[".mp4"]);
+  });
+
+  it("throws when simple-mode is used without a quality level", () => {
+    assert.throws(() => getDefaultQuality(".mp4", { ...basePrefs }));
+  });
+});
+
+describe("built-in-presets.json", () => {
+  it("includes a non-empty set of curated presets", () => {
+    assert.ok(builtInPresets.length >= 5, `expected >=5 built-in presets, got ${builtInPresets.length}`);
+  });
+
+  it("every preset points at a valid output extension", () => {
+    for (const p of builtInPresets) {
+      assert.ok(
+        (OUTPUT_ALL_EXTENSIONS as readonly AllOutputExtension[]).includes(p.outputFormat as AllOutputExtension),
+        `preset ${p.id} has invalid outputFormat ${p.outputFormat}`,
+      );
+    }
+  });
+
+  it("has unique preset ids", () => {
+    const ids = builtInPresets.map((p) => p.id);
+    assert.equal(new Set(ids).size, ids.length, "preset ids must be unique");
+  });
+
+  it("quality shape exists for the declared outputFormat", () => {
+    for (const p of builtInPresets) {
+      assert.ok(p.quality[p.outputFormat] !== undefined, `preset ${p.id} has no quality entry for ${p.outputFormat}`);
+    }
+  });
+
+  it("mediaType is one of image|video|audio|gif", () => {
+    for (const p of builtInPresets) {
+      assert.ok(
+        ["image", "video", "audio", "gif"].includes(p.mediaType),
+        `preset ${p.id} has invalid mediaType ${p.mediaType}`,
+      );
+    }
+  });
+
+  it("gif presets declare the required fps/width/loop quality keys", () => {
+    for (const p of builtInPresets) {
+      if (p.outputFormat === ".gif") {
+        const q = p.quality[".gif"] as Record<string, unknown>;
+        assert.equal(typeof q.fps, "string", `preset ${p.id} .gif.fps must be a string`);
+        assert.equal(typeof q.width, "string", `preset ${p.id} .gif.width must be a string`);
+        assert.equal(typeof q.loop, "boolean", `preset ${p.id} .gif.loop must be a boolean`);
+      }
+    }
+  });
+});

--- a/extensions/media-converter/test/unit/merge.test.ts
+++ b/extensions/media-converter/test/unit/merge.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseStreamInfo, canStreamCopy, type StreamInfo } from "../../src/utils/merge";
+
+// Note: we deliberately use a simple pix_fmt without parenthesised color info
+// (e.g. `yuv420p` instead of `yuv420p(tv, bt709)`) — the current parser
+// regex doesn't support commas inside the pix_fmt segment.
+const SAMPLE_STDERR_MP4 = `
+Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'a.mp4':
+  Duration: 00:00:10.00, start: 0.000000, bitrate: 5000 kb/s
+    Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], 4700 kb/s, 30 fps, 30 tbr, 15360 tbn (default)
+    Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 192 kb/s (default)
+`;
+
+describe("parseStreamInfo", () => {
+  it("extracts duration, video codec/resolution/fps, and audio codec/sample rate/channels", () => {
+    const info = parseStreamInfo(SAMPLE_STDERR_MP4);
+    assert.equal(info.durationSec, 10);
+    assert.equal(info.videoCodec, "h264");
+    assert.equal(info.videoWidth, 1920);
+    assert.equal(info.videoHeight, 1080);
+    assert.equal(info.videoFps, 30);
+    assert.equal(info.audioCodec, "aac");
+    assert.equal(info.audioSampleRate, 48000);
+    assert.equal(info.audioChannels, 2);
+  });
+
+  it("handles mono audio layouts", () => {
+    const stderr = `  Duration: 00:00:01.00\n    Stream #0:0: Audio: mp3, 44100 Hz, mono, s16p, 64 kb/s`;
+    const info = parseStreamInfo(stderr);
+    assert.equal(info.audioCodec, "mp3");
+    assert.equal(info.audioSampleRate, 44100);
+    assert.equal(info.audioChannels, 1);
+  });
+
+  it("returns an empty-ish StreamInfo for unrelated text", () => {
+    const info = parseStreamInfo("no media metadata here");
+    assert.equal(info.durationSec, undefined);
+    assert.equal(info.videoCodec, undefined);
+    assert.equal(info.audioCodec, undefined);
+  });
+
+  it("extracts at least the video codec when the detail regex misses", () => {
+    const stderr = `Stream #0:0: Video: vp9, yuv420p`;
+    const info = parseStreamInfo(stderr);
+    assert.equal(info.videoCodec, "vp9");
+    assert.equal(info.videoWidth, undefined);
+  });
+});
+
+describe("canStreamCopy", () => {
+  const A: StreamInfo = {
+    videoCodec: "h264",
+    videoWidth: 1920,
+    videoHeight: 1080,
+    videoFps: 30,
+    audioCodec: "aac",
+    audioSampleRate: 48000,
+    audioChannels: 2,
+  };
+
+  it("returns true for identical streams", () => {
+    assert.equal(canStreamCopy([A, { ...A }]), true);
+  });
+
+  it("returns true for 3 identical streams", () => {
+    assert.equal(canStreamCopy([A, { ...A }, { ...A }]), true);
+  });
+
+  it("returns false when video codec differs", () => {
+    assert.equal(canStreamCopy([A, { ...A, videoCodec: "hevc" }]), false);
+  });
+
+  it("returns false when resolution differs", () => {
+    assert.equal(canStreamCopy([A, { ...A, videoWidth: 1280, videoHeight: 720 }]), false);
+  });
+
+  it("returns false when fps differs", () => {
+    assert.equal(canStreamCopy([A, { ...A, videoFps: 60 }]), false);
+  });
+
+  it("returns false when audio codec differs", () => {
+    assert.equal(canStreamCopy([A, { ...A, audioCodec: "mp3" }]), false);
+  });
+
+  it("returns false when audio sample rate differs", () => {
+    assert.equal(canStreamCopy([A, { ...A, audioSampleRate: 44100 }]), false);
+  });
+
+  it("returns false when audio channel count differs", () => {
+    assert.equal(canStreamCopy([A, { ...A, audioChannels: 1 }]), false);
+  });
+
+  it("returns false when one stream has audio and the other does not", () => {
+    const noAudio: StreamInfo = { ...A, audioCodec: undefined, audioSampleRate: undefined, audioChannels: undefined };
+    assert.equal(canStreamCopy([A, noAudio]), false);
+  });
+
+  it("returns false for a single stream (need at least 2 to merge)", () => {
+    assert.equal(canStreamCopy([A]), false);
+  });
+
+  it("returns false when a required field is missing (safety)", () => {
+    const incomplete: StreamInfo = { videoCodec: "h264" };
+    assert.equal(canStreamCopy([A, incomplete]), false);
+  });
+
+  it("tolerates tiny fps drift (< 0.1 fps)", () => {
+    assert.equal(canStreamCopy([A, { ...A, videoFps: 30.05 }]), true);
+  });
+});

--- a/extensions/media-converter/test/unit/merge.test.ts
+++ b/extensions/media-converter/test/unit/merge.test.ts
@@ -108,4 +108,51 @@ describe("canStreamCopy", () => {
   it("tolerates tiny fps drift (< 0.1 fps)", () => {
     assert.equal(canStreamCopy([A, { ...A, videoFps: 30.05 }]), true);
   });
+
+  describe("audio-only inputs", () => {
+    const AUDIO: StreamInfo = {
+      audioCodec: "mp3",
+      audioSampleRate: 44100,
+      audioChannels: 2,
+    };
+
+    it("returns true for two compatible audio-only streams", () => {
+      assert.equal(canStreamCopy([AUDIO, { ...AUDIO }]), true);
+    });
+
+    it("returns false when audio-only sample rates differ", () => {
+      assert.equal(canStreamCopy([AUDIO, { ...AUDIO, audioSampleRate: 48000 }]), false);
+    });
+
+    it("returns false when audio-only codecs differ", () => {
+      assert.equal(canStreamCopy([AUDIO, { ...AUDIO, audioCodec: "aac" }]), false);
+    });
+
+    it("returns false when one input has video and the other is audio-only", () => {
+      assert.equal(canStreamCopy([A, AUDIO]), false);
+      assert.equal(canStreamCopy([AUDIO, A]), false);
+    });
+  });
+});
+
+describe("concat list path escaping", () => {
+  // Mirrors the escape logic in mergeMedia (FFmpeg concat demuxer format,
+  // not shell). Backslashes first, then single quotes — both with `\` prefix.
+  const escape = (p: string) => p.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+
+  it("escapes single quotes with backslash (concat demuxer style, not shell)", () => {
+    assert.equal(escape("/Users/alice's files/clip.mp4"), "/Users/alice\\'s files/clip.mp4");
+  });
+
+  it("escapes backslashes before quotes so the order is correct", () => {
+    assert.equal(escape("a\\'b"), "a\\\\\\'b");
+  });
+
+  it("leaves vanilla paths untouched", () => {
+    assert.equal(escape("/Users/maia/Desktop/clip.mp4"), "/Users/maia/Desktop/clip.mp4");
+  });
+
+  it("does NOT produce shell-style escape sequences", () => {
+    assert.notEqual(escape("alice's"), "alice'\\''s");
+  });
 });

--- a/extensions/media-converter/test/unit/merge.test.ts
+++ b/extensions/media-converter/test/unit/merge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseStreamInfo, canStreamCopy, type StreamInfo } from "../../src/utils/merge";
+import { parseStreamInfo, canStreamCopy, buildReencodeConcatGraph, type StreamInfo } from "../../src/utils/merge";
 
 // Note: we deliberately use a simple pix_fmt without parenthesised color info
 // (e.g. `yuv420p` instead of `yuv420p(tv, bt709)`) — the current parser
@@ -154,5 +154,34 @@ describe("concat list path escaping", () => {
 
   it("does NOT produce shell-style escape sequences", () => {
     assert.notEqual(escape("alice's"), "alice'\\''s");
+  });
+});
+
+describe("buildReencodeConcatGraph", () => {
+  it("omits audio pads for video inputs without audio streams", () => {
+    const graph = buildReencodeConcatGraph(2, "video", [{ videoCodec: "h264" }, { videoCodec: "h264" }]);
+
+    assert.equal(graph.filter, "[0:v:0][1:v:0]concat=n=2:v=1:a=0[v]");
+    assert.equal(graph.mapArgs, ` -map "[v]"`);
+  });
+
+  it("keeps audio pads when every video input has audio", () => {
+    const graph = buildReencodeConcatGraph(2, "video", [
+      { videoCodec: "h264", audioCodec: "aac" },
+      { videoCodec: "h264", audioCodec: "aac" },
+    ]);
+
+    assert.equal(graph.filter, "[0:v:0][0:a:0][1:v:0][1:a:0]concat=n=2:v=1:a=1[v][a]");
+    assert.equal(graph.mapArgs, ` -map "[v]" -map "[a]"`);
+  });
+
+  it("omits audio pads when only some video inputs have audio", () => {
+    const graph = buildReencodeConcatGraph(2, "video", [
+      { videoCodec: "h264", audioCodec: "aac" },
+      { videoCodec: "h264" },
+    ]);
+
+    assert.equal(graph.filter, "[0:v:0][1:v:0]concat=n=2:v=1:a=0[v]");
+    assert.equal(graph.mapArgs, ` -map "[v]"`);
   });
 });

--- a/extensions/media-converter/test/unit/time.test.ts
+++ b/extensions/media-converter/test/unit/time.test.ts
@@ -1,0 +1,116 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseTimeString, formatTimeString, toFfmpegTime } from "../../src/utils/time";
+
+describe("parseTimeString", () => {
+  it("parses bare seconds (integer)", () => {
+    assert.equal(parseTimeString("90"), 90);
+  });
+
+  it("parses bare seconds (decimal)", () => {
+    assert.equal(parseTimeString("12.5"), 12.5);
+  });
+
+  it("parses MM:SS", () => {
+    assert.equal(parseTimeString("1:30"), 90);
+  });
+
+  it("parses MM:SS with leading zero", () => {
+    assert.equal(parseTimeString("01:30"), 90);
+  });
+
+  it("parses MM:SS with millisecond fraction", () => {
+    assert.equal(parseTimeString("01:30.250"), 90.25);
+  });
+
+  it("parses HH:MM:SS", () => {
+    assert.equal(parseTimeString("00:01:30"), 90);
+  });
+
+  it("parses HH:MM:SS with hours > 0", () => {
+    assert.equal(parseTimeString("1:02:03"), 1 * 3600 + 2 * 60 + 3);
+  });
+
+  it("parses HH:MM:SS.mmm", () => {
+    assert.equal(parseTimeString("00:00:10.500"), 10.5);
+  });
+
+  it("returns null for empty string", () => {
+    assert.equal(parseTimeString(""), null);
+  });
+
+  it("returns null for whitespace", () => {
+    assert.equal(parseTimeString("   "), null);
+  });
+
+  it("returns null for undefined/null", () => {
+    assert.equal(parseTimeString(undefined), null);
+    assert.equal(parseTimeString(null), null);
+  });
+
+  it("returns null for non-numeric input", () => {
+    assert.equal(parseTimeString("abc"), null);
+    assert.equal(parseTimeString("1:ab"), null);
+  });
+
+  it("returns null when a segment >= 60 in MM:SS", () => {
+    assert.equal(parseTimeString("1:60"), null);
+  });
+
+  it("returns null when a segment >= 60 in HH:MM:SS", () => {
+    assert.equal(parseTimeString("1:60:00"), null);
+    assert.equal(parseTimeString("1:00:60"), null);
+  });
+
+  it("returns null for negative values", () => {
+    assert.equal(parseTimeString("-1"), null);
+  });
+
+  it("returns null for 4+ segments", () => {
+    assert.equal(parseTimeString("1:2:3:4"), null);
+  });
+
+  it("trims surrounding whitespace", () => {
+    assert.equal(parseTimeString("  0:30  "), 30);
+  });
+});
+
+describe("formatTimeString", () => {
+  it("formats seconds < 60 as M:SS", () => {
+    assert.equal(formatTimeString(5), "0:05");
+    assert.equal(formatTimeString(59), "0:59");
+  });
+
+  it("formats minutes as M:SS", () => {
+    assert.equal(formatTimeString(90), "1:30");
+    assert.equal(formatTimeString(125), "2:05");
+  });
+
+  it("formats hours as H:MM:SS", () => {
+    assert.equal(formatTimeString(3600), "1:00:00");
+    assert.equal(formatTimeString(3665), "1:01:05");
+  });
+
+  it("handles 0 and negatives as 0:00", () => {
+    assert.equal(formatTimeString(0), "0:00");
+    assert.equal(formatTimeString(-5), "0:00");
+  });
+
+  it("handles non-finite as 0:00", () => {
+    assert.equal(formatTimeString(Number.NaN), "0:00");
+    assert.equal(formatTimeString(Number.POSITIVE_INFINITY), "0:00");
+  });
+});
+
+describe("toFfmpegTime", () => {
+  it("always uses HH:MM:SS.mmm with millisecond precision", () => {
+    assert.equal(toFfmpegTime(0), "00:00:00.000");
+    assert.equal(toFfmpegTime(1.5), "00:00:01.500");
+    assert.equal(toFfmpegTime(90), "00:01:30.000");
+    assert.equal(toFfmpegTime(3661.25), "01:01:01.250");
+  });
+
+  it("clamps negative inputs to 0", () => {
+    assert.equal(toFfmpegTime(-10), "00:00:00.000");
+  });
+});


### PR DESCRIPTION
## Description

This PR adds **nine new features** to the Media Converter extension, along with a comprehensive test suite.

### New features

- **Merge Media** — new command to concatenate multiple video or audio files into a single output. Automatically uses FFmpeg's fast stream-copy path when all inputs share codec/resolution/fps/sample-rate, and falls back to a full re-encode via the concat filter otherwise. A "Force re-encode" toggle is also available.
- **View Conversion History** — new command showing recent conversions grouped by day, with actions to Open the file, Show in Finder, Re-run with the same settings, Copy the FFmpeg command, Remove, or Clear all.
- **Manage Presets** — new command for browsing, creating, editing and deleting conversion presets. Ships with eight curated built-in presets (Web Image WebP/JPG 80, Email-friendly MP4, WhatsApp MP4, Podcast MP3, Lossless FLAC, Twitter/X GIF, Voice Memo M4A).
- **Trim / clip** — new Start / End fields in the Convert form accepting `HH:MM:SS[.mmm]` or bare seconds, with validation and a live preview of the resulting duration.
- **Animated GIF output** — `.gif` is now a selectable output format when converting a video, with configurable fps, width, and loop behaviour. Uses FFmpeg's `palettegen` + `paletteuse` pipeline for clean, low-size GIFs.
- **Live video conversion progress** — conversion toasts now stream real-time percent + ETA while FFmpeg works, instead of a static "Converting…" spinner.
- **Before/after size comparison** — success toasts now report savings, e.g. "saved 42 MB (58%)".
- **Custom output location** — new "Save to" dropdown and preferences let you choose same-folder-as-input, a preference-configured custom folder, or a per-run override.
- **Strip metadata** — new checkbox that wires `-map_metadata -1` through for video/audio/image outputs, plus a best-effort strip for HEIC via `sips`.

### AI tools

- New `merge-media` tool for merging files via natural-language prompts.
- Existing `convert-media` tool extended with `outputDir`, `stripMetadata`, `trimStart`, `trimEnd`, `presetId`, `gifFps`, `gifWidth`, `gifLoop` parameters.
- Added 7 new `ai.evals` entries covering the new parameters.

### New preferences

- Default GIF FPS
- Default GIF Width
- Default Output Location (same folder / custom folder)
- Custom Output Folder
- Strip Metadata By Default

### Tests

- 85 unit tests (Node's built-in test runner via `tsx`) covering time parsing, size formatting, FFmpeg stdout/stderr parsers, merge stream-info helpers, media type helpers, and built-in preset validation.
- 11 FFmpeg smoke tests that auto-generate tiny fixtures (via `testsrc`/`sine`/`color` filters, no binary fixtures in the repo) and exercise `convertMedia` + `mergeMedia` end-to-end.
- The smoke test caught and fixed a real bug: the re-encode merge path emitted a video+audio filter graph for audio-only inputs, which FFmpeg rejected with `Stream specifier ':v:0' matches no streams`.
- `TESTING.md` with a manual UI checklist for every command.

Run tests with `npm test` and `npm run test:smoke`.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
