### PR TITLE
[Hue] Fix manual bridge IP pairing on multi-bridge networks

### DIFF
--- a/extensions/hue/CHANGELOG.md
+++ b/extensions/hue/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hue Changelog
 
+## [Fix manual bridge IP pairing] - 2026-05-10
+
+- Fix "No bridge ID" failure when pairing using a manually-configured Bridge IP address. The bridge ID is now auto-fetched from `/api/0/config` so the certificate validator has the value it needs. Previously, the manual-IP path was unusable on networks with multiple bridges where auto-discovery picks the wrong one.
+
 ## [Update HTTPS support] - 2025-12-25
 
 - Add CA Certificate

--- a/extensions/hue/CHANGELOG.md
+++ b/extensions/hue/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Hue Changelog
 
-## [Fix manual bridge IP pairing] - 2026-05-10
+## [Fix manual bridge IP pairing] - {PR_MERGE_DATE}
 
 - Fix "No bridge ID" failure when pairing using a manually-configured Bridge IP address. The bridge ID is now auto-fetched from `/api/0/config` so the certificate validator has the value it needs. Previously, the manual-IP path was unusable on networks with multiple bridges where auto-discovery picks the wrong one.
 

--- a/extensions/hue/src/lib/hueBridgeMachine.ts
+++ b/extensions/hue/src/lib/hueBridgeMachine.ts
@@ -8,7 +8,46 @@ import createHueClient from "./createHueClient";
 import { discoverBridgeUsingHuePublicApi, discoverBridgeUsingMdns } from "../helpers/hueNetworking";
 import { linkWithBridge } from "./linkWithBridge";
 import * as net from "net";
+import * as https from "https";
 import Style = Toast.Style;
+
+async function fetchBridgeIdFromIp(ipAddress: string): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    const req = https.request(
+      {
+        hostname: ipAddress,
+        port: 443,
+        path: "/api/0/config",
+        method: "GET",
+        rejectUnauthorized: false,
+        timeout: 5000,
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          try {
+            const config = JSON.parse(data);
+            const bridgeid = config.bridgeid;
+            if (typeof bridgeid === "string" && bridgeid.length > 0) {
+              resolve(bridgeid.toLowerCase());
+              return;
+            }
+          } catch {
+            /* fall through */
+          }
+          resolve(undefined);
+        });
+      },
+    );
+    req.on("error", () => resolve(undefined));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(undefined);
+    });
+    req.end();
+  });
+}
 
 export type HueBridgeState = {
   value: StateValue;
@@ -81,9 +120,20 @@ export default function hueBridgeMachine(
               console.log("Using bridge username from preferences");
             }
 
+            let bridgeId: string | undefined = undefined;
+            if (bridgeIpAddress) {
+              bridgeId = await fetchBridgeIdFromIp(bridgeIpAddress);
+              if (bridgeId) {
+                console.log(`Auto-detected bridge ID ${bridgeId} from manual IP ${bridgeIpAddress}`);
+              } else {
+                console.warn(`Could not fetch bridge ID from ${bridgeIpAddress}/api/0/config`);
+              }
+            }
+
             return {
               bridgeIpAddress: bridgeIpAddress,
               bridgeUsername: bridgeUsername,
+              bridgeId: bridgeId,
             };
           }),
           onDone: {
@@ -91,6 +141,7 @@ export default function hueBridgeMachine(
             actions: assign({
               bridgeIpAddress: ({ event }) => event.output.bridgeIpAddress,
               bridgeUsername: ({ event }) => event.output.bridgeUsername,
+              bridgeId: ({ event }) => event.output.bridgeId,
             }),
           },
           onError: {


### PR DESCRIPTION
## Description

The Hue extension's manual bridge IP preference (`bridgeIpAddress`) is currently unusable as a workaround when auto-discovery picks the wrong bridge. The state machine's `loadingPreferences` step reads only IP and username from preferences — it never populates `bridgeId`, which the TLS certificate validator requires (`HueClient`'s `validateBridgeCertificate` checks `peerCertificate.subject.CN === bridgeId`).

When a manual IP is set with no existing LocalStorage config, the machine routes to `linking`, which immediately throws:

```ts
if (input.bridgeId === undefined) throw Error("No bridge ID");
```

This breaks the manual-IP escape hatch entirely. It's most visible on networks with multiple bridges, where `discoverBridgeUsingHuePublicApi`'s `hueApiResults[0]` can return a different bridge than the user wants — and the manual override that should fix it doesn't work either.

## Fix

In `loadingPreferences`, when a manual `bridgeIpAddress` is set, fetch `https://<ip>/api/0/config` (an unauthenticated endpoint that returns `bridgeid`) and put the result in machine context. Subsequent `linking` and cert validation now have the value they need.

The unauthenticated config call uses `rejectUnauthorized: false` because we don't yet know the bridge ID at that point — same trust model as the existing `discoverBridgeUsingHuePublicApi` path, which trusts whatever `discovery.meethue.com` returns.

## Verification

Repro (before this fix):
1. Have multiple Hue Bridges on the network so `discovery.meethue.com` returns more than one.
2. Note the bridge you want to use is not at index 0.
3. In Raycast → Hue extension preferences, set Bridge IP address (manual) to the desired bridge.
4. Run any Hue command. Result: silent failure / "No bridge ID" in logs.

After this fix:
1. Same setup.
2. Pairing succeeds against the manually-specified bridge. Console logs show `Auto-detected bridge ID <id> from manual IP <ip>`.

Tested against a Hue Bridge Pro (BSB003, firmware 2071318010) that was buried behind two other bridges in the discovery response. Pairing went through cleanly on the first try after the patch.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basic/prepare-an-extension-for-store)
- [x] I read the [Raycast contribution guidelines](https://github.com/raycast/extensions/blob/main/CONTRIBUTING.md)
- [x] I added a CHANGELOG.md entry
- [x] I tested the changes locally