### PR TITLE
fix(tny): update scopes and authorization request

### DIFF
--- a/extensions/tny/CHANGELOG.md
+++ b/extensions/tny/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Tny Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fix issue where you are unable to sign in
+
 ## [Initial Version] - 2024-02-07

--- a/extensions/tny/CHANGELOG.md
+++ b/extensions/tny/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tny Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-05-04
 
 - Fix issue where you are unable to sign in
 

--- a/extensions/tny/package.json
+++ b/extensions/tny/package.json
@@ -56,5 +56,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/tny/src/utils/Auth.ts
+++ b/extensions/tny/src/utils/Auth.ts
@@ -4,7 +4,7 @@ import { OAuth } from "@raycast/api";
 const clientId = "raycast_tny";
 const tokenURL = "https://account.chief.app/api/oauth/token";
 const authorizeURL = "https://account.chief.app/login/oauth/authorize";
-const scopes = "tny offline_access";
+const scopes = "profile email tny:links:write offline_access";
 
 const client = new OAuth.PKCEClient({
   redirectMethod: OAuth.RedirectMethod.App,
@@ -14,7 +14,17 @@ const client = new OAuth.PKCEClient({
   providerId: "tny",
 });
 
+let authorizationPromise: Promise<void> | undefined;
+
 export async function authorize(): Promise<void> {
+  authorizationPromise ??= authorizeWithTokens().finally(() => {
+    authorizationPromise = undefined;
+  });
+
+  return authorizationPromise;
+}
+
+async function authorizeWithTokens(): Promise<void> {
   const tokenSet = await client.getTokens();
 
   if (tokenSet?.accessToken) {


### PR DESCRIPTION
## Description

It seems like the token exchange request was executed twice causing the login to fail depending on which resolves first. This solves that and also updates the list of scopes requested. No functional changes just a bugfix.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)