### PR TITLE
[Skills] Add skills CLI telemetry opt-out preference

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Add Skills CLI Telemetry Opt-Out] - {PR_MERGE_DATE}
+## [Add Skills CLI Telemetry Opt-Out] - 2026-04-28
 
 - Add an extension preference to opt out of anonymous usage telemetry collected by the underlying Skills CLI when commands are run from Raycast
 - Pass `DISABLE_TELEMETRY=1` to all Skills CLI invocations when the preference is enabled

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Skills Changelog
 
+## [Add Skills CLI Telemetry Opt-Out] - {PR_MERGE_DATE}
+
+- Add an extension preference to opt out of anonymous usage telemetry collected by the underlying Skills CLI when commands are run from Raycast
+- Pass `DISABLE_TELEMETRY=1` to all Skills CLI invocations when the preference is enabled
+- Trim the optional GitHub token preference before using it for repository stats and update checks
+
 ## [Fix Homebrew `node@` Resolution and add Custom `npx` Validation] - 2026-04-23
 
 - Detect versioned Homebrew Node formula bins like `/opt/homebrew/opt/node@24/bin` so the Skills CLI can find `node` when `npx` comes from Homebrew, while still preferring Node installs from version managers first

--- a/extensions/skills/package.json
+++ b/extensions/skills/package.json
@@ -51,6 +51,14 @@
       "description": "Optional token to increase the GitHub API rate limit from 60 to 5,000 requests/hour.",
       "type": "password",
       "required": false
+    },
+    {
+      "name": "disableSkillsCliTelemetry",
+      "title": "Disable Skills CLI Telemetry",
+      "label": "Opt out of Skills CLI telemetry",
+      "description": "Opt out of anonymous usage data collected by the underlying Skills CLI for commands run through this extension. The extension itself does not collect telemetry data.",
+      "type": "checkbox",
+      "required": false
     }
   ],
   "dependencies": {

--- a/extensions/skills/src/hooks/useRepoStats.ts
+++ b/extensions/skills/src/hooks/useRepoStats.ts
@@ -1,6 +1,6 @@
-import { getPreferenceValues } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 
+import { getGithubToken } from "../preferences";
 import { type Skill } from "../shared";
 
 export type RepoStats = {
@@ -10,7 +10,7 @@ export type RepoStats = {
 
 async function fetchRepoStats(source: string): Promise<RepoStats | undefined> {
   try {
-    const { githubToken } = getPreferenceValues<{ githubToken?: string }>();
+    const githubToken = getGithubToken();
     const headers: Record<string, string> = { Accept: "application/vnd.github+json" };
     if (githubToken) {
       headers["Authorization"] = `Bearer ${githubToken}`;

--- a/extensions/skills/src/preferences.ts
+++ b/extensions/skills/src/preferences.ts
@@ -2,7 +2,7 @@ import { getPreferenceValues } from "@raycast/api";
 import { homedir } from "node:os";
 import { sep } from "node:path";
 
-export const preferences = getPreferenceValues<Preferences>();
+const preferences = getPreferenceValues<Preferences>();
 
 export const getCustomNpxPath = (): string | undefined => {
   const customPath = preferences.customNpxPath?.trim();
@@ -18,3 +18,10 @@ export const getCustomNpxPath = (): string | undefined => {
 
   return customPath;
 };
+
+export const getGithubToken = (): string | undefined => {
+  const token = preferences.githubToken?.trim();
+  return token || undefined;
+};
+
+export const shouldDisableSkillsCliTelemetry = (): boolean => preferences.disableSkillsCliTelemetry === true;

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -2,7 +2,7 @@ import { access, readFile, stat } from "node:fs/promises";
 import { constants } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
-import { getCustomNpxPath, preferences } from "../preferences";
+import { getCustomNpxPath, getGithubToken, shouldDisableSkillsCliTelemetry } from "../preferences";
 import type { InstalledSkill, Skill, SkillLockEntry } from "../shared";
 import { execAsync } from "./exec-async";
 import { getExecOptions } from "./exec-options";
@@ -44,6 +44,10 @@ function buildSkillsCliCommand(npxCommand: string, args: string[]): string {
   return [npxCommand, "-y", "skills@latest", ...args].map(shellEscape).join(" ");
 }
 
+function getSkillsCliEnvOverrides(): Record<string, string> {
+  return shouldDisableSkillsCliTelemetry() ? { DISABLE_TELEMETRY: "1" } : {};
+}
+
 async function runSkillsCli(args: string[]): Promise<string> {
   const customNpxPath = getCustomNpxPath();
   if (customNpxPath) {
@@ -53,6 +57,10 @@ async function runSkillsCli(args: string[]): Promise<string> {
   const npxCommand = customNpxPath ?? "npx";
   try {
     const execOptions = await getExecOptions();
+    execOptions.env = {
+      ...execOptions.env,
+      ...getSkillsCliEnvOverrides(),
+    };
     const { stdout } = await execAsync(buildSkillsCliCommand(npxCommand, args), execOptions);
     return stdout;
   } catch (error) {
@@ -338,7 +346,7 @@ export async function checkForUpdates(): Promise<string[]> {
     byRepo.set(entry.source, list);
   }
 
-  const { githubToken } = preferences;
+  const githubToken = getGithubToken();
 
   const results = await Promise.all(
     [...byRepo.entries()].map(async ([source, skills]) => {


### PR DESCRIPTION
## Description

Adds a new Skills extension preference to opt out of anonymous usage telemetry collected by the underlying Skills CLI when commands are run from Raycast.

When enabled, the extension passes `DISABLE_TELEMETRY=1` to all Skills CLI invocations. The preference description tries to make it clear that the Raycast extension itself does not collect telemetry; it only controls telemetry for the CLI used underneath.

This change also centralizes preference access for the optional GitHub token and trims it before using it for repository stats and update checks.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
