### PR TITLE
Update clean-keyboard extension

### DIFF
--- a/extensions/clean-keyboard/CHANGELOG.md
+++ b/extensions/clean-keyboard/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Clean Keyboard Changelog
 
+## [Lock Fn Keys] - 2026-05-03
+
+- Added opt-in preference to also block the function row while cleaning (macOS Tahoe 26+ only)
+
 ## [Windows Support] - 2026-03-18
 
 - Added Windows support using rust implementation

--- a/extensions/clean-keyboard/CHANGELOG.md
+++ b/extensions/clean-keyboard/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clean Keyboard Changelog
 
-## [Lock Fn Keys] - 2026-05-03
+## [Lock Fn Keys] - {PR_MERGE_DATE}
 
 - Added opt-in preference to also block the function row while cleaning (macOS Tahoe 26+ only)
 

--- a/extensions/clean-keyboard/CHANGELOG.md
+++ b/extensions/clean-keyboard/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clean Keyboard Changelog
 
-## [Lock Fn Keys] - {PR_MERGE_DATE}
+## [Lock Fn Keys] - 2026-05-07
 
 - Added opt-in preference to also block the function row while cleaning (macOS Tahoe 26+ only)
 

--- a/extensions/clean-keyboard/README.md
+++ b/extensions/clean-keyboard/README.md
@@ -5,3 +5,5 @@ Lock your keyboard to clean it easily.
 Due to the limitation from the operating system level, some crucial keys like Fn key, media controls (volume, play/pause, etc.) or the Touch ID button are unaffected by this extension.
 
 To reenable the keyboard, simply press `Ctrl + U` at any time.
+
+On macOS Tahoe (26+), you can enable **Lock Fn / function row keys** in the extension preferences to also block the function row while cleaning.

--- a/extensions/clean-keyboard/package-lock.json
+++ b/extensions/clean-keyboard/package-lock.json
@@ -1211,6 +1211,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1270,6 +1271,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -1474,6 +1476,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1816,6 +1819,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2571,6 +2575,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2594,6 +2599,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2800,6 +2806,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/clean-keyboard/package.json
+++ b/extensions/clean-keyboard/package.json
@@ -10,7 +10,8 @@
     "xilopaint",
     "ridemountainpig",
     "litomore",
-    "yusifaliyevpro"
+    "yusifaliyevpro",
+    "shivraj-roy"
   ],
   "platforms": [
     "macOS",
@@ -34,6 +35,17 @@
         "lock",
         "freeze",
         "dirty"
+      ],
+      "preferences": [
+        {
+          "name": "lockFnKeys",
+          "title": "Lock Function Row Keys",
+          "description": "Also block function row keys while cleaning. Original setting is restored on unlock. macOS Tahoe (26+) only.",
+          "type": "checkbox",
+          "label": "Lock Fn / function row keys (macOS Tahoe only)",
+          "default": false,
+          "required": false
+        }
       ]
     }
   ],

--- a/extensions/clean-keyboard/src/clean-keyboard.tsx
+++ b/extensions/clean-keyboard/src/clean-keyboard.tsx
@@ -1,6 +1,10 @@
-import { Action, ActionPanel, Icon, List, showToast, Toast } from "@raycast/api";
-import { useEffect, useState } from "react";
-import { isMac } from "./lib/utils";
+import { Action, ActionPanel, Icon, List, getPreferenceValues, showToast, Toast } from "@raycast/api";
+import { useEffect, useRef, useState } from "react";
+import { isMac, isTahoe, readFnState, setFnState } from "./lib/utils";
+
+interface Preferences {
+  lockFnKeys: boolean;
+}
 
 interface Duration {
   display: string;
@@ -55,6 +59,22 @@ export default function Command() {
   const [isRunning, setIsRunning] = useState(false);
   const [timeLeft, setTimeLeft] = useState<number | null>(null);
   const [icon, setIcon] = useState<string | null>(null);
+  const savedFnState = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    if (!isRunning && savedFnState.current !== null) {
+      try {
+        setFnState(savedFnState.current);
+      } catch {
+        showToast({
+          title: "Could not restore Fn key setting",
+          message: "Go to System Settings > Keyboard to restore manually",
+          style: Toast.Style.Failure,
+        });
+      }
+      savedFnState.current = null;
+    }
+  }, [isRunning]);
 
   const lockAction = async (duration: Duration) => {
     let handler: (duration: number) => void;
@@ -64,6 +84,16 @@ export default function Command() {
     } else {
       const { handler: handlerRust } = await import("rust:../rust/clean-keyboard");
       handler = handlerRust;
+    }
+
+    const { lockFnKeys } = getPreferenceValues<Preferences>();
+    if (lockFnKeys && isTahoe) {
+      try {
+        savedFnState.current = readFnState();
+        setFnState(true);
+      } catch {
+        savedFnState.current = null;
+      }
     }
 
     setTimeLeft(duration.seconds);

--- a/extensions/clean-keyboard/src/clean-keyboard.tsx
+++ b/extensions/clean-keyboard/src/clean-keyboard.tsx
@@ -101,7 +101,7 @@ export default function Command() {
         savedFnState.current = readFnState();
         setFnState(true);
       } catch {
-        savedFnState.current = null;
+        // keep savedFnState so restore effects can undo any partial defaults write
       }
     }
 

