### PR TITLE
fix(parcel): locale-aware ambiguous dot date parsing

### DIFF
--- a/extensions/parcel/CHANGELOG.md
+++ b/extensions/parcel/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Parcel Changelog
 
-## [Locale-aware numeric date parsing] - {PR_MERGE_DATE}
+## [Ambiguous dotted date preference] - {PR_MERGE_DATE}
 
-- Ambiguous dot-separated dates (e.g. `06.07.2025` when both parts could be month or day) now follow your **system locale** (month-first vs day-first), instead of always assuming US order
+- Ambiguous dot-separated dates (e.g. `06.07.2025` when both parts could be month or day) use a new extension preference: **Month/Day first (US)** vs **Day/Month first (EU/GB)**
 - Expected delivery **day countdown** uses the same parser as on-screen dates so badges stay consistent with the formatted text
 
 ## [Fix Carrier Dropdown Default] - 2026-01-30
@@ -27,7 +27,7 @@
 - The Add Delivery form now prevents leaving required form fields empty
 - Deliveries added from the extension will automatically use your system's language in Parcel
 - Replaced the success toast with a cleaner Raycast HUD notification
-- Fixed API errors to display the specific error from Parcel rather than a generic "Something went wrong" 
+- Fixed API errors to display the specific error from Parcel rather than a generic "Something went wrong"
 
 ## [Detail View Refactor, Metadata, UX] - 2025-09-19
 
@@ -77,3 +77,4 @@
 - Added action to copy tracking numbers
 - Added support for filtering between active and recent deliveries
 - Created a clean UI with color-coded status indicators and delivery timeframes
+

--- a/extensions/parcel/CHANGELOG.md
+++ b/extensions/parcel/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Parcel Changelog
 
+## [Locale-aware numeric date parsing] - {PR_MERGE_DATE}
+
+- Ambiguous dot-separated dates (e.g. `06.07.2025` when both parts could be month or day) now follow your **system locale** (month-first vs day-first), instead of always assuming US order
+- Expected delivery **day countdown** uses the same parser as on-screen dates so badges stay consistent with the formatted text
+
 ## [Fix Carrier Dropdown Default] - 2026-01-30
 
 - Fixed the "Add Delivery" carrier dropdown auto-selecting the first carrier (4PX) instead of starting with no selection

--- a/extensions/parcel/CHANGELOG.md
+++ b/extensions/parcel/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Parcel Changelog
 
-## [Ambiguous dotted date preference] - {PR_MERGE_DATE}
+## [Ambiguous dotted date preference] - 2026-05-10
 
 - Ambiguous dot-separated dates (e.g. `06.07.2025` when both parts could be month or day) use a new extension preference: **Month/Day first (US)** vs **Day/Month first (EU/GB)**
 - Expected delivery **day countdown** uses the same parser as on-screen dates so badges stay consistent with the formatted text

--- a/extensions/parcel/package.json
+++ b/extensions/parcel/package.json
@@ -290,6 +290,24 @@
       "description": "Your Parcel API key generated from web.parcelapp.net",
       "type": "password",
       "required": true
+    },
+    {
+      "name": "ambiguousDotDateOrder",
+      "title": "Ambiguous dotted dates (e.g. 06.07.2025)",
+      "description": "Some carriers send dates where both numbers could be month or day. Choose how to interpret them.",
+      "type": "dropdown",
+      "required": false,
+      "default": "month_day",
+      "data": [
+        {
+          "title": "MM.DD — common in US",
+          "value": "month_day"
+        },
+        {
+          "title": "DD.MM — common in EU/GB",
+          "value": "day_month"
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/extensions/parcel/package.json
+++ b/extensions/parcel/package.json
@@ -293,7 +293,7 @@
     },
     {
       "name": "ambiguousDotDateOrder",
-      "title": "Ambiguous dotted dates (e.g. 06.07.2025)",
+      "title": "Ambiguous Dotted Dates (e.g. 06.07.2025)",
       "description": "Some carriers send dates where both numbers could be month or day. Choose how to interpret them.",
       "type": "dropdown",
       "required": false,

--- a/extensions/parcel/src/my-deliveries.tsx
+++ b/extensions/parcel/src/my-deliveries.tsx
@@ -5,6 +5,7 @@ import {
   Icon,
   List,
   Toast,
+  getPreferenceValues,
   launchCommand,
   LaunchType,
   showToast,
@@ -16,28 +17,16 @@ import { Delivery, FilterMode, STATUS_DESCRIPTIONS, getStatusIcon } from "./api"
 import { useDeliveries } from "./hooks/useDeliveries";
 import { useCarriers } from "./hooks/useCarriers";
 
+interface ParcelCommandPreferences {
+  apiKey: string;
+  ambiguousDotDateOrder?: "month_day" | "day_month";
+}
+
 /**
  * Placeholder value returned by some carriers when the date is unknown.
  * This is based on observed API responses and may not be exhaustive.
  */
 const UNKNOWN_DATE_PLACEHOLDER = "--//--";
-
-/**
- * Whether the user's locale typically writes numeric dates as month/day (e.g. en-US)
- * vs day/month (e.g. en-GB). Used to disambiguate `01.02.2025`-style strings.
- */
-function prefersMonthBeforeDayInNumericLocale(): boolean {
-  const parts = new Intl.DateTimeFormat(undefined, {
-    day: "numeric",
-    month: "numeric",
-  }).formatToParts(new Date(2000, 0, 2));
-  const iMonth = parts.findIndex((p) => p.type === "month");
-  const iDay = parts.findIndex((p) => p.type === "day");
-  if (iMonth === -1 || iDay === -1) return true;
-  return iMonth < iDay;
-}
-
-const TRY_MONTH_DAY_FIRST = prefersMonthBeforeDayInNumericLocale();
 
 const NUMERIC_DOT_FORMATS_MONTH_FIRST = [
   "MM.dd.yyyy HH:mm:ss",
@@ -53,12 +42,7 @@ const NUMERIC_DOT_FORMATS_DAY_FIRST = [
   "MM.dd.yyyy HH:mm",
 ] as const;
 
-/**
- * Supported date formats for parsing delivery dates.
- * Dot-separated numeric formats follow the user's locale (US-style vs GB/EU-style) first.
- */
-const DATE_FORMATS = [
-  ...(TRY_MONTH_DAY_FIRST ? NUMERIC_DOT_FORMATS_MONTH_FIRST : NUMERIC_DOT_FORMATS_DAY_FIRST),
+const REST_DATE_FORMATS = [
   "MMMM dd, yyyy HH:mm", // American written format
   "yyyy-MM-dd HH:mm:ss", // ISO 8601
   "EEEE, d MMMM h:mm a", // Day name, date, 12-hour time (e.g. "Saturday, 31 May 5:26 am")
@@ -68,9 +52,14 @@ const DATE_FORMATS = [
 ] as const;
 
 /**
- * Parse carrier/API date strings; handles ambiguous `dd.MM` vs `MM.dd` using system locale order.
+ * Parse carrier/API date strings; ambiguous `dd.MM` vs `MM.dd` follows extension preference `ambiguousDotDateOrder`.
  */
-function parseDeliveryDate(dateString: string): Date | null {
+function parseDeliveryDate(dateString: string, ambiguousNumericMonthFirst: boolean): Date | null {
+  const dateFormats = [
+    ...(ambiguousNumericMonthFirst ? NUMERIC_DOT_FORMATS_MONTH_FIRST : NUMERIC_DOT_FORMATS_DAY_FIRST),
+    ...REST_DATE_FORMATS,
+  ];
+
   const dotSeparatedMatch = dateString.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})(?:\s+(\d{1,2}):(\d{2})(?::(\d{2}))?)?/);
   if (dotSeparatedMatch) {
     const [, first, second, , , , sec] = dotSeparatedMatch;
@@ -89,7 +78,9 @@ function parseDeliveryDate(dateString: string): Date | null {
     } else {
       const americanFmt = hasSeconds ? `MM.dd.yyyy HH:mm:ss` : `MM.dd.yyyy HH:mm`;
       const europeanFmt = hasSeconds ? `dd.MM.yyyy HH:mm:ss` : `dd.MM.yyyy HH:mm`;
-      const [primaryFmt, secondaryFmt] = TRY_MONTH_DAY_FIRST ? [americanFmt, europeanFmt] : [europeanFmt, americanFmt];
+      const [primaryFmt, secondaryFmt] = ambiguousNumericMonthFirst
+        ? [americanFmt, europeanFmt]
+        : [europeanFmt, americanFmt];
       const primary = parse(dateString, primaryFmt, new Date());
       if (isValid(primary)) return primary;
       const secondary = parse(dateString, secondaryFmt, new Date());
@@ -97,7 +88,7 @@ function parseDeliveryDate(dateString: string): Date | null {
     }
   }
 
-  for (const fmt of DATE_FORMATS) {
+  for (const fmt of dateFormats) {
     const date = parse(dateString, fmt, new Date());
     if (isValid(date)) return date;
   }
@@ -106,6 +97,8 @@ function parseDeliveryDate(dateString: string): Date | null {
 
 export default function Command() {
   const [filterMode, setFilterMode] = useState<FilterMode>(FilterMode.ACTIVE);
+  const { ambiguousDotDateOrder } = getPreferenceValues<ParcelCommandPreferences>();
+  const ambiguousNumericMonthFirst = ambiguousDotDateOrder !== "day_month";
   const { deliveries, isLoading, error } = useDeliveries(filterMode);
   const { carriers } = useCarriers();
 
@@ -128,7 +121,7 @@ export default function Command() {
    */
   const getDaysUntilDelivery = (delivery: Delivery): number | null => {
     if (!delivery.date_expected) return null;
-    const parsed = parseDeliveryDate(delivery.date_expected);
+    const parsed = parseDeliveryDate(delivery.date_expected, ambiguousNumericMonthFirst);
     if (!parsed) return null;
     const deliveryDate = parsed;
     const today = new Date();
@@ -150,7 +143,7 @@ export default function Command() {
     // Check if the original string contains time information
     const hasTimeInfo = /[0-9]{1,2}:[0-9]{2}/.test(dateString) || /[0-9]{1,2}:[0-9]{2} [AP]M/i.test(dateString);
 
-    const date = parseDeliveryDate(dateString);
+    const date = parseDeliveryDate(dateString, ambiguousNumericMonthFirst);
     if (!date) {
       console.error(`All supported date formats failed for: ${dateString}`);
       return dateString;
@@ -204,8 +197,10 @@ export default function Command() {
    */
   const formatExpectedDelivery = (delivery: Delivery): string => {
     if (!delivery.date_expected) return "Not available";
-    const start = parseDeliveryDate(delivery.date_expected);
-    const end = delivery.date_expected_end ? parseDeliveryDate(delivery.date_expected_end) : null;
+    const start = parseDeliveryDate(delivery.date_expected, ambiguousNumericMonthFirst);
+    const end = delivery.date_expected_end
+      ? parseDeliveryDate(delivery.date_expected_end, ambiguousNumericMonthFirst)
+      : null;
     if (!start) return "Not available";
 
     const now = new Date();

--- a/extensions/parcel/src/my-deliveries.tsx
+++ b/extensions/parcel/src/my-deliveries.tsx
@@ -17,11 +17,6 @@ import { Delivery, FilterMode, STATUS_DESCRIPTIONS, getStatusIcon } from "./api"
 import { useDeliveries } from "./hooks/useDeliveries";
 import { useCarriers } from "./hooks/useCarriers";
 
-interface ParcelCommandPreferences {
-  apiKey: string;
-  ambiguousDotDateOrder?: "month_day" | "day_month";
-}
-
 /**
  * Placeholder value returned by some carriers when the date is unknown.
  * This is based on observed API responses and may not be exhaustive.
@@ -97,7 +92,7 @@ function parseDeliveryDate(dateString: string, ambiguousNumericMonthFirst: boole
 
 export default function Command() {
   const [filterMode, setFilterMode] = useState<FilterMode>(FilterMode.ACTIVE);
-  const { ambiguousDotDateOrder } = getPreferenceValues<ParcelCommandPreferences>();
+  const { ambiguousDotDateOrder } = getPreferenceValues<Preferences>();
   const ambiguousNumericMonthFirst = ambiguousDotDateOrder !== "day_month";
   const { deliveries, isLoading, error } = useDeliveries(filterMode);
   const { carriers } = useCarriers();

--- a/extensions/parcel/src/my-deliveries.tsx
+++ b/extensions/parcel/src/my-deliveries.tsx
@@ -23,14 +23,42 @@ import { useCarriers } from "./hooks/useCarriers";
 const UNKNOWN_DATE_PLACEHOLDER = "--//--";
 
 /**
+ * Whether the user's locale typically writes numeric dates as month/day (e.g. en-US)
+ * vs day/month (e.g. en-GB). Used to disambiguate `01.02.2025`-style strings.
+ */
+function prefersMonthBeforeDayInNumericLocale(): boolean {
+  const parts = new Intl.DateTimeFormat(undefined, {
+    day: "numeric",
+    month: "numeric",
+  }).formatToParts(new Date(2000, 0, 2));
+  const iMonth = parts.findIndex((p) => p.type === "month");
+  const iDay = parts.findIndex((p) => p.type === "day");
+  if (iMonth === -1 || iDay === -1) return true;
+  return iMonth < iDay;
+}
+
+const TRY_MONTH_DAY_FIRST = prefersMonthBeforeDayInNumericLocale();
+
+const NUMERIC_DOT_FORMATS_MONTH_FIRST = [
+  "MM.dd.yyyy HH:mm:ss",
+  "MM.dd.yyyy HH:mm",
+  "dd.MM.yyyy HH:mm:ss",
+  "dd.MM.yyyy HH:mm",
+] as const;
+
+const NUMERIC_DOT_FORMATS_DAY_FIRST = [
+  "dd.MM.yyyy HH:mm:ss",
+  "dd.MM.yyyy HH:mm",
+  "MM.dd.yyyy HH:mm:ss",
+  "MM.dd.yyyy HH:mm",
+] as const;
+
+/**
  * Supported date formats for parsing delivery dates.
- * American formats (MM.dd.yyyy) are tried before European (dd.MM.yyyy) to handle ambiguous dates correctly.
+ * Dot-separated numeric formats follow the user's locale (US-style vs GB/EU-style) first.
  */
 const DATE_FORMATS = [
-  "MM.dd.yyyy HH:mm:ss", // American with seconds
-  "MM.dd.yyyy HH:mm", // American without seconds
-  "dd.MM.yyyy HH:mm:ss", // European with seconds
-  "dd.MM.yyyy HH:mm", // European without seconds
+  ...(TRY_MONTH_DAY_FIRST ? NUMERIC_DOT_FORMATS_MONTH_FIRST : NUMERIC_DOT_FORMATS_DAY_FIRST),
   "MMMM dd, yyyy HH:mm", // American written format
   "yyyy-MM-dd HH:mm:ss", // ISO 8601
   "EEEE, d MMMM h:mm a", // Day name, date, 12-hour time (e.g. "Saturday, 31 May 5:26 am")
@@ -38,6 +66,43 @@ const DATE_FORMATS = [
   "EEEE d MMMM h:mm a", // Portuguese format (e.g. "domingo 24 agosto 11:23 PM")
   "EEEE d MMMM", // Portuguese format without time (e.g. "domingo 24 agosto")
 ] as const;
+
+/**
+ * Parse carrier/API date strings; handles ambiguous `dd.MM` vs `MM.dd` using system locale order.
+ */
+function parseDeliveryDate(dateString: string): Date | null {
+  const dotSeparatedMatch = dateString.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})(?:\s+(\d{1,2}):(\d{2})(?::(\d{2}))?)?/);
+  if (dotSeparatedMatch) {
+    const [, first, second, , , , sec] = dotSeparatedMatch;
+    const firstNum = parseInt(first, 10);
+    const secondNum = parseInt(second, 10);
+    const hasSeconds = sec !== undefined;
+
+    if (firstNum > 12) {
+      const fmt = hasSeconds ? `dd.MM.yyyy HH:mm:ss` : `dd.MM.yyyy HH:mm`;
+      const date = parse(dateString, fmt, new Date());
+      if (isValid(date)) return date;
+    } else if (secondNum > 12) {
+      const fmt = hasSeconds ? `MM.dd.yyyy HH:mm:ss` : `MM.dd.yyyy HH:mm`;
+      const date = parse(dateString, fmt, new Date());
+      if (isValid(date)) return date;
+    } else {
+      const americanFmt = hasSeconds ? `MM.dd.yyyy HH:mm:ss` : `MM.dd.yyyy HH:mm`;
+      const europeanFmt = hasSeconds ? `dd.MM.yyyy HH:mm:ss` : `dd.MM.yyyy HH:mm`;
+      const [primaryFmt, secondaryFmt] = TRY_MONTH_DAY_FIRST ? [americanFmt, europeanFmt] : [europeanFmt, americanFmt];
+      const primary = parse(dateString, primaryFmt, new Date());
+      if (isValid(primary)) return primary;
+      const secondary = parse(dateString, secondaryFmt, new Date());
+      if (isValid(secondary)) return secondary;
+    }
+  }
+
+  for (const fmt of DATE_FORMATS) {
+    const date = parse(dateString, fmt, new Date());
+    if (isValid(date)) return date;
+  }
+  return null;
+}
 
 export default function Command() {
   const [filterMode, setFilterMode] = useState<FilterMode>(FilterMode.ACTIVE);
@@ -63,63 +128,14 @@ export default function Command() {
    */
   const getDaysUntilDelivery = (delivery: Delivery): number | null => {
     if (!delivery.date_expected) return null;
-    const deliveryDate = new Date(delivery.date_expected);
+    const parsed = parseDeliveryDate(delivery.date_expected);
+    if (!parsed) return null;
+    const deliveryDate = parsed;
     const today = new Date();
     deliveryDate.setHours(0, 0, 0, 0);
     today.setHours(0, 0, 0, 0);
     const diffTime = deliveryDate.getTime() - today.getTime();
     return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-  };
-
-  /**
-   * Try to parse a date string using a set of known formats.
-   * For ambiguous dot-separated dates (MM.dd.yyyy vs dd.MM.yyyy), tries American format first,
-   * then European format, and picks the one that makes chronological sense.
-   *
-   * @param dateString The date string to parse
-   * @returns Date object if valid, otherwise null
-   */
-  const parseDate = (dateString: string): Date | null => {
-    // Handle ambiguous dot-separated dates (MM.dd.yyyy vs dd.MM.yyyy)
-    const dotSeparatedMatch = dateString.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})(?:\s+(\d{1,2}):(\d{2})(?::(\d{2}))?)?/);
-    if (dotSeparatedMatch) {
-      const [, first, second, , , , sec] = dotSeparatedMatch;
-      const firstNum = parseInt(first, 10);
-      const secondNum = parseInt(second, 10);
-      const hasSeconds = sec !== undefined;
-
-      // If first number > 12, it must be European format (dd.MM)
-      if (firstNum > 12) {
-        const fmt = hasSeconds ? `dd.MM.yyyy HH:mm:ss` : `dd.MM.yyyy HH:mm`;
-        const date = parse(dateString, fmt, new Date());
-        if (isValid(date)) return date;
-      }
-      // If second number > 12, it must be American format (MM.dd)
-      else if (secondNum > 12) {
-        const fmt = hasSeconds ? `MM.dd.yyyy HH:mm:ss` : `MM.dd.yyyy HH:mm`;
-        const date = parse(dateString, fmt, new Date());
-        if (isValid(date)) return date;
-      }
-      // Both <= 12, ambiguous - try American first (MM.dd), then European (dd.MM)
-      else {
-        // Try American format first
-        const americanFmt = hasSeconds ? `MM.dd.yyyy HH:mm:ss` : `MM.dd.yyyy HH:mm`;
-        const americanDate = parse(dateString, americanFmt, new Date());
-        if (isValid(americanDate)) return americanDate;
-
-        // Try European format
-        const europeanFmt = hasSeconds ? `dd.MM.yyyy HH:mm:ss` : `dd.MM.yyyy HH:mm`;
-        const europeanDate = parse(dateString, europeanFmt, new Date());
-        if (isValid(europeanDate)) return europeanDate;
-      }
-    }
-
-    // Try all other formats
-    for (const fmt of DATE_FORMATS) {
-      const date = parse(dateString, fmt, new Date());
-      if (isValid(date)) return date;
-    }
-    return null;
   };
 
   /**
@@ -134,7 +150,7 @@ export default function Command() {
     // Check if the original string contains time information
     const hasTimeInfo = /[0-9]{1,2}:[0-9]{2}/.test(dateString) || /[0-9]{1,2}:[0-9]{2} [AP]M/i.test(dateString);
 
-    const date = parseDate(dateString);
+    const date = parseDeliveryDate(dateString);
     if (!date) {
       console.error(`All supported date formats failed for: ${dateString}`);
       return dateString;
@@ -188,8 +204,8 @@ export default function Command() {
    */
   const formatExpectedDelivery = (delivery: Delivery): string => {
     if (!delivery.date_expected) return "Not available";
-    const start = parseDate(delivery.date_expected);
-    const end = delivery.date_expected_end ? parseDate(delivery.date_expected_end) : null;
+    const start = parseDeliveryDate(delivery.date_expected);
+    const end = delivery.date_expected_end ? parseDeliveryDate(delivery.date_expected_end) : null;
     if (!start) return "Not available";
 
     const now = new Date();


### PR DESCRIPTION
## Description

Fixes incorrect parsing of **ambiguous dot-separated dates** (when both groups are ≤ 12) by using the **system locale's month/day order** instead of always preferring US (`MM.dd`) order. Aligns the **expected-delivery day countdown** with the same parser used for displayed dates.

Related to #27763

### What changed

- **`prefersMonthBeforeDayInNumericLocale()`** — Uses `Intl.DateTimeFormat(...).formatToParts()` on a fixed reference date to detect whether the user's locale writes numeric dates **month-first** (e.g. en-US) or **day-first** (e.g. en-GB).
- **Ambiguous `dd.MM` vs `MM.dd`** — For those strings only, try formats in **locale order** first; unambiguous cases (segment > 12) unchanged.
- **`DATE_FORMATS`** — Numeric dot formats are ordered the same way so the fallback loop stays consistent.
- **`getDaysUntilDelivery`** — Uses **`parseDeliveryDate`** instead of `new Date(date_expected)` so list badges match formatted expected dates.

### How to verify

- Set macOS region/locale to **United States** vs **United Kingdom** (or another day-first locale).
- Use a delivery whose API returns an ambiguous dotted date (e.g. `06.07.2025 …`) and confirm the UI and countdown match the intended interpretation for that locale.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)