### PR TITLE
fix(visual-studio-code): fall back to storage.json for recent projects when state.vscdb key is missing

### DIFF
--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Visual Studio Code Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed `Search Recent Projects` returning no results for VS Code Insiders users. Recent Insiders builds no longer write `history.recentlyOpenedPathsList` to `state.vscdb`; the extension now falls back to reading recent folders from `storage.json` (`lastKnownMenubarData`) when the DB key is absent. Stable VS Code builds are unaffected. (Fixes [#27440](https://github.com/raycast/extensions/issues/27440))
+
 ## [Update] - 2026-04-07
 
 - Added support for Qoder.

--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Visual Studio Code Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-05-04
 
 - Fixed `Search Recent Projects` returning no results for VS Code Insiders users. Recent Insiders builds no longer write `history.recentlyOpenedPathsList` to `state.vscdb`; the extension now falls back to reading recent folders from `storage.json` (`lastKnownMenubarData`) when the DB key is absent. Stable VS Code builds are unaffected. (Fixes [#27440](https://github.com/raycast/extensions/issues/27440))
 

--- a/extensions/visual-studio-code-recent-projects/src/lib/db.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/db.ts
@@ -17,11 +17,11 @@ export function useRecentEntries() {
   const path = getStoragePath("state.vscdb");
 
   if (!fs.existsSync(path)) {
+    const storageEntries = getEntriesFromStorageJSON();
     return {
-      data: [],
+      data: storageEntries ?? [],
       isLoading: false,
-      error: true,
-
+      error: !storageEntries,
       removeEntry: () => Promise.resolve(),
       removeAllEntries: () => Promise.resolve(),
     };

--- a/extensions/visual-studio-code-recent-projects/src/lib/db.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/db.ts
@@ -13,6 +13,10 @@ export type RemoveMethods = {
   removeAllEntries: () => Promise<void>;
 };
 
+async function warnRemoveNotSupported() {
+  await showToast(Toast.Style.Failure, "Removing entries is not supported when reading from storage.json");
+}
+
 export function useRecentEntries() {
   const path = getStoragePath("state.vscdb");
 
@@ -22,8 +26,8 @@ export function useRecentEntries() {
       data: storageEntries ?? [],
       isLoading: false,
       error: !storageEntries,
-      removeEntry: () => Promise.resolve(),
-      removeAllEntries: () => Promise.resolve(),
+      removeEntry: warnRemoveNotSupported,
+      removeAllEntries: warnRemoveNotSupported,
     };
   }
 
@@ -39,7 +43,7 @@ export function useRecentEntries() {
 
   async function removeEntry(entry: EntryLike) {
     if (!parsedEntries) {
-      await showToast(Toast.Style.Failure, "Removing entries is not supported when reading from storage.json");
+      await warnRemoveNotSupported();
       return;
     }
 
@@ -54,7 +58,7 @@ export function useRecentEntries() {
 
   async function removeAllEntries() {
     if (!parsedEntries) {
-      await showToast(Toast.Style.Failure, "Removing entries is not supported when reading from storage.json");
+      await warnRemoveNotSupported();
       return;
     }
 

--- a/extensions/visual-studio-code-recent-projects/src/lib/db.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/db.ts
@@ -112,23 +112,29 @@ function getEntriesFromStorageJSON(): EntryLike[] | undefined {
     const seen = new Set<string>();
     const results: EntryLike[] = [];
 
+    function buildUri(uri: Record<string, unknown>): string | undefined {
+      const scheme = typeof uri.scheme === "string" ? uri.scheme : "file";
+      const authority = typeof uri.authority === "string" ? uri.authority : "";
+      const uriPath = typeof uri.path === "string" ? uri.path : undefined;
+      return uriPath ? `${scheme}://${authority}${uriPath}` : undefined;
+    }
+
     function walkItems(items: unknown[]) {
       for (const item of items) {
         if (!item || typeof item !== "object") continue;
         const obj = item as Record<string, unknown>;
+        const uri = obj.uri as Record<string, unknown> | undefined;
 
-        if (obj.id === "openRecentFolder") {
-          const uri = obj.uri as Record<string, unknown> | undefined;
-          if (uri) {
-            const scheme = typeof uri.scheme === "string" ? uri.scheme : "file";
-            const uriPath = typeof uri.path === "string" ? uri.path : undefined;
-            const authority = typeof uri.authority === "string" ? uri.authority : "";
-            if (uriPath) {
-              const folderUri = `${scheme}://${authority}${uriPath}`;
-              if (!seen.has(folderUri)) {
-                seen.add(folderUri);
-                results.push({ folderUri });
-              }
+        if (uri) {
+          const uriStr = buildUri(uri);
+          if (uriStr && !seen.has(uriStr)) {
+            seen.add(uriStr);
+            if (obj.id === "openRecentFolder") {
+              results.push({ folderUri: uriStr });
+            } else if (obj.id === "openRecentFile") {
+              results.push({ fileUri: uriStr });
+            } else if (obj.id === "openRecentWorkspace") {
+              results.push({ workspace: { configPath: uriStr } });
             }
           }
         }

--- a/extensions/visual-studio-code-recent-projects/src/lib/db.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/db.ts
@@ -14,7 +14,7 @@ export type RemoveMethods = {
 };
 
 export function useRecentEntries() {
-  const path = getPath();
+  const path = getStoragePath("state.vscdb");
 
   if (!fs.existsSync(path)) {
     return {
@@ -35,9 +35,11 @@ export function useRecentEntries() {
   const entries = data && data.length ? data[0].entries : undefined;
   const parsedEntries = entries ? (JSON.parse(entries) as EntryLike[]) : undefined;
 
+  const effectiveEntries = parsedEntries ?? (!isLoading ? getEntriesFromStorageJSON() : undefined);
+
   async function removeEntry(entry: EntryLike) {
     if (!parsedEntries) {
-      await showToast(Toast.Style.Failure, "No recent entries found");
+      await showToast(Toast.Style.Failure, "Removing entries is not supported when reading from storage.json");
       return;
     }
 
@@ -51,6 +53,11 @@ export function useRecentEntries() {
   }
 
   async function removeAllEntries() {
+    if (!parsedEntries) {
+      await showToast(Toast.Style.Failure, "Removing entries is not supported when reading from storage.json");
+      return;
+    }
+
     try {
       if (
         await confirmAlert({
@@ -80,19 +87,72 @@ export function useRecentEntries() {
     }
   }
 
-  return { data: parsedEntries, isLoading, removeEntry, removeAllEntries };
+  return { data: effectiveEntries, isLoading, removeEntry, removeAllEntries };
 }
 
-function getPath() {
+function getStoragePath(filename: string) {
   const build = getBuildNamePreference();
   if (isWin) {
-    return `${homedir()}\\AppData\\Roaming\\${build}\\User\\globalStorage\\state.vscdb`;
+    return `${homedir()}\\AppData\\Roaming\\${build}\\User\\globalStorage\\${filename}`;
   }
-  return `${homedir()}/Library/Application Support/${build}/User/globalStorage/state.vscdb`;
+  return `${homedir()}/Library/Application Support/${build}/User/globalStorage/${filename}`;
+}
+
+function getEntriesFromStorageJSON(): EntryLike[] | undefined {
+  try {
+    const storagePath = getStoragePath("storage.json");
+    if (!fs.existsSync(storagePath)) return undefined;
+
+    const raw = fs.readFileSync(storagePath, "utf-8");
+    const storage = JSON.parse(raw) as Record<string, unknown>;
+
+    const menus = (storage?.lastKnownMenubarData as Record<string, unknown> | undefined)?.menus;
+    if (!menus || typeof menus !== "object" || Array.isArray(menus)) return undefined;
+
+    const seen = new Set<string>();
+    const results: EntryLike[] = [];
+
+    function walkItems(items: unknown[]) {
+      for (const item of items) {
+        if (!item || typeof item !== "object") continue;
+        const obj = item as Record<string, unknown>;
+
+        if (obj.id === "openRecentFolder") {
+          const uri = obj.uri as Record<string, unknown> | undefined;
+          if (uri) {
+            const scheme = typeof uri.scheme === "string" ? uri.scheme : "file";
+            const uriPath = typeof uri.path === "string" ? uri.path : undefined;
+            const authority = typeof uri.authority === "string" ? uri.authority : "";
+            if (uriPath) {
+              const folderUri = `${scheme}://${authority}${uriPath}`;
+              if (!seen.has(folderUri)) {
+                seen.add(folderUri);
+                results.push({ folderUri });
+              }
+            }
+          }
+        }
+
+        const submenu = obj.submenu as Record<string, unknown> | undefined;
+        if (submenu && Array.isArray(submenu.items)) walkItems(submenu.items as unknown[]);
+      }
+    }
+
+    for (const menu of Object.values(menus as Record<string, unknown>)) {
+      if (menu && typeof menu === "object") {
+        const menuObj = menu as Record<string, unknown>;
+        if (Array.isArray(menuObj.items)) walkItems(menuObj.items as unknown[]);
+      }
+    }
+
+    return results.length > 0 ? results : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 async function saveEntries(entries: EntryLike[]) {
   const data = JSON.stringify({ entries });
   const query = `INSERT INTO ItemTable (key, value) VALUES ('history.recentlyOpenedPathsList', '${data}');`;
-  await execFilePromise("sqlite3", [getPath(), query]);
+  await execFilePromise("sqlite3", [getStoragePath("state.vscdb"), query]);
 }


### PR DESCRIPTION
## Summary

Fixes #27440 — `Search Recent Projects` returns no results for VS Code Insiders users.

### What broke

Recent VS Code Insiders builds stopped writing `history.recentlyOpenedPathsList` to `state.vscdb`. The key is simply absent, so `useSQL` returns no data and the list is empty.

### Where the data now lives

The same recent-folder list is available in:

```
~/Library/Application Support/Code - Insiders/User/globalStorage/storage.json
```

under `lastKnownMenubarData.menus` — a dict keyed by menu name (`"File"`, `"Edit"`, …). Items with `"id": "openRecentFolder"` inside each menu's `submenu.items` carry the folder URI:

```json
{
  "id": "openRecentFolder",
  "uri": { "scheme": "file", "authority": "", "path": "/Users/you/project" }
}
```

### The fix

Added `getEntriesFromStorageJSON()` which reads and parses `storage.json`, walks the menu tree, and returns the recent folders as `EntryLike[]` — the same shape the rest of the extension already expects.

In `useRecentEntries()`, the result is used as a non-breaking fallback:

```ts
const effectiveEntries = parsedEntries ?? (!isLoading ? getEntriesFromStorageJSON() : undefined);
```

Stable VS Code builds are completely unaffected — `parsedEntries` is defined for them and the fallback path is never reached.

### Also

- Merged the duplicated `getPath()` / `getStorageJSONPath()` helpers into a single `getStoragePath(filename)` function.
- Fixed URI construction to correctly include `uri.authority` so local paths produce `file:///path` instead of `file:////path`.
- Removed a dead recursion branch (`obj.items`) that never fires in the real `storage.json` structure.

## Test plan

- [ ] Set Build to **Code - Insiders** in extension preferences → `Search Recent Projects` shows recent folders
- [ ] Set Build to **Code** (stable) → behaviour unchanged, still reads from `state.vscdb`
- [ ] Verify `remove entry` and `remove all entries` actions still work on the stable build