### PR TITLE
Update claudecast extension

### DIFF
--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -1,5 +1,20 @@
 # ClaudeCast Changelog
 
+## [1.6.0] - {PR_MERGE_DATE}
+
+### Fixed
+
+- **Ghostty Terminal Launch**: Replaced System Events keystroke simulation with Ghostty's native AppleScript surface API. The previous approach typed commands into whichever window was focused, interfering with active sessions.
+- **Warp Terminal Launch**: Replaced the non-functional `warp://action/new_tab?command=` URL scheme with a temporary YAML launch configuration opened via `warp://launch/`. Reliably opens a new window with the correct working directory and command. Double quotes in the cwd path are escaped, and the temp config cleanup window is 30 seconds to handle cold launches.
+
+### Changed
+
+- **Extension description**: Refreshed the store and repository description to highlight session search, instant resume, and agentic automation alongside quick prompts.
+
+### Contributors
+
+- Ghostty and Warp terminal launch fixes by [@Haknt](https://github.com/Haknt) ([#1](https://github.com/qazi0/claude-cast/pull/1))
+
 ## [1.5.0] - 2026-04-30
 
 ### Added

--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ClaudeCast Changelog
 
-## [1.6.0] - {PR_MERGE_DATE}
+## [1.6.0] - 2026-05-04
 
 ### Fixed
 

--- a/extensions/claudecast/README.md
+++ b/extensions/claudecast/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">ClaudeCast</h1>
 
 <p align="center">
-  <strong>Claude Code workflows at your fingertips</strong><br>
-  A comprehensive Raycast extension that bridges Claude Code's powerful agentic CLI with Raycast's instant-access UI.
+  <strong>Discover, resume, and automate Claude Code sessions</strong><br>
+  Deep full-text search, one-keystroke resume, agentic loops, usage analytics, and quick prompts &mdash; bridging Claude Code's powerful agentic CLI with Raycast's instant-access UI.
 </p>
 
 ![ClaudeCast Main Menu](metadata/claudecast-10.png)

--- a/extensions/claudecast/package.json
+++ b/extensions/claudecast/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "claudecast",
   "title": "ClaudeCast",
-  "description": "Claude Code workflows at your fingertips: Quick prompts, session management, and agentic workflows",
+  "description": "Discover, resume, and automate Claude Code sessions: deep full-text search, one-keystroke resume, agentic loops, usage analytics, and quick prompts",
   "icon": "command-icon.png",
   "author": "qazi0",
   "contributors": [

--- a/extensions/claudecast/src/lib/terminal.ts
+++ b/extensions/claudecast/src/lib/terminal.ts
@@ -1,9 +1,10 @@
 import { getPreferenceValues, showToast, Toast, open } from "@raycast/api";
 import { execFile } from "child_process";
 import { promisify } from "util";
-import { writeFileSync } from "fs";
+import { writeFileSync, unlinkSync, mkdirSync, existsSync } from "fs";
 import { tmpdir, homedir } from "os";
 import { join } from "path";
+import { randomUUID } from "crypto";
 import type { PermissionMode } from "./session-parser";
 
 const execFilePromise = promisify(execFile);
@@ -113,9 +114,32 @@ async function openInITerm(command: string, cwd: string): Promise<void> {
 }
 
 async function openInWarp(command: string, cwd: string): Promise<void> {
-  // Warp supports a special URL scheme
-  const encodedCommand = encodeURIComponent(`cd "${cwd}" && ${command}`);
-  await open(`warp://action/new_tab?command=${encodedCommand}`);
+  // Use dynamic launch configuration for reliable command execution
+  const lcId = randomUUID();
+  const lcDir = join(homedir(), ".warp", "launch_configurations");
+  if (!existsSync(lcDir)) {
+    mkdirSync(lcDir, { recursive: true });
+  }
+  const lcFile = join(lcDir, `${lcId}.yaml`);
+  const yaml = `---
+name: ${lcId}
+windows:
+  - tabs:
+      - layout:
+          cwd: "${cwd.replace(/"/g, '\\"')}"
+          commands:
+            - exec: "${command.replace(/"/g, '\\"')}"
+`;
+  writeFileSync(lcFile, yaml, "utf-8");
+  await open(`warp://launch/${lcId}`);
+  // Clean up the temp config after launch
+  setTimeout(() => {
+    try {
+      unlinkSync(lcFile);
+    } catch {
+      /* ignore */
+    }
+  }, 30_000);
 }
 
 async function openInKitty(command: string, cwd: string): Promise<void> {
@@ -131,32 +155,21 @@ async function openInKitty(command: string, cwd: string): Promise<void> {
 }
 
 async function openInGhostty(command: string, cwd: string): Promise<void> {
-  const escapedCommand = command.replace(/"/g, '\\"').replace(/\$/g, "\\$");
-  const escapedCwd = cwd.replace(/"/g, '\\"');
+  const escapedCommand = command.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const escapedCwd = cwd.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 
-  // Try direct invocation first via execFile with array arguments
-  try {
-    await execFilePromise("ghostty", [
-      `--working-directory=${cwd}`,
-      "-e",
-      "sh",
-      "-c",
-      command,
-    ]);
-  } catch {
-    // Fallback to AppleScript using execFile with array arguments
-    const script = `
-      tell application "Ghostty"
-        activate
-      end tell
-      delay 0.5
-      tell application "System Events"
-        keystroke "cd \\"${escapedCwd}\\" && ${escapedCommand}"
-        keystroke return
-      end tell
-    `;
-    await execFilePromise("osascript", ["-e", script]);
-  }
+  // Use Ghostty's native AppleScript API with surface configuration
+  const script = `
+    tell application "Ghostty"
+      activate
+      set cfg to new surface configuration
+      set initial working directory of cfg to "${escapedCwd}"
+      set initial input of cfg to "${escapedCommand}\n"
+      new window with configuration cfg
+    end tell
+  `;
+
+  await execFilePromise("osascript", ["-e", script]);
 }
 
 /**

--- a/extensions/claudecast/src/lib/terminal.ts
+++ b/extensions/claudecast/src/lib/terminal.ts
@@ -113,6 +113,18 @@ async function openInITerm(command: string, cwd: string): Promise<void> {
   await execFilePromise("osascript", ["-e", script]);
 }
 
+// Escape a value for use inside a YAML double-quoted scalar (YAML 1.2).
+// Backslash must be escaped first; LF/CR/TAB get their YAML escape forms so
+// embedded whitespace can never break the document layout.
+function escapeYamlDoubleQuoted(s: string): string {
+  return s
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+}
+
 async function openInWarp(command: string, cwd: string): Promise<void> {
   // Use dynamic launch configuration for reliable command execution
   const lcId = randomUUID();
@@ -126,9 +138,9 @@ name: ${lcId}
 windows:
   - tabs:
       - layout:
-          cwd: "${cwd.replace(/"/g, '\\"')}"
+          cwd: "${escapeYamlDoubleQuoted(cwd)}"
           commands:
-            - exec: "${command.replace(/"/g, '\\"')}"
+            - exec: "${escapeYamlDoubleQuoted(command)}"
 `;
   writeFileSync(lcFile, yaml, "utf-8");
   await open(`warp://launch/${lcId}`);
@@ -164,7 +176,7 @@ async function openInGhostty(command: string, cwd: string): Promise<void> {
       activate
       set cfg to new surface configuration
       set initial working directory of cfg to "${escapedCwd}"
-      set initial input of cfg to "${escapedCommand}\n"
+      set initial input of cfg to "${escapedCommand}" & (ASCII character 10)
       new window with configuration cfg
     end tell
   `;


### PR DESCRIPTION
## Description

ClaudeCast v1.6.0 ships two terminal launch bug fixes (Ghostty, Warp) and a refreshed extension description that better reflects the deep session search and session management features added in recent versions.

### Bug fixes

- **Ghostty**: Replaced the System Events keystroke approach with Ghostty's native AppleScript surface API. The old approach typed the launch command into whichever window happened to be focused, which could interfere with an active session.
- **Warp**: Replaced the non-functional `warp://action/new_tab?command=` URL scheme (the `command` parameter is not supported) with a temporary YAML launch configuration opened via `warp://launch/`. Reliably opens a new window with the correct working directory and command. Double quotes in the cwd path are escaped, and a 30 second cleanup window handles cold launches where Warp may not have read the temp file yet.

### Changes

- Refreshed the extension description in `package.json` and the README tagline to highlight session search, instant resume, and agentic automation alongside quick prompts.

### Contributors

Ghostty and Warp terminal launch fixes contributed by [@Haknt](https://github.com/Haknt) (originally [qazi0/claude-cast#1](https://github.com/qazi0/claude-cast/pull/1)).

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder