### PR TITLE
Fix Clean Agent Text clipboard read on Windows

### DIFF
--- a/extensions/clean-agent-text/CHANGELOG.md
+++ b/extensions/clean-agent-text/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Clean Agent Text Changelog
 
+## [Fix Windows Clipboard Reading] - {PR_MERGE_DATE}
+
+- Read the clipboard's text slot explicitly so a file reference on the clipboard (common when copying from web pages on Windows) no longer gets pasted back as a filename
+- Show a clearer HUD message when the clipboard holds a file instead of text
+
 ## [Initial Version] - 2026-04-15
 
 - Clean box-drawing characters from clipboard text

--- a/extensions/clean-agent-text/package-lock.json
+++ b/extensions/clean-agent-text/package-lock.json
@@ -1131,7 +1131,7 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -2626,7 +2626,7 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {

--- a/extensions/clean-agent-text/src/clean.tsx
+++ b/extensions/clean-agent-text/src/clean.tsx
@@ -204,14 +204,14 @@ function cleanText(raw: string, mode: "auto" | "text" | "code"): { cleaned: stri
 
 export default async function Command() {
   const { mode } = getPreferenceValues<Preferences.Clean>();
-  const raw = await Clipboard.readText();
+  const { text, file } = await Clipboard.read();
 
-  if (!raw) {
-    await showHUD("Clipboard is empty");
+  if (!text) {
+    await showHUD(file ? "Clipboard contains a file, not text" : "Clipboard is empty");
     return;
   }
 
-  const { cleaned, resolvedMode } = cleanText(raw, mode);
+  const { cleaned, resolvedMode } = cleanText(text, mode);
   await Clipboard.copy(cleaned);
   await showHUD(`Cleaned clipboard (${resolvedMode})`);
 }


### PR DESCRIPTION
## Description

Fixes [#27566](https://github.com/raycast/extensions/issues/27566) — on the Raycast Windows beta, copying a selection from a Chromium browser (Edge) and running Clean Agent Text was replacing the clipboard with a single filename instead of the cleaned text.

The selection from a browser puts multiple formats on the OS clipboard at once: plain text, HTML, and often a file reference for any inline images in the selection. `Clipboard.readText()` on the Windows beta appears to be returning that file reference rather than the plain text slot, so the cleaner was running on a filename and writing it back.

This change:

- Switches from `Clipboard.readText()` to `Clipboard.read()` and uses the `text` field explicitly.
- Adds a clearer HUD message ("Clipboard contains a file, not text") when the clipboard genuinely only holds a file, instead of silently writing a filename back.

No behavioral change on macOS — verified locally.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder