### PR TITLE
Update hammerspoon extension

### DIFF
--- a/extensions/hammerspoon/CHANGELOG.md
+++ b/extensions/hammerspoon/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hammerspoon Changelog
 
+## [New Command] - {PR_MERGE_DATE}
+
+- add `List Scripts` command to trigger user defined hammerspoon scripts.
+
 ## [Improvements] - 2026-03-08
 
 - add `Clear Console` preference to `Reload Configuration File` command to optionally clear the Hammerspoon Console before reloading

--- a/extensions/hammerspoon/CHANGELOG.md
+++ b/extensions/hammerspoon/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Hammerspoon Changelog
 
-## [New Command] - {PR_MERGE_DATE}
+## [New Command] - 2026-05-01
 
 - add `List Scripts` command to trigger user defined hammerspoon scripts.
 

--- a/extensions/hammerspoon/README.md
+++ b/extensions/hammerspoon/README.md
@@ -8,3 +8,53 @@ Control 🔨 Hammerspoon directly from Raycast.
 - With Hammerspoon installed, open your configuration file. By default Hammerspoon configuration file is located at `~/.hammerspoon/init.lua`. If you don't have this file, you can create it by running `touch ~/.hammerspoon/init.lua` in your terminal.
 - Add this line at the top of your configuration file: `hs.allowAppleScript(true)`, save the file and reload Hammerspoon.
 - All set! You can now control Hammerspoon from Raycast.
+
+## List Scripts setup
+
+The `List Scripts` command allows you to list and run custom Hammerspoon scripts directly from Raycast.
+
+To set it up, you first need to define a lua global variable in your Hammerspoon configuration file, this variable should be a table that contains two functions, `list` and `execute`. These two functions are going to be called by this raycast extension when listing and running scripts:
+
+- The `list` function should return a json array describing your scripts. each item in the array can have the following properties:
+  - `id`: a unique identifier for the script (must be unique, it is used to run scripts) **(required)**.
+  - `name`: the name of the script to be displayed in Raycast **(required)**.
+  - `description`: a short description of the script to be displayed in Raycast.
+  - `keywords`: an array of keywords to help with searching for the script in Raycast.
+- The `execute` function expects to receive a script id as an argument, and execute the corresponding script.
+
+Finally, you need to put the name of the global variable you created in your Hammerspoon configuration file in the `List Scripts` command preferences.
+
+Example of a Hammerspoon configuration file with the `List Scripts` setup:
+
+```lua
+-- <<rest of your configuration file>>
+
+local scriptDefs = {
+  { id = 'test', name = 'Test', description = 'This is a test script' },
+  { id = 'test2', name = 'Test 2', description = 'This is another test script' }
+}
+
+local scriptActions = {
+  test = function ()
+    hs.alert.show('Test script executed')
+  end,
+  test2 = function ()
+    hs.alert.show('Test 2 script executed')
+  end
+}
+
+__SCRIPTS__ = {
+  list = function ()
+    return hs.json.encode(scriptDefs)
+  end,
+  execute = function (id)
+    local scriptAction = scriptActions[id]
+
+    if not scriptAction then
+      error('User Script with id "' .. id .. '" not found')
+    end
+
+    scriptAction()
+  end
+}
+```

--- a/extensions/hammerspoon/package.json
+++ b/extensions/hammerspoon/package.json
@@ -3,7 +3,7 @@
   "name": "hammerspoon",
   "title": "Hammerspoon",
   "description": "Control Hammerspoon from Raycast",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "icon": "icon-prod.png",
   "author": "bjrmatos",
   "contributors": [
@@ -87,6 +87,26 @@
       "title": "Search Documentation",
       "description": "Search Hammerspoon Documentation",
       "mode": "view"
+    },
+    {
+      "name": "list-scripts",
+      "title": "List Scripts",
+      "description": "List and quickly trigger User Defined Hammerspoon Scripts",
+      "keywords": [
+        "Macros",
+        "Actions"
+      ],
+      "mode": "view",
+      "preferences": [
+        {
+          "name": "scriptsVariableName",
+          "title": "Scripts Variable Name",
+          "description": "The name of the global variable exported in your Hammerspoon configuration file that contains the methods to work with scripts",
+          "type": "textfield",
+          "default": "__SCRIPTS__",
+          "required": true
+        }
+      ]
     },
     {
       "name": "restart",

--- a/extensions/hammerspoon/src/list-scripts.tsx
+++ b/extensions/hammerspoon/src/list-scripts.tsx
@@ -58,8 +58,8 @@ export default function main() {
         }
       }
 
