### PR TITLE
claudecast: add cmux support, update cost calculation, new usage dashboard, fix ooms, etc.

### DIFF
--- a/extensions/claudecast/.gitignore
+++ b/extensions/claudecast/.gitignore
@@ -5,3 +5,4 @@ dist/
 SESSION_NOTES.md
 CLAUDE.md
 PR-*.md
+PR_*.md

--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -11,7 +11,8 @@
 ### Fixed
 
 - **Cost Calculation: Streaming Chunk Deduplication**: Anthropic streams response chunks where each chunk's `usage` is cumulative. Naive summing inflated session totals by 2x to 4x. Now deduped by `(message.id, requestId)` so per-message totals reflect the final cumulative value once per request.
-- **Cost Calculation: Sonnet 200K Token Tier**: Above 200K input tokens per message, Sonnet rates double. The pricing table now applies tier pricing per message (per request), so heavy sessions are no longer underbilled by ~43%.
+- **Cost Calculation: Sonnet 200K Token Tier**: Above 200K input tokens per message, Sonnet rates double across all token types (input, output, cache read, cache write). The pricing now applies a flat per-request high tier keyed off the message's input token count, matching Anthropic's billing.
+- **Cost Calculation: Date-Range Filter Skips Timestampless Entries**: When a date range is active (today/week/month/daily chart), entries without a `timestamp` field are excluded. Previously they passed through the filter and inflated reported costs for users with older session files.
 - **Cost Calculation: Opus 4.7 Pricing Row**: Added an explicit `opus-4-7` row at the $5/$25 tier. Without it, Opus 4.7 sessions matched the older `opus` substring and were billed at the $15/$75 tier (3x overcharge).
 - **Cost Calculation: Daily Chart Bucketing**: Daily costs are now attributed to each day's actual usage timestamps. Previously a multi-day session stamped all of its cost on the file's last-modified date.
 - **Cost Calculation: Opus 4.1 Pricing Row**: Added an explicit `opus-4-1` row at the $15/$75 tier for users still resuming pre-4.5 sessions.

--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ClaudeCast Changelog
 
-## [1.8.0] - {PR_MERGE_DATE}
+## [1.8.0] - 2026-05-08
 
 ### Added
 

--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -1,6 +1,29 @@
 # ClaudeCast Changelog
 
-## [1.7.0] - {PR_MERGE_DATE}
+## [1.8.0] - {PR_MERGE_DATE}
+
+### Added
+
+- **cmux Terminal Support**: Added cmux ([cmux.com](https://cmux.com)) as a first-class terminal alongside Terminal, iTerm, Warp, kitty, and Ghostty. Sessions launch via the macOS open-handler so cwd is set as the shell's process pwd, then the command types and submits via cmux's own input pipeline (no Accessibility permission needed). cmux honors the global Open In preference: New Tab uses the open-handler path; New Window uses cmux's AppleScript `new window` verb plus a typed `cd "<cwd>" && <command>`.
+- **Usage Dashboard Revamp**: Real SVG bar chart for daily cost trend, side-by-side range comparison table, top projects table, top sessions table with project + first-message preview + cost. Sidebar metadata shows totals, token breakdowns, top projects as colored tags, and the most expensive session.
+- **Auth Gate for Claude API Commands**: Ask Claude Code, Git Actions, Transform Selection, and Agentic Workflows preflight authentication before invoking the CLI. The check accepts Raycast preferences (`anthropicApiKey`, `oauthToken`), the env vars `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN`, and existing credentials reported by `claude auth status --json`. When none are present the user gets a friendly "Add token in preferences" toast instead of seeing the CLI's `/login` prompt inside the spawned process.
+
+### Fixed
+
+- **Cost Calculation: Streaming Chunk Deduplication**: Anthropic streams response chunks where each chunk's `usage` is cumulative. Naive summing inflated session totals by 2x to 4x. Now deduped by `(message.id, requestId)` so per-message totals reflect the final cumulative value once per request.
+- **Cost Calculation: Sonnet 200K Token Tier**: Above 200K input tokens per message, Sonnet rates double. The pricing table now applies tier pricing per message (per request), so heavy sessions are no longer underbilled by ~43%.
+- **Cost Calculation: Opus 4.7 Pricing Row**: Added an explicit `opus-4-7` row at the $5/$25 tier. Without it, Opus 4.7 sessions matched the older `opus` substring and were billed at the $15/$75 tier (3x overcharge).
+- **Cost Calculation: Daily Chart Bucketing**: Daily costs are now attributed to each day's actual usage timestamps. Previously a multi-day session stamped all of its cost on the file's last-modified date.
+- **Cost Calculation: Opus 4.1 Pricing Row**: Added an explicit `opus-4-1` row at the $15/$75 tier for users still resuming pre-4.5 sessions.
+- **OOM Crashes (menu-bar-monitor, usage-dashboard, browse-sessions)**: Multiple structural fixes for "JS heap out of memory" worker crashes affecting users with large session histories. Persistent LocalStorage cache for today's stats so menu-bar cold starts don't re-scan; `LaunchType.Background` skip of the project-discovery scan; bounded newest-first iterator in `listAllSessions` that stops statting once it has the top N; message and content caps in `getSessionDetail` (last 200 messages, 5KB per message) so browse-sessions detail view stops materializing megabyte arrays into React state; explicit stream-listener cleanup in `streamSessionUsage` for back-to-back invocations.
+- **Terminal Launch: `$` Escape Bug**: Stopped escaping `$` in commands sent to Terminal.app and iTerm. Previously a command like `bash -c 'echo $SHELL'` would print the literal text `$SHELL` instead of expanding the variable.
+- **`usage-dashboard` Redundant Daily Stats Scans**: The 7-day daily stats no longer reload on every range tab switch (today/week/month/all). Loaded once on mount.
+- **`calculateStatsWithUsage` Mutation**: Stopped mutating SessionMetadata objects with computed costs. Top sessions are now a lightweight `{id, projectName, firstMessage, cost}` projection.
+- **Per-Project Path Resolution**: Memoized within each stats call so each unique project directory is resolved at most once per call instead of once per session.
+- **Session Detail View: Last 20 Messages**: Browse Sessions and Deep Search Sessions detail views now render the most recent 20 messages, with an accurate "Showing last N of M messages" notice keyed to the rendered count. The banner now appears for any session with more than 20 messages.
+- **Kitty Window Mode**: Restored `--single-instance` so window-mode launches reuse the running kitty instance rather than spawning a separate process.
+
+## [1.7.0] - 2026-05-05
 
 ### Added
 

--- a/extensions/claudecast/README.md
+++ b/extensions/claudecast/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>Discover, resume, and automate Claude Code sessions</strong><br>
-  Deep full-text search, one-keystroke resume, agentic loops, usage analytics, and quick prompts &mdash; bridging Claude Code's powerful agentic CLI with Raycast's instant-access UI.
+  Deep full-text search, one-keystroke resume, agentic loops, usage analytics, and quick prompts. Bridges Claude Code's agentic CLI with Raycast's instant-access UI.
 </p>
 
 ![ClaudeCast Main Menu](metadata/claudecast-10.png)
@@ -24,14 +24,23 @@ Fast project switching for Claude Code. Browse all your projects with favorites,
 - Open in VS Code or Finder
 - Manage favorites
 
+### Deep Search Sessions
+Full-text search across every Claude Code conversation on disk.
+
+- Streams JSONL files incrementally so results appear as they are found
+- Match snippets show ~15 words of context around the query, with the match bolded
+- Debounced search with cancellation when the query changes
+- Resume, fork, or delete any matched session in place
+- Cleans `<local-command-*>` and short slash-only prompts out of the result list
+
 ### Browse Sessions
 Find and resume any Claude Code conversation across all projects.
 
-- Search sessions by content
 - Filter by project
-- View conversation preview
+- Inline conversation preview with the most recent 20 messages and a "Showing last N of M messages" notice for long sessions
 - Resume, fork, or delete sessions
 - See cost and token usage per session
+- Restores the original permission mode and model on resume
 
 ### Agentic Workflows
 Curated collection of production-tested prompts with variable substitution.
@@ -116,12 +125,13 @@ Real-time Claude Code status in your menu bar.
 - Quick access to all commands
 
 ### Usage Dashboard
-Detailed cost and usage metrics.
+Detailed cost and usage metrics with a live SVG bar chart.
 
-- Daily/weekly/monthly trends
-- Cost breakdown by project
-- Top expensive sessions
-- ASCII cost charts
+- Range tabs adapt the chart granularity: Today/Week (daily bars), Month (weekly), All Time (up to 12 monthly bars)
+- Per-range totals, token breakdown (input, output, cache read, cache write)
+- Top projects as colored tags; "Cost by Project" and "Top Sessions" tables
+- Streaming-chunk dedup so cumulative usage reports match Anthropic's actual billing
+- Per-model pricing including Opus 4.7, Opus 4.1, and the Sonnet 200K-token tier
 
 ## Installation
 
@@ -166,9 +176,10 @@ Some features (Ask Claude Code, Transform Selection, Git Actions) require an OAu
 Open Raycast preferences and configure ClaudeCast:
 
 - **Default Model**: Choose between Sonnet (balanced), Opus (most capable), or Haiku (fastest)
-- **Terminal Application**: Select your preferred terminal (Terminal, iTerm, Warp, Kitty, Ghostty)
+- **Terminal Application**: Pick from Terminal, iTerm, Warp, kitty, Ghostty, or cmux. Each launcher uses the terminal's native AppleScript or CLI for reliable launches.
+- **Open In**: Choose New Window or New Tab. Honored by Terminal, iTerm, kitty, Ghostty, and cmux. Warp always opens a new window.
 - **Claude Code Path**: Optionally specify a custom path to the Claude CLI binary
-- **OAuth Token**: Long-lived token from `claude setup-token` (required for API features)
+- **Anthropic API Key / OAuth Token**: For API features (Ask Claude Code, Git Actions, Transform Selection, Agentic Workflows). Either preference works. The auth gate also accepts `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, or `CLAUDE_CODE_OAUTH_TOKEN` env vars, or existing `claude auth login` credentials.
 
 ## Usage
 
@@ -218,23 +229,25 @@ npm run fix-lint
 ```
 claude-cast/
 ├── src/
-│   ├── ask-claude.tsx          # Quick Prompt command
-│   ├── browse-sessions.tsx     # Session Browser
-│   ├── launch-project.tsx      # Project Launcher
-│   ├── quick-continue.tsx      # Quick Continue
-│   ├── git-actions.tsx         # Git Actions
-│   ├── prompt-library.tsx      # Agentic Workflows
-│   ├── transform-selection.tsx # Transform Selection
-│   ├── menu-bar-monitor.tsx    # Menu Bar Monitor
-│   ├── usage-dashboard.tsx     # Usage Dashboard
+│   ├── ask-claude.tsx            # Quick Prompt command
+│   ├── browse-sessions.tsx       # Session Browser
+│   ├── deep-search-sessions.tsx  # Full-text Deep Search
+│   ├── launch-project.tsx        # Project Launcher
+│   ├── quick-continue.tsx        # Quick Continue
+│   ├── git-actions.tsx           # Git Actions
+│   ├── prompt-library.tsx        # Agentic Workflows
+│   ├── transform-selection.tsx   # Transform Selection
+│   ├── menu-bar-monitor.tsx      # Menu Bar Monitor
+│   ├── usage-dashboard.tsx       # Usage Dashboard
 │   └── lib/
-│       ├── claude-cli.ts       # Claude CLI integration
-│       ├── session-parser.ts   # JSONL session parsing
-│       ├── project-discovery.ts # Project detection
-│       ├── context-capture.ts  # VS Code context capture
-│       ├── terminal.ts         # Terminal launch utilities
-│       ├── prompts.ts          # Built-in prompts
-│       └── usage-stats.ts      # Usage statistics
+│       ├── claude-cli.ts         # Claude CLI integration and auth gate
+│       ├── session-parser.ts     # JSONL session parsing and streaming usage scanner
+│       ├── project-discovery.ts  # Project detection
+│       ├── context-capture.ts    # VS Code context capture
+│       ├── terminal.ts           # Terminal launch utilities (Terminal, iTerm, Warp, kitty, Ghostty, cmux)
+│       ├── svg-chart.ts          # SVG bar chart for the Usage Dashboard
+│       ├── prompts.ts            # Built-in prompts
+│       └── usage-stats.ts        # Usage statistics
 ├── assets/
 │   └── command-icon.png        # Extension icon
 ├── package.json

--- a/extensions/claudecast/package.json
+++ b/extensions/claudecast/package.json
@@ -199,8 +199,8 @@
           "name": "showCostInMenuBar",
           "type": "checkbox",
           "default": false,
-          "label": "Show Cost in Menu Bar",
-          "description": "Display today's cost next to the menu bar icon",
+          "label": "Show Today's Cost",
+          "description": "Display today's spend (USD) next to the menu bar icon. Updates every 30 seconds.",
           "required": false
         }
       ]
