### PR TITLE
Slack: accent-insensitive search in Open Channel and Send Message

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Accent-insensitive search] - {PR_MERGE_DATE}
+## [Accent-insensitive search] - 2026-05-07
 
 - "Open Channel" and "Send Message" now match channel and user names regardless of diacritics, so typing `Angeles` finds `Ángeles` (and the same for any accented characters).
 

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Changelog
 
+## [Accent-insensitive search] - {PR_MERGE_DATE}
+
+- "Open Channel" and "Send Message" now match channel and user names regardless of diacritics, so typing `Angeles` finds `Ángeles` (and the same for any accented characters).
+
 ## [Add Direct command for setting slack status] - 2026-02-23
 
 - Merged slack-status Extension into the main Slack extension, enabling users to view, set, update, AI-generate, and clear their status in one place.

--- a/extensions/slack/src/search.tsx
+++ b/extensions/slack/src/search.tsx
@@ -47,11 +47,18 @@ function searchItemAccessories(
   return searchMetadata;
 }
 
+function foldForSearch(s: string): string {
+  return s
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+}
+
 function matchesAllWords(text: string, searchText: string): boolean {
   if (!searchText.trim()) return true;
-  const words = searchText.toLowerCase().split(/\s+/).filter(Boolean);
-  const lowerText = text.toLowerCase();
-  return words.every((word) => lowerText.includes(word));
+  const words = foldForSearch(searchText).split(/\s+/).filter(Boolean);
+  const folded = foldForSearch(text);
+  return words.every((word) => folded.includes(word));
 }
 
 function CopyIdAction({ id }: { id: string }) {

--- a/extensions/slack/src/send-message.tsx
+++ b/extensions/slack/src/send-message.tsx
@@ -19,11 +19,18 @@ interface SendMessageProps {
 
 const selectRecipient = "SELECT_RECIPIENT";
 
+function foldForSearch(s: string): string {
+  return s
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+}
+
 function matchesAllWords(text: string, searchText: string): boolean {
   if (!searchText.trim()) return true;
-  const words = searchText.toLowerCase().split(/\s+/).filter(Boolean);
-  const lowerText = text.toLowerCase();
-  return words.every((word) => lowerText.includes(word));
+  const words = foldForSearch(searchText).split(/\s+/).filter(Boolean);
+  const folded = foldForSearch(text);
+  return words.every((word) => folded.includes(word));
 }
 
 function SendMessage({ recipient }: SendMessageProps) {


### PR DESCRIPTION
## Description

Folds names through Unicode NFD + diacritic stripping before matching, so typing `Angeles` finds `Ángeles` (and the same for any other accented characters).

**Bug:** the `matchesAllWords` helper in both `src/search.tsx` and `src/send-message.tsx` only lowercased — accented names were unfindable unless you typed the exact diacritic. Even typing the accented form could miss when the source string and the input were in different normalization forms (NFC `U+00E1` vs NFD `a` + `U+0301`).

**Fix:** new `foldForSearch(s)` helper applied to both sides of the comparison:

```ts
function foldForSearch(s: string): string {
  return s
    .normalize("NFD")
    .replace(/\p{Diacritic}/gu, "")
    .toLowerCase();
}
```

Both commands (`Open Channel` and `Send Message`) had a copy of `matchesAllWords` and both are updated.

## Screencast

Tested locally against a workspace containing a member named "Ángeles" — typing `angeles`, `Angeles`, `ángeles`, and `Ángeles` all match the entry now (previously only `Ángeles` matched, sometimes).

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our metadata tool