### PR TITLE
Update todoist extension

### DIFF
--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Todoist Changelog
 
-## [Scheduling, repeat options, and sync reliability] - {PR_MERGE_DATE}
+## [Scheduling, repeat options, and sync reliability] - 2026-04-30
 
 - **Set Repeat** in task actions: presets plus search (e.g. `every 2 days`), and an option to clear repeat.
 - **Pick date**: when you set a **due time** (not an all-day date), the extension can add Todoist’s **“at time of task”** relative reminder if you don’t already have one; **hourly** repeat rules get the same treatment.

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Todoist Changelog
 
+## [Scheduling, repeat options, and sync reliability] - {PR_MERGE_DATE}
+
+- **Set Repeat** in task actions: presets plus search (e.g. `every 2 days`), and an option to clear repeat.
+- **Pick date**: when you set a **due time** (not an all-day date), the extension can add Todoist’s **“at time of task”** relative reminder if you don’t already have one; **hourly** repeat rules get the same treatment.
+- **Accurate list after edits**: Todoist sync results merge onto the **latest** cached data so chained updates (e.g. due then reminder) don’t leave wrong or missing icons until you restart.
+- **Clear due date**: clearing the due date also applies **reminder** changes from the server so the alarm accessory matches Todoist.
+- **Complete recurring tasks**: completing uses the sync response so the **next occurrence** appears instead of the task vanishing until a full reload.
+- **Task details**: shows **Repeat** details when the task is recurring.
+
 ## [Fix group and sort actions in filter views] - 2026-04-27
 
 - In **My Tasks**, when a custom Todoist filter is selected, **Group tasks by** and **Sort tasks by** now update the list (they were previously no-ops because the UI ignored grouped/sorted output for filters).

--- a/extensions/todoist/src/api.ts
+++ b/extensions/todoist/src/api.ts
@@ -53,6 +53,11 @@ export type CachedDataParams = {
   setData: Dispatch<SetStateAction<SyncData | undefined>>;
 };
 
+/** Optional third argument to `updateTask` — called synchronously after merge with reminders from sync when callers need fresh data before re-render */
+export type TaskUpdateSyncedContext = {
+  syncReminders: SyncData["reminders"] | undefined;
+};
+
 // Applies sync deltas on top of the latest React state so consecutive writes cannot use a stale snapshot.
 function mergeIntoCachedData(
   setData: Dispatch<SetStateAction<SyncData | undefined>>,
@@ -312,17 +317,11 @@ export async function addTask(args: AddTaskArgs, { data, setData }: CachedDataPa
     ],
   });
 
-  const newData = data ? { ...data, items: updatedData.items } : updatedData;
   if (data) {
     mergeIntoCachedData(setData, (prev) => ({ ...prev, items: updatedData.items }));
   }
 
