### PR TITLE
Fix Markdown Navigator file indexing

### DIFF
--- a/extensions/markdown-navigator/CHANGELOG.md
+++ b/extensions/markdown-navigator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Markdown Navigator Changelog
 
-## [Fix Markdown File Indexing] - {PR_MERGE_DATE}
+## [Fix Markdown File Indexing] - 2026-04-24
 
 ### Fixed
 

--- a/extensions/markdown-navigator/CHANGELOG.md
+++ b/extensions/markdown-navigator/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Markdown Navigator Changelog
 
+## [Fix Markdown File Indexing] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Fixed incomplete Markdown file indexing by recursively scanning supported Markdown files instead of relying on Spotlight search results.
+- Fixed search missing files beyond the initial 50-file load by searching across the complete indexed file list.
+- Fixed refresh behavior to clear stale cached file indexes before reloading files.
+- Fixed broad folder indexing to skip macOS user Library folders and VS Code history files without excluding regular note folders named `Library`.
+
+### Changed
+
+- Removed the "Load More Files" flow; large file collections now use pagination over the complete Markdown index.
+
 ## [Maintenance] - 2025-05-16
 
 - Remove duplicate files

--- a/extensions/markdown-navigator/CHANGELOG.md
+++ b/extensions/markdown-navigator/CHANGELOG.md
@@ -8,10 +8,12 @@
 - Fixed search missing files beyond the initial 50-file load by searching across the complete indexed file list.
 - Fixed refresh behavior to clear stale cached file indexes before reloading files.
 - Fixed broad folder indexing to skip macOS user Library folders and VS Code history files without excluding regular note folders named `Library`.
+- Fixed indexing resilience so a single deleted or inaccessible Markdown file no longer clears the whole file list.
 
 ### Changed
 
 - Removed the "Load More Files" flow; large file collections now use pagination over the complete Markdown index.
+- Changed recursive folder indexing to use asynchronous filesystem reads.
 
 ## [Maintenance] - 2025-05-16
 

--- a/extensions/markdown-navigator/README.md
+++ b/extensions/markdown-navigator/README.md
@@ -9,14 +9,14 @@ A powerful Raycast extension for managing and navigating your Markdown files wit
 
 ## Features
 
-- **Fast File Browsing**: Quickly browse and search through all your Markdown files
+- **Complete File Indexing**: Recursively indexes all supported Markdown files in your configured directory
 - **Pagination**: Navigate through large collections of files with easy pagination
 - **Tag Filtering**: Filter files by tags extracted from your Markdown content
 - **Color-coded Tags**: Visually identify important, draft, complete, review, and archive tags
 - **Folder Organization**: Files are automatically grouped by folder for better organization
 - **File Management**: Create, open, delete, and move files to trash directly from Raycast
 - **Editor Integration**: Open files in your preferred Markdown editor, including Typora
-- **Progressive Loading**: Initially loads a subset of files for performance, with option to load more as needed
+- **Full Search Coverage**: Search always runs across the complete Markdown file index
 
 ## Installation
 
@@ -42,7 +42,6 @@ The extension requires a valid Markdown directory to be set in preferences:
 - **Search**: Type to search for file names or folders
 - **Browse**: Use arrow keys to navigate through the list
 - **Pagination**: Use `⌘` + `←` and `⌘` + `→` to navigate between pages
-- **Load More Files**: Press `⌘` + `⇧` + `M` to load more files when needed
 
 ### File Actions
 
@@ -108,17 +107,19 @@ The extension requires a valid Markdown directory to be set in preferences:
 ### Other Actions
 
 - **Refresh List**: Press `⌘` + `R` to refresh the file list
-- **Load More Files**: Press `⌘` + `⇧` + `M` to load more files
 - **Open Preferences**: Press `⌘` + `⇧` + `P` to open extension preferences
 
 ## Performance Considerations
 
-The extension initially loads a limited number of files for better performance. If you have a large collection of Markdown files, you can:
+The extension indexes all supported Markdown files in your configured directory, then displays them with pagination for easier browsing. If you have a large collection of Markdown files, you can:
 
