### PR TITLE
[WhatsApp] Open unsaved numbers, default-country preference, import from local DB

### DIFF
--- a/extensions/whatsapp/CHANGELOG.md
+++ b/extensions/whatsapp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # WhatsApp Changelog
 
-## [Enhancements] - {PR_MERGE_DATE}
+## [Enhancements] - 2026-05-16
 - Type a phone number in Open Chat to open it without saving (also offers to save the contact)
 - Added a `Default Country` preference so local phone numbers (e.g. `0530572910`) are accepted alongside international format
 - New `Import Chats from Database` command (macOS) to bulk-import individual chats from the local WhatsApp database

--- a/extensions/whatsapp/CHANGELOG.md
+++ b/extensions/whatsapp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # WhatsApp Changelog
 
+## [Enhancements] - {PR_MERGE_DATE}
+- Type a phone number in Open Chat to open it without saving (also offers to save the contact)
+- Added a `Default Country` preference so local phone numbers (e.g. `0530572910`) are accepted alongside international format
+- New `Import Chats from Database` command (macOS) to bulk-import individual chats from the local WhatsApp database
+
 ## [AI Extension] - 2025-04-05
 - Added AI tools: `add-new-whatsapp-chat`, `add-whatsapp-group`, and `open-chat`
 - Updated Raycast packages to support AI extensions

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -31,6 +31,14 @@
       "subtitle": "WhatsApp",
       "description": "Add existing WhatsApp groups to open them later",
       "mode": "view"
