### PR TITLE
fix(cmux): add /usr/local/bin to PATH for execFile calls

### DIFF
--- a/extensions/cmux/CHANGELOG.md
+++ b/extensions/cmux/CHANGELOG.md
@@ -1,5 +1,9 @@
 # cmux
 
+## [Fix PATH resolution] - 2026-04-24
+
+- Fix `spawn cmux ENOENT` errors in Raycast by injecting Homebrew paths into the environment used for CLI calls (covers both Intel `/usr/local/bin` and Apple Silicon `/opt/homebrew/bin`)
+
 ## [Initial Version] - 2026-04-10
 
 - Search and jump to a workspace in cmux

--- a/extensions/cmux/src/cli.ts
+++ b/extensions/cmux/src/cli.ts
@@ -1,8 +1,13 @@
 import { execFile } from "child_process";
 
+const expandedEnv = {
+  ...process.env,
+  PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH ?? "/usr/bin:/bin:/usr/sbin:/sbin"}`,
+};
+
 export function execFileAsync(command: string, args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
-    execFile(command, args, { encoding: "utf8" }, (error, stdout) => {
+    execFile(command, args, { encoding: "utf8", env: expandedEnv }, (error, stdout) => {
       if (error) {
         reject(error);
         return;


### PR DESCRIPTION
## Purpose

All cmux commands fail with `Error: spawn cmux ENOENT` when triggered from Raycast. Raycast's process launches with a hardcoded PATH of `/usr/bin:/bin:/usr/sbin:/sbin` — it does not inherit the user's shell PATH, so it cannot find the `cmux` binary even after following the documented CLI setup.

## Approach

Inject `/usr/local/bin` into the `env` passed to every `execFile` call by prepending it to a hardcoded base PATH before spreading `process.env`. This matches the pattern used by other Raycast extensions that wrap CLI tools (e.g. the Music and brew-services extensions).

## Learning

The [cmux CLI setup docs](https://developers.raycast.com/information/developer-tools/forked-extensions) instruct users to create a symlink:

```sh
sudo ln -sf "/Applications/cmux.app/Contents/Resources/bin/cmux" /usr/local/bin/cmux
```

Once that symlink exists, commands like the following work from any terminal:

```sh
cmux list-workspaces
cmux notify --title "Build Complete" --body "Your build finished"
```

But Raycast's restricted process PATH means the symlink is invisible to the extension without this fix.

#### References

- [cmux CLI setup docs](https://cmux.com/docs/getting-started)
- [Music extension PATH pattern](https://github.com/raycast/extensions/blob/main/extensions/music/src/util/exec.ts)