### PR TITLE
google-chrome-profiles: fix silent failure via detached osascript spawn, fix bookmark crash

### DIFF
--- a/extensions/google-chrome-profiles/CHANGELOG.md
+++ b/extensions/google-chrome-profiles/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Google Chrome Profiles Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fix silent failure of all profile actions (Bring to Front, New Tab, New Window, Open URL) for users who have not previously granted Raycast `AppleEvents` permission for `System Events.app`. `@raycast/utils.runAppleScript` spawns `osascript` without `detached: true`, so it inherits the extension's Node process group. Raycast tears that group down ~40ms after the action handler returns control to React, which kills `osascript` mid-flight and also cancels the asynchronous TCC permission prompt that macOS tries to render on first run, leaving no path for the user to actually grant the permission. Run AppleScript via a detached `child_process.spawn("/usr/bin/osascript", [...], { detached: true, stdio: "ignore" })` + `child.unref()` so the subprocess survives teardown, the TCC prompt renders, and the script runs to completion.
+- Fix bookmark favicon crash on `chrome://` / `about:` URLs: `new URL(...).origin` is `null` for opaque-origin schemes; passing that to `getFavicon` threw `TypeError: Invalid URL` and broke the bookmarks list. Only resolve favicons for `http(s)` bookmarks; use the globe icon for everything else.
+
 ## [Feature] - 2026-04-08
 
 - Add "New Window" action to open a new Chrome window for a profile

--- a/extensions/google-chrome-profiles/CHANGELOG.md
+++ b/extensions/google-chrome-profiles/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Chrome Profiles Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-05-26
 
 - Fix silent failure of all profile actions (Bring to Front, New Tab, New Window, Open URL) for users who have not previously granted Raycast `AppleEvents` permission for `System Events.app`. `@raycast/utils.runAppleScript` spawns `osascript` without `detached: true`, so it inherits the extension's Node process group. Raycast tears that group down ~40ms after the action handler returns control to React, which kills `osascript` mid-flight and also cancels the asynchronous TCC permission prompt that macOS tries to render on first run, leaving no path for the user to actually grant the permission. Run AppleScript via a detached `child_process.spawn("/usr/bin/osascript", [...], { detached: true, stdio: "ignore" })` + `child.unref()` so the subprocess survives teardown, the TCC prompt renders, and the script runs to completion.
 - Fix bookmark favicon crash on `chrome://` / `about:` URLs: `new URL(...).origin` is `null` for opaque-origin schemes; passing that to `getFavicon` threw `TypeError: Invalid URL` and broke the bookmarks list. Only resolve favicons for `http(s)` bookmarks; use the globe icon for everything else.

