### PR TITLE
Update todoist extension

### DIFF
--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Filter completion UI and incremental reminder sync] - {PR_MERGE_DATE}
 
 - **Filter views after completing a task**: Filter results are merged with cached items by id only; tasks no longer present in sync cache (for example a completed non-recurring task) are omitted instead of falling back to stale filter API rows, so the list updates immediately without reopening the extension.
-- **Merge incremental Sync reminder updates**: Todoist’s Sync API often returns **partial** `reminders` arrays. The extension now merges those deltas into the local cache (`mergeSyncedReminders` in `updateTask`, `closeTask`, and `addReminder`) instead of replacing the whole list, so editing one task’s schedule or reminders no longer clears other tasks’ alarm accessories until a full reload.
+- **Merge incremental Sync reminder updates**: Todoist’s Sync API often returns **partial** `reminders` arrays on incremental sync. The extension now merges those deltas into the local cache (`mergeSyncedReminders` in `updateTask` and `closeTask`) instead of replacing the whole list, so editing one task’s schedule or reminders no longer clears other tasks’ alarm accessories until a full reload. **`addReminder`** still uses `sync_token: "*"` for the requested resource type, so its `reminders` response remains a **full replace** of the cached list (avoids stale rows after deletes elsewhere).
 
 ## [Fix filter task freshness and recurrence reminder guard] - 2026-05-01
 

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Filter completion UI and incremental reminder sync] - {PR_MERGE_DATE}
 
+- **Duplicate “at task time” reminders on hourly repeat**: Applying the **same** hourly recurrence twice (when the task already had a timed due and a relative-at-task reminder) no longer queues a second identical reminder; the extension now trusts the merged cache whenever Sync returns an empty `reminders` delta, not only when the field was omitted entirely.
 - **Filter views after completing a task**: Filter results are merged with cached items by id only; tasks no longer present in sync cache (for example a completed non-recurring task) are omitted instead of falling back to stale filter API rows, so the list updates immediately without reopening the extension.
 - **Merge incremental Sync reminder updates**: Todoist’s Sync API often returns **partial** `reminders` arrays on incremental sync. The extension now merges those deltas into the local cache (`mergeSyncedReminders` in `updateTask` and `closeTask`) instead of replacing the whole list, so editing one task’s schedule or reminders no longer clears other tasks’ alarm accessories until a full reload. **`addReminder`** still uses `sync_token: "*"` for the requested resource type, so its `reminders` response remains a **full replace** of the cached list (avoids stale rows after deletes elsewhere).
 

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Todoist Changelog
 
-## [Filter completion UI and incremental reminder sync] - {PR_MERGE_DATE}
+## [Filter completion UI and incremental reminder sync] - 2026-05-04
 
 - **Duplicate “at task time” reminders on hourly repeat**: Applying the **same** hourly recurrence twice (when the task already had a timed due and a relative-at-task reminder) no longer queues a second identical reminder; the extension now trusts the merged cache whenever Sync returns an empty `reminders` delta, not only when the field was omitted entirely.
 - **Filter views after completing a task**: Filter results are merged with cached items by id only; tasks no longer present in sync cache (for example a completed non-recurring task) are omitted instead of falling back to stale filter API rows, so the list updates immediately without reopening the extension.

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Todoist Changelog
 
+## [Filter completion UI and incremental reminder sync] - {PR_MERGE_DATE}
+
+- **Filter views after completing a task**: Filter results are merged with cached items by id only; tasks no longer present in sync cache (for example a completed non-recurring task) are omitted instead of falling back to stale filter API rows, so the list updates immediately without reopening the extension.
+- **Merge incremental Sync reminder updates**: Todoist’s Sync API often returns **partial** `reminders` arrays. The extension now merges those deltas into the local cache (`mergeSyncedReminders` in `updateTask`, `closeTask`, and `addReminder`) instead of replacing the whole list, so editing one task’s schedule or reminders no longer clears other tasks’ alarm accessories until a full reload.
+
 ## [Fix filter task freshness and recurrence reminder guard] - 2026-05-01
 
 - **Filter task typing + freshness**: Typed filter sections in `FilterTasks` and resolve each displayed task against the latest cached item by id, preventing stale task state in filter views after updates.

--- a/extensions/todoist/src/api.ts
+++ b/extensions/todoist/src/api.ts
@@ -537,9 +537,8 @@ export async function addReminder(args: AddReminderArgs, { setData }: CachedData
 
   mergeIntoCachedData(setData, (prev) => ({
     ...prev,
-    reminders: Array.isArray(updatedData.reminders)
-      ? mergeSyncedReminders(prev.reminders, updatedData.reminders)
-      : prev.reminders,
+    // Full sync token: response reminders are the full active set for this resource, so replace the cache.
+    reminders: Array.isArray(updatedData.reminders) ? updatedData.reminders : prev.reminders,
   }));
 
   return updatedData.temp_id_mapping ? updatedData.temp_id_mapping[temp_id] : null;

--- a/extensions/todoist/src/api.ts
+++ b/extensions/todoist/src/api.ts
@@ -372,7 +372,7 @@ export async function updateTask(
   mergeIntoCachedData(cachedData.setData, (prev) => ({
     ...prev,
     items: prev.items.map((i) => (i.id === args.id ? updatedData.items[0] : i)),
-    ...(syncReminders ? { reminders: syncReminders } : {}),
+    ...(syncReminders !== undefined ? { reminders: mergeSyncedReminders(prev.reminders, syncReminders) } : {}),
   }));
   onSynced?.({ syncReminders, updatedTask });
   return true;
@@ -402,7 +402,9 @@ export async function closeTask(id: string, { setData }: CachedDataParams) {
         : prev.items.filter((i) => i.id !== id);
     return {
       ...prev,
-      ...(Array.isArray(updatedData.reminders) ? { reminders: updatedData.reminders } : {}),
+      ...(Array.isArray(updatedData.reminders)
+        ? { reminders: mergeSyncedReminders(prev.reminders, updatedData.reminders) }
+        : {}),
       items,
     };
   });
@@ -487,6 +489,23 @@ export type Reminder = {
   is_deleted: number; // 1 for deleted, 0 for not deleted
 };
 
+/**
+ * Todoist Sync returns incremental `reminders` rows, not the full list. Merge into cache by id
+ * (upsert active rows, drop when `is_deleted === 1`). Empty `incoming` leaves `prev` unchanged.
+ */
+function mergeSyncedReminders(prev: Reminder[], incoming: Reminder[]): Reminder[] {
+  if (incoming.length === 0) return prev;
+  const byId = new Map(prev.map((r) => [r.id, r]));
+  for (const r of incoming) {
+    if (r.is_deleted === 1) {
+      byId.delete(r.id);
+    } else {
+      byId.set(r.id, r);
+    }
+  }
+  return [...byId.values()];
+}
+
 export type AddReminderArgs = {
   item_id: string;
   type: "relative" | "absolute" | "location";
@@ -518,7 +537,9 @@ export async function addReminder(args: AddReminderArgs, { setData }: CachedData
 
   mergeIntoCachedData(setData, (prev) => ({
     ...prev,
-    reminders: updatedData.reminders,
+    reminders: Array.isArray(updatedData.reminders)
+      ? mergeSyncedReminders(prev.reminders, updatedData.reminders)
+      : prev.reminders,
   }));
 
   return updatedData.temp_id_mapping ? updatedData.temp_id_mapping[temp_id] : null;

--- a/extensions/todoist/src/components/FilterTasks.tsx
+++ b/extensions/todoist/src/components/FilterTasks.tsx
@@ -42,7 +42,10 @@ function FilterTasks({ name, quickLinkView }: FilterTasksProps) {
   const tasks = useMemo(() => {
     if (!cachedData) return sections.flatMap((section) => section.tasks);
     const byId = new Map(cachedData.items.map((item) => [item.id, item]));
-    return sections.flatMap((section) => section.tasks.map((task) => byId.get(task.id) ?? task));
+    // Omit ids missing from sync cache so completed/deleted tasks do not stick to stale filter API rows.
+    return sections.flatMap((section) =>
+      section.tasks.map((task) => byId.get(task.id)).filter((t): t is Task => t !== undefined),
+    );
   }, [sections, cachedData]);
 
   const {

--- a/extensions/todoist/src/components/TaskActions.tsx
+++ b/extensions/todoist/src/components/TaskActions.tsx
@@ -107,9 +107,9 @@ export default function TaskActions({
 
   /** Ensures Todoist relative reminder offset 0 when user sets a timed due / hourly repeat and none exists yet. */
   async function ensureAtTaskTimeReminder(itemId: string, syncReminders?: Reminder[]) {
-    const hasAtTimeInSync = syncReminders !== undefined && hasAtTaskTimeRelativeReminder(syncReminders, itemId);
+    // Sync batches are incremental; empty `[]` means "no reminder deltas" — still check merged cache via `data.reminders`.
     const hasAtTimeInCache = hasAtTaskTimeRelativeReminder(data?.reminders, itemId);
-    if (hasAtTimeInSync || (syncReminders === undefined && hasAtTimeInCache)) return;
+    if (hasAtTaskTimeRelativeReminder(syncReminders, itemId) || hasAtTimeInCache) return;
     try {
       await apiAddReminder({ item_id: itemId, type: "relative", minute_offset: 0 }, { data, setData });
     } catch (error) {


### PR DESCRIPTION
## Description

Fixes sync/cache/UI issues related to filters, reminders, and hourly repeat reminders:

1. **Filter views** — After completing a non-recurring task, the list no longer keeps a ghost row from stale `/tasks/filter` data. Rows are shown only when the task id still exists in cached `items` (`FilterTasks.tsx`).

2. **Reminders (incremental sync)** — Sync responses return **incremental** `reminders` arrays. Replacing the entire local list wiped other tasks’ reminders in the UI (e.g. alarm accessory disappearing when changing due on one task). `mergeSyncedReminders` now merges by id in `updateTask`, `closeTask`, and **`addReminder`** (`api.ts`).

3. **Hourly repeat + duplicate reminders** — Re-applying the same hourly repeat no longer adds a second identical “at task time” reminder; we now respect the merged cache when Sync returns an empty `reminders` delta (`ensureAtTaskTimeReminder` in `TaskActions.tsx`).

## Screencast

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [X] I checked that files in the `assets` folder are used by the extension itself
- [X] I checked that assets used by the `README` are placed outside of the `metadata` folder