### PR TITLE
[Skills] Standardize open actions across commands

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Skills Changelog
 
+## [Standardize Open Actions] - {PR_MERGE_DATE}
+
+- Standardize **Open on skills.sh** and **Open Repository** actions across Search Skills and Manage Skills
+
 ## [Fix Support Directory Initialization] - 2026-05-11
 
 - Ensure the extension support directory exists before cached hooks run, preventing "Could not create extension support directory" errors on first launch

--- a/extensions/skills/eslint.config.js
+++ b/extensions/skills/eslint.config.js
@@ -10,6 +10,12 @@ module.exports = defineConfig([
     },
     rules: {
       "n/prefer-node-protocol": ["error", { version: ">=16.0.0" }],
+      "@raycast/prefer-title-case": [
+        "warn",
+        {
+          extraFixedCaseWords: ["skills.sh"],
+        },
+      ],
     },
   },
 ]);

--- a/extensions/skills/src/components/InstalledSkillListItem.tsx
+++ b/extensions/skills/src/components/InstalledSkillListItem.tsx
@@ -48,7 +48,7 @@ function InlineDetail({ skill, isSelected }: { skill: InstalledSkill; isSelected
           )}
           {skill.sourceUrl && (
             <List.Item.Detail.Metadata.Link
-              title="Source"
+              title="Repository"
               text={skill.source ?? skill.sourceUrl}
               target={skill.sourceUrl}
             />
@@ -125,10 +125,10 @@ export function InstalledSkillListItem({
             <Action.ShowInFinder path={skill.path} icon={Icon.Finder} />
             {skill.sourceUrl && (
               <Action.OpenInBrowser
-                title="Open on GitHub"
+                title="Open Repository"
                 url={skill.sourceUrl}
                 icon={Icon.Globe}
-                shortcut={{ modifiers: ["cmd"], key: "g" }}
+                shortcut={Keyboard.Shortcut.Common.OpenWith}
               />
             )}
           </ActionPanel.Section>

--- a/extensions/skills/src/components/SkillDetailView.tsx
+++ b/extensions/skills/src/components/SkillDetailView.tsx
@@ -4,11 +4,11 @@ import {
   type AuditStatus,
   AUDIT_PROVIDER_LABELS,
   buildInstallCommand,
+  buildSkillUrl,
   formatInstalls,
   formatRelativeDate,
   normalizeAllowedTools,
   type Skill,
-  SKILLS_BASE_URL,
 } from "../shared";
 import { useRepoStats } from "../hooks/useRepoStats";
 import { useSkillAudits } from "../hooks/useSkillAudits";
@@ -53,6 +53,8 @@ export function SkillDetailView({ skill, onSkillInstalled }: SkillDetailViewProp
   const installCommand = buildInstallCommand(skill);
   const allowedTools = normalizeAllowedTools(frontmatter["allowed-tools"]);
   const shownErrorTimestampRef = useRef<string | undefined>(undefined);
+  const skillUrl = buildSkillUrl(skill.source, skill.skillId);
+
   const refreshSkillStatus = useCallback(async () => {
     await Promise.all([revalidateInstalledSkillMatches(), onSkillInstalled?.()]);
   }, [revalidateInstalledSkillMatches, onSkillInstalled]);
@@ -151,12 +153,8 @@ ${installCommand}
             </Detail.Metadata.TagList>
           )}
           <Detail.Metadata.Separator />
+          <Detail.Metadata.Link title="skills.sh" text={`${skill.source}/${skill.skillId}`} target={skillUrl} />
           <Detail.Metadata.Link title="Repository" text={skill.source} target={`https://github.com/${skill.source}`} />
-          <Detail.Metadata.Link
-            title="View on Skills"
-            text={`${skill.source}/${skill.skillId}`}
-            target={`${SKILLS_BASE_URL}/${skill.source}/${skill.skillId}`}
-          />
           <Detail.Metadata.Separator />
           {audits.results.length > 0 ? (
             audits.results.map((audit) =>
@@ -199,12 +197,18 @@ ${installCommand}
             icon={Icon.Terminal}
             shortcut={Keyboard.Shortcut.Common.Copy}
           />
-          <Action.OpenInBrowser title="Open Repository" url={`https://github.com/${skill.source}`} icon={Icon.Globe} />
           <Action.OpenInBrowser
-            title="Open Skills"
-            url={`${SKILLS_BASE_URL}/${skill.source}/${skill.skillId}`}
-            icon={Icon.Link}
+            // eslint-disable-next-line @raycast/prefer-title-case
+            title="Open on skills.sh"
+            url={skillUrl}
+            icon={Icon.Globe}
             shortcut={Keyboard.Shortcut.Common.Open}
+          />
+          <Action.OpenInBrowser
+            title="Open Repository"
+            url={`https://github.com/${skill.source}`}
+            icon={Icon.Globe}
+            shortcut={Keyboard.Shortcut.Common.OpenWith}
           />
           <OpenSecurityAuditActions audits={audits.results} />
         </ActionPanel>

--- a/extensions/skills/src/components/SkillDetailView.tsx
+++ b/extensions/skills/src/components/SkillDetailView.tsx
@@ -198,7 +198,6 @@ ${installCommand}
             shortcut={Keyboard.Shortcut.Common.Copy}
           />
           <Action.OpenInBrowser
-            // eslint-disable-next-line @raycast/prefer-title-case
             title="Open on skills.sh"
             url={skillUrl}
             icon={Icon.Globe}

--- a/extensions/skills/src/components/SkillListItem.tsx
+++ b/extensions/skills/src/components/SkillListItem.tsx
@@ -1,5 +1,5 @@
 import { Action, ActionPanel, Color, Icon, Keyboard, List } from "@raycast/api";
-import { buildInstallCommand, formatInstalls, type Skill, SKILLS_BASE_URL } from "../shared";
+import { buildInstallCommand, buildSkillUrl, formatInstalls, type Skill } from "../shared";
 import { type InstalledSkillMatch } from "../hooks/useInstalledSkillMatches";
 import { InstallSkillAction } from "./actions/InstallSkillAction";
 import { SkillDetailView } from "./SkillDetailView";
@@ -23,6 +23,7 @@ export function SkillListItem({
   const isInstalled = installedMatch.type === "exact";
   const hasSourceConflict = installedMatch.type === "conflict";
   const installedSource = installedMatch.type === "conflict" ? (installedMatch.source ?? "Unknown source") : undefined;
+  const skillUrl = buildSkillUrl(skill.source, skill.skillId);
 
   const iconValue = isInstalled
     ? { source: Icon.CheckCircle, tintColor: Color.Green }
@@ -64,16 +65,17 @@ export function SkillListItem({
             shortcut={Keyboard.Shortcut.Common.Copy}
           />
           <Action.OpenInBrowser
+            // eslint-disable-next-line @raycast/prefer-title-case
+            title="Open on skills.sh"
+            url={skillUrl}
+            icon={Icon.Globe}
+            shortcut={Keyboard.Shortcut.Common.Open}
+          />
+          <Action.OpenInBrowser
             title="Open Repository"
             url={`https://github.com/${skill.source}`}
             icon={Icon.Globe}
             shortcut={Keyboard.Shortcut.Common.OpenWith}
-          />
-          <Action.OpenInBrowser
-            title="Open Skills"
-            url={`${SKILLS_BASE_URL}/${skill.source}/${skill.skillId}`}
-            icon={Icon.Link}
-            shortcut={Keyboard.Shortcut.Common.Open}
           />
         </ActionPanel>
       }

--- a/extensions/skills/src/components/SkillListItem.tsx
+++ b/extensions/skills/src/components/SkillListItem.tsx
@@ -65,7 +65,6 @@ export function SkillListItem({
             shortcut={Keyboard.Shortcut.Common.Copy}
           />
           <Action.OpenInBrowser
-            // eslint-disable-next-line @raycast/prefer-title-case
             title="Open on skills.sh"
             url={skillUrl}
             icon={Icon.Globe}

--- a/extensions/skills/src/shared.ts
+++ b/extensions/skills/src/shared.ts
@@ -171,6 +171,10 @@ export function buildInstallCommand(skill: Skill): string {
   return `npx skills add ${skill.source}@${skill.skillId}`;
 }
 
+export function buildSkillUrl(source: string, skillId: string): string {
+  return `${SKILLS_BASE_URL}/${source}/${skillId}`;
+}
+
 export function deduplicateSkills(skills: Skill[]): Skill[] {
   const seen = new Set<string>();
   return skills.filter((skill) => {


### PR DESCRIPTION
## Description

The Skills extension has similar open actions across multiple views, but their labels and keyboard shortcuts aren't fully aligned. The repository action is missing a shortcut in some places after it was introduced to search results in #27534. The same action already exists in the "Manage Skills" command, but its title and shortcut are inconsistent with the new action introduced for the "Search Skills" command.

This change standardizes the repository action's title and keyboard shortcut across these views. It keeps skills.sh as the primary destination for opening a skill, preserving the existing `Cmd+O` behavior, while making the repository action a consistent secondary action with `Cmd+Shift+O`.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
