### PR TITLE
Add Hong Kong SAR and Macau SAR to Team Time extension cities

### DIFF
--- a/extensions/team-time/CHANGELOG.md
+++ b/extensions/team-time/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Team Time Changelog
 
-## [Add China Special Administrative Regions as Cities in China Timezone] - {PR_MERGE_DATE}
+## [Add China Special Administrative Regions as Cities in China Timezone] - 2026-04-30
 
 - Added two records (Hong Kong SAR, Macau SAR) to [src/world_cities_timezones.json].
 

--- a/extensions/team-time/CHANGELOG.md
+++ b/extensions/team-time/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Team Time Changelog
 
+## [Add China Special Administrive Regions as Cities in China Timezone] - {PR_MERGE_DATE}
+
+- Added two records (Hong Kong SAR, Macau SAR) to [src/world_cities_timezones.json].
+
 ## [Menu Bar Title Group Count Preference and Team Time Menu Bar Functionality] - 2025-11-21
 
 - Added a new preference for the number of time groups to display in the menu bar title.

--- a/extensions/team-time/CHANGELOG.md
+++ b/extensions/team-time/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Team Time Changelog
 
-## [Add China Special Administrive Regions as Cities in China Timezone] - {PR_MERGE_DATE}
+## [Add China Special Administrative Regions as Cities in China Timezone] - {PR_MERGE_DATE}
 
 - Added two records (Hong Kong SAR, Macau SAR) to [src/world_cities_timezones.json].
 

--- a/extensions/team-time/package.json
+++ b/extensions/team-time/package.json
@@ -35,7 +35,8 @@
   "icon": "icon.png",
   "author": "david_nakhapetian",
   "contributors": [
-    "0xdhrv"
+    "0xdhrv",
+    "dylan_penney"
   ],
   "platforms": [
     "macOS",

--- a/extensions/team-time/src/world_cities_timezones.json
+++ b/extensions/team-time/src/world_cities_timezones.json
@@ -387,7 +387,9 @@
           "Nanjing",
           "Wuhan",
           "Xi'an",
-          "Hangzhou"
+          "Hangzhou",
+          "Hong Kong SAR",
+          "Macau SAR"
         ]
       },
       { "zone": "Asia/Urumqi", "cities": ["Ürümqi", "Kashgar"] }


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->
This PR adds two China Special Administrative Regions as selectable cities in the Team Time extension:

  - Hong Kong SAR                                                     
  - Macau SAR

I have added both to the `Asia/Shanghai` timezone list in `src/world_cities_timezones.json` so users can select them directly when configuring Team Time.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

<img width="237" height="70" alt="Screenshot 2026-04-29 at 18 09 58" src="https://github.com/user-attachments/assets/527a2c19-b940-4376-98ca-3ec60259f7ed" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