-      const docsRepository = parsed as ScriptItem[]
-      return docsRepository
+      const scripts = parsed as ScriptItem[]
+      return scripts
     },
     [],
     {
@@ -104,14 +104,21 @@ function renderListItems(items: ScriptItem[], revalidateScripts: () => void) {
               onAction={async () => {
                 const preferences = getPreferenceValues()
 
+                // NOTE: we sanitize the script id to avoid Lua syntax errors caused by double-quotes or escape sensitive characters
                 try {
                   const output = await runAppleScript(
                     `
                     ;(() => {
                       const app = Application('Hammerspoon')
                       const output = app.executeLuaCode(\`
+                        local ok, sanitizedId = pcall(function() return hs.json.decode('${JSON.stringify(item.id)}') end)
+
+                        if not ok then
+                          return hs.json.encode({ error = "Failed to decode script id" })
+                        end
+
                         if ${preferences.scriptsVariableName} and type(${preferences.scriptsVariableName}.execute) == 'function' then
-                          ${preferences.scriptsVariableName}.execute("${item.id}")
+                          ${preferences.scriptsVariableName}.execute(sanitizedId)
                           return
                         end
 

--- a/extensions/hammerspoon/src/list-scripts.tsx
+++ b/extensions/hammerspoon/src/list-scripts.tsx
@@ -1,0 +1,159 @@
+import { ActionPanel, List, Action, Icon, Color, getPreferenceValues, closeMainWindow } from '@raycast/api'
+import { runAppleScript, showFailureToast, useCachedPromise } from '@raycast/utils'
+
+interface ScriptItem {
+  id: string
+  name: string
+  description?: string
+  keywords?: string[]
+}
+
+export default function main() {
+  const {
+    isLoading,
+    data: scriptItems,
+    revalidate: revalidateScripts,
+    error
+  } = useCachedPromise(
+    async (): Promise<ScriptItem[]> => {
+      const preferences = getPreferenceValues()
+      const output = await runAppleScript(
+        `
+        ;(() => {
+          const app = Application('Hammerspoon')
+          const output = app.executeLuaCode(\`
+            if ${preferences.scriptsVariableName} and type(${preferences.scriptsVariableName}.list) == 'function' then
+              return ${preferences.scriptsVariableName}.list()
+            end
+
+            return hs.json.encode({ error = "Could not find scripts variable '${
+              preferences.scriptsVariableName
+            }' or it does not have a .list function. Make sure it exists in your Hammerspoon configuration file or that it is a valid object with functions" })
+          \`)
+          return output
+        })()
+      `,
+        { language: 'JavaScript' }
+      )
+
+      const parsed = JSON.parse(output)
+
+      if (parsed.error) {
+        throw new Error(parsed.error)
+      }
+
+      const baseErrMsg = `"${preferences.scriptsVariableName}.list()" returned invalid output.`
+
+      if (!Array.isArray(parsed)) {
+        throw new Error(`${baseErrMsg} It should return an array of script objects.`)
+      }
+
+      for (const script of parsed) {
+        if (typeof script.id !== 'string' || typeof script.name !== 'string') {
+          throw new Error(`${baseErrMsg} Each script object should have at least an .id and .name property.`)
+        }
+
+        if (script.id.trim() === '' || script.name.trim() === '') {
+          throw new Error(`${baseErrMsg} Each script object should have a non-empty .id and .name property.`)
+        }
+      }
+
+      const docsRepository = parsed as ScriptItem[]
+      return docsRepository
+    },
+    [],
+    {
+      initialData: [],
+      failureToastOptions: {
+        title: "Couldn't resolve user scripts of Hammerspoon"
+      }
+    }
+  )
+
+  let targetScripts: ScriptItem[] = scriptItems
+
+  if (error) {
+    targetScripts = []
+  }
+
+  const listContentEl = (
+    <List.Section title={'User Scripts'}>{renderListItems(targetScripts, revalidateScripts)}</List.Section>
+  )
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Type to search...">
+      {listContentEl}
+    </List>
+  )
+}
+
+function renderListItems(items: ScriptItem[], revalidateScripts: () => void) {
+  return items.map((item) => {
+    return (
+      <List.Item
+        key={item.id}
+        icon={{ source: Icon.Bolt, tintColor: Color.Yellow }}
+        title={item.name}
+        keywords={item.keywords ?? []}
+        subtitle={{ value: item.description, tooltip: item.description }}
+        actions={
+          <ActionPanel>
+            <Action
+              title="Execute Script"
+              icon={{ source: Icon.PlayFilled, tintColor: Color.Yellow }}
+              onAction={async () => {
+                const preferences = getPreferenceValues()
+
+                try {
+                  const output = await runAppleScript(
+                    `
+                    ;(() => {
+                      const app = Application('Hammerspoon')
+                      const output = app.executeLuaCode(\`
+                        if ${preferences.scriptsVariableName} and type(${preferences.scriptsVariableName}.execute) == 'function' then
+                          ${preferences.scriptsVariableName}.execute("${item.id}")
+                          return
+                        end
+
+                        return hs.json.encode({ error = "Could not find scripts variable '${
+                          preferences.scriptsVariableName
+                        }' or it does not have a .execute function. Make sure it exists in your Hammerspoon configuration file or that it is a valid object with functions" })
+                      \`)
+                      return output
+                    })()
+                  `,
+                    { language: 'JavaScript' }
+                  )
+
+                  if (output !== '') {
+                    let parsed
+                    try {
+                      parsed = JSON.parse(output)
+                    } catch {
+                      throw new Error(output)
+                    }
+
+                    if (parsed.error) {
+                      throw new Error(parsed.error)
+                    }
+                  }
+                } catch (error) {
+                  await showFailureToast(error, { title: 'Script Execution Failed' })
+                  return
+                }
+
+                await closeMainWindow({ clearRootSearch: true })
+              }}
+            />
+            <Action
+              title="Refresh"
+              onAction={revalidateScripts}
+              shortcut={{ modifiers: ['cmd'], key: 'r' }}
+              icon={Icon.RotateClockwise}
+            />
+          </ActionPanel>
+        }
+      />
+    )
+  })
+}


### PR DESCRIPTION
## Description

add `List Scripts` command to trigger user defined hammerspoon scripts.

## Screencast

<img width="1872" height="1320" alt="CleanShot 2026-04-28 at 20 17 31@2x" src="https://github.com/user-attachments/assets/96af6c4a-72a1-4bb1-9576-f722819119c6" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
