### PR TITLE
[Ente Auth] Fix parsing for Ente export URL variants

### DIFF
--- a/extensions/ente-auth/CHANGELOG.md
+++ b/extensions/ente-auth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Ente Auth Changelog
 
+## [Fixed Ente Auth import] - {PR_MERGE_DATE}
+
+- Fixed parsing of Ente exports with bare issuer parameters
+- Handled secrets containing whitespace, dashes, or plus signs
+- Improved error logging for import failures
+
 ## [Fix spaces in export path] - 2026-03-09
 
 - Fixed issue with spaces in export path causing export to fail

--- a/extensions/ente-auth/CHANGELOG.md
+++ b/extensions/ente-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ente Auth Changelog
 
-## [Fixed Ente Auth import] - {PR_MERGE_DATE}
+## [Fixed Ente Auth import] - 2026-05-10
 
 - Fixed parsing of Ente exports with bare issuer parameters
 - Handled secrets containing whitespace, dashes, or plus signs

--- a/extensions/ente-auth/src/helpers/secrets.ts
+++ b/extensions/ente-auth/src/helpers/secrets.ts
@@ -13,11 +13,11 @@ const sanitizeURL = (url: string): string => {
 	// Fix double URL encoding (%25XX → %XX)
 	url = url.replace(/%25([0-9A-Fa-f]{2})/g, "%$1");
 
-	// Strip dashes and plus signs from the secret parameter (ente sometimes adds those)
-	url = url.replace(
-		/(secret=)([A-Za-z0-9\-+]+)/g,
-		(_, prefix, secret) => prefix + secret.replace(/[-+]/g, "")
-	);
+	// Fix bare issuer parameters (`&issuer&` → `&issuer=&`) emitted by some Ente Auth exports.
+	url = url.replace(/([?&]issuer)(?=&|$)/g, "$1=");
+
+	// Strip whitespace, dashes and plus signs from the secret parameter (ente sometimes adds those)
+	url = url.replace(/([?&]secret=)([^&]+)/g, (_, prefix, secret) => prefix + secret.replace(/[\s\-+]/g, ""));
 
 	return url;
 };
@@ -62,8 +62,8 @@ export const parseSecrets = (rawSecretsURLs: string[]): Secret[] => {
 				if (secret) {
 					secretsList.push(secret);
 				}
-			} catch {
-				console.error("Error parsing line:", line);
+			} catch (error) {
+				console.error("Error parsing line:", line, error);
 			}
 		}
 	});


### PR DESCRIPTION
## Description

Fixes Ente Auth imports for otpauth URLs that contain bare issuer parameters and visually separated secrets.

Some Ente Auth exports can contain URLs like:

```
otpauth://totp/example?secret=ABCD+EFGH&issuer&algorithm=SHA1
```

`OTPAuth.URI.parse` rejects these because `issuer` is not represented as a `key=value` query parameter, causing Import Secrets to parse zero entries and show “No secrets found”.

This change normalizes those URLs before parsing by:

- converting bare `issuer` parameters to `issuer=`
- stripping whitespace, dashes, and plus signs from the `secret` query value
- including the parser error in logs for easier future debugging

## Screencast

N/A – parser/import fix.

## Checklist

- [x] I ran `npm run lint -- --fix` from the extension directory
- [x] I ran `npm run build` from the extension directory
- [x] I tested the import locally with an Ente export containing `&issuer&algorithm=SHA1` and `+` separated secrets