--- a/extensions/google-chrome-profiles/src/index.tsx
+++ b/extensions/google-chrome-profiles/src/index.tsx
@@ -334,7 +334,11 @@ function ListBookmarks(props: { profile: Profile; browser: BrowserConfig }) {
               key={index}
               title={b.title}
               subtitle={b.subtitle}
-              icon={getFavicon(b.iconURL, { fallback: Icon.Globe, mask: Image.Mask.Circle })}
+              icon={
+                b.iconURL
+                  ? getFavicon(b.iconURL, { fallback: Icon.Globe, mask: Image.Mask.Circle })
+                  : { source: Icon.Globe, mask: Image.Mask.Circle }
+              }
               actions={
                 <ActionPanelForTarget
                   profile={props.profile}

--- a/extensions/google-chrome-profiles/src/util/util.ts
+++ b/extensions/google-chrome-profiles/src/util/util.ts
@@ -209,7 +209,16 @@ export const escapeAppleScriptString = (str: string): string => {
  */
 const runDetachedAppleScript = (script: string): void => {
   const scriptPath = join(tmpdir(), `raycast-google-chrome-profiles-${randomUUID()}.applescript`);
-  writeFileSync(scriptPath, script);
+  try {
+    writeFileSync(scriptPath, script);
+  } catch (writeError) {
+    showToast({
+      style: Toast.Style.Failure,
+      title: "Could not write script file",
+      message: String(writeError),
+    });
+    return;
+  }
 
   let child;
   try {

--- a/extensions/google-chrome-profiles/src/util/util.ts
+++ b/extensions/google-chrome-profiles/src/util/util.ts
@@ -1,6 +1,10 @@
 import { URL } from "url";
-import { confirmAlert, Icon } from "@raycast/api";
-import { runAppleScript } from "@raycast/utils";
+import { writeFileSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { spawn } from "child_process";
+import { randomUUID } from "crypto";
+import { showToast, Toast } from "@raycast/api";
 import { BrowserConfig } from "./types";
 
 export type ChromeTarget =
@@ -17,13 +21,21 @@ export const ChromeAction = {
 };
 
 export const createBookmarkListItem = (url: string, name?: string) => {
-  const urlOrigin = new URL(url).origin;
   const urlToDisplay = url.replace(/(^\w+:|^)\/\//, "");
+  let iconURL: string | undefined;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      iconURL = parsed.origin;
+    }
+  } catch {
+    // opaque or invalid URL; fall through to globe icon
+  }
   return {
     url: url,
     title: name ? name : urlToDisplay,
     subtitle: name ? urlToDisplay : undefined,
-    iconURL: urlOrigin,
+    iconURL,
   };
 };
 
@@ -172,10 +184,77 @@ export const escapeAppleScriptString = (str: string): string => {
 };
 
 /**
+ * Run an AppleScript in a detached `osascript` subprocess that survives the
+ * extension's view-teardown.
+ *
+ * Raycast tears down the extension's Node process roughly 40ms after the
+ * action handler returns control to React, regardless of whether `onAction`
+ * awaits the Promise. `@raycast/utils`'s `runAppleScript` spawns `osascript`
+ * as a regular child of Node (no `detached: true`), so the osascript
+ * subprocess inherits Node's process group and gets killed mid-flight. This
+ * also means any asynchronous TCC permission prompt that macOS tries to
+ * render (e.g. "Raycast.app wants access to control System Events.app" on
+ * first run) is cancelled before the user can see it, leaving the extension
+ * in a silent-failure loop where first-time grant of the permission is
+ * impossible from within the extension itself.
+ *
+ * Spawning `osascript` with `detached: true` + `stdio: "ignore"` and
+ * `child.unref()` puts it in its own process group and detaches it from
+ * Node's event loop. The subprocess survives the parent's teardown, the TCC
+ * prompt renders, and the AppleScript runs to completion.
+ *
+ * The temp script file is removed on the child's `exit` event when the
+ * parent is still alive; if the parent dies first, macOS cleans `/tmp`
+ * during normal maintenance.
+ */
+const runDetachedAppleScript = (script: string): void => {
+  const scriptPath = join(tmpdir(), `raycast-google-chrome-profiles-${randomUUID()}.applescript`);
+  writeFileSync(scriptPath, script);
+
+  let child;
+  try {
+    child = spawn("/usr/bin/osascript", [scriptPath], {
+      detached: true,
+      stdio: "ignore",
+    });
+  } catch (spawnError) {
+    try {
+      unlinkSync(scriptPath);
+    } catch {
+      // ignore
+    }
+    showToast({
+      style: Toast.Style.Failure,
+      title: "Could not start osascript",
+      message: String(spawnError),
+    });
+    return;
+  }
+
+  child.on("exit", () => {
+    try {
+      unlinkSync(scriptPath);
+    } catch {
+      // ignore
+    }
+  });
+  child.on("error", (err) => {
+    showToast({
+      style: Toast.Style.Failure,
+      title: "osascript failed",
+      message: err.message,
+    });
+  });
+
+  child.unref();
+};
+
+/**
  * Run the script that opens Google Chrome.
  *
  * - `ChromeAction.Focus`: focuses the existing profile window (or opens it if not open)
  * - `ChromeAction.NewTab`: focuses the profile window, then opens a new blank tab
+ * - `ChromeAction.NewWindow`: opens a new window for the profile
  * - `ChromeAction.openUrl(url)`: focuses the profile window, then opens the URL in a new tab
  *
  * @param profile The Chrome profile to open
@@ -191,41 +270,21 @@ export const openGoogleChrome = async (
   const action = target.action;
   const url = action === "openUrl" ? target.url : undefined;
 
-  const fallbackScript = (action: ChromeTarget["action"]): string => {
-    const escapedProfileDirectory = escapeAppleScriptString(profile.directory);
-    const escapedBinaryPath = escapeAppleScriptString(browser.binaryPath);
+  await willOpen();
 
-    if (action === "newWindow") {
-      return `
-        set theAppPath to quoted form of "${escapedBinaryPath}"
-        set theProfile to quoted form of "${escapedProfileDirectory}"
-        do shell script theAppPath & " --profile-directory=" & theProfile & " --new-window"
-      `;
-    }
+  const escapedProfileDirectory = escapeAppleScriptString(profile.directory);
+  const escapedBinaryPath = escapeAppleScriptString(browser.binaryPath);
 
-    const fallbackUrl = action === "focus" ? "about:blank" : url || "about:blank";
-    const escapedFallbackUrl = escapeAppleScriptString(fallbackUrl);
-
-    return `
+  if (action === "newWindow") {
+    const newWindowScript = `
       set theAppPath to quoted form of "${escapedBinaryPath}"
       set theProfile to quoted form of "${escapedProfileDirectory}"
-      set theLink to quoted form of "${escapedFallbackUrl}"
-      do shell script theAppPath & " --profile-directory=" & theProfile & " " & theLink
+      do shell script theAppPath & " --profile-directory=" & theProfile & " --new-window"
     `;
-  };
-
-  // For newWindow, launch Chrome directly via CLI to avoid focusing an existing window first
-  if (action === "newWindow") {
-    try {
-      await willOpen();
-      await runAppleScript(fallbackScript(action));
-    } catch (error) {
-      // Handle errors silently
-    }
+    runDetachedAppleScript(newWindowScript);
     return;
   }
 
-  // Escape all user-controlled input to prevent AppleScript injection
   const escapedProfileName = escapeAppleScriptString(profile.name);
   const escapedUrl = url ? escapeAppleScriptString(url) : undefined;
   const escapedAppName = escapeAppleScriptString(browser.appName);
@@ -236,7 +295,6 @@ export const openGoogleChrome = async (
     tell application "${escapedAppName}" to activate
     tell application "System Events"
       tell process "${escapedAppName}"
-        -- Focus the profile window via Profiles menu (menu bar item 8, language-independent)
         set profileMenu to menu 1 of menu bar item 8 of menu bar 1
         set menuItems to name of menu items of profileMenu
 
@@ -268,7 +326,6 @@ export const openGoogleChrome = async (
         ? `
     tell application "${escapedAppName}"
       set currentURL to URL of active tab of front window
-      -- Check if current tab is already a new tab
       if currentURL is not "chrome://newtab/" then
         make new tab at end of tabs of front window
       end if
@@ -301,38 +358,5 @@ export const openGoogleChrome = async (
     }
   `;
 
-  let profilesMenuError: unknown;
-
-  try {
-    await willOpen();
-    await runAppleScript(script);
-    return;
-  } catch (error) {
-    // If the Profiles menu approach fails, fall back to the shell script method
-    profilesMenuError = error;
-    console.error("Profiles menu approach failed, falling back to shell script:", error);
-  }
-
-  // Fallback: use shell script to open Chrome with profile directory
-  try {
-    await willOpen();
-    await runAppleScript(fallbackScript(action));
-  } catch (fallbackError) {
-    console.error("Fallback shell script failed:", fallbackError);
-
-    await confirmAlert({
-      title: `Failed to open ${browser.appName}`,
-      icon: Icon.ExclamationMark,
-      message: [
-        `Profile: ${profile.name}`,
-        "",
-        `Profiles menu error: ${String(profilesMenuError)}`,
-        "",
-        `Fallback error: ${String(fallbackError)}`,
-        "",
-        `Is ${browser.appName} installed and accessible at "${browser.binaryPath}"?`,
-      ].join("\n"),
-      primaryAction: { title: "OK" },
-    });
-  }
+  runDetachedAppleScript(script);
 };


### PR DESCRIPTION
## Description

Updated 2026-05-12: this PR has been rewritten end to end. The earlier description below the line is no longer accurate. See [my reply](https://github.com/raycast/extensions/pull/27615#issuecomment-4427796551) for the full investigation.

### TL;DR

Two real bugs in `google-chrome-profiles`:

1. **All profile actions silently no-op for users who haven't already granted Raycast AppleEvents permission for `System Events.app`.** `runAppleScript` from `@raycast/utils` spawns `osascript` without `detached: true`, so it inherits the extension's Node process group. Raycast tears that group down ~40ms after the action handler returns to React, killing `osascript` mid-flight before the script can drive Chrome. The first-run TCC prompt for `kTCCServiceAppleEvents → com.apple.systemevents` is queued on a future tick and gets cancelled along with the subprocess, so the user never sees the dialog and has no path to grant the permission.
2. **`TypeError: Invalid URL` crash in the bookmark list** when any bookmark has an opaque-origin scheme (`chrome://`, `about:`, etc.), because `getFavicon(new URL(url).origin)` is `null` for those.

### Fix

- **Keep** the AppleScript Profiles-menu design from #24147 intact (the bring-to-front + tab-focus UX is the right one; nothing else preserves it without an extra `about:blank` tab on already-running Chrome).
- **Route every AppleScript through a small `runDetachedAppleScript` helper** that writes the script to a temp file and spawns `osascript` with `{ detached: true, stdio: "ignore" }` + `child.unref()`. The subprocess survives Raycast's teardown, the TCC prompt renders, the script runs to completion. Spawn errors and the child's `error` event surface via `showToast` instead of being swallowed.
- **Same treatment for the `newWindow` path** (which uses `do shell script` for Chrome flags) — it was failing for the same lifecycle reason.
- **Favicon guard**: only resolve favicons for `http(s)` bookmarks; use `Icon.Globe` otherwise.

### Reproduction

Reproduced on a fresh macOS user with no prior Raycast → System Events grant. With file-based logging and 200ms heartbeats: 24 attempts across `focus`, `newTab`, `newWindow` for two profiles, every one logging the script-about-to-run, then `process:exit code=0` at ~38ms. Zero successes, zero errors, zero heartbeats, no TCC dialog. Same AppleScript run from a terminal `osascript` completes in 836ms and focuses Chrome correctly, confirming the script itself is fine and the failure is purely the subprocess lifecycle.

### Behaviour after the fix

- `Bring to Front` focuses the existing window in the target profile, no extra tab.
- `New Tab` opens `chrome://newtab/` in the target profile.
- `New Window` opens a new window in the target profile via `--profile-directory`.
- `Open URL` opens the URL in the target profile.
- On a system without the System Events grant, the macOS TCC dialog now actually renders on first action; once granted, all subsequent actions work.
- Bookmark list opens cleanly with `chrome://` and `about:` bookmarks present.

Tested on macOS 25.4, two profiles, Slovenian system locale, English Chrome menu.

### Upstream

`@raycast/utils.runAppleScript` arguably should use `detached: true` by default, or at minimum document the teardown gotcha. I'll open a separate issue on `raycast/utils` once this lands.

## Screencast

n/a, behavioral fix. Visible difference: actions now reliably hit the right profile, and the first-run macOS permission dialog actually appears.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
