### PR TITLE
Fix optimistic tab closing in helium

### DIFF
--- a/extensions/helium/CHANGELOG.md
+++ b/extensions/helium/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Helium Changelog
 
-## [Fix Optimistic Tab Closing] - {PR_MERGE_DATE}
+## [Fix Optimistic Tab Closing] - 2026-04-27
 
 - Use the stable Helium tab id for list identity and optimistic updates so quickly closing tabs no longer removes the wrong rows or mixes up favicons.
 - Rework tab close and deduplicate actions to keep pending closes hidden until Helium confirms the close, then refresh Search Tabs and Search Web from the latest tab state.

--- a/extensions/helium/CHANGELOG.md
+++ b/extensions/helium/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Helium Changelog
 
+## [Fix Optimistic Tab Closing] - {PR_MERGE_DATE}
+
+- Use the stable Helium tab id for list identity and optimistic updates so quickly closing tabs no longer removes the wrong rows or mixes up favicons.
+- Rework tab close and deduplicate actions to keep pending closes hidden until Helium confirms the close, then refresh Search Tabs and Search Web from the latest tab state.
+
 ## [Fix Search Tab Switching] - 2026-04-25
 
 - AppleScript to switch tabs was not running due to `closeMainWindow()` in actions.tsx killing the process before. Fix was to move `closeMainWindow()` to **after** the AppleScript succeeds.

--- a/extensions/helium/src/search-tabs.tsx
+++ b/extensions/helium/src/search-tabs.tsx
@@ -1,5 +1,5 @@
 import { List, ActionPanel, Icon } from "@raycast/api";
