### PR TITLE
Update numpy-documentation-search extension

### DIFF
--- a/extensions/numpy-documentation-search/CHANGELOG.md
+++ b/extensions/numpy-documentation-search/CHANGELOG.md
@@ -1,6 +1,16 @@
 # NumPy Documentation Search Changelog
 
-## [1.3.0] - 2026-04-21
+## [1.3.1] - {PR_MERGE_DATE}
+
+### Changed
+- Remove the standalone local documentation fallback guide from the packaged repository
+- Default to online documentation without requiring an initial source-selection prompt
+- Document the optional source preference pattern in the local docs fallback guide for reuse in other repos
+
+### Fixed
+- Remove an unused Raycast import so lint passes
+
+## [1.3.0] - 2026-04-20
 
 ### Added
 
@@ -10,7 +20,10 @@
 ### Changed
 
 - Fall back to local documentation when remote inventory loading fails
-- Load inline documentation previews from a configured local docs directory when network access is unavailable
+- Document how to replicate the Windows local-docs symlink fallback in other documentation-search extensions
+
+### Fixed
+- Support local documentation checkouts on Windows where the `stable` symlink is stored as a text file
 
 ## [1.2.3] - 2025-10-09
 

--- a/extensions/numpy-documentation-search/CHANGELOG.md
+++ b/extensions/numpy-documentation-search/CHANGELOG.md
@@ -3,11 +3,13 @@
 ## [1.3.1] - {PR_MERGE_DATE}
 
 ### Changed
+
 - Remove the standalone local documentation fallback guide from the packaged repository
 - Default to online documentation without requiring an initial source-selection prompt
 - Document the optional source preference pattern in the local docs fallback guide for reuse in other repos
 
 ### Fixed
+
 - Remove an unused Raycast import so lint passes
 
 ## [1.3.0] - 2026-04-20
@@ -23,6 +25,7 @@
 - Document how to replicate the Windows local-docs symlink fallback in other documentation-search extensions
 
 ### Fixed
+
 - Support local documentation checkouts on Windows where the `stable` symlink is stored as a text file
 
 ## [1.2.3] - 2025-10-09

--- a/extensions/numpy-documentation-search/CHANGELOG.md
+++ b/extensions/numpy-documentation-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NumPy Documentation Search Changelog
 
-## [1.3.1] - {PR_MERGE_DATE}
+## [1.3.1] - 2026-04-30
 
 ### Changed
 