+    },
+    {
+      "name": "import-from-database",
+      "title": "Import Chats from Database",
+      "subtitle": "WhatsApp",
+      "description": "Import chats from the local WhatsApp database on macOS",
+      "mode": "view",
+      "platforms": ["macOS"]
     }
   ],
   "tools": [
@@ -137,6 +145,17 @@
     "Applications",
     "Communication",
     "Productivity"
+  ],
+  "preferences": [
+    {
+      "name": "defaultCountry",
+      "title": "Default Country",
+      "description": "ISO 3166-1 country code (e.g. IL, US, GB) used to parse local phone numbers without a + prefix. Leave empty to require full international format.",
+      "type": "textfield",
+      "required": false,
+      "default": "",
+      "placeholder": "IL"
+    }
   ],
   "dependencies": {
     "@raycast/api": "^1.93.0",

--- a/extensions/whatsapp/src/import-from-database.tsx
+++ b/extensions/whatsapp/src/import-from-database.tsx
@@ -1,0 +1,127 @@
+import { Action, ActionPanel, Icon, List, showToast, Toast } from "@raycast/api";
+import { useEffect, useState } from "react";
+import { nanoid as randomId } from "nanoid";
+import formatTimeDistance from "fromnow";
+import { useWhatsAppChats } from "./utils/use-whatsapp-chats";
+import { isPhoneChat, PhoneChat, WhatsAppChat } from "./utils/types";
+import { DatabaseChat, isDatabaseAvailable, readDatabaseChats } from "./services/readLocalDatabase";
+
+type Filter = "new" | "all";
+
+export default function ImportFromDatabase() {
+  const [chats, setChats] = useWhatsAppChats();
+  const [dbChats, setDbChats] = useState<DatabaseChat[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<Filter>("new");
+
+  useEffect(() => {
+    if (!isDatabaseAvailable()) {
+      setError("WhatsApp database not found at the expected macOS path. Is WhatsApp installed?");
+      setDbChats([]);
+      return;
+    }
+    readDatabaseChats()
+      .then(setDbChats)
+      .catch((e: Error) => {
+        setError(e.message);
+        setDbChats([]);
+      });
+  }, []);
+
+  const existingPhones = new Set(chats.filter(isPhoneChat).map((c) => c.phone));
+  const visibleChats = (dbChats ?? []).filter((c) => filter === "all" || !existingPhones.has(c.phone));
+  const newCount = (dbChats ?? []).filter((c) => !existingPhones.has(c.phone)).length;
+
+  function importChats(toImport: DatabaseChat[]) {
+    const already = new Set(chats.filter(isPhoneChat).map((c) => c.phone));
+    const additions: WhatsAppChat[] = [];
+    for (const c of toImport) {
+      if (already.has(c.phone)) continue;
+      already.add(c.phone);
+      const newChat: PhoneChat = {
+        id: randomId(),
+        name: c.name,
+        phone: c.phone,
+        pinned: false,
+        lastOpened: undefined,
+      };
+      additions.push(newChat);
+    }
+    if (additions.length === 0) {
+      showToast(Toast.Style.Success, "Nothing to import", "All matching chats are already added.");
+      return;
+    }
+    setChats([...chats, ...additions]);
+    showToast(Toast.Style.Success, `Imported ${additions.length} chat${additions.length === 1 ? "" : "s"}`);
+  }
+
+  return (
+    <List
+      isLoading={dbChats === null}
+      searchBarPlaceholder="Filter by name or phone number..."
+      searchBarAccessory={
+        <List.Dropdown tooltip="Filter" value={filter} onChange={(v) => setFilter(v as Filter)}>
+          <List.Dropdown.Item title={`New (${newCount})`} value="new" />
+          <List.Dropdown.Item title={`All (${dbChats?.length ?? 0})`} value="all" />
+        </List.Dropdown>
+      }
+      actions={
+        newCount > 0 ? (
+          <ActionPanel>
+            <Action
+              title={`Import All ${newCount} New Chat${newCount === 1 ? "" : "s"}`}
+              icon={Icon.Download}
+              onAction={() => importChats(dbChats ?? [])}
+            />
+          </ActionPanel>
+        ) : null
+      }
+    >
+      {error ? (
+        <List.EmptyView icon={Icon.Warning} title="Cannot read WhatsApp database" description={error} />
+      ) : dbChats && dbChats.length === 0 ? (
+        <List.EmptyView icon={Icon.Person} title="No chats found in the local database" />
+      ) : (
+        <List.Section
+          title={filter === "new" ? "New Chats" : "All Chats"}
+          subtitle={`${visibleChats.length} chat${visibleChats.length === 1 ? "" : "s"}`}
+        >
+          {visibleChats.map((c) => {
+            const alreadyAdded = existingPhones.has(c.phone);
+            return (
+              <List.Item
+                key={c.phone}
+                title={c.name}
+                subtitle={c.phone}
+                icon={alreadyAdded ? Icon.CheckCircle : Icon.Person}
+                accessories={[
+                  {
+                    text: c.lastMessageAt ? formatTimeDistance(c.lastMessageAt, { suffix: true, max: 1 }) : "",
+                    tooltip: "Last message",
+                  },
+                ]}
+                keywords={[c.phone, c.phone.replace(/\D/g, "")]}
+                actions={
+                  <ActionPanel>
+                    {!alreadyAdded ? (
+                      <Action title="Import This Chat" icon={Icon.Plus} onAction={() => importChats([c])} />
+                    ) : null}
+                    {newCount > 0 ? (
+                      <Action
+                        title={`Import All ${newCount} New Chat${newCount === 1 ? "" : "s"}`}
+                        icon={Icon.Download}
+                        onAction={() => importChats(dbChats ?? [])}
+                      />
+                    ) : null}
+                    <Action.CopyToClipboard title="Copy Phone Number" content={c.phone} />
+                    <Action.CopyToClipboard title="Copy Name" content={c.name} />
+                  </ActionPanel>
+                }
+              />
+            );
+          })}
+        </List.Section>
+      )}
+    </List>
+  );
+}

--- a/extensions/whatsapp/src/import-from-database.tsx
+++ b/extensions/whatsapp/src/import-from-database.tsx
@@ -65,17 +65,6 @@ export default function ImportFromDatabase() {
           <List.Dropdown.Item title={`All (${dbChats?.length ?? 0})`} value="all" />
         </List.Dropdown>
       }
-      actions={
-        newCount > 0 ? (
-          <ActionPanel>
-            <Action
-              title={`Import All ${newCount} New Chat${newCount === 1 ? "" : "s"}`}
-              icon={Icon.Download}
-              onAction={() => importChats(dbChats ?? [])}
-            />
-          </ActionPanel>
-        ) : null
-      }
     >
       {error ? (
         <List.EmptyView icon={Icon.Warning} title="Cannot read WhatsApp database" description={error} />

--- a/extensions/whatsapp/src/open-chat.tsx
+++ b/extensions/whatsapp/src/open-chat.tsx
@@ -48,12 +48,13 @@ export default function ChatList() {
   return (
     <List
       selectedItemId={selectedItemId}
+      filtering={true}
       onSearchTextChange={setSearchText}
       searchBarPlaceholder="Filter by name or enter a phone number..."
     >
       {showUnknownNumber ? (
         <List.Section title="Unknown Number">
-          <UnknownNumberItem phoneNumber={parsedSearchPhone.phoneNumber} />
+          <UnknownNumberItem phoneNumber={parsedSearchPhone.phoneNumber} searchText={searchText} />
         </List.Section>
       ) : null}
       {chats.length === 0 ? (
@@ -145,7 +146,7 @@ function getChatItemProps(chat: WhatsAppChat) {
   }
 }
 
-function UnknownNumberItem({ phoneNumber }: { phoneNumber: string }) {
+function UnknownNumberItem({ phoneNumber, searchText }: { phoneNumber: string; searchText: string }) {
   const digits = phoneNumber.replace(/\D/g, "");
   const appUrl = `whatsapp://send?phone=${digits}&text=`;
   const webUrl = `https://web.whatsapp.com/send?phone=${digits}&text=`;
@@ -155,6 +156,7 @@ function UnknownNumberItem({ phoneNumber }: { phoneNumber: string }) {
       title={phoneNumber}
       subtitle="Not in your chats"
       icon={Icon.PhoneRinging}
+      keywords={[searchText, phoneNumber, digits]}
       actions={
         <ActionPanel>
           <ActionPanel.Section>

--- a/extensions/whatsapp/src/open-chat.tsx
+++ b/extensions/whatsapp/src/open-chat.tsx
@@ -1,17 +1,23 @@
 import { Action, ActionPanel, Alert, confirmAlert, Icon, Keyboard, List } from "@raycast/api";
 import { useWhatsAppChats } from "./utils/use-whatsapp-chats";
-import { isGroupChat, isPhoneChat, WhatsAppChat } from "./utils/types";
+import { isGroupChat, isPhoneChat, PhoneChat, WhatsAppChat } from "./utils/types";
 import WhatsAppPhoneChatForm from "./add-chat";
 import { useState } from "react";
 import WhatsAppGroupChatForm from "./add-existing-group";
 import formatTimeDistance from "fromnow";
+import { parseUserPhone } from "./utils/parsePhone";
 
 export default function ChatList() {
   const [chats, setChats] = useWhatsAppChats();
   const [selectedItemId, setSelectedItemId] = useState<string>();
+  const [searchText, setSearchText] = useState("");
 
   const pinnedChats = chats.filter((chat) => chat.pinned).sort((a, b) => (b.lastOpened || 0) - (a.lastOpened || 0));
   const unpinnedChats = chats.filter((chat) => !chat.pinned).sort((a, b) => (b.lastOpened || 0) - (a.lastOpened || 0));
+
+  const parsedSearchPhone = parseUserPhone(searchText);
+  const showUnknownNumber =
+    parsedSearchPhone.isValid && !chats.some((c) => isPhoneChat(c) && c.phone === parsedSearchPhone.phoneNumber);
 
   function handlePin(chat: WhatsAppChat) {
     const newChats = chats.map((c) => {
@@ -40,7 +46,16 @@ export default function ChatList() {
   }
 
   return (
-    <List selectedItemId={selectedItemId} searchBarPlaceholder="Filter chats by name...">
+    <List
+      selectedItemId={selectedItemId}
+      onSearchTextChange={setSearchText}
+      searchBarPlaceholder="Filter by name or enter a phone number..."
+    >
+      {showUnknownNumber ? (
+        <List.Section title="Unknown Number">
+          <UnknownNumberItem phoneNumber={parsedSearchPhone.phoneNumber} />
+        </List.Section>
+      ) : null}
       {chats.length === 0 ? (
         <List.EmptyView
           icon={Icon.Person}
@@ -128,6 +143,36 @@ function getChatItemProps(chat: WhatsAppChat) {
       form: <WhatsAppGroupChatForm defaultValue={chat} />,
     };
   }
+}
+
+function UnknownNumberItem({ phoneNumber }: { phoneNumber: string }) {
+  const digits = phoneNumber.replace(/\D/g, "");
+  const appUrl = `whatsapp://send?phone=${digits}&text=`;
+  const webUrl = `https://web.whatsapp.com/send?phone=${digits}&text=`;
+  const draftChat: PhoneChat = { id: "", name: "", phone: phoneNumber, pinned: false };
+  return (
+    <List.Item
+      title={phoneNumber}
+      subtitle="Not in your chats"
+      icon={Icon.PhoneRinging}
+      actions={
+        <ActionPanel>
+          <ActionPanel.Section>
+            <Action.OpenInBrowser title="Open in Whatsapp" icon="whatsapp-outline.png" url={appUrl} />
+            <Action.OpenInBrowser title="Open in Web" icon={Icon.Globe} url={webUrl} />
+          </ActionPanel.Section>
+          <ActionPanel.Section>
+            <Action.Push
+              title="Save to Chats"
+              icon={Icon.SaveDocument}
+              target={<WhatsAppPhoneChatForm defaultValue={draftChat} />}
+            />
+            <Action.CopyToClipboard title="Copy Phone Number" content={phoneNumber} />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+    />
+  );
 }
 
 function ChatListItem({ chat, onPinAction, onDeleteChat, onOpenChat }: ChatListItemProps) {

--- a/extensions/whatsapp/src/services/readLocalDatabase.ts
+++ b/extensions/whatsapp/src/services/readLocalDatabase.ts
@@ -1,0 +1,74 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { homedir, platform } from "os";
+import { existsSync } from "fs";
+import { join } from "path";
+import { phone as parsePhone } from "phone";
+
+const execFileAsync = promisify(execFile);
+
+export interface DatabaseChat {
+  name: string;
+  /** E.164 phone number (e.g. "+15551234567") */
+  phone: string;
+  /** Apple Core Data timestamp in ms since epoch, or null. */
+  lastMessageAt: number | null;
+}
+
+export function getDatabasePath(): string | null {
+  if (platform() === "darwin") {
+    return join(homedir(), "Library/Group Containers/group.net.whatsapp.WhatsApp.shared/ChatStorage.sqlite");
+  }
+  return null;
+}
+
+export function isDatabaseAvailable(): boolean {
+  const path = getDatabasePath();
+  return path !== null && existsSync(path);
+}
+
+/**
+ * Read individual (non-group, non-LID) chats from the local WhatsApp database.
+ * Groups are skipped because the DB stores their internal JID, not the invite
+ * code that the `whatsapp://chat?code=...` deep link requires.
+ * @lid chats are skipped because they're WhatsApp's pseudo-IDs for hidden
+ * numbers, not real phone numbers we can dial.
+ */
+export async function readDatabaseChats(): Promise<DatabaseChat[]> {
+  const dbPath = getDatabasePath();
+  if (!dbPath || !existsSync(dbPath)) {
+    throw new Error("WhatsApp database not found. This command only works on macOS with WhatsApp installed.");
+  }
+
+  const query = `
+    SELECT
+      ZPARTNERNAME as name,
+      ZCONTACTJID as jid,
+      ZLASTMESSAGEDATE as last_msg
+    FROM ZWACHATSESSION
+    WHERE ZPARTNERNAME IS NOT NULL
+      AND ZSESSIONTYPE = 0
+      AND ZCONTACTJID LIKE '%@s.whatsapp.net'
+    ORDER BY ZLASTMESSAGEDATE DESC
+  `.trim();
+
+  const { stdout } = await execFileAsync("/usr/bin/sqlite3", ["-readonly", "-json", dbPath, query], {
+    maxBuffer: 32 * 1024 * 1024,
+  });
+
+  if (!stdout.trim()) return [];
+
+  const rows = JSON.parse(stdout) as Array<{ name: string; jid: string; last_msg: number | null }>;
+
+  const chats: DatabaseChat[] = [];
+  for (const row of rows) {
+    const digits = row.jid.split("@")[0];
+    if (!digits || !/^\d+$/.test(digits)) continue;
+    const parsed = parsePhone("+" + digits);
+    if (!parsed.isValid) continue;
+    // Core Data timestamps are seconds since 2001-01-01 UTC.
+    const lastMessageAt = row.last_msg != null ? Math.round((row.last_msg + 978307200) * 1000) : null;
+    chats.push({ name: row.name, phone: parsed.phoneNumber, lastMessageAt });
+  }
+  return chats;
+}

--- a/extensions/whatsapp/src/services/saveChat.ts
+++ b/extensions/whatsapp/src/services/saveChat.ts
@@ -1,5 +1,5 @@
 import { isPhoneChat, WhatsAppChat, PhoneChat } from "../utils/types";
-import { phone as parsePhone } from "phone";
+import { parseUserPhone } from "../utils/parsePhone";
 import { nanoid as randomId } from "nanoid";
 
 interface SaveChatProps {
@@ -9,7 +9,7 @@ interface SaveChatProps {
 }
 
 export async function saveChat({ chat, chats, setChats }: SaveChatProps) {
-  const phoneInformation = parsePhone(chat.phone);
+  const phoneInformation = parseUserPhone(chat.phone);
 
   const isCreation = !chat.id;
 

--- a/extensions/whatsapp/src/utils/parsePhone.ts
+++ b/extensions/whatsapp/src/utils/parsePhone.ts
@@ -1,0 +1,24 @@
+import { getPreferenceValues } from "@raycast/api";
+import { phone as parsePhone } from "phone";
+
+type Preferences = {
+  defaultCountry?: string;
+};
+
+/**
+ * Parse a user-entered phone number using the configured default country.
+ * If the input already starts with "+" we treat it as international and ignore
+ * the preference (so an IL user can still paste a US +1 number).
+ */
+export function parseUserPhone(input: string): ReturnType<typeof parsePhone> {
+  const trimmed = input.trim();
+  if (trimmed.startsWith("+")) {
+    return parsePhone(trimmed);
+  }
+  const { defaultCountry } = getPreferenceValues<Preferences>();
+  const country = defaultCountry?.trim().toUpperCase();
+  if (country) {
+    return parsePhone(trimmed, { country });
+  }
+  return parsePhone(trimmed);
+}

--- a/extensions/whatsapp/src/utils/parsePhone.ts
+++ b/extensions/whatsapp/src/utils/parsePhone.ts
@@ -1,10 +1,6 @@
 import { getPreferenceValues } from "@raycast/api";
 import { phone as parsePhone } from "phone";
 
-type Preferences = {
-  defaultCountry?: string;
-};
-
 /**
  * Parse a user-entered phone number using the configured default country.
  * If the input already starts with "+" we treat it as international and ignore
@@ -16,7 +12,7 @@ export function parseUserPhone(input: string): ReturnType<typeof parsePhone> {
     return parsePhone(trimmed);
   }
   const { defaultCountry } = getPreferenceValues<Preferences>();
-  const country = defaultCountry?.trim().toUpperCase();
+  const country = defaultCountry.trim().toUpperCase();
   if (country) {
     return parsePhone(trimmed, { country });
   }

--- a/extensions/whatsapp/tsconfig.json
+++ b/extensions/whatsapp/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node 16",
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "raycast-env.d.ts"],
   "compilerOptions": {
     "lib": ["es2020"],
     "module": "commonjs",


### PR DESCRIPTION
## Description

Three quality-of-life improvements to the WhatsApp extension:

**Open Chat by phone number, even if unsaved.** Typing a phone number into the Open Chat search bar surfaces an item that opens WhatsApp directly via `whatsapp://send?phone=...`. Secondary action saves the number to the chat list.

**`Default Country` preference.** ISO 3166-1 alpha-2 (e.g. `IL`, `US`, `GB`). When set, local-format numbers like `0530572910` are accepted everywhere the extension parses user-entered phone numbers (Open Chat search, Add Chat form, AI tool). Inputs that start with `+` still parse as international regardless of the preference, so cross-country numbers work either way.

**`Import Chats from Database` command (macOS).** Reads individual chats from `~/Library/Group Containers/group.net.whatsapp.WhatsApp.shared/ChatStorage.sqlite` via the system `sqlite3` binary (no native deps, readonly + WAL so it works while WhatsApp is open). Lists chats with status indicators for already-imported, supports per-item import and bulk "Import All New". Groups and `@lid` pseudo-IDs are skipped — neither has a usable identifier for the `whatsapp://` URL scheme.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our metadata tool