### PR TITLE
fix: guard against null history in getSearchHistory

### DIFF
--- a/extensions/kagi-search/CHANGELOG.md
+++ b/extensions/kagi-search/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Kagi Search Changelog
 
+## [1.2.5] - {PR_MERGE_DATE}
+* Fix crash when corrupted null value in history storage
+
 ## [1.2.4] - 2026-02-06
 
 * Add `Action` to Remove History when API disabled

--- a/extensions/kagi-search/CHANGELOG.md
+++ b/extensions/kagi-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kagi Search Changelog
 
-## [1.2.5] - {PR_MERGE_DATE}
+## [1.2.5] - 2026-04-30
 * Fix crash when corrupted null value in history storage
 
 ## [1.2.4] - 2026-02-06

--- a/extensions/kagi-search/src/utils/handleResults.ts
+++ b/extensions/kagi-search/src/utils/handleResults.ts
@@ -11,8 +11,8 @@ export async function getSearchHistory(): Promise<SearchResult[]> {
     return [];
   }
 
-  const items: SearchResult[] = JSON.parse(historyString);
-  return items;
+  const items = JSON.parse(historyString);
+  return Array.isArray(items) ? items : [];
 }
 
 export async function getSearchResults(


### PR DESCRIPTION
## Description

JSON.parse can return null if the stored history value is "null", which bypasses the undefined check and causes a crash when .length is called on it. Added an Array.isArray guard to handle this case.

This makes the extension work on Vicinae on Fedora Linux 44. I've not tested it anywhere else.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
