### PR TITLE
Update media-converter extension

### DIFF
--- a/extensions/media-converter/CHANGELOG.md
+++ b/extensions/media-converter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Media Converter Changelog
 
+## [1.6.1] - {PR_MERGE_DATE}
+
+### Fixed
+
+- **Convert Media** now reliably pre-fills the file picker with files selected in Finder, even when Raycast provides the Finder selection after the form initially renders. The same delayed prefill handling also applies to **Merge Media**.
+
 ## [1.6.0] - 2026-04-27
 
 ### Added

--- a/extensions/media-converter/CHANGELOG.md
+++ b/extensions/media-converter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Media Converter Changelog
 
-## [1.6.1] - {PR_MERGE_DATE}
+## [1.6.1] - 2026-04-28
 
 ### Fixed
 

--- a/extensions/media-converter/src/components/ConverterForm.tsx
+++ b/extensions/media-converter/src/components/ConverterForm.tsx
@@ -188,6 +188,7 @@ export function ConverterForm({
         });
         setCurrentFiles([]);
         setSelectedFileType(null);
+        setIsLoading(false);
         return;
       }
 

--- a/extensions/media-converter/src/components/ConverterForm.tsx
+++ b/extensions/media-converter/src/components/ConverterForm.tsx
@@ -10,7 +10,7 @@ import {
   useNavigation,
 } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import fs from "fs";
 import path from "path";
 import { convertMedia } from "../utils/converter";
@@ -90,9 +90,11 @@ export function ConverterForm({
 } = {}) {
   const preferences = getPreferenceValues<Preferences>();
   const prefill = launchContext?.prefill;
+  const initialInputFiles = prefill?.inputs ?? initialFiles ?? [];
+  const initialInputKey = initialInputFiles.join("\0");
 
   const [selectedFileType, setSelectedFileType] = useState<MediaType | null>(null);
-  const [currentFiles, setCurrentFiles] = useState<string[]>(prefill?.inputs ?? initialFiles ?? []);
+  const [currentFiles, setCurrentFiles] = useState<string[]>(initialInputFiles);
   const [outputFormat, setOutputFormat] = useState<AllOutputExtension | null>(prefill?.outputFormat ?? null);
   const [currentQualitySetting, setCurrentQualitySetting] = useState<QualitySettings | null>(prefill?.quality ?? null);
   const [simpleQuality, setSimpleQuality] = useState<QualityLevel>(DEFAULT_SIMPLE_QUALITY);
@@ -111,6 +113,8 @@ export function ConverterForm({
   const [customOutputFolderOverride, setCustomOutputFolderOverride] = useState<string>(prefill?.outputDir ?? "");
 
   const [isLoading, setIsLoading] = useState(true);
+  const appliedInitialInputKey = useRef<string | null>(null);
+  const hasUserSelectedFiles = useRef(false);
   const { push } = useNavigation();
 
   useEffect(() => {
@@ -125,18 +129,32 @@ export function ConverterForm({
   }, []);
 
   useEffect(() => {
-    if (currentFiles.length > 0) {
-      handleFileSelect(currentFiles);
-    } else {
+    if (initialInputFiles.length === 0) {
+      if (appliedInitialInputKey.current === null) {
+        appliedInitialInputKey.current = initialInputKey;
+        setCurrentFiles([]);
+      }
       setIsLoading(false);
+      return;
     }
-    // Intentionally run only on mount to process initial files once.
-  }, []);
 
-  const handleFileSelect = (files: string[]) => {
+    if (hasUserSelectedFiles.current || appliedInitialInputKey.current === initialInputKey) {
+      return;
+    }
+
+    appliedInitialInputKey.current = initialInputKey;
+    handleFileSelect(initialInputFiles);
+  }, [initialInputKey]);
+
+  const handleFileSelect = (files: string[], options: { markAsUserSelection?: boolean } = {}) => {
+    if (options.markAsUserSelection) {
+      hasUserSelectedFiles.current = true;
+    }
+
     if (files.length === 0) {
       setCurrentFiles([]);
       setSelectedFileType(null);
+      setIsLoading(false);
       return;
     }
 
@@ -427,7 +445,7 @@ export function ConverterForm({
         title="Select files"
         allowMultipleSelection={true}
         value={currentFiles}
-        onChange={(newFiles) => handleFileSelect(newFiles)}
+        onChange={(newFiles) => handleFileSelect(newFiles, { markAsUserSelection: true })}
       />
 
       {selectedFileType && presets.length > 0 && (

--- a/extensions/media-converter/src/components/MergeForm.tsx
+++ b/extensions/media-converter/src/components/MergeForm.tsx
@@ -1,6 +1,6 @@
 import { Form, ActionPanel, Action, Icon, showToast, Toast, showInFinder, getPreferenceValues } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import fs from "fs";
 import path from "path";
 import { mergeMedia } from "../utils/merge";
@@ -15,6 +15,7 @@ import {
 
 export function MergeForm({ initialFiles = [] }: { initialFiles?: string[] }) {
   const preferences = getPreferenceValues<Preferences>();
+  const initialFilesKey = initialFiles.join("\0");
   const [files, setFiles] = useState<string[]>(initialFiles);
   const [outputFormat, setOutputFormat] = useState<AllOutputExtension>(".mp4");
   const [outputFileName, setOutputFileName] = useState<string>("merged");
@@ -27,12 +28,31 @@ export function MergeForm({ initialFiles = [] }: { initialFiles?: string[] }) {
   const [stripMetadata, setStripMetadata] = useState<boolean>(Boolean(preferences.defaultStripMetadata));
   const [forceReencode, setForceReencode] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState(false);
+  const appliedInitialFilesKey = useRef<string | null>(null);
+  const hasUserSelectedFiles = useRef(false);
 
   const mediaType: MediaType | null = useMemo(() => {
     if (files.length === 0) return null;
     const t = getMediaType(path.extname(files[0]));
     return t === "image" ? null : t; // merging images doesn't really make sense
   }, [files]);
+
+  useEffect(() => {
+    if (initialFiles.length === 0) {
+      if (appliedInitialFilesKey.current === null) {
+        appliedInitialFilesKey.current = initialFilesKey;
+        setFiles([]);
+      }
+      return;
+    }
+
+    if (hasUserSelectedFiles.current || appliedInitialFilesKey.current === initialFilesKey) {
+      return;
+    }
+
+    appliedInitialFilesKey.current = initialFilesKey;
+    setFiles(initialFiles);
+  }, [initialFilesKey]);
 
   useEffect(() => {
     if (
@@ -173,7 +193,10 @@ export function MergeForm({ initialFiles = [] }: { initialFiles?: string[] }) {
         title="Select files to merge"
         allowMultipleSelection={true}
         value={files}
-        onChange={setFiles}
+        onChange={(nextFiles) => {
+          hasUserSelectedFiles.current = true;
+          setFiles(nextFiles);
+        }}
       />
       {files.length > 0 && (
         <Form.Description


### PR DESCRIPTION
## Description

Fixes #27464 .
- Restore `Convert Media` auto-population from Finder-selected files when the selection arrives after the form initially renders.
- Preserve launch-context/history prefill priority and avoid overwriting files after the user manually changes the picker.
- Apply the same delayed initial-file sync to `Merge Media`, which had the same Finder prefill race.
- Keep mixed-selection behavior unchanged: one media type per conversion run, with other selected file types discarded via the existing warning toast.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
