### PR TITLE
My Daily Log: handle macOS path permission errors

### DIFF
--- a/extensions/my-daily-log/CHANGELOG.md
+++ b/extensions/my-daily-log/CHANGELOG.md
@@ -1,5 +1,9 @@
 # my-daily-log Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Handle macOS permission errors (EPERM/EACCES) when the Daily Log Path is in a protected location (e.g. `~/Downloads`, `~/Desktop`, `~/Library/CloudStorage/…`). The extension now shows a failure toast with guidance to grant Full Disk Access or change the preference, instead of crashing.
+
 ## [Fixes] - 2023-09-08
 
 - Fixed a bug where if the folder for logs did not exist, the extension would crash

--- a/extensions/my-daily-log/src/infrastructure/loggedDays/JsonLoggedDaysRepository.tsx
+++ b/extensions/my-daily-log/src/infrastructure/loggedDays/JsonLoggedDaysRepository.tsx
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import { LoggedDay } from "../../domain/loggedDay/LoggedDay";
 import { LoggedDaysRepository } from "../../domain/loggedDay/LoggedDaysRepository";
 import { getDailyLogsPath } from "../../shared/getDailyLogPath";
-import { isPathPermissionError, showPathPermissionToast } from "../../shared/pathPermissionError";
+import { runWithPathPermissionFallback } from "../../shared/pathPermissionError";
 
 export class JsonLoggedDaysRepository implements LoggedDaysRepository {
   getLoggedDays(): LoggedDay[] {
@@ -10,20 +10,14 @@ export class JsonLoggedDaysRepository implements LoggedDaysRepository {
     if (!fs.existsSync(dailyLogPath)) {
       return [];
     }
-    try {
-      return fs
+    return runWithPathPermissionFallback<LoggedDay[]>(dailyLogPath, [], () =>
+      fs
         .readdirSync(dailyLogPath)
         .filter((file) => file.endsWith(".json"))
         .map((fileName) => fileName.replace(".json", ""))
         .map((fileName) => new Date(fileName))
         .sort((a, b) => b.getTime() - a.getTime())
-        .map((d) => new LoggedDay(d));
-    } catch (error) {
-      if (isPathPermissionError(error)) {
-        showPathPermissionToast(dailyLogPath);
-        return [];
-      }
-      throw error;
-    }
+        .map((d) => new LoggedDay(d))
+    );
   }
 }

--- a/extensions/my-daily-log/src/infrastructure/loggedDays/JsonLoggedDaysRepository.tsx
+++ b/extensions/my-daily-log/src/infrastructure/loggedDays/JsonLoggedDaysRepository.tsx
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import { LoggedDay } from "../../domain/loggedDay/LoggedDay";
 import { LoggedDaysRepository } from "../../domain/loggedDay/LoggedDaysRepository";
 import { getDailyLogsPath } from "../../shared/getDailyLogPath";
+import { isPathPermissionError, showPathPermissionToast } from "../../shared/pathPermissionError";
 
 export class JsonLoggedDaysRepository implements LoggedDaysRepository {
   getLoggedDays(): LoggedDay[] {
@@ -9,12 +10,20 @@ export class JsonLoggedDaysRepository implements LoggedDaysRepository {
     if (!fs.existsSync(dailyLogPath)) {
       return [];
     }
-    return fs
-      .readdirSync(dailyLogPath)
-      .filter((file) => file.endsWith(".json"))
-      .map((fileName) => fileName.replace(".json", ""))
-      .map((fileName) => new Date(fileName))
-      .sort((a, b) => b.getTime() - a.getTime())
-      .map((d) => new LoggedDay(d));
+    try {
+      return fs
+        .readdirSync(dailyLogPath)
+        .filter((file) => file.endsWith(".json"))
+        .map((fileName) => fileName.replace(".json", ""))
+        .map((fileName) => new Date(fileName))
+        .sort((a, b) => b.getTime() - a.getTime())
+        .map((d) => new LoggedDay(d));
+    } catch (error) {
+      if (isPathPermissionError(error)) {
+        showPathPermissionToast(dailyLogPath);
+        return [];
+      }
+      throw error;
+    }
   }
 }

--- a/extensions/my-daily-log/src/infrastructure/loggedDays/LegacyLoggedDaysRepository.tsx
+++ b/extensions/my-daily-log/src/infrastructure/loggedDays/LegacyLoggedDaysRepository.tsx
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import { LoggedDay } from "../../domain/loggedDay/LoggedDay";
 import { LoggedDaysRepository } from "../../domain/loggedDay/LoggedDaysRepository";
 import { getDailyLogsPath } from "../../shared/getDailyLogPath";
+import { isPathPermissionError, showPathPermissionToast } from "../../shared/pathPermissionError";
 
 export class LegacyLoggedDaysRepository implements LoggedDaysRepository {
   getLoggedDays(): LoggedDay[] {
@@ -9,12 +10,20 @@ export class LegacyLoggedDaysRepository implements LoggedDaysRepository {
     if (!fs.existsSync(dailyLogPath)) {
       return [];
     }
-    return fs
-      .readdirSync(dailyLogPath)
-      .filter((file) => file.endsWith(".md"))
-      .map((fileName) => fileName.replace(".md", ""))
-      .map((fileName) => new Date(fileName))
-      .sort((a, b) => b.getTime() - a.getTime())
-      .map((d) => new LoggedDay(d));
+    try {
+      return fs
+        .readdirSync(dailyLogPath)
+        .filter((file) => file.endsWith(".md"))
+        .map((fileName) => fileName.replace(".md", ""))
+        .map((fileName) => new Date(fileName))
+        .sort((a, b) => b.getTime() - a.getTime())
+        .map((d) => new LoggedDay(d));
+    } catch (error) {
+      if (isPathPermissionError(error)) {
+        showPathPermissionToast(dailyLogPath);
+        return [];
+      }
+      throw error;
+    }
   }
 }

--- a/extensions/my-daily-log/src/infrastructure/loggedDays/LegacyLoggedDaysRepository.tsx
+++ b/extensions/my-daily-log/src/infrastructure/loggedDays/LegacyLoggedDaysRepository.tsx
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import { LoggedDay } from "../../domain/loggedDay/LoggedDay";
 import { LoggedDaysRepository } from "../../domain/loggedDay/LoggedDaysRepository";
 import { getDailyLogsPath } from "../../shared/getDailyLogPath";
-import { isPathPermissionError, showPathPermissionToast } from "../../shared/pathPermissionError";
+import { runWithPathPermissionFallback } from "../../shared/pathPermissionError";
 
 export class LegacyLoggedDaysRepository implements LoggedDaysRepository {
   getLoggedDays(): LoggedDay[] {
@@ -10,20 +10,14 @@ export class LegacyLoggedDaysRepository implements LoggedDaysRepository {
     if (!fs.existsSync(dailyLogPath)) {
       return [];
     }
-    try {
-      return fs
+    return runWithPathPermissionFallback<LoggedDay[]>(dailyLogPath, [], () =>
+      fs
         .readdirSync(dailyLogPath)
         .filter((file) => file.endsWith(".md"))
         .map((fileName) => fileName.replace(".md", ""))
         .map((fileName) => new Date(fileName))
         .sort((a, b) => b.getTime() - a.getTime())
-        .map((d) => new LoggedDay(d));
-    } catch (error) {
-      if (isPathPermissionError(error)) {
-        showPathPermissionToast(dailyLogPath);
-        return [];
-      }
-      throw error;
-    }
+        .map((d) => new LoggedDay(d))
+    );
   }
 }

--- a/extensions/my-daily-log/src/infrastructure/shared/LocalFilesDataStorage.tsx
+++ b/extensions/my-daily-log/src/infrastructure/shared/LocalFilesDataStorage.tsx
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { DataStorage } from "./DataStorage";
+import { isPathPermissionError, showPathPermissionToast } from "../../shared/pathPermissionError";
 
 export class LocalFilesDataStorage implements DataStorage {
   constructor(private readonly getFilePath: (date: Date) => string) {}
@@ -8,10 +9,17 @@ export class LocalFilesDataStorage implements DataStorage {
   save(data: string, date: Date) {
     const filePath = this.getFilePath(date);
     const dirPath = path.dirname(filePath);
-    if (!fs.existsSync(dirPath)) {
-      fs.mkdirSync(dirPath, { recursive: true });
+    try {
+      if (!fs.existsSync(dirPath)) {
+        fs.mkdirSync(dirPath, { recursive: true });
+      }
+      fs.writeFileSync(filePath, data);
+    } catch (error) {
+      if (isPathPermissionError(error)) {
+        showPathPermissionToast(dirPath);
+      }
+      throw error;
     }
-    fs.writeFileSync(filePath, data);
   }
 
   dataForDateExists(date: Date): boolean {

--- a/extensions/my-daily-log/src/infrastructure/shared/LocalFilesDataStorage.tsx
+++ b/extensions/my-daily-log/src/infrastructure/shared/LocalFilesDataStorage.tsx
@@ -14,9 +14,8 @@ export class LocalFilesDataStorage implements DataStorage {
         fs.mkdirSync(dirPath, { recursive: true });
       }
       fs.writeFileSync(filePath, data);
-    } catch (error) {
       if (isPathPermissionError(error)) {
-        showPathPermissionToast(dirPath);
+        showPathPermissionToast(filePath);
       }
       throw error;
     }

--- a/extensions/my-daily-log/src/infrastructure/shared/LocalFilesDataStorage.tsx
+++ b/extensions/my-daily-log/src/infrastructure/shared/LocalFilesDataStorage.tsx
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { DataStorage } from "./DataStorage";
-import { isPathPermissionError, showPathPermissionToast } from "../../shared/pathPermissionError";
+import { runWithPathPermissionToast } from "../../shared/pathPermissionError";
 
 export class LocalFilesDataStorage implements DataStorage {
   constructor(private readonly getFilePath: (date: Date) => string) {}
@@ -9,16 +9,12 @@ export class LocalFilesDataStorage implements DataStorage {
   save(data: string, date: Date) {
     const filePath = this.getFilePath(date);
     const dirPath = path.dirname(filePath);
-    try {
+    runWithPathPermissionToast(dirPath, () => {
       if (!fs.existsSync(dirPath)) {
         fs.mkdirSync(dirPath, { recursive: true });
       }
       fs.writeFileSync(filePath, data);
-      if (isPathPermissionError(error)) {
-        showPathPermissionToast(filePath);
-      }
-      throw error;
-    }
+    });
   }
 
   dataForDateExists(date: Date): boolean {

--- a/extensions/my-daily-log/src/shared/pathPermissionError.tsx
+++ b/extensions/my-daily-log/src/shared/pathPermissionError.tsx
@@ -15,7 +15,28 @@ export function showPathPermissionToast(path: string): void {
       title: "Open Extension Preferences",
       onAction: () => openExtensionPreferences(),
     },
-  }).catch(() => {
-    // ignore toast display errors
-  });
+  }).catch(() => undefined);
+}
+
+export function runWithPathPermissionToast<T>(path: string, fn: () => T): T {
+  try {
+    return fn();
+  } catch (error) {
+    if (isPathPermissionError(error)) {
+      showPathPermissionToast(path);
+    }
+    throw error;
+  }
+}
+
+export function runWithPathPermissionFallback<T>(path: string, fallback: T, fn: () => T): T {
+  try {
+    return fn();
+  } catch (error) {
+    if (isPathPermissionError(error)) {
+      showPathPermissionToast(path);
+      return fallback;
+    }
+    throw error;
+  }
 }

--- a/extensions/my-daily-log/src/shared/pathPermissionError.tsx
+++ b/extensions/my-daily-log/src/shared/pathPermissionError.tsx
@@ -1,0 +1,21 @@
+import { showToast, Toast, openExtensionPreferences } from "@raycast/api";
+
+export function isPathPermissionError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "EPERM" || code === "EACCES";
+}
+
+export function showPathPermissionToast(path: string): void {
+  showToast({
+    style: Toast.Style.Failure,
+    title: "Can't access Daily Log folder",
+    message: `macOS blocked access to ${path}. Grant Raycast Full Disk Access in System Settings → Privacy & Security, or change the Daily Log Path preference.`,
+    primaryAction: {
+      title: "Open Extension Preferences",
+      onAction: () => openExtensionPreferences(),
+    },
+  }).catch(() => {
+    // ignore toast display errors
+  });
+}


### PR DESCRIPTION
## Description

Fixes unresolved `EPERM`/`EACCES` crashes reported for the My Daily Log extension when the **Daily Log Path** preference points to a location that macOS protects behind TCC (e.g. `~/Downloads/DailyLog`, `~/Library/CloudStorage/OneDrive-.../daily-log`).

Previously, `fs.readdirSync` / `fs.mkdirSync` would throw and surface as an unresolved error:

- `Error: EPERM: operation not permitted, scandir '.../Downloads/DailyLog'`
- `Error: EACCES: permission denied, mkdir '.../Library/CloudStorage/OneDrive-.../daily-log'`

Now those three call sites (`JsonLoggedDaysRepository`, `LegacyLoggedDaysRepository`, `LocalFilesDataStorage`) catch `EPERM`/`EACCES` and show a failure toast with a "Open Extension Preferences" action, guiding the user to either grant Raycast Full Disk Access or change the preference. Reads degrade gracefully to an empty list; writes still throw so the caller knows the save failed.

## Screencast / Validation

- `npx ray lint` – no issues
- `npx ray build -e dist` – clean TypeScript + build

## Checklist

- [x] I read the [contribution guidelines](https://github.com/raycast/extensions/blob/main/CONTRIBUTING.md)
- [x] I read the [Developer Guide](https://developers.raycast.com/basics/contribute-to-an-extension)
- [x] I ran `npm run lint` / `ray build` locally and both pass
- [x] Updated `CHANGELOG.md` with `{PR_MERGE_DATE}`