### PR TITLE
Update window-layouts extension

### DIFF
--- a/extensions/window-layouts/CHANGELOG.md
+++ b/extensions/window-layouts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Window Layouts Changelog
 
-## [Improvements] - {PR_MERGE_DATE}
+## [Improvements] - 2026-05-06
 
 - Improved the error message shown when the Raycast `WindowManagement` API is not available, clarifying that the extension requires both Raycast Pro and Accessibility permission
 

--- a/extensions/window-layouts/CHANGELOG.md
+++ b/extensions/window-layouts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Window Layouts Changelog
 
+## [Improvements] - {PR_MERGE_DATE}
+
+- Improved the error message shown when the Raycast `WindowManagement` API is not available, clarifying that the extension requires both Raycast Pro and Accessibility permission
+
 ## [New Features & Improvements] - 2026-04-11
 
 ### New Layouts

--- a/extensions/window-layouts/src/utils/get-desktop-context.ts
+++ b/extensions/window-layouts/src/utils/get-desktop-context.ts
@@ -9,8 +9,9 @@ export type DesktopContext = Readonly<{
 
 export async function getDesktopContext(): Promise<DesktopContext | null> {
   if (!environment.canAccess(WindowManagement)) {
-    await showFailureToast("Not Supported", {
-      message: "This command requires access to Raycast WindowManagement API.",
+    await showFailureToast("WindowManagement Not Available", {
+      message:
+        "This extension requires Raycast Pro and Accessibility permission. Make sure you are signed in with a Pro account and have granted Accessibility access in System Settings → Privacy & Security → Accessibility, then fully quit and reopen Raycast.",
     });
     return null;
   }

--- a/extensions/window-layouts/src/utils/get-desktop-context.ts
+++ b/extensions/window-layouts/src/utils/get-desktop-context.ts
@@ -11,7 +11,7 @@ export async function getDesktopContext(): Promise<DesktopContext | null> {
   if (!environment.canAccess(WindowManagement)) {
     await showFailureToast("WindowManagement Not Available", {
       message:
-        "This extension requires Raycast Pro and Accessibility permission. Make sure you are signed in with a Pro account and have granted Accessibility access in System Settings → Privacy & Security → Accessibility, then fully quit and reopen Raycast.",
+        "Requires Raycast Pro and Accessibility permission. Grant access in System Settings → Privacy & Security → Accessibility, then restart Raycast.",
     });
     return null;
   }


### PR DESCRIPTION
## Description

Improves the error message shown when the Raycast `WindowManagement` API is not available (`environment.canAccess(WindowManagement)` returns `false`).

The previous message was a generic *"Not Supported — This command requires access to Raycast WindowManagement API"*, which doesn't help users understand which requirement is actually missing. Since `canAccess()` returns a single boolean, we cannot programmatically distinguish between the two preconditions, so the new message lists both explicitly:

- Raycast Pro subscription (the `WindowManagement` API is Pro-only)
- Accessibility permission for Raycast in System Settings → Privacy & Security
- A reminder to fully quit and reopen Raycast after granting permission, as on macOS Tahoe (26.x) the toggle sometimes only takes effect after a restart of the app

This came up in #27676, where a user enabled Accessibility but kept seeing "Not Supported" — the most likely cause being that they were on the Free plan rather than Pro, but the toast didn't make that clear.

Fixes #27676

## Screencast

N/A — text-only change to a failure toast.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder