### PR TITLE
obsidian: read obsidian.json from per-platform location

### DIFF
--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Obsidian Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-05-05
 
 - Fix vault auto-discovery on Windows and Linux by reading `obsidian.json` from the per-platform Obsidian config dir
 

--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Obsidian Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fix vault auto-discovery on Windows and Linux by reading `obsidian.json` from the per-platform Obsidian config dir
+
 ## [Fix] - 2026-04-10
 
 - Fix Open in New Obsidian Tab failing on Windows due to path separator handling

--- a/extensions/obsidian/src/obsidian/internal/obsidian.ts
+++ b/extensions/obsidian/src/obsidian/internal/obsidian.ts
@@ -1,10 +1,21 @@
 import { getPreferenceValues } from "@raycast/api";
 import * as fs from "fs";
 import * as fsAsync from "fs/promises";
-import { homedir } from "os";
+import { homedir, platform } from "os";
 import path from "path";
 import { GlobalPreferences } from "../../utils/preferences";
 import { ObsidianVault } from "./vault";
+
+function obsidianJsonPath(): string {
+  switch (platform()) {
+    case "win32":
+      return path.join(process.env.APPDATA ?? path.join(homedir(), "AppData", "Roaming"), "obsidian", "obsidian.json");
+    case "linux":
+      return path.join(process.env.XDG_CONFIG_HOME ?? path.join(homedir(), ".config"), "obsidian", "obsidian.json");
+    default:
+      return path.join(homedir(), "Library", "Application Support", "obsidian", "obsidian.json");
+  }
+}
 
 interface ObsidianVaultJSON {
   path: string;
@@ -41,12 +52,10 @@ export function getVaultsFromPreferences(): ObsidianVault[] {
 }
 
 export async function getVaultsFromObsidianJson(): Promise<ObsidianVault[]> {
-  const obsidianJsonPath = path.resolve(
-    path.join(homedir(), "Library", "Application Support", "obsidian", "obsidian.json")
-  );
+  const jsonPath = path.resolve(obsidianJsonPath());
 
   try {
-    const obsidianJson = JSON.parse(await fsAsync.readFile(obsidianJsonPath, "utf8")) as ObsidianJSON;
+    const obsidianJson = JSON.parse(await fsAsync.readFile(jsonPath, "utf8")) as ObsidianJSON;
     return Object.values(obsidianJson.vaults).map(({ path }) => ({
       name: getVaultNameFromPath(path) ?? "invalid vault name",
       key: path,


### PR DESCRIPTION
Closes #27595. Vault discovery hardcoded `~/Library/Application Support/...`. Use APPDATA on Windows and XDG_CONFIG_HOME on Linux.