### PR TITLE
[Tabby] Windows support

### DIFF
--- a/extensions/tabby/CHANGELOG.md
+++ b/extensions/tabby/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Tabby Changelog
 
+## [Windows Support] - {PR_MERGE_DATE}
+
+- Added Windows platform support
+- Added preferences to override the Tabby executable and config paths
+- Switched profile launching to `execFileSync` for safer argument handling
+
 ## [Initial Version] - 2026-01-19
 
 - Added `Open Tabby Profile` command to open specific Tabby profiles

--- a/extensions/tabby/CHANGELOG.md
+++ b/extensions/tabby/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tabby Changelog
 
-## [Windows Support] - {PR_MERGE_DATE}
+## [Windows Support] - 2026-05-10
 
 - Added Windows platform support
 - Added preferences to override the Tabby executable and config paths

--- a/extensions/tabby/package.json
+++ b/extensions/tabby/package.json
@@ -21,6 +21,24 @@
       "mode": "view"
     }
   ],
+  "preferences": [
+    {
+      "name": "tabbyPath",
+      "type": "textfield",
+      "required": false,
+      "title": "Tabby Executable Path",
+      "description": "Optional. Override the path to the Tabby executable. Leave empty to use the default for your OS.",
+      "default": ""
+    },
+    {
+      "name": "configPath",
+      "type": "textfield",
+      "required": false,
+      "title": "Tabby Config Path",
+      "description": "Optional. Override the path to Tabby's config.yaml. Leave empty to use the default for your OS.",
+      "default": ""
+    }
+  ],
   "dependencies": {
     "@raycast/api": "^1.93.2",
     "@raycast/utils": "^1.18.1",
@@ -44,6 +62,7 @@
     "publish": "npx @raycast/api@latest publish"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ]
 }

--- a/extensions/tabby/src/open-tabby-profile.tsx
+++ b/extensions/tabby/src/open-tabby-profile.tsx
@@ -7,11 +7,6 @@ import { homedir } from "os";
 import { join } from "path";
 import { getTabbyProfiles, getProfileGroups, TabbyProfile } from "./utils/get-tabby-profiles";
 
