### PR TITLE
MCP Registry: Add VC Deal Flow Signal

### DIFF
--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -906,4 +906,16 @@ export const COMMUNITY_ENTRIES: RegistryEntry[] = [
       },
     },
   },
+  {
+    name: "vc-deal-flow-signal",
+    title: "VC Deal Flow Signal",
+    description:
+      "GitHub-derived engineering acceleration signals for ~400 venture-backed startups across 20 sectors. Six free read-only tools for VC sourcing — trending startups, sector lookup, individual signal, methodology, dataset summary, scout receipts. No auth required.",
+    icon: "https://signals.gitdealflow.com/icon.png",
+    homepage: "https://github.com/kindrat86/mcp-deal-flow-signal",
+    configuration: {
+      command: "npx",
+      args: ["-y", "@gitdealflow/mcp-signal"],
+    },
+  },
 ];


### PR DESCRIPTION
## Description

Adds **VC Deal Flow Signal** to the MCP Registry — an MCP server exposing GitHub-derived engineering acceleration signals for ~400 venture-backed startups across 20 sectors.

## Why

Raycast users in VC, fintech, and developer-tooling spaces can use this to query startup signals directly from the launcher. Six read-only tools, all free, no API key required.

## Verification

- npm: https://www.npmjs.com/package/@gitdealflow/mcp-signal (v1.5.2)
- MCP Registry: `io.github.kindrat86/vc-deal-flow-signal`
- Already listed: Smithery (Verified, Quality 98/100), Cursor Directory, awesome-mcp-servers, mcp.so, Block Goose (PR open)
- Public mirror: https://github.com/kindrat86/mcp-deal-flow-signal
- Streamable HTTP variant available: https://signals.gitdealflow.com/api/mcp/rpc

## Schema notes

Mirrors the brave-search/circleback pattern (npx-installable stdio MCP, no env vars required). Entry placed at end of `OFFICIAL_ENTRIES` array following recent additions ordering.

## Checklist

- [x] I read the [contribution guidelines](https://developers.raycast.com/basics/contribute-to-an-extension)
- [x] My change touches a single extension (model-context-protocol-registry)
- [x] No new dependencies added
