### PR TITLE
feat(kaomoji-search): use native copy/paste actions, preserve recents, and add contributor

### DIFF
--- a/extensions/kaomoji-search/CHANGELOG.md
+++ b/extensions/kaomoji-search/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Kaomoji Search Changelog
 
+## [Use native copy/paste actions] - {PR_MERGE_DATE}
+
+- Replace manual `Clipboard.copy` / `Clipboard.paste` actions with `Action.CopyToClipboard` and `Action.Paste`
+- Keep recent history behavior by adding kaomoji through `onCopy` / `onPaste` callbacks
+
 ## [Update] - 2025-10-14
 
 - Added support for pinning kaomojis

--- a/extensions/kaomoji-search/CHANGELOG.md
+++ b/extensions/kaomoji-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kaomoji Search Changelog
 
-## [Use native copy/paste actions] - {PR_MERGE_DATE}
+## [Use native copy/paste actions] - 2026-05-10
 
 - Replace manual `Clipboard.copy` / `Clipboard.paste` actions with `Action.CopyToClipboard` and `Action.Paste`
 - Keep recent history behavior by adding kaomoji through `onCopy` / `onPaste` callbacks

--- a/extensions/kaomoji-search/src/components/KaomojiActions.tsx
+++ b/extensions/kaomoji-search/src/components/KaomojiActions.tsx
@@ -1,13 +1,4 @@
-import {
-  ActionPanel,
-  Action,
-  Clipboard,
-  Icon,
-  Keyboard,
-  showToast,
-  Toast,
-  openExtensionPreferences,
-} from "@raycast/api";
+import { ActionPanel, Action, Icon, Keyboard, showToast, Toast, openExtensionPreferences } from "@raycast/api";
 import { useCallback, useMemo } from "react";
 import { useRecentKaomoji } from "../hooks/useRecentKaomoji";
 import { SearchResult } from "../types";
@@ -22,16 +13,33 @@ interface KaomojiActionsProps {
 export function KaomojiActions({ searchResult, primaryAction, toggleFavorite, isFavorite }: KaomojiActionsProps) {
   const { addKaomoji } = useRecentKaomoji();
 
-  const pasteInActiveApp = useCallback(() => {
-    addKaomoji(searchResult);
-    Clipboard.paste(searchResult.name);
-  }, [addKaomoji, searchResult]);
+  const pasteInActiveApp = useMemo(
+    () => (
+      <Action.Paste
+        title="Paste in Active App"
+        content={searchResult.name}
+        icon={Icon.Clipboard}
+        onPaste={() => addKaomoji(searchResult)}
+        key="paste-in-active-app"
+      />
+    ),
+    [searchResult, addKaomoji],
+  );
 
-  const copyToClipboard = useCallback(() => {
-    addKaomoji(searchResult);
-    Clipboard.copy(searchResult.name);
-    showToast({ title: "Copied to Clipboard", style: Toast.Style.Success });
-  }, [addKaomoji, searchResult]);
+  const copyToClipboard = useMemo(
+    () => (
+      <Action.CopyToClipboard
+        title="Copy to Clipboard"
+        content={searchResult.name}
+        icon={Icon.Clipboard}
+        onCopy={() => {
+          addKaomoji(searchResult);
+        }}
+        key="copy-to-clipboard"
+      />
+    ),
+    [searchResult, addKaomoji],
+  );
 
   const isPinned = isFavorite(searchResult);
 
@@ -43,25 +51,13 @@ export function KaomojiActions({ searchResult, primaryAction, toggleFavorite, is
     });
   }, [toggleFavorite, searchResult, isPinned]);
 
-  const PasteInActiveAppAction = useMemo(() => {
-    return (
-      <Action title="Paste in Active App" onAction={pasteInActiveApp} icon={Icon.Clipboard} key="paste-in-active-app" />
-    );
-  }, [pasteInActiveApp]);
-
-  const CopyToClipboardAction = useMemo(() => {
-    return (
-      <Action title="Copy to Clipboard" onAction={copyToClipboard} icon={Icon.Clipboard} key="copy-to-clipboard" />
-    );
-  }, [copyToClipboard]);
-
   const actions = useMemo(() => {
     if (primaryAction === "copy-to-clipboard") {
-      return [CopyToClipboardAction, PasteInActiveAppAction];
+      return [copyToClipboard, pasteInActiveApp];
     } else {
-      return [PasteInActiveAppAction, CopyToClipboardAction];
+      return [pasteInActiveApp, copyToClipboard];
     }
-  }, [primaryAction, CopyToClipboardAction, PasteInActiveAppAction]);
+  }, [primaryAction, copyToClipboard, pasteInActiveApp]);
 
   return (
     <ActionPanel>


### PR DESCRIPTION
## Description

Uses native copy/paste actions.

Fixes issue in Vicinae where copy and paste do not close the window.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
