### PR TITLE
Fix: handle undefined notesDir preference to prevent startsWith error

### DIFF
--- a/extensions/typora-note-creator/CHANGELOG.md
+++ b/extensions/typora-note-creator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Typora Note Creator Changelog
 
-## [Initial Version] - {PR_MERGE_DATE}
+## [Initial Version] - 2025-08-22
 
 ## [Bug Fixes] - {PR_MERGE_DATE}
 

--- a/extensions/typora-note-creator/CHANGELOG.md
+++ b/extensions/typora-note-creator/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Typora Note Creator Changelog
 
-## [Initial Version] - 2025-08-22
-
 ## [Bug Fixes] - {PR_MERGE_DATE}
 
 - Handle undefined notesDir preference to prevent startsWith error
+
+## [Initial Version] - 2025-08-22

--- a/extensions/typora-note-creator/CHANGELOG.md
+++ b/extensions/typora-note-creator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Typora Note Creator Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-05-06
 
 - Handle undefined notesDir preference to prevent startsWith error
 

--- a/extensions/typora-note-creator/CHANGELOG.md
+++ b/extensions/typora-note-creator/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Typora Note Creator Changelog
 
-## [Initial Version] - 2025-08-22
+## [Initial Version] - {PR_MERGE_DATE}
+
+## [Bug Fixes] - {PR_MERGE_DATE}
+
+- Handle undefined notesDir preference to prevent startsWith error

--- a/extensions/typora-note-creator/package.json
+++ b/extensions/typora-note-creator/package.json
@@ -6,7 +6,9 @@
   "icon": "extension_icon.png",
   "author": "mynameisny",
   "license": "MIT",
-  "categories": ["Productivity"],
+  "categories": [
+    "Productivity"
+  ],
   "commands": [
     {
       "name": "create-note",
@@ -54,5 +56,8 @@
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
   },
-  "version": "0.0.2"
+  "version": "0.0.2",
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/typora-note-creator/package.json
+++ b/extensions/typora-note-creator/package.json
@@ -53,5 +53,6 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "version": "0.0.2"
 }