--- a/extensions/clean-keyboard/src/clean-keyboard.tsx
+++ b/extensions/clean-keyboard/src/clean-keyboard.tsx
@@ -2,10 +2,6 @@ import { Action, ActionPanel, Icon, List, getPreferenceValues, showToast, Toast 
 import { useEffect, useRef, useState } from "react";
 import { isMac, isTahoe, readFnState, setFnState } from "./lib/utils";
 
-interface Preferences {
-  lockFnKeys: boolean;
-}
-
 interface Duration {
   display: string;
   seconds: number;
@@ -62,6 +58,19 @@ export default function Command() {
   const savedFnState = useRef<boolean | null>(null);
 
   useEffect(() => {
+    return () => {
+      if (savedFnState.current !== null) {
+        try {
+          setFnState(savedFnState.current);
+        } catch {
+          // best-effort restore on unmount
+        }
+        savedFnState.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     if (!isRunning && savedFnState.current !== null) {
       try {
         setFnState(savedFnState.current);
@@ -86,7 +95,7 @@ export default function Command() {
       handler = handlerRust;
     }
 
-    const { lockFnKeys } = getPreferenceValues<Preferences>();
+    const { lockFnKeys } = getPreferenceValues<Preferences.CleanKeyboard>();
     if (lockFnKeys && isTahoe) {
       try {
         savedFnState.current = readFnState();

--- a/extensions/clean-keyboard/src/lib/utils.ts
+++ b/extensions/clean-keyboard/src/lib/utils.ts
@@ -1,1 +1,22 @@
+import { execSync } from "child_process";
+import os from "os";
+
 export const isMac = process.platform === "darwin";
+
+export const isTahoe = isMac && parseInt(os.release().split(".")[0]) >= 25;
+
+const ACTIVATE_SETTINGS = "/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings";
+
+export function readFnState(): boolean {
+  try {
+    const out = execSync("defaults read -g com.apple.keyboard.fnState", { encoding: "utf8" }).trim();
+    return out === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function setFnState(standard: boolean): void {
+  execSync(`defaults write -g com.apple.keyboard.fnState -bool ${standard}`);
+  execSync(`${ACTIVATE_SETTINGS} -u`);
+}


### PR DESCRIPTION
## Description

**Lock Fn / Function Row Keys (macOS Tahoe)**

Adds an opt-in preference to also block the function row while cleaning the keyboard. When enabled, the extension temporarily switches the function row to Standard mode so F-keys emit regular key events that the existing lock can intercept. The original setting is restored automatically on unlock.

- macOS Tahoe (26+) only
- Off by default

> The fnState toggling approach is based on the [Toggle Fn](https://www.raycast.com/elonwoo/toggle-fn) Raycast extension, specifically the macOS Tahoe implementation using defaults write -g com.apple.keyboard.fnState + activateSettings -u.

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="646" height="606" alt="70222" src="https://github.com/user-attachments/assets/0734b411-665a-4c69-811c-d125026ede73" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