-  // In the case where the user uploads a file, we need to return the updated data
-  // so that addComment doesn't overwrite the cached data with the newly created task
-  return {
-    id: updatedData.temp_id_mapping ? updatedData.temp_id_mapping[temp_id] : null,
-    data: newData,
-  };
+  return { id: updatedData.temp_id_mapping ? updatedData.temp_id_mapping[temp_id] : null };
 }
 
 export type UpdateTaskArgs = {
@@ -339,7 +338,11 @@ export type UpdateTaskArgs = {
   day_order?: number;
 };
 
-export async function updateTask(args: UpdateTaskArgs, cachedData?: CachedDataParams) {
+export async function updateTask(
+  args: UpdateTaskArgs,
+  cachedData?: CachedDataParams,
+  onSynced?: (ctx: TaskUpdateSyncedContext) => void,
+): Promise<void> {
   const updatedData = await syncRequest({
     sync_token,
     resource_types: ["items", "reminders"],
@@ -352,14 +355,18 @@ export async function updateTask(args: UpdateTaskArgs, cachedData?: CachedDataPa
     ],
   });
 
+  const syncReminders = Array.isArray(updatedData.reminders) ? updatedData.reminders : undefined;
+
   // If returned items length is 0 then no update is needed, we can skip.
   if (cachedData?.setData && updatedData.items.length > 0) {
     mergeIntoCachedData(cachedData.setData, (prev) => ({
       ...prev,
       items: prev.items.map((i) => (i.id === args.id ? updatedData.items[0] : i)),
-      ...(Array.isArray(updatedData.reminders) ? { reminders: updatedData.reminders } : {}),
+      ...(syncReminders ? { reminders: syncReminders } : {}),
     }));
   }
+
+  onSynced?.({ syncReminders });
 }
 
 export async function closeTask(id: string, { setData }: CachedDataParams) {

--- a/extensions/todoist/src/api.ts
+++ b/extensions/todoist/src/api.ts
@@ -53,12 +53,14 @@ export type CachedDataParams = {
   setData: Dispatch<SetStateAction<SyncData | undefined>>;
 };
 
-/** Optional third argument to `updateTask` — called synchronously after merge with reminders from sync when callers need fresh data before re-render */
+/** Context for `updateTask` third argument — only invoked after a successful item + optional reminders merge into cache. */
 export type TaskUpdateSyncedContext = {
   syncReminders: SyncData["reminders"] | undefined;
 };
 
-// Applies sync deltas on top of the latest React state so consecutive writes cannot use a stale snapshot.
+/**
+ * Functional `setState` merge: always reads latest `SyncData`, avoiding stale closures from `setData({ ...data })`.
+ */
 function mergeIntoCachedData(
   setData: Dispatch<SetStateAction<SyncData | undefined>>,
   merge: (prev: SyncData) => SyncData,
@@ -338,11 +340,15 @@ export type UpdateTaskArgs = {
   day_order?: number;
 };
 
+/**
+ * PATCH task via Sync `item_update`. Returns whether the updated item row was merged into cache.
+ * Empty `updatedData.items` is treated as a no-op: cache unchanged, `onSynced` not called.
+ */
 export async function updateTask(
   args: UpdateTaskArgs,
   cachedData?: CachedDataParams,
   onSynced?: (ctx: TaskUpdateSyncedContext) => void,
-): Promise<void> {
+): Promise<boolean> {
   const updatedData = await syncRequest({
     sync_token,
     resource_types: ["items", "reminders"],
@@ -357,18 +363,20 @@ export async function updateTask(
 
   const syncReminders = Array.isArray(updatedData.reminders) ? updatedData.reminders : undefined;
 
-  // If returned items length is 0 then no update is needed, we can skip.
-  if (cachedData?.setData && updatedData.items.length > 0) {
-    mergeIntoCachedData(cachedData.setData, (prev) => ({
-      ...prev,
-      items: prev.items.map((i) => (i.id === args.id ? updatedData.items[0] : i)),
-      ...(syncReminders ? { reminders: syncReminders } : {}),
-    }));
+  if (!cachedData?.setData || updatedData.items.length === 0) {
+    return false;
   }
 
+  mergeIntoCachedData(cachedData.setData, (prev) => ({
+    ...prev,
+    items: prev.items.map((i) => (i.id === args.id ? updatedData.items[0] : i)),
+    ...(syncReminders ? { reminders: syncReminders } : {}),
+  }));
   onSynced?.({ syncReminders });
+  return true;
 }
 
+/** Complete task; merges returned items + reminders so recurring tasks show the next due in cache. */
 export async function closeTask(id: string, { setData }: CachedDataParams) {
   const updatedData = await syncRequest({
     sync_token,

--- a/extensions/todoist/src/api.ts
+++ b/extensions/todoist/src/api.ts
@@ -53,6 +53,14 @@ export type CachedDataParams = {
   setData: Dispatch<SetStateAction<SyncData | undefined>>;
 };
 
+// Applies sync deltas on top of the latest React state so consecutive writes cannot use a stale snapshot.
+function mergeIntoCachedData(
+  setData: Dispatch<SetStateAction<SyncData | undefined>>,
+  merge: (prev: SyncData) => SyncData,
+) {
+  setData((prev) => (prev ? merge(prev) : prev));
+}
+
 class SyncError extends Error {
   code: number;
   tag?: string;
@@ -120,7 +128,7 @@ export type AddProjectArgs = {
   view_style?: ProjectViewStyle;
 };
 
-export async function addProject(args: AddProjectArgs, { data, setData }: CachedDataParams) {
+export async function addProject(args: AddProjectArgs, { setData }: CachedDataParams) {
   const temp_id = crypto.randomUUID();
 
   const updatedData = await syncRequest({
@@ -136,12 +144,10 @@ export async function addProject(args: AddProjectArgs, { data, setData }: Cached
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      projects: updatedData.projects,
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    projects: updatedData.projects,
+  }));
 
   return updatedData.temp_id_mapping ? updatedData.temp_id_mapping[temp_id] : null;
 }
@@ -155,7 +161,7 @@ export type UpdateProjectArgs = {
   view_style?: ProjectViewStyle;
 };
 
-export async function updateProject(args: UpdateProjectArgs, { data, setData }: CachedDataParams) {
+export async function updateProject(args: UpdateProjectArgs, { setData }: CachedDataParams) {
   const updatedData = await syncRequest({
     sync_token,
     resource_types: ["projects"],
@@ -168,15 +174,13 @@ export async function updateProject(args: UpdateProjectArgs, { data, setData }: 
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      projects: data.projects.map((p) => (p.id === args.id ? updatedData.projects[0] : p)),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    projects: prev.projects.map((p) => (p.id === args.id ? updatedData.projects[0] : p)),
+  }));
 }
 
-export async function archiveProject(id: string, { data, setData }: CachedDataParams) {
+export async function archiveProject(id: string, { setData }: CachedDataParams) {
   await syncRequest({
     sync_token,
     resource_types: ["projects"],
@@ -189,15 +193,13 @@ export async function archiveProject(id: string, { data, setData }: CachedDataPa
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      projects: data.projects.filter((p) => p.id !== id),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    projects: prev.projects.filter((p) => p.id !== id),
+  }));
 }
 
-export async function deleteProject(id: string, { data, setData }: CachedDataParams) {
+export async function deleteProject(id: string, { setData }: CachedDataParams) {
   await syncRequest({
     sync_token,
     resource_types: ["projects"],
@@ -210,12 +212,10 @@ export async function deleteProject(id: string, { data, setData }: CachedDataPar
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      projects: data.projects.filter((p) => p.id !== id),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    projects: prev.projects.filter((p) => p.id !== id),
+  }));
 }
 
 export type Date = {
@@ -271,7 +271,7 @@ export async function quickAddTask(args: QuickAddTaskArgs) {
   return data;
 }
 
-export type DateOrString = { date: string; string?: undefined } | { date?: undefined; string: string };
+export type DateOrString = { date: string; string?: string } | { string: string; date?: string };
 
 export type AddTaskArgs = {
   content: string;
@@ -314,7 +314,7 @@ export async function addTask(args: AddTaskArgs, { data, setData }: CachedDataPa
 
   const newData = data ? { ...data, items: updatedData.items } : updatedData;
   if (data) {
-    setData(newData);
+    mergeIntoCachedData(setData, (prev) => ({ ...prev, items: updatedData.items }));
   }
 
   // In the case where the user uploads a file, we need to return the updated data
@@ -342,7 +342,7 @@ export type UpdateTaskArgs = {
 export async function updateTask(args: UpdateTaskArgs, cachedData?: CachedDataParams) {
   const updatedData = await syncRequest({
     sync_token,
-    resource_types: ["items"],
+    resource_types: ["items", "reminders"],
     commands: [
       {
         type: "item_update",
@@ -353,18 +353,19 @@ export async function updateTask(args: UpdateTaskArgs, cachedData?: CachedDataPa
   });
 
   // If returned items length is 0 then no update is needed, we can skip.
-  if (cachedData?.data && updatedData.items.length > 0) {
-    cachedData.setData({
-      ...cachedData.data,
-      items: cachedData.data.items.map((i) => (i.id === args.id ? updatedData.items[0] : i)),
-    });
+  if (cachedData?.setData && updatedData.items.length > 0) {
+    mergeIntoCachedData(cachedData.setData, (prev) => ({
+      ...prev,
+      items: prev.items.map((i) => (i.id === args.id ? updatedData.items[0] : i)),
+      ...(Array.isArray(updatedData.reminders) ? { reminders: updatedData.reminders } : {}),
+    }));
   }
 }
 
-export async function closeTask(id: string, { data, setData }: CachedDataParams) {
-  await syncRequest({
+export async function closeTask(id: string, { setData }: CachedDataParams) {
+  const updatedData = await syncRequest({
     sync_token,
-    resource_types: ["items"],
+    resource_types: ["items", "reminders"],
     commands: [
       {
         type: "item_close",
@@ -374,15 +375,23 @@ export async function closeTask(id: string, { data, setData }: CachedDataParams)
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      items: data.items.filter((i) => i.id !== id),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => {
+    const touched = updatedData.items?.find((i) => i.id === id);
+    const items =
+      touched && !touched.checked && !touched.is_deleted
+        ? prev.items.some((i) => i.id === id)
+          ? prev.items.map((i) => (i.id === id ? touched : i))
+          : [...prev.items, touched]
+        : prev.items.filter((i) => i.id !== id);
+    return {
+      ...prev,
+      ...(Array.isArray(updatedData.reminders) ? { reminders: updatedData.reminders } : {}),
+      items,
+    };
+  });
 }
 
-export async function deleteTask(id: string, { data, setData }: CachedDataParams) {
+export async function deleteTask(id: string, { setData }: CachedDataParams) {
   await syncRequest({
     sync_token,
     resource_types: ["items"],
@@ -395,12 +404,10 @@ export async function deleteTask(id: string, { data, setData }: CachedDataParams
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      items: data.items.filter((i) => i.id !== id),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    items: prev.items.filter((i) => i.id !== id),
+  }));
 }
 
 export type MoveTaskArgs = {
@@ -410,7 +417,7 @@ export type MoveTaskArgs = {
   project_id?: string;
 };
 
-export async function moveTask(args: MoveTaskArgs, { data, setData }: CachedDataParams) {
+export async function moveTask(args: MoveTaskArgs, { setData }: CachedDataParams) {
   const updatedData = await syncRequest({
     sync_token,
     resource_types: ["items"],
@@ -423,15 +430,13 @@ export async function moveTask(args: MoveTaskArgs, { data, setData }: CachedData
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      items: data.items.map((i) => (i.id === args.id ? updatedData.items[0] : i)),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    items: prev.items.map((i) => (i.id === args.id ? updatedData.items[0] : i)),
+  }));
 }
 
-export async function uncompleteTask(id: string, { data, setData }: CachedDataParams) {
+export async function uncompleteTask(id: string, { setData }: CachedDataParams) {
   const updatedData = await syncRequest({
     sync_token: "*",
     resource_types: ["items"],
@@ -444,12 +449,10 @@ export async function uncompleteTask(id: string, { data, setData }: CachedDataPa
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      items: updatedData.items,
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    items: updatedData.items,
+  }));
 }
 
 export type Reminder = {
@@ -480,7 +483,7 @@ export type AddReminderArgs = {
   radius?: number;
 };
 
-export async function addReminder(args: AddReminderArgs, { data, setData }: CachedDataParams) {
+export async function addReminder(args: AddReminderArgs, { setData }: CachedDataParams) {
   const temp_id = crypto.randomUUID();
 
   const updatedData = await syncRequest({
@@ -496,17 +499,15 @@ export async function addReminder(args: AddReminderArgs, { data, setData }: Cach
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      reminders: updatedData.reminders,
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    reminders: updatedData.reminders,
+  }));
 
   return updatedData.temp_id_mapping ? updatedData.temp_id_mapping[temp_id] : null;
 }
 
-export async function deleteReminder(id: string, { data, setData }: CachedDataParams) {
+export async function deleteReminder(id: string, { setData }: CachedDataParams) {
   await syncRequest({
     sync_token,
     resource_types: ["reminders"],
@@ -519,12 +520,10 @@ export async function deleteReminder(id: string, { data, setData }: CachedDataPa
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      reminders: data.reminders.filter((r) => r.id !== id),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    reminders: prev.reminders.filter((r) => r.id !== id),
+  }));
 }
 
 export type Label = {
@@ -543,7 +542,7 @@ type AddLabelArgs = {
   is_favorite?: boolean;
 };
 
-export async function addLabel(args: AddLabelArgs, { data, setData }: CachedDataParams) {
+export async function addLabel(args: AddLabelArgs, { setData }: CachedDataParams) {
   try {
     const addedData = await syncRequest({
       sync_token,
@@ -558,12 +557,10 @@ export async function addLabel(args: AddLabelArgs, { data, setData }: CachedData
       ],
     });
 
-    if (data) {
-      setData({
-        ...data,
-        labels: [...data.labels, addedData.labels[0]],
-      });
-    }
+    mergeIntoCachedData(setData, (prev) => ({
+      ...prev,
+      labels: [...prev.labels, addedData.labels[0]],
+    }));
   } catch (err) {
     if (err instanceof SyncError && err.tag === "LABEL_ALREADY_EXISTS") {
       return;
@@ -580,7 +577,7 @@ type UpdateLabelArgs = {
   is_favorite?: boolean;
 };
 
-export async function updateLabel(args: UpdateLabelArgs, { data, setData }: CachedDataParams) {
+export async function updateLabel(args: UpdateLabelArgs, { setData }: CachedDataParams) {
   const updatedData = await syncRequest({
     sync_token,
     resource_types: ["labels"],
@@ -593,15 +590,13 @@ export async function updateLabel(args: UpdateLabelArgs, { data, setData }: Cach
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      labels: data.labels.map((p) => (p.id === args.id ? updatedData.labels[0] : p)),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    labels: prev.labels.map((p) => (p.id === args.id ? updatedData.labels[0] : p)),
+  }));
 }
 
-export async function deleteLabel(id: string, { data, setData }: CachedDataParams) {
+export async function deleteLabel(id: string, { setData }: CachedDataParams) {
   await syncRequest({
     sync_token,
     resource_types: ["labels"],
@@ -614,14 +609,12 @@ export async function deleteLabel(id: string, { data, setData }: CachedDataParam
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      labels: data.labels.filter((l) => {
-        return l.id != id;
-      }),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    labels: prev.labels.filter((l) => {
+      return l.id != id;
+    }),
+  }));
 }
 
 export type Filter = {
@@ -642,7 +635,7 @@ type UpdateFilterArgs = {
   is_favorite?: boolean;
 };
 
-export async function updateFilter(args: UpdateFilterArgs, { data, setData }: CachedDataParams) {
+export async function updateFilter(args: UpdateFilterArgs, { setData }: CachedDataParams) {
   const updatedData = await syncRequest({
     sync_token,
     resource_types: ["filters"],
@@ -655,15 +648,13 @@ export async function updateFilter(args: UpdateFilterArgs, { data, setData }: Ca
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      filters: data.filters.map((p) => (p.id === args.id ? updatedData.filters[0] : p)),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    filters: prev.filters.map((p) => (p.id === args.id ? updatedData.filters[0] : p)),
+  }));
 }
 
-export async function deleteFilter(id: string, { data, setData }: CachedDataParams) {
+export async function deleteFilter(id: string, { setData }: CachedDataParams) {
   await syncRequest({
     sync_token,
     resource_types: ["filters"],
@@ -676,14 +667,12 @@ export async function deleteFilter(id: string, { data, setData }: CachedDataPara
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      filters: data.filters.filter((l) => {
-        return l.id != id;
-      }),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    filters: prev.filters.filter((l) => {
+      return l.id != id;
+    }),
+  }));
 }
 
 export type Section = {
@@ -718,7 +707,7 @@ type AddCommentArgs = {
   uids_to_notify?: string[];
 };
 
-export async function addComment(args: AddCommentArgs, { data, setData }: CachedDataParams) {
+export async function addComment(args: AddCommentArgs, { setData }: CachedDataParams) {
   const temp_id = crypto.randomUUID();
 
   const updatedData = await syncRequest({
@@ -734,12 +723,10 @@ export async function addComment(args: AddCommentArgs, { data, setData }: Cached
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      notes: updatedData.notes,
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    notes: updatedData.notes,
+  }));
 
   return updatedData.temp_id_mapping ? updatedData.temp_id_mapping[temp_id] : null;
 }
@@ -749,7 +736,7 @@ type UpdateCommentArgs = {
   content: string;
 };
 
-export async function updateComment(args: UpdateCommentArgs, { data, setData }: CachedDataParams) {
+export async function updateComment(args: UpdateCommentArgs, { setData }: CachedDataParams) {
   const updatedData = await syncRequest({
     sync_token,
     resource_types: ["notes"],
@@ -762,15 +749,13 @@ export async function updateComment(args: UpdateCommentArgs, { data, setData }: 
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      notes: data.notes.map((c) => (c.id === args.id ? updatedData.notes[0] : c)),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    notes: prev.notes.map((c) => (c.id === args.id ? updatedData.notes[0] : c)),
+  }));
 }
 
-export async function deleteComment(id: string, { data, setData }: CachedDataParams) {
+export async function deleteComment(id: string, { setData }: CachedDataParams) {
   await syncRequest({
     sync_token,
     resource_types: ["comments"],
@@ -783,12 +768,10 @@ export async function deleteComment(id: string, { data, setData }: CachedDataPar
     ],
   });
 
-  if (data) {
-    setData({
-      ...data,
-      notes: data.notes.filter((c) => c.id !== id),
-    });
-  }
+  mergeIntoCachedData(setData, (prev) => ({
+    ...prev,
+    notes: prev.notes.filter((c) => c.id !== id),
+  }));
 }
 
 export type Collaborator = {

--- a/extensions/todoist/src/components/TaskActions.tsx
+++ b/extensions/todoist/src/components/TaskActions.tsx
@@ -20,6 +20,7 @@ import {
   Reminder,
   SyncData,
   Task,
+  TaskUpdateSyncedContext,
   UpdateTaskArgs,
   addTask,
   addReminder as apiAddReminder,
@@ -109,11 +110,14 @@ export default function TaskActions({
     }
   }
 
-  async function updateTask(payload: UpdateTaskArgs): Promise<boolean> {
+  async function updateTask(
+    payload: UpdateTaskArgs,
+    onSynced?: (ctx: TaskUpdateSyncedContext) => void,
+  ): Promise<boolean> {
     await showToast({ style: Toast.Style.Animated, title: "Updating task" });
 
     try {
-      await apiUpdateTask(payload, { data, setData });
+      await apiUpdateTask(payload, { data, setData }, onSynced);
       await showToast({ style: Toast.Style.Success, title: "Task updated" });
       await refreshMenuBarCommand();
       return true;
@@ -123,18 +127,28 @@ export default function TaskActions({
     }
   }
 
-  async function ensureAtTaskTimeReminder(itemId: string) {
-    if (hasAtTaskTimeRelativeReminder(data?.reminders, itemId)) return;
+  async function ensureAtTaskTimeReminder(itemId: string, syncReminders?: Reminder[]) {
+    const hasAtTimeInSync = syncReminders !== undefined && hasAtTaskTimeRelativeReminder(syncReminders, itemId);
+    const hasAtTimeInCache = hasAtTaskTimeRelativeReminder(data?.reminders, itemId);
+    if (hasAtTimeInSync || (syncReminders === undefined && hasAtTimeInCache)) return;
     try {
       await apiAddReminder({ item_id: itemId, type: "relative", minute_offset: 0 }, { data, setData });
     } catch (error) {
+      // Sync said "missing" but cached props said "present": treat Bad Request as duplicate conflict.
+      if (hasAtTimeInCache && syncReminders !== undefined && `${error}`.includes("Bad Request")) return;
       await showFailureToast(error, { title: "Unable to add reminder" });
     }
   }
 
   async function setRecurrence(recurrence?: string) {
-    if (!(await updateTask({ id: task.id, due: repeatDuePayload(task, recurrence) }))) return;
-    if (isHourlyDueString(recurrence)) await ensureAtTaskTimeReminder(task.id);
+    let syncReminders: Reminder[] | undefined;
+    if (
+      !(await updateTask({ id: task.id, due: repeatDuePayload(task, recurrence) }, (ctx) => {
+        syncReminders = ctx.syncReminders;
+      }))
+    )
+      return;
+    if (isHourlyDueString(recurrence)) await ensureAtTaskTimeReminder(task.id, syncReminders);
   }
 
   const repeatOptions = [...buildDynamicRepeatOptions(repeatSearchText), ...filterRepeatPresets(repeatSearchText)];
@@ -283,8 +297,14 @@ export default function TaskActions({
               const due = date
                 ? { date: Action.PickDate.isFullDay(date) ? getAPIDate(date) : date.toISOString() }
                 : { string: "no date" };
-              if (!(await updateTask({ id: task.id, due }))) return;
-              if (date && !Action.PickDate.isFullDay(date)) await ensureAtTaskTimeReminder(task.id);
+              let syncReminders: Reminder[] | undefined;
+              if (
+                !(await updateTask({ id: task.id, due }, (ctx) => {
+                  syncReminders = ctx.syncReminders;
+                }))
+              )
+                return;
+              if (date && !Action.PickDate.isFullDay(date)) await ensureAtTaskTimeReminder(task.id, syncReminders);
             }}
           />
           <ActionPanel.Submenu

--- a/extensions/todoist/src/components/TaskActions.tsx
+++ b/extensions/todoist/src/components/TaskActions.tsx
@@ -83,6 +83,53 @@ export default function TaskActions({
   const remainingLabels = task && data?.labels ? getRemainingLabels(task, data.labels) : [];
   const [repeatSearchText, setRepeatSearchText] = useState("");
 
+  /**
+   * Wrapper around sync `updateTask`: returns whether Todoist returned an item row that we merged into cache.
+   * The optional callback runs only in that success path — use it so "at time of task" reminders follow real due updates.
+   */
+  async function updateTask(
+    payload: UpdateTaskArgs,
+    onSynced?: (ctx: TaskUpdateSyncedContext) => void,
+  ): Promise<boolean> {
+    await showToast({ style: Toast.Style.Animated, title: "Updating task" });
+
+    try {
+      const merged = await apiUpdateTask(payload, { data, setData }, onSynced);
+      await showToast({ style: Toast.Style.Success, title: "Task updated" });
+      await refreshMenuBarCommand();
+      return merged;
+    } catch (error) {
+      await showFailureToast(error, { title: "Unable to update task" });
+      return false;
+    }
+  }
+
+  /** Ensures Todoist relative reminder offset 0 when user sets a timed due / hourly repeat and none exists yet. */
+  async function ensureAtTaskTimeReminder(itemId: string, syncReminders?: Reminder[]) {
+    const hasAtTimeInSync = syncReminders !== undefined && hasAtTaskTimeRelativeReminder(syncReminders, itemId);
+    const hasAtTimeInCache = hasAtTaskTimeRelativeReminder(data?.reminders, itemId);
+    if (hasAtTimeInSync || (syncReminders === undefined && hasAtTimeInCache)) return;
+    try {
+      await apiAddReminder({ item_id: itemId, type: "relative", minute_offset: 0 }, { data, setData });
+    } catch (error) {
+      if (hasAtTimeInCache && syncReminders !== undefined && `${error}`.includes("Bad Request")) return;
+      await showFailureToast(error, { title: "Unable to add reminder" });
+    }
+  }
+
+  async function setRecurrence(recurrence?: string) {
+    let syncReminders: Reminder[] | undefined;
+    if (
+      !(await updateTask({ id: task.id, due: repeatDuePayload(task, recurrence) }, (ctx) => {
+        syncReminders = ctx.syncReminders;
+      }))
+    )
+      return;
+    if (isHourlyDueString(recurrence)) await ensureAtTaskTimeReminder(task.id, syncReminders);
+  }
+
+  const repeatOptions = [...buildDynamicRepeatOptions(repeatSearchText), ...filterRepeatPresets(repeatSearchText)];
+
   async function completeTask(task: Task) {
     await showToast({ style: Toast.Style.Animated, title: "Completing task" });
 
@@ -109,49 +156,6 @@ export default function TaskActions({
       }
     }
   }
-
-  async function updateTask(
-    payload: UpdateTaskArgs,
-    onSynced?: (ctx: TaskUpdateSyncedContext) => void,
-  ): Promise<boolean> {
-    await showToast({ style: Toast.Style.Animated, title: "Updating task" });
-
-    try {
-      await apiUpdateTask(payload, { data, setData }, onSynced);
-      await showToast({ style: Toast.Style.Success, title: "Task updated" });
-      await refreshMenuBarCommand();
-      return true;
-    } catch (error) {
-      await showFailureToast(error, { title: "Unable to update task" });
-      return false;
-    }
-  }
-
-  async function ensureAtTaskTimeReminder(itemId: string, syncReminders?: Reminder[]) {
-    const hasAtTimeInSync = syncReminders !== undefined && hasAtTaskTimeRelativeReminder(syncReminders, itemId);
-    const hasAtTimeInCache = hasAtTaskTimeRelativeReminder(data?.reminders, itemId);
-    if (hasAtTimeInSync || (syncReminders === undefined && hasAtTimeInCache)) return;
-    try {
-      await apiAddReminder({ item_id: itemId, type: "relative", minute_offset: 0 }, { data, setData });
-    } catch (error) {
-      // Sync said "missing" but cached props said "present": treat Bad Request as duplicate conflict.
-      if (hasAtTimeInCache && syncReminders !== undefined && `${error}`.includes("Bad Request")) return;
-      await showFailureToast(error, { title: "Unable to add reminder" });
-    }
-  }
-
-  async function setRecurrence(recurrence?: string) {
-    let syncReminders: Reminder[] | undefined;
-    if (
-      !(await updateTask({ id: task.id, due: repeatDuePayload(task, recurrence) }, (ctx) => {
-        syncReminders = ctx.syncReminders;
-      }))
-    )
-      return;
-    if (isHourlyDueString(recurrence)) await ensureAtTaskTimeReminder(task.id, syncReminders);
-  }
-
-  const repeatOptions = [...buildDynamicRepeatOptions(repeatSearchText), ...filterRepeatPresets(repeatSearchText)];
 
   async function addReminder(payload: AddReminderArgs) {
     await showToast({ style: Toast.Style.Animated, title: "Adding reminder" });
@@ -298,12 +302,10 @@ export default function TaskActions({
                 ? { date: Action.PickDate.isFullDay(date) ? getAPIDate(date) : date.toISOString() }
                 : { string: "no date" };
               let syncReminders: Reminder[] | undefined;
-              if (
-                !(await updateTask({ id: task.id, due }, (ctx) => {
-                  syncReminders = ctx.syncReminders;
-                }))
-              )
-                return;
+              const merged = await updateTask({ id: task.id, due }, (ctx) => {
+                syncReminders = ctx.syncReminders;
+              });
+              if (!merged) return;
               if (date && !Action.PickDate.isFullDay(date)) await ensureAtTaskTimeReminder(task.id, syncReminders);
             }}
           />

--- a/extensions/todoist/src/components/TaskActions.tsx
+++ b/extensions/todoist/src/components/TaskActions.tsx
@@ -11,7 +11,7 @@ import {
   getPreferenceValues,
 } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 
 import {
   AddReminderArgs,
@@ -36,7 +36,8 @@ import { getRemainingLabels, getTaskLabels } from "../helpers/labels";
 import { refreshMenuBarCommand } from "../helpers/menu-bar";
 import { getPriorityIcon, priorities } from "../helpers/priorities";
 import { getProjectIcon } from "../helpers/projects";
-import { displayReminderName } from "../helpers/reminders";
+import { displayReminderName, hasAtTaskTimeRelativeReminder } from "../helpers/reminders";
+import { buildDynamicRepeatOptions, filterRepeatPresets, isHourlyDueString, repeatDuePayload } from "../helpers/repeat";
 import { ViewMode, getTaskAppUrl, getTaskUrl } from "../helpers/tasks";
 import { QuickLinkView } from "../home";
 import { useFocusedTask } from "../hooks/useFocusedTask";
@@ -79,6 +80,7 @@ export default function TaskActions({
   const comments = data?.notes;
   const taskLabels = task && data?.labels ? getTaskLabels(task, data.labels) : [];
   const remainingLabels = task && data?.labels ? getRemainingLabels(task, data.labels) : [];
+  const [repeatSearchText, setRepeatSearchText] = useState("");
 
   async function completeTask(task: Task) {
     await showToast({ style: Toast.Style.Animated, title: "Completing task" });
@@ -107,17 +109,35 @@ export default function TaskActions({
     }
   }
 
-  async function updateTask(payload: UpdateTaskArgs) {
+  async function updateTask(payload: UpdateTaskArgs): Promise<boolean> {
     await showToast({ style: Toast.Style.Animated, title: "Updating task" });
 
     try {
       await apiUpdateTask(payload, { data, setData });
       await showToast({ style: Toast.Style.Success, title: "Task updated" });
       await refreshMenuBarCommand();
+      return true;
     } catch (error) {
       await showFailureToast(error, { title: "Unable to update task" });
+      return false;
     }
   }
+
+  async function ensureAtTaskTimeReminder(itemId: string) {
+    if (hasAtTaskTimeRelativeReminder(data?.reminders, itemId)) return;
+    try {
+      await apiAddReminder({ item_id: itemId, type: "relative", minute_offset: 0 }, { data, setData });
+    } catch (error) {
+      await showFailureToast(error, { title: "Unable to add reminder" });
+    }
+  }
+
+  async function setRecurrence(recurrence?: string) {
+    if (!(await updateTask({ id: task.id, due: repeatDuePayload(task, recurrence) }))) return;
+    if (isHourlyDueString(recurrence)) await ensureAtTaskTimeReminder(task.id);
+  }
+
+  const repeatOptions = [...buildDynamicRepeatOptions(repeatSearchText), ...filterRepeatPresets(repeatSearchText)];
 
   async function addReminder(payload: AddReminderArgs) {
     await showToast({ style: Toast.Style.Animated, title: "Adding reminder" });
@@ -259,20 +279,28 @@ export default function TaskActions({
           <Action.PickDate
             title="Pick Date"
             type={Action.PickDate.Type.DateTime}
-            onChange={(date) =>
-              updateTask({
-                id: task.id,
-                due: date
-                  ? { date: Action.PickDate.isFullDay(date) ? getAPIDate(date) : date.toISOString() }
-                  : { string: "no date" },
-              })
-            }
+            onChange={async (date) => {
+              const due = date
+                ? { date: Action.PickDate.isFullDay(date) ? getAPIDate(date) : date.toISOString() }
+                : { string: "no date" };
+              if (!(await updateTask({ id: task.id, due }))) return;
+              if (date && !Action.PickDate.isFullDay(date)) await ensureAtTaskTimeReminder(task.id);
+            }}
           />
-          <Action
-            title="Set Due to Every Day"
+          <ActionPanel.Submenu
+            title="Set Repeat"
             icon={Icon.Repeat}
-            onAction={() => updateTask({ id: task.id, due: { string: "every day" } })}
-          />
+            filtering={false}
+            onOpen={() => setRepeatSearchText("")}
+            onSearchTextChange={setRepeatSearchText}
+          >
+            {(!repeatSearchText.trim() || repeatSearchText.toLowerCase().includes("no repeat")) && (
+              <Action title="No Repeat" icon={Icon.XMarkCircle} onAction={() => setRecurrence()} />
+            )}
+            {repeatOptions.map(({ key, title, icon, recurrence }) => (
+              <Action key={key} title={title} icon={icon} onAction={() => setRecurrence(recurrence)} />
+            ))}
+          </ActionPanel.Submenu>
         </ActionPanel.Submenu>
 
         {data?.user?.premium_status !== "not_premium" ? (

--- a/extensions/todoist/src/components/TaskDetail.tsx
+++ b/extensions/todoist/src/components/TaskDetail.tsx
@@ -3,7 +3,7 @@ import { format } from "date-fns";
 
 import { Task } from "../api";
 import { getCollaboratorIcon } from "../helpers/collaborators";
-import { displayIncomingDate, isExactTimeTask } from "../helpers/dates";
+import { displayIncomingDate, displayRecurrence, isExactTimeTask } from "../helpers/dates";
 import { getTaskLabels } from "../helpers/labels";
 import { priorities } from "../helpers/priorities";
 import { getProjectIcon } from "../helpers/projects";
@@ -55,6 +55,7 @@ export default function TaskDetail({ taskId }: TaskDetailProps) {
     }) ?? [];
 
   const use12HourFormat = data?.user?.time_format === 1;
+  const recurrenceText = task ? displayRecurrence(task) : null;
 
   return (
     <Detail
@@ -81,6 +82,9 @@ export default function TaskDetail({ taskId }: TaskDetailProps) {
                 ) : null}
 
                 <Detail.Metadata.Label title="Date" text={displayedDate} icon={Icon.Calendar} />
+                {recurrenceText ? (
+                  <Detail.Metadata.Label title="Repeat" text={recurrenceText} icon={Icon.Repeat} />
+                ) : null}
                 <Detail.Metadata.Label title="Deadline" text={displayedDeadline} icon={Icon.BullsEye} />
 
                 {subTasks && subTasks?.length > 0 ? (

--- a/extensions/todoist/src/create-task.tsx
+++ b/extensions/todoist/src/create-task.tsx
@@ -155,7 +155,7 @@ function CreateTask({ fromProjectId, fromLabel, fromTodayEmptyView, draftValues 
         }
 
         // Use addTask API with structured parameters for reliable assignment
-        const taskData = await addTask(
+        const { id } = await addTask(
           {
             content: cleanContent,
             description: values.description || undefined,
@@ -178,8 +178,6 @@ function CreateTask({ fromProjectId, fromLabel, fromTodayEmptyView, draftValues 
           },
           { data, setData },
         );
-
-        const id = taskData.id;
 
         toast.style = Toast.Style.Success;
         toast.title = "Task created";

--- a/extensions/todoist/src/helpers/dates.ts
+++ b/extensions/todoist/src/helpers/dates.ts
@@ -6,6 +6,11 @@ export function isRecurring(task: Task) {
   return task.due?.is_recurring || false;
 }
 
+export function displayRecurrence(task: Task): string | null {
+  const s = task.due?.is_recurring ? task.due.string?.trim() : "";
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : null;
+}
+
 export function isExactTimeTask(task: Task) {
   if (!task.due) {
     return false;

--- a/extensions/todoist/src/helpers/dates.ts
+++ b/extensions/todoist/src/helpers/dates.ts
@@ -6,6 +6,7 @@ export function isRecurring(task: Task) {
   return task.due?.is_recurring || false;
 }
 
+/** Sentence-case of `due.string` for recurring tasks (detail metadata). */
 export function displayRecurrence(task: Task): string | null {
   const s = task.due?.is_recurring ? task.due.string?.trim() : "";
   return s ? s.charAt(0).toUpperCase() + s.slice(1) : null;

--- a/extensions/todoist/src/helpers/reminders.ts
+++ b/extensions/todoist/src/helpers/reminders.ts
@@ -2,6 +2,12 @@ import { Reminder } from "../api";
 
 import { displayDateTime } from "./dates";
 
+export function hasAtTaskTimeRelativeReminder(reminders: Reminder[] | undefined, itemId: string) {
+  return !!reminders?.some(
+    (r) => r.item_id === itemId && r.is_deleted !== 1 && r.type === "relative" && (r.mm_offset ?? 0) === 0,
+  );
+}
+
 export function displayReminderName(reminder: Reminder, use12HourFormat: boolean) {
   if (reminder.type === "location" && reminder.name) {
     return `${reminder.loc_trigger === "on_enter" ? "Arriving: " : "Departing: "}${reminder.name}`;

--- a/extensions/todoist/src/helpers/reminders.ts
+++ b/extensions/todoist/src/helpers/reminders.ts
@@ -2,6 +2,7 @@ import { Reminder } from "../api";
 
 import { displayDateTime } from "./dates";
 
+/** Todoist 'at time of task' relative reminder (`minute_offset: 0` in API calls; sync stores `mm_offset`). */
 export function hasAtTaskTimeRelativeReminder(reminders: Reminder[] | undefined, itemId: string) {
   return !!reminders?.some(
     (r) => r.item_id === itemId && r.is_deleted !== 1 && r.type === "relative" && (r.mm_offset ?? 0) === 0,

--- a/extensions/todoist/src/helpers/repeat.ts
+++ b/extensions/todoist/src/helpers/repeat.ts
@@ -19,10 +19,21 @@ function repeatIcon(unit: RecurrenceUnit) {
   return unit === "hour" ? Icon.Clock : Icon.Calendar;
 }
 
+function anchorAllDayDateToNow(date: string): string {
+  if (date.includes("T")) return date;
+  const [y, m, d] = date.split("-").map((n) => Number.parseInt(n, 10));
+  if (![y, m, d].every(Number.isFinite)) return date;
+  const now = new Date();
+  return new Date(y, m - 1, d, now.getHours(), now.getMinutes(), now.getSeconds(), now.getMilliseconds()).toISOString();
+}
+
 export function repeatDuePayload(task: Task, recurrence?: string): DateOrString {
   return recurrence
     ? task.due?.date
-      ? { string: recurrence, date: task.due.date }
+      ? {
+          string: recurrence,
+          date: isHourlyDueString(recurrence) ? anchorAllDayDateToNow(task.due.date) : task.due.date,
+        }
       : { string: recurrence }
     : task.due?.date
       ? { date: task.due.date }
@@ -47,7 +58,7 @@ export function buildDynamicRepeatOptions(searchText: string) {
   const m = searchText
     .trim()
     .toLowerCase()
-    .match(/^every\s+(\d+)(?:\s+([a-z]+))?$/i);
+    .match(/^every\s+(\d+)(?:\s+([a-z]+))?$/);
   if (!m) return [];
   const interval = parseInt(m[1], 10);
   if (!Number.isFinite(interval) || interval <= 1) return [];

--- a/extensions/todoist/src/helpers/repeat.ts
+++ b/extensions/todoist/src/helpers/repeat.ts
@@ -1,4 +1,5 @@
 import { Icon } from "@raycast/api";
+import { format } from "date-fns";
 
 import type { DateOrString, Task } from "../api";
 
@@ -19,12 +20,19 @@ function repeatIcon(unit: RecurrenceUnit) {
   return unit === "hour" ? Icon.Clock : Icon.Calendar;
 }
 
+/**
+ * All-day due + current local clock for hourly recurrence anchors.
+ *
+ * Todoist Sync "floating" due datetimes expect `YYYY-MM-DDTHH:MM:SS` with no zone suffix
+ */
 function anchorAllDayDateToNow(date: string): string {
   if (date.includes("T")) return date;
   const [y, m, d] = date.split("-").map((n) => Number.parseInt(n, 10));
   if (![y, m, d].every(Number.isFinite)) return date;
   const now = new Date();
-  return new Date(y, m - 1, d, now.getHours(), now.getMinutes(), now.getSeconds(), now.getMilliseconds()).toISOString();
+  const anchor = new Date(y, m - 1, d, now.getHours(), now.getMinutes(), now.getSeconds(), now.getMilliseconds());
+  if (Number.isNaN(+anchor)) return date;
+  return format(anchor, "yyyy-MM-dd'T'HH:mm:ss");
 }
 
 export function repeatDuePayload(task: Task, recurrence?: string): DateOrString {
@@ -40,18 +48,31 @@ export function repeatDuePayload(task: Task, recurrence?: string): DateOrString 
       : { string: "no date" };
 }
 
+/** When the query uses Todoist-style "every 1 …", show matching titles ("Every 1 Day"); otherwise keep shorthand ("Every Day"). */
+function presetDisplayTitle(unit: RecurrenceUnit, recurrence: string, searchTrimmed: string): string {
+  const standardTitle = `Every ${unit[0].toUpperCase()}${unit.slice(1)}`;
+  if (!/^every\s+1\b/i.test(searchTrimmed)) return standardTitle;
+  return recurrence
+    .split(" ")
+    .map((word) => (/^\d+$/.test(word) ? word : word.charAt(0).toUpperCase() + word.slice(1)))
+    .join(" ");
+}
+
 export function filterRepeatPresets(search: string) {
-  const q = search.trim().toLowerCase();
+  const trimmed = search.trim();
+  const q = trimmed.toLowerCase();
   const rows = REPEAT_UNITS.map((unit) => {
     const recurrence = buildRecurringDueString(unit, 1);
     return {
       key: recurrence,
-      title: `Every ${unit[0].toUpperCase()}${unit.slice(1)}`,
+      title: presetDisplayTitle(unit, recurrence, trimmed),
       recurrence,
       icon: repeatIcon(unit),
     };
   });
-  return q ? rows.filter((row) => row.title.toLowerCase().includes(q)) : rows;
+  return q
+    ? rows.filter((row) => row.title.toLowerCase().includes(q) || row.recurrence.toLowerCase().includes(q))
+    : rows;
 }
 
 export function buildDynamicRepeatOptions(searchText: string) {

--- a/extensions/todoist/src/helpers/repeat.ts
+++ b/extensions/todoist/src/helpers/repeat.ts
@@ -1,0 +1,65 @@
+import { Icon } from "@raycast/api";
+
+import type { DateOrString, Task } from "../api";
+
+export type RecurrenceUnit = "hour" | "day" | "week" | "month" | "year";
+
+export const REPEAT_UNITS: RecurrenceUnit[] = ["hour", "day", "week", "month", "year"];
+
+export function buildRecurringDueString(unit: RecurrenceUnit, interval = 1): string {
+  const n = Number.isFinite(interval) ? Math.max(1, Math.floor(interval)) : 1;
+  return `every ${n} ${n === 1 ? unit : `${unit}s`}`;
+}
+
+export function isHourlyDueString(s: string | undefined): boolean {
+  return !!s && /^every \d+ (hour|hours)$/.test(s.trim());
+}
+
+function repeatIcon(unit: RecurrenceUnit) {
+  return unit === "hour" ? Icon.Clock : Icon.Calendar;
+}
+
+export function repeatDuePayload(task: Task, recurrence?: string): DateOrString {
+  return recurrence
+    ? task.due?.date
+      ? { string: recurrence, date: task.due.date }
+      : { string: recurrence }
+    : task.due?.date
+      ? { date: task.due.date }
+      : { string: "no date" };
+}
+
+export function filterRepeatPresets(search: string) {
+  const q = search.trim().toLowerCase();
+  const rows = REPEAT_UNITS.map((unit) => {
+    const recurrence = buildRecurringDueString(unit, 1);
+    return {
+      key: recurrence,
+      title: `Every ${unit[0].toUpperCase()}${unit.slice(1)}`,
+      recurrence,
+      icon: repeatIcon(unit),
+    };
+  });
+  return q ? rows.filter((row) => row.title.toLowerCase().includes(q)) : rows;
+}
+
+export function buildDynamicRepeatOptions(searchText: string) {
+  const m = searchText
+    .trim()
+    .toLowerCase()
+    .match(/^every\s+(\d+)(?:\s+([a-z]+))?$/i);
+  if (!m) return [];
+  const interval = parseInt(m[1], 10);
+  if (!Number.isFinite(interval) || interval <= 1) return [];
+  const t = m[2]?.toLowerCase();
+  const units = t ? REPEAT_UNITS.filter((u) => u.startsWith(t) || `${u}s`.startsWith(t)) : REPEAT_UNITS;
+  return units.map((unit) => {
+    const lab = interval === 1 ? unit : `${unit}s`;
+    return {
+      key: `${unit}-${interval}`,
+      title: `Every ${interval} ${lab.charAt(0).toUpperCase()}${lab.slice(1)}`,
+      recurrence: buildRecurringDueString(unit, interval),
+      icon: repeatIcon(unit),
+    };
+  });
+}

--- a/extensions/todoist/src/helpers/repeat.ts
+++ b/extensions/todoist/src/helpers/repeat.ts
@@ -86,7 +86,7 @@ export function buildDynamicRepeatOptions(searchText: string) {
   const t = m[2]?.toLowerCase();
   const units = t ? REPEAT_UNITS.filter((u) => u.startsWith(t) || `${u}s`.startsWith(t)) : REPEAT_UNITS;
   return units.map((unit) => {
-    const lab = interval === 1 ? unit : `${unit}s`;
+    const lab = `${unit}s`;
     return {
       key: `${unit}-${interval}`,
       title: `Every ${interval} ${lab.charAt(0).toUpperCase()}${lab.slice(1)}`,

--- a/extensions/todoist/src/helpers/repeat.ts
+++ b/extensions/todoist/src/helpers/repeat.ts
@@ -1,3 +1,7 @@
+/**
+ * Todoist recurrence strings (`every N unit(s)`) and Raycast UI helpers for the Set Repeat menu.
+ * Presets cover interval 1; free-form `every 2 day` / `every 3 weeks` style input uses `buildDynamicRepeatOptions`.
+ */
 import { Icon } from "@raycast/api";
 import { format } from "date-fns";
 
@@ -21,9 +25,8 @@ function repeatIcon(unit: RecurrenceUnit) {
 }
 
 /**
- * All-day due + current local clock for hourly recurrence anchors.
- *
- * Todoist Sync "floating" due datetimes expect `YYYY-MM-DDTHH:MM:SS` with no zone suffix
+ * Combines an all-day `YYYY-MM-DD` due with "now" local time for hourly repeat.
+ * Todoist floating dues use `YYYY-MM-DDTHH:mm:ss` (no `Z` / offset) — avoids shifting the calendar day vs `toISOString()`.
  */
 function anchorAllDayDateToNow(date: string): string {
   if (date.includes("T")) return date;
@@ -35,17 +38,18 @@ function anchorAllDayDateToNow(date: string): string {
   return format(anchor, "yyyy-MM-dd'T'HH:mm:ss");
 }
 
+/** Builds `{ string, date? }` for `item_update` from current task due + optional recurrence rule. */
 export function repeatDuePayload(task: Task, recurrence?: string): DateOrString {
-  return recurrence
-    ? task.due?.date
-      ? {
-          string: recurrence,
-          date: isHourlyDueString(recurrence) ? anchorAllDayDateToNow(task.due.date) : task.due.date,
-        }
-      : { string: recurrence }
-    : task.due?.date
-      ? { date: task.due.date }
-      : { string: "no date" };
+  if (!recurrence) {
+    return task.due?.date ? { date: task.due.date } : { string: "no date" };
+  }
+  if (!task.due?.date) {
+    return { string: recurrence };
+  }
+  return {
+    string: recurrence,
+    date: isHourlyDueString(recurrence) ? anchorAllDayDateToNow(task.due.date) : task.due.date,
+  };
 }
 
 /** When the query uses Todoist-style "every 1 …", show matching titles ("Every 1 Day"); otherwise keep shorthand ("Every Day"). */
@@ -58,6 +62,7 @@ function presetDisplayTitle(unit: RecurrenceUnit, recurrence: string, searchTrim
     .join(" ");
 }
 
+/** Presets for `every 1 hour` … `every 1 year`; search matches title or canonical `due.string` form. */
 export function filterRepeatPresets(search: string) {
   const trimmed = search.trim();
   const q = trimmed.toLowerCase();
@@ -75,6 +80,7 @@ export function filterRepeatPresets(search: string) {
     : rows;
 }
 
+/** Matches `every N …` for N ≥ 2 (`every 1 …` is handled by `filterRepeatPresets`). */
 export function buildDynamicRepeatOptions(searchText: string) {
   const m = searchText
     .trim()
@@ -83,13 +89,15 @@ export function buildDynamicRepeatOptions(searchText: string) {
   if (!m) return [];
   const interval = parseInt(m[1], 10);
   if (!Number.isFinite(interval) || interval <= 1) return [];
-  const t = m[2]?.toLowerCase();
-  const units = t ? REPEAT_UNITS.filter((u) => u.startsWith(t) || `${u}s`.startsWith(t)) : REPEAT_UNITS;
+  const unitPrefix = m[2]?.toLowerCase();
+  const units = unitPrefix
+    ? REPEAT_UNITS.filter((u) => u.startsWith(unitPrefix) || `${u}s`.startsWith(unitPrefix))
+    : REPEAT_UNITS;
   return units.map((unit) => {
-    const lab = `${unit}s`;
+    const plural = `${unit}s`;
     return {
       key: `${unit}-${interval}`,
-      title: `Every ${interval} ${lab.charAt(0).toUpperCase()}${lab.slice(1)}`,
+      title: `Every ${interval} ${plural.charAt(0).toUpperCase()}${plural.slice(1)}`,
       recurrence: buildRecurringDueString(unit, interval),
       icon: repeatIcon(unit),
     };


### PR DESCRIPTION
## Description

Updates the **Todoist** extension’s task scheduling UX, while fixing several **sync/cache** issues so the UI matches Todoist without exiting and reopening the extension.

**Task actions**
- **Set Repeat**: submenu with presets (every hour/day/week/month/year), search-style options with support for custom intervals (e.g. `every 2 days`), and clear repeat.
- **Pick date**: when setting a **due time** (not all-day), adds Todoist’s **relative “at time of task”** reminder if missing to mirror behavior on Todoist; **hourly** repeats get the same behavior. This works for both free and premium Todoist users.
- **Complete task**: recurring completions use the **sync response** so the **next occurrence** stays visible (no more disappearing until reopen).

**Sync / reliability**
- All relevant Todoist sync merges go through **functional `setData` updates** so back-to-back writes (e.g. update due then add reminder) don’t overwrite each other with stale snapshots.
- **`item_update`** and **`item_close`** also refresh **`reminders`** when the API returns them so list accessories (e.g. alarm icon) stay correct after clearing or changing due dates.

**Task Details**
- **Task details** show a **Repeat** line for recurring tasks (sentence-cased Todoist phrase).

## Screencast


https://github.com/user-attachments/assets/5fc39180-4208-4278-a73d-19de0f3fb30c



## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [X] I checked that files in the `assets` folder are used by the extension itself
- [X] I checked that assets used by the `README` are placed outside of the `metadata` folder