### PR TITLE
Copy Path: Support QSpace Pro

### DIFF
--- a/extensions/copy-path/CHANGELOG.md
+++ b/extensions/copy-path/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Copy Path Changelog
 
+## [Support QSpace Pro] - {PR_MERGE_DATE}
+
+- Support copying selected item paths and the current location from QSpace Pro.
+
 ## [Fix browser support] - 2025-08-28
 
 - Fix support for browsers.

--- a/extensions/copy-path/CHANGELOG.md
+++ b/extensions/copy-path/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Copy Path Changelog
 
-## [Support QSpace Pro] - {PR_MERGE_DATE}
+## [Support QSpace Pro] - 2026-05-11
 
 - Support copying selected item paths and the current location from QSpace Pro.
 

--- a/extensions/copy-path/README.md
+++ b/extensions/copy-path/README.md
@@ -8,6 +8,7 @@ Copy path of the selected file or the current Finder window.
 
 - Priority detection of the selected files.
 - If no files are detected, detect the path of the window where the Finder currently gets focus.
+- Support QSpace Pro, including selected items on QSpace Desktop and the current QSpace location.
 
 ## ✨Feature 2
 

--- a/extensions/copy-path/src/copy-path.tsx
+++ b/extensions/copy-path/src/copy-path.tsx
@@ -1,5 +1,5 @@
 import { closeMainWindow, getFrontmostApplication } from "@raycast/api";
-import { finderBundleId } from "./utils/constants";
+import { finderBundleId, qSpaceBundleId } from "./utils/constants";
 import {
   copyFinderPath,
   copyBrowserTabUrl,
@@ -7,6 +7,7 @@ import {
   isEmpty,
   copyUnSupportedAppContent,
   copyWindowPath,
+  copyQSpacePath,
 } from "./utils/common-utils";
 
 export default async () => {
@@ -16,6 +17,8 @@ export default async () => {
   if (frontmostApp.bundleId === finderBundleId) {
     // get finder path
     await copyFinderPath();
+  } else if (frontmostApp.bundleId === qSpaceBundleId) {
+    await copyQSpacePath();
   } else {
     const windowPath = await copyWindowPath(frontmostApp);
     if (!isEmpty(windowPath)) {

--- a/extensions/copy-path/src/utils/applescript-utils.ts
+++ b/extensions/copy-path/src/utils/applescript-utils.ts
@@ -21,6 +21,45 @@ export const getFocusFinderPath = async () => {
   }
 };
 
+export const scriptQSpacePath = `
+tell application id "com.jinghaoshe.qspace.pro"
+  set urlList to {}
+
+  try
+    repeat with itemRef in selected items
+      set end of urlList to urlstr of itemRef
+    end repeat
+  end try
+
+  if (count of urlList) = 0 then
+    try
+      repeat with desktopRef in qs desktops
+        repeat with itemRef in selected items of desktopRef
+          set end of urlList to urlstr of itemRef
+        end repeat
+      end repeat
+    end try
+  end if
+
+  if (count of urlList) = 0 then
+    try
+      set end of urlList to urlstr of root item
+    end try
+  end if
+
+  set AppleScript's text item delimiters to linefeed
+  return urlList as text
+end tell
+`;
+
+export const getQSpacePathUrls = async () => {
+  try {
+    return await runAppleScript(scriptQSpacePath);
+  } catch (e) {
+    return "";
+  }
+};
+
 export const scriptWindowPath = (app: Application) => `
 set windowPath to ""
 tell application "System Events"

--- a/extensions/copy-path/src/utils/common-utils.ts
+++ b/extensions/copy-path/src/utils/common-utils.ts
@@ -5,6 +5,7 @@ import {
   getFocusFinderPath,
   getFocusWindowPath,
   getFocusWindowTitle,
+  getQSpacePathUrls,
   getWebkitBrowserPath,
 } from "./applescript-utils";
 import {
@@ -47,6 +48,49 @@ const copyFinerFilesPath = async (fileSystemItems: FileSystemItem[]) => {
     hud: (filePaths.length > 1 ? "📑 " : "📄 ") + filePaths[0],
     path: filePaths.join(multiPathSeparator),
   };
+};
+
+const qSpaceUrlToPath = (url: string) => {
+  if (!url.startsWith("file://")) {
+    return url;
+  }
+
+  try {
+    return decodeURIComponent(new URL(url).pathname);
+  } catch {
+    try {
+      return decodeURIComponent(url.replace(/^file:\/\/(?:localhost)?/, ""));
+    } catch {
+      return url;
+    }
+  }
+};
+
+export const copyQSpacePath = async () => {
+  const { useTildeForHome } = await getPreferenceValues();
+  const urls = await getQSpacePathUrls();
+  const paths = urls
+    .split(/\r?\n/)
+    .map((url) => url.trim())
+    .filter(Boolean)
+    .map(qSpaceUrlToPath);
+
+  if (paths.length === 0) {
+    return "";
+  }
+
+  let path = paths.join(multiPathSeparator);
+  let hud = (paths.length > 1 ? "📑 " : "📂 ") + paths[0];
+
+  if (useTildeForHome) {
+    path = path.replace(os.homedir(), "~");
+    hud = hud.replace(os.homedir(), "~");
+  }
+
+  await Clipboard.copy(path);
+  await showSuccessHUD(hud);
+  await customUpdateCommandMetadata(path.replace(os.homedir(), "~"));
+  return path;
 };
 
 export const copyFinderPath = async () => {

--- a/extensions/copy-path/src/utils/common-utils.ts
+++ b/extensions/copy-path/src/utils/common-utils.ts
@@ -76,6 +76,7 @@ export const copyQSpacePath = async () => {
     .map(qSpaceUrlToPath);
 
   if (paths.length === 0) {
+    await showFailureHUD({ title: "Nothing to Copy", style: Toast.Style.Failure });
     return "";
   }
 

--- a/extensions/copy-path/src/utils/constants.ts
+++ b/extensions/copy-path/src/utils/constants.ts
@@ -1,3 +1,4 @@
 export const finderBundleId = "com.apple.finder";
+export const qSpaceBundleId = "com.jinghaoshe.qspace.pro";
 
 export const firefoxBrowsers = ["firefox", "zen"];


### PR DESCRIPTION
## Summary
- add QSpace Pro as a supported file manager in Copy Path
- read selected items and the current location through QSpace Pro's AppleScript interface
- support selected items on QSpace Desktop and keep the existing multi-path separator and tilde preferences

## Testing
- `npm run lint`
- `npm run build`
- Tested locally in Raycast development mode with QSpace Pro frontmost, including copying the current folder from a QSpace window.
