### PR TITLE
Fix Google Chrome history search when Chrome is running

### DIFF
--- a/extensions/google-chrome/CHANGELOG.md
+++ b/extensions/google-chrome/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Chrome Changelog
 
-## [Fix Chrome History Search When Chrome Is Running] - {PR_MERGE_DATE}
+## [Fix Chrome History Search When Chrome Is Running] - 2026-05-07
 
 - Fix searching Chrome history while Chrome keeps the history database locked.
 

--- a/extensions/google-chrome/CHANGELOG.md
+++ b/extensions/google-chrome/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Chrome Changelog
 
+## [Fix Chrome History Search When Chrome Is Running] - {PR_MERGE_DATE}
+
+- Fix searching Chrome history while Chrome keeps the history database locked.
+
 ## [Add Name Window Command] - 2026-03-04
 
 - Add Name Window command to name the currently active Google Chrome window.

--- a/extensions/google-chrome/package-lock.json
+++ b/extensions/google-chrome/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.1",
-        "@raycast/utils": "^2.2.2",
+        "@raycast/utils": "^2.2.4",
         "run-applescript": "^7.1.0",
         "sql.js": "^1.13.0"
       },
@@ -1244,9 +1244,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.2.tgz",
-      "integrity": "sha512-tZcyWCHZvz4L/i1CGEnSZkBoK6wwX1pzlTKjcWWugbrQyG0QCMOxjKJfRC/iNkD+hHaqhMWUj4Y0LNo/NknvFw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.4.tgz",
+      "integrity": "sha512-XkxW5bUZACxl2zP4M6Qtkj9a1nbOKcRBm96BLkJ6O4Q7L/vFSnc+3pPJ/i0ZLVOExx5LJMJY0jnNPo91xqJnFQ==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1288,6 +1288,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1359,6 +1360,7 @@
       "integrity": "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.0",
         "@typescript-eslint/types": "8.46.0",
@@ -1564,6 +1566,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1928,6 +1931,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2784,6 +2788,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2831,6 +2836,7 @@
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3043,6 +3049,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3107,6 +3114,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/google-chrome/package.json
+++ b/extensions/google-chrome/package.json
@@ -420,7 +420,7 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.104.1",
-    "@raycast/utils": "^2.2.2",
+    "@raycast/utils": "^2.2.4",
     "run-applescript": "^7.1.0",
     "sql.js": "^1.13.0"
   },


### PR DESCRIPTION
## Description

Bumps `@raycast/utils` from `^2.2.2` to `^2.2.4` to pick up the `useSQL` lock fallback fix for `node:sqlite`.

When Chrome is running, searching Chrome history can fail with `database is locked`. The extension already uses `useSQL`, which has a fallback that copies the database to a temporary file when SQLite reports the source DB is locked. However, older `@raycast/utils` versions only detected lock errors from message text like `(5)`/`(14)`. With Raycast's newer Node runtime, `node:sqlite` reports the lock as `errcode: 5` with message `database is locked`, so the fallback was not triggered.

This matches the root cause fixed for Zen Browser in #27373. Updating `@raycast/utils` makes `useSQL` detect the `node:sqlite` error code and use the existing DB-copy fallback.

Fixes #27493

## Verification

- Reproduced the failure locally with `@raycast/utils` 2.2.2 while Chrome was running.
- Verified that the same extension works after bumping to `@raycast/utils` 2.2.4.
- Ran `npx tsc --noEmit`.
- Ran `npm run lint`.
- Ran `npm run build`.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
