### PR TITLE
gather: support Gather V2 alongside V1

### DIFF
--- a/extensions/gather/CHANGELOG.md
+++ b/extensions/gather/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Gather Changelog
 
+## [Gather V2 support] - {PR_MERGE_DATE}
+Detect `/Applications/GatherV2.app` in addition to `/Applications/Gather.app` and activate the app via its POSIX path so the extension works on Gather V2.
+
 ## [1.0.1] - 2022-07-11
 Add a proper README.md file and rewrite the extension description
 

--- a/extensions/gather/CHANGELOG.md
+++ b/extensions/gather/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Gather Changelog
 
-## [Gather V2 support] - {PR_MERGE_DATE}
+## [Gather V2 support] - 2026-05-25
 Detect `/Applications/GatherV2.app` in addition to `/Applications/Gather.app` and activate the app via its POSIX path so the extension works on Gather V2.
 
 ## [1.0.1] - 2022-07-11

--- a/extensions/gather/package.json
+++ b/extensions/gather/package.json
@@ -5,7 +5,7 @@
   "description": "Control Gather from Raycast",
   "icon": "command-icon.png",
   "author": "yannglt",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "categories": [
     "Communication",
     "Productivity"

--- a/extensions/gather/src/toggle-afk.ts
+++ b/extensions/gather/src/toggle-afk.ts
@@ -1,6 +1,6 @@
 import { closeMainWindow, open, showToast, Toast } from "@raycast/api";
 import { runAppleScript } from "run-applescript";
-import { gatherInstalled } from "./utils";
+import { gatherInstalled, GATHER_APP_PATH } from "./utils";
 
 export default async () => {
   const installed = await gatherInstalled();
@@ -22,7 +22,7 @@ export default async () => {
     await showToast(options);
   } else {
     await closeMainWindow();
-    await runAppleScript('activate application "Gather"');
+    await runAppleScript(`tell application (POSIX file "${GATHER_APP_PATH}" as alias) to activate`);
 
     // Toggle microphone
     await runAppleScript('tell application "System Events" to key code 0 using {shift down, command down}');

--- a/extensions/gather/src/toggle-availability-status.ts
+++ b/extensions/gather/src/toggle-availability-status.ts
@@ -1,6 +1,6 @@
 import { closeMainWindow, open, showToast, Toast } from "@raycast/api";
 import { runAppleScript } from "run-applescript";
-import { gatherInstalled } from "./utils";
+import { gatherInstalled, GATHER_APP_PATH } from "./utils";
 
 export default async () => {
   const installed = await gatherInstalled();
@@ -22,7 +22,7 @@ export default async () => {
     await showToast(options);
   } else {
     await closeMainWindow();
-    await runAppleScript('activate application "Gather"');
+    await runAppleScript(`tell application (POSIX file "${GATHER_APP_PATH}" as alias) to activate`);
 
     // Toggle availability status
     await runAppleScript('tell application "System Events" to key code 32 using command down');

--- a/extensions/gather/src/toggle-camera.ts
+++ b/extensions/gather/src/toggle-camera.ts
@@ -1,6 +1,6 @@
 import { closeMainWindow, open, showToast, Toast } from "@raycast/api";
 import { runAppleScript } from "run-applescript";
-import { gatherInstalled } from "./utils";
+import { gatherInstalled, GATHER_APP_PATH } from "./utils";
 
 export default async () => {
   const installed = await gatherInstalled();
@@ -22,7 +22,7 @@ export default async () => {
     await showToast(options);
   } else {
     await closeMainWindow();
-    await runAppleScript('activate application "Gather"');
+    await runAppleScript(`tell application (POSIX file "${GATHER_APP_PATH}" as alias) to activate`);
 
     // Toggle camera
     await runAppleScript('tell application "System Events" to key code 9 using {shift down, command down}');

--- a/extensions/gather/src/toggle-microphone.ts
+++ b/extensions/gather/src/toggle-microphone.ts
@@ -1,6 +1,6 @@
 import { closeMainWindow, open, showToast, Toast } from "@raycast/api";
 import { runAppleScript } from "run-applescript";
-import { gatherInstalled } from "./utils";
+import { gatherInstalled, GATHER_APP_PATH } from "./utils";
 
 export default async () => {
   const installed = await gatherInstalled();
@@ -22,7 +22,7 @@ export default async () => {
     await showToast(options);
   } else {
     await closeMainWindow();
-    await runAppleScript('activate application "Gather"');
+    await runAppleScript(`tell application (POSIX file "${GATHER_APP_PATH}" as alias) to activate`);
 
     // Toggle microphone
     await runAppleScript('tell application "System Events" to key code 0 using {shift down, command down}');

--- a/extensions/gather/src/utils.ts
+++ b/extensions/gather/src/utils.ts
@@ -1,8 +1,13 @@
 import fs from "fs";
 
+const GATHER_V2 = "/Applications/GatherV2.app";
+const GATHER_V1 = "/Applications/Gather.app";
+
+export const GATHER_APP_PATH = fs.existsSync(GATHER_V2) ? GATHER_V2 : GATHER_V1;
+
 export async function gatherInstalled() {
   try {
-    return fs.existsSync("/Applications/Gather.app");
+    return fs.existsSync(GATHER_APP_PATH);
   } catch (e) {
     console.error(String(e));
     return false;


### PR DESCRIPTION
## Description

Gather's v2 desktop client installs at `/Applications/GatherV2.app` rather than `/Applications/Gather.app`, so the existing `existsSync` check (and the subsequent `activate application "Gather"` call) silently fail for v2-only users — every command shows the "Gather is not installed" toast. This PR adds v2 detection and uses POSIX-file activation so the extension works on whichever client is installed.

## Changes

- `gatherInstalled()` now returns true if either `/Applications/GatherV2.app` or `/Applications/Gather.app` is present, preferring v2 when both coexist.
- Activate the app via its POSIX file path (`tell application (POSIX file "${GATHER_APP_PATH}" as alias) to activate`) so we don't depend on the bundle's `CFBundleName` matching the `.app` filename — robust whether v2's bundle is named "Gather", "Gather V2", or "GatherV2".
- Keystrokes (⌘⇧A / ⌘⇧V / ⌘U) are unchanged — they remain Gather's documented defaults; any rebinding is the user's choice in `Gather → Preferences → Keyboard Shortcuts`.
- Version bump 1.0.1 → 1.0.2 and a CHANGELOG entry.

## Checklist

- [x] Behavior unchanged for V1 users (`/Applications/Gather.app`)
- [x] No new dependencies; minimum-diff (~6 net code lines)
- [x] CHANGELOG and version bumped
- [ ] V2 verification on `/Applications/GatherV2.app` — requested from extension author / Raycast reviewer with v2 installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)