-interface Preferences {
-  tabbyPath?: string;
-  configPath?: string;
-}
-
 function resolveTabbyCli(): string {
   const { tabbyPath } = getPreferenceValues<Preferences>();
   if (tabbyPath && tabbyPath.trim().length > 0) {

--- a/extensions/tabby/src/open-tabby-profile.tsx
+++ b/extensions/tabby/src/open-tabby-profile.tsx
@@ -1,10 +1,32 @@
-import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import { Action, ActionPanel, Icon, List, getPreferenceValues } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { useEffect, useState } from "react";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
+import { existsSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
 import { getTabbyProfiles, getProfileGroups, TabbyProfile } from "./utils/get-tabby-profiles";
 
-const TABBY_CLI = "/Applications/Tabby.app/Contents/MacOS/Tabby";
+interface Preferences {
+  tabbyPath?: string;
+  configPath?: string;
+}
+
+function resolveTabbyCli(): string {
+  const { tabbyPath } = getPreferenceValues<Preferences>();
+  if (tabbyPath && tabbyPath.trim().length > 0) {
+    return tabbyPath;
+  }
+
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local");
+    const programFiles = process.env["ProgramFiles"] ?? "C:\\Program Files";
+    const candidates = [join(localAppData, "Programs", "Tabby", "Tabby.exe"), join(programFiles, "Tabby", "Tabby.exe")];
+    return candidates.find((p) => existsSync(p)) ?? candidates[0];
+  }
+
+  return "/Applications/Tabby.app/Contents/MacOS/Tabby";
+}
 
 function getProfileIcon(type: string): Icon {
   switch (type) {
@@ -34,8 +56,9 @@ export default function Command() {
 
   const openProfile = async (profile: TabbyProfile) => {
     try {
+      const cli = resolveTabbyCli();
       // Use Tabby CLI to open profile by name
-      execSync(`"${TABBY_CLI}" profile "${profile.name}"`, { encoding: "utf-8" });
+      execFileSync(cli, ["profile", profile.name], { encoding: "utf-8" });
     } catch (error) {
       await showFailureToast(error, { title: `Cannot open profile "${profile.name}"` });
     }

--- a/extensions/tabby/src/utils/get-tabby-profiles.ts
+++ b/extensions/tabby/src/utils/get-tabby-profiles.ts
@@ -4,15 +4,12 @@ import { join } from "path";
 import { getPreferenceValues } from "@raycast/api";
 import yaml from "js-yaml";
 
-interface Preferences {
-  tabbyPath?: string;
-  configPath?: string;
-}
-
 function getDefaultConfigPath(): string {
   if (process.platform === "win32") {
     const appData = process.env.APPDATA ?? join(homedir(), "AppData", "Roaming");
-    return join(appData, "tabby", "config.yaml");
+    const localAppData = process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local");
+    const candidates = [join(appData, "tabby", "config.yaml"), join(localAppData, "tabby", "config.yaml")];
+    return candidates.find(existsSync) ?? candidates[0];
   }
   return join(homedir(), "Library", "Application Support", "tabby", "config.yaml");
 }

--- a/extensions/tabby/src/utils/get-tabby-profiles.ts
+++ b/extensions/tabby/src/utils/get-tabby-profiles.ts
@@ -1,7 +1,26 @@
 import { readFileSync, existsSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
+import { getPreferenceValues } from "@raycast/api";
 import yaml from "js-yaml";
+
+interface Preferences {
+  tabbyPath?: string;
+  configPath?: string;
+}
+
+function getDefaultConfigPath(): string {
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA ?? join(homedir(), "AppData", "Roaming");
+    return join(appData, "tabby", "config.yaml");
+  }
+  return join(homedir(), "Library", "Application Support", "tabby", "config.yaml");
+}
+
+export function getConfigPath(): string {
+  const { configPath } = getPreferenceValues<Preferences>();
+  return configPath && configPath.trim().length > 0 ? configPath : getDefaultConfigPath();
+}
 
 export interface TabbyProfile {
   id: string;
@@ -16,16 +35,15 @@ interface TabbyConfig {
   groups?: Array<{ id: string; name: string }>;
 }
 
-const CONFIG_PATH = join(homedir(), "Library/Application Support/tabby/config.yaml");
-
 export function getTabbyProfiles(): TabbyProfile[] {
-  if (!existsSync(CONFIG_PATH)) {
-    console.error("Tabby config file not found at:", CONFIG_PATH);
+  const configPath = getConfigPath();
+  if (!existsSync(configPath)) {
+    console.error("Tabby config file not found at:", configPath);
     return [];
   }
 
   try {
-    const fileContent = readFileSync(CONFIG_PATH, "utf-8");
+    const fileContent = readFileSync(configPath, "utf-8");
     const config = yaml.load(fileContent) as TabbyConfig;
 
     if (!config.profiles || !Array.isArray(config.profiles)) {
@@ -46,12 +64,13 @@ export function getTabbyProfiles(): TabbyProfile[] {
 }
 
 export function getProfileGroups(): Map<string, string> {
-  if (!existsSync(CONFIG_PATH)) {
+  const configPath = getConfigPath();
+  if (!existsSync(configPath)) {
     return new Map();
   }
 
   try {
-    const fileContent = readFileSync(CONFIG_PATH, "utf-8");
+    const fileContent = readFileSync(configPath, "utf-8");
     const config = yaml.load(fileContent) as TabbyConfig;
 
     const groupMap = new Map<string, string>();


### PR DESCRIPTION
Fixes #27279

## Description

This PR adds Windows support to the Tabby extension and improves profile launch reliability.

### Changes
- Added Windows platform to the supported platforms list in `package.json`
- Added two new preferences to allow users to override:
  - Tabby executable path (defaults to standard Windows installation paths)
  - Tabby config path (defaults to standard Windows config location)
- Updated profile launching to use `execFileSync` for safer argument handling and cross-platform compatibility
- Updated config path resolution logic to properly handle Windows paths using `APPDATA` and `LOCALAPPDATA` environment variables
- Added comprehensive changelog entry

### Technical Details
- Profiles are now loaded from `%APPDATA%\tabby\config.yaml` on Windows (with fallback to `%LOCALAPPDATA%\tabby\config.yaml`)
- Executable path detection supports both `Program Files` and `Local\Programs` installation paths
- All existing macOS functionality is preserved

## Screencast

This PR enhances an existing extension with Windows support. No new commands are added - the "Open Tabby Profile" command now works on Windows in addition to macOS.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)