### PR TITLE
Google Meet: Add profile-refocus command and fix Dia clipboard bug

### DIFF
--- a/extensions/google-meet/CHANGELOG.md
+++ b/extensions/google-meet/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Google Meet Changelog
 
+## [New Command & Bug Fix] - {PR_MERGE_DATE}
+
+- Add "Create Meet and Refocus with Specified Profile" command — creates a meeting using a selected profile, copies the link, and refocuses the previous app
+- A refocus failure (e.g. the keystroke can't be sent) no longer reports a clipboard failure when the link was already copied. Also aligned the profile-list failure toast with the one used by the refocus command for consistency.
+- Fix "Couldn't copy to clipboard" error on Dia browser. Dia's AppleScript dictionary rejects the flat `active tab of front window` form used for most Chromium browsers and throws a coercion error. Route Dia through the nested `tell front window` form (previously only used for Arc). Both browsers are from The Browser Company and share the same scripting quirk.
+- Fix frontmost-browser detection. The previous `lsappinfo metainfo | grep` approach returned the first supported-browser name found anywhere in the metadata dump, so a background Chrome process or an Electron app whose bundle path contains "Google Chrome Framework" would be reported as the frontmost browser even when a different browser was actually in use. Replaced with a System Events query for the actual frontmost process name.
+
 ## [New Command] - 2026-04-12
 
 - Add "Create Meet and Refocus" command that creates a meeting, copies the link, and switches back to your previous app

--- a/extensions/google-meet/CHANGELOG.md
+++ b/extensions/google-meet/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Meet Changelog
 
-## [New Command & Bug Fix] - {PR_MERGE_DATE}
+## [New Command & Bug Fix] - 2026-04-28
 
 - Add "Create Meet and Refocus with Specified Profile" command — creates a meeting using a selected profile, copies the link, and refocuses the previous app
 - A refocus failure (e.g. the keystroke can't be sent) no longer reports a clipboard failure when the link was already copied. Also aligned the profile-list failure toast with the one used by the refocus command for consistency.

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -33,6 +33,13 @@
       "subtitle": "Google Meet",
       "description": "Creates a new meeting room with your default browser and copy the link to your clipboard.",
       "mode": "view"
+    },
+    {
+      "name": "manual-profile-and-refocus",
+      "title": "Create Meet and Refocus with Specified Profile",
+      "subtitle": "Google Meet",
+      "description": "Creates a new meeting room using a selected profile, copies the link, and refocuses your previous app.",
+      "mode": "view"
     }
   ],
   "preferences": [

--- a/extensions/google-meet/src/components/ProfileCommand.tsx
+++ b/extensions/google-meet/src/components/ProfileCommand.tsx
@@ -1,0 +1,36 @@
+import { ActionPanel, Action, List, Icon } from "@raycast/api";
+import { useCallback, useState } from "react";
+import { ProfileList, ProfileForm } from "./";
+
+type SelectionMode = "add_profile" | undefined;
+
+export function ProfileCommand({ refocus }: { refocus?: boolean }) {
+  const [selectionMode, setSelectionMode] = useState<SelectionMode>();
+
+  const onFinish = useCallback(() => setSelectionMode(undefined), []);
+
+  return (
+    <>
+      <List>
+        <List.Item
+          title="Create a new profile..."
+          icon={{
+            value: Icon.AddPerson,
+            tooltip: "Add new profile to the list",
+          }}
+          actions={
+            <ActionPanel>
+              <Action title="Create a New Profile" onAction={() => setSelectionMode("add_profile")}></Action>
+            </ActionPanel>
+          }
+        />
+
+        <List.Section title="Profiles" subtitle="List of created profiles to start a new Google Meet">
+          <ProfileList refocus={refocus} />
+        </List.Section>
+      </List>
+
+      {selectionMode === "add_profile" && <ProfileForm onFinish={onFinish} />}
+    </>
+  );
+}

--- a/extensions/google-meet/src/components/ProfileList/ProfileList.tsx
+++ b/extensions/google-meet/src/components/ProfileList/ProfileList.tsx
@@ -1,29 +1,46 @@
 import { ActionPanel, Action, showHUD, Clipboard, showToast, Toast, List } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
 import { FC, useCallback } from "react";
-import { getMeetTab, openMeetTabSelectedProfile, getTimeout, sleep } from "../../helpers";
+import { getMeetTab, openMeetTabSelectedProfile, getTimeout, sleep, switchToPreviousApp } from "../../helpers";
 import { useCacheHelpers } from "../../hooks";
 
-export const ProfileList: FC = () => {
+type ProfileListProps = {
+  refocus?: boolean;
+};
+
+export const ProfileList: FC<ProfileListProps> = ({ refocus = false }) => {
   const { profiles, onRemoveItem } = useCacheHelpers();
 
-  const onSelect = useCallback(async (email: string) => {
-    try {
-      await openMeetTabSelectedProfile(email);
+  const onSelect = useCallback(
+    async (email: string) => {
+      try {
+        await openMeetTabSelectedProfile(email);
 
-      const timeout = getTimeout();
-      await sleep(timeout);
+        const timeout = getTimeout();
+        await sleep(timeout);
 
-      const meetTab = await getMeetTab();
+        const meetTab = await getMeetTab();
 
-      await Clipboard.copy(meetTab.split("?")[0]);
-      await showHUD("Copied meet link to clipboard");
-    } catch {
-      await showToast({
-        style: Toast.Style.Failure,
-        title: "Couldn't copy to clipboard",
-      });
-    }
-  }, []);
+        await Clipboard.copy(meetTab.split("?")[0]);
+        await showHUD("Copied meet link to clipboard");
+      } catch {
+        await showFailureToast("Failed to create meet link. Make sure your browser is supported and try again.");
+        return;
+      }
+
+      // Refocus is best-effort and runs after the link is already on the
+      // clipboard, so a keystroke failure here must not be reported as a
+      // clipboard failure.
+      if (refocus) {
+        try {
+          await switchToPreviousApp();
+        } catch {
+          // Swallow — the user already has the link.
+        }
+      }
+    },
+    [refocus],
+  );
 
   const onRemove = useCallback(
     (email: string) => {

--- a/extensions/google-meet/src/components/index.ts
+++ b/extensions/google-meet/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./ProfileList";
 export * from "./ProfileForm";
+export * from "./ProfileCommand";

--- a/extensions/google-meet/src/helpers.ts
+++ b/extensions/google-meet/src/helpers.ts
@@ -2,7 +2,7 @@ import { getPreferenceValues, open } from "@raycast/api";
 import { runAppleScript } from "run-applescript";
 import {
   getOpenedBrowserScript,
-  getOpenedUrlForArc,
+  getOpenedUrlForBrowserCompany,
   getOpenedUrlForFirefox,
   getOpenedUrlsScript,
   getSwitchToPreviousAppScript,
@@ -35,16 +35,11 @@ export function sleep(ms: number): Promise<void> {
 async function getOpenTabs(): Promise<string> {
   const browserName = await getOpenedBrowser();
 
-  if (browserName === "Arc") {
-    return await runAppleScript(getOpenedUrlForArc());
+  if (browserName === "Arc" || browserName === "Dia") {
+    return await runAppleScript(getOpenedUrlForBrowserCompany(browserName));
   }
 
-  if (
-    browserName === "Firefox" ||
-    browserName === "Firefox Developer Edition" ||
-    browserName === "Zen" ||
-    browserName === "Dia"
-  ) {
+  if (browserName === "Firefox" || browserName === "Firefox Developer Edition" || browserName === "Zen") {
     return await runAppleScript(getOpenedUrlForFirefox(browserName));
   }
 

--- a/extensions/google-meet/src/manual-profile-and-refocus.tsx
+++ b/extensions/google-meet/src/manual-profile-and-refocus.tsx
@@ -1,36 +1,5 @@
-import { ActionPanel, Action, List, Icon } from "@raycast/api";
-import { useCallback, useState } from "react";
-import { ProfileList, ProfileForm } from "./components";
-
-type SelectionMode = "add_profile" | undefined;
+import { ProfileCommand } from "./components";
 
 export default function Command() {
-  const [selectionMode, setSelectionMode] = useState<SelectionMode>();
-
-  const onFinish = useCallback(() => setSelectionMode(undefined), []);
-
-  return (
-    <>
-      <List>
-        <List.Item
-          title="Create a new profile..."
-          icon={{
-            value: Icon.AddPerson,
-            tooltip: "Add new profile to the list",
-          }}
-          actions={
-            <ActionPanel>
-              <Action title="Create a New Profile" onAction={() => setSelectionMode("add_profile")}></Action>
-            </ActionPanel>
-          }
-        />
-
-        <List.Section title="Profiles" subtitle="List of created profiles to start a new Google Meet">
-          <ProfileList refocus />
-        </List.Section>
-      </List>
-
-      {selectionMode === "add_profile" && <ProfileForm onFinish={onFinish} />}
-    </>
-  );
+  return <ProfileCommand refocus />;
 }

--- a/extensions/google-meet/src/manual-profile-and-refocus.tsx
+++ b/extensions/google-meet/src/manual-profile-and-refocus.tsx
@@ -1,0 +1,36 @@
+import { ActionPanel, Action, List, Icon } from "@raycast/api";
+import { useCallback, useState } from "react";
+import { ProfileList, ProfileForm } from "./components";
+
+type SelectionMode = "add_profile" | undefined;
+
+export default function Command() {
+  const [selectionMode, setSelectionMode] = useState<SelectionMode>();
+
+  const onFinish = useCallback(() => setSelectionMode(undefined), []);
+
+  return (
+    <>
+      <List>
+        <List.Item
+          title="Create a new profile..."
+          icon={{
+            value: Icon.AddPerson,
+            tooltip: "Add new profile to the list",
+          }}
+          actions={
+            <ActionPanel>
+              <Action title="Create a New Profile" onAction={() => setSelectionMode("add_profile")}></Action>
+            </ActionPanel>
+          }
+        />
+
+        <List.Section title="Profiles" subtitle="List of created profiles to start a new Google Meet">
+          <ProfileList refocus />
+        </List.Section>
+      </List>
+
+      {selectionMode === "add_profile" && <ProfileForm onFinish={onFinish} />}
+    </>
+  );
+}

--- a/extensions/google-meet/src/manual-profile.tsx
+++ b/extensions/google-meet/src/manual-profile.tsx
@@ -1,36 +1,5 @@
-import { ActionPanel, Action, List, Icon } from "@raycast/api";
-import { useCallback, useState } from "react";
-import { ProfileList, ProfileForm } from "./components";
-
-type SelectionMode = "add_profile" | undefined;
+import { ProfileCommand } from "./components";
 
 export default function Command() {
-  const [selectionMode, setSelectionMode] = useState<SelectionMode>();
-
-  const onFinish = useCallback(() => setSelectionMode(undefined), []);
-
-  return (
-    <>
-      <List>
-        <List.Item
-          title="Create a new profile..."
-          icon={{
-            value: Icon.AddPerson,
-            tooltip: "Add new profile to the list",
-          }}
-          actions={
-            <ActionPanel>
-              <Action title="Create a New Profile" onAction={() => setSelectionMode("add_profile")}></Action>
-            </ActionPanel>
-          }
-        />
-
-        <List.Section title="Profiles" subtitle="List of created profiles to start a new Google Meet">
-          <ProfileList />
-        </List.Section>
-      </List>
-
-      {selectionMode === "add_profile" && <ProfileForm onFinish={onFinish} />}
-    </>
-  );
+  return <ProfileCommand />;
 }

--- a/extensions/google-meet/src/utils/scripts.ts
+++ b/extensions/google-meet/src/utils/scripts.ts
@@ -16,12 +16,17 @@ export function getOpenedUrlsScript(browserName: SupportedBrowsers): string {
 }
 
 /**
- * Get current tab URL for Arc
+ * Get current tab URL for browsers built by The Browser Company (Arc, Dia).
+ *
+ * Their scripting dictionaries reject the flat `active tab of front window`
+ * form that the default script uses (`-1700` coercion error) and require the
+ * nested `tell front window` form instead.
+ *
  * @returns Google Meet url i.e `https://meet.google.com/pen-adzt-swz`
  */
-export function getOpenedUrlForArc() {
+export function getOpenedUrlForBrowserCompany(browserName: "Arc" | "Dia") {
   return `
-    tell application "Arc"
+    tell application "${browserName}"
       tell front window
         set activeTabURL to URL of active tab
         return activeTabURL
@@ -91,13 +96,18 @@ export const supportedBrowsers = [
   "Dia",
 ] as const;
 
-// Easy way to access the focused window when the meet link opens
+// Identify which browser the meet link landed in by asking System Events for
+// the frontmost application. The previous `lsappinfo metainfo | grep | head -1`
+// approach returned the first supported-browser name found anywhere in the
+// metadata dump — including background Chrome helper processes and Electron
+// apps whose bundle paths contain "Google Chrome Framework" — which
+// misidentified the actual frontmost browser on machines running any
+// Chromium-based browser that wasn't the default.
 export const getOpenedBrowserScript = `
-    set cmd to "lsappinfo metainfo | grep -E -o '${supportedBrowsers.join("|")}' | head -1"
-
-    set frontmostBrowser to do shell script cmd
-
-    return frontmostBrowser
+    tell application "System Events"
+      set frontApp to name of first application process whose frontmost is true
+    end tell
+    return frontApp
 `;
 
 export type SupportedBrowsers = (typeof supportedBrowsers)[number];


### PR DESCRIPTION
## Description

- Adds a new **"Create Meet and Refocus with Specified Profile"** view command — mirrors the existing profile picker and refocuses the previous app after copying the link to the clipboard.
- Fixes the **"Couldn't copy to clipboard"** error on Dia. Dia's sdef rejects the flat `active tab of front window` form used for most Chromium browsers. Routed Dia through the nested `tell front window` form (previously only used for Arc; both browsers are from The Browser Company and share the same scripting quirk). Removed Dia from the Firefox-keystroke branch.
- Fixes **frontmost-browser detection**. The previous `lsappinfo metainfo | grep | head -1` approach returned the first supported-browser name found anywhere in the metadata dump — including background Chrome helper processes and Electron apps whose bundle paths contain "Google Chrome Framework" — misidentifying the actual frontmost browser on machines where the user's default browser was not the one lsappinfo happened to surface first. Replaced with a System Events query for the actual frontmost process name.
- Refocus failure in the profile commands no longer reports a clipboard failure when the link was already copied. Aligned the profile-list failure toast with the one used by the refocus command.

## Note

This is a re-submission of #27330, which was auto-closed after my fork was inadvertently deleted during a local cleanup. Same commit (`5466586`), no changes from the original PR.

## Screencast

(Same as the original PR.)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I confirmed that the extension doesn't require the `--remote-debugging-port` Chromium flag to work
- [x] I tested the experience after my changes
