### PR TITLE
Fix VS Code recent projects after storage changes

### DIFF
--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Visual Studio Code Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed missing recent projects by reading VS Code workspace storage in addition to the recently opened paths list.
+
 ## [Update] - 2026-04-07
 
 - Added support for Qoder.

--- a/extensions/visual-studio-code-recent-projects/package.json
+++ b/extensions/visual-studio-code-recent-projects/package.json
@@ -31,7 +31,8 @@
     "roberto.cinetto",
     "emiliocantuc",
     "raxityo",
-    "yusifaliyevpro"
+    "yusifaliyevpro",
+    "kzheartgyf"
   ],
   "keywords": [
     "vscode",

--- a/extensions/visual-studio-code-recent-projects/src/lib/db.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/db.ts
@@ -2,6 +2,8 @@ import { Alert, Icon, Toast, confirmAlert, showToast } from "@raycast/api";
 import { useSQL } from "@raycast/utils";
 import fs from "fs";
 import { homedir } from "os";
+import path from "path";
+import { useEffect } from "react";
 import { build } from "./preferences";
 import { EntryLike, RecentEntries } from "./types";
 import { isSameEntry, isWin } from "./utils";
@@ -12,6 +14,8 @@ export type RemoveMethods = {
   removeEntry: (entry: EntryLike) => Promise<void>;
   removeAllEntries: () => Promise<void>;
 };
+
+const WORKSPACE_STORAGE_RECENT_LIMIT = 500;
 
 export function useRecentEntries() {
   const path = getPath();
@@ -34,6 +38,21 @@ export function useRecentEntries() {
 
   const entries = data && data.length ? data[0].entries : undefined;
   const parsedEntries = entries ? (JSON.parse(entries) as EntryLike[]) : undefined;
+
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+
+    const currentEntries = parsedEntries ?? [];
+    const mergedEntries = mergeRecentEntries(readWorkspaceStorageEntries(), currentEntries);
+
+    if (areSameEntries(currentEntries, mergedEntries)) {
+      return;
+    }
+
+    saveEntries(mergedEntries).then(revalidate).catch(console.error);
+  }, [entries, isLoading, revalidate]);
 
   async function removeEntry(entry: EntryLike) {
     if (!parsedEntries) {
@@ -92,7 +111,144 @@ function getPath() {
 }
 
 async function saveEntries(entries: EntryLike[]) {
-  const data = JSON.stringify({ entries });
-  const query = `INSERT INTO ItemTable (key, value) VALUES ('history.recentlyOpenedPathsList', '${data}');`;
+  const data = Buffer.from(JSON.stringify({ entries }), "utf8").toString("hex");
+  const query = `INSERT INTO ItemTable (key, value) VALUES ('history.recentlyOpenedPathsList', CAST(x'${data}' AS TEXT));`;
   await execFilePromise("sqlite3", [getPath(), query]);
+}
+
+function getWorkspaceStoragePath() {
+  const build = getBuildNamePreference();
+  if (isWin) {
+    return `${homedir()}\\AppData\\Roaming\\${build}\\User\\workspaceStorage`;
+  }
+  return `${homedir()}/Library/Application Support/${build}/User/workspaceStorage`;
+}
+
+function readWorkspaceStorageEntries() {
+  const workspaceStoragePath = getWorkspaceStoragePath();
+
+  if (!fs.existsSync(workspaceStoragePath)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(workspaceStoragePath)
+    .map((storageFolder) => {
+      const workspaceFilePath = path.join(workspaceStoragePath, storageFolder, "workspace.json");
+
+      try {
+        const stat = fs.statSync(workspaceFilePath);
+        return { workspaceFilePath, mtime: stat.mtimeMs };
+      } catch {
+        return undefined;
+      }
+    })
+    .filter((item): item is { workspaceFilePath: string; mtime: number } => item !== undefined)
+    .sort((a, b) => b.mtime - a.mtime)
+    .slice(0, WORKSPACE_STORAGE_RECENT_LIMIT)
+    .map(({ workspaceFilePath }) => {
+      try {
+        const workspace = JSON.parse(fs.readFileSync(workspaceFilePath, "utf8")) as {
+          folder?: string;
+          workspace?: string;
+        };
+
+        return getEntryFromWorkspaceStorage(workspace);
+      } catch {
+        return undefined;
+      }
+    })
+    .filter((entry): entry is EntryLike => entry !== undefined);
+}
+
+function getEntryFromWorkspaceStorage(workspace: { folder?: string; workspace?: string }): EntryLike | undefined {
+  if (workspace.folder) {
+    const remoteAuthority = getRemoteAuthority(workspace.folder);
+
+    if (remoteAuthority) {
+      return {
+        folderUri: workspace.folder,
+        remoteAuthority,
+        label: getRemoteLabel(workspace.folder),
+      };
+    }
+
+    return { folderUri: workspace.folder };
+  }
+
+  if (workspace.workspace) {
+    const remoteAuthority = getRemoteAuthority(workspace.workspace);
+
+    if (remoteAuthority) {
+      return {
+        workspace: { configPath: workspace.workspace },
+        remoteAuthority,
+        label: getRemoteLabel(workspace.workspace),
+      };
+    }
+
+    return { workspace: { configPath: workspace.workspace } };
+  }
+}
+
+function getRemoteAuthority(uri: string) {
+  if (!uri.startsWith("vscode-remote://")) {
+    return undefined;
+  }
+
+  try {
+    return decodeURIComponent(new URL(uri).host);
+  } catch {
+    return undefined;
+  }
+}
+
+function getRemoteLabel(uri: string) {
+  try {
+    return decodeURIComponent(new URL(uri).pathname);
+  } catch {
+    return "/";
+  }
+}
+
+function getEntryId(entry: EntryLike) {
+  if ("fileUri" in entry) {
+    return entry.fileUri;
+  }
+
+  if ("folderUri" in entry) {
+    return entry.folderUri;
+  }
+
+  if ("workspace" in entry) {
+    return entry.workspace.configPath;
+  }
+
+  return "";
+}
+
+export function mergeRecentEntries(primaryEntries: EntryLike[], secondaryEntries: EntryLike[]) {
+  const entryIds = new Set<string>();
+  const entries: EntryLike[] = [];
+
+  for (const entry of [...primaryEntries, ...secondaryEntries]) {
+    const entryId = getEntryId(entry);
+
+    if (!entryId || entryIds.has(entryId)) {
+      continue;
+    }
+
+    entryIds.add(entryId);
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+function areSameEntries(a: EntryLike[], b: EntryLike[]) {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return a.every((entry, index) => getEntryId(entry) === getEntryId(b[index]));
 }


### PR DESCRIPTION
## Description

Fixes the Visual Studio Code Recent Projects command when newer VS Code versions no longer keep newly opened folders in the `history.recentlyOpenedPathsList` global storage entry.

The command now keeps the existing SQLite-backed fast path, then performs a background sync from VS Code's `workspaceStorage/*/workspace.json` files. Missing entries are merged into `history.recentlyOpenedPathsList` and persisted, so subsequent launches keep using the existing recent-projects path.

## Testing

- `npm run lint`
- `npm run build`
