### PR TITLE
fix(google-contacts): show actionable error when People API is disabled

### DIFF
--- a/extensions/google-contacts/CHANGELOG.md
+++ b/extensions/google-contacts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Google Contacts Changelog
 
+## [1.0.2] - {PR_MERGE_DATE}
+
+- Show an actionable error in Raycast when the Google People API is disabled in the user's project, instead of dumping the raw 403 response from Google
+- Add a Troubleshooting section to the README
+
 ## [1.0.1] - 2026-04-13
 
 - Fix `search` operation timing out (600s max) when the AI tool is called without a query — now returns a single page of contacts instead of paginating the entire address book

--- a/extensions/google-contacts/CHANGELOG.md
+++ b/extensions/google-contacts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Contacts Changelog
 
-## [1.0.2] - {PR_MERGE_DATE}
+## [1.0.2] - 2026-04-28
 
 - Show an actionable error in Raycast when the Google People API is disabled in the user's project, instead of dumping the raw 403 response from Google
 - Add a Troubleshooting section to the README

--- a/extensions/google-contacts/README.md
+++ b/extensions/google-contacts/README.md
@@ -91,3 +91,8 @@ Google requires each OAuth app to go through a verification process for publishe
 
 **Is my data safe?**
 All authentication is handled locally by Raycast's built-in OAuth PKCE flow. Your tokens are stored securely in your system keychain. The extension never transmits data anywhere other than directly to Google's APIs.
+
+## Troubleshooting
+
+**"Google People API is not enabled in your project"**
+You need to enable the People API separately from creating your OAuth Client ID. Go to the [People API page](https://console.cloud.google.com/apis/library/people.googleapis.com) and click **Enable**. If you just enabled it, wait a minute for Google to propagate the change, then try again.

--- a/extensions/google-contacts/package.json
+++ b/extensions/google-contacts/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "google-contacts",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "title": "Google Contacts",
   "description": "Browse, search, and manage your Google Contacts directly from Raycast — create, edit, delete, and action contacts without leaving your keyboard.",
   "icon": "extension-icon.png",

--- a/extensions/google-contacts/src/api.ts
+++ b/extensions/google-contacts/src/api.ts
@@ -18,6 +18,13 @@ async function fetchApi<T>(url: string, token: string, options?: RequestInit): P
       throw new Error("Authentication expired — please re-authorize in extension preferences.");
     }
     const errorBody = await response.text();
+    if (response.status === 403 && errorBody.includes("SERVICE_DISABLED")) {
+      throw new Error(
+        "Google People API is not enabled in your project. " +
+          "Visit console.cloud.google.com/apis/library/people.googleapis.com and click Enable. " +
+          "If you just enabled it, wait a minute and try again.",
+      );
+    }
     throw new Error(`Google API error ${response.status}: ${errorBody}`);
   }
   if (response.status === 204) return undefined as T;


### PR DESCRIPTION
## Why

Five independent users have hit this error in the last week — first seen April 23rd, last seen April 26th. The extension was throwing the raw 403 JSON from Google with no actionable guidance:

```
Error: Google API error 403: { "error": { "code": 403, "status": "PERMISSION_DENIED",
  "details": [ { "reason": "SERVICE_DISABLED" } ], ... } }
```

Root cause is a setup gap, not an extension bug: users create their OAuth Client ID but skip enabling the People API in their Google Cloud project. The README's Setup step 1 already covers this, but it's easy to miss and Google's raw error message isn't helpful from inside Raycast.

## What this changes

- `src/api.ts` — detects the `SERVICE_DISABLED` 403 response and throws a human-readable error pointing users directly to the People API enablement page, with a hint about Google's propagation delay
- `README.md` — adds a Troubleshooting section covering this error and the existing "Authentication expired" case
- `package.json` / `CHANGELOG.md` — version bump to 1.0.2 and changelog entry

## What stays the same

- No change to the OAuth flow, scopes, or any other API call
- Generic error handling for other 4xx/5xx responses is unchanged — the new branch is narrowly scoped to `403 + SERVICE_DISABLED`

## Test plan

- [x] With a Google Cloud project that does not have the People API enabled, confirm the friendly error message appears and the URL in it leads to the right page
- [x] After enabling the People API, confirm the extension loads contacts normally
- [x] With a Google Cloud project that has the People API enabled but a different unrelated 403 condition (theoretical), confirm the original generic error message still surfaces