### PR TITLE
Fix Safari history SQLite search quoting

### DIFF
--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Safari Changelog
 
+## [Fix] - 2026-05-06
+
+- Fix `Search History` command failing with `no such column: "%...%"` by using single-quoted string literals for search terms in the SQL query.
+
 ## [Fix] - 2026-04-28
 
 - Fix `Search History` command failing with `no such column: "unixepoch"` by using single-quoted string literals in the SQL query.

--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Safari Changelog
 
-## [Fix] - 2026-05-06
+## [Fix] - {PR_MERGE_DATE}
 
 - Fix `Search History` command failing with `no such column: "%...%"` by using single-quoted string literals for search terms in the SQL query.
 

--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Safari Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-05-06
 
 - Fix `Search History` command failing with `no such column: "%...%"` by using single-quoted string literals for search terms in the SQL query.
 

--- a/extensions/safari/src/hooks/useHistorySearch.ts
+++ b/extensions/safari/src/hooks/useHistorySearch.ts
@@ -8,12 +8,15 @@ import { safariAppIdentifier } from "../utils";
 export const HISTORY_DB = `${resolve(homedir(), `Library/${safariAppIdentifier.replace(/ /g, "")}/`)}/History.db`;
 const LIMIT = 100;
 
+const escapeSQLStringLiteral = (value: string) => value.replace(/'/g, "''");
+
 export const getHistoryQuery = (searchText?: string) => {
   const whereClause = searchText
     ? _.chain(searchText)
         .split(" ")
         .filter((word) => word.length > 0)
-        .map((term) => `(url LIKE "%${term}%" OR title LIKE "%${term}%")`)
+        .map((term) => escapeSQLStringLiteral(term))
+        .map((term) => `(url LIKE '%${term}%' OR title LIKE '%${term}%')`)
         .join(" AND ")
         .value()
     : undefined;


### PR DESCRIPTION
## Summary
- Fix Safari history search LIKE clauses to use SQLite string literals.
- Escape apostrophes in search terms before building the query.

Fixes #27669
Fixes #27500
Fixes #27504

## Validation
- npm run lint
- npm run build
- Checked generated SQL for single-term, multi-term, and apostrophe-containing searches.