### PR TITLE
Customize download folder location and fix Windows autodetection

### DIFF
--- a/extensions/immich/CHANGELOG.md
+++ b/extensions/immich/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Immich Changelog
 
-## [Custom Downloads folder] - {PR_MERGE_DATE}
+## [Custom Downloads folder] - 2026-05-05
 
 - Add custom download folder in preferences
 - Better auto-detection of the default downloads folder on Windows

--- a/extensions/immich/CHANGELOG.md
+++ b/extensions/immich/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Immich Changelog
 
+## [Custom Downloads folder] - {PR_MERGE_DATE}
+
+- Add custom download folder in preferences
+- Better auto-detection of the default downloads folder on Windows
+
 ## [Open, Copy and Download assets] - 2026-01-14
 
 - Add Open in Immich, Copy and Download actions for assets in the Asset View

--- a/extensions/immich/package.json
+++ b/extensions/immich/package.json
@@ -32,6 +32,14 @@
       "description": "Immich API Key",
       "type": "password",
       "required": true
+    },
+    {
+      "name": "download_folder",
+      "title": "Download Folder",
+      "placeholder": "~/Downloads",
+      "description": "Folder to save photos and videos. Default is the system's Downloads folder.",
+      "type": "directory",
+      "required": false
     }
   ],
   "commands": [

--- a/extensions/immich/src/utils/download.ts
+++ b/extensions/immich/src/utils/download.ts
@@ -1,7 +1,61 @@
-import { Clipboard, showHUD, showToast, Toast } from "@raycast/api";
-import { homedir, tmpdir } from "node:os";
+import { Cache, Clipboard, getPreferenceValues, showHUD, showToast, Toast } from "@raycast/api";
+import { runPowerShellScript } from "@raycast/utils";
+import { homedir, platform, tmpdir } from "node:os";
 import { join } from "node:path";
-import { writeFile, realpath } from "node:fs/promises";
+import { realpath, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+
+const WINDOWS_REG_DOWNLOAD_KEY = String.raw`HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders`;
+const WINDOWS_REG_DOWNLOAD_VALUE = "{374DE290-123F-4565-9164-39C4925E467B}";
+
+const cache = new Cache();
+
+/**
+ * Attempts to read the user's Downloads folder path from the Windows registry (in case user has moved it).
+ * Caches the result to avoid repeated registry reads (takes about 250ms on my machine).
+ * @returns The path to the Downloads folder, or null if it cannot be determined.
+ */
+async function windowsGetDownloadFolder() {
+  if (cache.has("download_folder")) {
+    return cache.get("download_folder") || null;
+  }
+
+  const path = await runPowerShellScript(
+    `(Get-ItemProperty -Path "${WINDOWS_REG_DOWNLOAD_KEY}")."${WINDOWS_REG_DOWNLOAD_VALUE}"`,
+    { timeout: 2000 },
+  ).catch(() => null);
+
+  if (path && existsSync(path)) {
+    const realPath = await realpath(path);
+    cache.set("download_folder", realPath);
+    return realPath;
+  }
+
+  cache.set("download_folder", "");
+  return null;
+}
+
+/**
+ * Gets the path to the user's Downloads folder path
+ * On Windows, it attempts to read the Downloads folder path from the registry to support custom locations.
+ * Defaults to ~/Downloads
+ * @returns The path to the Downloads folder.
+ */
+async function getDownloadFolderPath() {
+  const preferences = getPreferenceValues<Preferences>();
+  if (preferences.download_folder) {
+    return preferences.download_folder;
+  }
+
+  if (platform() === "win32") {
+    const path = await windowsGetDownloadFolder();
+    if (path) {
+      return path;
+    }
+  }
+
+  return join(homedir(), "Downloads");
+}
 
 /**
  * Fetches a file from a URL and writes it to the specified file path on disk.
@@ -80,7 +134,7 @@ export async function downloadImageToDownloads(url: string, filename: string) {
   const toast = await showToast(Toast.Style.Animated, "Downloading image", "Please wait...");
 
   try {
-    const path = join(homedir(), "Downloads", safeFileName(filename));
+    const path = join(await getDownloadFolderPath(), safeFileName(filename));
     await fetchFileToDisk(path, url, (percent) => {
       toast.message = `${percent}%`;
     });

--- a/extensions/immich/src/utils/download.ts
+++ b/extensions/immich/src/utils/download.ts
@@ -5,7 +5,7 @@ import { realpath, writeFile } from "node:fs/promises";
 import { homedir, platform, tmpdir } from "node:os";
 import { join } from "node:path";
 
-const WINDOWS_REG_DOWNLOAD_KEY = String.raw`HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders`;
+const WINDOWS_REG_DOWNLOAD_KEY = String.raw`HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders`;
 const WINDOWS_REG_DOWNLOAD_VALUE = "{374DE290-123F-4565-9164-39C4925E467B}";
 const WINDOWS_REG_DOWNLOAD_CACHE_TTL = 1000 * 60 * 60; // 1 hour
 
@@ -27,7 +27,7 @@ async function windowsGetDownloadFolder() {
   }
 
   const path = await runPowerShellScript(
-    `(Get-ItemProperty -Path "${WINDOWS_REG_DOWNLOAD_KEY}")."${WINDOWS_REG_DOWNLOAD_VALUE}"`,
+    `[Environment]::ExpandEnvironmentVariables((Get-ItemProperty -Path "${WINDOWS_REG_DOWNLOAD_KEY}")."${WINDOWS_REG_DOWNLOAD_VALUE}")`,
     { timeout: 2000 },
   )
     .then((p) => p.trim())

--- a/extensions/immich/src/utils/download.ts
+++ b/extensions/immich/src/utils/download.ts
@@ -1,9 +1,9 @@
 import { Cache, Clipboard, getPreferenceValues, showHUD, showToast, Toast } from "@raycast/api";
 import { runPowerShellScript } from "@raycast/utils";
+import { existsSync } from "node:fs";
+import { realpath, writeFile } from "node:fs/promises";
 import { homedir, platform, tmpdir } from "node:os";
 import { join } from "node:path";
-import { realpath, writeFile } from "node:fs/promises";
-import { existsSync } from "node:fs";
 
 const WINDOWS_REG_DOWNLOAD_KEY = String.raw`HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders`;
 const WINDOWS_REG_DOWNLOAD_VALUE = "{374DE290-123F-4565-9164-39C4925E467B}";
@@ -23,7 +23,9 @@ async function windowsGetDownloadFolder() {
   const path = await runPowerShellScript(
     `(Get-ItemProperty -Path "${WINDOWS_REG_DOWNLOAD_KEY}")."${WINDOWS_REG_DOWNLOAD_VALUE}"`,
     { timeout: 2000 },
-  ).catch(() => null);
+  )
+    .then((p) => p.trim())
+    .catch(() => null);
 
   if (path && existsSync(path)) {
     const realPath = await realpath(path);

--- a/extensions/immich/src/utils/download.ts
+++ b/extensions/immich/src/utils/download.ts
@@ -7,16 +7,22 @@ import { join } from "node:path";
 
 const WINDOWS_REG_DOWNLOAD_KEY = String.raw`HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders`;
 const WINDOWS_REG_DOWNLOAD_VALUE = "{374DE290-123F-4565-9164-39C4925E467B}";
+const WINDOWS_REG_DOWNLOAD_CACHE_TTL = 1000 * 60 * 60; // 1 hour
 
 const cache = new Cache();
 
 /**
  * Attempts to read the user's Downloads folder path from the Windows registry (in case user has moved it).
  * Caches the result to avoid repeated registry reads (takes about 250ms on my machine).
+ * Cache expires after 1 hour
  * @returns The path to the Downloads folder, or null if it cannot be determined.
  */
 async function windowsGetDownloadFolder() {
-  if (cache.has("download_folder")) {
+  const cacheExpired = cache.has("download_folder_fetch_timestamp")
+    ? Date.now() - parseInt(cache.get("download_folder_fetch_timestamp") || "0") > WINDOWS_REG_DOWNLOAD_CACHE_TTL
+    : true;
+
+  if (!cacheExpired && cache.has("download_folder")) {
     return cache.get("download_folder") || null;
   }
 
@@ -30,10 +36,12 @@ async function windowsGetDownloadFolder() {
   if (path && existsSync(path)) {
     const realPath = await realpath(path);
     cache.set("download_folder", realPath);
+    cache.set("download_folder_fetch_timestamp", Date.now().toString());
     return realPath;
   }
 
   cache.set("download_folder", "");
+  cache.set("download_folder_fetch_timestamp", Date.now().toString());
   return null;
 }
 
@@ -140,7 +148,7 @@ export async function downloadImageToDownloads(url: string, filename: string) {
     await fetchFileToDisk(path, url, (percent) => {
       toast.message = `${percent}%`;
     });
-    // New toast to because the progress callback can overwrite the path
+    // New toast because the progress callback can overwrite the path
     await showToast(Toast.Style.Success, "Download complete", path);
   } catch (error) {
     toast.style = Toast.Style.Failure;


### PR DESCRIPTION
## Description

Previously, when downloading an asset on Windows, it always went to `C:\Users\<user>\Downloads`. This caused problems for users that moved their download folder to another location (see #27396)

Now, users can customize their download folder in the preferences.

<img width="800" height="560" alt="image" src="https://github.com/user-attachments/assets/4fa56c75-281e-461a-a5ed-c35023cb095b" />
<br/>

Alternatively, if they don't specify a download folder and they're on Windows, the download folder path detection has been improved, looking for the value in the registry.

On MacOS, default path will still always be `~/Downloads`

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
