### PR TITLE
[Browser Bookmarks] Add Windows support for Chromium browsers

### DIFF
--- a/extensions/browser-bookmarks/CHANGELOG.md
+++ b/extensions/browser-bookmarks/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Browser Bookmarks Changelog
 
+## [Windows Support for Chromium Browsers] - {PR_MERGE_DATE}
+
+- Added Windows support for Chrome, Edge, and Brave bookmarks
+- Automatically refresh Chromium bookmarks when the selected profile changes on disk
+
 ## [Support for Perplexity Comet Browser] - 2026-03-04
 
 - Added support for `Perplexity Comet` browser

--- a/extensions/browser-bookmarks/CHANGELOG.md
+++ b/extensions/browser-bookmarks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Browser Bookmarks Changelog
 
-## [Windows Support for Chromium Browsers] - {PR_MERGE_DATE}
+## [Windows Support for Chromium Browsers] - 2026-04-30
 
 - Added Windows support for Chrome, Edge, and Brave bookmarks
 - Automatically refresh Chromium bookmarks when the selected profile changes on disk

--- a/extensions/browser-bookmarks/README.md
+++ b/extensions/browser-bookmarks/README.md
@@ -6,6 +6,14 @@ Integrate bookmarks from Brave, ChatGPT Atlas, Chrome, Edge, Firefox, Safari, Ar
 
 The extension retrieves bookmarks from two sources: your browsers and their profiles. The default browser is enabled by default, while the others are disabled. You can enable them using the `Select Browsers` action (`⌘` + `⇧` + `S`). This will directly get your bookmarks.
 
+On Windows, the first supported browsers are:
+
+- Chrome
+- Edge
+- Brave
+
+Chromium bookmarks are automatically refreshed when the selected profile's bookmark file changes.
+
 If you have multiple profiles, you can select the one you want from the enabled browsers:
 
 - ChatGPT Atlas `⌘` + `⇧` + `G`

--- a/extensions/browser-bookmarks/package.json
+++ b/extensions/browser-bookmarks/package.json
@@ -21,7 +21,8 @@
     "ridemountainpig",
     "msms",
     "0xdhrv",
-    "pernielsentikaer"
+    "pernielsentikaer",
+    "haneul486"
   ],
   "pastContributors": [
     "danulqua"
@@ -84,6 +85,7 @@
     "publish": "ray publish"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ]
 }

