### PR TITLE
[Skills] Fix support directory initialization on first launch

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Skills Changelog
 
+## [Fix Support Directory Initialization] - {PR_MERGE_DATE}
+
+- Ensure the extension support directory exists before cached hooks run, preventing "Could not create extension support directory" errors on first launch
+
 ## [Add Newly Supported Agents] - 2026-05-05
 
 - Add 11 agents supported by the Skills CLI: AiderDesk, Code Studio, CodeArts Agent, Codemaker, Devin for Terminal, Dexto, ForgeCode, IBM Bob, Rovo Dev, Tabnine CLI, and Universal

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Fix Support Directory Initialization] - {PR_MERGE_DATE}
+## [Fix Support Directory Initialization] - 2026-05-11
 
 - Ensure the extension support directory exists before cached hooks run, preventing "Could not create extension support directory" errors on first launch
 

--- a/extensions/skills/src/manage-skills.tsx
+++ b/extensions/skills/src/manage-skills.tsx
@@ -1,9 +1,12 @@
 import { List, Detail, Icon, ActionPanel, Action, Color, openExtensionPreferences } from "@raycast/api";
 import { useState } from "react";
+import { ensureSupportDir } from "./utils/ensure-support-dir";
 import { useInstalledSkills } from "./hooks/useInstalledSkills";
 import { isInvalidCustomNpxPathError, isNpxResolutionError } from "./utils/skills-cli";
 import { InstalledSkillListItem } from "./components/InstalledSkillListItem";
 import { UpdateSkillAction } from "./components/actions/UpdateSkillAction";
+
+ensureSupportDir();
 
 export default function Command() {
   const { skills, isLoading, error, revalidate, mutate } = useInstalledSkills();

--- a/extensions/skills/src/search-skills.tsx
+++ b/extensions/skills/src/search-skills.tsx
@@ -1,11 +1,14 @@
 import { List, ActionPanel, Action, Detail, Icon } from "@raycast/api";
 import { useCallback, useState } from "react";
 
+import { ensureSupportDir } from "./utils/ensure-support-dir";
 import { SkillListItem } from "./components/SkillListItem";
 import { useInstalledSkillMatches } from "./hooks/useInstalledSkillMatches";
 import { useOwnerFilter } from "./hooks/useOwnerFilter";
 import { useDebouncedSearch } from "./hooks/useDebouncedSearch";
 import { buildGithubIssueUrl } from "./shared";
+
+ensureSupportDir();
 
 export default function Command() {
   const [searchText, setSearchText] = useState("");

--- a/extensions/skills/src/utils/ensure-support-dir.ts
+++ b/extensions/skills/src/utils/ensure-support-dir.ts
@@ -1,0 +1,19 @@
+import { mkdirSync } from "node:fs";
+import { environment } from "@raycast/api";
+
+/**
+ * Ensure the extension support directory exists before any Cache or
+ * LocalStorage operations run.  Raycast's framework expects this directory
+ * to be present when `useCachedPromise` (which relies on `Cache`) is used,
+ * but it may not exist on first launch or after a Raycast update.
+ *
+ * Calling `mkdirSync` with `recursive: true` is a no-op when the directory
+ * already exists, so this is safe to call on every command invocation.
+ */
+export function ensureSupportDir(): void {
+  try {
+    mkdirSync(environment.supportPath, { recursive: true });
+  } catch {
+    // Best-effort — if this fails, the framework will surface its own error.
+  }
+}


### PR DESCRIPTION
## Summary

- Prevent "Could not create extension support directory" errors by ensuring `environment.supportPath` exists before `useCachedPromise` hooks run
- Add `ensureSupportDir()` utility that calls `mkdirSync` with `recursive: true` at module scope in both `search-skills` and `manage-skills` commands

## Details

The Raycast framework expects the extension support directory to exist when `Cache` (used internally by `useCachedPromise`) is initialised. On first launch or after a Raycast update, this directory may not yet exist, causing the error.

The fix is a best-effort `mkdirSync` call that:
- Runs at module scope (before any React hooks)
- Is a no-op when the directory already exists (`recursive: true`)
- Silently catches errors, deferring to the framework's own error handling

## Test plan

- [ ] Fresh install: delete the extension support directory, launch "Search Skills", verify no error
- [ ] Existing install: launch both commands, verify no regression
- [ ] Build passes: `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)