### PR TITLE
Instagram Media Downloader: Fix gallery downloads, add browser fallback

### DIFF
--- a/extensions/instagram-media-downloader/CHANGELOG.md
+++ b/extensions/instagram-media-downloader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Instagram Media Downloader Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-05-11
 
 - Fix gallery (carousel) posts intermittently failing with `401 Unauthorized` or "No media found" by retrying the GraphQL request with exponential backoff (up to 3 attempts) when Instagram rate-limits an unauthenticated caller. Also adds the `X-IG-App-ID` header and a post-specific `Referer`, both of which Instagram's web client sends.
 - Add an "Open in Browser" action to the failure toast for media downloads. Loading the post in a browser first often clears Instagram's transient rate limit so that retrying the download succeeds.

--- a/extensions/instagram-media-downloader/CHANGELOG.md
+++ b/extensions/instagram-media-downloader/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Fixes] - {PR_MERGE_DATE}
 
-- Fix gallery (carousel) posts intermittently failing with `401 Unauthorized` or "No media found" by retrying the GraphQL request with exponential backoff (up to 4 attempts) when Instagram rate-limits an unauthenticated caller. Also adds the `X-IG-App-ID` header and a post-specific `Referer`, both of which Instagram's web client sends.
+- Fix gallery (carousel) posts intermittently failing with `401 Unauthorized` or "No media found" by retrying the GraphQL request with exponential backoff (up to 3 attempts) when Instagram rate-limits an unauthenticated caller. Also adds the `X-IG-App-ID` header and a post-specific `Referer`, both of which Instagram's web client sends.
 - Add an "Open in Browser" action to the failure toast for media downloads. Loading the post in a browser first often clears Instagram's transient rate limit so that retrying the download succeeds.
 - Add an explicit "Copy Error" action to all failure toasts (replacing `@raycast/utils`'s default "Report Error" action) so users always have a way to capture the failure message.
 - Bump `@raycast/api`, `@raycast/utils`, `axios`, and dev dependencies to their latest versions; drop the redundant `@types/cheerio` stub.

--- a/extensions/instagram-media-downloader/CHANGELOG.md
+++ b/extensions/instagram-media-downloader/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fix gallery (carousel) posts intermittently failing with `401 Unauthorized` or "No media found" by retrying the GraphQL request with exponential backoff (up to 3 attempts) when Instagram rate-limits an unauthenticated caller. Also adds the `X-IG-App-ID` header and a post-specific `Referer`, both of which Instagram's web client sends.
 - Add an "Open in Browser" action to the failure toast for media downloads. Loading the post in a browser first often clears Instagram's transient rate limit so that retrying the download succeeds.
 - Add an explicit "Copy Error" action to all failure toasts (replacing `@raycast/utils`'s default "Report Error" action) so users always have a way to capture the failure message.
-- Bump `@raycast/api`, `@raycast/utils`, `axios`, and dev dependencies to their latest versions; drop the redundant `@types/cheerio` stub.
+- Bump `@raycast/api`, `axios`, and dev dependencies to their latest versions; drop the unused `@raycast/utils` and the redundant `@types/cheerio` stub.
 
 ## [Update] - 2026-02-13
 

--- a/extensions/instagram-media-downloader/CHANGELOG.md
+++ b/extensions/instagram-media-downloader/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Instagram Media Downloader Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Fix gallery (carousel) posts intermittently failing with `401 Unauthorized` or "No media found" by retrying the GraphQL request with exponential backoff (up to 4 attempts) when Instagram rate-limits an unauthenticated caller. Also adds the `X-IG-App-ID` header and a post-specific `Referer`, both of which Instagram's web client sends.
+- Add an "Open in Browser" action to the failure toast for media downloads. Loading the post in a browser first often clears Instagram's transient rate limit so that retrying the download succeeds.
+- Add an explicit "Copy Error" action to all failure toasts (replacing `@raycast/utils`'s default "Report Error" action) so users always have a way to capture the failure message.
+- Bump `@raycast/api`, `@raycast/utils`, `axios`, and dev dependencies to their latest versions; drop the redundant `@types/cheerio` stub.
+
 ## [Update] - 2026-02-13
 
 - Add support for downloading Instagram Reels.

--- a/extensions/instagram-media-downloader/package-lock.json
+++ b/extensions/instagram-media-downloader/package-lock.json
@@ -8,7 +8,6 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.16",
-        "@raycast/utils": "^2.2.4",
         "axios": "^1.16.0",
         "cheerio": "^1.2.0"
       },
@@ -1246,24 +1245,6 @@
         "eslint": ">=8.23.0"
       }
     },