--- a/extensions/typora-note-creator/src/create-note.tsx
+++ b/extensions/typora-note-creator/src/create-note.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Form, showToast, Toast, popToRoot, Icon, getPreferenceValues } from "@raycast/api";
+import { Action, ActionPanel, Form, showToast, Toast, popToRoot, Icon, getPreferenceValues, openExtensionPreferences } from "@raycast/api";
 import { useState, useEffect } from "react";
 import { readdirSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
@@ -6,7 +6,8 @@ import { join } from "path";
 import { exec } from "child_process";
 
 function resolveNotesDir(): string {
-  const { notesDir } = getPreferenceValues<{ notesDir: string }>();
+  const { notesDir } = getPreferenceValues<{ notesDir?: string }>();
+  if (!notesDir) return "";
   return notesDir.startsWith("~") ? join(homedir(), notesDir.slice(1)) : notesDir;
 }
 
@@ -28,6 +29,20 @@ export default function CreateNoteCommand() {
 
   useEffect(() => {
     const baseDir = resolveNotesDir();
+    if (!baseDir) {
+      showToast({
+        style: Toast.Style.Failure,
+        title: "Notes directory not configured",
+        message: "Open preferences to set it",
+        primaryAction: {
+          title: "Open Preferences",
+          onAction: () => openExtensionPreferences(),
+        },
+      });
+      setLoadingTemplates(false);
+      return;
+    }
+
     const templateDir = join(baseDir, ".note-templates");
 
     if (!existsSync(templateDir)) {
@@ -47,6 +62,16 @@ export default function CreateNoteCommand() {
     }
 
     const baseDir = resolveNotesDir();
+    if (!baseDir) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Notes directory not configured",
+        message: "Open preferences to set it",
+        primaryAction: { title: "Open Preferences", onAction: () => openExtensionPreferences() },
+      });
+      return;
+    }
+
     const folderPath = join(baseDir, folderName);
     const fileName = values.useIndex ? "index.md" : `${folderName}.md`;
     const filePath = join(folderPath, fileName);

--- a/extensions/typora-note-creator/src/create-note.tsx
+++ b/extensions/typora-note-creator/src/create-note.tsx
@@ -1,4 +1,14 @@
-import { Action, ActionPanel, Form, showToast, Toast, popToRoot, Icon, getPreferenceValues, openExtensionPreferences } from "@raycast/api";
+import {
+  Action,
+  ActionPanel,
+  Form,
+  showToast,
+  Toast,
+  popToRoot,
+  Icon,
+  getPreferenceValues,
+  openExtensionPreferences,
+} from "@raycast/api";
 import { useState, useEffect } from "react";
 import { readdirSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
@@ -6,29 +16,23 @@ import { join } from "path";
 import { exec } from "child_process";
 
 function resolveNotesDir(): string {
-  const { notesDir } = getPreferenceValues<{ notesDir?: string }>();
+  const { notesDir } = getPreferenceValues<Preferences.CreateNote>();
   if (!notesDir) return "";
   return notesDir.startsWith("~") ? join(homedir(), notesDir.slice(1)) : notesDir;
 }
 
 function resolveNoteApp(): string {
-  type AppPickerValue = string | { name?: string; path?: string };
-  const { appPath } = getPreferenceValues<{ appPath: AppPickerValue }>();
-  if (typeof appPath === "string") {
-    return appPath;
-  }
-  if (appPath && typeof appPath === "object") {
-    return appPath.name || appPath.path || "Typora";
-  }
-  return "Typora";
+  const { appPath } = getPreferenceValues<Preferences.CreateNote>();
+  return appPath?.name || appPath?.path || "Typora";
 }
 
 export default function CreateNoteCommand() {
   const [templates, setTemplates] = useState<string[]>([]);
   const [loadingTemplates, setLoadingTemplates] = useState(true);
+  const baseDir = resolveNotesDir();
+  const templateDir = baseDir ? join(baseDir, ".note-templates") : "";
 
   useEffect(() => {
-    const baseDir = resolveNotesDir();
     if (!baseDir) {
       showToast({
         style: Toast.Style.Failure,
@@ -42,8 +46,6 @@ export default function CreateNoteCommand() {
       setLoadingTemplates(false);
       return;
     }
-
-    const templateDir = join(baseDir, ".note-templates");
 
     if (!existsSync(templateDir)) {
       mkdirSync(templateDir, { recursive: true });
@@ -61,7 +63,6 @@ export default function CreateNoteCommand() {
       return;
     }
 
-    const baseDir = resolveNotesDir();
     if (!baseDir) {
       await showToast({
         style: Toast.Style.Failure,
@@ -109,15 +110,18 @@ export default function CreateNoteCommand() {
       actions={
         <ActionPanel>
           <Action.SubmitForm title="Create Note" onSubmit={handleSubmit} icon={Icon.Document} />
-          <Action
-            title="Open Template Directory in Finder"
-            onAction={() => exec(`open "${join(resolveNotesDir(), ".note-templates")}"`)}
-            icon={Icon.Finder}
-          />
-          <Action.CopyToClipboard
-            title="Copy Template Directory Path"
-            content={join(resolveNotesDir(), ".note-templates")}
-          />
+          {baseDir ? (
+            <>
+              <Action
+                title="Open Template Directory in Finder"
+                onAction={() => exec(`open "${templateDir}"`)}
+                icon={Icon.Finder}
+              />
+              <Action.CopyToClipboard title="Copy Template Directory Path" content={templateDir} />
+            </>
+          ) : (
+            <Action title="Open Extension Preferences" onAction={() => openExtensionPreferences()} icon={Icon.Gear} />
+          )}
         </ActionPanel>
       }
       searchBarAccessory={
@@ -138,10 +142,11 @@ export default function CreateNoteCommand() {
         ))}
       </Form.Dropdown>
       <Form.Description
-        text={`The template directory is located at ".note-templates" under your notes root directory (${join(
-          resolveNotesDir(),
-          ".note-templates",
-        )}). This location is fixed and cannot be changed.`}
+        text={
+          baseDir
+            ? `The template directory is located at ".note-templates" under your notes root directory (${templateDir}). This location is fixed and cannot be changed.`
+            : `The notes directory is not configured yet. Open the extension preferences to set it.`
+        }
       />
     </Form>
   );


### PR DESCRIPTION
## Description

handle undefined notesDir preference to prevent startsWith error

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
