### PR TITLE
Fix useRecentEntries to support shared storage

### DIFF
--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Visual Studio Code Changelog
 
+## [Fix: Shared Storage Support] - {PR_MERGE_DATE}
+
+- Added Shared Storage support for new version of VS Code
+
 ## [Update] - 2026-04-07
 
 - Added support for Qoder.

--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Visual Studio Code Changelog
 
-## [Fix: Shared Storage Support] - {PR_MERGE_DATE}
+## [Fix: Shared Storage Support] - 2026-05-07
 
 - Added Shared Storage support for new version of VS Code
 

--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Visual Studio Code Changelog
 
-## [Fix] - 2026-05-04
-
-- Fixed `Search Recent Projects` returning no results for VS Code Insiders users. Recent Insiders builds no longer write `history.recentlyOpenedPathsList` to `state.vscdb`; the extension now falls back to reading recent folders from `storage.json` (`lastKnownMenubarData`) when the DB key is absent. Stable VS Code builds are unaffected. (Fixes [#27440](https://github.com/raycast/extensions/issues/27440))
-
 ## [Update] - 2026-04-07
 
 - Added support for Qoder.

--- a/extensions/visual-studio-code-recent-projects/src/lib/db.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/db.ts
@@ -2,11 +2,12 @@ import { Alert, Icon, Toast, confirmAlert, showToast } from "@raycast/api";
 import { useSQL } from "@raycast/utils";
 import fs from "fs";
 import { homedir } from "os";
+import path from "path";
 import { build } from "./preferences";
 import { EntryLike, RecentEntries } from "./types";
 import { isSameEntry, isWin } from "./utils";
 import { execFilePromise } from "../utils/exec";
-import { getBuildNamePreference } from "./vscode";
+import { getBuildNamePreference, getProductJSONPath } from "./vscode";
 
 export type RemoveMethods = {
   removeEntry: (entry: EntryLike) => Promise<void>;
@@ -84,11 +85,52 @@ export function useRecentEntries() {
 }
 
 function getPath() {
+  // Newer VS Code releases store history.recentlyOpenedPathsList in
+  // StorageScope.APPLICATION_SHARED instead of StorageScope.APPLICATION.
+  // The shared storage root is product-specific and is
+  // defined by product.json's sharedDataFolderName.
+  // https://github.com/microsoft/vscode/pull/311317
+  const sharedStoragePath = getSharedStoragePath();
+
+  if (sharedStoragePath && fs.existsSync(sharedStoragePath)) {
+    return sharedStoragePath;
+  }
+
+  return getGlobalStoragePath();
+}
+
+function getGlobalStoragePath() {
   const build = getBuildNamePreference();
   if (isWin) {
     return `${homedir()}\\AppData\\Roaming\\${build}\\User\\globalStorage\\state.vscdb`;
   }
   return `${homedir()}/Library/Application Support/${build}/User/globalStorage/state.vscdb`;
+}
+
+function getSharedStoragePath() {
+  const sharedDataFolderName = getSharedDataFolderName();
+
+  const sharedPath = sharedDataFolderName
+    ? path.join(homedir(), sharedDataFolderName, "sharedStorage", "state.vscdb")
+    : undefined;
+
+  return sharedPath;
+}
+
+function getSharedDataFolderName() {
+  const productJSONPath = getProductJSONPath();
+
+  if (productJSONPath && fs.existsSync(productJSONPath)) {
+    try {
+      const productJSONString = fs.readFileSync(productJSONPath, "utf-8");
+      const productJSON = JSON.parse(productJSONString) as { sharedDataFolderName?: string };
+      if (productJSON.sharedDataFolderName) return productJSON.sharedDataFolderName;
+    } catch {
+      // Ignore malformed product.json.
+    }
+  }
+
+  return undefined;
 }
 
 async function saveEntries(entries: EntryLike[]) {

--- a/extensions/visual-studio-code-recent-projects/src/lib/db.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/db.ts
@@ -13,21 +13,17 @@ export type RemoveMethods = {
   removeAllEntries: () => Promise<void>;
 };
 
-async function warnRemoveNotSupported() {
-  await showToast(Toast.Style.Failure, "Removing entries is not supported when reading from storage.json");
-}
-
 export function useRecentEntries() {
-  const path = getStoragePath("state.vscdb");
+  const path = getPath();
 
   if (!fs.existsSync(path)) {
-    const storageEntries = getEntriesFromStorageJSON();
     return {
-      data: storageEntries ?? [],
+      data: [],
       isLoading: false,
-      error: !storageEntries,
-      removeEntry: warnRemoveNotSupported,
-      removeAllEntries: warnRemoveNotSupported,
+      error: true,
+
+      removeEntry: () => Promise.resolve(),
+      removeAllEntries: () => Promise.resolve(),
     };
   }
 
@@ -39,11 +35,9 @@ export function useRecentEntries() {
   const entries = data && data.length ? data[0].entries : undefined;
   const parsedEntries = entries ? (JSON.parse(entries) as EntryLike[]) : undefined;
 
-  const effectiveEntries = parsedEntries ?? (!isLoading ? getEntriesFromStorageJSON() : undefined);
-
   async function removeEntry(entry: EntryLike) {
     if (!parsedEntries) {
-      await warnRemoveNotSupported();
+      await showToast(Toast.Style.Failure, "No recent entries found");
       return;
     }
 
@@ -57,11 +51,6 @@ export function useRecentEntries() {
   }
 
   async function removeAllEntries() {
-    if (!parsedEntries) {
-      await warnRemoveNotSupported();
-      return;
-    }
-
     try {
       if (
         await confirmAlert({
@@ -91,78 +80,19 @@ export function useRecentEntries() {
     }
   }
 
-  return { data: effectiveEntries, isLoading, removeEntry, removeAllEntries };
+  return { data: parsedEntries, isLoading, removeEntry, removeAllEntries };
 }
 
-function getStoragePath(filename: string) {
+function getPath() {
   const build = getBuildNamePreference();
   if (isWin) {
-    return `${homedir()}\\AppData\\Roaming\\${build}\\User\\globalStorage\\${filename}`;
+    return `${homedir()}\\AppData\\Roaming\\${build}\\User\\globalStorage\\state.vscdb`;
   }
-  return `${homedir()}/Library/Application Support/${build}/User/globalStorage/${filename}`;
-}
-
-function getEntriesFromStorageJSON(): EntryLike[] | undefined {
-  try {
-    const storagePath = getStoragePath("storage.json");
-    if (!fs.existsSync(storagePath)) return undefined;
-
-    const raw = fs.readFileSync(storagePath, "utf-8");
-    const storage = JSON.parse(raw) as Record<string, unknown>;
-
-    const menus = (storage?.lastKnownMenubarData as Record<string, unknown> | undefined)?.menus;
-    if (!menus || typeof menus !== "object" || Array.isArray(menus)) return undefined;
-
-    const seen = new Set<string>();
-    const results: EntryLike[] = [];
-
-    function buildUri(uri: Record<string, unknown>): string | undefined {
-      const scheme = typeof uri.scheme === "string" ? uri.scheme : "file";
-      const authority = typeof uri.authority === "string" ? uri.authority : "";
-      const uriPath = typeof uri.path === "string" ? uri.path : undefined;
-      return uriPath ? `${scheme}://${authority}${uriPath}` : undefined;
-    }
-
-    function walkItems(items: unknown[]) {
-      for (const item of items) {
-        if (!item || typeof item !== "object") continue;
-        const obj = item as Record<string, unknown>;
-        const uri = obj.uri as Record<string, unknown> | undefined;
-
-        if (uri) {
-          const uriStr = buildUri(uri);
-          if (uriStr && !seen.has(uriStr)) {
-            seen.add(uriStr);
-            if (obj.id === "openRecentFolder") {
-              results.push({ folderUri: uriStr });
-            } else if (obj.id === "openRecentFile") {
-              results.push({ fileUri: uriStr });
-            } else if (obj.id === "openRecentWorkspace") {
-              results.push({ workspace: { configPath: uriStr } });
-            }
-          }
-        }
-
-        const submenu = obj.submenu as Record<string, unknown> | undefined;
-        if (submenu && Array.isArray(submenu.items)) walkItems(submenu.items as unknown[]);
-      }
-    }
-
-    for (const menu of Object.values(menus as Record<string, unknown>)) {
-      if (menu && typeof menu === "object") {
-        const menuObj = menu as Record<string, unknown>;
-        if (Array.isArray(menuObj.items)) walkItems(menuObj.items as unknown[]);
-      }
-    }
-
-    return results.length > 0 ? results : undefined;
-  } catch {
-    return undefined;
-  }
+  return `${homedir()}/Library/Application Support/${build}/User/globalStorage/state.vscdb`;
 }
 
 async function saveEntries(entries: EntryLike[]) {
   const data = JSON.stringify({ entries });
   const query = `INSERT INTO ItemTable (key, value) VALUES ('history.recentlyOpenedPathsList', '${data}');`;
-  await execFilePromise("sqlite3", [getStoragePath("state.vscdb"), query]);
+  await execFilePromise("sqlite3", [getPath(), query]);
 }

--- a/extensions/visual-studio-code-recent-projects/src/lib/vscode.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/vscode.ts
@@ -119,6 +119,58 @@ export function getVSCodeCLIFilename(): string {
   return name;
 }
 
+function productJSONPaths(): Record<string, string> {
+  let productJSONPaths: Record<string, string> = {};
+
+  if (isWin) {
+    const programsFolder = path.join(os.homedir(), "AppData", "Local", "Programs");
+    productJSONPaths = {
+      Antigravity: path.join(programsFolder, "Antigravity", "resources", "app", "product.json"),
+      Code: path.join(programsFolder, "Microsoft VS Code", "resources", "app", "product.json"),
+      "Code - Insiders": path.join(programsFolder, "Microsoft VS Code Insiders", "resources", "app", "product.json"),
+      Cursor: path.join(programsFolder, "cursor", "resources", "app", "product.json"),
+      Kiro: path.join(programsFolder, "Kiro", "resources", "app", "product.json"),
+      Positron: path.join(programsFolder, "Positron", "resources", "app", "product.json"),
+      Qoder: path.join(programsFolder, "Qoder", "resources", "app", "product.json"),
+      Trae: path.join(programsFolder, "Trae", "resources", "app", "product.json"),
+      "Trae CN": path.join(programsFolder, "Trae CN", "resources", "app", "product.json"),
+      VSCodium: path.join(programsFolder, "VSCodium", "resources", "app", "product.json"),
+      "VSCodium - Insiders": path.join(programsFolder, "VSCodium Insiders", "resources", "app", "product.json"),
+      Windsurf: path.join(programsFolder, "Windsurf", "resources", "app", "product.json"),
+      Lingma: path.join(programsFolder, "Lingma", "resources", "app", "product.json"),
+    };
+  }
+
+  if (isMac) {
+    productJSONPaths = {
+      Antigravity: "/Applications/Antigravity.app/Contents/Resources/app/product.json",
+      Code: "/Applications/Visual Studio Code.app/Contents/Resources/app/product.json",
+      "Code - Insiders": "/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/product.json",
+      Cursor: "/Applications/Cursor.app/Contents/Resources/app/product.json",
+      Kiro: "/Applications/Kiro.app/Contents/Resources/app/product.json",
+      Positron: "/Applications/Positron.app/Contents/Resources/app/product.json",
+      Qoder: "/Applications/Qoder.app/Contents/Resources/app/product.json",
+      Trae: "/Applications/Trae.app/Contents/Resources/app/product.json",
+      "Trae CN": "/Applications/Trae CN.app/Contents/Resources/app/product.json",
+      VSCodium: "/Applications/VSCodium.app/Contents/Resources/app/product.json",
+      "VSCodium - Insiders": "/Applications/VSCodium - Insiders.app/Contents/Resources/app/product.json",
+      Windsurf: "/Applications/Windsurf.app/Contents/Resources/app/product.json",
+      Lingma: "/Applications/Lingma.app/Contents/Resources/app/product.json",
+    };
+  }
+
+  return productJSONPaths;
+}
+
+export function getProductJSONPath(): string {
+  const productJSONPathsForPlatform = productJSONPaths();
+  const name = productJSONPathsForPlatform[getBuildNamePreference()];
+  if (!name || name.length <= 0) {
+    return productJSONPathsForPlatform.Code;
+  }
+  return name;
+}
+
 export class VSCodeCLI {
   private cliFilename: string;
   private execOptions: child_process.ExecFileOptions | undefined;


### PR DESCRIPTION
## Description

Fixes: #27537 

- Support VS Code 1.118+ moving `history.recentlyOpenedPathsList` from `StorageScope.APPLICATION` (global storage) to `StorageScope.APPLICATION_SHARED` (shared storage)
- Read product.json `sharedDataFolderName` to resolve the shared storage database path
- Fall back to the existing global storage path when shared storage is unavailable

Closes: #27686
Closes: #27637
Closes: #27599
Closes: #27585
Closes: #27560

## Test

- [x] Visual Studio Code (1.118+)
- [x] Visual Studio Code - Insiders (1.118+)
- [x] Cursor (Not Supporting shared storage yet)

## Screencast

Before

<img width="862" height="586" alt="Screenshot 2026-04-30 at 12 28 33" src="https://github.com/user-attachments/assets/170ecea4-ce5b-4df9-8349-90c0696154f0" />

After

<img width="862" height="586" alt="Screenshot 2026-04-30 at 14 39 21" src="https://github.com/user-attachments/assets/f5b58612-c16f-4389-b95c-95b898991a17" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