-    "node_modules/@raycast/utils": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.4.tgz",
-      "integrity": "sha512-XkxW5bUZACxl2zP4M6Qtkj9a1nbOKcRBm96BLkJ6O4Q7L/vFSnc+3pPJ/i0ZLVOExx5LJMJY0jnNPo91xqJnFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      },
-      "peerDependencies": {
-        "@raycast/api": ">=1.99.4",
-        "react": ">=19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1934,15 +1915,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/dom-serializer": {

--- a/extensions/instagram-media-downloader/package-lock.json
+++ b/extensions/instagram-media-downloader/package-lock.json
@@ -7,25 +7,24 @@
       "name": "instagram-media-downloader",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.4",
-        "@raycast/utils": "^2.2.2",
-        "@types/cheerio": "^1.0.0",
-        "axios": "^1.13.4",
+        "@raycast/api": "^1.104.16",
+        "@raycast/utils": "^2.2.4",
+        "axios": "^1.16.0",
         "cheerio": "^1.2.0"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
-        "@types/node": "25.2.0",
-        "@types/react": "19.2.10",
+        "@types/node": "^25.6.2",
+        "@types/react": "^19.2.14",
         "eslint": "^9.39.2",
-        "prettier": "^3.8.1",
+        "prettier": "^3.8.3",
         "typescript": "^5.9.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -39,9 +38,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -55,9 +54,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -71,9 +70,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -87,9 +86,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -103,9 +102,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -119,9 +118,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -135,9 +134,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -151,9 +150,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -167,9 +166,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -183,9 +182,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -199,9 +198,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -215,9 +214,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -231,9 +230,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -247,9 +246,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -263,9 +262,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -279,9 +278,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -295,9 +294,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -311,9 +310,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -327,9 +326,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -343,9 +342,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -359,9 +358,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -375,9 +374,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -391,9 +390,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -407,9 +406,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -423,9 +422,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -1047,9 +1046,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.0.tgz",
-      "integrity": "sha512-jteNUQKgJHLHFbbz806aGZqf+RJJ7t4gwF4MYa8fCwCxQ8/klJNWc0MvaJiBebk7Mc+J39mdlsB4XraaCKznFw==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.2.tgz",
+      "integrity": "sha512-LWDalCgy+hYyAkLa9sMIXMXk6ws5RzQhVnkmfXtVIIyEEYigbXQ/9/x+s76p53MiXxNc6SJB7lfwkPF+SdzfMQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -1062,8 +1061,8 @@
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
-        "minimatch": "^9.0.5",
-        "semver": "^7.7.3",
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.0",
         "string-width": "^4.2.3",
         "supports-color": "^8",
         "tinyglobby": "^0.2.14",
@@ -1073,6 +1072,42 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@oclif/plugin-autocomplete": {
@@ -1118,28 +1153,28 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.4",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.4.tgz",
-      "integrity": "sha512-Pz6qmLVfHp1OLKGyzDhFN9IPczG6EiGFIE6pq23SVsYB6lRpfABSVsscnjioa5NAX3cI5/6cz+/nk142ZncupA==",
+      "version": "1.104.16",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.16.tgz",
+      "integrity": "sha512-PFUDslQgRGDhoTVJUDvJylezew6medQ2oZBfOk9HMdB7RfyhyQxZSnqihrRPCMin5FCg30W+M6oTOCwdwbRHRA==",
       "license": "MIT",
       "dependencies": {
-        "@oclif/core": "^4.5.4",
-        "@oclif/plugin-autocomplete": "^3.2.35",
-        "@oclif/plugin-help": "^6.2.33",
-        "@oclif/plugin-not-found": "^3.2.68",
-        "@types/node": "22.13.10",
+        "@oclif/core": "^4.8.4",
+        "@oclif/plugin-autocomplete": "^3.2.40",
+        "@oclif/plugin-help": "^6.2.37",
+        "@oclif/plugin-not-found": "^3.2.74",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
-        "esbuild": "^0.25.10",
+        "esbuild": "^0.27.3",
         "react": "19.0.0"
       },
       "bin": {
         "ray": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.14.0"
+        "node": ">=22.22.2"
       },
       "peerDependencies": {
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "react-devtools": "6.1.1"
       },
@@ -1156,12 +1191,12 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@raycast/api/node_modules/@types/react": {
@@ -1174,9 +1209,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/@raycast/eslint-config": {
@@ -1212,9 +1247,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.2.tgz",
-      "integrity": "sha512-tZcyWCHZvz4L/i1CGEnSZkBoK6wwX1pzlTKjcWWugbrQyG0QCMOxjKJfRC/iNkD+hHaqhMWUj4Y0LNo/NknvFw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.4.tgz",
+      "integrity": "sha512-XkxW5bUZACxl2zP4M6Qtkj9a1nbOKcRBm96BLkJ6O4Q7L/vFSnc+3pPJ/i0ZLVOExx5LJMJY0jnNPo91xqJnFQ==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1227,16 +1262,6 @@
         "react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@types/cheerio": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-1.0.0.tgz",
-      "integrity": "sha512-zAaImHWoh5RY2CLgU2mvg3bl2k3F65B0N5yphuII3ythFLPmJhL7sj1RDu6gSxcgqHlETbr/lhA2OBY+WF1fXQ==",
-      "deprecated": "This is a stub types definition. cheerio provides its own type definitions, so you do not need this installed.",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -1254,19 +1279,19 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
-      "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
-      "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1624,12 +1649,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -2081,9 +2106,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2093,32 +2118,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2950,6 +2975,7 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -3163,9 +3189,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3223,9 +3249,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3425,9 +3451,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/extensions/instagram-media-downloader/package.json
+++ b/extensions/instagram-media-downloader/package.json
@@ -71,18 +71,17 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.104.4",
-    "@raycast/utils": "^2.2.2",
-    "@types/cheerio": "^1.0.0",
-    "axios": "^1.13.4",
+    "@raycast/api": "^1.104.16",
+    "@raycast/utils": "^2.2.4",
+    "axios": "^1.16.0",
     "cheerio": "^1.2.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",
-    "@types/node": "25.2.0",
-    "@types/react": "19.2.10",
+    "@types/node": "^25.6.2",
+    "@types/react": "^19.2.14",
     "eslint": "^9.39.2",
-    "prettier": "^3.8.1",
+    "prettier": "^3.8.3",
     "typescript": "^5.9.3"
   },
   "scripts": {

--- a/extensions/instagram-media-downloader/package.json
+++ b/extensions/instagram-media-downloader/package.json
@@ -72,7 +72,6 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.104.16",
-    "@raycast/utils": "^2.2.4",
     "axios": "^1.16.0",
     "cheerio": "^1.2.0"
   },

--- a/extensions/instagram-media-downloader/src/download-instagram-highlight-story.tsx
+++ b/extensions/instagram-media-downloader/src/download-instagram-highlight-story.tsx
@@ -1,19 +1,19 @@
-import { useState, useEffect } from "react";
 import {
+  Action,
+  ActionPanel,
+  Grid,
+  Icon,
   LaunchProps,
   Toast,
-  showToast,
   getPreferenceValues,
   popToRoot,
-  Grid,
-  ActionPanel,
-  Action,
-  Icon,
+  showToast,
 } from "@raycast/api";
-import { getInstagramHighlightStoryURL, handleDownload } from "./download-media";
+import { existsSync, writeFileSync } from "fs";
 import { homedir } from "os";
-import { writeFileSync, existsSync } from "fs";
 import { join } from "path";
+import { useEffect, useState } from "react";
+import { getInstagramHighlightStoryURL, handleDownload, mediaExtensionAndId, showErrorToast } from "./download-media";
 
 function getUniqueFilePath(folder: string, baseName: string, extension: string): string {
   let filePath = join(folder, `${baseName}${extension}`);
@@ -70,11 +70,8 @@ export default function Command({
 
     try {
       for (const item of selectedItems) {
-        const mediaExtension = item.url.includes(".jpg") ? ".jpg" : ".mp4";
-        const fileId = item.url.includes(".jpg")
-          ? item.url.split(".jpg")[0].split("/").pop()
-          : item.url.split(".mp4")[0].split("/").pop();
-        await handleDownload(item.url, fileId || "instagram-story", downloadFolder, mediaExtension);
+        const { ext, fileId } = mediaExtensionAndId(item.url);
+        await handleDownload(item.url, fileId || "instagram-story", downloadFolder, ext);
       }
       await showToast({
         title: "Success",
@@ -82,11 +79,8 @@ export default function Command({
         style: Toast.Style.Success,
       });
     } catch (error) {
-      await showToast({
-        title: "Error",
-        message: error instanceof Error ? error.message : "Unknown error occurred",
-        style: Toast.Style.Failure,
-      });
+      const message = error instanceof Error ? error.message : "Unknown error occurred";
+      await showErrorToast("Error", message);
     }
   };
 
@@ -103,23 +97,16 @@ export default function Command({
         style: Toast.Style.Success,
       });
     } catch (error) {
-      await showToast({
-        title: "Error",
-        message: error instanceof Error ? error.message : "Unknown error occurred",
-        style: Toast.Style.Failure,
-      });
+      const message = error instanceof Error ? error.message : "Unknown error occurred";
+      await showErrorToast("Error", message);
     }
   };
 
   useEffect(() => {
     const fetchHighlightStory = async () => {
       if (!instagramUrl.includes("instagram.com")) {
-        popToRoot();
-        await showToast({
-          title: "Error",
-          message: "Invalid URL provided. Please provide a valid instagram URL",
-          style: Toast.Style.Failure,
-        });
+        await popToRoot();
+        await showErrorToast("Error", "Invalid URL provided. Please provide a valid instagram URL");
         return;
       }
 
@@ -128,38 +115,33 @@ export default function Command({
         const pathParts = parsedUrl.pathname.replace(/^\/+|\/+$/g, "").split("/");
 
         if (pathParts.length !== 3 || pathParts[0] !== "stories" || pathParts[1] !== "highlights") {
-          popToRoot();
-          await showToast({
-            title: "Error",
-            message: "Invalid Instagram highlight story URL format.",
-            style: Toast.Style.Failure,
-          });
+          await popToRoot();
+          await showErrorToast("Error", "Invalid Instagram highlight story URL format.");
           return;
         }
 
-        const highlightUrls = await getInstagramHighlightStoryURL(instagramUrl);
+        const fetchedUrls = await getInstagramHighlightStoryURL(instagramUrl);
 
-        if (highlightUrls.length === 0) {
-          popToRoot();
-          await showToast({
-            title: "Error",
-            message: "No highlight story found at the provided URL",
-            style: Toast.Style.Failure,
-          });
+        if (fetchedUrls === null) {
+          // Helper already showed a failure toast.
+          await popToRoot();
           return;
         }
 
-        highlightUrls.reverse();
+        if (fetchedUrls.length === 0) {
+          await popToRoot();
+          await showErrorToast("Error", "No highlight story found at the provided URL");
+          return;
+        }
 
-        setHighlightUrls(highlightUrls);
+        fetchedUrls.reverse();
+
+        setHighlightUrls(fetchedUrls);
         setIsLoading(false);
       } catch (error) {
-        popToRoot();
-        await showToast({
-          title: "Error",
-          message: error instanceof Error ? error.message : "Unknown error occurred",
-          style: Toast.Style.Failure,
-        });
+        await popToRoot();
+        const message = error instanceof Error ? error.message : "Unknown error occurred";
+        await showErrorToast("Error", message);
       }
     };
 
@@ -234,17 +216,11 @@ export default function Command({
                     icon={Icon.Download}
                     onAction={async () => {
                       try {
-                        const mediaExtension = item.url.includes(".jpg") ? ".jpg" : ".mp4";
-                        const fileId = item.url.includes(".jpg")
-                          ? item.url.split(".jpg")[0].split("/").pop()
-                          : item.url.split(".mp4")[0].split("/").pop();
-                        await handleDownload(item.url, fileId || "instagram-story", downloadFolder, mediaExtension);
+                        const { ext, fileId } = mediaExtensionAndId(item.url);
+                        await handleDownload(item.url, fileId || "instagram-story", downloadFolder, ext);
                       } catch (error) {
-                        await showToast({
-                          title: "Error",
-                          message: error instanceof Error ? error.message : "Unknown error occurred",
-                          style: Toast.Style.Failure,
-                        });
+                        const message = error instanceof Error ? error.message : "Unknown error occurred";
+                        await showErrorToast("Error", message);
                       }
                     }}
                     shortcut={{
@@ -265,11 +241,8 @@ export default function Command({
                           style: Toast.Style.Success,
                         });
                       } catch (error) {
-                        await showToast({
-                          title: "Error",
-                          message: error instanceof Error ? error.message : "Unknown error occurred",
-                          style: Toast.Style.Failure,
-                        });
+                        const message = error instanceof Error ? error.message : "Unknown error occurred";
+                        await showErrorToast("Error", message);
                       }
                     }}
                     shortcut={{

--- a/extensions/instagram-media-downloader/src/download-instagram-media.tsx
+++ b/extensions/instagram-media-downloader/src/download-instagram-media.tsx
@@ -1,6 +1,6 @@
-import { LaunchProps, Toast, showToast, getPreferenceValues } from "@raycast/api";
-import { getInstagramMediaURLByGraphQL, handleDownload } from "./download-media";
+import { getPreferenceValues, LaunchProps, showToast, Toast } from "@raycast/api";
 import { homedir } from "os";
+import { getInstagramMediaURLByGraphQL, handleDownload, mediaExtensionAndId, showErrorToast } from "./download-media";
 
 export default async function Command({
   arguments: { instagramUrl },
@@ -11,11 +11,7 @@ export default async function Command({
   const downloadFolder = mediaDownloadPath || `${homedir()}/Downloads`;
 
   if (!instagramUrl.includes("instagram.com")) {
-    await showToast({
-      title: "Error",
-      message: "Invalid URL provided. Please provide a valid instagram URL",
-      style: Toast.Style.Failure,
-    });
+    await showErrorToast("Error", "Invalid URL provided. Please provide a valid instagram URL");
     return;
   }
 
@@ -24,38 +20,29 @@ export default async function Command({
     const pathParts = parsedUrl.pathname.replace(/^\/+|\/+$/g, "").split("/");
 
     if (pathParts.length < 2 || !["p", "reel", "reels"].includes(pathParts[0])) {
-      await showToast({
-        title: "Error",
-        message: "Invalid Instagram post or reel URL format.",
-        style: Toast.Style.Failure,
-      });
+      await showErrorToast("Error", "Invalid Instagram post or reel URL format.");
       return;
     }
 
     const shortcode = pathParts[1];
 
-    await showToast({
+    const fetchToast = await showToast({
       title: "Fetching Media",
       style: Toast.Style.Animated,
     });
 
-    const instagramMedias = await getInstagramMediaURLByGraphQL(shortcode);
+    const instagramMedias = await getInstagramMediaURLByGraphQL(shortcode, fetchToast, instagramUrl);
     if (!instagramMedias) {
-      throw new Error("No media found at the provided URL");
+      // Helper already showed a failure toast.
+      return;
     }
 
     for (const media of instagramMedias) {
-      const mediaExtension = media.includes(".jpg") ? ".jpg" : ".mp4";
-      const fileId = media.includes(".jpg")
-        ? media.split(".jpg")[0].split("/").pop()
-        : media.split(".mp4")[0].split("/").pop();
-      await handleDownload(media, fileId, downloadFolder, mediaExtension);
+      const { ext, fileId } = mediaExtensionAndId(media);
+      await handleDownload(media, fileId || "instagram-media", downloadFolder, ext);
     }
   } catch (error) {
-    await showToast({
-      title: "Error",
-      message: error instanceof Error ? error.message : "Unknown error occurred",
-      style: Toast.Style.Failure,
-    });
+    const message = error instanceof Error ? error.message : "Unknown error occurred";
+    await showErrorToast("Error", message);
   }
 }

--- a/extensions/instagram-media-downloader/src/download-instagram-story.tsx
+++ b/extensions/instagram-media-downloader/src/download-instagram-story.tsx
@@ -1,6 +1,6 @@
-import { LaunchProps, Toast, showToast, getPreferenceValues } from "@raycast/api";
-import { getInstagramStoryURL, handleDownload } from "./download-media";
+import { getPreferenceValues, LaunchProps, showToast, Toast } from "@raycast/api";
 import { homedir } from "os";
+import { getInstagramStoryURL, handleDownload, mediaExtensionAndId, showErrorToast } from "./download-media";
 
 export default async function Command({
   arguments: { instagramUrl },
@@ -11,11 +11,7 @@ export default async function Command({
   const downloadFolder = mediaDownloadPath || `${homedir()}/Downloads`;
 
   if (!instagramUrl.includes("instagram.com")) {
-    await showToast({
-      title: "Error",
-      message: "Invalid URL provided. Please provide a valid instagram URL",
-      style: Toast.Style.Failure,
-    });
+    await showErrorToast("Error", "Invalid URL provided. Please provide a valid instagram URL");
     return;
   }
 
@@ -24,18 +20,10 @@ export default async function Command({
     const pathParts = parsedUrl.pathname.replace(/^\/+|\/+$/g, "").split("/");
 
     if ((pathParts.length !== 2 && pathParts.length !== 3) || pathParts[0] !== "stories") {
-      await showToast({
-        title: "Error",
-        message: "Invalid Instagram story URL format.",
-        style: Toast.Style.Failure,
-      });
+      await showErrorToast("Error", "Invalid Instagram story URL format.");
       return;
     } else if (instagramUrl.includes("highlights")) {
-      await showToast({
-        title: "Error",
-        message: "Please use the highlight story command to download highlight stories.",
-        style: Toast.Style.Failure,
-      });
+      await showErrorToast("Error", "Please use the highlight story command to download highlight stories.");
       return;
     }
 
@@ -48,8 +36,14 @@ export default async function Command({
 
     const instagramStories = await getInstagramStoryURL(username);
 
-    if (!instagramStories) {
-      throw new Error("No story found at the provided URL");
+    if (instagramStories === null) {
+      // Helper already showed a failure toast.
+      return;
+    }
+
+    if (instagramStories.length === 0) {
+      await showErrorToast("Error", "No story found at the provided URL");
+      return;
     }
 
     let storyUrl = "";
@@ -65,19 +59,14 @@ export default async function Command({
     }
 
     if (!storyUrl) {
-      throw new Error("No story found at the provided URL");
+      await showErrorToast("Error", "No story found at the provided URL");
+      return;
     }
 
-    const mediaExtension = storyUrl.includes(".jpg") ? ".jpg" : ".mp4";
-    const fileId = storyUrl.includes(".jpg")
-      ? storyUrl.split(".jpg")[0].split("/").pop()
-      : storyUrl.split(".mp4")[0].split("/").pop();
-    await handleDownload(storyUrl, fileId || "instagram-story", downloadFolder, mediaExtension);
+    const { ext, fileId } = mediaExtensionAndId(storyUrl);
+    await handleDownload(storyUrl, fileId || "instagram-story", downloadFolder, ext);
   } catch (error) {
-    await showToast({
-      title: "Error",
-      message: error instanceof Error ? error.message : "Unknown error occurred",
-      style: Toast.Style.Failure,
-    });
+    const message = error instanceof Error ? error.message : "Unknown error occurred";
+    await showErrorToast("Error", message);
   }
 }

--- a/extensions/instagram-media-downloader/src/download-media.ts
+++ b/extensions/instagram-media-downloader/src/download-media.ts
@@ -75,23 +75,29 @@ async function fetchInstagramMediaWithRetry(shortcode: string, progressToast?: T
   let lastError: unknown = null;
 
   for (let attempt = 1; attempt <= GRAPHQL_MAX_ATTEMPTS; attempt++) {
+    let response;
     try {
-      const response = await axios.get(`https://www.instagram.com/graphql/query?${params.toString()}`, {
+      response = await axios.get(`https://www.instagram.com/graphql/query?${params.toString()}`, {
         headers,
         validateStatus: (status) => status < 500,
       });
+    } catch (error) {
+      lastError = error;
+    }
 
+    if (response) {
       if (response.status === 200) {
         const media = response.data?.data?.xdt_shortcode_media;
         if (media) return media;
         lastError = new Error("Instagram returned an empty media response (likely rate-limited).");
       } else if (response.status === 401 || response.status === 429) {
         lastError = new Error(`Instagram rate-limit (status ${response.status}).`);
+      } else if (response.status === 400 || response.status === 403 || response.status === 404) {
+        // Post does not exist or is not accessible — don't waste retries.
+        throw new Error(`Instagram returned status ${response.status} — post may be private or deleted.`);
       } else {
         lastError = new Error(`Unexpected status ${response.status} from Instagram.`);
       }
-    } catch (error) {
-      lastError = error;
     }
 
     if (attempt < GRAPHQL_MAX_ATTEMPTS) {

--- a/extensions/instagram-media-downloader/src/download-media.ts
+++ b/extensions/instagram-media-downloader/src/download-media.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
+import { Clipboard, open, showHUD, showToast, Toast } from "@raycast/api";
 import { createWriteStream, existsSync } from "fs";
-import { showToast, Toast, open } from "@raycast/api";
-import { showFailureToast } from "@raycast/utils";
 import * as cheerio from "cheerio";
 
 interface InstagramMediaEdge {
@@ -11,15 +10,56 @@ interface InstagramMediaEdge {
   };
 }
 
-export async function getInstagramMediaURLByGraphQL(shortcode: string) {
-  const docId = "8845758582119845";
-  const variables = {
-    shortcode,
+const GRAPHQL_DOC_ID = "8845758582119845";
+const GRAPHQL_MAX_ATTEMPTS = 3;
+const GRAPHQL_BASE_DELAY_MS = 1000;
+const GRAPHQL_MAX_BACKOFF_MS = 2000;
+
+// Toast `onAction` handlers must `await` their side effects, otherwise the
+// runtime tears the no-view command down before the call reaches the OS.
+export async function showErrorToast(title: string, message: string, openUrl?: string) {
+  const copyAction: Toast.ActionOptions = {
+    title: "Copy Error",
+    onAction: async () => {
+      await Clipboard.copy(`${title}: ${message}`);
+      await showHUD("Copied error to clipboard");
+    },
   };
 
+  const openAction: Toast.ActionOptions | undefined = openUrl
+    ? {
+        title: "Open in Browser",
+        onAction: async () => {
+          await open(openUrl);
+        },
+      }
+    : undefined;
+
+  await showToast({
+    style: Toast.Style.Failure,
+    title,
+    message,
+    primaryAction: openAction ?? copyAction,
+    secondaryAction: openAction ? copyAction : undefined,
+  });
+}
+
+export function mediaExtensionAndId(url: string): { ext: string; fileId: string | undefined } {
+  const ext = url.includes(".jpg") ? ".jpg" : ".mp4";
+  return { ext, fileId: url.split(ext)[0].split("/").pop() };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Instagram throttles unauthenticated callers and intermittently returns 401
+// or a 200 with `xdt_shortcode_media: null`. Both are recoverable with a
+// short backoff — gallery posts are especially sensitive to this.
+async function fetchInstagramMediaWithRetry(shortcode: string, progressToast?: Toast) {
   const params = new URLSearchParams({
-    doc_id: docId,
-    variables: JSON.stringify(variables),
+    doc_id: GRAPHQL_DOC_ID,
+    variables: JSON.stringify({ shortcode }),
   });
 
   const headers = {
@@ -27,16 +67,50 @@ export async function getInstagramMediaURLByGraphQL(shortcode: string) {
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36",
     "X-Requested-With": "XMLHttpRequest",
     "X-Instagram-AJAX": "1",
-    Referer: "https://www.instagram.com/",
+    "X-IG-App-ID": "936619743392459",
+    Referer: `https://www.instagram.com/p/${shortcode}/`,
     Origin: "https://www.instagram.com",
   };
 
+  let lastError: unknown = null;
+
+  for (let attempt = 1; attempt <= GRAPHQL_MAX_ATTEMPTS; attempt++) {
+    try {
+      const response = await axios.get(`https://www.instagram.com/graphql/query?${params.toString()}`, {
+        headers,
+        validateStatus: (status) => status < 500,
+      });
+
+      if (response.status === 200) {
+        const media = response.data?.data?.xdt_shortcode_media;
+        if (media) return media;
+        lastError = new Error("Instagram returned an empty media response (likely rate-limited).");
+      } else if (response.status === 401 || response.status === 429) {
+        lastError = new Error(`Instagram rate-limit (status ${response.status}).`);
+      } else {
+        lastError = new Error(`Unexpected status ${response.status} from Instagram.`);
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (attempt < GRAPHQL_MAX_ATTEMPTS) {
+      const backoff = Math.min(GRAPHQL_BASE_DELAY_MS * Math.pow(2, attempt - 1), GRAPHQL_MAX_BACKOFF_MS);
+      const jitter = Math.floor(Math.random() * 500);
+      const wait = backoff + jitter;
+      if (progressToast) {
+        progressToast.message = `Rate-limited, retrying in ${Math.round(wait / 1000)}s (attempt ${attempt + 1} of ${GRAPHQL_MAX_ATTEMPTS})…`;
+      }
+      await delay(wait);
+    }
+  }
+
+  throw lastError ?? new Error("Failed to fetch Instagram media after multiple attempts.");
+}
+
+export async function getInstagramMediaURLByGraphQL(shortcode: string, progressToast?: Toast, sourceUrl?: string) {
   try {
-    const response = await axios.get(`https://www.instagram.com/graphql/query?${params.toString()}`, { headers });
-
-    const media = response.data?.data?.xdt_shortcode_media;
-
-    if (!media) throw new Error("Invalid response or shortcode not found");
+    const media = await fetchInstagramMediaWithRetry(shortcode, progressToast);
 
     const typenameMap: Record<string, string> = {
       XDTGraphImage: "GraphImage",
@@ -66,12 +140,13 @@ export async function getInstagramMediaURLByGraphQL(shortcode: string) {
 
     return null;
   } catch (error) {
-    showFailureToast(error, { title: "Could not fetch Instagram media" });
+    const message = error instanceof Error ? error.message : "Unknown error";
+    await showErrorToast("Could not fetch Instagram media", message, sourceUrl);
     return null;
   }
 }
 
-export async function getInstagramStoryURL(username: string): Promise<string[]> {
+export async function getInstagramStoryURL(username: string): Promise<string[] | null> {
   try {
     const response = await axios.get(`https://media.mollygram.com/?url=${username}&method=allstories`);
     const $ = cheerio.load(response.data["html"]);
@@ -87,12 +162,13 @@ export async function getInstagramStoryURL(username: string): Promise<string[]> 
 
     return downloadUrls;
   } catch (error) {
-    showFailureToast(error, { title: "Could not fetch Instagram story" });
-    return [];
+    const message = error instanceof Error ? error.message : "Unknown error";
+    await showErrorToast("Could not fetch Instagram story", message);
+    return null;
   }
 }
 
-export async function getInstagramHighlightStoryURL(url: string) {
+export async function getInstagramHighlightStoryURL(url: string): Promise<{ img: string; url: string }[] | null> {
   try {
     const response = await axios.get(`https://media.mollygram.com/?url=${url}`);
     const $ = cheerio.load(response.data["html"]);
@@ -130,8 +206,9 @@ export async function getInstagramHighlightStoryURL(url: string) {
 
     return highlightUrls;
   } catch (error) {
-    showFailureToast(error, { title: "Could not fetch Instagram highlight story" });
-    return [];
+    const message = error instanceof Error ? error.message : "Unknown error";
+    await showErrorToast("Could not fetch Instagram highlight story", message);
+    return null;
   }
 }
 
@@ -182,10 +259,7 @@ export async function handleDownload(mediaUrl: string, mediaId: string, download
       },
     });
   } catch (error) {
-    await showToast({
-      title: "Error While Downloading Media",
-      message: error instanceof Error ? error.message : "Unknown error occurred",
-      style: Toast.Style.Failure,
-    });
+    const message = error instanceof Error ? error.message : "Unknown error occurred";
+    await showErrorToast("Error While Downloading Media", message);
   }
 }


### PR DESCRIPTION
## Description

Fixes two issues I hit while using the extension:

1. **Gallery (carousel) downloads fail intermittently.** Pasting a gallery URL like `https://www.instagram.com/p/<shortcode>/` (with or without `?img_index=N`) would surface either `Request failed with status code 401` or `No media found at the provided URL`. Both errors trace to the same root cause: Instagram rate-limits unauthenticated callers to its `graphql/query` endpoint per IP/UA, and the existing code treats the first failure as terminal. Visiting the post in a browser before retrying often clears the rate limit — so the failure was recoverable but invisible to the user.

<img width="410" height="159" alt="image" src="https://github.com/user-attachments/assets/ecb187d7-cfdf-4a94-b1e5-3a68bda0428e" />

   This PR retries the GraphQL request with exponential backoff (3 attempts, capped at ~3.5s total wait, jittered) on `401`, `429`, transient 5xx, and on 200 responses with `xdt_shortcode_media: null`. Non-recoverable statuses (`400`, `403`, `404`) short-circuit so users don't wait through the full backoff for a deleted/private post. The progress toast updates between attempts so the user sees what's happening. Also sends the `X-IG-App-ID` header and a post-specific `Referer` — both are sent by Instagram's own web client and improve the success rate of unauthenticated GraphQL queries.

2. **Failure toasts now have an "Open in Browser" action** that opens the original Instagram URL. As described above, viewing the post in a browser first frequently lets the next retry succeed — this surfaces that workaround as a one-click recovery path on the toast itself. "Copy Error" is the secondary action.

<img width="397" height="229" alt="image" src="https://github.com/user-attachments/assets/ac5dad5b-bca1-4093-993a-6276ba22fc21" />

3. **All failure toasts have an explicit "Copy Error" action.** This replaces `@raycast/utils`'s default "Report Error" `primaryAction` (which is currently broken in a Raycast beta build I'm running). Even outside that bug, "Copy Error" is the [recommended pattern](https://developers.raycast.com) for store extensions.

Also bumps `@raycast/api`, `axios`, and dev dependencies to their current latest versions, and drops the unused `@raycast/utils` (no longer imported after the `showFailureToast` migration) and the redundant `@types/cheerio` stub (cheerio ships its own types now).

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and `npm run lint` and both pass
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)