### PR TITLE
Update gif search extension

### DIFF
--- a/extensions/gif-search/CHANGELOG.md
+++ b/extensions/gif-search/CHANGELOG.md
@@ -1,5 +1,10 @@
 # GIF Search Changelog
 
+## [Add Paste GIF Link action] - {PR_MERGE_DATE}
+
+- Added a new action to paste a GIF link into the front-most application
+- Added Windows shortcut support
+
 ## [Fix] - 2026-04-23
 
 - Sort Recents by most recently visited first, and move an already-recent GIF back to the top when it's visited again

--- a/extensions/gif-search/CHANGELOG.md
+++ b/extensions/gif-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GIF Search Changelog
 
-## [Add Paste GIF Link action] - {PR_MERGE_DATE}
+## [Add Paste GIF Link action] - 2026-05-06
 
 - Added a new action to paste a GIF link into the front-most application
 - Added Windows shortcut support

--- a/extensions/gif-search/package.json
+++ b/extensions/gif-search/package.json
@@ -115,6 +115,10 @@
           "value": "copyGifUrl"
         },
         {
+          "title": "Paste GIF Link",
+          "value": "pasteGifUrl"
+        },
+        {
           "title": "Copy GIF Markdown",
           "value": "copyGifMarkdown"
         },

--- a/extensions/gif-search/src/components/GifActions.tsx
+++ b/extensions/gif-search/src/components/GifActions.tsx
@@ -135,14 +135,17 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
           message: filePath,
           primaryAction: {
             title: "Open File",
-            shortcut: { modifiers: ["cmd"], key: "o" },
+            shortcut: { macOS: { modifiers: ["cmd"], key: "o" }, Windows: { modifiers: ["ctrl"], key: "o" } },
             onAction() {
               open(filePath);
             },
           },
           secondaryAction: {
             title: "Show GIF in Finder",
-            shortcut: { modifiers: ["cmd", "shift"], key: "o" },
+            shortcut: {
+              macOS: { modifiers: ["cmd", "shift"], key: "o" },
+              Windows: { modifiers: ["ctrl", "shift"], key: "o" },
+            },
             onAction() {
               showInFinder(filePath);
             },
@@ -164,7 +167,7 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
       key="copyFile"
       title="Copy GIF"
       onAction={copyGif}
-      shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
+      shortcut={{ macOS: { modifiers: ["cmd", "opt"], key: "c" }, Windows: { modifiers: ["ctrl", "opt"], key: "c" } }}
     />
   );
   const pasteFile = (
@@ -173,7 +176,7 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
       key="pasteFile"
       title="Paste GIF"
       onAction={pasteGif}
-      shortcut={{ modifiers: ["cmd", "opt"], key: "p" }}
+      shortcut={{ macOS: { modifiers: ["cmd", "opt"], key: "p" }, Windows: { modifiers: ["ctrl", "opt"], key: "p" } }}
     />
   );
   const copyGifUrl = (
@@ -188,7 +191,10 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
     <Action.CopyToClipboard
       key="copyGifMarkdown"
       title="Copy GIF Markdown"
-      shortcut={{ modifiers: ["cmd", "shift"], key: "enter" }}
+      shortcut={{
+        macOS: { modifiers: ["cmd", "shift"], key: "enter" },
+        Windows: { modifiers: ["ctrl", "shift"], key: "enter" },
+      }}
       content={`![${item.title}](${stripQParams(gif_url)})`}
       onCopy={trackUsage}
     />
@@ -197,8 +203,20 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
     <Action.Paste
       key="pasteGifMarkdown"
       title="Paste GIF Markdown"
-      shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
+      shortcut={{
+        macOS: { modifiers: ["cmd", "shift"], key: "p" },
+        Windows: { modifiers: ["ctrl", "shift"], key: "p" },
+      }}
       content={`![${item.title}](${stripQParams(gif_url)})`}
+      onPaste={trackUsage}
+    />
+  );
+  const pasteGifUrl = (
+    <Action.Paste
+      key="pasteGifUrl"
+      title="Paste GIF Link"
+      shortcut={{ macOS: { modifiers: ["cmd", "opt"], key: "l" }, Windows: { modifiers: ["ctrl", "opt"], key: "l" } }}
+      content={stripQParams(gif_url)}
       onPaste={trackUsage}
     />
   );
