### PR TITLE
Update thesaurus extension

### DIFF
--- a/extensions/thesaurus/CHANGELOG.md
+++ b/extensions/thesaurus/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Thesaurus (Merriam Webster) Changelog
 
+## [Copy Result Tags] - {PR_MERGE_DATE}
+
+- Added click-to-copy support for synonym and antonym result tags.
+
 ## [Search Selected Text] - 2025-04-23
 
 - Added the ability to search selected text. Simply highlight the word, then run the "Thesaurus Search Selected" command.

--- a/extensions/thesaurus/CHANGELOG.md
+++ b/extensions/thesaurus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Thesaurus (Merriam Webster) Changelog
 
-## [Copy Result Tags] - {PR_MERGE_DATE}
+## [Copy Result Tags] - 2026-05-05
 
 - Added click-to-copy support for synonym and antonym result tags.
 

--- a/extensions/thesaurus/package.json
+++ b/extensions/thesaurus/package.json
@@ -6,7 +6,8 @@
   "icon": "extension_icon.png",
   "author": "ABukSwienty",
   "contributors": [
-    "YourMCGeek"
+    "YourMCGeek",
+    "mbuvarp"
   ],
   "categories": [
     "Web",

--- a/extensions/thesaurus/src/lib/views/lookup-view.tsx
+++ b/extensions/thesaurus/src/lib/views/lookup-view.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Color, Detail, Icon, List } from "@raycast/api";
+import { Action, ActionPanel, Clipboard, Color, Detail, Icon, List, showToast, Toast } from "@raycast/api";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/shallow";
 import wordCacheHandler from "../cache";
@@ -20,6 +20,11 @@ const tagColor = (word: { strength: number }) => {
     dark: strengthColor(word.strength),
     light: strengthColor(word.strength),
   };
+};
+
+const copyWord = async (word: string) => {
+  await Clipboard.copy(word);
+  await showToast({ style: Toast.Style.Success, title: "Copied to Clipboard" });
 };
 
 const LookUpContent = ({ word }: { word: string }) => {
@@ -114,7 +119,12 @@ const LookUpContent = ({ word }: { word: string }) => {
                           <List.Item.Detail.Metadata.Label title="Synonyms:" />
                           <Detail.Metadata.TagList title="">
                             {value.synonyms.map((synonym, index) => (
-                              <Detail.Metadata.TagList.Item key={index} text={synonym.word} color={tagColor(synonym)} />
+                              <Detail.Metadata.TagList.Item
+                                key={index}
+                                text={synonym.word}
+                                color={tagColor(synonym)}
+                                onAction={() => copyWord(synonym.word)}
+                              />
                             ))}
                           </Detail.Metadata.TagList>
                         </>
@@ -124,7 +134,12 @@ const LookUpContent = ({ word }: { word: string }) => {
                           <List.Item.Detail.Metadata.Label title="Antonyms:" />
                           <Detail.Metadata.TagList title="">
                             {value.antonyms.map((antonym, index) => (
-                              <Detail.Metadata.TagList.Item key={index} text={antonym.word} color={tagColor(antonym)} />
+                              <Detail.Metadata.TagList.Item
+                                key={index}
+                                text={antonym.word}
+                                color={tagColor(antonym)}
+                                onAction={() => copyWord(antonym.word)}
+                              />
                             ))}
                           </Detail.Metadata.TagList>
                         </>

--- a/extensions/thesaurus/src/lib/views/lookup-view.tsx
+++ b/extensions/thesaurus/src/lib/views/lookup-view.tsx
@@ -24,7 +24,7 @@ const tagColor = (word: { strength: number }) => {
 
 const copyWord = async (word: string) => {
   await Clipboard.copy(word);
-  await showToast({ style: Toast.Style.Success, title: "Copied to Clipboard" });
+  await showToast({ style: Toast.Style.Success, title: "Copied to Clipboard", message: word });
 };
 
 const LookUpContent = ({ word }: { word: string }) => {


### PR DESCRIPTION
## Description

Adds click-to-copy support for synonym and antonym tags in the lookup detail view. Clicking a result tag now copies the word to the clipboard and shows a "Copied to Clipboard" toast. I regularly try to click the words to copy them, forgetting that it's not a feature, so I thought I'd add it myself if you want it 😊

Also updates the changelog and adds contributor metadata.

## Screencast


https://github.com/user-attachments/assets/36d7e17a-734c-4375-b6b3-f5169e574df0



## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