--- a/extensions/numpy-documentation-search/package-lock.json
+++ b/extensions/numpy-documentation-search/package-lock.json
@@ -1325,6 +1325,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1339,6 +1342,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1353,6 +1359,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1367,6 +1376,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1395,6 +1407,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1409,6 +1424,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1423,6 +1441,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1437,6 +1458,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1451,6 +1475,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1465,6 +1492,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1479,6 +1509,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1493,6 +1526,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3672,9 +3708,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {

--- a/extensions/numpy-documentation-search/package.json
+++ b/extensions/numpy-documentation-search/package.json
@@ -28,7 +28,7 @@
     {
       "name": "documentationSourceMode",
       "type": "dropdown",
-      "required": true,
+      "required": false,
       "title": "Documentation Source",
       "description": "Choose where the extension should load NumPy documentation from",
       "default": "online",

--- a/extensions/numpy-documentation-search/src/__tests__/docs-source.test.ts
+++ b/extensions/numpy-documentation-search/src/__tests__/docs-source.test.ts
@@ -51,6 +51,29 @@ describe("loadInventory", () => {
     expect(result.data.some((item) => item.id === "numpy.linspace")).toBe(true);
   });
 
+  it("follows a stable symlink file from Windows checkouts", async () => {
+    const localDocsDirectory = createLocalDocsDirectory();
+    const versionDir = path.join(localDocsDirectory, "2.3");
+    mkdirSync(versionDir, { recursive: true });
+    writeFileSync(path.join(localDocsDirectory, "stable"), "2.3\n");
+    writeFileSync(path.join(versionDir, "objects.inv"), buildInventoryFixture());
+
+    const result = await loadInventory(
+      {
+        localDocsDirectory,
+        mode: "local",
+      },
+      {
+        fetchImpl: vi.fn() as typeof fetch,
+        readBinaryFileImpl: async (filePath) => readFileSync(filePath),
+        readTextFileImpl: async (filePath) => readFileSync(filePath, "utf8"),
+      },
+    );
+
+    expect(result.source).toBe("local");
+    expect(result.data.some((item) => item.id === "numpy.linspace")).toBe(true);
+  });
+
   it("surfaces the remote error when online mode has no local docs fallback", async () => {
     await expect(
       loadInventory(
@@ -74,6 +97,27 @@ describe("loadDocDetail", () => {
     const localDocsDirectory = createLocalDocsDirectory();
     const referenceDir = path.join(localDocsDirectory, "stable/reference/generated");
     mkdirSync(referenceDir, { recursive: true });
+    writeFileSync(
+      path.join(referenceDir, "numpy.linspace.html"),
+      readFileSync(path.join(process.cwd(), "src/__tests__/fixtures/numpy.linspace.html"), "utf8"),
+    );
+
+    const result = await loadDocDetail({
+      inventorySource: "local",
+      item: linspaceItem,
+      localDocsDirectory,
+      mode: "local",
+    });
+
+    expect(result.source).toBe("local");
+    expect(result.data?.signature).toContain("numpy.linspace");
+  });
+
+  it("loads documentation detail through a stable symlink file from Windows checkouts", async () => {
+    const localDocsDirectory = createLocalDocsDirectory();
+    const referenceDir = path.join(localDocsDirectory, "2.3/reference/generated");
+    mkdirSync(referenceDir, { recursive: true });
+    writeFileSync(path.join(localDocsDirectory, "stable"), "2.3\n");
     writeFileSync(
       path.join(referenceDir, "numpy.linspace.html"),
       readFileSync(path.join(process.cwd(), "src/__tests__/fixtures/numpy.linspace.html"), "utf8"),

--- a/extensions/numpy-documentation-search/src/lib/docs-source.ts
+++ b/extensions/numpy-documentation-search/src/lib/docs-source.ts
@@ -126,7 +126,7 @@ async function loadInventoryFromDirectory(
   localDocsDirectory: string | undefined,
   deps: LoaderDeps,
 ): Promise<InventoryItem[]> {
-  const directory = getStableDocsDirectory(localDocsDirectory);
+  const directory = await getStableDocsDirectory(localDocsDirectory, deps);
   return loadInventoryFromFile(path.join(directory, "objects.inv"), deps);
 }
 
@@ -148,13 +148,26 @@ async function loadLocalDocDetail(
   localDocsDirectory: string | undefined,
   deps: LoaderDeps,
 ): Promise<DocDetail> {
-  const directory = getStableDocsDirectory(localDocsDirectory);
+  const directory = await getStableDocsDirectory(localDocsDirectory, deps);
   const htmlPath = path.join(directory, item.docPath.split("#")[0] ?? item.docPath);
   return parseDocDetail(await deps.readTextFileImpl(htmlPath), item);
 }
 
-function getStableDocsDirectory(localDocsDirectory: string | undefined): string {
-  return path.join(requireLocalDocsDirectory(localDocsDirectory), "stable");
+async function getStableDocsDirectory(localDocsDirectory: string | undefined, deps: LoaderDeps): Promise<string> {
+  const directory = requireLocalDocsDirectory(localDocsDirectory);
+  const stablePath = path.join(directory, "stable");
+
+  try {
+    const symlinkTarget = (await deps.readTextFileImpl(stablePath)).trim();
+    if (symlinkTarget) {
+      return path.resolve(directory, symlinkTarget);
+    }
+  } catch {
+    // Most local docs downloads have a real stable directory. Windows Git checkouts
+    // can turn the stable symlink into a text file containing the target path.
+  }
+
+  return stablePath;
 }
 
 function requireLocalDocsDirectory(localDocsDirectory: string | undefined): string {

--- a/extensions/numpy-documentation-search/src/numpy-docs.tsx
+++ b/extensions/numpy-documentation-search/src/numpy-docs.tsx
@@ -3,16 +3,14 @@ import { useEffect, useMemo, useState } from "react";
 import { useDocDetail } from "./hooks/useDocDetail";
 import { useInventory } from "./hooks/useInventory";
 import { type DocDetail, buildMarkdown } from "./lib/doc-detail";
-import { type DocumentationSourceMode } from "./lib/docs-source";
+// `DocumentationSourceMode` is not needed here; preferences are typed via
+// the generated `Preferences` in `raycast-env.d.ts`.
 import { type InventoryItem } from "./lib/inventory";
 import { applyPrefixPreference } from "./lib/prefix";
 import { searchInventory } from "./lib/search";
 
-interface Preferences {
-  documentationSourceMode?: DocumentationSourceMode;
-  localDocsDirectory?: string;
-  useShortPrefix: boolean;
-}
+// `Preferences` is generated at runtime in `raycast-env.d.ts` from `package.json`.
+// Do not manually declare it here to avoid drift with the manifest.
 
 type DetailRenderState = {
   detail?: DocDetail;

--- a/extensions/numpy-documentation-search/src/numpy-docs.tsx
+++ b/extensions/numpy-documentation-search/src/numpy-docs.tsx
@@ -1,13 +1,4 @@
-import {
-  Action,
-  ActionPanel,
-  Detail,
-  getPreferenceValues,
-  Icon,
-  List,
-  openCommandPreferences,
-  type PreferenceValues,
-} from "@raycast/api";
+import { Action, ActionPanel, Detail, getPreferenceValues, Icon, List, openCommandPreferences } from "@raycast/api";
 import { useEffect, useMemo, useState } from "react";
 import { useDocDetail } from "./hooks/useDocDetail";
 import { useInventory } from "./hooks/useInventory";
@@ -16,6 +7,12 @@ import { type DocumentationSourceMode } from "./lib/docs-source";
 import { type InventoryItem } from "./lib/inventory";
 import { applyPrefixPreference } from "./lib/prefix";
 import { searchInventory } from "./lib/search";
+
+interface Preferences {
+  documentationSourceMode?: DocumentationSourceMode;
+  localDocsDirectory?: string;
+  useShortPrefix: boolean;
+}
 
 type DetailRenderState = {
   detail?: DocDetail;
@@ -28,7 +25,8 @@ const RECOVERY_ITEM_ID = "__recovery__";
 export default function Command() {
   const [searchText, setSearchText] = useState("");
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
-  const preferences = getPreferenceValues<PreferenceValues>();
+  const preferences = getPreferenceValues<Preferences>();
+  const documentationSourceMode = preferences.documentationSourceMode ?? "online";
 
   const {
     data: inventory = [],
@@ -38,8 +36,8 @@ export default function Command() {
     revalidate: revalidateInventory,
     source: inventorySource,
   } = useInventory({
-    localDocsDirectory: preferences.localDocsDirectory as string | undefined,
-    mode: preferences.documentationSourceMode as DocumentationSourceMode,
+    localDocsDirectory: preferences.localDocsDirectory,
+    mode: documentationSourceMode,
   });
 
   const results = useMemo(() => searchInventory(inventory, searchText), [inventory, searchText]);
@@ -80,8 +78,8 @@ export default function Command() {
   } = useDocDetail({
     inventorySource,
     item: selectedItem,
-    localDocsDirectory: preferences.localDocsDirectory as string | undefined,
-    mode: preferences.documentationSourceMode as DocumentationSourceMode,
+    localDocsDirectory: preferences.localDocsDirectory,
+    mode: documentationSourceMode,
   });
 
   const listIsLoading = isLoadingInventory;


### PR DESCRIPTION
## Description

Reading a certain path on windows for the "local documentation" option was not working as it did on macOs.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
