### PR TITLE
feat(addy): add AI alias creation command

### DIFF
--- a/extensions/anonaddy/CHANGELOG.md
+++ b/extensions/anonaddy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Addy Changelog
 
-## [AI Alias Creation] - 2026-05-06
+## [AI Alias Creation] - {PR_MERGE_DATE}
 
 ### Added
 - New "Create Alias with AI" command: describe a purpose in plain language and AI generates a meaningful alias name and description

--- a/extensions/anonaddy/CHANGELOG.md
+++ b/extensions/anonaddy/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Addy Changelog
 
+## [AI Alias Creation] - 2026-05-06
+
+### Added
+- New "Create Alias with AI" command: describe a purpose in plain language and AI generates a meaningful alias name and description
+
 ## [Self-hosted Support] - 2026-01-15
 
 ### Added

--- a/extensions/anonaddy/CHANGELOG.md
+++ b/extensions/anonaddy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Addy Changelog
 
-## [AI Alias Creation] - {PR_MERGE_DATE}
+## [AI Alias Creation] - 2026-05-07
 
 ### Added
 - New "Create Alias with AI" command: describe a purpose in plain language and AI generates a meaningful alias name and description

--- a/extensions/anonaddy/package.json
+++ b/extensions/anonaddy/package.json
@@ -41,6 +41,12 @@
       "title": "Send an Email from an Alias",
       "description": "Send an email using one of your Addy aliases.",
       "mode": "view"
+    },
+    {
+      "name": "create-alias-ai",
+      "title": "Create Alias with AI",
+      "description": "Describe a purpose and let AI generate a meaningful alias name and description.",
+      "mode": "view"
     }
   ],
   "dependencies": {

--- a/extensions/anonaddy/src/create-alias-ai.tsx
+++ b/extensions/anonaddy/src/create-alias-ai.tsx
@@ -45,15 +45,18 @@ const CreateAliasAI = () => {
           AI.ask(AI_PROMPT(purpose), { creativity: "none" }),
         ]);
 
-        const cleaned = raw.replace(/```(?:json)?\n?/g, "").trim();
-        const { local_part, description } = JSON.parse(cleaned) as { local_part: string; description: string };
+        const jsonMatch = raw.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) throw new Error("AI returned an unexpected response format");
+        const { local_part, description } = JSON.parse(jsonMatch[0]) as { local_part: string; description: string };
 
         const isSharedDomain = options.sharedDomains.includes(options.defaultAliasDomain);
+        const fallbackFormat =
+          options.defaultAliasFormat === "custom" ? "random_characters" : options.defaultAliasFormat;
 
         const response = await alias.create({
           description,
           domain: options.defaultAliasDomain,
-          format: isSharedDomain ? options.defaultAliasFormat : "custom",
+          format: isSharedDomain ? fallbackFormat : "custom",
           ...(isSharedDomain ? {} : { local_part }),
         });
 

--- a/extensions/anonaddy/src/create-alias-ai.tsx
+++ b/extensions/anonaddy/src/create-alias-ai.tsx
@@ -1,0 +1,110 @@
+import {
+  AI,
+  Action,
+  ActionPanel,
+  Clipboard,
+  Form,
+  PopToRootType,
+  Toast,
+  captureException,
+  closeMainWindow,
+  environment,
+  showHUD,
+  showToast,
+} from "@raycast/api";
+import { useForm } from "@raycast/utils";
+
+import { alias, domains } from "./api";
+import { formatAPIError } from "./error-handler";
+
+type FormValues = {
+  purpose: string;
+};
+
+const AI_PROMPT = (purpose: string) => `Generate an email alias name and description for: "${purpose}"
+
+Respond with ONLY a JSON object, no other text:
+{
+  "local_part": "slug-style-name",
+  "description": "Brief description"
+}
+
+local_part rules: lowercase letters, numbers, and hyphens only; 3–20 characters; no spaces or underscores
+description rules: max 50 characters; clear and concise`;
+
+const CreateAliasAI = () => {
+  const canUseAI = environment.canAccess(AI);
+
+  const { handleSubmit, itemProps } = useForm<FormValues>({
+    async onSubmit({ purpose }) {
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Generating alias..." });
+
+      try {
+        const [options, raw] = await Promise.all([
+          domains.options(),
+          AI.ask(AI_PROMPT(purpose), { creativity: "none" }),
+        ]);
+
+        const cleaned = raw.replace(/```(?:json)?\n?/g, "").trim();
+        const { local_part, description } = JSON.parse(cleaned) as { local_part: string; description: string };
+
+        const isSharedDomain = options.sharedDomains.includes(options.defaultAliasDomain);
+
+        const response = await alias.create({
+          description,
+          domain: options.defaultAliasDomain,
+          format: isSharedDomain ? options.defaultAliasFormat : "custom",
+          ...(isSharedDomain ? {} : { local_part }),
+        });
+
+        if (!response.id) throw new Error("Unknown error");
+
+        toast.style = Toast.Style.Success;
+        toast.title = "Alias generated successfully";
+
+        await Clipboard.copy(response.email);
+        await closeMainWindow();
+        await showHUD("Alias copied to clipboard", { popToRootType: PopToRootType.Immediate });
+      } catch (error) {
+        captureException(error);
+        const formatted = formatAPIError(error, "Failed to generate alias");
+        toast.style = Toast.Style.Failure;
+        toast.title = formatted.title;
+        toast.message = formatted.message;
+      }
+    },
+    validation: {
+      purpose: (value) => {
+        if (!value || value.trim().length < 2) return "Describe the purpose of this alias";
+      },
+    },
+  });
+
+  if (!canUseAI) {
+    return (
+      <Form>
+        <Form.Description text="Raycast AI is required for this command. Please upgrade your Raycast plan to use AI features." />
+      </Form>
+    );
+  }
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Create Alias" onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField
+        {...itemProps.purpose}
+        autoFocus
+        info="Describe what this alias is for. AI will pick a meaningful name and description."
+        placeholder="e.g. Amazon shopping, tech newsletters, GitHub signups"
+        title="Purpose"
+      />
+    </Form>
+  );
+};
+
+export default CreateAliasAI;


### PR DESCRIPTION
## Summary

- Adds a new **"Create Alias with AI"** command to the Addy extension
- User types a plain-language description of the alias purpose (e.g. "Amazon shopping", "tech newsletters")
- `AI.ask()` generates a slug-style `local_part` and short `description`
- Alias is created using the user's default domain, copied to clipboard, and a HUD confirmation is shown
- Gracefully handles shared domains (falls back to the user's default format when `custom` local_part is unsupported)
- Shows an informative message if the user doesn't have Raycast AI access

## Test plan

- [x] Trigger "Create Alias with AI" in Raycast
- [x] Enter a purpose (e.g. "GitHub signups") and submit
- [x] Verify the alias is created in addy.io with a meaningful name and description
- [x] Verify the alias email is copied to clipboard
- [ ] Test with a Raycast account without AI access — confirm the fallback message appears
- [ ] Test with a self-hosted addy instance using the Custom URL preference