@@ -245,7 +245,7 @@
     {
       "name": "terminalApp",
       "title": "Terminal Application",
-      "description": "The terminal app to use for launching Claude Code sessions",
+      "description": "Choose which terminal opens new Claude Code sessions. Each app uses its native AppleScript or CLI so launches are reliable across macOS updates.",
       "type": "dropdown",
       "default": "Terminal",
       "required": false,
@@ -263,19 +263,23 @@
           "value": "Warp"
         },
         {
-          "title": "Kitty",
+          "title": "kitty",
           "value": "kitty"
         },
         {
           "title": "Ghostty",
           "value": "Ghostty"
+        },
+        {
+          "title": "cmux",
+          "value": "cmux"
         }
       ]
     },
     {
       "name": "openIn",
       "title": "Open In",
-      "description": "Whether to open Claude Code sessions in a new window or a new tab. Notes: kitty's New Tab requires `allow_remote_control yes` and a `listen_on` socket in kitty.conf (otherwise falls back to a new window). Warp always opens a new window.",
+      "description": "Choose whether new Claude Code sessions open in a new terminal window or a new tab in the front window. Per-terminal notes: kitty New Tab requires `allow_remote_control yes` and a `listen_on` socket in `kitty.conf` (otherwise falls back to a new window). Warp always opens a new window regardless of this setting.",
       "type": "dropdown",
       "default": "window",
       "required": false,

--- a/extensions/claudecast/src/ask-claude.tsx
+++ b/extensions/claudecast/src/ask-claude.tsx
@@ -15,6 +15,8 @@ import { useState, useEffect } from "react";
 import { existsSync, mkdirSync } from "fs";
 import { homedir } from "os";
 import {
+  ensureClaudeApiAuth,
+  ensureClaudeInstalled,
   executePrompt,
   isClaudeInstalled,
   ClaudeResponse,
@@ -156,13 +158,20 @@ function AskClaudeForm() {
     }
   }
 
-  // Manual context capture
+  // Manual context capture. Keeps only the user-controlled signals: selected
+  // text, clipboard, and frontmost app name. The working directory is set
+  // separately via the form's Project Path field.
   async function handleCaptureContext() {
     setIsCapturingContext(true);
     try {
-      const capturedContext = await captureContext();
-      setContext(capturedContext);
-      const summary = getContextSummary(capturedContext);
+      const captured = await captureContext();
+      const sanitized = {
+        selectedText: captured.selectedText,
+        clipboard: captured.clipboard,
+        frontmostApp: captured.frontmostApp,
+      };
+      setContext(sanitized);
+      const summary = getContextSummary(sanitized);
       if (summary) {
         await showToast({
           style: Toast.Style.Success,
@@ -220,6 +229,15 @@ function AskClaudeForm() {
           setIsSubmitting(false);
           return;
         }
+      }
+
+      if (!(await ensureClaudeInstalled())) {
+        setIsSubmitting(false);
+        return;
+      }
+      if (!(await ensureClaudeApiAuth())) {
+        setIsSubmitting(false);
+        return;
       }
 
       await showToast({

--- a/extensions/claudecast/src/browse-sessions.tsx
+++ b/extensions/claudecast/src/browse-sessions.tsx
@@ -392,28 +392,40 @@ function formatSessionMarkdown(session: SessionDetail): string {
     md += `> ${session.summary}\n\n`;
   }
 
+  // Render budget is 20 messages; the banner reflects what the user actually sees.
+  const rendered = session.messages.slice(-20);
+  if (session.totalMessageCount > rendered.length) {
+    md += `*Showing last ${rendered.length} of ${session.totalMessageCount} messages.*\n\n`;
+  }
+
   md += `---\n\n`;
   md += `## Conversation\n\n`;
 
-  for (const message of session.messages.slice(0, 20)) {
+  for (const message of rendered) {
     const role = message.type === "user" ? "**You**" : "**Claude**";
     const content = safeTruncate(message.content, 500, "...");
 
     md += `${role}:\n${content}\n\n`;
   }
 
-  if (session.messages.length > 20) {
-    md += `\n*...and ${session.messages.length - 20} more messages*\n`;
-  }
-
   return md;
 }
 
 function formatConversationText(session: SessionDetail): string {
-  return session.messages
+  // session.messages is already capped (default last 200) by the parser.
+  // The clipboard reflects what the user is actually viewing.
+  const body = session.messages
     .map((m) => {
       const role = m.type === "user" ? "User" : "Claude";
       return `${role}: ${m.content}`;
     })
     .join("\n\n");
+
+  if (session.totalMessageCount > session.messages.length) {
+    return (
+      body +
+      `\n\n[truncated: copied last ${session.messages.length} of ${session.totalMessageCount} messages]`
+    );
+  }
+  return body;
 }

--- a/extensions/claudecast/src/deep-search-sessions.tsx
+++ b/extensions/claudecast/src/deep-search-sessions.tsx
@@ -463,18 +463,20 @@ function formatSessionMarkdown(session: SessionDetail): string {
     md += `> ${session.summary}\n\n`;
   }
 
+  // Render budget is 20 messages; the banner reflects what the user actually sees.
+  const rendered = session.messages.slice(-20);
+  if (session.totalMessageCount > rendered.length) {
+    md += `*Showing last ${rendered.length} of ${session.totalMessageCount} messages.*\n\n`;
+  }
+
   md += `---\n\n`;
   md += `## Conversation\n\n`;
 
-  for (const message of session.messages.slice(0, 20)) {
+  for (const message of rendered) {
     const role = message.type === "user" ? "**You**" : "**Claude**";
     const content = safeTruncate(message.content, 500, "...");
 
     md += `${role}:\n${content}\n\n`;
-  }
-
-  if (session.messages.length > 20) {
-    md += `\n*...and ${session.messages.length - 20} more messages*\n`;
   }
 
   return md;

--- a/extensions/claudecast/src/git-actions.tsx
+++ b/extensions/claudecast/src/git-actions.tsx
@@ -13,12 +13,17 @@ import {
 import { useState, useEffect } from "react";
 import { exec } from "child_process";
 import { promisify } from "util";
-import { captureContext, CapturedContext } from "./lib/context-capture";
 import {
   executePrompt,
   ClaudeResponse,
+  ensureClaudeApiAuth,
   ensureClaudeInstalled,
 } from "./lib/claude-cli";
+import {
+  getAllProjects,
+  Project,
+  addRecentProject,
+} from "./lib/project-discovery";
 import { launchClaudeCode } from "./lib/terminal";
 
 const execPromise = promisify(exec);
@@ -109,7 +114,96 @@ Return ONLY the commit message, nothing else.`,
 
 export default function GitActions() {
   const [isLoading, setIsLoading] = useState(true);
-  const [context, setContext] = useState<CapturedContext | null>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [authReady, setAuthReady] = useState(false);
+
+  useEffect(() => {
+    async function init() {
+      if (!(await ensureClaudeInstalled())) {
+        setIsLoading(false);
+        return;
+      }
+      if (!(await ensureClaudeApiAuth())) {
+        setIsLoading(false);
+        return;
+      }
+      setAuthReady(true);
+
+      const { favorites, recent, all } = await getAllProjects();
+      const seen = new Set<string>();
+      const ordered: Project[] = [];
+      for (const p of [...favorites, ...recent, ...all]) {
+        if (seen.has(p.path)) continue;
+        seen.add(p.path);
+        ordered.push(p);
+      }
+      setProjects(ordered);
+      setIsLoading(false);
+    }
+    init();
+  }, []);
+
+  if (!authReady && !isLoading) {
+    return null; // ensureClaudeApiAuth already showed a toast
+  }
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Pick a project to run git actions on..."
+    >
+      {projects.length === 0 && !isLoading && (
+        <List.EmptyView
+          title="No Claude Code Projects Found"
+          description="Run Claude Code in any project first; recent projects appear here."
+          icon={Icon.Folder}
+        />
+      )}
+      {projects.map((p) => (
+        <ProjectPickerItem key={p.path} project={p} />
+      ))}
+    </List>
+  );
+}
+
+function ProjectPickerItem({ project }: { project: Project }) {
+  const accessories: List.Item.Accessory[] = [];
+  if (project.isFavorite) {
+    accessories.push({
+      icon: { source: Icon.Star, tintColor: Color.Yellow },
+      tooltip: "Favorite",
+    });
+  }
+  if (project.lastAccessed) {
+    accessories.push({ date: project.lastAccessed });
+  }
+  return (
+    <List.Item
+      title={project.name}
+      subtitle={project.path}
+      icon={Icon.Folder}
+      accessories={accessories}
+      actions={
+        <ActionPanel>
+          <Action.Push
+            title="Open Git Actions"
+            icon={Icon.MagnifyingGlass}
+            target={<GitActionsForProject projectPath={project.path} />}
+            onPush={() => addRecentProject(project.path)}
+          />
+          <Action.CopyToClipboard
+            title="Copy Project Path"
+            content={project.path}
+            shortcut={{ modifiers: ["cmd"], key: "c" }}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+function GitActionsForProject({ projectPath }: { projectPath: string }) {
+  const [isLoading, setIsLoading] = useState(true);
   const [gitStatus, setGitStatus] = useState<{
     hasStagedChanges: boolean;
     hasUnstagedChanges: boolean;
@@ -118,44 +212,24 @@ export default function GitActions() {
   } | null>(null);
 
   useEffect(() => {
-    async function init() {
-      // Check if Claude is installed first
-      const claudeInstalled = await ensureClaudeInstalled();
-      if (!claudeInstalled) {
-        setIsLoading(false);
-        return;
-      }
-
-      const ctx = await captureContext();
-      setContext(ctx);
-
-      if (ctx.projectPath) {
-        const status = await checkGitStatus(ctx.projectPath);
-        setGitStatus(status);
-      } else {
-        setGitStatus({
-          hasStagedChanges: false,
-          hasUnstagedChanges: false,
-          branch: "",
-          isGitRepo: false,
-        });
-      }
-
+    async function load() {
+      const status = await checkGitStatus(projectPath);
+      setGitStatus(status);
       setIsLoading(false);
     }
-    init();
-  }, []);
+    load();
+  }, [projectPath]);
 
   if (isLoading) {
     return <List isLoading={true} />;
   }
 
-  if (!context?.projectPath || !gitStatus?.isGitRepo) {
+  if (!gitStatus?.isGitRepo) {
     return (
       <List>
         <List.EmptyView
-          title="No Git Repository Detected"
-          description="Open a project in VS Code or navigate to a git repository to use Git Actions"
+          title="Not a Git Repository"
+          description={`${projectPath} has no .git directory. Pick a different project.`}
           icon={Icon.ExclamationMark}
         />
       </List>
@@ -165,11 +239,10 @@ export default function GitActions() {
   return (
     <List searchBarPlaceholder="Search git actions...">
       <List.Section
-        title={`${context.projectPath}`}
+        title={projectPath}
         subtitle={gitStatus.branch ? `on ${gitStatus.branch}` : undefined}
       >
         {GIT_ACTIONS.map((action) => {
-          // Check if action is disabled based on explicit change requirement
           let isDisabled = false;
           let disabledReason: string | undefined;
 
@@ -196,7 +269,6 @@ export default function GitActions() {
               }
               break;
             case "none":
-              // No changes required
               break;
           }
 
@@ -204,7 +276,7 @@ export default function GitActions() {
             <GitActionItem
               key={action.id}
               action={action}
-              projectPath={context.projectPath!}
+              projectPath={projectPath}
               isDisabled={isDisabled}
               disabledReason={disabledReason}
             />
@@ -261,15 +333,27 @@ function GitActionItem({
         return;
       }
 
+      const diffKB = Math.round(Buffer.byteLength(diff, "utf8") / 1024);
       await showToast({
         style: Toast.Style.Animated,
         title: "Asking Claude Code...",
+        message:
+          diffKB > 50
+            ? `Large diff (${diffKB} KB). This may take a few minutes.`
+            : undefined,
       });
 
-      // Send to Claude
+      // Scale timeout with diff size: ~30s per 50KB, min 3 min, max 15 min.
+      // Reviews of multi-hundred-KB diffs can legitimately take 5-10 min.
+      const timeoutMs = Math.min(
+        15 * 60 * 1000,
+        Math.max(3 * 60 * 1000, Math.ceil(diffKB / 50) * 30 * 1000),
+      );
+
       const response = await executePrompt(action.prompt, {
         context: `Git diff output:\n\`\`\`diff\n${diff}\n\`\`\``,
         cwd: projectPath,
+        timeoutMs,
       });
 
       await showToast({ style: Toast.Style.Success, title: "Done" });

--- a/extensions/claudecast/src/lib/claude-cli.ts
+++ b/extensions/claudecast/src/lib/claude-cli.ts
@@ -78,7 +78,10 @@ export async function getClaudePath(): Promise<string | null> {
 }
 
 /**
- * Execute a prompt using Claude CLI
+ * Execute a prompt using Claude CLI.
+ *
+ * The default 10-minute timeout covers most reviews of large diffs / contexts.
+ * Callers with shorter or longer expectations can pass `timeoutMs` explicitly.
  */
 export async function executePrompt(
   prompt: string,
@@ -87,6 +90,7 @@ export async function executePrompt(
     context?: string;
     cwd?: string;
     sessionId?: string;
+    timeoutMs?: number;
   } = {},
 ): Promise<ClaudeResponse> {
   const claudePath = await getClaudePath();
@@ -98,6 +102,7 @@ export async function executePrompt(
 
   const preferences = getPreferenceValues<Preferences>();
   const model = options.model || preferences.defaultModel || "sonnet";
+  const timeoutMs = options.timeoutMs ?? 10 * 60 * 1000;
 
   // Build the full prompt with context
   let fullPrompt = prompt;
@@ -149,11 +154,11 @@ export async function executePrompt(
     let stdout = "";
     let stderr = "";
 
-    // Add timeout (2 minutes)
     const timeout = setTimeout(() => {
       child.kill();
-      reject(new Error("Claude CLI timed out after 2 minutes"));
-    }, 120000);
+      const minutes = Math.round(timeoutMs / 60000);
+      reject(new Error(`Claude CLI timed out after ${minutes} minutes`));
+    }, timeoutMs);
 
     child.stdout.on("data", (data) => {
       stdout += data.toString();
@@ -391,13 +396,49 @@ export async function ensureClaudeInstalled(): Promise<boolean> {
   return installed;
 }
 
-/**
- * Check if authentication is configured (either API key or OAuth token)
- */
+// Accepts Raycast prefs, ANTHROPIC_API_KEY/CLAUDE_CODE_OAUTH_TOKEN env vars,
+// or `claude auth status --json` reporting loggedIn (covers `claude auth login`).
 export async function isAuthConfigured(): Promise<boolean> {
   const { getPreferenceValues } = await import("@raycast/api");
   const preferences = getPreferenceValues<Preferences>();
-  return !!(preferences.anthropicApiKey || preferences.oauthToken);
+  if (preferences.anthropicApiKey || preferences.oauthToken) return true;
+  if (
+    process.env.ANTHROPIC_API_KEY ||
+    process.env.ANTHROPIC_AUTH_TOKEN ||
+    process.env.CLAUDE_CODE_OAUTH_TOKEN
+  )
+    return true;
+
+  const claudePath = await getClaudePath();
+  if (!claudePath) return false;
+  try {
+    const { stdout } = await execPromise(`"${claudePath}" auth status --json`, {
+      timeout: 3000,
+    });
+    const parsed = JSON.parse(stdout);
+    return parsed?.loggedIn === true;
+  } catch {
+    return false;
+  }
+}
+
+// Bail early when no auth is available; otherwise the spawned claude would
+// stall on its own /login prompt inside the non-interactive child process.
+export async function ensureClaudeApiAuth(): Promise<boolean> {
+  if (await isAuthConfigured()) return true;
+  const { showToast, Toast, openCommandPreferences } =
+    await import("@raycast/api");
+  await showToast({
+    style: Toast.Style.Failure,
+    title: "Claude authentication missing",
+    message:
+      "Run 'claude setup-token' or 'claude auth login', set ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN/CLAUDE_CODE_OAUTH_TOKEN, or add credentials in Raycast preferences",
+    primaryAction: {
+      title: "Open Preferences",
+      onAction: () => openCommandPreferences(),
+    },
+  });
+  return false;
 }
 
 /**

--- a/extensions/claudecast/src/lib/session-parser.ts
+++ b/extensions/claudecast/src/lib/session-parser.ts
@@ -1222,12 +1222,14 @@ export async function streamSessionUsage(
       try {
         const entry: JSONLEntry = JSON.parse(line);
         if (!entry.message?.usage) return;
-        if (
-          afterDate &&
-          entry.timestamp &&
-          new Date(entry.timestamp) < afterDate
-        ) {
-          return;
+        if (afterDate) {
+          // Skip entries older than the cutoff. Entries lacking a timestamp
+          // (older JSONL formats) are also skipped: without a timestamp we
+          // can't verify they fall inside the requested range, so counting
+          // them would inflate today/week/month totals.
+          if (!entry.timestamp || new Date(entry.timestamp) < afterDate) {
+            return;
+          }
         }
 
         const usage = entry.message.usage;

--- a/extensions/claudecast/src/lib/session-parser.ts
+++ b/extensions/claudecast/src/lib/session-parser.ts
@@ -36,6 +36,7 @@ export interface SessionMessage {
 
 export interface SessionDetail extends SessionMetadata {
   messages: SessionMessage[];
+  totalMessageCount: number;
 }
 
 interface JSONLEntry {
@@ -43,7 +44,11 @@ interface JSONLEntry {
   summary?: string;
   leafUuid?: string;
   uuid?: string;
+  // Used as part of the streaming-chunk dedup key.
+  requestId?: string;
   message?: {
+    // Other half of the streaming-chunk dedup key.
+    id?: string;
     role: string;
     model?: string;
     content: string | Array<{ type: string; text?: string }>;
@@ -83,6 +88,78 @@ export function safeTruncate(str: string, maxLen: number, suffix = ""): string {
     end--;
   }
   return str.slice(0, end) + suffix;
+}
+
+/**
+ * Pull the plain text out of a JSONL message.content value, which can be
+ * either a string or an array of typed blocks. Concatenates all text blocks
+ * and ignores tool_use / tool_result / image / etc.
+ */
+function extractUserText(
+  content: string | Array<{ type: string; text?: string }> | undefined,
+): string {
+  if (!content) return "";
+  if (typeof content === "string") return content;
+  return content
+    .filter((b) => b.type === "text")
+    .map((b) => b.text || "")
+    .join("\n");
+}
+
+/**
+ * Threshold (chars) below which a slash-command-style prompt is treated as
+ * configuration (`/model`, `/effort high`, `/clear`) rather than the user's
+ * real intent, and the caller should fall back to the next user message.
+ */
+const SHORT_SLASH_COMMAND_MAX_LEN = 30;
+
+/**
+ * Clean a raw user-message string for display as the session "prompt".
+ *
+ * Claude Code wraps certain user-side content with metadata tags that aren't
+ * the user's actual prompt:
+ *
+ *  1. Any `<local-command-*>` block is injected when local commands run.
+ *     Known variants: `<local-command-caveat>` (the boilerplate disclaimer),
+ *     `<local-command-stdout>` (output echoed from /model, /effort, etc.).
+ *     Pure metadata; never the user's prompt. Skip entirely.
+ *  2. `<command-name>/X</command-name><command-message>X</command-message>
+ *     <command-args>...</command-args>` wraps slash-command invocations. Tag
+ *     order varies (some sessions lead with `<command-message>` instead of
+ *     `<command-name>`). We extract `/name` and `<command-args>` content and
+ *     render as "/cmd args".
+ *
+ * Additionally, short slash-command-only prompts (`/model`, `/effort high`,
+ * `/clear`) are typically configuration commands rather than the user's real
+ * intent, so we return null for those too. The caller should keep looking at
+ * subsequent user messages.
+ *
+ * Returns the cleaned string, or null when the content should be skipped.
+ */
+export function cleanUserMessageContent(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  // Any local-command-* wrapper is metadata, not a user prompt.
+  if (trimmed.startsWith("<local-command-")) return null;
+
+  // The slash-command wrapper can lead with any of the three tags. Detect by
+  // the common `<command-` prefix.
+  if (trimmed.startsWith("<command-")) {
+    const nameMatch = trimmed.match(/<command-name>([\s\S]*?)<\/command-name>/);
+    const argsMatch = trimmed.match(/<command-args>([\s\S]*?)<\/command-args>/);
+    const name = nameMatch?.[1]?.trim() || "";
+    const args = argsMatch?.[1]?.trim() || "";
+    const combined = args ? `${name} ${args}`.trim() : name;
+    if (!combined) return null;
+    return isShortSlashCommand(combined) ? null : combined;
+  }
+
+  return isShortSlashCommand(trimmed) ? null : trimmed;
+}
+
+function isShortSlashCommand(text: string): boolean {
+  return text.startsWith("/") && text.length < SHORT_SLASH_COMMAND_MAX_LEN;
 }
 
 /**
@@ -131,7 +208,7 @@ const PROJECTS_DIR = path.join(CLAUDE_DIR, "projects");
 
 /**
  * Decode an encoded project path from Claude's directory naming.
- * WARNING: This is a lossy heuristic — Claude encodes both / and . as -,
+ * WARNING: This is a lossy heuristic. Claude encodes both / and . as -,
  * so the result may be wrong. Prefer resolveProjectPath() which reads
  * sessions-index.json for the authoritative original path.
  */
@@ -147,10 +224,10 @@ const resolvedPathCache = new Map<string, string>();
  * Resolve an encoded project directory name to its original filesystem path.
  *
  * Resolution order:
- *   1. sessions-index.json — authoritative originalPath written by Claude Code
- *   2. Filesystem-guided walk — uses os.homedir() as anchor, then probes the
- *      filesystem to disambiguate each "-" (could be /, ., or literal -)
- *   3. Naive decode — replaces every "-" with "/" (known-lossy, last resort)
+ *   1. sessions-index.json (authoritative originalPath written by Claude Code)
+ *   2. Filesystem-guided walk (uses os.homedir() as anchor, then probes the
+ *      filesystem to disambiguate each "-" which could be /, ., or literal -)
+ *   3. Naive decode (replaces every "-" with "/", known-lossy, last resort)
  */
 export async function resolveProjectPath(
   encodedDirName: string,
@@ -187,7 +264,7 @@ export async function resolveProjectPath(
     return fsResolved;
   }
 
-  // 3. Naive decode (last resort — known-lossy, only cache if path exists)
+  // 3. Naive decode (last resort, known-lossy, only cache if path exists)
   const decoded = decodeProjectPath(encodedDirName);
   try {
     await fs.promises.access(decoded);
@@ -203,7 +280,7 @@ export async function resolveProjectPath(
  *
  * Uses os.homedir() to anchor the known prefix (resolving the username dot
  * ambiguity), then splits the remainder on "-" and greedily matches path
- * components against real directory entries — longest component first so
+ * components against real directory entries, longest component first so
  * literal dashes in names (e.g. "helm-charts") are preferred over deeper
  * directory nesting.
  *
@@ -262,14 +339,14 @@ async function walkPathSegments(
     if (component.startsWith("-")) {
       component = "." + component.slice(1);
     } else if (component === "") {
-      // Single empty part — skip (a bare "." by itself is not useful)
+      // Single empty part; skip (a bare "." by itself is not useful)
       continue;
     }
 
     // Claude Code also encodes underscores as dashes, so try both variants.
     // Original (with dashes) is tried first to prefer literal dash names.
     // Note: mixed dash/underscore names within a single component (e.g.
-    // "helm-charts_v2") are not attempted — the encoding is inherently lossy
+    // "helm-charts_v2") are not attempted; the encoding is inherently lossy
     // and trying all 2^n combinations per component is impractical. In
     // practice, the outer `take` loop handles this by splitting the encoded
     // string at different points, so "helm-charts" and "my_service" are
@@ -286,7 +363,7 @@ async function walkPathSegments(
         const stat = await fs.promises.stat(candidatePath);
 
         if (remaining.length === 0) {
-          // Last component — any file type is fine
+          // Last component, any file type is fine
           return candidatePath;
         }
 
@@ -407,14 +484,10 @@ async function parseSessionMetadataFast(
             result.permissionMode = entry.permissionMode;
           }
           if (!result.firstMessage && entry.message?.content) {
-            const content = entry.message.content;
-            if (typeof content === "string") {
-              result.firstMessage = sanitizeString(safeTruncate(content, 200));
-            } else if (Array.isArray(content)) {
-              const textBlock = content.find((b) => b.type === "text");
-              result.firstMessage = sanitizeString(
-                safeTruncate(textBlock?.text || "", 200),
-              );
+            const raw = extractUserText(entry.message.content);
+            const cleaned = cleanUserMessageContent(raw);
+            if (cleaned) {
+              result.firstMessage = sanitizeString(safeTruncate(cleaned, 200));
             }
           }
         }
@@ -454,13 +527,26 @@ async function parseSessionMetadataFast(
   });
 }
 
+export interface SessionDetailOptions {
+  /** Maximum number of messages to retain in the returned array. Default 200. */
+  maxMessages?: number;
+  /** Maximum characters per message content. Default 5000. */
+  maxContentChars?: number;
+}
+
+const DEFAULT_DETAIL_MAX_MESSAGES = 200;
+const DEFAULT_DETAIL_MAX_CONTENT_CHARS = 5000;
+
 /**
- * Get full session details including all messages
+ * Get full session details including all messages.
+ * Caps the returned messages array (defaults: last 200 messages, 5KB per message)
+ * so React state can hold any session without OOM. The original count is exposed
+ * via SessionDetail.totalMessageCount.
  */
 export async function getSessionDetail(
   sessionId: string,
+  options?: SessionDetailOptions,
 ): Promise<SessionDetail | null> {
-  // Find the session file
   const projectDirs = await listProjectDirs();
 
   for (const projectDir of projectDirs) {
@@ -471,7 +557,7 @@ export async function getSessionDetail(
 
     if (matchingFile) {
       const filePath = path.join(PROJECTS_DIR, projectDir, matchingFile);
-      return parseFullSession(filePath, projectDir);
+      return parseFullSession(filePath, projectDir, options);
     }
   }
 
@@ -479,12 +565,19 @@ export async function getSessionDetail(
 }
 
 /**
- * Parse a full session file using streaming to handle large files
+ * Parse a full session file using streaming to handle large files.
+ * Caps per-message content during parsing and slices the final array to the
+ * last N messages so memory stays bounded for huge sessions.
  */
 async function parseFullSession(
   filePath: string,
   encodedProjectPath: string,
+  options?: SessionDetailOptions,
 ): Promise<SessionDetail> {
+  const maxMessages = options?.maxMessages ?? DEFAULT_DETAIL_MAX_MESSAGES;
+  const maxContentChars =
+    options?.maxContentChars ?? DEFAULT_DETAIL_MAX_CONTENT_CHARS;
+
   return new Promise((resolve, reject) => {
     const messages: SessionMessage[] = [];
     let summary = "";
@@ -507,25 +600,19 @@ async function parseFullSession(
         }
 
         if (entry.type === "user" || entry.type === "human") {
-          let content = "";
-          if (typeof entry.message?.content === "string") {
-            content = sanitizeString(entry.message.content);
-          } else if (Array.isArray(entry.message?.content)) {
-            content = sanitizeString(
-              entry.message.content
-                .filter((b) => b.type === "text")
-                .map((b) => b.text)
-                .join("\n"),
-            );
-          }
+          const raw = extractUserText(entry.message?.content);
+          const content = sanitizeString(raw);
 
           if (!firstMessage) {
-            firstMessage = safeTruncate(content, 200);
+            const cleaned = cleanUserMessageContent(content);
+            if (cleaned) {
+              firstMessage = safeTruncate(cleaned, 200);
+            }
           }
 
           messages.push({
             type: "user",
-            content,
+            content: safeTruncate(content, maxContentChars, "…"),
             timestamp: entry.timestamp ? new Date(entry.timestamp) : undefined,
           });
         }
@@ -549,7 +636,7 @@ async function parseFullSession(
 
           messages.push({
             type: "assistant",
-            content,
+            content: safeTruncate(content, maxContentChars, "…"),
             timestamp: entry.timestamp ? new Date(entry.timestamp) : undefined,
             toolUse: hasToolUse,
           });
@@ -569,6 +656,12 @@ async function parseFullSession(
         const stat = await fs.promises.stat(filePath);
         const projectPath = await resolveProjectPath(encodedProjectPath);
 
+        const totalMessageCount = messages.length;
+        const trimmedMessages =
+          totalMessageCount > maxMessages
+            ? messages.slice(totalMessageCount - maxMessages)
+            : messages;
+
         resolve({
           id,
           filePath,
@@ -577,10 +670,11 @@ async function parseFullSession(
           summary,
           firstMessage,
           lastModified: stat.mtime,
-          turnCount: messages.length,
+          turnCount: totalMessageCount,
           cost: 0,
           model,
-          messages,
+          messages: trimmedMessages,
+          totalMessageCount,
         });
       } catch (err) {
         reject(err);
@@ -590,6 +684,72 @@ async function parseFullSession(
     rl.on("error", reject);
     stream.on("error", reject);
   });
+}
+
+interface SessionFileInfo {
+  filePath: string;
+  projectDir: string;
+  mtime: Date;
+}
+
+/**
+ * Collect session files newest-first, bounded by `limit` when provided.
+ *
+ * When a limit is set, maintains a sorted array of size ≤ limit so we never
+ * stat more files than necessary to know the newest N. Each new file replaces
+ * the oldest entry only if it's strictly newer, avoiding O(N) work per
+ * insertion while still giving exact newest-N results.
+ *
+ * Without a limit, falls back to a flat collection + final sort (legacy
+ * behavior, used by getAllTimeStats).
+ */
+async function collectSessionFiles(
+  projectDirs: string[],
+  limit: number | undefined,
+  afterDate: Date | undefined,
+): Promise<SessionFileInfo[]> {
+  if (!limit) {
+    const all: SessionFileInfo[] = [];
+    for (const projectDir of projectDirs) {
+      const sessionFiles = await listSessionFiles(projectDir);
+      for (const sessionFile of sessionFiles) {
+        const filePath = path.join(PROJECTS_DIR, projectDir, sessionFile);
+        try {
+          const stat = await fs.promises.stat(filePath);
+          if (afterDate && stat.mtime < afterDate) continue;
+          all.push({ filePath, projectDir, mtime: stat.mtime });
+        } catch {
+          /* ignore unreadable */
+        }
+      }
+    }
+    all.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+    return all;
+  }
+
+  // Bounded path: keep top-N newest with insertion-sorted array.
+  const top: SessionFileInfo[] = [];
+  for (const projectDir of projectDirs) {
+    const sessionFiles = await listSessionFiles(projectDir);
+    for (const sessionFile of sessionFiles) {
+      const filePath = path.join(PROJECTS_DIR, projectDir, sessionFile);
+      try {
+        const stat = await fs.promises.stat(filePath);
+        if (afterDate && stat.mtime < afterDate) continue;
+        if (top.length < limit) {
+          top.push({ filePath, projectDir, mtime: stat.mtime });
+          // Keep newest-first
+          top.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+        } else if (stat.mtime > top[top.length - 1].mtime) {
+          top[top.length - 1] = { filePath, projectDir, mtime: stat.mtime };
+          top.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+        }
+      } catch {
+        /* ignore unreadable */
+      }
+    }
+  }
+  return top;
 }
 
 /**
@@ -603,54 +763,29 @@ export async function listAllSessions(options?: {
 }): Promise<SessionMetadata[]> {
   const sessions: SessionMetadata[] = [];
   const projectDirs = await listProjectDirs();
-  const afterDate = options?.afterDate;
-  const limit = options?.limit;
 
-  // First, collect all file paths with their modification times
-  // This is faster than parsing each file
-  const fileInfos: Array<{
-    filePath: string;
-    projectDir: string;
-    mtime: Date;
-  }> = [];
+  const filesToParse = await collectSessionFiles(
+    projectDirs,
+    options?.limit,
+    options?.afterDate,
+  );
 
-  for (const projectDir of projectDirs) {
-    const sessionFiles = await listSessionFiles(projectDir);
+  // Memo project resolution per call so each unique projectDir is resolved once.
+  const projectPathMemo = new Map<string, string>();
+  const resolveProjectPathOnce = async (
+    projectDir: string,
+  ): Promise<string> => {
+    const cached = projectPathMemo.get(projectDir);
+    if (cached !== undefined) return cached;
+    const resolved = await resolveProjectPath(projectDir);
+    projectPathMemo.set(projectDir, resolved);
+    return resolved;
+  };
 
-    for (const sessionFile of sessionFiles) {
-      const filePath = path.join(PROJECTS_DIR, projectDir, sessionFile);
-
-      try {
-        const stat = await fs.promises.stat(filePath);
-
-        // Skip files older than afterDate if specified
-        if (afterDate && stat.mtime < afterDate) {
-          continue;
-        }
-
-        fileInfos.push({
-          filePath,
-          projectDir,
-          mtime: stat.mtime,
-        });
-      } catch {
-        // Skip files we can't stat
-      }
-    }
-  }
-
-  // Sort by modification time (most recent first) before parsing
-  // This way we can stop early if we have a limit
-  fileInfos.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
-
-  // Apply limit to reduce the number of files we need to parse
-  const filesToParse = limit ? fileInfos.slice(0, limit) : fileInfos;
-
-  // Now parse only the files we need
   for (const { filePath, projectDir, mtime } of filesToParse) {
     try {
       const metadata = await parseSessionMetadataFast(filePath);
-      const projectPath = await resolveProjectPath(projectDir);
+      const projectPath = await resolveProjectPathOnce(projectDir);
 
       sessions.push({
         id: metadata.id || path.basename(filePath, ".jsonl"),
@@ -670,7 +805,6 @@ export async function listAllSessions(options?: {
     }
   }
 
-  // Already sorted, just return
   return sessions;
 }
 
@@ -905,7 +1039,10 @@ async function searchSingleSession(
             permissionMode = entry.permissionMode;
           }
           if (!firstMessage && content) {
-            firstMessage = safeTruncate(content, 200);
+            const cleaned = cleanUserMessageContent(content);
+            if (cleaned) {
+              firstMessage = safeTruncate(cleaned, 200);
+            }
           }
         }
 
@@ -975,21 +1112,53 @@ export interface SessionUsage {
   model?: string;
 }
 
+/** Per-message tokens, used for tier-aware cost calculation per request. */
+export interface MessageUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  model?: string;
+  /** ISO timestamp from the entry; used for per-day bucketing in dailyByDate. */
+  timestamp?: string;
+}
+
+export interface SessionUsageDetailed extends SessionUsage {
+  /** Per-message usage, deduplicated across streaming chunks. */
+  messages: MessageUsage[];
+  /**
+   * Optional per-day bucketing keyed by YYYY-MM-DD. Populated only when the
+   * caller passes `bucketByDay: true`. Costs/tokens stay scoped to the day
+   * each message's timestamp falls into. Fixes attribution that previously
+   * stamped all of a session's cost on its file mtime.
+   */
+  dailyByDate?: Map<string, MessageUsage[]>;
+}
+
 /**
- * Streaming usage scanner that reads the entire JSONL file for accurate
- * token totals. Keeps only counters in memory (no messages array).
- * Optionally filters tokens to entries with timestamps >= afterDate.
+ * Streaming usage scanner. Reads the JSONL file and sums tokens.
+ *
+ * Anthropic's Messages API emits cumulative `usage` in each streaming chunk
+ * (running totals, not deltas). The CLI persists one JSONL line per chunk, so
+ * naive summing multiplies by chunk count. We dedup by (message.id + requestId)
+ * and keep the last (largest) value per key, then sum across keys. Lines
+ * without both IDs (older logs) tally directly.
+ *
+ * Stream listeners get explicit cleanup to keep V8 GC pressure low under
+ * back-to-back invocations.
  */
 export async function streamSessionUsage(
   filePath: string,
   afterDate?: Date,
-): Promise<SessionUsage> {
+  options?: { bucketByDay?: boolean },
+): Promise<SessionUsageDetailed> {
   return new Promise((resolve) => {
-    let inputTokens = 0;
-    let outputTokens = 0;
-    let cacheReadTokens = 0;
-    let cacheCreationTokens = 0;
     let model: string | undefined;
+    // Streaming chunks share message.id + requestId. Keep the last (cumulative
+    // final) per key. Lines lacking both IDs (older logs) tally separately.
+    const seenChunks = new Map<string, MessageUsage>();
+    const unkeyed: MessageUsage[] = [];
+    let resolved = false;
 
     const stream = fs.createReadStream(filePath, {
       encoding: "utf8",
@@ -997,36 +1166,93 @@ export async function streamSessionUsage(
     });
     const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
-    const safeResolve = () =>
+    const cleanup = () => {
+      rl.removeAllListeners();
+      stream.removeAllListeners();
+      rl.close();
+      stream.destroy();
+    };
+
+    const safeResolve = () => {
+      if (resolved) return;
+      resolved = true;
+      cleanup();
+
+      const messages: MessageUsage[] = [...seenChunks.values(), ...unkeyed];
+
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let cacheReadTokens = 0;
+      let cacheCreationTokens = 0;
+      for (const m of messages) {
+        inputTokens += m.inputTokens;
+        outputTokens += m.outputTokens;
+        cacheReadTokens += m.cacheReadTokens;
+        cacheCreationTokens += m.cacheCreationTokens;
+      }
+
+      let dailyByDate: Map<string, MessageUsage[]> | undefined;
+      if (options?.bucketByDay) {
+        dailyByDate = new Map();
+        for (const m of messages) {
+          if (!m.timestamp) continue;
+          const dateStr = m.timestamp.slice(0, 10);
+          let bucket = dailyByDate.get(dateStr);
+          if (!bucket) {
+            bucket = [];
+            dailyByDate.set(dateStr, bucket);
+          }
+          bucket.push(m);
+        }
+      }
+
       resolve({
         inputTokens,
         outputTokens,
         cacheReadTokens,
         cacheCreationTokens,
         model,
+        messages,
+        dailyByDate,
       });
+    };
 
     rl.on("line", (line) => {
+      if (resolved) return;
       try {
         const entry: JSONLEntry = JSON.parse(line);
-        if (entry.message?.usage) {
-          if (
-            afterDate &&
-            entry.timestamp &&
-            new Date(entry.timestamp) < afterDate
-          ) {
-            return;
-          }
-          inputTokens += entry.message.usage.input_tokens || 0;
-          outputTokens += entry.message.usage.output_tokens || 0;
-          cacheReadTokens += entry.message.usage.cache_read_input_tokens || 0;
-          cacheCreationTokens +=
-            entry.message.usage.cache_creation_input_tokens || 0;
+        if (!entry.message?.usage) return;
+        if (
+          afterDate &&
+          entry.timestamp &&
+          new Date(entry.timestamp) < afterDate
+        ) {
+          return;
         }
-        const m = entry.message?.model || entry.model;
+
+        const usage = entry.message.usage;
+        const msg: MessageUsage = {
+          inputTokens: usage.input_tokens || 0,
+          outputTokens: usage.output_tokens || 0,
+          cacheReadTokens: usage.cache_read_input_tokens || 0,
+          cacheCreationTokens: usage.cache_creation_input_tokens || 0,
+          model: entry.message?.model || entry.model,
+          timestamp: entry.timestamp,
+        };
+
+        const msgId = entry.message?.id;
+        const reqId = entry.requestId;
+        if (msgId && reqId) {
+          // Last write wins → preserves the final cumulative value.
+          seenChunks.set(`${msgId}:${reqId}`, msg);
+        } else {
+          unkeyed.push(msg);
+        }
+
+        const m = msg.model;
         if (m) model = m;
       } catch {
-        // skip
+        // skip unparseable
       }
     });
 

--- a/extensions/claudecast/src/lib/svg-chart.ts
+++ b/extensions/claudecast/src/lib/svg-chart.ts
@@ -1,0 +1,142 @@
+import { createHash } from "crypto";
+import { writeFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+/**
+ * Pure-string SVG bar chart renderer for embedding in Raycast Detail markdown
+ * via `![](file://path?raycast-width=N)`. Caches by content hash so repeated
+ * renders of the same data hit the same temp file.
+ *
+ * Raycast's markdown engine doesn't accept inline SVG or HTML, so writing to
+ * disk and embedding by file path is the only way to show a real chart.
+ */
+
+export interface BarChartPoint {
+  label: string;
+  value: number;
+}
+
+export interface BarChartOptions {
+  width?: number;
+  height?: number;
+  barColor?: string;
+  axisColor?: string;
+  labelColor?: string;
+  valueFormatter?: (n: number) => string;
+}
+
+const DEFAULTS: Required<Omit<BarChartOptions, "valueFormatter">> = {
+  width: 800,
+  height: 360,
+  // Raycast renders the embedded SVG image against whichever theme the user
+  // is on; we have no theme hint at render time. Use white text painted with
+  // a thin dark stroke (paint-order:stroke fill) so labels read against both
+  // dark and light backgrounds. The bar color reads on both themes already.
+  barColor: "#5B8DEF",
+  axisColor: "#FFFFFF",
+  labelColor: "#FFFFFF",
+};
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Render a vertical bar chart as an SVG string.
+ */
+export function renderBarChartSVG(
+  points: BarChartPoint[],
+  options?: BarChartOptions,
+): string {
+  const opts = { ...DEFAULTS, ...options };
+  const fmt = options?.valueFormatter ?? ((n: number) => n.toString());
+
+  const padTop = 36;
+  const padBottom = 72;
+  // Y labels are right-aligned at (padLeft - 10) and grow leftward; for
+  // 3+ digit dollar values like "$100.50" at font-size 15 they need ~70px
+  // of room before x=0 to keep the leading "$" visible.
+  const padLeft = 90;
+  const padRight = 24;
+
+  const innerW = opts.width - padLeft - padRight;
+  const innerH = opts.height - padTop - padBottom;
+
+  const maxValue = Math.max(...points.map((p) => p.value), 0.0001);
+  const barWidth = points.length > 0 ? (innerW / points.length) * 0.7 : 0;
+  const barGap = points.length > 0 ? (innerW / points.length) * 0.3 : 0;
+
+  // Label styling: pure white fill stays maximally bright on dark themes.
+  // For light-theme readability, an SVG drop-shadow filter paints a soft
+  // black halo OUTSIDE the glyph rather than thickening it (which is what an
+  // SVG stroke would do, muting the white).
+  const labelFont = 'font-family="-apple-system,BlinkMacSystemFont,sans-serif"';
+  const labelStyle = `${labelFont} fill="${opts.labelColor}" filter="url(#textHalo)"`;
+
+  const defs = `
+  <defs>
+    <filter id="textHalo" x="-20%" y="-50%" width="140%" height="200%">
+      <feDropShadow dx="0" dy="0" stdDeviation="1" flood-color="#000" flood-opacity="0.95"/>
+      <feDropShadow dx="0" dy="0" stdDeviation="1" flood-color="#000" flood-opacity="0.95"/>
+    </filter>
+  </defs>`;
+
+  const yAxisLines: string[] = [];
+  const yTickCount = 4;
+  for (let i = 0; i <= yTickCount; i++) {
+    const y = padTop + innerH - (innerH * i) / yTickCount;
+    const tickValue = (maxValue * i) / yTickCount;
+    yAxisLines.push(
+      `<line x1="${padLeft}" y1="${y}" x2="${padLeft + innerW}" y2="${y}" stroke="${opts.axisColor}" stroke-opacity="0.25" stroke-width="1"/>`,
+      `<text x="${padLeft - 10}" y="${y + 5}" text-anchor="end" font-size="15" font-weight="700" ${labelStyle}>${escapeXml(fmt(tickValue))}</text>`,
+    );
+  }
+
+  const bars: string[] = points.map((p, i) => {
+    const x = padLeft + (innerW / points.length) * i + barGap / 2;
+    const h = (p.value / maxValue) * innerH;
+    const y = padTop + innerH - h;
+    const valueLabel =
+      p.value > 0
+        ? `<text x="${x + barWidth / 2}" y="${y - 6}" text-anchor="middle" font-size="14" font-weight="700" ${labelStyle}>${escapeXml(fmt(p.value))}</text>`
+        : "";
+    const xLabel = `<text x="${x + barWidth / 2}" y="${padTop + innerH + 22}" text-anchor="middle" font-size="15" font-weight="700" ${labelStyle}>${escapeXml(p.label)}</text>`;
+    return [
+      `<rect x="${x}" y="${y}" width="${barWidth}" height="${h}" rx="3" fill="${opts.barColor}"/>`,
+      valueLabel,
+      xLabel,
+    ].join("");
+  });
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${opts.width} ${opts.height}" width="${opts.width}" height="${opts.height}">${defs}
+  ${yAxisLines.join("\n  ")}
+  ${bars.join("\n  ")}
+</svg>`;
+}
+
+/**
+ * Render the chart and write to a stable temp file keyed by content hash.
+ * Returns the absolute file path, suitable for `file://` embedding.
+ *
+ * Same data produces the same path, so the file is written once per unique
+ * dataset across the worker lifetime.
+ */
+export function renderBarChartToFile(
+  points: BarChartPoint[],
+  options?: BarChartOptions,
+): string {
+  const svg = renderBarChartSVG(points, options);
+  const hash = createHash("sha1").update(svg).digest("hex").slice(0, 16);
+  const filePath = join(tmpdir(), `claudecast-chart-${hash}.svg`);
+  if (!existsSync(filePath)) {
+    writeFileSync(filePath, svg, "utf-8");
+  }
+  return filePath;
+}

--- a/extensions/claudecast/src/lib/terminal.ts
+++ b/extensions/claudecast/src/lib/terminal.ts
@@ -35,7 +35,7 @@ function normalizeModelName(model: string): string {
   return model;
 }
 
-type TerminalApp = "Terminal" | "iTerm" | "Warp" | "kitty" | "Ghostty";
+type TerminalApp = "Terminal" | "iTerm" | "Warp" | "kitty" | "Ghostty" | "cmux";
 type OpenIn = "window" | "tab";
 
 /**
@@ -66,7 +66,9 @@ export async function openTerminalWithCommand(
         await openInITerm(command, cwd, openIn);
         break;
       case "Warp":
-        // Warp's YAML launch config always opens a new window; openIn is N/A
+        // Warp always opens a new window. The YAML launch-config flow is the
+        // only reliable mechanism; new-tab via System Events keystroke or
+        // the warp:// URL scheme is unreliable in practice.
         await openInWarp(command, cwd);
         break;
       case "kitty":
@@ -74,6 +76,9 @@ export async function openTerminalWithCommand(
         break;
       case "Ghostty":
         await openInGhostty(command, cwd, openIn);
+        break;
+      case "cmux":
+        await openInCmux(command, cwd, openIn);
         break;
       default:
         await openInTerminalApp(command, cwd, openIn);
@@ -87,16 +92,24 @@ export async function openTerminalWithCommand(
   }
 }
 
+// Escape a value for safe inclusion in an AppleScript double-quoted string.
+// AppleScript does not expand `$` inside string literals, so we only need to
+// escape `"` (and pass through `\` since AppleScript treats `\\` as `\`).
+function escapeAppleScriptDoubleQuoted(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
 async function openInTerminalApp(
   command: string,
   cwd: string,
   openIn: OpenIn,
 ): Promise<void> {
+  const escapedCommand = escapeAppleScriptDoubleQuoted(command);
+  const escapedCwd = escapeAppleScriptDoubleQuoted(cwd);
+
   if (openIn === "tab") {
-    // ⌘T keystroke via System Events creates a real new tab.
-    // Raycast has Accessibility permission so this works from the extension.
-    const escapedCommand = command.replace(/"/g, '\\"').replace(/\$/g, "\\$");
-    const escapedCwd = cwd.replace(/"/g, '\\"');
+    // Cmd+T keystroke via System Events creates a real new tab in the front
+    // Terminal window. Requires Raycast Accessibility access.
     const script = `
       tell application "Terminal"
         activate
@@ -111,18 +124,19 @@ async function openInTerminalApp(
       end tell
     `;
     await execFilePromise("osascript", ["-e", script]);
-  } else {
-    // Write command to a temp .command file and open it with Terminal.
-    // 'open -a Terminal file.command' always spawns a fresh window.
-    const tempFile = join(tmpdir(), `claudecast-${Date.now()}.command`);
-    const escapedCwdForBash = cwd.replace(/"/g, '\\"');
-    writeFileSync(
-      tempFile,
-      `#!/bin/bash\ncd "${escapedCwdForBash}"\nrm -f "${tempFile}"\n${command}\n`,
-      { mode: 0o755 },
-    );
-    await execFilePromise("open", ["-a", "Terminal", tempFile]);
+    return;
   }
+
+  // Window mode: write command to a temp .command file and open it with
+  // Terminal. `open -a Terminal file.command` always spawns a fresh window.
+  const tempFile = join(tmpdir(), `claudecast-${Date.now()}.command`);
+  const escapedCwdForBash = cwd.replace(/"/g, '\\"');
+  writeFileSync(
+    tempFile,
+    `#!/bin/bash\ncd "${escapedCwdForBash}"\nrm -f "${tempFile}"\n${command}\n`,
+    { mode: 0o755 },
+  );
+  await execFilePromise("open", ["-a", "Terminal", tempFile]);
 }
 
 async function openInITerm(
@@ -130,8 +144,8 @@ async function openInITerm(
   cwd: string,
   openIn: OpenIn,
 ): Promise<void> {
-  const escapedCommand = command.replace(/"/g, '\\"').replace(/\$/g, "\\$");
-  const escapedCwd = cwd.replace(/"/g, '\\"');
+  const escapedCommand = escapeAppleScriptDoubleQuoted(command);
+  const escapedCwd = escapeAppleScriptDoubleQuoted(cwd);
 
   let script: string;
   if (openIn === "tab") {
@@ -180,11 +194,11 @@ function escapeYamlDoubleQuoted(s: string): string {
     .replace(/\t/g, "\\t");
 }
 
-// Warp's YAML launch config opens a new window; openIn does not apply here
-// (the previous warp://action/new_tab?command= URL scheme was unreliable
-// at executing the command).
+// Warp launcher. Always opens a new window via a temporary YAML launch
+// configuration opened with `warp://launch/`. Warp's `warp://action/new_tab`
+// URL scheme and System Events Cmd+T keystroke are both unreliable, so we
+// don't expose a tab mode for Warp.
 async function openInWarp(command: string, cwd: string): Promise<void> {
-  // Use dynamic launch configuration for reliable command execution
   const lcId = randomUUID();
   const lcDir = join(homedir(), ".warp", "launch_configurations");
   if (!existsSync(lcDir)) {
@@ -234,10 +248,11 @@ async function openInKitty(
       ]);
       return;
     } catch {
-      // Remote control not configured — fall through to window mode
+      // Remote control not configured; fall through to window mode
     }
   }
   await execFilePromise("kitty", [
+    "--single-instance",
     `--directory=${cwd}`,
     "-e",
     "sh",
@@ -251,8 +266,8 @@ async function openInGhostty(
   cwd: string,
   openIn: OpenIn,
 ): Promise<void> {
-  const escapedCommand = command.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-  const escapedCwd = cwd.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const escapedCommand = escapeAppleScriptDoubleQuoted(command);
+  const escapedCwd = escapeAppleScriptDoubleQuoted(cwd);
 
   // Use Ghostty's native AppleScript API with surface configuration.
   // `new tab` opens the surface as a tab in the front window when one
@@ -268,6 +283,63 @@ async function openInGhostty(
     end tell
   `;
 
+  await execFilePromise("osascript", ["-e", script]);
+}
+
+/**
+ * Launch a command inside a cmux workspace.
+ *
+ * Tab mode uses `open -a cmux <dir>`, which routes through cmux's
+ * application:openFile: handler to create a new workspace in the front window
+ * with the shell's pwd set to <dir> (no `cd` typed). The cmux CLI socket is
+ * unreliable across installs, so we avoid it.
+ *
+ * Window mode uses cmux's AppleScript `new window` verb to spawn a fresh
+ * window, then types `cd "<cwd>" && <command>` via cmux's `perform action`
+ * Ghostty input pipeline (no System Events / Accessibility needed in either
+ * mode). Window mode pays the shell-escape cost on the cwd because there is
+ * no open-handler equivalent for "new window."
+ */
+async function openInCmux(
+  command: string,
+  cwd: string,
+  openIn: OpenIn,
+): Promise<void> {
+  const escapedCommand = escapeAppleScriptDoubleQuoted(command);
+
+  if (openIn === "window") {
+    // Shell escaping for cwd inside the typed `cd "..."`. Backslash and double
+    // quote both need handling at the shell layer.
+    const shellEscapedCwd = cwd.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    // Then escape the whole typed string for the AppleScript double-quoted
+    // scalar. The shell-escaped cwd already contains \\ and \" so the
+    // AppleScript-layer escape converts those to \\\\ and \\\".
+    const typed = escapeAppleScriptDoubleQuoted(
+      `cd "${shellEscapedCwd}" && ${command}`,
+    );
+    const script = `
+      tell application "cmux"
+        activate
+        set w to new window
+        delay 0.7
+        perform action ("text:" & "${typed}" & (ASCII character 10)) on focused terminal of selected tab of w
+      end tell
+    `;
+    await execFilePromise("osascript", ["-e", script]);
+    return;
+  }
+
+  // Tab mode: open-handler creates a workspace in the front window with cwd
+  // set as the shell's process pwd.
+  await execFilePromise("open", ["-a", "cmux", cwd]);
+  // Wait for the new workspace's terminal to initialize. 700ms covers warm
+  // relaunches; cold first-launch tested at ~500ms.
+  await new Promise((resolve) => setTimeout(resolve, 700));
+  const script = `
+    tell application "cmux"
+      perform action ("text:" & "${escapedCommand}" & (ASCII character 10)) on focused terminal of selected tab of front window
+    end tell
+  `;
   await execFilePromise("osascript", ["-e", script]);
 }
 
@@ -1054,6 +1126,7 @@ export async function getAvailableTerminals(): Promise<TerminalApp[]> {
     ["Warp", "Warp"],
     ["kitty", "kitty"],
     ["Ghostty", "Ghostty"],
+    ["cmux", "cmux"],
   ];
 
   for (const [appName, terminal] of checks) {

--- a/extensions/claudecast/src/lib/usage-stats.ts
+++ b/extensions/claudecast/src/lib/usage-stats.ts
@@ -2,9 +2,23 @@ import { LocalStorage } from "@raycast/api";
 import {
   listAllSessions,
   streamSessionUsage,
+  MessageUsage,
   SessionMetadata,
   SessionUsage,
 } from "./session-parser";
+
+/**
+ * Lightweight projection of a session, used for "Top Sessions" lists in
+ * UsageStats. Avoids retaining the full SessionMetadata reference inside the
+ * cached stats object (which previously aliased the same memory across the
+ * in-memory cache and React state).
+ */
+export interface TopSessionSummary {
+  id: string;
+  projectName: string;
+  firstMessage: string;
+  cost: number;
+}
 
 export interface UsageStats {
   totalSessions: number;
@@ -14,19 +28,44 @@ export interface UsageStats {
   totalCacheReadTokens: number;
   totalCacheCreationTokens: number;
   sessionsByProject: Record<string, { count: number; cost: number }>;
-  topSessions: SessionMetadata[];
+  topSessions: TopSessionSummary[];
 }
 
-// Pricing per million tokens from https://docs.anthropic.com/en/docs/about-claude/pricing
-// Cache read = 0.1x base input, cache write (5-min TTL) = 1.25x base input
-// Ordered most-specific first for substring matching
-const MODEL_PRICING: Array<{
+/**
+ * Per-model pricing. Rows are matched by substring against `usage.model`,
+ * most-specific first. Sonnet 4.x has a 200K-input-token tier where the rate
+ * doubles. The tier applies per-message (per-request), not per-session, so a
+ * session with several messages each below 200K still pays the base rate.
+ *
+ * Pricing source: https://docs.anthropic.com/en/docs/about-claude/pricing
+ */
+interface Pricing {
   match: string;
   inputPerMTok: number;
   outputPerMTok: number;
   cacheReadPerMTok: number;
   cacheWritePerMTok: number;
-}> = [
+  /** Optional tier applied to per-message tokens above thresholdTokens. */
+  tier?: {
+    thresholdTokens: number;
+    inputPerMTok: number;
+    outputPerMTok: number;
+    cacheReadPerMTok: number;
+    cacheWritePerMTok: number;
+  };
+}
+
+const MODEL_PRICING: Pricing[] = [
+  // Opus 4.7 (latest, $5/$25 tier). MUST come before bare "opus" so substring
+  // match resolves here first; without this row, opus-4-7 sessions fall through
+  // to the older $15/$75 "opus" row.
+  {
+    match: "opus-4-7",
+    inputPerMTok: 5,
+    outputPerMTok: 25,
+    cacheReadPerMTok: 0.5,
+    cacheWritePerMTok: 6.25,
+  },
   // Opus 4.5/4.6 ($5/$25 tier)
   {
     match: "opus-4-5",
@@ -42,7 +81,15 @@ const MODEL_PRICING: Array<{
     cacheReadPerMTok: 0.5,
     cacheWritePerMTok: 6.25,
   },
-  // Opus 4/4.1 ($15/$75 tier)
+  // Opus 4.1 (older $15/$75 tier)
+  {
+    match: "opus-4-1",
+    inputPerMTok: 15,
+    outputPerMTok: 75,
+    cacheReadPerMTok: 1.5,
+    cacheWritePerMTok: 18.75,
+  },
+  // Opus 4 / generic opus fallback ($15/$75 tier)
   {
     match: "opus",
     inputPerMTok: 15,
@@ -50,13 +97,20 @@ const MODEL_PRICING: Array<{
     cacheReadPerMTok: 1.5,
     cacheWritePerMTok: 18.75,
   },
-  // All Sonnet 4.x ($3/$15 tier)
+  // Sonnet 4.x: 200K-token tier doubles the rate above the threshold.
   {
     match: "sonnet",
     inputPerMTok: 3,
     outputPerMTok: 15,
     cacheReadPerMTok: 0.3,
     cacheWritePerMTok: 3.75,
+    tier: {
+      thresholdTokens: 200_000,
+      inputPerMTok: 6,
+      outputPerMTok: 22.5,
+      cacheReadPerMTok: 0.6,
+      cacheWritePerMTok: 7.5,
+    },
   },
   // Haiku 4.5 ($1/$5 tier)
   {
@@ -78,7 +132,7 @@ const MODEL_PRICING: Array<{
 
 const DEFAULT_PRICING = MODEL_PRICING.find((p) => p.match === "sonnet")!;
 
-function resolvePricing(model?: string) {
+function resolvePricing(model?: string): Pricing {
   if (!model) return DEFAULT_PRICING;
   const lower = model.toLowerCase();
   for (const pricing of MODEL_PRICING) {
@@ -87,14 +141,77 @@ function resolvePricing(model?: string) {
   return DEFAULT_PRICING;
 }
 
-function calculateUsageCost(usage: SessionUsage): number {
-  const p = resolvePricing(usage.model);
+/**
+ * Apply per-token-type tier pricing for a single token count. The threshold
+ * applies independently to each token type (input, output, cache_*). Anthropic
+ * documents the threshold as input-tokens-per-request; we apply it to each
+ * type independently for simplicity, which slightly over-prices on the safe
+ * side rather than undercounting.
+ */
+function pricedTokens(
+  tokens: number,
+  basePerMTok: number,
+  abovePerMTok: number | undefined,
+  threshold: number | undefined,
+): number {
+  if (!threshold || abovePerMTok === undefined) {
+    return (tokens / 1_000_000) * basePerMTok;
+  }
+  const below = Math.min(tokens, threshold);
+  const above = Math.max(tokens - threshold, 0);
+  return (below / 1_000_000) * basePerMTok + (above / 1_000_000) * abovePerMTok;
+}
+
+/**
+ * Compute the cost of a single deduplicated message using tier-aware pricing.
+ * The streaming-chunk dedup inside streamSessionUsage ensures `msg` represents
+ * the cumulative final usage for one request, not double-counted chunks.
+ */
+function calculateMessageCost(msg: MessageUsage): number {
+  const p = resolvePricing(msg.model);
   return (
-    (usage.inputTokens / 1_000_000) * p.inputPerMTok +
-    (usage.outputTokens / 1_000_000) * p.outputPerMTok +
-    (usage.cacheReadTokens / 1_000_000) * p.cacheReadPerMTok +
-    (usage.cacheCreationTokens / 1_000_000) * p.cacheWritePerMTok
+    pricedTokens(
+      msg.inputTokens,
+      p.inputPerMTok,
+      p.tier?.inputPerMTok,
+      p.tier?.thresholdTokens,
+    ) +
+    pricedTokens(
+      msg.outputTokens,
+      p.outputPerMTok,
+      p.tier?.outputPerMTok,
+      p.tier?.thresholdTokens,
+    ) +
+    pricedTokens(
+      msg.cacheReadTokens,
+      p.cacheReadPerMTok,
+      p.tier?.cacheReadPerMTok,
+      p.tier?.thresholdTokens,
+    ) +
+    pricedTokens(
+      msg.cacheCreationTokens,
+      p.cacheWritePerMTok,
+      p.tier?.cacheWritePerMTok,
+      p.tier?.thresholdTokens,
+    )
   );
+}
+
+/**
+ * Backward-compatible session-total cost used by callers that already have a
+ * single SessionUsage rollup (no per-message granularity). Loses tier accuracy
+ * for sessions where a single message exceeded 200K tokens, but matches the
+ * legacy behavior. Prefer summing calculateMessageCost over deduped messages
+ * when per-message data is available.
+ */
+function calculateUsageCost(usage: SessionUsage): number {
+  return calculateMessageCost({
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    cacheReadTokens: usage.cacheReadTokens,
+    cacheCreationTokens: usage.cacheCreationTokens,
+    model: usage.model,
+  });
 }
 
 export interface DailyStats {
@@ -105,6 +222,7 @@ export interface DailyStats {
 
 const STATS_CACHE_KEY = "claudecast-stats-v2";
 const STATS_CACHE_TTL = 60 * 60 * 1000; // 1 hour
+const TODAY_STATS_LOCALSTORAGE_KEY = "claudecast-today-stats-v1";
 
 // In-memory cache for today's stats to prevent repeated disk reads
 // This is especially important for menu bar monitors that refresh frequently
@@ -120,17 +238,24 @@ interface CachedStats {
   timestamp: number;
 }
 
+interface PersistedTodayStats {
+  stats: UsageStats;
+  timestamp: number;
+  date: string;
+}
+
 /**
- * Get usage statistics for today
- * Uses in-memory caching to prevent repeated disk reads (important for menu bar)
- * Also uses date filtering to only parse today's session files
+ * Get usage statistics for today.
+ * Two-tier cache: in-memory (fast, lost on worker restart) + LocalStorage
+ * (persists across Raycast menu-bar cold starts so the 30s background tick
+ * doesn't pay full disk cost on every refresh).
  */
 export async function getTodayStats(): Promise<UsageStats> {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const todayStr = today.toISOString().split("T")[0];
 
-  // Check in-memory cache
+  // Tier 1: in-memory cache.
   if (
     todayStatsCache &&
     todayStatsCache.date === todayStr &&
@@ -139,16 +264,38 @@ export async function getTodayStats(): Promise<UsageStats> {
     return todayStatsCache.stats;
   }
 
-  // Only load sessions modified today - much more efficient
+  // Tier 2: LocalStorage. Survives worker restarts.
+  try {
+    const persisted = await LocalStorage.getItem<string>(
+      TODAY_STATS_LOCALSTORAGE_KEY,
+    );
+    if (persisted) {
+      const parsed: PersistedTodayStats = JSON.parse(persisted);
+      if (
+        parsed.date === todayStr &&
+        Date.now() - parsed.timestamp < TODAY_STATS_CACHE_TTL
+      ) {
+        todayStatsCache = parsed;
+        return parsed.stats;
+      }
+    }
+  } catch {
+    // ignore parse / storage errors and fall through to recompute
+  }
+
+  // Compute fresh.
   const todaySessions = await listAllSessions({ afterDate: today });
   const stats = await calculateStatsWithUsage(todaySessions, today);
 
-  // Update in-memory cache
-  todayStatsCache = {
-    stats,
-    timestamp: Date.now(),
-    date: todayStr,
-  };
+  todayStatsCache = { stats, timestamp: Date.now(), date: todayStr };
+  try {
+    await LocalStorage.setItem(
+      TODAY_STATS_LOCALSTORAGE_KEY,
+      JSON.stringify(todayStatsCache),
+    );
+  } catch {
+    // ignore storage errors
+  }
 
   return stats;
 }
@@ -161,9 +308,7 @@ export async function getWeekStats(): Promise<UsageStats> {
   weekAgo.setDate(weekAgo.getDate() - 7);
   weekAgo.setHours(0, 0, 0, 0);
 
-  // Only load sessions from the past week
   const weekSessions = await listAllSessions({ afterDate: weekAgo });
-
   return calculateStatsWithUsage(weekSessions, weekAgo);
 }
 
@@ -175,17 +320,16 @@ export async function getMonthStats(): Promise<UsageStats> {
   monthAgo.setMonth(monthAgo.getMonth() - 1);
   monthAgo.setHours(0, 0, 0, 0);
 
-  // Only load sessions from the past month
   const monthSessions = await listAllSessions({ afterDate: monthAgo });
-
   return calculateStatsWithUsage(monthSessions, monthAgo);
 }
 
 /**
- * Get all-time usage statistics (cached)
+ * Get all-time usage statistics (cached for 1 hour).
+ * No truncation: bounded streaming plus per-message processing keeps memory low
+ * even across thousands of sessions.
  */
 export async function getAllTimeStats(): Promise<UsageStats> {
-  // Check cache
   const cached = await LocalStorage.getItem<string>(STATS_CACHE_KEY);
   if (cached) {
     const cachedStats: CachedStats = JSON.parse(cached);
@@ -197,7 +341,6 @@ export async function getAllTimeStats(): Promise<UsageStats> {
   const allSessions = await listAllSessions();
   const stats = await calculateStatsWithUsage(allSessions);
 
-  // Cache the result
   await LocalStorage.setItem(
     STATS_CACHE_KEY,
     JSON.stringify({
@@ -210,40 +353,46 @@ export async function getAllTimeStats(): Promise<UsageStats> {
 }
 
 /**
- * Invalidate the stats cache
- * Call this after creating/deleting sessions to ensure fresh data
+ * Invalidate the stats cache.
+ * Call this after creating/deleting sessions to ensure fresh data.
  */
 export async function invalidateStatsCache(): Promise<void> {
   await LocalStorage.removeItem(STATS_CACHE_KEY);
+  await LocalStorage.removeItem(TODAY_STATS_LOCALSTORAGE_KEY);
+  todayStatsCache = null;
 }
 
 /**
- * Get daily stats for the last N days
- * Optimized to only load sessions from the requested time range
+ * Get daily stats for the last N days.
+ * Buckets cost by per-entry timestamp (not file mtime), so a multi-day session
+ * gets its cost attributed to each day it was actually used on.
  */
 export async function getDailyStats(days: number = 7): Promise<DailyStats[]> {
-  // Calculate the earliest date we need
   const startDate = new Date();
   startDate.setDate(startDate.getDate() - days + 1);
   startDate.setHours(0, 0, 0, 0);
 
-  // Only load sessions from the requested period
   const allSessions = await listAllSessions({ afterDate: startDate });
 
-  // Scan each session for usage within the date range
+  // Per-day map: dateStr → { unique session ids, summed cost }.
   const dailyMap = new Map<string, { sessions: Set<string>; cost: number }>();
 
   for (const session of allSessions) {
-    const usage = await streamSessionUsage(session.filePath, startDate);
-    const cost = calculateUsageCost(usage);
-    const dateStr = session.lastModified.toISOString().split("T")[0];
-    const existing = dailyMap.get(dateStr) || {
-      sessions: new Set<string>(),
-      cost: 0,
-    };
-    existing.sessions.add(session.id);
-    existing.cost += cost;
-    dailyMap.set(dateStr, existing);
+    const usage = await streamSessionUsage(session.filePath, startDate, {
+      bucketByDay: true,
+    });
+    if (!usage.dailyByDate) continue;
+    for (const [dateStr, msgs] of usage.dailyByDate) {
+      let entry = dailyMap.get(dateStr);
+      if (!entry) {
+        entry = { sessions: new Set<string>(), cost: 0 };
+        dailyMap.set(dateStr, entry);
+      }
+      entry.sessions.add(session.id);
+      for (const m of msgs) {
+        entry.cost += calculateMessageCost(m);
+      }
+    }
   }
 
   const dailyStats: DailyStats[] = [];
@@ -263,7 +412,11 @@ export async function getDailyStats(days: number = 7): Promise<DailyStats[]> {
 }
 
 /**
- * Calculate stats by streaming each session file for accurate token totals.
+ * Stream each session and aggregate tier-aware per-message cost.
+ * Does NOT mutate the input session array. Costs are tracked in a local Map
+ * and the lightweight TopSessionSummary projection is used for the returned
+ * topSessions list.
+ *
  * afterDate filters tokens to entries within the time range.
  */
 async function calculateStatsWithUsage(
@@ -277,11 +430,17 @@ async function calculateStatsWithUsage(
   let totalCacheCreationTokens = 0;
   const sessionsByProject: Record<string, { count: number; cost: number }> = {};
   const projectCostCents: Record<string, number> = {};
+  const sessionCosts = new Map<string, number>();
 
   for (const session of sessions) {
     const usage = await streamSessionUsage(session.filePath, afterDate);
-    const cost = calculateUsageCost(usage);
-    session.cost = cost;
+
+    // Tier-aware: sum per-message costs, not session-total costs.
+    let cost = 0;
+    for (const m of usage.messages) {
+      cost += calculateMessageCost(m);
+    }
+    sessionCosts.set(session.id, cost);
 
     const costCents = Math.round(cost * 10000);
     totalCostCents += costCents;
@@ -303,7 +462,15 @@ async function calculateStatsWithUsage(
     sessionsByProject[projectName].cost = projectCostCents[projectName] / 10000;
   }
 
-  const topSessions = [...sessions]
+  // Lightweight projection only. Never retain full SessionMetadata refs
+  // inside the cached UsageStats (would alias the same memory across calls).
+  const topSessions: TopSessionSummary[] = sessions
+    .map((s) => ({
+      id: s.id,
+      projectName: s.projectName,
+      firstMessage: s.firstMessage,
+      cost: sessionCosts.get(s.id) ?? 0,
+    }))
     .filter((s) => s.cost > 0)
     .sort((a, b) => b.cost - a.cost)
     .slice(0, 10);
@@ -341,7 +508,8 @@ export function formatTokens(count: number): string {
 }
 
 /**
- * Generate ASCII bar chart for daily costs
+ * Generate ASCII bar chart for daily costs (legacy fallback for any caller
+ * that still uses the markdown view)
  */
 export function generateCostChart(dailyStats: DailyStats[]): string {
   const maxCost = Math.max(...dailyStats.map((d) => d.cost), 0.01);
@@ -401,3 +569,6 @@ export async function isClaudeActive(): Promise<boolean> {
     return false;
   }
 }
+
+// Re-export for callers that still import the legacy single-cost helper.
+export { calculateUsageCost };

--- a/extensions/claudecast/src/lib/usage-stats.ts
+++ b/extensions/claudecast/src/lib/usage-stats.ts
@@ -142,58 +142,32 @@ function resolvePricing(model?: string): Pricing {
 }
 
 /**
- * Apply per-token-type tier pricing for a single token count. The threshold
- * applies independently to each token type (input, output, cache_*). Anthropic
- * documents the threshold as input-tokens-per-request; we apply it to each
- * type independently for simplicity, which slightly over-prices on the safe
- * side rather than undercounting.
- */
-function pricedTokens(
-  tokens: number,
-  basePerMTok: number,
-  abovePerMTok: number | undefined,
-  threshold: number | undefined,
-): number {
-  if (!threshold || abovePerMTok === undefined) {
-    return (tokens / 1_000_000) * basePerMTok;
-  }
-  const below = Math.min(tokens, threshold);
-  const above = Math.max(tokens - threshold, 0);
-  return (below / 1_000_000) * basePerMTok + (above / 1_000_000) * abovePerMTok;
-}
-
-/**
  * Compute the cost of a single deduplicated message using tier-aware pricing.
  * The streaming-chunk dedup inside streamSessionUsage ensures `msg` represents
  * the cumulative final usage for one request, not double-counted chunks.
+ *
+ * Per Anthropic, the 200K-token tier is keyed on *input tokens per request*:
+ * if a single request crosses the threshold, ALL token types (input, output,
+ * cache read, cache write) bill at the high-tier flat rate for that request.
+ * The high tier is not a split-at-threshold calculation per token type.
  */
 function calculateMessageCost(msg: MessageUsage): number {
   const p = resolvePricing(msg.model);
+  const inHighTier =
+    p.tier !== undefined && msg.inputTokens > p.tier.thresholdTokens;
+  const inputRate = inHighTier ? p.tier!.inputPerMTok : p.inputPerMTok;
+  const outputRate = inHighTier ? p.tier!.outputPerMTok : p.outputPerMTok;
+  const cacheReadRate = inHighTier
+    ? p.tier!.cacheReadPerMTok
+    : p.cacheReadPerMTok;
+  const cacheWriteRate = inHighTier
+    ? p.tier!.cacheWritePerMTok
+    : p.cacheWritePerMTok;
   return (
-    pricedTokens(
-      msg.inputTokens,
-      p.inputPerMTok,
-      p.tier?.inputPerMTok,
-      p.tier?.thresholdTokens,
-    ) +
-    pricedTokens(
-      msg.outputTokens,
-      p.outputPerMTok,
-      p.tier?.outputPerMTok,
-      p.tier?.thresholdTokens,
-    ) +
-    pricedTokens(
-      msg.cacheReadTokens,
-      p.cacheReadPerMTok,
-      p.tier?.cacheReadPerMTok,
-      p.tier?.thresholdTokens,
-    ) +
-    pricedTokens(
-      msg.cacheCreationTokens,
-      p.cacheWritePerMTok,
-      p.tier?.cacheWritePerMTok,
-      p.tier?.thresholdTokens,
-    )
+    (msg.inputTokens / 1_000_000) * inputRate +
+    (msg.outputTokens / 1_000_000) * outputRate +
+    (msg.cacheReadTokens / 1_000_000) * cacheReadRate +
+    (msg.cacheCreationTokens / 1_000_000) * cacheWriteRate
   );
 }
 

--- a/extensions/claudecast/src/menu-bar-monitor.tsx
+++ b/extensions/claudecast/src/menu-bar-monitor.tsx
@@ -4,6 +4,7 @@ import {
   launchCommand,
   LaunchType,
   Color,
+  environment,
   openCommandPreferences,
   getPreferenceValues,
 } from "@raycast/api";
@@ -25,15 +26,23 @@ export default function MenuBarMonitor() {
 
   async function refresh() {
     try {
-      const [active, stats, recent] = await Promise.all([
-        isClaudeActive(),
-        getTodayStats(),
-        getMostRecentProject(),
-      ]);
+      const isBackground = environment.launchType === LaunchType.Background;
 
-      setIsActive(active);
-      setTodayStats(stats);
-      setRecentProject(recent?.name || null);
+      // Cheap signals always: process check + LocalStorage-cached today stats.
+      // Skip the full-history "last project" scan on background ticks; only run
+      // it when the user actually opens the menu.
+      const fetches: Promise<unknown>[] = [isClaudeActive(), getTodayStats()];
+      if (!isBackground) {
+        fetches.push(getMostRecentProject());
+      }
+
+      const results = await Promise.all(fetches);
+      setIsActive(results[0] as boolean);
+      setTodayStats(results[1] as UsageStats);
+      if (!isBackground) {
+        const recent = results[2] as { name?: string } | null;
+        setRecentProject(recent?.name || null);
+      }
       setError(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Unknown error");

--- a/extensions/claudecast/src/prompt-library.tsx
+++ b/extensions/claudecast/src/prompt-library.tsx
@@ -27,6 +27,7 @@ import {
 import {
   executePrompt,
   ClaudeResponse,
+  ensureClaudeApiAuth,
   ensureClaudeInstalled,
 } from "./lib/claude-cli";
 import { captureContext, getCodeContext } from "./lib/context-capture";
@@ -708,9 +709,13 @@ function ExecutingPromptView({
 
     async function execute() {
       try {
-        // Check if Claude is installed first
         if (!(await ensureClaudeInstalled())) {
           setError("Claude Code not installed");
+          setIsLoading(false);
+          return;
+        }
+        if (!(await ensureClaudeApiAuth())) {
+          setError("Claude authentication missing");
           setIsLoading(false);
           return;
         }

--- a/extensions/claudecast/src/transform-selection.tsx
+++ b/extensions/claudecast/src/transform-selection.tsx
@@ -16,6 +16,7 @@ import { useState, useEffect } from "react";
 import {
   executePrompt,
   ClaudeResponse,
+  ensureClaudeApiAuth,
   ensureClaudeInstalled,
 } from "./lib/claude-cli";
 
@@ -435,9 +436,13 @@ function ExecutingTransformView({
   useEffect(() => {
     async function execute() {
       try {
-        // Check if Claude is installed first
         if (!(await ensureClaudeInstalled())) {
           setError("Claude Code not installed");
+          setIsLoading(false);
+          return;
+        }
+        if (!(await ensureClaudeApiAuth())) {
+          setError("Claude authentication missing");
           setIsLoading(false);
           return;
         }

--- a/extensions/claudecast/src/usage-dashboard.tsx
+++ b/extensions/claudecast/src/usage-dashboard.tsx
@@ -1,105 +1,126 @@
-import { Action, ActionPanel, Detail, Icon, Color } from "@raycast/api";
-import { useState, useEffect } from "react";
+import { Action, ActionPanel, Color, Detail, Icon } from "@raycast/api";
+import { useEffect, useMemo, useState } from "react";
 import {
-  getTodayStats,
-  getWeekStats,
-  getMonthStats,
-  getAllTimeStats,
-  getDailyStats,
+  DailyStats,
   formatCost,
   formatTokens,
-  generateCostChart,
   generateProjectTable,
+  getAllTimeStats,
+  getDailyStats,
+  getMonthStats,
+  getTodayStats,
+  getWeekStats,
+  TopSessionSummary,
   UsageStats,
-  DailyStats,
 } from "./lib/usage-stats";
-import { safeTruncate } from "./lib/session-parser";
+import { renderBarChartToFile } from "./lib/svg-chart";
 
-type TimeRange = "today" | "week" | "month" | "all";
+type RangeKey = "today" | "week" | "month" | "all";
+
+const RANGE_LABEL: Record<RangeKey, string> = {
+  today: "Today",
+  week: "This Week",
+  month: "This Month",
+  all: "All Time",
+};
 
 export default function UsageDashboard() {
-  const [isLoading, setIsLoading] = useState(true);
-  const [timeRange, setTimeRange] = useState<TimeRange>("today");
-  const [stats, setStats] = useState<UsageStats | null>(null);
-  const [dailyStats, setDailyStats] = useState<DailyStats[]>([]);
+  const [statsByRange, setStatsByRange] = useState<
+    Partial<Record<RangeKey, UsageStats>>
+  >({});
+  const [statsLoading, setStatsLoading] = useState(true);
+  const [daily, setDaily] = useState<DailyStats[]>([]);
+  // Tracks which range `daily` was fetched for. Without this, switching range
+  // briefly aggregates stale data with the new range (e.g. 7 daily points
+  // bucketed as "monthly"), producing a mismatched chart for ~100ms before
+  // the new fetch lands. By aggregating against `dailyRange`, the chart
+  // keeps showing the previous range's correct view until the new data is
+  // ready, then swaps atomically.
+  const [dailyRange, setDailyRange] = useState<RangeKey>("today");
+  const [range, setRange] = useState<RangeKey>("today");
 
-  async function loadStats(range: TimeRange) {
-    setIsLoading(true);
-
-    let newStats: UsageStats;
-    switch (range) {
-      case "today":
-        newStats = await getTodayStats();
-        break;
-      case "week":
-        newStats = await getWeekStats();
-        break;
-      case "month":
-        newStats = await getMonthStats();
-        break;
-      case "all":
-        newStats = await getAllTimeStats();
-        break;
-    }
-
-    const daily = await getDailyStats(7);
-
-    setStats(newStats);
-    setDailyStats(daily);
-    setIsLoading(false);
-  }
+  // Fetch a daily series sized for the selected range. Cancellation token
+  // protects against stale responses from rapid range switches.
+  useEffect(() => {
+    let cancelled = false;
+    getDailyStats(daysForRange(range)).then((data) => {
+      if (cancelled) return;
+      setDaily(data);
+      setDailyRange(range);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [range]);
 
   useEffect(() => {
-    loadStats(timeRange);
-  }, [timeRange]);
+    setStatsLoading(true);
+    Promise.all([
+      getTodayStats().then((s) => ["today" as const, s] as const),
+      getWeekStats().then((s) => ["week" as const, s] as const),
+      getMonthStats().then((s) => ["month" as const, s] as const),
+      getAllTimeStats().then((s) => ["all" as const, s] as const),
+    ])
+      .then((entries) => {
+        const next: Partial<Record<RangeKey, UsageStats>> = {};
+        for (const [k, v] of entries) next[k] = v;
+        setStatsByRange(next);
+      })
+      .finally(() => setStatsLoading(false));
+  }, []);
 
-  const timeRangeLabel = {
-    today: "Today",
-    week: "This Week",
-    month: "This Month",
-    all: "All Time",
-  }[timeRange];
+  const chart = useMemo(() => {
+    if (daily.length === 0) return null;
+    // Aggregate against dailyRange (the range `daily` was fetched for), not
+    // the current `range`. During a range switch the chart keeps showing the
+    // previous range's correct view; when the new fetch lands, dailyRange and
+    // range realign and the chart updates cleanly.
+    const { points, header } = aggregateForChart(daily, dailyRange);
+    if (points.length === 0) return null;
+    const path = renderBarChartToFile(points, {
+      valueFormatter: (n) => (n >= 0.01 ? `$${n.toFixed(2)}` : ""),
+    });
+    const total = points.reduce((s, p) => s + p.value, 0);
+    return { path, header, total };
+  }, [daily, dailyRange]);
 
-  const markdown = stats
-    ? generateDashboardMarkdown(stats, dailyStats, timeRangeLabel)
-    : "";
+  const stats = statsByRange[range];
+
+  const markdown = buildMarkdown({
+    range,
+    stats,
+    chart,
+    statsLoading,
+  });
 
   return (
     <Detail
-      isLoading={isLoading}
+      isLoading={statsLoading}
       markdown={markdown}
-      metadata={stats ? <StatsMetadata stats={stats} /> : undefined}
+      navigationTitle={`Usage: ${RANGE_LABEL[range]}`}
+      metadata={<Sidebar stats={stats} />}
       actions={
         <ActionPanel>
           <ActionPanel.Section title="Time Range">
             <Action
               title="Today"
-              icon={timeRange === "today" ? Icon.Checkmark : Icon.Calendar}
-              onAction={() => setTimeRange("today")}
+              icon={range === "today" ? Icon.CheckCircle : Icon.Calendar}
+              onAction={() => setRange("today")}
             />
             <Action
               title="This Week"
-              icon={timeRange === "week" ? Icon.Checkmark : Icon.Calendar}
-              onAction={() => setTimeRange("week")}
+              icon={range === "week" ? Icon.CheckCircle : Icon.Calendar}
+              onAction={() => setRange("week")}
             />
             <Action
               title="This Month"
-              icon={timeRange === "month" ? Icon.Checkmark : Icon.Calendar}
-              onAction={() => setTimeRange("month")}
+              icon={range === "month" ? Icon.CheckCircle : Icon.Calendar}
+              onAction={() => setRange("month")}
             />
             <Action
               title="All Time"
-              icon={timeRange === "all" ? Icon.Checkmark : Icon.Calendar}
-              onAction={() => setTimeRange("all")}
-            />
-          </ActionPanel.Section>
-
-          <ActionPanel.Section>
-            <Action
-              title="Refresh"
-              icon={Icon.ArrowClockwise}
-              shortcut={{ modifiers: ["cmd"], key: "r" }}
-              onAction={() => loadStats(timeRange)}
+              icon={range === "all" ? Icon.CheckCircle : Icon.Calendar}
+              onAction={() => setRange("all")}
             />
           </ActionPanel.Section>
         </ActionPanel>
@@ -108,8 +129,15 @@ export default function UsageDashboard() {
   );
 }
 
-function StatsMetadata({ stats }: { stats: UsageStats }) {
-  // Sort projects by cost
+function Sidebar({ stats }: { stats: UsageStats | undefined }) {
+  if (!stats) {
+    return (
+      <Detail.Metadata>
+        <Detail.Metadata.Label title="Loading..." text="" />
+      </Detail.Metadata>
+    );
+  }
+
   const topProjects = Object.entries(stats.sessionsByProject)
     .sort(([, a], [, b]) => b.cost - a.cost)
     .slice(0, 5);
@@ -117,35 +145,63 @@ function StatsMetadata({ stats }: { stats: UsageStats }) {
   return (
     <Detail.Metadata>
       <Detail.Metadata.Label
-        title="Total Sessions"
+        title="Total Cost"
+        text={formatCost(stats.totalCost)}
+        icon={{ source: Icon.Coins, tintColor: Color.Yellow }}
+      />
+      <Detail.Metadata.Label
+        title="Sessions"
         text={stats.totalSessions.toString()}
         icon={Icon.Message}
       />
       <Detail.Metadata.Label
-        title="Total Cost"
-        text={formatCost(stats.totalCost)}
-        icon={Icon.Coins}
+        title="Avg / Session"
+        text={formatCost(
+          stats.totalSessions > 0 ? stats.totalCost / stats.totalSessions : 0,
+        )}
       />
 
       <Detail.Metadata.Separator />
 
-      <Detail.Metadata.TagList title="Top Projects">
-        {topProjects.map(([project, data]) => (
-          <Detail.Metadata.TagList.Item
-            key={project}
-            text={`${project}: ${formatCost(data.cost)}`}
-            color={Color.Blue}
-          />
-        ))}
-      </Detail.Metadata.TagList>
+      <Detail.Metadata.Label
+        title="Input Tokens"
+        text={formatTokens(stats.totalInputTokens)}
+      />
+      <Detail.Metadata.Label
+        title="Output Tokens"
+        text={formatTokens(stats.totalOutputTokens)}
+      />
+      <Detail.Metadata.Label
+        title="Cache Read"
+        text={formatTokens(stats.totalCacheReadTokens)}
+      />
+      <Detail.Metadata.Label
+        title="Cache Write"
+        text={formatTokens(stats.totalCacheCreationTokens)}
+      />
+
+      {topProjects.length > 0 && (
+        <>
+          <Detail.Metadata.Separator />
+          <Detail.Metadata.TagList title="Top Projects">
+            {topProjects.map(([project, data]) => (
+              <Detail.Metadata.TagList.Item
+                key={project}
+                text={`${project} (${formatCost(data.cost)})`}
+                color={Color.Blue}
+              />
+            ))}
+          </Detail.Metadata.TagList>
+        </>
+      )}
 
       {stats.topSessions.length > 0 && (
         <>
           <Detail.Metadata.Separator />
           <Detail.Metadata.Label
             title="Most Expensive Session"
-            text={`${formatCost(stats.topSessions[0].cost)} - ${stats.topSessions[0].projectName}`}
-            icon={Icon.Warning}
+            text={`${formatCost(stats.topSessions[0].cost)} in ${stats.topSessions[0].projectName}`}
+            icon={{ source: Icon.Warning, tintColor: Color.Orange }}
           />
         </>
       )}
@@ -153,56 +209,145 @@ function StatsMetadata({ stats }: { stats: UsageStats }) {
   );
 }
 
-function generateDashboardMarkdown(
-  stats: UsageStats,
-  dailyStats: DailyStats[],
-  timeRangeLabel: string,
-): string {
-  let md = `# Claude Code Usage - ${timeRangeLabel}\n\n`;
-
-  // Summary stats
-  md += `## Summary\n\n`;
-  md += `| Metric | Value |\n`;
-  md += `|--------|-------|\n`;
-  md += `| Total Sessions | ${stats.totalSessions} |\n`;
-  md += `| Total Cost | ${formatCost(stats.totalCost)} |\n`;
-  md += `| Avg Cost/Session | ${formatCost(stats.totalSessions > 0 ? stats.totalCost / stats.totalSessions : 0)} |\n`;
-  md += `| Input Tokens | ${formatTokens(stats.totalInputTokens)} |\n`;
-  md += `| Output Tokens | ${formatTokens(stats.totalOutputTokens)} |\n`;
-  md += `| Cache Read | ${formatTokens(stats.totalCacheReadTokens)} |\n`;
-  md += `| Cache Write | ${formatTokens(stats.totalCacheCreationTokens)} |\n\n`;
-
-  // Daily chart
-  if (dailyStats.length > 0) {
-    md += `## Daily Trend\n\n`;
-    md += generateCostChart(dailyStats);
-    md += "\n\n";
+// How many days of underlying daily data to fetch per range. The chart later
+// aggregates into the right bin size so the X axis stays readable.
+function daysForRange(range: RangeKey): number {
+  switch (range) {
+    case "today":
+    case "week":
+      return 7;
+    case "month":
+      return 30;
+    case "all":
+      return 365;
   }
+}
 
-  // Project breakdown
-  if (Object.keys(stats.sessionsByProject).length > 0) {
-    md += `## Cost by Project\n\n`;
-    md += generateProjectTable(stats.sessionsByProject);
-    md += "\n";
-  }
-
-  // Top expensive sessions
-  if (stats.topSessions.length > 0) {
-    md += `## Top Sessions by Cost\n\n`;
-    md += `| Project | First Message | Cost |\n`;
-    md += `|---------|---------------|------|\n`;
-
-    for (const session of stats.topSessions.slice(0, 5)) {
-      const preview = session.firstMessage
-        ? safeTruncate(session.firstMessage, 40, "...")
-        : "No message";
-      md += `| ${session.projectName} | ${preview} | ${formatCost(session.cost)} |\n`;
+// Bucket daily data into chart points sized for the selected range:
+//   today/week => one bar per day
+//   month      => one bar per 7-day chunk (4-5 weekly bars)
+//   all        => one bar per calendar month (up to 12 most recent)
+// Returns chart points and a header label that describes the binning.
+function aggregateForChart(
+  daily: DailyStats[],
+  range: RangeKey,
+): { points: { label: string; value: number }[]; header: string } {
+  if (range === "month") {
+    const points: { label: string; value: number }[] = [];
+    for (let i = 0; i < daily.length; i += 7) {
+      const chunk = daily.slice(i, i + 7);
+      const total = chunk.reduce((s, d) => s + d.cost, 0);
+      const start = chunk[0].date.slice(5);
+      const end = chunk[chunk.length - 1].date.slice(5);
+      points.push({
+        label: chunk.length > 1 ? `${start} to ${end}` : start,
+        value: total,
+      });
     }
+    return { points, header: "Weekly Cost (Last 30 Days)" };
   }
 
-  // Tips
+  if (range === "all") {
+    const monthMap = new Map<string, number>();
+    for (const d of daily) {
+      const monthKey = d.date.slice(0, 7); // YYYY-MM
+      monthMap.set(monthKey, (monthMap.get(monthKey) || 0) + d.cost);
+    }
+    const sorted = Array.from(monthMap.entries()).sort();
+    const recent = sorted.slice(-12);
+    const monthNames = [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ];
+    const points = recent.map(([key, value]) => {
+      const [year, month] = key.split("-");
+      return {
+        label: `${monthNames[parseInt(month, 10) - 1]} ${year.slice(2)}`,
+        value,
+      };
+    });
+    const header =
+      recent.length > 0
+        ? `Monthly Cost (Last ${recent.length} Months)`
+        : "Monthly Cost";
+    return { points, header };
+  }
+
+  // today / week: one bar per day, MM-DD label.
+  return {
+    points: daily.map((d) => ({ label: d.date.slice(5), value: d.cost })),
+    header: `Daily Cost (Last ${daily.length} Days)`,
+  };
+}
+
+function buildMarkdown(args: {
+  range: RangeKey;
+  stats: UsageStats | undefined;
+  chart: { path: string; header: string; total: number } | null;
+  statsLoading: boolean;
+}): string {
+  const { range, stats, chart, statsLoading } = args;
+
+  let md = `# Claude Code Usage: ${RANGE_LABEL[range]}\n\n`;
+
+  // Range-adapted chart. The aggregator picks the right granularity (daily,
+  // weekly, or monthly) so the X-axis stays readable regardless of window.
+  if (chart) {
+    md += `## ${chart.header}\n\n`;
+    md += `![${chart.header}](file://${chart.path}?raycast-width=820)\n\n`;
+    md += `_Total: **${formatCost(chart.total)}**_\n\n`;
+  }
+
+  if (!stats) {
+    md += statsLoading
+      ? `_Loading ${RANGE_LABEL[range]}..._\n`
+      : `_No data for ${RANGE_LABEL[range]}._\n`;
+    return md;
+  }
+
+  // Project breakdown for the selected range.
+  const projectKeys = Object.keys(stats.sessionsByProject);
+  if (projectKeys.length > 0) {
+    md += `## Cost by Project (${RANGE_LABEL[range]})\n\n`;
+    md += generateProjectTable(stats.sessionsByProject);
+    md += `\n`;
+  }
+
+  // Top sessions for the selected range.
+  if (stats.topSessions.length > 0) {
+    md += `## Top Sessions (${RANGE_LABEL[range]})\n\n`;
+    md += `| # | Project | First Message | Cost |\n`;
+    md += `|--:|---------|---------------|-----:|\n`;
+    stats.topSessions.slice(0, 10).forEach((s, i) => {
+      const preview = sessionPreview(s);
+      md += `| ${i + 1} | ${escapeMd(s.projectName)} | ${escapeMd(preview)} | ${formatCost(s.cost)} |\n`;
+    });
+    md += `\n`;
+  }
+
   md += `\n---\n\n`;
-  md += `*Tip: Use the action menu (⌘+K) to change the time range or refresh data.*\n`;
+  md += `_Tip: use ⌘K to switch range. Sidebar totals update with the range._\n`;
 
   return md;
+}
+
+function sessionPreview(s: TopSessionSummary): string {
+  const text = s.firstMessage || "(no message)";
+  return text.length > 80 ? `${text.slice(0, 80)}...` : text;
+}
+
+// Markdown table cells get broken by raw `|` and `\n`. Replace newlines and
+// escape pipes so the table still renders.
+function escapeMd(text: string): string {
+  return text.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
 }


### PR DESCRIPTION
# ClaudeCast 1.8.0

Cost calculation correctness, OOM crash fixes, dashboard rewrite, cmux terminal support, broadened auth gate, Git Actions rewrite, and a sync of upstream PR #27154.

## Cost calculation (correctness)

- **Streaming-chunk dedup.** `streamSessionUsage` dedups by `(message.id, requestId)` and keeps the last cumulative value per key. Anthropic's `message_delta` events emit cumulative usage; the CLI persists one JSONL line per chunk, so naive summing inflated session totals 2-4x. Verified on real sessions: one went 440K -> 114K, another 242K -> 95K.
- **Sonnet 4.x 200K-token tier.** Above 200K input tokens per message, rates double ($3/$15 -> $6/$22.50, cache scaled). `MODEL_PRICING` rows accept an optional `tier` block applied per-message (per-request), not per-session.
- **Opus 4.7 pricing row** at the $5/$25 tier. Without it, Opus 4.7 sessions matched the older `opus` substring and were billed at the deprecated $15/$75 tier (3x overcharge).
- **Opus 4.1 pricing row** at the older $15/$75 tier.
- **Daily chart bucketing.** `getDailyStats` now buckets per-entry timestamps via `streamSessionUsage(..., { bucketByDay: true })` instead of stamping a session's full cost on its file mtime date.
- **`calculateStatsWithUsage` no longer mutates input.** Costs computed into a local `Map<string, number>`. Top sessions returned as a lightweight `TopSessionSummary` so cached `UsageStats` does not alias `SessionMetadata` references the menu bar holds.

## OOM crash fixes (menu-bar-monitor, usage-dashboard, browse-sessions)

- **Persistent today-stats cache.** `getTodayStats` writes/reads `claudecast-today-stats-v1` in LocalStorage with a 30s TTL.
- **`environment.launchType` differentiation in menu bar.** Background ticks fetch only `isClaudeActive()` + cached today stats. The full-history `getMostRecentProject()` scan only runs on `LaunchType.UserInitiated`.
- **Bounded newest-first iterator in `listAllSessions`.** When a `limit` is provided, maintains a sorted top-N array and skips files older than the current N-th-oldest, instead of statting every file then sorting.
- **Message and content caps in `getSessionDetail`** (defaults: last 200 messages, 5KB per message). Returns `SessionDetail.totalMessageCount` so the UI can show the truncation notice.
- **Defensive stream cleanup in `streamSessionUsage`** mirrors the pattern from `parseSessionMetadataFast`.

## Usage Dashboard rewrite

- Single `Detail` page with range tabs (Today / This Week / This Month / All Time) that drive both the chart bin granularity and the rest of the page (Today/Week: 7 daily bars, Month: 4-5 weekly bars, All Time: up to 12 monthly bars).
- Real SVG bar chart embedded via `file://` URL, generated by new `src/lib/svg-chart.ts`. White text fill with a stacked `feDropShadow` halo so labels read on both Raycast themes.
- Sidebar metadata shows range-specific totals, token breakdowns, top 5 projects as colored tags, and the most expensive session.
- Range-switch flicker fixed: chart aggregator runs against `dailyRange` (the range the loaded data was fetched for), not the current `range`. Stale fetches are cancelled.

## cmux terminal support

- New entry in the `terminalApp` preference dropdown.
- Tab mode: `open -a cmux <cwd>` + AppleScript `perform action ("text:" & "<cmd>" & (ASCII character 10))` via cmux's own input pipeline. No Accessibility permission needed.
- Window mode: cmux's AppleScript `new window` verb + typed `cd "<cwd>" && <cmd>`.
- Honors the global Open In preference.

## Auth gate for Claude API commands

`ensureClaudeApiAuth()` preflights authentication before spawning claude. Accepts:

- Raycast preferences (`anthropicApiKey` or `oauthToken`)
- Env vars `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, or `CLAUDE_CODE_OAUTH_TOKEN`
- Existing credentials reported by `claude auth status --json` (covers `claude auth login`)

When none are configured the user gets a Failure toast with an "Open Preferences" action instead of a hung claude process waiting on its `/login` prompt. Wired into `ask-claude`, `git-actions`, `transform-selection`, `prompt-library`.

## Git Actions rewrite

- Entry now shows a project picker from recent Claude Code projects (favorites -> recent -> all, deduplicated, mtime-sorted via `discoverClaudeProjects()`).
- Empty states for "no Claude projects yet" and "picked path is not a git repo."
- `executePrompt` default timeout extended from 2 to 10 minutes; git review actions scale further (3-15 min) based on diff size, with a "Large diff (NNN KB). This may take a few minutes." toast when >50KB.

## Session prompt extraction (Browse Sessions, Deep Search Sessions)

- New `cleanUserMessageContent(raw)` helper applied wherever `firstMessage` is derived (`parseSessionMetadataFast`, `searchSingleSession`, `parseFullSession`):
  - Returns `null` for any `<local-command-*>` wrapper (catches both `<local-command-caveat>` boilerplate and `<local-command-stdout>` echo from `/model`, `/effort`, etc.).
  - Returns `null` for short slash-only prompts (`/model`, `/effort high`, `/clear`, anything `/`-prefixed under 30 chars). Long slash commands with substantive args (`/review https://github.com/.../pull/123 ...`) are kept.
  - Detects `<command-` prefix in any leading order and unwraps to `/cmd args`.
- New `extractUserText(content)` helper centralizes the "string vs array-of-blocks" content shape handling.

## Detail view: last 20 messages

Browse Sessions and Deep Search Sessions detail views now render the most recent 20 messages with a "Showing last N of M messages" notice keyed to the rendered count. The banner now also appears for any session over 20 messages, not just sessions over 200.

## Kitty window mode

Restored `--single-instance` on the kitty window-mode fallback so launches reuse the running kitty instance instead of spawning a separate process.

## Synced from upstream PR #27154

- Global `openIn: "window" | "tab"` preference (default `window`). Each terminal honors it: Terminal/iTerm send `Cmd+T` via System Events for tab; kitty uses `kitten @ launch --type=tab` (falls back to window if remote-control disabled); Ghostty uses `new tab` vs `new window` AppleScript verbs; cmux gets both modes; Warp ignores the preference.
- `Continue with Prompt` shortcut in Launch Project changed `Cmd+P` -> `Cmd+Shift+P` (Cmd+P is Raycast-reserved).
- Author `user_675a985a803f8cc8105b` added back to `contributors`.

## Other fixes

- **`$` escape bug in `openInTerminalApp` and `openInITerm`.** Removed the `.replace(/\$/g, "\\$")` that converted `bash -c 'echo $SHELL'` into the literal text `$SHELL`. Centralized into a shared `escapeAppleScriptDoubleQuoted()` helper.
- **Ask Claude Code Cmd+G** captures only selected text + clipboard.

## Test plan

- `npm run lint`, `npx tsc --noEmit`, and `npm run build` clean.
- Cost numbers in usage-dashboard match expectations after the dedup + tier fixes.
- Range tabs in the dashboard update chart, project table, top-sessions table, and sidebar atomically with no flicker.
- Browse Sessions detail loads large sessions without OOM and shows the "Showing last N of M messages" notice on any session over 20 messages.
- Menu bar updates over a 5+ minute window without crashing.
- cmux selected as terminal: tab mode opens new workspace via open-handler; window mode via AppleScript `new window` verb. Both run the typed command.
- Auth missing in prefs but `ANTHROPIC_AUTH_TOKEN` exported in shell: Ask Claude Code works; auth toast does not appear.
- Auth missing everywhere: friendly "Add token in preferences" toast; claude is not spawned.
- Git Actions opens to the project picker; review on a large diff runs to completion within the scaled timeout.
- kitty with `openIn = "window"` reuses the running kitty instance.
