### PR TITLE
Update resend-wallpaper extension

### DIFF
--- a/extensions/resend-wallpaper/CHANGELOG.md
+++ b/extensions/resend-wallpaper/CHANGELOG.md
@@ -4,6 +4,3 @@
 - Fix broken wallpaper previews by encoding the full image URL
 
 ## [Initial Version] - 2025-07-01
-- Fix broken wallpaper previews by encoding the full image URL
-
-## [Initial Version] - 2025-07-01

--- a/extensions/resend-wallpaper/CHANGELOG.md
+++ b/extensions/resend-wallpaper/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Resend Wallpaper Changelog
 
+## [Fix Thumbnail URLs] - 2026-04-28
+
+- Fix broken wallpaper previews by encoding the full image URL
+
 ## [Initial Version] - 2025-07-01

--- a/extensions/resend-wallpaper/CHANGELOG.md
+++ b/extensions/resend-wallpaper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Resend Wallpaper Changelog
 
-## [Fix Wallpaper Previews] - {PR_MERGE_DATE}
+## [Fix Wallpaper Previews] - 2026-04-29
 - Fix broken wallpaper previews by encoding the full image URL
 
 ## [Initial Version] - 2025-07-01

--- a/extensions/resend-wallpaper/CHANGELOG.md
+++ b/extensions/resend-wallpaper/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Resend Wallpaper Changelog
 
-## [Fix Thumbnail URLs] - 2026-04-28
+## [Fix Wallpaper Previews] - {PR_MERGE_DATE}
+- Fix broken wallpaper previews by encoding the full image URL
 
+## [Initial Version] - 2025-07-01
 - Fix broken wallpaper previews by encoding the full image URL
 
 ## [Initial Version] - 2025-07-01

--- a/extensions/resend-wallpaper/package.json
+++ b/extensions/resend-wallpaper/package.json
@@ -228,5 +228,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/resend-wallpaper/package.json
+++ b/extensions/resend-wallpaper/package.json
@@ -5,6 +5,9 @@
   "description": "Get and set Resend official wallpapers.",
   "icon": "resend-icon.png",
   "author": "jopcmelo",
+  "contributors": [
+    "alexi.build"
+  ],
   "license": "MIT",
   "commands": [
     {

--- a/extensions/resend-wallpaper/src/utils/common-utils.ts
+++ b/extensions/resend-wallpaper/src/utils/common-utils.ts
@@ -35,9 +35,8 @@ export const axiosGetImageArrayBuffer = async (url: string) => {
 
 export const getThumbnailUrl = (url: string) => {
   try {
-    const urlObj = new URL(url);
-    const encodedPath = encodeURIComponent(urlObj.pathname);
-    return `https://resend.com/_next/image?url=${encodedPath}&w=1920&q=75`;
+    new URL(url);
+    return `https://resend.com/_next/image?url=${encodeURIComponent(url)}&w=1920&q=75`;
   } catch (error) {
     console.error(error);
     return url;


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

- Fix broken wallpaper previews by encoding the full image URL

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
