### PR TITLE
Update brightness-control extension

### DIFF
--- a/extensions/brightness-control/CHANGELOG.md
+++ b/extensions/brightness-control/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "Brightness Down" failed with "Error: Unknown option '-10'" since subprocess evaluates the "-10" as an argument. Added a leading "--" to prevent it.
 
+## [Fix WMI brightness on Windows] - {PR_MERGE_DATE}
+
+- Fixed brightness control failing on Windows by replacing the deprecated `WmiSetBrightness` call pattern with `Invoke-CimMethod`, which properly returns a result that can be checked for success.
+
 ## [Update] - 2026-04-28
 
 - Add windows support

--- a/extensions/brightness-control/CHANGELOG.md
+++ b/extensions/brightness-control/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Brightness Control Changelog
 
-## [Fix Brightness Down bug] - 2026-04-28
-
-- "Brightness Down" failed with "Error: Unknown option '-10'" since subprocess evaluates the "-10" as an argument. Added a leading "--" to prevent it.
-
 ## [Fix WMI brightness on Windows] - {PR_MERGE_DATE}
 
 - Fixed brightness control failing on Windows by replacing the deprecated `WmiSetBrightness` call pattern with `Invoke-CimMethod`, which properly returns a result that can be checked for success.
+
+## [Fix Brightness Down bug] - 2026-04-28
+
+- "Brightness Down" failed with "Error: Unknown option '-10'" since subprocess evaluates the "-10" as an argument. Added a leading "--" to prevent it.
 
 ## [Update] - 2026-04-28
 

--- a/extensions/brightness-control/CHANGELOG.md
+++ b/extensions/brightness-control/CHANGELOG.md
@@ -5,6 +5,7 @@
 - "Brightness Down" failed with "Error: Unknown option '-10'" since subprocess evaluates the "-10" as an argument. Added a leading "--" to prevent it.
 
 ## [Update] - 2026-04-28
+
 - Add windows support
 - Update packages
 

--- a/extensions/brightness-control/CHANGELOG.md
+++ b/extensions/brightness-control/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Brightness Control Changelog
 
-## [Fix WMI brightness on Windows] - {PR_MERGE_DATE}
+## [Fix WMI brightness on Windows] - 2026-04-29
 
 - Fixed brightness control failing on Windows by replacing the deprecated `WmiSetBrightness` call pattern with `Invoke-CimMethod`, which properly returns a result that can be checked for success.
 

--- a/extensions/brightness-control/package-lock.json
+++ b/extensions/brightness-control/package-lock.json
@@ -1200,7 +1200,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1423,7 +1422,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1772,7 +1770,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2550,7 +2547,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2574,7 +2570,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2781,7 +2776,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2849,7 +2843,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",

--- a/extensions/brightness-control/package.json
+++ b/extensions/brightness-control/package.json
@@ -7,7 +7,8 @@
   "author": "cali",
   "contributors": [
     "pavzagor",
-    "fatih_isaogullari"
+    "fatih_isaogullari",
+    "0xdhrv"
   ],
   "categories": [
     "System"

--- a/extensions/brightness-control/src/utils/ddc-ci.ts
+++ b/extensions/brightness-control/src/utils/ddc-ci.ts
@@ -111,9 +111,20 @@ try {
                 $methods = Get-CimInstance -Namespace root/WMI -ClassName WmiMonitorBrightnessMethods |
                     Where-Object { $_.InstanceName -eq $mon.InstanceName }
                 if ($methods) {
-                    $methods | ForEach-Object { $_.WmiSetBrightness(1, [byte]$newVal) }
+                    $setSucceeded = $false
+                    foreach ($method in $methods) {
+                        $invokeResult = Invoke-CimMethod -InputObject $method -MethodName WmiSetBrightness -Arguments @{
+                            Timeout = [uint32]1
+                            Brightness = [byte]$newVal
+                        } -ErrorAction Stop
+
+                        if ($null -eq $invokeResult.ReturnValue -or [int]$invokeResult.ReturnValue -eq 0) {
+                            $setSucceeded = $true
+                        }
+                    }
+
                     $entry['newBrightness'] = $newVal
-                    $entry['setResult'] = $true
+                    $entry['setResult'] = $setSucceeded
                 } else {
                     $entry['setResult'] = $false
                 }


### PR DESCRIPTION
## Description

Fixes brightness-control error on Windows

<img width="592" height="140" alt="image" src="https://github.com/user-attachments/assets/6c17838a-18b9-4dc1-a2b3-a0d82bf71933" />


## Screencast



## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
