### PR TITLE
Fix aerospace window switcher search to match on window title

### DIFF
--- a/extensions/aerospace/CHANGELOG.md
+++ b/extensions/aerospace/CHANGELOG.md
@@ -1,5 +1,9 @@
 # aerospace Changelog
 
+## [Fix] - 2026-04-24
+
+- Fix window switcher search to match on both app name and window title, enabling fuzzy finding by title keywords (e.g. searching "huddle" now finds Slack Huddle windows)
+
 ## [Feature] - 2026-04-22
 
 - Add "Set to Tiling" action to window switcher (Cmd+T) — converts a floating window to tiling layout via `aerospace layout tiling`

--- a/extensions/aerospace/CHANGELOG.md
+++ b/extensions/aerospace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # aerospace Changelog
 
-## [Fix] - 2026-04-24
+## [Fix] - {PR_MERGE_DATE}
 
 - Fix window switcher search to match on both app name and window title, enabling fuzzy finding by title keywords (e.g. searching "huddle" now finds Slack Huddle windows)
 

--- a/extensions/aerospace/CHANGELOG.md
+++ b/extensions/aerospace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # aerospace Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-04-24
 
 - Fix window switcher search to match on both app name and window title, enabling fuzzy finding by title keywords (e.g. searching "huddle" now finds Slack Huddle windows)
 

--- a/extensions/aerospace/src/switchApps.tsx
+++ b/extensions/aerospace/src/switchApps.tsx
@@ -59,9 +59,14 @@ export default function Command(
       {Object.entries(groupedByWorkspace).map(([workspaceName, group]) => (
         <List.Section key={workspaceName} title={`Workspace ${workspaceName} - ${group.monitor}`}>
           {group.windows
-            .filter((window) =>
-              searchText ? window["app-name"].toLowerCase().startsWith(searchText?.toLowerCase()) : true,
-            )
+            .filter((window) => {
+              if (!searchText) return true;
+              const search = searchText.toLowerCase();
+              return (
+                window["app-name"].toLowerCase().includes(search) ||
+                (window["window-title"] ?? "").toLowerCase().includes(search)
+              );
+            })
             .map((window) => (
               <List.Item
                 key={window["window-id"]}


### PR DESCRIPTION
## Summary

- The window switcher filter previously only matched the **beginning of the app name**, ignoring the window title entirely
- This made it impossible to find windows by their title (e.g. typing "huddle" wouldn't surface a Slack Huddle window, even though the title is visible in the list)
- The filter now checks both `app-name` and `window-title` using substring (`includes`) matching, so the full visible text in the list is searchable

## Test plan

- [ ] Open "Switch Apps in Workspace" command
- [ ] Type a word that appears only in a window title (e.g. "huddle", "issues", a document name) and confirm the window appears in results
- [ ] Confirm app-name search still works as before