### PR TITLE
Currency Exchange: add UniRateAPI as alternate rate provider

### DIFF
--- a/extensions/currency-exchange/CHANGELOG.md
+++ b/extensions/currency-exchange/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Currency Exchange Changelog
 
+## [Add UniRateAPI as alternate provider] - {PR_MERGE_DATE}
+
+- Added a "Rate Provider" preference. ExchangeRate-API remains the default; UniRateAPI is selectable as an alternative.
+- API key field now applies to whichever provider is selected.
+
 ## [Added missing contributor] - 2025-11-25
 
 ## [Update] - 2025-11-04

--- a/extensions/currency-exchange/CHANGELOG.md
+++ b/extensions/currency-exchange/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Currency Exchange Changelog
 
-## [Add UniRateAPI as alternate provider] - {PR_MERGE_DATE}
+## [Add UniRateAPI as alternate provider] - 2026-04-29
 
 - Added a "Rate Provider" preference. ExchangeRate-API remains the default; UniRateAPI is selectable as an alternative.
 - API key field now applies to whichever provider is selected.

--- a/extensions/currency-exchange/README.md
+++ b/extensions/currency-exchange/README.md
@@ -2,12 +2,12 @@
 
 ## Features
 
-* Support 161 currencies, see list: https://www.exchangerate-api.com/docs/supported-currencies
-* Support calculate expression e.g `1+2/3*4`
-* Support find target currency by filter, format: `${expression} in ${filter key word}`
-* Support pin your favorite currencies
-* Remember the source currency
-* Support find historical currency by date, format: `${expression} at ${yyyy/mm/dd}` or use Action 'Set Currency Date' [*Attention]
+- Support 161 currencies, see list: https://www.exchangerate-api.com/docs/supported-currencies
+- Support calculate expression e.g `1+2/3*4`
+- Support find target currency by filter, format: `${expression} in ${filter key word}`
+- Support pin your favorite currencies
+- Remember the source currency
+- Support find historical currency by date, format: `${expression} at ${yyyy/mm/dd}` or use Action 'Set Currency Date' [*Attention]
 
 \* use historical currency needs Pro/Business/Volume Plan subscription, Free version does not allow query historical currency API.
 See detail:
@@ -28,8 +28,18 @@ exchange with historical currency
 
 ## How to get API Keys
 
-* Go to https://www.exchangerate-api.com/ and register a account, it is free
-* Go to https://app.exchangerate-api.com/keys to find your API Key
+The extension supports two providers; pick one in the **Rate Provider** preference and supply that provider's key.
+
+### ExchangeRate-API (default)
+
+- Go to https://www.exchangerate-api.com/ and register a account, it is free
+- Go to https://app.exchangerate-api.com/keys to find your API Key
+
+### UniRateAPI
+
+- Go to https://unirateapi.com/ and register, it is free
+- Copy your key from https://unirateapi.com/dashboard
+- Free tier covers latest rates; historical rates require a Pro plan
 
 currency rate will be queried every 24 hours to reduce API usage.
 
@@ -37,9 +47,9 @@ currency rate will be queried every 24 hours to reduce API usage.
 
 There's a currency exchange function out of box in Raycast's Calculator.
 
-* You can type like `12 usd in gbp` to show the currency exchange result.
+- You can type like `12 usd in gbp` to show the currency exchange result.
 
-* You can type like `12 usd in gbp at 2022/9/25` to show the historical currency exchange result. (Need API Pro/Business/Volume Plan subscription)
+- You can type like `12 usd in gbp at 2022/9/25` to show the historical currency exchange result. (Need API Pro/Business/Volume Plan subscription)
 
 In some case, when you exactly know the currency code, it works fine, but it still has some challenges:
 

--- a/extensions/currency-exchange/package.json
+++ b/extensions/currency-exchange/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "currency-exchange",
   "title": "Currency Exchange",