--- a/extensions/browser-bookmarks/src/components/SelectBrowsers.tsx
+++ b/extensions/browser-bookmarks/src/components/SelectBrowsers.tsx
@@ -15,11 +15,11 @@ export default function SelectBrowsers({ browsers: initialBrowsers, onSelect }: 
   return (
     <List isLoading={isLoading}>
       {data?.map((browser) => {
-        const isSelected = browsers.includes(browser.bundleId as string);
+        const isSelected = browsers.includes(browser.browserId);
 
         return (
           <List.Item
-            key={browser.bundleId}
+            key={browser.browserId}
             icon={isSelected ? { source: Icon.CheckCircle, tintColor: Color.Green } : Icon.Circle}
             title={browser.name}
             actions={
@@ -29,8 +29,8 @@ export default function SelectBrowsers({ browsers: initialBrowsers, onSelect }: 
                   icon={isSelected ? Icon.Circle : { source: Icon.CheckCircle, tintColor: Color.Green }}
                   onAction={() => {
                     const newBrowsers = isSelected
-                      ? browsers.filter((b) => b !== browser.bundleId)
-                      : [...browsers, browser.bundleId as string];
+                      ? browsers.filter((b) => b !== browser.browserId)
+                      : [...browsers, browser.browserId];
                     setBrowsers(newBrowsers);
                     onSelect(newBrowsers);
                   }}

--- a/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
+++ b/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
@@ -139,7 +139,7 @@ function matchesWindowsBrowser(app: Application, definition: BrowserDefinition) 
   return Boolean(
     definition.windowsDisplayNames?.some((name) => {
       const normalizedDisplayName = normalize(name);
-      return normalizedName === normalizedDisplayName || normalizedName.includes(normalizedDisplayName);
+      return normalizedName === normalizedDisplayName;
     }) ||
     definition.windowsExecutables?.some(
       (executable) => normalizedPath.endsWith(`\\${executable}`) || normalizedPath.includes(`\\${executable}`),

--- a/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
+++ b/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
@@ -140,8 +140,7 @@ function matchesWindowsBrowser(app: Application, definition: BrowserDefinition) 
     definition.windowsDisplayNames?.some((name) => {
       const normalizedDisplayName = normalize(name);
       return normalizedName === normalizedDisplayName;
-    }) ||
-    definition.windowsExecutables?.some((executable) => normalizedPath.endsWith(`\\${executable}`)),
+    }) || definition.windowsExecutables?.some((executable) => normalizedPath.endsWith(`\\${executable}`)),
   );
 }
 

--- a/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
+++ b/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
@@ -141,9 +141,7 @@ function matchesWindowsBrowser(app: Application, definition: BrowserDefinition) 
       const normalizedDisplayName = normalize(name);
       return normalizedName === normalizedDisplayName;
     }) ||
-    definition.windowsExecutables?.some(
-      (executable) => normalizedPath.endsWith(`\\${executable}`) || normalizedPath.includes(`\\${executable}`),
-    ),
+    definition.windowsExecutables?.some((executable) => normalizedPath.endsWith(`\\${executable}`)),
   );
 }
 

--- a/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
+++ b/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
@@ -1,5 +1,28 @@
-import { getApplications } from "@raycast/api";
+import { Application, getApplications } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
+import { existsSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+function getWindowsLocalAppData() {
+  if (process.env.LOCALAPPDATA) {
+    return process.env.LOCALAPPDATA;
+  }
+
+  if (process.env.USERPROFILE) {
+    return join(process.env.USERPROFILE, "AppData", "Local");
+  }
+
+  const homeDirectory = homedir();
+
+  if (homeDirectory) {
+    return join(homeDirectory, "AppData", "Local");
+  }
+
+  return "";
+}
+
+const WINDOWS_LOCAL_APPDATA = process.platform === "win32" ? getWindowsLocalAppData() : "";
 
 export const BROWSERS_BUNDLE_ID = {
   arc: "company.thebrowser.browser",
@@ -28,19 +51,170 @@ export const BROWSERS_BUNDLE_ID = {
   libreWolf: "org.mozilla.librewolf",
   whale: "com.naver.whale",
   helium: "net.imput.helium",
+} as const;
+
+export type BrowserId = (typeof BROWSERS_BUNDLE_ID)[keyof typeof BROWSERS_BUNDLE_ID];
+
+type BrowserDefinition = {
+  id: BrowserId;
+  name: string;
+  macBundleId?: string;
+  windowsDisplayNames?: string[];
+  windowsExecutables?: string[];
+  windowsUserDataPath?: string;
 };
 
-export const availableBrowsers = Object.values(BROWSERS_BUNDLE_ID);
+export type BrowserApplication = Application & {
+  browserId: BrowserId;
+};
+
+const BROWSER_DEFINITIONS: BrowserDefinition[] = [
+  { id: BROWSERS_BUNDLE_ID.arc, name: "Arc", macBundleId: "company.thebrowser.browser" },
+  {
+    id: BROWSERS_BUNDLE_ID.brave,
+    name: "Brave",
+    macBundleId: "com.brave.browser",
+    windowsDisplayNames: ["Brave"],
+    windowsExecutables: ["brave.exe"],
+    windowsUserDataPath: WINDOWS_LOCAL_APPDATA
+      ? join(WINDOWS_LOCAL_APPDATA, "BraveSoftware", "Brave-Browser", "User Data")
+      : undefined,
+  },
+  { id: BROWSERS_BUNDLE_ID.braveBeta, name: "Brave Beta", macBundleId: "com.brave.browser.beta" },
+  { id: BROWSERS_BUNDLE_ID.braveNightly, name: "Brave Nightly", macBundleId: "com.brave.browser.nightly" },
+  {
+    id: BROWSERS_BUNDLE_ID.chrome,
+    name: "Chrome",
+    macBundleId: "com.google.chrome",
+    windowsDisplayNames: ["Google Chrome", "Chrome"],
+    windowsExecutables: ["chrome.exe"],
+    windowsUserDataPath: WINDOWS_LOCAL_APPDATA
+      ? join(WINDOWS_LOCAL_APPDATA, "Google", "Chrome", "User Data")
+      : undefined,
+  },
+  { id: BROWSERS_BUNDLE_ID.chromeBeta, name: "Chrome Beta", macBundleId: "com.google.chrome.beta" },
+  { id: BROWSERS_BUNDLE_ID.chromeDev, name: "Chrome Dev", macBundleId: "com.google.chrome.dev" },
+  { id: BROWSERS_BUNDLE_ID.comet, name: "Comet", macBundleId: "ai.perplexity.comet" },
+  { id: BROWSERS_BUNDLE_ID.dia, name: "Dia", macBundleId: "company.thebrowser.dia" },
+  { id: BROWSERS_BUNDLE_ID.chatGPTAtlas, name: "ChatGPT Atlas", macBundleId: "com.openai.atlas" },
+  { id: BROWSERS_BUNDLE_ID.firefox, name: "Firefox", macBundleId: "org.mozilla.firefox" },
+  { id: BROWSERS_BUNDLE_ID.firefoxDev, name: "Firefox Dev", macBundleId: "org.mozilla.firefoxdeveloperedition" },
+  { id: BROWSERS_BUNDLE_ID.ghostBrowser, name: "Ghost Browser", macBundleId: "com.ghostbrowser.gb1" },
+  { id: BROWSERS_BUNDLE_ID.island, name: "Island", macBundleId: "io.island.island" },
+  { id: BROWSERS_BUNDLE_ID.safari, name: "Safari", macBundleId: "com.apple.safari" },
+  { id: BROWSERS_BUNDLE_ID.sidekick, name: "Sidekick", macBundleId: "com.pushplaylabs.sidekick" },
+  {
+    id: BROWSERS_BUNDLE_ID.edge,
+    name: "Edge",
+    macBundleId: "com.microsoft.edgemac",
+    windowsDisplayNames: ["Microsoft Edge", "Edge"],
+    windowsExecutables: ["msedge.exe"],
+    windowsUserDataPath: WINDOWS_LOCAL_APPDATA
+      ? join(WINDOWS_LOCAL_APPDATA, "Microsoft", "Edge", "User Data")
+      : undefined,
+  },
+  { id: BROWSERS_BUNDLE_ID.edgeDev, name: "Edge Dev", macBundleId: "com.microsoft.edgemac.dev" },
+  { id: BROWSERS_BUNDLE_ID.edgeCanary, name: "Edge Canary", macBundleId: "com.microsoft.edgemac.canary" },
+  { id: BROWSERS_BUNDLE_ID.prismaAccess, name: "Prisma Access", macBundleId: "com.talon-sec.work" },
+  { id: BROWSERS_BUNDLE_ID.vivaldi, name: "Vivaldi", macBundleId: "com.vivaldi.vivaldi" },
+  { id: BROWSERS_BUNDLE_ID.vivaldiSnapshot, name: "Vivaldi Snapshot", macBundleId: "com.vivaldi.vivaldi.snapshot" },
+  { id: BROWSERS_BUNDLE_ID.zen, name: "Zen", macBundleId: "app.zen-browser.zen" },
+  { id: BROWSERS_BUNDLE_ID.libreWolf, name: "LibreWolf", macBundleId: "org.mozilla.librewolf" },
+  { id: BROWSERS_BUNDLE_ID.whale, name: "Whale", macBundleId: "com.naver.whale" },
+  { id: BROWSERS_BUNDLE_ID.helium, name: "Helium", macBundleId: "net.imput.helium" },
+];
+
+const BROWSER_DEFINITION_BY_ID = new Map(BROWSER_DEFINITIONS.map((definition) => [definition.id, definition]));
+
+export const availableBrowsers = BROWSER_DEFINITIONS.map((definition) => definition.id);
+
+function normalize(value?: string) {
+  return value?.toLowerCase() ?? "";
+}
+
+function matchesWindowsBrowser(app: Application, definition: BrowserDefinition) {
+  const normalizedName = normalize(app.name);
+  const normalizedPath = normalize(app.path);
+
+  return Boolean(
+    definition.windowsDisplayNames?.some((name) => {
+      const normalizedDisplayName = normalize(name);
+      return normalizedName === normalizedDisplayName || normalizedName.includes(normalizedDisplayName);
+    }) ||
+    definition.windowsExecutables?.some(
+      (executable) => normalizedPath.endsWith(`\\${executable}`) || normalizedPath.includes(`\\${executable}`),
+    ),
+  );
+}
+
+export function getBrowserDefinition(browserId: string) {
+  return BROWSER_DEFINITION_BY_ID.get(browserId as BrowserId);
+}
+
+export function getBrowserIdForApplication(app: Application): BrowserId | undefined {
+  if (process.platform === "win32") {
+    return BROWSER_DEFINITIONS.find((definition) => matchesWindowsBrowser(app, definition))?.id;
+  }
+
+  const normalizedBundleId = normalize(app.bundleId);
+  return BROWSER_DEFINITIONS.find((definition) => definition.macBundleId === normalizedBundleId)?.id;
+}
+
+export function getBrowserDataPath(browserId: string, macOSPath: string) {
+  if (process.platform !== "win32") {
+    return macOSPath;
+  }
+
+  return getBrowserDefinition(browserId)?.windowsUserDataPath ?? macOSPath;
+}
+
+export async function listAvailableBrowsers(): Promise<BrowserApplication[]> {
+  const apps = await getApplications();
+
+  if (process.platform === "win32") {
+    const browsersById = new Map<BrowserId, BrowserApplication>();
+
+    for (const app of apps) {
+      const browserId = getBrowserIdForApplication(app);
+
+      if (!browserId || browsersById.has(browserId)) {
+        continue;
+      }
+
+      browsersById.set(browserId, { ...app, browserId });
+    }
+
+    for (const definition of BROWSER_DEFINITIONS) {
+      if (
+        !definition.windowsUserDataPath ||
+        browsersById.has(definition.id) ||
+        !existsSync(definition.windowsUserDataPath)
+      ) {
+        continue;
+      }
+
+      browsersById.set(definition.id, {
+        name: definition.name,
+        path: "",
+        bundleId: "",
+        executable: "",
+        browserId: definition.id,
+      } as BrowserApplication);
+    }
+
+    return BROWSER_DEFINITIONS.map((definition) => browsersById.get(definition.id)).filter(
+      Boolean,
+    ) as BrowserApplication[];
+  }
+
+  return apps
+    .map((app) => {
+      const browserId = getBrowserIdForApplication(app);
+      return browserId ? { ...app, bundleId: normalize(app.bundleId), browserId } : undefined;
+    })
+    .filter(Boolean) as BrowserApplication[];
+}
 
 export default function useAvailableBrowsers() {
-  return useCachedPromise(async () => {
-    const apps = await getApplications();
-
-    return (
-      apps
-        // The default macOS browser's bundle ID is lowercased, so let's lowercase all bundleIds
-        .map((app) => ({ ...app, bundleId: app.bundleId?.toLowerCase() }))
-        .filter((app) => availableBrowsers.includes(app.bundleId?.toLowerCase() as string))
-    );
-  });
+  return useCachedPromise(listAvailableBrowsers);
 }

--- a/extensions/browser-bookmarks/src/hooks/useBraveBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useBraveBookmarks.ts
@@ -1,9 +1,12 @@
 import { homedir } from "os";
 
-import { BROWSERS_BUNDLE_ID } from "./useAvailableBrowsers";
+import { BROWSERS_BUNDLE_ID, getBrowserDataPath } from "./useAvailableBrowsers";
 import useChromiumBookmarks from "./useChromiumBookmarks";
 
-const BRAVE_BOOKMARKS_PATH = `${homedir()}/Library/Application Support/BraveSoftware/Brave-Browser`;
+const BRAVE_BOOKMARKS_PATH = getBrowserDataPath(
+  BROWSERS_BUNDLE_ID.brave,
+  `${homedir()}/Library/Application Support/BraveSoftware/Brave-Browser`,
+);
 
 export default function useBraveBookmarks(enabled: boolean) {
   return useChromiumBookmarks(enabled, {

--- a/extensions/browser-bookmarks/src/hooks/useChromeBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useChromeBookmarks.ts
@@ -1,9 +1,12 @@
 import { homedir } from "os";
 
-import { BROWSERS_BUNDLE_ID } from "./useAvailableBrowsers";
+import { BROWSERS_BUNDLE_ID, getBrowserDataPath } from "./useAvailableBrowsers";
 import useChromiumBookmarks from "./useChromiumBookmarks";
 
-const CHROME_PATH = `${homedir()}/Library/Application Support/Google/Chrome`;
+const CHROME_PATH = getBrowserDataPath(
+  BROWSERS_BUNDLE_ID.chrome,
+  `${homedir()}/Library/Application Support/Google/Chrome`,
+);
 
 export default function useChromeBookmarks(enabled: boolean) {
   return useChromiumBookmarks(enabled, {

--- a/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import { promisify } from "util";
 
 import { useCachedPromise, useCachedState } from "@raycast/utils";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 const read = promisify(readFile);
 
@@ -226,9 +226,9 @@ export default function useChromiumBookmarks(
     [currentProfile, enabled, path],
   );
 
-  async function mutate() {
+  const mutate = useCallback(async () => {
     await Promise.all([mutateProfiles(), mutateBookmarks()]);
-  }
+  }, [mutateBookmarks, mutateProfiles]);
 
   const isLoading =
     isLoadingProfiles || isLoadingBookmarks || (enabled && currentProfile === "" && profiles.length > 0);
@@ -296,7 +296,7 @@ export default function useChromiumBookmarks(
       isActive = false;
       clearInterval(timer);
     };
-  }, [currentProfile, enabled, isLoading, path]);
+  }, [currentProfile, enabled, isLoading, mutate, path]);
 
   const toolbarBookmarks = data ? getBookmarks(data.roots.bookmark_bar) : [];
   const toolbarFolders = data ? getFolders(data.roots.bookmark_bar) : [];

--- a/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
@@ -1,8 +1,10 @@
 import { existsSync, readdirSync, readFile } from "fs";
+import { stat } from "fs/promises";
 import { join } from "path";
 import { promisify } from "util";
 
 import { useCachedPromise, useCachedState } from "@raycast/utils";
+import { useEffect, useRef } from "react";
 
 const read = promisify(readFile);
 
@@ -55,6 +57,16 @@ type Folder = {
   title: string;
 };
 
+type ChromiumProfile = {
+  path: string;
+  name: string;
+};
+
+type ChromiumProfilesResult = {
+  profiles: ChromiumProfile[];
+  defaultProfile: string;
+};
+
 function getFolders(bookmark: BookmarkFolder | BookmarkItem, hierarchy = ""): Folder[] {
   const folders: Folder[] = [];
 
@@ -70,7 +82,7 @@ function getFolders(bookmark: BookmarkFolder | BookmarkItem, hierarchy = ""): Fo
   return folders;
 }
 
-async function getChromiumProfilesFallback(path: string) {
+async function getChromiumProfilesFallback(path: string): Promise<ChromiumProfilesResult> {
   if (!existsSync(path)) return { profiles: [], defaultProfile: "" };
 
   let profiles;
@@ -88,7 +100,7 @@ async function getChromiumProfilesFallback(path: string) {
   return { profiles, defaultProfile };
 }
 
-async function getChromiumProfiles(path: string) {
+async function getChromiumProfiles(path: string): Promise<ChromiumProfilesResult> {
   if (!existsSync(`${path}/Local State`)) {
     return { profiles: [], defaultProfile: "" };
   }
@@ -112,7 +124,6 @@ async function getChromiumProfiles(path: string) {
   const profileInfoCache: Record<string, any> = localState.profile.info_cache;
 
   const profiles = Object.entries(profileInfoCache)
-    // Only keep profiles that have bookmarks
     .filter(([profilePath]) => {
       try {
         const profileDirectory = readdirSync(`${path}/${profilePath}`);
@@ -135,6 +146,25 @@ async function getChromiumProfiles(path: string) {
   return { profiles, defaultProfile };
 }
 
+async function getFileSignature(filePath: string) {
+  try {
+    const fileStat = await stat(filePath);
+    return `${filePath}:${fileStat.size}:${fileStat.mtimeMs}`;
+  } catch {
+    return `${filePath}:missing`;
+  }
+}
+
+async function getChromiumSourceSignature(path: string, profile: string) {
+  const signatures = [await getFileSignature(join(path, "Local State"))];
+
+  if (profile) {
+    signatures.push(await getFileSignature(join(path, profile, "Bookmarks")));
+  }
+
+  return signatures.join("|");
+}
+
 type UseChromiumBookmarksParams = {
   path: string;
   browserIcon: string;
@@ -146,37 +176,127 @@ export default function useChromiumBookmarks(
   enabled: boolean,
   { path, browserIcon, browserName, browserBundleId }: UseChromiumBookmarksParams,
 ) {
-  const [currentProfile, setCurrentProfile] = useCachedState(`${browserName}-profile`, "");
+  const [storedCurrentProfile, setCurrentProfile] = useCachedState(`${browserName}-profile`, "");
+  const lastKnownSourceSignatureRef = useRef<string | undefined>(undefined);
+  const isCheckingForChangesRef = useRef(false);
 
-  const { data: profiles } = useCachedPromise(
-    async (enabled, path) => {
-      if (!enabled) {
-        return;
+  const {
+    data: profilesData,
+    isLoading: isLoadingProfiles,
+    mutate: mutateProfiles,
+  } = useCachedPromise(
+    async (isEnabled, currentPath) => {
+      if (!isEnabled) {
+        return { profiles: [], defaultProfile: "" };
       }
 
-      const { profiles, defaultProfile } = await getChromiumProfiles(path);
-
-      // Initially set the current profile when nothing is set in the cache yet
-      if (currentProfile === "") {
-        setCurrentProfile(defaultProfile);
-      }
-
-      return profiles;
+      return getChromiumProfiles(currentPath);
     },
     [enabled, path],
   );
 
-  const { data, isLoading, mutate } = useCachedPromise(
-    async (profile, enabled, path) => {
-      if (!profile || !enabled || !existsSync(`${path}/${profile}/Bookmarks`)) {
+  const profiles = profilesData?.profiles || [];
+  const isStoredProfileValid = profiles.some((profile) => profile.path === storedCurrentProfile);
+  const currentProfile =
+    storedCurrentProfile && isStoredProfileValid ? storedCurrentProfile : profilesData?.defaultProfile || "";
+
+  useEffect(() => {
+    if (!enabled || !profilesData?.defaultProfile) {
+      return;
+    }
+
+    if (storedCurrentProfile === "" || !isStoredProfileValid) {
+      setCurrentProfile(profilesData.defaultProfile);
+    }
+  }, [enabled, isStoredProfileValid, profilesData, setCurrentProfile, storedCurrentProfile]);
+
+  const {
+    data,
+    isLoading: isLoadingBookmarks,
+    mutate: mutateBookmarks,
+  } = useCachedPromise(
+    async (profile, isEnabled, currentPath) => {
+      if (!profile || !isEnabled || !existsSync(`${currentPath}/${profile}/Bookmarks`)) {
         return;
       }
 
-      const file = await read(`${path}/${profile}/Bookmarks`);
+      const file = await read(`${currentPath}/${profile}/Bookmarks`);
       return JSON.parse(file.toString()) as BookmarksRoot;
     },
     [currentProfile, enabled, path],
   );
+
+  async function mutate() {
+    await Promise.all([mutateProfiles(), mutateBookmarks()]);
+  }
+
+  const isLoading =
+    isLoadingProfiles || isLoadingBookmarks || (enabled && currentProfile === "" && profiles.length > 0);
+
+  useEffect(() => {
+    if (!enabled) {
+      lastKnownSourceSignatureRef.current = undefined;
+      return;
+    }
+
+    let isActive = true;
+
+    async function primeSignature() {
+      const sourceSignature = await getChromiumSourceSignature(path, currentProfile);
+
+      if (isActive) {
+        lastKnownSourceSignatureRef.current = sourceSignature;
+      }
+    }
+
+    void primeSignature();
+
+    return () => {
+      isActive = false;
+    };
+  }, [currentProfile, enabled, path]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    let isActive = true;
+
+    async function checkForUpdates() {
+      if (!isActive || isLoading || isCheckingForChangesRef.current) {
+        return;
+      }
+
+      isCheckingForChangesRef.current = true;
+
+      try {
+        const nextSourceSignature = await getChromiumSourceSignature(path, currentProfile);
+        const previousSourceSignature = lastKnownSourceSignatureRef.current;
+
+        if (!previousSourceSignature) {
+          lastKnownSourceSignatureRef.current = nextSourceSignature;
+          return;
+        }
+
+        if (nextSourceSignature !== previousSourceSignature) {
+          lastKnownSourceSignatureRef.current = nextSourceSignature;
+          await mutate();
+        }
+      } finally {
+        isCheckingForChangesRef.current = false;
+      }
+    }
+
+    const timer = setInterval(() => {
+      void checkForUpdates();
+    }, 3000);
+
+    return () => {
+      isActive = false;
+      clearInterval(timer);
+    };
+  }, [currentProfile, enabled, isLoading, path]);
 
   const toolbarBookmarks = data ? getBookmarks(data.roots.bookmark_bar) : [];
   const toolbarFolders = data ? getFolders(data.roots.bookmark_bar) : [];

--- a/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
@@ -296,7 +296,7 @@ export default function useChromiumBookmarks(
       isActive = false;
       clearInterval(timer);
     };
-  }, [currentProfile, enabled, isLoading, mutate, path]);
+  }, [currentProfile, enabled, mutate, path]);
 
   const toolbarBookmarks = data ? getBookmarks(data.roots.bookmark_bar) : [];
   const toolbarFolders = data ? getFolders(data.roots.bookmark_bar) : [];

--- a/extensions/browser-bookmarks/src/hooks/useEdgeBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useEdgeBookmarks.ts
@@ -1,9 +1,12 @@
 import { homedir } from "os";
 
-import { BROWSERS_BUNDLE_ID } from "./useAvailableBrowsers";
+import { BROWSERS_BUNDLE_ID, getBrowserDataPath } from "./useAvailableBrowsers";
 import useChromiumBookmarks from "./useChromiumBookmarks";
 
-const EDGE_BOOKMARKS_PATH = `${homedir()}/Library/Application Support/Microsoft Edge`;
+const EDGE_BOOKMARKS_PATH = getBrowserDataPath(
+  BROWSERS_BUNDLE_ID.edge,
+  `${homedir()}/Library/Application Support/Microsoft Edge`,
+);
 
 export default function useEdgeBookmarks(enabled: boolean) {
   return useChromiumBookmarks(enabled, {

--- a/extensions/browser-bookmarks/src/index.tsx
+++ b/extensions/browser-bookmarks/src/index.tsx
@@ -17,7 +17,7 @@ import { useEffect, useMemo, useState } from "react";
 import PermissionErrorScreen from "./components/PermissionErrorScreen";
 import SelectBrowsers from "./components/SelectBrowsers";
 import useArcBookmarks from "./hooks/useArcBookmarks";
-import useAvailableBrowsers, { BROWSERS_BUNDLE_ID } from "./hooks/useAvailableBrowsers";
+import useAvailableBrowsers, { BROWSERS_BUNDLE_ID, BrowserApplication } from "./hooks/useAvailableBrowsers";
 import useBraveBetaBookmarks from "./hooks/useBraveBetaBookmarks";
 import useBraveBookmarks from "./hooks/useBraveBookmarks";
 import useBraveNightlyBookmarks from "./hooks/useBraveNightlyBookmarks";
@@ -42,7 +42,7 @@ import useVivaldiBookmarks from "./hooks/useVivaldiBrowser";
 import useVivaldiSnapshotBookmarks from "./hooks/useVivaldiSnapshotBrowser";
 import useWhaleBookmarks from "./hooks/useWhaleBookmarks";
 import useZenBookmarks from "./hooks/useZenBookmarks";
-import { getMacOSDefaultBrowser } from "./utils/browsers";
+import { getInitialBrowserSelection } from "./utils/browsers";
 // Note: frecency is intentionally misspelled: https://wiki.mozilla.org/User:Jesse/NewFrecency.
 import { getBookmarkIcon } from "./utils/icons";
 import { BookmarkFrecency, getBookmarkFrecency } from "./utils/frecency";
@@ -64,8 +64,19 @@ type Folder = {
   title: string;
 };
 
+const LEGACY_WINDOWS_BROWSER_IDS: Record<string, string> = {
+  chrome: BROWSERS_BUNDLE_ID.chrome,
+  edge: BROWSERS_BUNDLE_ID.edge,
+  brave: BROWSERS_BUNDLE_ID.brave,
+};
+
+function normalizeStoredBrowsers(browsers: string[]) {
+  return browsers.map((browser) => LEGACY_WINDOWS_BROWSER_IDS[browser] ?? browser);
+}
+
 export default function Command() {
-  const { data: availableBrowsers } = useAvailableBrowsers();
+  const { data: availableBrowsers, isLoading: isLoadingAvailableBrowsers } = useAvailableBrowsers();
+  const availableBrowserIdsKey = availableBrowsers?.map((browser) => browser.browserId).join("|") ?? "__pending__";
 
   const { showDomain, openBookmarkBrowser } = getPreferenceValues<Preferences>();
 
@@ -73,16 +84,30 @@ export default function Command() {
     data: storedBrowsers,
     isLoading: isLoadingBrowsers,
     mutate: mutateBrowsers,
-  } = useCachedPromise(async () => {
-    const browsersItem = await LocalStorage.getItem("browsers");
-    if (browsersItem) {
-      return JSON.parse(browsersItem.toString()) as string[];
-    }
+  } = useCachedPromise(
+    async (browserIdsKey: string) => {
+      if (browserIdsKey === "__pending__" || !availableBrowsers) {
+        return undefined;
+      }
 
-    // First run: use the macOS default browser
-    const defaultBrowser = await getMacOSDefaultBrowser();
-    return [defaultBrowser];
-  });
+      const browsersItem = await LocalStorage.getItem("browsers");
+
+      if (browsersItem) {
+        const parsedBrowsers = normalizeStoredBrowsers(JSON.parse(browsersItem.toString()) as string[]);
+        await LocalStorage.setItem("browsers", JSON.stringify(parsedBrowsers));
+        return parsedBrowsers;
+      }
+
+      const initialBrowsers = await getInitialBrowserSelection(availableBrowsers);
+
+      if (initialBrowsers.length > 0) {
+        await LocalStorage.setItem("browsers", JSON.stringify(initialBrowsers));
+      }
+
+      return initialBrowsers;
+    },
+    [availableBrowserIdsKey],
+  );
 
   async function setBrowsers(browsers: string[]) {
     await LocalStorage.setItem("browsers", JSON.stringify(browsers));
@@ -490,15 +515,17 @@ export default function Command() {
     return <PermissionErrorScreen />;
   }
 
-  // Get the browser Application from the bundle ID to open the bookmark in its associated browser
+  // Get the browser Application from the browser ID to open the bookmark in its associated browser
   function browserBundleToApp(bundleId: string) {
-    return availableBrowsers?.find((browser) => browser.bundleId === bundleId);
+    const app = availableBrowsers?.find((browser) => browser.browserId === bundleId);
+    return app?.path ? app : undefined;
   }
 
   return (
     <List
       isLoading={
         isLoadingBrowsers ||
+        isLoadingAvailableBrowsers ||
         isLoadingFrecencies ||
         arc.isLoading ||
         brave.isLoading ||
@@ -882,7 +909,7 @@ type SelectProfileSubmenuProps = {
   profiles: { path: string; name: string }[];
   currentProfile: string;
   setCurrentProfile: (path: string) => void;
-  availableBrowsers?: { bundleId?: string }[];
+  availableBrowsers?: BrowserApplication[];
 };
 
 function SelectProfileSubmenu({
@@ -895,7 +922,7 @@ function SelectProfileSubmenu({
   setCurrentProfile,
   availableBrowsers,
 }: SelectProfileSubmenuProps) {
-  const hasBrowser = availableBrowsers?.map((browser) => browser.bundleId).includes(bundleId);
+  const hasBrowser = availableBrowsers?.map((browser) => browser.browserId as string).includes(bundleId);
   if (!hasBrowser || profiles.length <= 1) {
     return null;
   }

--- a/extensions/browser-bookmarks/src/index.tsx
+++ b/extensions/browser-bookmarks/src/index.tsx
@@ -93,8 +93,13 @@ export default function Command() {
       const browsersItem = await LocalStorage.getItem("browsers");
 
       if (browsersItem) {
-        const parsedBrowsers = normalizeStoredBrowsers(JSON.parse(browsersItem.toString()) as string[]);
-        await LocalStorage.setItem("browsers", JSON.stringify(parsedBrowsers));
+        const originalBrowsers = JSON.parse(browsersItem.toString()) as string[];
+        const parsedBrowsers = normalizeStoredBrowsers(originalBrowsers);
+
+        if (JSON.stringify(parsedBrowsers) !== JSON.stringify(originalBrowsers)) {
+          await LocalStorage.setItem("browsers", JSON.stringify(parsedBrowsers));
+        }
+
         return parsedBrowsers;
       }
 

--- a/extensions/browser-bookmarks/src/utils/browsers.ts
+++ b/extensions/browser-bookmarks/src/utils/browsers.ts
@@ -1,14 +1,43 @@
-import { exec } from "child_process";
+import { getDefaultApplication } from "@raycast/api";
 
-export function getMacOSDefaultBrowser() {
-  return new Promise<string>((resolve, reject) => {
-    const command = `defaults read ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure | awk -F'"' '/http;/{print window[(NR)-1]}{window[NR]=$2}'`;
-    exec(command, (error, stdout) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(stdout.trim() as string);
-      }
-    });
-  });
+import { BrowserApplication, getBrowserIdForApplication, listAvailableBrowsers } from "../hooks/useAvailableBrowsers";
+
+export async function getDefaultBrowserId(availableBrowsers?: BrowserApplication[]) {
+  const resolvedBrowsers = availableBrowsers ?? (await listAvailableBrowsers());
+
+  if (resolvedBrowsers.length === 0) {
+    return "";
+  }
+
+  if (resolvedBrowsers.length === 1) {
+    return resolvedBrowsers[0].browserId;
+  }
+
+  try {
+    const defaultApplication = await getDefaultApplication("https://raycast.com");
+    const browserId = getBrowserIdForApplication(defaultApplication);
+
+    if (browserId) {
+      return browserId;
+    }
+  } catch {
+    // Fall back to the first available browser if the system default cannot be resolved.
+  }
+
+  return resolvedBrowsers[0].browserId;
+}
+
+export async function getInitialBrowserSelection(availableBrowsers?: BrowserApplication[]) {
+  const resolvedBrowsers = availableBrowsers ?? (await listAvailableBrowsers());
+
+  if (resolvedBrowsers.length === 0) {
+    return [];
+  }
+
+  if (process.platform === "win32") {
+    return resolvedBrowsers.map((browser) => browser.browserId);
+  }
+
+  const defaultBrowserId = await getDefaultBrowserId(resolvedBrowsers);
+  return defaultBrowserId ? [defaultBrowserId] : [];
 }


### PR DESCRIPTION
## What Changed

- added Windows support for Chromium-based bookmarks
- added support for Chrome, Edge, and Brave on Windows
- added automatic bookmark refresh when Chromium bookmark files change
- preserved existing macOS browser identifiers for storage compatibility

## Testing

- npm run lint
- npm run build
- tested in Raycast for Windows
- verified Chrome bookmark search and open flow
- verified bookmark title updates are picked up after file changes
