### PR TITLE
Fix Blip Finder service lookup

### DIFF
--- a/extensions/blip-raycast/CHANGELOG.md
+++ b/extensions/blip-raycast/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Blip Changelog
 
+## [Bug Fixes] - 2026-05-02
+
+- Fix triggering Blip from Finder Services on localized macOS systems.
+
 ## [Initial Release] - 2026-04-13
 
 - Add the initial Blip extension

--- a/extensions/blip-raycast/CHANGELOG.md
+++ b/extensions/blip-raycast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Blip Changelog
 
-## [Bug Fixes] - 2026-05-02
+## [Bug Fixes] - {PR_MERGE_DATE}
 
 - Fix triggering Blip from Finder Services on localized macOS systems.
 

--- a/extensions/blip-raycast/CHANGELOG.md
+++ b/extensions/blip-raycast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Blip Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-05-05
 
 - Fix triggering Blip from Finder Services on localized macOS systems.
 

--- a/extensions/blip-raycast/package-lock.json
+++ b/extensions/blip-raycast/package-lock.json
@@ -1227,6 +1227,7 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1286,6 +1287,7 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -1490,6 +1492,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1838,6 +1841,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2615,6 +2619,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2638,6 +2643,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2844,6 +2850,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/blip-raycast/src/blip.ts
+++ b/extensions/blip-raycast/src/blip.ts
@@ -5,6 +5,9 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 const ACCESSIBILITY_SETTINGS_PATH = "System Settings > Privacy & Security > Accessibility";
 const ACCESSIBILITY_ERROR_PREFIX = "Raycast needs Accessibility permission to trigger Blip via Finder Services.";
