### PR TITLE
fix(raindrop.io): add support for Arc

### DIFF
--- a/extensions/raindrop-io/CHANGELOG.md
+++ b/extensions/raindrop-io/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Raindrop.io Extension Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-05-04
 
 - Add AppleScript fallback support for Arc browser in `src/hooks/useBrowserLink.ts`
 

--- a/extensions/raindrop-io/CHANGELOG.md
+++ b/extensions/raindrop-io/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Raindrop.io Extension Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Add AppleScript fallback support for Arc browser in `src/hooks/useBrowserLink.ts`
+
 ## [Fixes] - 2026-03-31
 
 - Fix loading collections in the Save Browser Tab form by building the dropdown options directly from the collections API response.

--- a/extensions/raindrop-io/src/hooks/useBrowserLink.ts
+++ b/extensions/raindrop-io/src/hooks/useBrowserLink.ts
@@ -96,9 +96,10 @@ export function useBrowserLink() {
           break;
       }
 
-      // Fallback for Vivaldi Browser not recognized by bundleId
-      if (app?.name === "Vivaldi.app") {
-        return runAppleScript(`tell application "Vivaldi" to return URL of active tab of front window`);
+      // Fallback for browsers whose bundleId is not recognized by Raycast API (Vivaldi + Arc)
+      if (app?.name === "Vivaldi.app" || app?.name === "Arc") {
+        const scriptName = app.name === "Arc" ? "Arc" : "Vivaldi";
+        return runAppleScript(`tell application "${scriptName}" to return URL of active tab of front window`);
       }
 
       throw new Error(`Unsupported App: ${app.name}`);


### PR DESCRIPTION
## Description

Fixes "Unsupported App: Arc" and adds full Arc browser support (URL + title) in the Raindrop.io Raycast extension #27602

The useBrowserLink hook was throwing `Unsupported App: Arc` for many users because getFrontmostApplication() sometimes returns a different bundleId (or undefined) for Arc, even though the explicit case "company.thebrowser.Browser" exists.

This PR adds a safe name-based fallback (which is already the case for Vivaldi) so Arc works reliably in the AppleScript path.

## Screencast

I tested the fix on my local fork of this extension and it works as expected. I also ran `npm run build` and it works as expected.

<img width="1265" height="931" alt="Screenshot 2026-05-02 at 3 41 15 AM" src="https://github.com/user-attachments/assets/0e55cb23-936f-4bbc-baa0-d297794c475a" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
