### PR TITLE
Update todoist extension

### DIFF
--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Fix group and sort actions in filter views] - {PR_MERGE_DATE}
 
 - In **My Tasks**, when a custom Todoist filter is selected, **Group tasks by** and **Sort tasks by** now update the list (they were previously no-ops because the UI ignored grouped/sorted output for filters).
+- Filters whose query is comma-separated (multiple sub-queries) still show one section per sub-query when **Group tasks by** is **Default**; sort order applies within that layout.
 
 ## [Show deadline as how many days remains] - 2026-03-31
 - The task deadlines are shown as "in X days" instead of a specific date, like the todoist app.

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Todoist Changelog
 
-## [Fix group and sort actions in filter views] - {PR_MERGE_DATE}
+## [Fix group and sort actions in filter views] - 2026-04-27
 
 - In **My Tasks**, when a custom Todoist filter is selected, **Group tasks by** and **Sort tasks by** now update the list (they were previously no-ops because the UI ignored grouped/sorted output for filters).
 - Filters whose query is comma-separated (multiple sub-queries) still show one section per sub-query when **Group tasks by** is **Default**; sort order applies within that layout.

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Todoist Changelog
 
+## [Fix group and sort actions in filter views] - {PR_MERGE_DATE}
+
+- In **My Tasks**, when a custom Todoist filter is selected, **Group tasks by** and **Sort tasks by** now update the list (they were previously no-ops because the UI ignored grouped/sorted output for filters).
+
 ## [Show deadline as how many days remains] - 2026-03-31
 - The task deadlines are shown as "in X days" instead of a specific date, like the todoist app.
 

--- a/extensions/todoist/package.json
+++ b/extensions/todoist/package.json
@@ -30,7 +30,8 @@
     "alanwill",
     "erayack",
     "chialiyun",
-    "jakoss"
+    "jakoss",
+    "yashpatel21"
   ],
   "platforms": [
     "macOS",

--- a/extensions/todoist/src/components/FilterTasks.tsx
+++ b/extensions/todoist/src/components/FilterTasks.tsx
@@ -1,7 +1,7 @@
 import { List, ActionPanel, Action, Icon } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 
-import { getFilterTasks } from "../api";
+import { getFilterTasks, type Task } from "../api";
 import { filterSort } from "../helpers/filters";
 import { QuickLinkView, ViewMode } from "../home";
 import useCachedData from "../hooks/useCachedData";
@@ -73,7 +73,15 @@ function FilterTasks({ name, quickLinkView }: FilterTasksProps) {
     );
   }
 
-  const displayedSections = viewProps.groupBy?.value === "default" ? [{ name, tasks: sortedTasks }] : groupedSections;
+  const displayedSections =
+    viewProps.groupBy?.value !== "default"
+      ? groupedSections
+      : sections.length > 1
+        ? sections.map((s) => {
+            const idSet = new Set(s.tasks.map((t: Task) => t.id));
+            return { name: s.name, tasks: sortedTasks.filter((t: Task) => idSet.has(t.id)) };
+          })
+        : [{ name, tasks: sortedTasks }];
 
   return (
     <TaskListSections

--- a/extensions/todoist/src/components/FilterTasks.tsx
+++ b/extensions/todoist/src/components/FilterTasks.tsx
@@ -37,8 +37,16 @@ function FilterTasks({ name, quickLinkView }: FilterTasksProps) {
   );
 
   const sections = data ?? [];
+  const tasks = sections.flatMap((section) => section.tasks);
 
-  const { viewProps } = useViewTasks(`todoist.filter${name}`, { tasks: sections.flatMap((section) => section.tasks) });
+  const {
+    sections: groupedSections,
+    sortedTasks,
+    viewProps,
+  } = useViewTasks(`todoist.filter${name}`, {
+    tasks,
+    data: cachedData,
+  });
 
   if (sections.length === 0) {
     return (
@@ -65,8 +73,15 @@ function FilterTasks({ name, quickLinkView }: FilterTasksProps) {
     );
   }
 
+  const displayedSections = viewProps.groupBy?.value === "default" ? [{ name, tasks: sortedTasks }] : groupedSections;
+
   return (
-    <TaskListSections mode={ViewMode.project} sections={sections} viewProps={viewProps} quickLinkView={quickLinkView} />
+    <TaskListSections
+      mode={ViewMode.project}
+      sections={displayedSections}
+      viewProps={viewProps}
+      quickLinkView={quickLinkView}
+    />
   );
 }
 


### PR DESCRIPTION
## Description

Fixes a bug in the Todoist `My Tasks` filter view where **Group Tasks by** and **Sort Tasks by** actions appeared in the action menu but had no effect.

In `FilterTasks`, the view now renders the grouped/sorted output from `useViewTasks` (instead of always rendering the original fetched sections), and passes cached sync data into `useViewTasks` so grouping/sorting options that depend on metadata (projects/labels/assignees) work correctly.

This is a fix for [#27273](https://github.com/raycast/extensions/issues/27273).

## Screencast

<!-- Add a short before/after screencast here.
Suggested flow:
1. Open My Tasks -> select a custom filter
2. Show Group Tasks by / Sort Tasks by not changing list (before)
3. Show same actions changing list (after)
-->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder