### PR TITLE
Fix product JSON path resolution for Windows to handle versioned resources

### DIFF
--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Visual Studio Code Changelog
 
+## [Fix: Windows app path resolution] - {PR_MERGE_DATE}
+
+- Fixed `product.json` resolution for Windows builds that use VS Code's versioned resources layout.
+
 ## [Fix: Shared Storage Support] - 2026-05-07
 
 - Added Shared Storage support for new version of VS Code

--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Visual Studio Code Changelog
 
-## [Fix: Windows app path resolution] - {PR_MERGE_DATE}
+## [Fix: Windows app path resolution] - 2026-05-11
 
 - Fixed `product.json` resolution for Windows builds that use VS Code's versioned resources layout.
 

--- a/extensions/visual-studio-code-recent-projects/src/lib/vscode.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/vscode.ts
@@ -1,5 +1,6 @@
 import { getPreferenceValues, open } from "@raycast/api";
 import * as child_process from "child_process";
+import * as fs from "fs";
 import * as afs from "fs/promises";
 import * as os from "os";
 import path from "path";
@@ -119,56 +120,92 @@ export function getVSCodeCLIFilename(): string {
   return name;
 }
 
-function productJSONPaths(): Record<string, string> {
-  let productJSONPaths: Record<string, string> = {};
+function programPaths(): Record<string, string> {
+  let programPaths: Record<string, string> = {};
 
   if (isWin) {
     const programsFolder = path.join(os.homedir(), "AppData", "Local", "Programs");
-    productJSONPaths = {
-      Antigravity: path.join(programsFolder, "Antigravity", "resources", "app", "product.json"),
-      Code: path.join(programsFolder, "Microsoft VS Code", "resources", "app", "product.json"),
-      "Code - Insiders": path.join(programsFolder, "Microsoft VS Code Insiders", "resources", "app", "product.json"),
-      Cursor: path.join(programsFolder, "cursor", "resources", "app", "product.json"),
-      Kiro: path.join(programsFolder, "Kiro", "resources", "app", "product.json"),
-      Positron: path.join(programsFolder, "Positron", "resources", "app", "product.json"),
-      Qoder: path.join(programsFolder, "Qoder", "resources", "app", "product.json"),
-      Trae: path.join(programsFolder, "Trae", "resources", "app", "product.json"),
-      "Trae CN": path.join(programsFolder, "Trae CN", "resources", "app", "product.json"),
-      VSCodium: path.join(programsFolder, "VSCodium", "resources", "app", "product.json"),
-      "VSCodium - Insiders": path.join(programsFolder, "VSCodium Insiders", "resources", "app", "product.json"),
-      Windsurf: path.join(programsFolder, "Windsurf", "resources", "app", "product.json"),
-      Lingma: path.join(programsFolder, "Lingma", "resources", "app", "product.json"),
+    programPaths = {
+      Antigravity: path.join(programsFolder, "Antigravity"),
+      Code: path.join(programsFolder, "Microsoft VS Code"),
+      "Code - Insiders": path.join(programsFolder, "Microsoft VS Code Insiders"),
+      Cursor: path.join(programsFolder, "cursor"),
+      Kiro: path.join(programsFolder, "Kiro"),
+      Positron: path.join(programsFolder, "Positron"),
+      Qoder: path.join(programsFolder, "Qoder"),
+      Trae: path.join(programsFolder, "Trae"),
+      "Trae CN": path.join(programsFolder, "Trae CN"),
+      VSCodium: path.join(programsFolder, "VSCodium"),
+      "VSCodium - Insiders": path.join(programsFolder, "VSCodium Insiders"),
+      Windsurf: path.join(programsFolder, "Windsurf"),
+      Lingma: path.join(programsFolder, "Lingma"),
     };
   }
 
   if (isMac) {
-    productJSONPaths = {
-      Antigravity: "/Applications/Antigravity.app/Contents/Resources/app/product.json",
-      Code: "/Applications/Visual Studio Code.app/Contents/Resources/app/product.json",
-      "Code - Insiders": "/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/product.json",
-      Cursor: "/Applications/Cursor.app/Contents/Resources/app/product.json",
-      Kiro: "/Applications/Kiro.app/Contents/Resources/app/product.json",
-      Positron: "/Applications/Positron.app/Contents/Resources/app/product.json",
-      Qoder: "/Applications/Qoder.app/Contents/Resources/app/product.json",
-      Trae: "/Applications/Trae.app/Contents/Resources/app/product.json",
-      "Trae CN": "/Applications/Trae CN.app/Contents/Resources/app/product.json",
-      VSCodium: "/Applications/VSCodium.app/Contents/Resources/app/product.json",
-      "VSCodium - Insiders": "/Applications/VSCodium - Insiders.app/Contents/Resources/app/product.json",
-      Windsurf: "/Applications/Windsurf.app/Contents/Resources/app/product.json",
-      Lingma: "/Applications/Lingma.app/Contents/Resources/app/product.json",
+    programPaths = {
+      Antigravity: "/Applications/Antigravity.app/Contents/Resources/app",
+      Code: "/Applications/Visual Studio Code.app/Contents/Resources/app",
+      "Code - Insiders": "/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app",
+      Cursor: "/Applications/Cursor.app/Contents/Resources/app",
+      Kiro: "/Applications/Kiro.app/Contents/Resources/app",
+      Positron: "/Applications/Positron.app/Contents/Resources/app",
+      Qoder: "/Applications/Qoder.app/Contents/Resources/app",
+      Trae: "/Applications/Trae.app/Contents/Resources/app",
+      "Trae CN": "/Applications/Trae CN.app/Contents/Resources/app",
+      VSCodium: "/Applications/VSCodium.app/Contents/Resources/app",
+      "VSCodium - Insiders": "/Applications/VSCodium - Insiders.app/Contents/Resources/app",
+      Windsurf: "/Applications/Windsurf.app/Contents/Resources/app",
+      Lingma: "/Applications/Lingma.app/Contents/Resources/app",
     };
   }
 
-  return productJSONPaths;
+  return programPaths;
+}
+
+function resolveWindowsProductJSONPath(installDir: string): string {
+  const defaultProductJSONPath = path.join(installDir, "resources", "app", "product.json");
+
+  if (fs.existsSync(defaultProductJSONPath)) {
+    return defaultProductJSONPath;
+  }
+
+  try {
+    // VS Code's Windows versioned resources folder is commit.substring(0, 10).
+    // https://github.com/microsoft/vscode/blob/8cc98deb3ce25f83f2fd240507e682da0b6dad41/build/gulpfile.vscode.win32.ts#L76
+    const versionedResourcesDirs = fs
+      .readdirSync(installDir, { withFileTypes: true })
+      .filter((dirent) => dirent.isDirectory() && /^[0-9a-f]{10}$/i.test(dirent.name));
+
+    const versionedResourcesDir =
+      versionedResourcesDirs.length <= 1
+        ? versionedResourcesDirs[0]?.name
+        : versionedResourcesDirs
+            .map(({ name }) => ({
+              name,
+              stats: fs.statSync(path.join(installDir, name)),
+            }))
+            .sort((a, b) => b.stats.mtimeMs - a.stats.mtimeMs)[0]?.name;
+
+    const productJSONPath = versionedResourcesDir
+      ? path.join(installDir, versionedResourcesDir, "resources", "app", "product.json")
+      : undefined;
+
+    return productJSONPath && fs.existsSync(productJSONPath) ? productJSONPath : defaultProductJSONPath;
+  } catch {
+    return defaultProductJSONPath;
+  }
 }
 
 export function getProductJSONPath(): string {
-  const productJSONPathsForPlatform = productJSONPaths();
-  const name = productJSONPathsForPlatform[getBuildNamePreference()];
-  if (!name || name.length <= 0) {
-    return productJSONPathsForPlatform.Code;
+  const programPathsForPlatform = programPaths();
+  const programPath = programPathsForPlatform[getBuildNamePreference()] || programPathsForPlatform.Code;
+
+  if (isWin) {
+    return resolveWindowsProductJSONPath(programPath);
   }
-  return name;
+
+  return path.join(programPath, "product.json");
 }
 
 export class VSCodeCLI {


### PR DESCRIPTION
## Description

Fixes: #27732

### Before

<img width="764" height="488" alt="image" src="https://github.com/user-attachments/assets/cd794dab-94ec-4f5d-baa3-212466577920" />

### After

<img width="760" height="488" alt="image" src="https://github.com/user-attachments/assets/b88bcdfc-ded6-4dee-831d-bf538439e842" />

## Test

- [x] Windows - Visual Studio Code (1.118+)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