+const SERVICES_SETTINGS_PATH = "System Settings > Keyboard > Keyboard Shortcuts > Services";
+const BLIP_SERVICE_NOT_FOUND_MESSAGE = `Blip's Finder service was not found. Make sure Blip is installed and enabled in ${SERVICES_SETTINGS_PATH}.`;
+const BLIP_SERVICE_DISABLED_MESSAGE = `Blip's Finder service is disabled for the selected item. Select the file in Finder and make sure Blip is enabled in ${SERVICES_SETTINGS_PATH}.`;
 
 export async function sendPathToBlip(path: string) {
   if (!path) {
@@ -15,21 +18,71 @@ export async function sendPathToBlip(path: string) {
     throw new Error(`Path does not exist: ${path}`);
   }
 
-  const script = [
-    'tell application "Finder" to activate',
-    `tell application "Finder" to reveal POSIX file ${quoted(path)}`,
-    `tell application "Finder" to select POSIX file ${quoted(path)}`,
-    'tell application "System Events" to tell process "Finder" to click menu item "Blip…" of menu 1 of menu item "Services" of menu 1 of menu bar item "Finder" of menu bar 1',
-  ];
+  const script = buildBlipFinderServiceScript(path);
 
   try {
-    for (const line of script) {
-      await execFileAsync("/usr/bin/osascript", ["-e", line]);
-    }
+    await execFileAsync(
+      "/usr/bin/osascript",
+      script.flatMap((line) => ["-e", line]),
+    );
   } catch (error) {
     const details = error instanceof Error ? error.message : "Unknown AppleScript failure.";
     throw new Error(buildAppleScriptError(details));
   }
+}
+
+function buildBlipFinderServiceScript(path: string) {
+  return [
+    "on isBlipServiceName(menuItemName)",
+    "  if menuItemName is missing value then return false",
+    "  set normalizedName to menuItemName as text",
+    '  return normalizedName is "Blip…" or normalizedName is "Blip..."',
+    "end isBlipServiceName",
+    "",
+    "on clickBlipService()",
+    '  tell application "System Events"',
+    '    tell process "Finder"',
+    "      set frontmost to true",
+    '      set finderMenu to menu 1 of menu bar item "Finder" of menu bar 1',
+    "      repeat with topLevelItem in menu items of finderMenu",
+    "        set nestedMenu to missing value",
+    "        try",
+    "          set nestedMenu to menu 1 of topLevelItem",
+    "        end try",
+    "        if nestedMenu is not missing value then",
+    "          repeat with serviceItem in menu items of nestedMenu",
+    "            set serviceName to name of serviceItem",
+    "            if my isBlipServiceName(serviceName) then",
+    "              if enabled of serviceItem is false then",
+    '                return "disabled"',
+    "              end if",
+    "              click serviceItem",
+    '              return "clicked"',
+    "            end if",
+    "          end repeat",
+    "        end if",
+    "      end repeat",
+    "    end tell",
+    "  end tell",
+    '  return "missing"',
+    "end clickBlipService",
+    "",
+    'tell application "Finder"',
+    "  activate",
+    `  reveal POSIX file ${quoted(path)}`,
+    `  select POSIX file ${quoted(path)}`,
+    "end tell",
+    "delay 0.2",
+    "set sawDisabledService to false",
+    "repeat 5 times",
+    "  set serviceState to my clickBlipService()",
+    '  if serviceState is "clicked" then return "clicked"',
+    '  if serviceState is "disabled" then set sawDisabledService to true',
+    "  delay 0.2",
+    "end repeat",
+    `if sawDisabledService then error ${quoted(BLIP_SERVICE_DISABLED_MESSAGE)}`,
+    `error ${quoted(BLIP_SERVICE_NOT_FOUND_MESSAGE)}`,
+  ];
 }
 
 function quoted(value: string) {
@@ -42,9 +95,18 @@ function buildAppleScriptError(details: string) {
   if (
     normalizedDetails.includes("not allowed assistive access") ||
     normalizedDetails.includes("not authorised to send keystrokes") ||
-    normalizedDetails.includes("not authorized to send apple events")
+    normalizedDetails.includes("not authorized to send apple events") ||
+    normalizedDetails.includes("-1743")
   ) {
     return `${ACCESSIBILITY_ERROR_PREFIX} Enable Raycast in ${ACCESSIBILITY_SETTINGS_PATH}.`;
+  }
+
+  if (normalizedDetails.includes(BLIP_SERVICE_DISABLED_MESSAGE.toLowerCase())) {
+    return BLIP_SERVICE_DISABLED_MESSAGE;
+  }
+
+  if (normalizedDetails.includes(BLIP_SERVICE_NOT_FOUND_MESSAGE.toLowerCase())) {
+    return BLIP_SERVICE_NOT_FOUND_MESSAGE;
   }
 
   if (
@@ -52,7 +114,7 @@ function buildAppleScriptError(details: string) {
     normalizedDetails.includes("blip") &&
     normalizedDetails.includes("not found")
   ) {
-    return "Blip's Finder service was not found. Make sure Blip is installed and its `Services > Blip…` action is available in Finder.";
+    return BLIP_SERVICE_NOT_FOUND_MESSAGE;
   }
 
   return `Blip could not be triggered from Finder Services. ${details}`;

--- a/extensions/blip-raycast/src/blip.ts
+++ b/extensions/blip-raycast/src/blip.ts
@@ -77,8 +77,8 @@ function buildBlipFinderServiceScript(path: string) {
     "repeat 5 times",
     "  set serviceState to my clickBlipService()",
     '  if serviceState is "clicked" then return "clicked"',
-    '  if serviceState is "disabled" then set sawDisabledService to true',
-    "  delay 0.2",
+  if serviceState is "disabled" then set sawDisabledService to true
+  if sawDisabledService then exit repeat
     "end repeat",
     `if sawDisabledService then error ${quoted(BLIP_SERVICE_DISABLED_MESSAGE)}`,
     `error ${quoted(BLIP_SERVICE_NOT_FOUND_MESSAGE)}`,

--- a/extensions/blip-raycast/src/blip.ts
+++ b/extensions/blip-raycast/src/blip.ts
@@ -77,8 +77,8 @@ function buildBlipFinderServiceScript(path: string) {
     "repeat 5 times",
     "  set serviceState to my clickBlipService()",
     '  if serviceState is "clicked" then return "clicked"',
-  if serviceState is "disabled" then set sawDisabledService to true
-  if sawDisabledService then exit repeat
+    '  if serviceState is "disabled" then set sawDisabledService to true',
+    "  if sawDisabledService then exit repeat",
     "end repeat",
     `if sawDisabledService then error ${quoted(BLIP_SERVICE_DISABLED_MESSAGE)}`,
     `error ${quoted(BLIP_SERVICE_NOT_FOUND_MESSAGE)}`,


### PR DESCRIPTION
## Description

Fixes the Blip extension's Finder service lookup on localized macOS systems.

The previous AppleScript clicked `Finder > Services > Blip…` by referencing the `Services` menu item by its English name. On localized systems, such as Korean macOS, Finder exposes that menu as a localized label, so the lookup fails before Blip can be triggered.

This change keeps the interaction scoped to Finder's app menu, but scans the app menu's nested menu items for the Blip service instead of hardcoding the localized Services menu label. It also runs the Finder selection and service lookup in a single `osascript` invocation and preserves clearer errors for missing Accessibility permission or unavailable Blip service items.

## Screencast

N/A

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [contribution guidelines](https://github.com/raycast/extensions/blob/main/CONTRIBUTING.md)
- [x] I ran `npm run build` and `npm run lint`
