### PR TITLE
[Skills] Fix bunx error on windows

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Skills Changelog
 
+## [Fix Windows bunx Fallback] - {PR_MERGE_DATE}
+
+- Fix the Skills CLI throwing `'"bunx"' is not recognized as an internal or external command` on Windows when Bun is not installed; the extension now correctly falls back to `npx` as intended
+
 ## [Add bunx support] - 2026-04-28
 
 - Added initial support for `bunx`, it is only called optimally if `npx` is not found

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Fix Windows bunx Fallback] - {PR_MERGE_DATE}
+## [Fix Windows bunx Fallback] - 2026-04-30
 
 - Fix the Skills CLI throwing `'"bunx"' is not recognized as an internal or external command` on Windows when Bun is not installed; the extension now correctly falls back to `npx` as intended
 

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -185,13 +185,17 @@ function isNpxCommandResolutionFailure(error: unknown, npxCommand: string): bool
   const normalizedNpxCommand = npxCommand.toLowerCase();
   const commandBase = basename(normalizedNpxCommand).replace(/\.(cmd|exe)$/, "");
   const windowsCommandNotFound = `'${commandBase}' is not recognized as an internal or external command`;
+  // cmd.exe echoes the command name with its surrounding double quotes from the shell-escaped invocation,
+  // so the error reads `'"bunx"' is not recognized...` when bunx is missing.
+  const windowsCommandNotFoundQuoted = `'"${commandBase}"' is not recognized as an internal or external command`;
 
   const mentionsCommand =
     details.includes(`spawn ${normalizedNpxCommand} `) ||
     details.includes(`spawn ${commandBase} `) ||
     details.includes(`command not found: ${commandBase}`) ||
     details.includes(`${commandBase}: command not found`) ||
-    details.includes(windowsCommandNotFound);
+    details.includes(windowsCommandNotFound) ||
+    details.includes(windowsCommandNotFoundQuoted);
 
   const npxShimModuleNotFound =
     commandBase === "npx" &&
@@ -205,7 +209,8 @@ function isNpxCommandResolutionFailure(error: unknown, npxCommand: string): bool
     details.includes(`spawn ${commandBase} enoent`) ||
     details.includes(`command not found: ${commandBase}`) ||
     details.includes(`${commandBase}: command not found`) ||
-    details.includes(windowsCommandNotFound)
+    details.includes(windowsCommandNotFound) ||
+    details.includes(windowsCommandNotFoundQuoted)
   );
 }
 


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->
Fixes #27509.

The Skills extension is supposed to try `bunx` first and then silently switch to `npx` if Bun isn't installed. However, on Windows, the fallback never happened. The shell-escape helper wraps every argument in double quotes for `cmd.exe`, so when `bunx` is missing, the error shows up as `'"bunx"' is not recognized as an internal or external command`. But the resolution-failure matcher only checked for the unquoted version, which is `'bunx' is not recognized...`, so the error went to the user instead of triggering the `npx` fallback. This change adds the cmd.exe-quoted version to the matcher, ensuring the fallback works as it should.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
