### PR TITLE
Whisper Dictation: configurable waveform width

### DIFF
--- a/extensions/whisper-dictation/CHANGELOG.md
+++ b/extensions/whisper-dictation/CHANGELOG.md
@@ -1,5 +1,13 @@
  # Changelog
 
+## [Configurable Waveform Width] - {PR_MERGE_DATE}
+
+### Added
+- New `Waveform Width` preference to control the width of the recording waveform animation. Pick a smaller value if the animation appears to wrap onto multiple lines for your Raycast window mode/text size combination.
+
+### Changed
+- Default waveform width reduced from 105 to 70 characters so the animation fits a default-width Raycast window without wrapping. Users who prefer the original look can select `105 (Original)` in preferences.
+
 ## [0.1.2] - 2025-07-29
 
 ### Fixed

--- a/extensions/whisper-dictation/package.json
+++ b/extensions/whisper-dictation/package.json
@@ -186,6 +186,40 @@
       "required": false,
       "placeholder": "llama3.2:latest",
       "default": "llama3.2:latest"
+    },
+    {
+      "name": "waveformWidth",
+      "title": "Waveform Width",
+      "description": "Width of the recording waveform animation in characters. Reduce if the animation wraps onto multiple lines (depends on Raycast window mode and text size).",
+      "type": "dropdown",
+      "required": false,
+      "default": "70",
+      "data": [
+        {
+          "title": "50 (Compact mode / Large text)",
+          "value": "50"
+        },
+        {
+          "title": "60",
+          "value": "60"
+        },
+        {
+          "title": "70 (Default)",
+          "value": "70"
+        },
+        {
+          "title": "80",
+          "value": "80"
+        },
+        {
+          "title": "90",
+          "value": "90"
+        },
+        {
+          "title": "105 (Original)",
+          "value": "105"
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/extensions/whisper-dictation/src/dictate-simple.tsx
+++ b/extensions/whisper-dictation/src/dictate-simple.tsx
@@ -220,7 +220,7 @@ export default function SimpleDictateCommand() {
 
   const generateWaveformMarkdown = useCallback(() => {
     const waveformHeight = 18;
-    const waveformWidth = 105;
+    const waveformWidth = parseInt(preferences.waveformWidth, 10) || 70;
     let waveform = "```\n";
     waveform += "RECORDING AUDIO... PRESS ENTER TO STOP\n\n";
 

--- a/extensions/whisper-dictation/src/dictate.tsx
+++ b/extensions/whisper-dictation/src/dictate.tsx
@@ -345,7 +345,7 @@ export default function DictateWithAICommand() {
 
   const generateWaveformMarkdown = useCallback(() => {
     const waveformHeight = 18;
-    const waveformWidth = 105;
+    const waveformWidth = parseInt(preferences.waveformWidth, 10) || 70;
     let waveform = "```\n"; // Start md code block
     waveform += "RECORDING AUDIO... PRESS ENTER TO STOP\n\n";
 


### PR DESCRIPTION
## Description

The recording-screen waveform animation in `dictate.tsx` and `dictate-simple.tsx` is a hardcoded 105 columns wide. Raycast's `Detail` view renders monospace markdown content at roughly 65-75 chars per line on a default-width window (varies with window mode and text size), so each row of the waveform wraps onto two visual lines, doubling the apparent height and breaking the animation. Raycast doesn't expose window-width or text-size APIs, so a single hardcoded constant can't fit every user's setup.

## Fix

Add a `Waveform Width` dropdown preference (`50` / `60` / `70` / `80` / `90` / `105`) so users can match the value to their window mode + text size. The default is lowered to `70`, which fits a default-width regular-mode window without wrapping out of the box. Users who prefer the previous look can select `105 (Original)` in preferences.

The width is read from preferences inside `generateWaveformMarkdown` in both `dictate.tsx` and `dictate-simple.tsx` via:

```ts
const waveformWidth = parseInt(preferences.waveformWidth, 10) || 70;
```

The fallback handles the (theoretically impossible) case of an unset/unparseable value.

## Type of Change

- [x] **Bug fix** (waveform wrapping in default windows)
- [x] **New feature** (configurable width preference)
- [ ] Breaking change

## Checklist

- [x] I read the [Contribution Guide](https://developers.raycast.com/basics/contribute-to-an-extension)
- [x] My code follows the style guidelines of this project
- [x] I checked the linter (`npm run lint`) and TypeScript compiler (`ray build`) — both clean
- [x] I tested locally that the waveform fits without wrapping at the new default

## Screenshots

Before (105, wraps to 2 lines per row on a default window) → After (70, single line per row).

## Notes

- No behavior change for users who explicitly want the wider look — they can pick `105 (Original)` from the dropdown.
- All existing preferences are unchanged; the new one is appended at the end of the `preferences` array to avoid reordering.
- CHANGELOG entry added under `{PR_MERGE_DATE}` per the contribution conventions.