### PR TITLE
Update tailscale extension

### DIFF
--- a/extensions/tailscale/CHANGELOG.md
+++ b/extensions/tailscale/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tailscale Changelog
 
-## [Add new features] - {PR_MERGE_DATE}
+## [Add new features] - 2026-05-07
 
 - Added Menu bar indicator: shows an icon when connected, nothing when disconnected
 

--- a/extensions/tailscale/CHANGELOG.md
+++ b/extensions/tailscale/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Tailscale Changelog
 
+## [Add new features] - {PR_MERGE_DATE}
+
+- Added Menu bar indicator: shows an icon when connected, nothing when disconnected
+
 ## [Fix Account Switcher] - 2026-04-12
 
 - Fix "Switch Account" not showing tailnet and account names correctly

--- a/extensions/tailscale/package.json
+++ b/extensions/tailscale/package.json
@@ -138,6 +138,7 @@
     {
       "name": "menubar",
       "title": "Menu Bar Tailscale",
+      "subtitle": "Tailscale",
       "description": "Shows Tailscale connection status in the menu bar when connected",
       "mode": "menu-bar",
       "interval": "10s",

--- a/extensions/tailscale/package.json
+++ b/extensions/tailscale/package.json
@@ -15,7 +15,8 @@
     "brandenw",
     "j3lte",
     "itsmatteomanf",
-    "MatteoGauthier"
+    "MatteoGauthier",
+    "McKeev"
   ],
   "categories": [
     "Developer Tools",
@@ -133,6 +134,53 @@
       "subtitle": "Tailscale",
       "description": "Tailscale netcheck",
       "mode": "view"
+    },
+    {
+      "name": "menubar",
+      "title": "Menu Bar Tailscale",
+      "description": "Shows Tailscale connection status in the menu bar when connected",
+      "mode": "menu-bar",
+      "interval": "10s",
+      "preferences": [
+        {
+          "name": "showHostname",
+          "title": "Status Display",
+          "description": "Show your device hostname next to the menu bar icon",
+          "type": "checkbox",
+          "label": "Show Hostname",
+          "default": false,
+          "required": false
+        },
+        {
+          "name": "showIP",
+          "description": "Show your Tailscale IP next to the menu bar icon",
+          "type": "checkbox",
+          "label": "Show IP Address",
+          "default": false,
+          "required": false
+        },
+        {
+          "name": "showTailnetName",
+          "description": "Show the tailnet name next to the menu bar icon",
+          "type": "checkbox",
+          "label": "Show Tailnet Name",
+          "default": false,
+          "required": false
+        },
+        {
+          "name": "iconStyle",
+          "title": "Menu Bar Icon",
+          "description": "Choose the icon to show in the menu bar when connected",
+          "type": "dropdown",
+          "required": false,
+          "default": "icon",
+          "data": [
+            { "title": "Tailscale Icon", "value": "command_icon" },
+            { "title": "Green Status Dot", "value": "connected" },
+            { "title": "Link Emoji", "value": "link_emoji" }
+          ]
+        }
+      ]
     }
   ],
   "preferences": [

--- a/extensions/tailscale/package.json
+++ b/extensions/tailscale/package.json
@@ -174,7 +174,7 @@
           "description": "Choose the icon to show in the menu bar when connected",
           "type": "dropdown",
           "required": false,
-          "default": "icon",
+          "default": "command_icon",
           "data": [
             { "title": "Tailscale Icon", "value": "command_icon" },
             { "title": "Green Status Dot", "value": "connected" },

--- a/extensions/tailscale/src/menubar.tsx
+++ b/extensions/tailscale/src/menubar.tsx
@@ -1,14 +1,6 @@
 import { MenuBarExtra, getPreferenceValues, openExtensionPreferences, Clipboard, Image, showHUD } from "@raycast/api";
 import { getDevices, getStatus } from "./shared";
 
-interface MenuBarPreferences {
-  showHostname: boolean;
-  showIP: boolean;
-  showTailnetName: boolean;
-  refreshInterval: string;
-  iconStyle: "command_icon" | "connected" | "link_emoji";
-}
-
 const ICONS: Record<string, Image.ImageLike> = {
   command_icon: { source: "command-icon.png" },
   connected: {
@@ -23,7 +15,7 @@ const ICONS: Record<string, Image.ImageLike> = {
 export default function MenuBar() {
   try {
     const data = getStatus();
-    const prefs = getPreferenceValues<MenuBarPreferences>();
+    const prefs = getPreferenceValues<Preferences.Menubar>();
 
     const hostname = data.Self.HostName;
     const ip = data.Self.TailscaleIPs[0];
@@ -36,7 +28,7 @@ export default function MenuBar() {
     if (prefs.showTailnetName) barTitle += (barTitle ? " · " : "") + tailnetName;
     if (activeExitNode) barTitle += (barTitle ? " · " : "") + `via ${activeExitNode.name}`;
 
-    const icon = ICONS[prefs.iconStyle] ?? ICONS["connected"];
+    const icon = ICONS[prefs.iconStyle] ?? ICONS["command_icon"];
 
     return (
       <MenuBarExtra icon={icon} title={barTitle || undefined} tooltip="Tailscale connected">

--- a/extensions/tailscale/src/menubar.tsx
+++ b/extensions/tailscale/src/menubar.tsx
@@ -1,0 +1,87 @@
+import { MenuBarExtra, getPreferenceValues, openExtensionPreferences, Clipboard, Image, showHUD } from "@raycast/api";
+import { getDevices, getStatus } from "./shared";
+
+interface MenuBarPreferences {
+  showHostname: boolean;
+  showIP: boolean;
+  showTailnetName: boolean;
+  refreshInterval: string;
+  iconStyle: "command_icon" | "connected" | "link_emoji";
+}
+
+const ICONS: Record<string, Image.ImageLike> = {
+  command_icon: { source: "command-icon.png" },
+  connected: {
+    source: {
+      light: "connected_light.png",
+      dark: "connected_dark.png",
+    },
+  },
+  link_emoji: "🔗",
+};
+
+export default function MenuBar() {
+  try {
+    const data = getStatus();
+    const prefs = getPreferenceValues<MenuBarPreferences>();
+
+    const hostname = data.Self.HostName;
+    const ip = data.Self.TailscaleIPs[0];
+    const tailnetName = data.CurrentTailnet.Name;
+    const activeExitNode = getDevices(data).find((d) => d.exitnode);
+
+    let barTitle = "";
+    if (prefs.showHostname) barTitle += hostname;
+    if (prefs.showIP) barTitle += (barTitle ? " · " : "") + ip;
+    if (prefs.showTailnetName) barTitle += (barTitle ? " · " : "") + tailnetName;
+    if (activeExitNode) barTitle += (barTitle ? " · " : "") + `via ${activeExitNode.name}`;
+
+    const icon = ICONS[prefs.iconStyle] ?? ICONS["connected"];
+
+    return (
+      <MenuBarExtra icon={icon} title={barTitle || undefined} tooltip="Tailscale connected">
+        <MenuBarExtra.Section title="Connected">
+          <MenuBarExtra.Item
+            title={hostname}
+            subtitle="hostname"
+            onAction={async () => {
+              await Clipboard.copy(hostname);
+              await showHUD("Copied hostname");
+            }}
+          />
+          <MenuBarExtra.Item
+            title={ip}
+            subtitle="IPv4"
+            onAction={async () => {
+              await Clipboard.copy(ip);
+              await showHUD("Copied IP address");
+            }}
+          />
+          {activeExitNode && (
+            <MenuBarExtra.Item
+              title={activeExitNode.name}
+              subtitle="exit node"
+              onAction={async () => {
+                await Clipboard.copy(activeExitNode.name);
+                await showHUD("Copied exit node name");
+              }}
+            />
+          )}
+          <MenuBarExtra.Item
+            title={tailnetName}
+            subtitle="tailnet"
+            onAction={async () => {
+              await Clipboard.copy(tailnetName);
+              await showHUD("Copied tailnet name");
+            }}
+          />
+        </MenuBarExtra.Section>
+        <MenuBarExtra.Section>
+          <MenuBarExtra.Item title="Preferences…" onAction={openExtensionPreferences} />
+        </MenuBarExtra.Section>
+      </MenuBarExtra>
+    );
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Description

Adds a menu bar command that displays a Tailscale connection indicator. When connected, an icon appears in the menu bar.  When disconnected, nothing is shown.

Clicking the icon reveals a dropdown with connection details (hostname, IPv4, tailnet name, active exit node) -> each item copies its value to clipboard on click.

The command includes preferences to:

- Choose the menu bar icon (Tailscale icon light/dark, or 🔗 emoji)
- Toggle hostname, IP address, and tailnet name display next to the icon
- Status refreshes every 10 seconds

## Screenshots

<img width="240" height="185" alt="image" src="https://github.com/user-attachments/assets/35028652-08f1-4a40-96d7-1055cf0206ba" />
<img width="284" height="187" alt="image" src="https://github.com/user-attachments/assets/f0742a86-a20e-452e-81a8-20f38ee78923" />
<img width="252" height="178" alt="image" src="https://github.com/user-attachments/assets/d1677bb0-a2aa-4ac1-a871-e6089a632da0" />


## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [X] I checked that files in the `assets` folder are used by the extension itself
- [X] I checked that assets used by the `README` are placed outside of the `metadata` folder
