### PR TITLE
Plexamp: Add Cmd+Enter shortcut to play albums from artist view

### DIFF
--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Plexamp CHANGELOG
 
+## [Play Shortcut] - {PR_MERGE_DATE}
+
+- Added a `Cmd+Enter` shortcut to `Play in Plexamp` on album rows in artist views (list and grid) so an album can be played directly without first drilling into its tracks.
+
 ## [Menubar Flicker Fix] - 2026-04-17
 
 - Fixed the menubar widget blinking "Nothing playing" and losing album art on every background refresh by caching playback state across remounts.

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plexamp CHANGELOG
 
-## [Play Shortcut] - {PR_MERGE_DATE}
+## [Play Shortcut] - 2026-05-04
 
 - Added a `Cmd+Enter` shortcut to `Play in Plexamp` on album rows in artist views (list and grid) so an album can be played directly without first drilling into its tracks.
 

--- a/extensions/plexamp/src/browse-media.tsx
+++ b/extensions/plexamp/src/browse-media.tsx
@@ -163,9 +163,6 @@ function AlbumRow(props: {
             icon={Icon.ArrowRight}
             onAction={() => push(<AlbumTrackList album={props.album} sectionKey={props.sectionKey} />)}
           />
-          {props.viewMode && props.onToggleView && (
-            <ToggleViewAction viewMode={props.viewMode} onToggle={props.onToggleView} />
-          )}
           <PlaybackActionItems
             item={props.album}
             onPlay={props.onPlay}
@@ -173,6 +170,9 @@ function AlbumRow(props: {
             onQueue={props.onQueue}
             nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
           />
+          {props.viewMode && props.onToggleView && (
+            <ToggleViewAction viewMode={props.viewMode} onToggle={props.onToggleView} />
+          )}
         </ActionPanel>
       }
     />
@@ -549,7 +549,6 @@ function AlbumGridItem(props: {
             icon={Icon.ArrowRight}
             onAction={() => push(<AlbumTrackList album={props.album} sectionKey={props.sectionKey} />)}
           />
-          <ToggleViewAction viewMode={props.viewMode} onToggle={props.onToggleView} />
           <PlaybackActionItems
             item={props.album}
             onPlay={props.onPlay}
@@ -557,6 +556,7 @@ function AlbumGridItem(props: {
             onQueue={props.onQueue}
             nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
           />
+          <ToggleViewAction viewMode={props.viewMode} onToggle={props.onToggleView} />
         </ActionPanel>
       }
     />


### PR DESCRIPTION
## Description

Adds a `Cmd+Enter` keyboard shortcut to the `Play in Plexamp` action on album rows in the artist view (both list and grid layouts), so an album can be played immediately without first drilling into its track list.

### User flow this enables

1. Invoke `Browse Library` (Raycast hotkey).
2. Type an artist name.
3. Press `Enter` to open the artist's albums.
4. Press `Cmd+Enter` on an album to start playback in Plexamp.

Previously step 4 required opening the Actions menu (`Cmd+K`) and selecting `Play in Plexamp` manually.

### Implementation

In `AlbumRow` and `AlbumGridItem`, `PlaybackActionItems` is reordered to come before `ToggleViewAction`. This makes `Play in Plexamp` the second action in the panel, which Raycast automatically binds to `Cmd+Enter` as the secondary action. `ToggleViewAction` keeps its explicit `Cmd+Shift+V` shortcut.

No new shortcut declarations — this leans on Raycast's built-in primary/secondary convention.

## Screencast / Validation

- `npm run lint` passes.
- Verified the flow in `npm run dev`: Browse Library → artist → Enter → Cmd+Enter on an album triggers playback. `Cmd+Shift+V` still toggles between list and grid views.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/raycast/extensions/blob/main/CONTRIBUTING.md).
- [x] I followed the commit convention (`Plexamp: ...`).
- [x] I added a changelog entry under `{PR_MERGE_DATE}`.
- [x] I tested the change locally with `npm run dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)