-1. Use the "Load More Files" action to progressively load more files (initially loads 50 files, with increments of 50)
-2. Use search and tag filtering to narrow down results
-3. Navigate through pages to browse all loaded files (20 files per page)
-4. View the loading status in the footer to see how many files are loaded
+1. Use search and tag filtering to narrow down results
+2. Navigate through pages to browse indexed files (20 files per page)
+3. Press `⌘` + `R` to refresh the index after adding, renaming, or deleting files outside Raycast
+
+Supported Markdown extensions are `.md`, `.markdown`, `.mdown`, and `.mkd`. Plain text files such as `.txt` are not indexed.
+
+The indexer skips hidden folders, `node_modules`, macOS user Library folders during broad scans, and VS Code history files. Regular note folders named `Library` are still indexed.
 
 ## Requirements
 
@@ -133,4 +134,3 @@ If you encounter any issues or have suggestions for improvements, please submit 
 ## License
 
 MIT
-

--- a/extensions/markdown-navigator/README.md
+++ b/extensions/markdown-navigator/README.md
@@ -111,7 +111,7 @@ The extension requires a valid Markdown directory to be set in preferences:
 
 ## Performance Considerations
 
-The extension indexes all supported Markdown files in your configured directory, then displays them with pagination for easier browsing. If you have a large collection of Markdown files, you can:
+The extension asynchronously indexes all supported Markdown files in your configured directory, then displays them with pagination for easier browsing. If you have a large collection of Markdown files, you can:
 
 1. Use search and tag filtering to narrow down results
 2. Navigate through pages to browse indexed files (20 files per page)
@@ -119,7 +119,7 @@ The extension indexes all supported Markdown files in your configured directory,
 
 Supported Markdown extensions are `.md`, `.markdown`, `.mdown`, and `.mkd`. Plain text files such as `.txt` are not indexed.
 
-The indexer skips hidden folders, `node_modules`, macOS user Library folders during broad scans, and VS Code history files. Regular note folders named `Library` are still indexed.
+The indexer skips hidden folders, `node_modules`, macOS user Library folders during broad scans, and VS Code history files. Regular note folders named `Library` are still indexed. If an individual Markdown file disappears or becomes inaccessible during indexing, it is skipped while the remaining files stay available.
 
 ## Requirements
 

--- a/extensions/markdown-navigator/package.json
+++ b/extensions/markdown-navigator/package.json
@@ -7,10 +7,10 @@
   "author": "chihkang",
   "categories": [
     "Productivity",
-    "Documentation"    
+    "Documentation"
   ],
   "license": "MIT",
-  "commands": [  
+  "commands": [
     {
       "name": "markdown-navigator",
       "title": "Markdown Navigator",
@@ -18,7 +18,7 @@
       "mode": "view",
       "subtitle": "Markdown",
       "icon": "extension-icon.png"
-    }    
+    }
   ],
   "dependencies": {
     "@raycast/api": "^1.93.2",
@@ -41,7 +41,7 @@
     "publish": "npx @raycast/api@latest publish"
   },
   "preferences": [
-    {      
+    {
       "name": "markdownDir",
       "title": "Markdown Files Directory",
       "description": "Specify the directory path for storing Markdown files",
@@ -57,5 +57,8 @@
       "placeholder": "Visual Studio Code, TextEdit, iA Writer, etc.",
       "required": false
     }
+  ],
+  "platforms": [
+    "macOS"
   ]
 }

--- a/extensions/markdown-navigator/src/components/ActionComponents.tsx
+++ b/extensions/markdown-navigator/src/components/ActionComponents.tsx
@@ -11,8 +11,6 @@ interface CommonActionsProps {
   showTagSearchList: () => void;
 }
 
-// Removed loadMoreFiles from CommonActionsProps since it has its own component
-
 export function CommonActions({
   showCreateFileForm,
   revalidate,
@@ -48,19 +46,6 @@ export function CommonActions({
           onAction={() => setShowColorTags(!showColorTags)}
         />
       </ActionPanel.Section>
-    </ActionPanel>
-  );
-}
-
-// Create a separate interface for LoadMoreAction to avoid dependency on CommonActionsProps
-interface LoadMoreActionProps {
-  loadMoreFiles: () => void;
-}
-
-export function LoadMoreAction({ loadMoreFiles }: LoadMoreActionProps) {
-  return (
-    <ActionPanel>
-      <Action title="Load More Files" icon={Icon.Plus} onAction={loadMoreFiles} />
     </ActionPanel>
   );
 }

--- a/extensions/markdown-navigator/src/components/FileListItem.tsx
+++ b/extensions/markdown-navigator/src/components/FileListItem.tsx
@@ -30,7 +30,6 @@ interface FileListItemProps {
   totalPages: number;
   setCurrentPage: (page: number) => void;
   markdownDir: string;
-  loadMoreFiles: () => void;
   showCreateFileForm: () => void;
   showTagSearchList: () => void;
   selectedTag: string | null;
@@ -88,7 +87,6 @@ export function FileListItem({
   totalPages,
   setCurrentPage,
   markdownDir,
-  loadMoreFiles,
   showCreateFileForm,
   showTagSearchList,
   selectedTag,
@@ -286,12 +284,6 @@ export function FileListItem({
               icon={Icon.RotateClockwise}
               shortcut={{ modifiers: ["cmd"], key: "r" }}
               onAction={revalidate}
-            />
-            <Action
-              title="Load More Files"
-              icon={Icon.Plus}
-              shortcut={{ modifiers: ["cmd", "shift"], key: "m" }}
-              onAction={loadMoreFiles}
             />
           </ActionPanel.Section>
 

--- a/extensions/markdown-navigator/src/components/PaginationSection.tsx
+++ b/extensions/markdown-navigator/src/components/PaginationSection.tsx
@@ -7,7 +7,6 @@ interface PaginationSectionProps {
   setCurrentPage: (page: number) => void;
   revalidate: () => void;
   pageInfoText: string;
-  loadMoreFiles: () => void;
   showTagSearchList: () => void;
   selectedTag: string | null;
   setSelectedTag: (tag: string | null) => void;
@@ -21,7 +20,6 @@ export function PaginationSection({
   setCurrentPage,
   revalidate,
   pageInfoText,
-  loadMoreFiles,
   showTagSearchList,
   selectedTag,
   setSelectedTag,
@@ -75,12 +73,6 @@ export function PaginationSection({
               icon={Icon.RotateClockwise}
               shortcut={{ modifiers: ["cmd"], key: "r" }}
               onAction={revalidate}
-            />
-            <Action
-              title="Load More Files"
-              icon={Icon.Plus}
-              shortcut={{ modifiers: ["cmd", "shift"], key: "m" }}
-              onAction={loadMoreFiles}
             />
           </ActionPanel>
         }

--- a/extensions/markdown-navigator/src/markdown-navigator.tsx
+++ b/extensions/markdown-navigator/src/markdown-navigator.tsx
@@ -1,4 +1,4 @@
-import { List, showToast, Toast, Icon, getPreferenceValues, useNavigation } from "@raycast/api";
+import { List, Icon, getPreferenceValues, useNavigation } from "@raycast/api";
 import { usePromise, showFailureToast } from "@raycast/utils";
 import { useState, useEffect, useCallback, useMemo } from "react";
 import fs from "fs";
@@ -8,7 +8,7 @@ import { groupFilesByFolder } from "./utils/groupOperations";
 import { CreateFileForm } from "./components/CreateFileForm";
 import { FileListItem } from "./components/FileListItem";
 import { PaginationSection } from "./components/PaginationSection";
-import { CommonActions, LoadMoreAction } from "./components/ActionComponents";
+import { CommonActions } from "./components/ActionComponents";
 import { MarkdownEmptyView } from "./components/MarkdownEmptyView";
 import { TagSearchList } from "./components/TagSearchList";
 import path from "path";
@@ -17,8 +17,6 @@ import { getTagTintColor } from "./utils/tagColorUtils";
 export const markdownDir = getPreferenceValues<{ markdownDir: string }>().markdownDir;
 
 const ITEMS_PER_PAGE = 20;
-const INITIAL_LOAD_LIMIT = 50;
-const LOAD_INCREMENT = 50;
 
 export default function Command() {
   const { push } = useNavigation();
@@ -27,8 +25,6 @@ export default function Command() {
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [showColorTags, setShowColorTags] = useState(true);
   const [selectedFolder, setSelectedFolder] = useState<string>("");
-  const [loadLimit, setLoadLimit] = useState<number>(INITIAL_LOAD_LIMIT);
-  const [totalFiles, setTotalFiles] = useState<number>(0);
   const [rootDirectory, setRootDirectory] = useState<string>(markdownDir);
 
   // Extracted shared function for directory validation
@@ -52,33 +48,13 @@ export default function Command() {
     }
   }, [markdownDir, isValidMarkdownDir]);
 
-  // Initialize total files count
-  useEffect(() => {
-    const getTotalFiles = async () => {
-      try {
-        if (!isValidMarkdownDir()) {
-          console.log("Skipping file count");
-          return;
-        }
-
-        const allFiles = await getMarkdownFiles();
-        setTotalFiles(allFiles.length);
-        console.log(`Total files in ${markdownDir}: ${allFiles.length}`);
-      } catch (error) {
-        console.error(`Error getting total files from ${markdownDir}:`, error);
-      }
-    };
-
-    getTotalFiles();
-  }, [markdownDir, isValidMarkdownDir]);
-
   // Define the fetch function
   const fetchMarkdownFiles = useCallback(async () => {
-    console.log(`Fetching files with limit: ${loadLimit}`);
-    const files = await getMarkdownFiles(loadLimit);
-    console.log(`Loaded ${files.length} files, limit: ${loadLimit}, total: ${totalFiles}`);
+    console.log("Fetching Markdown files");
+    const files = await getMarkdownFiles();
+    console.log(`Loaded ${files.length} files`);
     return files;
-  }, [loadLimit, totalFiles]);
+  }, []);
 
   // Get the Markdown files
   const { data, isLoading, error, revalidate } = usePromise(fetchMarkdownFiles, [], {
@@ -91,11 +67,6 @@ export default function Command() {
       showFailureToast("Loading Markdown files failed", error);
     }
   }, [error]);
-
-  // Reload files when loadLimit changes
-  useEffect(() => {
-    revalidate();
-  }, [loadLimit, revalidate]);
 
   // Filtering and paging data
   const filteredData = useMemo(() => {
@@ -112,6 +83,7 @@ export default function Command() {
   console.log("Filtered data count:", filteredData.length);
 
   const totalPages = Math.ceil(filteredData.length / ITEMS_PER_PAGE);
+  const totalFiles = data?.length ?? 0;
 
   const paginatedData = useMemo(() => {
     return filteredData.slice(currentPage * ITEMS_PER_PAGE, (currentPage + 1) * ITEMS_PER_PAGE);
@@ -164,31 +136,6 @@ export default function Command() {
     }
   }, [data, rootDirectory, markdownDir]);
 
-  // Load more files action
-  const loadMoreFiles = useCallback(() => {
-    if (loadLimit < totalFiles) {
-      setLoadLimit((prevLimit) => {
-        const newLimit = prevLimit + LOAD_INCREMENT;
-        console.log(`Increasing load limit from ${prevLimit} to ${newLimit}`);
-
-        // Display a Toast after the status is updated
-        showToast({
-          style: Toast.Style.Success,
-          title: "Loading more files",
-          message: `Increasing limit from ${prevLimit} to ${newLimit}`,
-        });
-
-        return newLimit;
-      });
-    } else {
-      showToast({
-        style: Toast.Style.Failure,
-        title: "All files loaded",
-        message: `Already loaded all ${totalFiles} files`,
-      });
-    }
-  }, [loadLimit, totalFiles]);
-
   // Handle tag selection
   const handleTagSelect = useCallback((tag: string) => {
     setSelectedTag(tag || null);
@@ -204,8 +151,7 @@ export default function Command() {
   const commonActionsProps = useMemo(
     () => ({
       showCreateFileForm,
-      revalidate,
-      loadMoreFiles,
+      revalidate: forceRevalidate,
       showColorTags,
       setShowColorTags,
       selectedTag,
@@ -214,8 +160,7 @@ export default function Command() {
     }),
     [
       showCreateFileForm,
-      revalidate,
-      loadMoreFiles,
+      forceRevalidate,
       showColorTags,
       setShowColorTags,
       selectedTag,
@@ -226,20 +171,6 @@ export default function Command() {
 
   // Common actions for both main view and empty view
   const commonActions = <CommonActions {...commonActionsProps} />;
-
-  // Add a footer section to display load status
-  const renderFooter = useCallback(() => {
-    if (loadLimit < totalFiles) {
-      return (
-        <List.Item
-          title={`Loaded ${loadLimit} of ${totalFiles} files`}
-          icon={Icon.Plus}
-          actions={<LoadMoreAction loadMoreFiles={loadMoreFiles} />}
-        />
-      );
-    }
-    return null;
-  }, [loadLimit, totalFiles, loadMoreFiles]);
 
   const handleSearchTextChange = useCallback((text: string) => {
     setSearchText(text);
@@ -316,9 +247,8 @@ export default function Command() {
               currentPage={currentPage}
               totalPages={totalPages}
               setCurrentPage={setCurrentPage}
-              revalidate={revalidate}
+              revalidate={forceRevalidate}
               pageInfoText={pageInfoText}
-              loadMoreFiles={loadMoreFiles}
               showTagSearchList={showTagSearchList}
               selectedTag={selectedTag}
               setSelectedTag={setSelectedTag}
@@ -336,12 +266,11 @@ export default function Command() {
                   file={file}
                   showColorTags={showColorTags}
                   setShowColorTags={setShowColorTags}
-                  revalidate={revalidate}
+                  revalidate={forceRevalidate}
                   currentPage={currentPage}
                   totalPages={totalPages}
                   setCurrentPage={setCurrentPage}
                   markdownDir={rootDirectory}
-                  loadMoreFiles={loadMoreFiles}
                   showCreateFileForm={showCreateFileForm}
                   showTagSearchList={showTagSearchList}
                   selectedTag={selectedTag}
@@ -350,9 +279,6 @@ export default function Command() {
               ))}
             </List.Section>
           ))}
-
-          {/* Load more footer */}
-          {renderFooter()}
         </>
       ) : (
         <MarkdownEmptyView

--- a/extensions/markdown-navigator/src/utils/fileOperations.ts
+++ b/extensions/markdown-navigator/src/utils/fileOperations.ts
@@ -2,21 +2,32 @@ import { showToast, Toast, getPreferenceValues, trash as raycastTrash } from "@r
 import { exec } from "child_process";
 import { promisify } from "util";
 import fs from "fs";
+import { homedir } from "os";
 import path from "path";
 import { MarkdownFile } from "../types/markdownTypes";
 import { extractTags } from "./tagOperations";
-import { markdownDir } from "../markdown-navigator";
 import { LocalStorage } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 
 const execAsync = promisify(exec);
 const CACHE_KEY = "markdownFilesCache";
+const CACHE_VERSION = 2;
 const CACHE_EXPIRY = 3600000; // one hour
+const MARKDOWN_EXTENSIONS = new Set([".md", ".markdown", ".mdown", ".mkd"]);
+const IGNORED_DIRECTORY_NAMES = new Set(["node_modules"]);
+const VS_CODE_HISTORY_PATH_SEGMENTS = ["Library", "Application Support", "Code", "User", "History"];
 
 // Get preferences for default editor
 interface Preferences {
   markdownDir: string;
   defaultEditor: string;
+}
+
+interface MarkdownFilesCache {
+  version: number;
+  markdownDir: string;
+  files: MarkdownFile[];
+  timestamp: number;
 }
 
 // Clear the markdown files cache
@@ -41,9 +52,95 @@ export async function checkEditorExists(editor: string): Promise<boolean> {
   }
 }
 
-// Get the Markdown file with optional limit
-export async function getMarkdownFiles(limit?: number): Promise<MarkdownFile[]> {
+const isPathSameOrInside = (targetPath: string, parentPath: string): boolean => {
+  const relativePath = path.relative(path.resolve(parentPath), path.resolve(targetPath));
+  return relativePath === "" || (!!relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+};
+
+const pathEndsWithSegments = (targetPath: string, segments: string[]): boolean => {
+  const targetSegments = path.resolve(targetPath).split(path.sep).filter(Boolean);
+  if (targetSegments.length < segments.length) {
+    return false;
+  }
+
+  return segments.every((segment, index) => {
+    return targetSegments[targetSegments.length - segments.length + index] === segment;
+  });
+};
+
+export const shouldIgnoreScanPath = (entryPath: string, rootDirectory: string): boolean => {
+  const directoryName = path.basename(entryPath);
+  if (directoryName.startsWith(".") || IGNORED_DIRECTORY_NAMES.has(directoryName)) {
+    return true;
+  }
+
+  if (pathEndsWithSegments(entryPath, VS_CODE_HISTORY_PATH_SEGMENTS)) {
+    return true;
+  }
+
+  const homeDirectory = homedir();
+  const userLibraryPath = path.join(homeDirectory, "Library");
+  return isPathSameOrInside(homeDirectory, rootDirectory) && path.resolve(entryPath) === path.resolve(userLibraryPath);
+};
+
+const isMarkdownFile = (filePath: string): boolean => {
+  return MARKDOWN_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+};
+
+function scanMarkdownFilePathsInDirectory(directory: string, rootDirectory: string): string[] {
+  const filePaths: string[] = [];
+  let entries: fs.Dirent[];
+
   try {
+    entries = fs.readdirSync(directory, { withFileTypes: true });
+  } catch (error) {
+    console.warn(`Unable to scan directory ${directory}:`, error);
+    return filePaths;
+  }
+
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name, "en-US"))) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (!shouldIgnoreScanPath(entryPath, rootDirectory)) {
+        filePaths.push(...scanMarkdownFilePathsInDirectory(entryPath, rootDirectory));
+      }
+      continue;
+    }
+
+    if (entry.isFile() && isMarkdownFile(entryPath)) {
+      filePaths.push(entryPath);
+    }
+  }
+
+  return filePaths;
+}
+
+export function scanMarkdownFilePaths(directory: string): string[] {
+  const rootDirectory = path.resolve(directory);
+  return scanMarkdownFilePathsInDirectory(rootDirectory, rootDirectory);
+}
+
+function toMarkdownFile(filePath: string, rootDirectory: string): MarkdownFile {
+  const stats = fs.statSync(filePath);
+  const dirname = path.dirname(filePath);
+  const folder = path.relative(rootDirectory, dirname) || path.basename(dirname);
+
+  return {
+    path: filePath,
+    name: path.basename(filePath),
+    lastModified: stats.mtime.getTime(),
+    folder: folder,
+    tags: extractTags(filePath),
+    size: stats.size,
+  };
+}
+
+// Get Markdown files from the configured directory.
+export async function getMarkdownFiles(): Promise<MarkdownFile[]> {
+  try {
+    const { markdownDir } = getPreferenceValues<Preferences>();
+
     if (!markdownDir || !fs.existsSync(markdownDir)) {
       throw new Error("Markdown directory is not set or invalid");
     }
@@ -51,106 +148,43 @@ export async function getMarkdownFiles(limit?: number): Promise<MarkdownFile[]> 
     const cached = await LocalStorage.getItem<string>(CACHE_KEY);
     const now = Date.now();
 
-    if (cached && !limit) {
-      const { files, timestamp } = JSON.parse(cached);
-      if (now - timestamp < CACHE_EXPIRY) {
-        console.log("Using cached files");
-        return files;
-      }
-    }
-
-    // Use the mdfind command to search within markdownDir
-    const { stdout } = await execAsync(
-      `mdfind -onlyin "${markdownDir}" "kind:markdown" | grep -v "/Library/Application Support/Code/User/History/" | grep -v "node_modules"`,
-    );
-
-    let filePaths = stdout.split("\n").filter(Boolean);
-    console.log(`Found ${filePaths.length} Markdown files using mdfind in ${markdownDir}`);
-
-    if (limit && filePaths.length > limit) {
-      filePaths = filePaths.slice(0, limit);
-      console.log(`Limited to ${limit} files`);
-    }
-
-    const files: MarkdownFile[] = [];
-
-    for (const filePath of filePaths) {
+    if (cached) {
       try {
-        if (fs.existsSync(filePath)) {
-          const stats = fs.statSync(filePath);
-          const dirname = path.dirname(filePath);
-          const folder = path.relative(markdownDir, dirname) || path.basename(dirname);
-
-          files.push({
-            path: filePath,
-            name: path.basename(filePath),
-            lastModified: stats.mtime.getTime(),
-            folder: folder,
-            tags: extractTags(filePath),
-            size: stats.size,
-          });
-          console.log(`Processed file: ${filePath}, folder: ${folder}`);
-        } else {
-          console.warn(`File not found: ${filePath}`);
+        const cache = JSON.parse(cached) as Partial<MarkdownFilesCache>;
+        if (
+          cache.version === CACHE_VERSION &&
+          cache.markdownDir === markdownDir &&
+          Array.isArray(cache.files) &&
+          typeof cache.timestamp === "number" &&
+          now - cache.timestamp < CACHE_EXPIRY
+        ) {
+          console.log("Using cached files");
+          return cache.files;
         }
       } catch (error) {
-        console.error(`Error processing file ${filePath}:`, error);
+        console.warn("Ignoring invalid Markdown files cache:", error);
       }
     }
+
+    const filePaths = scanMarkdownFilePaths(markdownDir);
+    console.log(`Found ${filePaths.length} Markdown files in ${markdownDir}`);
+
+    const files = filePaths.map((filePath) => toMarkdownFile(filePath, markdownDir));
 
     // Sort by last modified time, with the latest one first
-    const sortedFiles = files.sort((a, b) => b.lastModified - a.lastModified);
-    if (!limit) {
-      await LocalStorage.setItem(CACHE_KEY, JSON.stringify({ files: sortedFiles, timestamp: now }));
-    }
+    const sortedFiles = files.sort((a, b) => b.lastModified - a.lastModified || a.path.localeCompare(b.path, "en-US"));
+    await LocalStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ version: CACHE_VERSION, markdownDir, files: sortedFiles, timestamp: now }),
+    );
     return sortedFiles;
   } catch (error) {
-    console.error("Error while searching for Markdown files with mdfind:", error);
-
-    // Fallback to find command
-    try {
-      console.log("Falling back to find command");
-      const { stdout } = await execAsync(
-        `find "${markdownDir}" -name "*.md" -type f -not -path "*/\\.*" -not -path "*/node_modules/*" -not -path "*/Library/*"`,
-      );
-
-      let filePaths = stdout.split("\n").filter(Boolean);
-      console.log(`Found ${filePaths.length} Markdown files using find in ${markdownDir}`);
-
-      if (limit && filePaths.length > limit) {
-        filePaths = filePaths.slice(0, limit);
-        console.log(`Limited to ${limit} files`);
-      }
-
-      const files = filePaths.map((filePath) => {
-        const stats = fs.statSync(filePath);
-        const dirname = path.dirname(filePath);
-        const folder = path.relative(markdownDir, dirname) || path.basename(dirname);
-
-        return {
-          path: filePath,
-          name: path.basename(filePath),
-          lastModified: stats.mtime.getTime(),
-          folder: folder,
-          tags: extractTags(filePath),
-          size: stats.size,
-        };
-      });
-
-      const sortedFiles = files.sort((a, b) => b.lastModified - a.lastModified);
-      if (!limit) {
-        const now = Date.now();
-        await LocalStorage.setItem(CACHE_KEY, JSON.stringify({ files: sortedFiles, timestamp: now }));
-      }
-      return sortedFiles;
-    } catch (fallbackError) {
-      console.error("Alternative method also failed:", fallbackError);
-      showFailureToast({
-        title: "Failed to load Markdown files",
-        message: "Both mdfind and find commands failed. Check console for details.",
-      });
-      return [];
-    }
+    console.error("Error while scanning Markdown files:", error);
+    showFailureToast({
+      title: "Failed to load Markdown files",
+      message: error instanceof Error ? error.message : "Check console for details.",
+    });
+    return [];
   }
 }
 

--- a/extensions/markdown-navigator/src/utils/fileOperations.ts
+++ b/extensions/markdown-navigator/src/utils/fileOperations.ts
@@ -87,12 +87,12 @@ const isMarkdownFile = (filePath: string): boolean => {
   return MARKDOWN_EXTENSIONS.has(path.extname(filePath).toLowerCase());
 };
 
-function scanMarkdownFilePathsInDirectory(directory: string, rootDirectory: string): string[] {
+async function scanMarkdownFilePathsInDirectory(directory: string, rootDirectory: string): Promise<string[]> {
   const filePaths: string[] = [];
   let entries: fs.Dirent[];
 
   try {
-    entries = fs.readdirSync(directory, { withFileTypes: true });
+    entries = await fs.promises.readdir(directory, { withFileTypes: true });
   } catch (error) {
     console.warn(`Unable to scan directory ${directory}:`, error);
     return filePaths;
@@ -103,7 +103,7 @@ function scanMarkdownFilePathsInDirectory(directory: string, rootDirectory: stri
 
     if (entry.isDirectory()) {
       if (!shouldIgnoreScanPath(entryPath, rootDirectory)) {
-        filePaths.push(...scanMarkdownFilePathsInDirectory(entryPath, rootDirectory));
+        filePaths.push(...(await scanMarkdownFilePathsInDirectory(entryPath, rootDirectory)));
       }
       continue;
     }
@@ -116,24 +116,29 @@ function scanMarkdownFilePathsInDirectory(directory: string, rootDirectory: stri
   return filePaths;
 }
 
-export function scanMarkdownFilePaths(directory: string): string[] {
+export function scanMarkdownFilePaths(directory: string): Promise<string[]> {
   const rootDirectory = path.resolve(directory);
   return scanMarkdownFilePathsInDirectory(rootDirectory, rootDirectory);
 }
 
-function toMarkdownFile(filePath: string, rootDirectory: string): MarkdownFile {
-  const stats = fs.statSync(filePath);
-  const dirname = path.dirname(filePath);
-  const folder = path.relative(rootDirectory, dirname) || path.basename(dirname);
+async function toMarkdownFileOrNull(filePath: string, rootDirectory: string): Promise<MarkdownFile | null> {
+  try {
+    const stats = await fs.promises.stat(filePath);
+    const dirname = path.dirname(filePath);
+    const folder = path.relative(rootDirectory, dirname) || path.basename(dirname);
 
-  return {
-    path: filePath,
-    name: path.basename(filePath),
-    lastModified: stats.mtime.getTime(),
-    folder: folder,
-    tags: extractTags(filePath),
-    size: stats.size,
-  };
+    return {
+      path: filePath,
+      name: path.basename(filePath),
+      lastModified: stats.mtime.getTime(),
+      folder: folder,
+      tags: extractTags(filePath),
+      size: stats.size,
+    };
+  } catch (error) {
+    console.warn(`Skipping inaccessible Markdown file ${filePath}:`, error);
+    return null;
+  }
 }
 
 // Get Markdown files from the configured directory.
@@ -166,10 +171,16 @@ export async function getMarkdownFiles(): Promise<MarkdownFile[]> {
       }
     }
 
-    const filePaths = scanMarkdownFilePaths(markdownDir);
+    const filePaths = await scanMarkdownFilePaths(markdownDir);
     console.log(`Found ${filePaths.length} Markdown files in ${markdownDir}`);
 
-    const files = filePaths.map((filePath) => toMarkdownFile(filePath, markdownDir));
+    const files: MarkdownFile[] = [];
+    for (const filePath of filePaths) {
+      const file = await toMarkdownFileOrNull(filePath, markdownDir);
+      if (file) {
+        files.push(file);
+      }
+    }
 
     // Sort by last modified time, with the latest one first
     const sortedFiles = files.sort((a, b) => b.lastModified - a.lastModified || a.path.localeCompare(b.path, "en-US"));


### PR DESCRIPTION
## Description

Fixes #27385.

Markdown Navigator could report an incomplete file index for larger folders because the command only searched the initially loaded file subset and relied on Spotlight-backed `mdfind` results. This update switches indexing to a deterministic recursive filesystem scan, searches across the complete indexed file list, and keeps pagination only for display.

The scanner now supports `.md`, `.markdown`, `.mdown`, and `.mkd` files while avoiding noisy or expensive paths such as hidden folders, `node_modules`, macOS user Library folders during broad scans, and VS Code history files. Regular note folders named `Library` are still indexed.

## Screencast

Not included. This is a bug fix for file indexing behavior.

## Validation

- `npm run lint`
- `npm run build`
- Fixture check with 120 nested Markdown files, unsupported `.txt`, hidden folders, `node_modules`, VS Code history, and a regular `notes/Library` folder

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