@@ -211,7 +229,10 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
         key="toggleFav"
         title="Remove from Favorites"
         onAction={removeFav}
-        shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
+        shortcut={{
+          macOS: { modifiers: ["cmd", "shift"], key: "f" },
+          Windows: { modifiers: ["ctrl", "shift"], key: "f" },
+        }}
       />
     ) : (
       <Action
@@ -219,7 +240,10 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
         key="toggleFav"
         title="Add to Favorites"
         onAction={addToFav}
-        shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
+        shortcut={{
+          macOS: { modifiers: ["cmd", "shift"], key: "f" },
+          Windows: { modifiers: ["ctrl", "shift"], key: "f" },
+        }}
       />
     );
   }
@@ -230,7 +254,10 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
       key="removeRecent"
       title="Remove from Recents"
       onAction={removeFromRecents}
-      shortcut={{ modifiers: ["ctrl", "shift"], key: "r" }}
+      shortcut={{
+        macOS: { modifiers: ["ctrl", "shift"], key: "r" },
+        Windows: { modifiers: ["ctrl", "shift"], key: "r" },
+      }}
     />
   ) : undefined;
 
@@ -240,7 +267,10 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
       key="viewDetails"
       title="View GIF Details"
       target={<GifDetails item={item} mutate={mutate} />}
-      shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
+      shortcut={{
+        macOS: { modifiers: ["cmd", "shift"], key: "d" },
+        Windows: { modifiers: ["ctrl", "shift"], key: "d" },
+      }}
       onPush={trackUsage}
     />
   );
@@ -250,7 +280,10 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
       key="copyPageUrl"
       title="Copy Page Link"
       content={url}
-      shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+      shortcut={{
+        macOS: { modifiers: ["cmd", "shift"], key: "c" },
+        Windows: { modifiers: ["ctrl", "shift"], key: "c" },
+      }}
       onCopy={trackUsage}
     />
   ) : undefined;
@@ -258,14 +291,17 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
     <Action.OpenInBrowser
       key="openUrlInBrowser"
       url={url}
-      shortcut={{ modifiers: ["cmd", "shift"], key: "b" }}
+      shortcut={{
+        macOS: { modifiers: ["cmd", "shift"], key: "b" },
+        Windows: { modifiers: ["ctrl", "shift"], key: "b" },
+      }}
       onOpen={trackUsage}
     />
   ) : undefined;
   const downloadFileAction = (
     <Action
       key="downloadFile"
-      shortcut={{ modifiers: ["cmd", "opt"], key: "d" }}
+      shortcut={{ macOS: { modifiers: ["cmd", "opt"], key: "d" }, Windows: { modifiers: ["ctrl", "opt"], key: "d" } }}
       icon={Icon.Download}
       title="Download GIF"
       onAction={downloadGIFAction}
@@ -273,7 +309,7 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
   );
 
   const actions: Array<(React.JSX.Element | undefined)[]> = [
-    [copyFile, pasteFile, copyGifUrl, copyGifMarkdown, pasteGifMarkdown],
+    [copyFile, pasteFile, copyGifUrl, pasteGifUrl, copyGifMarkdown, pasteGifMarkdown],
     [toggleFav, removeRecent, showViewDetails ? viewDetails : undefined],
     [copyPageUrl, openUrlInBrowser, downloadFileAction],
   ];


### PR DESCRIPTION
## Description
- Added a new action to paste a GIF link into the front-most application. Close #27660.
- Added Windows shortcut support
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