-import { usePromise } from "@raycast/utils";
+import { getFavicon, usePromise } from "@raycast/utils";
 import { useState, useRef } from "react";
 import { getBrowserTabs } from "./utils/browser";
 import {
@@ -18,13 +18,13 @@ import { filterSearchable } from "./utils/search";
 export default function SearchTabs() {
   const [searchText, setSearchText] = useState("");
   const { data: tabs, isLoading, mutate, revalidate } = usePromise(getBrowserTabs);
-  const deletedTabIdsRef = useRef(new Set<number>());
+  const pendingCloseIdsRef = useRef(new Set<string>());
 
-  // Filter out deleted tabs first (tabs that are being closed but might still appear in fetched data)
-  const tabsWithoutDeleted = tabs ? tabs.filter((t) => !deletedTabIdsRef.current.has(t.id)) : [];
+  // Keep tabs hidden while their close request is still in flight.
+  const tabsWithoutPendingClose = tabs ? tabs.filter((t) => !pendingCloseIdsRef.current.has(t.id)) : [];
 
   // Then filter by search text
-  const filteredTabs = tabsWithoutDeleted ? filterSearchable(tabsWithoutDeleted, searchText) : [];
+  const filteredTabs = tabsWithoutPendingClose ? filterSearchable(tabsWithoutPendingClose, searchText) : [];
 
   return (
     <List
@@ -42,22 +42,33 @@ export default function SearchTabs() {
       )}
       {filteredTabs.map((tab) => (
         <List.Item
+          id={tab.id}
           key={tab.id}
           title={tab.title || "Untitled"}
           subtitle={tab.url}
           keywords={[tab.url, tab.title || ""]}
-          icon={tab.favicon || Icon.Globe}
+          icon={tab.favicon || getFavicon(tab.url, { fallback: Icon.Globe })}
           actions={
             <ActionPanel>
               <SwitchToTabAction tab={tab} />
               <OpenNewTabAction />
-              <CloseTabAction tab={tab} mutate={mutate} deletedTabIdsRef={deletedTabIdsRef} />
+              <CloseTabAction
+                tab={tab}
+                mutate={mutate}
+                revalidate={revalidate}
+                pendingCloseIdsRef={pendingCloseIdsRef}
+              />
               <OpenInNewTabAction tab={tab} />
               <CopyUrlAction tab={tab} />
               <CopyTitleAction tab={tab} />
               <CreateQuicklinkAction url={tab.url} name={tab.title || "Untitled"} />
               <ReloadAction subject="Tabs" revalidate={revalidate} />
-              <DeduplicateTabsAction tabs={tabsWithoutDeleted} mutate={mutate} deletedTabIdsRef={deletedTabIdsRef} />
+              <DeduplicateTabsAction
+                tabs={tabsWithoutPendingClose}
+                mutate={mutate}
+                revalidate={revalidate}
+                pendingCloseIdsRef={pendingCloseIdsRef}
+              />
             </ActionPanel>
           }
         />

--- a/extensions/helium/src/search-web.tsx
+++ b/extensions/helium/src/search-web.tsx
@@ -1,7 +1,7 @@
 import { List, Action, ActionPanel, Icon, LaunchProps } from "@raycast/api";
 import { getFavicon, usePromise } from "@raycast/utils";
 import { useState, useRef } from "react";
-import { getBrowserTabs, isBrowserExtensionAvailable } from "./utils/browser";
+import { getBrowserTabs } from "./utils/browser";
 import { useHistorySearch } from "./utils/history";
 import { useSuggestions, getSearchEngineName } from "./utils/suggestions";
 import { normalizeURL, extractDomain } from "./utils/url";
@@ -22,20 +22,8 @@ import { filterSearchable } from "./utils/search";
 export default function SearchWeb(props: LaunchProps) {
   const [searchText, setSearchText] = useState(props.fallbackText ?? "");
 
-  // Fetch tabs if browser extension is available
-  const hasBrowserExtension = isBrowserExtensionAvailable();
-  const {
-    data: tabs,
-    isLoading: isLoadingTabs,
-    mutate,
-    revalidate,
-  } = usePromise(async () => {
-    if (!hasBrowserExtension) {
-      return [];
-    }
-    return getBrowserTabs();
-  });
-  const deletedTabIdsRef = useRef(new Set<number>());
+  const { data: tabs, isLoading: isLoadingTabs, mutate, revalidate } = usePromise(getBrowserTabs);
+  const pendingCloseIdsRef = useRef(new Set<string>());
 
   // Fetch history - will show recent history when no search text for debugging
   const { data: history, isLoading: isLoadingHistory, permissionView } = useHistorySearch(searchText, 25);
@@ -48,11 +36,11 @@ export default function SearchWeb(props: LaunchProps) {
     return permissionView;
   }
 
-  // Filter out deleted tabs first (tabs that are being closed but might still appear in fetched data)
-  const tabsWithoutDeleted = tabs ? tabs.filter((t) => !deletedTabIdsRef.current.has(t.id)) : [];
+  // Keep tabs hidden while their close request is still in flight.
+  const tabsWithoutPendingClose = tabs ? tabs.filter((t) => !pendingCloseIdsRef.current.has(t.id)) : [];
 
   // Then filter by search text
-  const filteredTabs = tabsWithoutDeleted ? filterSearchable(tabsWithoutDeleted, searchText) : [];
+  const filteredTabs = tabsWithoutPendingClose ? filterSearchable(tabsWithoutPendingClose, searchText) : [];
 
   // Separate URL suggestions from search suggestions
   const urlSuggestions = suggestions.filter((s) => s.type === "url");
@@ -91,15 +79,16 @@ export default function SearchWeb(props: LaunchProps) {
       )}
 
       {/* Open Tabs Section */}
-      {hasBrowserExtension && filteredTabs.length > 0 && (
+      {filteredTabs.length > 0 && (
         <List.Section title="Open Tabs" subtitle={`${filteredTabs.length} tab${filteredTabs.length !== 1 ? "s" : ""}`}>
           {filteredTabs.map((tab) => (
             <TabListItem
               key={tab.id}
               tab={tab}
+              tabs={tabsWithoutPendingClose}
               mutate={mutate}
               revalidate={revalidate}
-              deletedTabIdsRef={deletedTabIdsRef}
+              pendingCloseIdsRef={pendingCloseIdsRef}
             />
           ))}
         </List.Section>
@@ -134,35 +123,43 @@ export default function SearchWeb(props: LaunchProps) {
  */
 function TabListItem({
   tab,
+  tabs,
   mutate,
   revalidate,
-  deletedTabIdsRef,
+  pendingCloseIdsRef,
 }: {
   tab: Tab;
+  tabs: Tab[];
   mutate: import("@raycast/utils").MutatePromise<Tab[], undefined>;
   revalidate: () => Promise<Tab[]>;
-  deletedTabIdsRef: React.MutableRefObject<Set<number>>;
+  pendingCloseIdsRef: React.MutableRefObject<Set<string>>;
 }) {
   const domain = extractDomain(tab.url);
 
   return (
     <List.Item
+      id={tab.id}
       title={tab.title || "Untitled"}
       subtitle={domain}
       keywords={[tab.url, tab.title || ""]}
-      icon={getFavicon(tab.url)}
+      icon={tab.favicon || getFavicon(tab.url, { fallback: Icon.Globe })}
       accessories={[{ text: "Tab", tooltip: tab.url }]}
       actions={
         <ActionPanel>
           <SwitchToTabAction tab={tab} />
           <OpenNewTabAction />
-          <CloseTabAction tab={tab} mutate={mutate} deletedTabIdsRef={deletedTabIdsRef} />
+          <CloseTabAction tab={tab} mutate={mutate} revalidate={revalidate} pendingCloseIdsRef={pendingCloseIdsRef} />
           <OpenInNewTabAction tab={tab} />
           <CopyUrlAction tab={tab} />
           <CopyAsMarkdownAction tab={tab} />
           <CreateQuicklinkAction url={tab.url} name={tab.title || "Untitled"} />
           <ReloadAction subject="Tabs" revalidate={revalidate} />
-          <DeduplicateTabsAction mutate={mutate} deletedTabIdsRef={deletedTabIdsRef} />
+          <DeduplicateTabsAction
+            tabs={tabs}
+            mutate={mutate}
+            revalidate={revalidate}
+            pendingCloseIdsRef={pendingCloseIdsRef}
+          />
         </ActionPanel>
       }
     />

--- a/extensions/helium/src/types.ts
+++ b/extensions/helium/src/types.ts
@@ -1,10 +1,14 @@
-import { BrowserExtension } from "@raycast/api";
-
-// Re-export the Tab type from BrowserExtension, extended with the Helium
-// AppleScript `id` bridged in at fetch time. `heliumId` is optional because a
-// tab may not resolve (e.g., if the Helium app is not running or the AS lookup
-// fails); callers should fall back to URL-based operations in that case.
-export type Tab = BrowserExtension.Tab & { heliumId?: string };
+// Internal Helium tab model.
+//
+// `id` is the stable Helium AppleScript tab id and is the only identity used
+// throughout the UI, optimistic state, and actions. `favicon` is optional
+// display-only metadata when the Raycast Browser Extension can provide it.
+export interface Tab {
+  id: string;
+  url: string;
+  title: string;
+  favicon?: string;
+}
 
 // History entry from browsing history database
 export interface HistoryEntry {

--- a/extensions/helium/src/utils/actions.tsx
+++ b/extensions/helium/src/utils/actions.tsx
@@ -162,13 +162,22 @@ export function CloseTabAction({ tab, mutate, revalidate, pendingCloseIdsRef }: 
             title: "Tab closed",
           });
         } catch (error) {
+          pendingCloseIdsRef.current.delete(tab.id);
+
           try {
             await Promise.resolve(revalidate());
           } catch {
-            // `getBrowserTabs` already surfaces refresh failures.
+            // Restore the tab locally if the refresh also fails.
+            await mutate(undefined, {
+              optimisticUpdate(data) {
+                if (!data) return [tab];
+                if (data.some((t) => t.id === tab.id)) return data;
+                return [tab, ...data];
+              },
+              rollbackOnError: false,
+              shouldRevalidateAfter: false,
+            });
           }
-
-          pendingCloseIdsRef.current.delete(tab.id);
 
           await showToast({
             style: Toast.Style.Failure,
@@ -313,13 +322,13 @@ export function DeduplicateTabsAction({
             }
           } finally {
             if (optimisticContext) {
+              for (const id of duplicateIds) optimisticContext.pendingCloseIdsRef.current.delete(id);
+
               try {
                 await Promise.resolve(optimisticContext.revalidate());
               } catch {
                 // `getBrowserTabs` already surfaces refresh failures.
               }
-
-              for (const id of duplicateIds) optimisticContext.pendingCloseIdsRef.current.delete(id);
             }
           }
 

--- a/extensions/helium/src/utils/actions.tsx
+++ b/extensions/helium/src/utils/actions.tsx
@@ -1,13 +1,7 @@
 import { Action, Icon, showToast, Toast, closeMainWindow, open } from "@raycast/api";
 import type { MutatePromise } from "@raycast/utils";
 import type { Tab, Bookmark } from "../types";
-import {
-  switchToHeliumTab,
-  switchToHeliumTabById,
-  closeHeliumTab,
-  closeHeliumTabById,
-  openUrlInHelium,
-} from "./applescript";
+import { switchToHeliumTabById, closeHeliumTabById, openUrlInHelium } from "./applescript";
 import { getBrowserTabs } from "./browser";
 
 interface BaseActionProps {
@@ -16,17 +10,16 @@ interface BaseActionProps {
 
 interface MutationActionProps extends BaseActionProps {
   mutate: MutatePromise<Tab[], undefined>;
-  deletedTabIdsRef: React.MutableRefObject<Set<number>>;
+  revalidate: () => Promise<unknown> | void;
+  pendingCloseIdsRef: React.MutableRefObject<Set<string>>;
 }
 
 /**
  * Action to switch to an existing tab using AppleScript.
  *
- * Prefers the Helium AppleScript `id` bridged at fetch time (see
- * {@link getBrowserTabs}). This guarantees we hit the exact tab the user
- * picked even when several tabs share the same URL. Falls back to URL
- * matching if the id wasn't resolved (e.g., Helium wasn't running at fetch
- * time or the AS call failed).
+ * Uses the stable Helium AppleScript `id` bridged at fetch time (see
+ * {@link getBrowserTabs}) so we always target the exact tab the user picked,
+ * even when several tabs share the same URL.
  */
 export function SwitchToTabAction({ tab }: BaseActionProps) {
   return (
@@ -35,7 +28,7 @@ export function SwitchToTabAction({ tab }: BaseActionProps) {
       icon={Icon.ArrowRight}
       onAction={async () => {
         try {
-          const switched = tab.heliumId ? await switchToHeliumTabById(tab.heliumId) : await switchToHeliumTab(tab.url);
+          const switched = await switchToHeliumTabById(tab.id);
           if (switched) {
             await closeMainWindow();
           } else {
@@ -123,15 +116,15 @@ export function ReloadAction({ subject = "List", revalidate }: RevalidateActionP
 /**
  * Action to close a tab with optimistic updates
  */
-export function CloseTabAction({ tab, mutate, deletedTabIdsRef }: MutationActionProps) {
+export function CloseTabAction({ tab, mutate, revalidate, pendingCloseIdsRef }: MutationActionProps) {
   return (
     <Action
       title="Close Tab"
       icon={Icon.XMarkCircle}
       shortcut={{ modifiers: ["cmd", "shift"], key: "w" }}
       onAction={async () => {
-        // Mark tab as deleted immediately - it will be filtered out client-side
-        deletedTabIdsRef.current.add(tab.id);
+        // Keep in-flight closes hidden even if another mutation revalidates first.
+        pendingCloseIdsRef.current.add(tab.id);
 
         await showToast({
           style: Toast.Style.Animated,
@@ -139,32 +132,44 @@ export function CloseTabAction({ tab, mutate, deletedTabIdsRef }: MutationAction
         });
 
         try {
-          // Optimistically update the cache immediately
-          await mutate(
-            undefined, // Don't pass a promise - just keep the optimistic update
-            {
-              optimisticUpdate(data) {
-                if (!data) return [];
-                const filtered = data.filter((t) => t.id !== tab.id);
-                return filtered;
-              },
+          // Optimistically update the cache immediately, then reconcile after
+          // the real close finishes so we don't refetch stale tab data first.
+          await mutate(undefined, {
+            optimisticUpdate(data) {
+              if (!data) return [];
+              return data.filter((t) => t.id !== tab.id);
             },
-          );
+            rollbackOnError: false,
+            shouldRevalidateAfter: false,
+          });
 
-          // Execute the actual close in the browser (prefer id; fallback to URL)
-          const success = tab.heliumId ? await closeHeliumTabById(tab.heliumId) : await closeHeliumTab(tab.url);
+          const success = await closeHeliumTabById(tab.id);
 
           if (!success) {
             throw new Error("Tab not found or failed to close");
           }
+
+          try {
+            await Promise.resolve(revalidate());
+          } catch {
+            // `getBrowserTabs` already surfaces refresh failures.
+          }
+
+          pendingCloseIdsRef.current.delete(tab.id);
 
           await showToast({
             style: Toast.Style.Success,
             title: "Tab closed",
           });
         } catch (error) {
-          // On error, remove from deleted set so it shows again
-          deletedTabIdsRef.current.delete(tab.id);
+          try {
+            await Promise.resolve(revalidate());
+          } catch {
+            // `getBrowserTabs` already surfaces refresh failures.
+          }
+
+          pendingCloseIdsRef.current.delete(tab.id);
+
           await showToast({
             style: Toast.Style.Failure,
             title: "Failed to close tab",
@@ -233,16 +238,22 @@ export function CopyAsMarkdownAction({ tab }: BaseActionProps) {
  * provided (e.g., invoked from search-bookmarks or search-web), it fetches
  * the current tab list itself, so it can be safely dropped into any command.
  *
- * When used from a list that owns the tab cache, pass `mutate` and
- * `deletedTabIdsRef` to apply an optimistic update so the list reflects the
- * closures immediately.
+ * When used from a list that owns the tab cache, pass `mutate`, `revalidate`,
+ * and `pendingCloseIdsRef` to apply an optimistic update and then reconcile
+ * with the actual browser state after the closes finish.
  */
 interface DeduplicateTabsActionProps {
   tabs?: Tab[];
   mutate?: MutatePromise<Tab[], undefined>;
-  deletedTabIdsRef?: React.MutableRefObject<Set<number>>;
+  revalidate?: () => Promise<unknown> | void;
+  pendingCloseIdsRef?: React.MutableRefObject<Set<string>>;
 }
-export function DeduplicateTabsAction({ tabs, mutate, deletedTabIdsRef }: DeduplicateTabsActionProps = {}) {
+export function DeduplicateTabsAction({
+  tabs,
+  mutate,
+  revalidate,
+  pendingCloseIdsRef,
+}: DeduplicateTabsActionProps = {}) {
   return (
     <Action
       title="Deduplicate Tabs"
@@ -270,27 +281,45 @@ export function DeduplicateTabsAction({ tabs, mutate, deletedTabIdsRef }: Dedupl
             title: `Closing ${duplicates.length} duplicate tab${duplicates.length === 1 ? "" : "s"}`,
           });
 
-          // Optimistic update when the caller owns the cache.
-          if (mutate && deletedTabIdsRef) {
-            for (const t of duplicates) deletedTabIdsRef.current.add(t.id);
-            await mutate(undefined, {
-              optimisticUpdate(data) {
-                if (!data) return [];
-                const ids = new Set(duplicates.map((t) => t.id));
-                return data.filter((t) => !ids.has(t.id));
-              },
-            });
+          const duplicateIds = duplicates.map((t) => t.id);
+          const optimisticContext =
+            mutate && revalidate && pendingCloseIdsRef ? { mutate, revalidate, pendingCloseIdsRef } : undefined;
+
+          if (optimisticContext) {
+            for (const id of duplicateIds) optimisticContext.pendingCloseIdsRef.current.add(id);
           }
 
-          // Close each duplicate. Prefer heliumId (guaranteed to hit the exact
-          // duplicate); fall back to URL only if no id was resolved.
           let closed = 0;
-          for (const t of duplicates) {
-            try {
-              const ok = t.heliumId ? await closeHeliumTabById(t.heliumId) : await closeHeliumTab(t.url);
-              if (ok) closed += 1;
-            } catch {
-              // Ignore individual failures; surface aggregate below.
+          try {
+            if (optimisticContext) {
+              await optimisticContext.mutate(undefined, {
+                optimisticUpdate(data) {
+                  if (!data) return [];
+                  const ids = new Set(duplicateIds);
+                  return data.filter((t) => !ids.has(t.id));
+                },
+                rollbackOnError: false,
+                shouldRevalidateAfter: false,
+              });
+            }
+
+            for (const t of duplicates) {
+              try {
+                const ok = await closeHeliumTabById(t.id);
+                if (ok) closed += 1;
+              } catch {
+                // Ignore individual failures; surface aggregate below.
+              }
+            }
+          } finally {
+            if (optimisticContext) {
+              try {
+                await Promise.resolve(optimisticContext.revalidate());
+              } catch {
+                // `getBrowserTabs` already surfaces refresh failures.
+              }
+
+              for (const id of duplicateIds) optimisticContext.pendingCloseIdsRef.current.delete(id);
             }
           }
 

--- a/extensions/helium/src/utils/browser.ts
+++ b/extensions/helium/src/utils/browser.ts
@@ -24,13 +24,8 @@ export function isBrowserExtensionAvailable(): boolean {
  * these are attached by URL match. Tabs BE never sees (local files,
  * chrome://) simply have no favicon and the UI falls back to `Icon.Globe`.
  *
- * Each tab carries its Helium AS `id` as `heliumId`, which subsequent
- * actions use to target exact tabs (duplicate URLs included) via
- * {@link switchToHeliumTabById}/{@link closeHeliumTabById}.
- *
- * `Tab.id` here is a synthetic 1-indexed ordinal (from AS traversal order),
- * used only for React keys and optimistic-update tracking. It is not a Chrome
- * tab id and should not be treated as one.
+ * `Tab.id` is the stable Helium AppleScript `id`, used everywhere we need to
+ * refer to a specific tab (React keys, optimistic state, and tab actions).
  */
 export async function getBrowserTabs(): Promise<Tab[]> {
   try {
@@ -46,13 +41,11 @@ export async function getBrowserTabs(): Promise<Tab[]> {
       if (t.favicon && !faviconByUrl.has(t.url)) faviconByUrl.set(t.url, t.favicon);
     }
 
-    return asTabs.map((t, i) => ({
-      id: i + 1,
+    return asTabs.map((t) => ({
+      id: t.heliumId,
       url: t.url,
       title: t.title || "",
       favicon: faviconByUrl.get(t.url),
-      active: false,
-      heliumId: t.heliumId,
     }));
   } catch (error) {
     await showToast({


### PR DESCRIPTION
## Description

Fixes optimistic tab closing in the Helium extension so rapid closes no longer remove or reshuffle the wrong rows.

- use the stable Helium AppleScript tab id as the canonical tab identity in `search-tabs` and the Open Tabs section of `search-web`
- keep pending closes hidden until the real browser close finishes, then revalidate against the latest Helium tab state
- preserve favicons while removing the stale Browser Extension availability gate from `search-web`

Validation run locally:
- `npm run lint`
- `npm run build`

## Screencast

Not included. This PR fixes optimistic state handling in existing commands and does not add a new extension or command.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)