-  "description": "Simple Currency Exchange, uses Exchange Rate API as the data source",
+  "description": "Simple Currency Exchange with a selectable rate provider (ExchangeRate-API or UniRateAPI)",
   "icon": "currency.png",
   "author": "xeric",
   "contributors": [
@@ -20,12 +20,30 @@
   ],
   "preferences": [
     {
+      "name": "provider",
+      "type": "dropdown",
+      "required": true,
+      "title": "Rate Provider",
+      "description": "Which exchange rate API to query. Switch this if you prefer UniRateAPI's pricing or coverage.",
+      "default": "exchangerate-api",
+      "data": [
+        {
+          "title": "ExchangeRate-API",
+          "value": "exchangerate-api"
+        },
+        {
+          "title": "UniRateAPI",
+          "value": "unirate"
+        }
+      ]
+    },
+    {
       "name": "api_key",
       "type": "password",
       "required": true,
       "title": "API Key",
-      "description": "You can get API Key at https://app.exchangerate-api.com/dashboard",
-      "placeholder": "Exchange Rate API Key"
+      "description": "Key for the selected provider. ExchangeRate-API: https://app.exchangerate-api.com/dashboard — UniRateAPI: https://unirateapi.com/dashboard",
+      "placeholder": "API key for the selected provider"
     }
   ],
   "dependencies": {

--- a/extensions/currency-exchange/src/index.tsx
+++ b/extensions/currency-exchange/src/index.tsx
@@ -25,9 +25,14 @@ const PROVIDER_LABELS: Record<Provider, string> = {
 };
 
 function getProvider(): Provider {
-  const { provider } = getPreferenceValues<{ provider?: string }>();
+  const { provider } = getPreferenceValues<Preferences>();
   return provider === "unirate" ? "unirate" : "exchangerate-api";
 }
+
+const PROVIDER_DOC_URLS: Record<Provider, string> = {
+  "exchangerate-api": "https://www.exchangerate-api.com/docs/standard-requests",
+  unirate: "https://unirateapi.com/docs",
+};
 
 function cacheKey(provider: Provider, historyDate: Date | null): string {
   const dateSuffix = historyDate
@@ -116,9 +121,10 @@ function Exchange({
   setSearchText: (amountExpression: string) => void;
 }) {
   if (currencyResult.result !== "success") {
+    const provider = getProvider();
     const errorMessage = `
     * error code: ${currencyResult.result}.
-    * for ExchangeRate-API see https://www.exchangerate-api.com/docs/standard-requests`;
+    * for ${PROVIDER_LABELS[provider]} see ${PROVIDER_DOC_URLS[provider]}`;
     showToast({
       style: Toast.Style.Failure,
       title: "Exchange Error",
@@ -433,7 +439,7 @@ function currencyAPI(historyDate: Date | null, signal: AbortSignal): Promise<Res
 }
 
 function exchangeRateAPI(historyDate: Date | null, signal: AbortSignal): Promise<Response> {
-  const { api_key } = getPreferenceValues<{ api_key: string }>();
+  const { api_key } = getPreferenceValues<Preferences>();
 
   const url = `https://v6.exchangerate-api.com/v6/${api_key}/${historyDate ? "history" : "latest"}/USD${
     historyDate
@@ -456,7 +462,7 @@ interface UniRateRatesResponse {
 }
 
 async function uniRateAPI(historyDate: Date | null, signal: AbortSignal): Promise<Response> {
-  const { api_key } = getPreferenceValues<{ api_key: string }>();
+  const { api_key } = getPreferenceValues<Preferences>();
 
   const path = historyDate ? "historical/rates" : "rates";
   const dateParam = historyDate

--- a/extensions/currency-exchange/src/index.tsx
+++ b/extensions/currency-exchange/src/index.tsx
@@ -17,6 +17,25 @@ import { currencyCode2Name, currencyCode2CountryAndRegion } from "./currency";
 const STORAGE_KEY_FROM_CURRENCY_CODE = "fromCurrencyCode";
 const STORAGE_KEY_PINNED_CURRENCY_CODE = "pinnedCurrencyCode";
 
+type Provider = "exchangerate-api" | "unirate";
+
+const PROVIDER_LABELS: Record<Provider, string> = {
+  "exchangerate-api": "exchangerate-api.com",
+  unirate: "unirateapi.com",
+};
+
+function getProvider(): Provider {
+  const { provider } = getPreferenceValues<{ provider?: string }>();
+  return provider === "unirate" ? "unirate" : "exchangerate-api";
+}
+
+function cacheKey(provider: Provider, historyDate: Date | null): string {
+  const dateSuffix = historyDate
+    ? `${historyDate.getFullYear()}-${historyDate.getMonth() + 1}-${historyDate.getDate()}`
+    : "";
+  return `${provider}-currency${dateSuffix}`;
+}
+
 export default function Command() {
   const { searchText, state, setState, setSearchTextAndExchange } = useSearchText();
 
@@ -99,7 +118,7 @@ function Exchange({
   if (currencyResult.result !== "success") {
     const errorMessage = `
     * error code: ${currencyResult.result}.
-    * you can find all error code in here. (https://www.exchangerate-api.com/docs/standard-requests)`;
+    * for ExchangeRate-API see https://www.exchangerate-api.com/docs/standard-requests`;
     showToast({
       style: Toast.Style.Failure,
       title: "Exchange Error",
@@ -351,12 +370,10 @@ async function performExchange(
 ): Promise<CurrencyResult | undefined> {
   console.log(`start to exchange | ${fromCode} |${amount}|`);
   if (amount > 0) {
+    const provider = getProvider();
+    const key = cacheKey(provider, historyDate);
     // check if there's available cache for currency
-    return LocalStorage.getItem<string>(
-      `currency${
-        historyDate ? historyDate.getFullYear() + "-" + (historyDate.getMonth() + 1) + "-" + historyDate.getDate() : ""
-      }`,
-    )
+    return LocalStorage.getItem<string>(key)
       .then((content) => {
         if (content) {
           const cachedData = JSON.parse(content) as CurrencyResult;
@@ -376,14 +393,7 @@ async function performExchange(
 
             const result = responseJson as CurrencyResult;
             if (result.result === "success") {
-              LocalStorage.setItem(
-                `currency${
-                  historyDate
-                    ? historyDate.getFullYear() + "-" + (historyDate.getMonth() + 1) + "-" + historyDate.getDate()
-                    : ""
-                }`,
-                JSON.stringify(responseJson),
-              );
+              LocalStorage.setItem(key, JSON.stringify(responseJson));
               return result;
             } else {
               console.log(responseJson);
@@ -393,7 +403,7 @@ async function performExchange(
               ) {
                 throw Error("Invalid API Key, please check!");
               }
-              throw Error(`exchangerate-api.com: ${result["error-type"]}`);
+              throw Error(`${PROVIDER_LABELS[provider]}: ${result["error-type"]}`);
             }
           })
           .catch((error: Error) => {
@@ -415,27 +425,122 @@ async function performExchange(
 }
 
 function currencyAPI(historyDate: Date | null, signal: AbortSignal): Promise<Response> {
-  const { api_key } = getPreferenceValues();
+  const provider = getProvider();
+  if (provider === "unirate") {
+    return uniRateAPI(historyDate, signal);
+  }
+  return exchangeRateAPI(historyDate, signal);
+}
 
-  console.log(
-    `make API call to https://v6.exchangerate-api.com/v6/${api_key}/${historyDate ? "history" : "latest"}/USD${
-      historyDate
-        ? "/" + historyDate.getFullYear() + "/" + (historyDate.getMonth() + 1) + "/" + historyDate.getDate()
-        : ""
-    }`,
-  );
-  return fetch(
-    `https://v6.exchangerate-api.com/v6/${api_key}/${historyDate ? "history" : "latest"}/USD${
-      historyDate
-        ? "/" + historyDate.getFullYear() + "/" + (historyDate.getMonth() + 1) + "/" + historyDate.getDate()
-        : ""
-    }`,
-    {
-      signal: signal,
-      method: "GET",
-      headers: { "Content-Type": "application/json" },
-    },
-  );
+function exchangeRateAPI(historyDate: Date | null, signal: AbortSignal): Promise<Response> {
+  const { api_key } = getPreferenceValues<{ api_key: string }>();
+
+  const url = `https://v6.exchangerate-api.com/v6/${api_key}/${historyDate ? "history" : "latest"}/USD${
+    historyDate
+      ? "/" + historyDate.getFullYear() + "/" + (historyDate.getMonth() + 1) + "/" + historyDate.getDate()
+      : ""
+  }`;
+  console.log(`make API call to ${url}`);
+  return fetch(url, {
+    signal: signal,
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface UniRateRatesResponse {
+  base?: string;
+  rates?: { [key: string]: number | string };
+  error?: string;
+  message?: string;
+}
+
+async function uniRateAPI(historyDate: Date | null, signal: AbortSignal): Promise<Response> {
+  const { api_key } = getPreferenceValues<{ api_key: string }>();
+
+  const path = historyDate ? "historical/rates" : "rates";
+  const dateParam = historyDate
+    ? `&date=${historyDate.getFullYear()}-${String(historyDate.getMonth() + 1).padStart(2, "0")}-${String(
+        historyDate.getDate(),
+      ).padStart(2, "0")}`
+    : "";
+  const url = `https://api.unirateapi.com/api/${path}?from=USD${dateParam}&api_key=${encodeURIComponent(api_key)}`;
+  console.log(`make API call to https://api.unirateapi.com/api/${path}?from=USD${dateParam}&api_key=***`);
+
+  const upstream = await fetch(url, {
+    signal: signal,
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  let upstreamJson: UniRateRatesResponse;
+  try {
+    upstreamJson = (await upstream.json()) as UniRateRatesResponse;
+  } catch {
+    upstreamJson = { error: `HTTP ${upstream.status}` };
+  }
+
+  let mapped: CurrencyResult;
+  if (!upstream.ok) {
+    if (upstream.status === 401) {
+      mapped = {
+        base_code: "USD",
+        result: "error",
+        ["error-type"]: "invalid-key",
+        conversion_rates: {},
+      };
+    } else {
+      const detail = upstreamJson.message || upstreamJson.error || `HTTP ${upstream.status}`;
+      mapped = {
+        base_code: "USD",
+        result: "error",
+        ["error-type"]: detail,
+        conversion_rates: {},
+      };
+    }
+  } else if (!upstreamJson.rates) {
+    mapped = {
+      base_code: "USD",
+      result: "error",
+      ["error-type"]: upstreamJson.error || "missing rates in response",
+      conversion_rates: {},
+    };
+  } else {
+    const conversion_rates: { [key: string]: number } = {};
+    for (const [code, value] of Object.entries(upstreamJson.rates)) {
+      const n = typeof value === "number" ? value : Number(value);
+      if (!Number.isNaN(n)) {
+        conversion_rates[code] = n;
+      }
+    }
+    if (historyDate) {
+      mapped = {
+        base_code: upstreamJson.base ?? "USD",
+        result: "success",
+        ["error-type"]: "",
+        conversion_rates,
+        year: historyDate.getFullYear(),
+        month: historyDate.getMonth() + 1,
+        day: historyDate.getDate(),
+      };
+    } else {
+      const nowSec = Math.round(Date.now() / 1000);
+      mapped = {
+        base_code: upstreamJson.base ?? "USD",
+        result: "success",
+        ["error-type"]: "",
+        conversion_rates,
+        time_last_update_unix: nowSec,
+        time_next_update_unix: nowSec + 86400,
+        time_last_update_utc: new Date().toUTCString(),
+      };
+    }
+  }
+
+  return new Response(JSON.stringify(mapped), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 function enrichExchangeData(

--- a/extensions/currency-exchange/tsconfig.json
+++ b/extensions/currency-exchange/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node 16",
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "raycast-env.d.ts"],
   "compilerOptions": {
     "lib": ["es2020"],
     "module": "commonjs",


### PR DESCRIPTION
## Description

Adds [UniRateAPI](https://unirateapi.com/) as a selectable rate provider next to the existing ExchangeRate-API integration, so users can pick the source that suits them best. Default stays ExchangeRate-API — no behavior change for current users.

**What changed**

- New `Rate Provider` dropdown preference (default `ExchangeRate-API`).
- Existing `API Key` field now applies to whichever provider is selected; description lists both dashboard URLs.
- `currencyAPI()` dispatches to `exchangeRateAPI()` (existing path, untouched aside from a small extraction) or `uniRateAPI()` (new), which transforms the UniRate response (`{ base, rates }`) into the same `CurrencyResult` shape the rest of the extension already consumes — so filtering, pinning, the historical `at YYYY/MM/DD` syntax, and the local cache all work without further changes.
- Cache key now includes the provider (`${provider}-currency${date}`) so toggling providers doesn't serve stale cross-provider data.
- README explains how to grab keys for either provider; CHANGELOG entry uses `{PR_MERGE_DATE}`.

**Why**

The README has a long-standing line — *"If anyone find free version API for currency historical data, please contact with me!"* — and UniRateAPI happens to be one of the free latest-rate options out there (with paid historical, similar to ExchangeRate-API's tiering). Adding it as an alternative gives users a choice without forcing anything on existing installs.

**Disclosure:** I run UniRateAPI. The PR keeps ExchangeRate-API as the default, scopes the change to one preference + one provider function, and matches the existing style; happy to adjust framing or wording if you'd prefer it more neutral.

## Screencast

I don't have a clean screencast on hand — wanted to keep this PR small/reviewable. The visible UX delta is one new dropdown in Preferences:

```
Rate Provider:  [ ExchangeRate-API ▾ ]   ← default; existing behavior
                  ExchangeRate-API
                  UniRateAPI
```

Selecting `UniRateAPI` and entering a UniRate key makes the same calculator/list view work against UniRate's `/api/rates` (and `/api/historical/rates` for the `at YYYY/MM/DD` syntax). Happy to record one if it'd help review.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our metadata tool

cc @xeric @daudln @TakenMC — happy to iterate on naming/copy/UX if you'd prefer something different.
