### PR TITLE
Fix Safari Search History failing with "no such column: unixepoch"

### DIFF
--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Safari Changelog
 
+## [Fix] - 2026-04-28
+
+- Fix `Search History` command failing with `no such column: "unixepoch"` by using single-quoted string literals in the SQL query.
+
 ## [Performance] - 2026-01-12
 
 - Significantly improved `Search Tabs` loading speed by replacing JXA with native Swift ScriptingBridge (˜4x faster load). 

--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Safari Changelog
 
-## [Fix] - 2026-04-28
+## [Fix] - {PR_MERGE_DATE}
 
 - Fix `Search History` command failing with `no such column: "unixepoch"` by using single-quoted string literals in the SQL query.
 

--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Safari Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-04-28
 
 - Fix `Search History` command failing with `no such column: "unixepoch"` by using single-quoted string literals in the SQL query.
 

--- a/extensions/safari/src/hooks/useHistorySearch.ts
+++ b/extensions/safari/src/hooks/useHistorySearch.ts
@@ -18,7 +18,7 @@ export const getHistoryQuery = (searchText?: string) => {
         .value()
     : undefined;
   return `
-  SELECT history_items.id, title, url, datetime(visit_time+978307200, "unixepoch", "localtime") as lastVisited
+  SELECT history_items.id, title, url, datetime(visit_time+978307200, 'unixepoch', 'localtime') as lastVisited
   FROM history_items
     INNER JOIN history_visits
     ON history_visits.history_item = history_items.id


### PR DESCRIPTION
## Description

Fixes the `Search History` command in the Safari extension which currently fails with:

```
Error: no such column: "unixepoch" - should this be a string literal in single-quotes?
```

The history query uses double quotes around `unixepoch` and `localtime` in `datetime()`. Newer SQLite versions (notably the one shipping with macOS Tahoe) parse double-quoted tokens as identifiers, so the format strings are treated as missing columns. Switching to single quotes makes them unambiguous string literals.

One-character change per token in `extensions/safari/src/hooks/useHistorySearch.ts`. Verified locally by running `bun run dev` and confirming history results now load.

Fixes #27366
Fixes #27465
Fixes #27477
Fixes #27484

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our metadata tool