### PR TITLE
Update git-repos extension

### DIFF
--- a/extensions/git-repos/CHANGELOG.md
+++ b/extensions/git-repos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Git Repos Changelog
 
+## [Bug Fix] - {PR_MERGE_DATE}
+
+- Fix out-of-memory crash when searching repositories by replacing glob (which uses worker threads) with a native fs traversal.
+
 ## [Enhancement] - 2026-04-10
 
 - Added Windows compatibility

--- a/extensions/git-repos/CHANGELOG.md
+++ b/extensions/git-repos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Git Repos Changelog
 
-## [Bug Fix] - {PR_MERGE_DATE}
+## [Bug Fix] - 2026-05-05
 
 - Fix out-of-memory crash when searching repositories by replacing glob (which uses worker threads) with a native fs traversal.
 

--- a/extensions/git-repos/package-lock.json
+++ b/extensions/git-repos/package-lock.json
@@ -11,7 +11,6 @@
         "@raycast/utils": "^2.2.3",
         "default-browser": "^5.5.0",
         "get-installed-browsers": "^0.1.7",
-        "glob": "^13.0.6",
         "parse-git-config": "^3.0.0",
         "parse-github-url": "^1.0.3"
       },
@@ -2132,23 +2131,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2391,15 +2373,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -2413,15 +2386,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -2546,22 +2510,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/picocolors": {

--- a/extensions/git-repos/package.json
+++ b/extensions/git-repos/package.json
@@ -152,7 +152,6 @@
     "@raycast/utils": "^2.2.3",
     "default-browser": "^5.5.0",
     "get-installed-browsers": "^0.1.7",
-    "glob": "^13.0.6",
     "parse-git-config": "^3.0.0",
     "parse-github-url": "^1.0.3"
   },

--- a/extensions/git-repos/src/utils.tsx
+++ b/extensions/git-repos/src/utils.tsx
@@ -230,35 +230,54 @@ function findSubmodules(repoPath: string): string[] {
   }
 }
 
-function findGitEntries(dir: string, maxDepth: number, currentDepth = 0): { gitDirs: string[]; gitFiles: string[] } {
+async function statLink(fullPath: string, entry: fs.Dirent): Promise<fs.Stats | null> {
+  if (!entry.isSymbolicLink()) {
+    return null;
+  }
+
+  try {
+    return await fs.promises.stat(fullPath);
+  } catch {
+    return null;
+  }
+}
+
+async function findGitEntries(
+  dir: string,
+  maxDepth: number,
+  currentDepth = 0,
+): Promise<{ gitDirs: string[]; gitFiles: string[] }> {
   const gitDirs: string[] = [];
   const gitFiles: string[] = [];
 
   let entries: fs.Dirent[];
   try {
-    entries = fs.readdirSync(dir, { withFileTypes: true });
+    entries = await fs.promises.readdir(dir, { withFileTypes: true });
   } catch {
     return { gitDirs, gitFiles };
   }
 
-  for (const entry of entries) {
-    if (entry.name === ".git") {
+  await Promise.all(
+    entries.map(async (entry) => {
       const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        gitDirs.push(fullPath);
-      } else if (entry.isFile()) {
-        gitFiles.push(fullPath);
-      }
-      // Don't recurse into .git
-      continue;
-    }
+      const stat = await statLink(fullPath, entry);
 
-    if (currentDepth < maxDepth && entry.isDirectory()) {
-      const sub = findGitEntries(path.join(dir, entry.name), maxDepth, currentDepth + 1);
-      gitDirs.push(...sub.gitDirs);
-      gitFiles.push(...sub.gitFiles);
-    }
-  }
+      if (entry.name === ".git") {
+        if (entry.isDirectory() || stat?.isDirectory()) {
+          gitDirs.push(fullPath);
+        } else if (entry.isFile() || stat?.isFile()) {
+          gitFiles.push(fullPath);
+        }
+        return;
+      }
+
+      if (currentDepth < maxDepth && (entry.isDirectory() || stat?.isDirectory())) {
+        const sub = await findGitEntries(fullPath, maxDepth, currentDepth + 1);
+        gitDirs.push(...sub.gitDirs);
+        gitFiles.push(...sub.gitFiles);
+      }
+    }),
+  );
 
   return { gitDirs, gitFiles };
 }
@@ -267,7 +286,7 @@ export async function findRepos(paths: string[], maxDepth: number, includeSubmod
   let foundRepos: GitRepo[] = [];
   await Promise.allSettled(
     paths.map(async (scanPath) => {
-      const { gitDirs, gitFiles } = findGitEntries(scanPath, maxDepth);
+      const { gitDirs, gitFiles } = await findGitEntries(scanPath, maxDepth);
 
       const repos = parseRepoPaths(scanPath, gitDirs, false);
       const worktrees = parseRepoPaths(scanPath, gitFiles, false).map((repo) => ({

--- a/extensions/git-repos/src/utils.tsx
+++ b/extensions/git-repos/src/utils.tsx
@@ -3,7 +3,6 @@ import { getPreferenceValues, showToast, LocalStorage, Toast } from "@raycast/ap
 import { homedir, platform } from "os";
 import path from "path";
 import fs from "fs";
-import { glob, Path } from "glob";
 import parseGitConfig from "parse-git-config";
 import parseGithubURL from "parse-github-url";
 import getDefaultBrowser from "default-browser";
@@ -231,19 +230,44 @@ function findSubmodules(repoPath: string): string[] {
   }
 }
 
+function findGitEntries(dir: string, maxDepth: number, currentDepth = 0): { gitDirs: string[]; gitFiles: string[] } {
+  const gitDirs: string[] = [];
+  const gitFiles: string[] = [];
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return { gitDirs, gitFiles };
+  }
+
+  for (const entry of entries) {
+    if (entry.name === ".git") {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        gitDirs.push(fullPath);
+      } else if (entry.isFile()) {
+        gitFiles.push(fullPath);
+      }
+      // Don't recurse into .git
+      continue;
+    }
+
+    if (currentDepth < maxDepth && entry.isDirectory()) {
+      const sub = findGitEntries(path.join(dir, entry.name), maxDepth, currentDepth + 1);
+      gitDirs.push(...sub.gitDirs);
+      gitFiles.push(...sub.gitFiles);
+    }
+  }
+
+  return { gitDirs, gitFiles };
+}
+
 export async function findRepos(paths: string[], maxDepth: number, includeSubmodules: boolean): Promise<GitRepo[]> {
   let foundRepos: GitRepo[] = [];
   await Promise.allSettled(
     paths.map(async (scanPath) => {
-      const gitEntries = (await glob("**/.git", {
-        cwd: scanPath,
-        maxDepth,
-        follow: true,
-        withFileTypes: true,
-        dot: true,
-      })) as Path[];
-      const gitDirs = gitEntries.filter((p) => p.isDirectory()).map((p) => p.fullpath());
-      const gitFiles = gitEntries.filter((p) => p.isFile()).map((p) => p.fullpath());
+      const { gitDirs, gitFiles } = findGitEntries(scanPath, maxDepth);
 
       const repos = parseRepoPaths(scanPath, gitDirs, false);
       const worktrees = parseRepoPaths(scanPath, gitFiles, false).map((repo) => ({


### PR DESCRIPTION
## Description

Fixes out of memory error when scanning big directories by replacing glob with native recursive fs traversal. 

Closes #27129 

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
