### PR TITLE
[Obsidian Tasks] Add Quick Add Task command

### DIFF
--- a/extensions/obsidian-tasks/CHANGELOG.md
+++ b/extensions/obsidian-tasks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Obsidian Tasks Changelog
 
+## [Add Quick Add Task command] - {PR_MERGE_DATE}
+
+- Add a no-view Quick Add Task command with inline reminder, date, and tags arguments.
+
 ## [Append priority instead of prepend] - 2025-10-16
 - Update taskFormatter to append priority icon instead of prepending it. Prepending causes Obsidian to treat it
   as part of the description rather than as the priority. Appending it resolves this, allowing for searching

--- a/extensions/obsidian-tasks/CHANGELOG.md
+++ b/extensions/obsidian-tasks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Obsidian Tasks Changelog
 
-## [Add Quick Add Task command] - {PR_MERGE_DATE}
+## [Add Quick Add Task command] - 2026-06-01
 
 - Add a no-view Quick Add Task command with inline reminder, date, and tags arguments.
 

--- a/extensions/obsidian-tasks/package-lock.json
+++ b/extensions/obsidian-tasks/package-lock.json
@@ -8,6 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.94.3",
+        "chrono-node": "^2.9.1",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.0",
         "gray-matter": "^4.0.3"
@@ -1657,6 +1658,15 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
+    },
+    "node_modules/chrono-node": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.9.1.tgz",
+      "integrity": "sha512-nqP8Zp11efCYQIESXPxeDM8ikzN5BDb3Zzou+a66fZq+X2hzKFdsNLQE2/uBAh//BZEMbaMo1eTnagK7hOenAg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/clean-stack": {
       "version": "3.0.1",

--- a/extensions/obsidian-tasks/package.json
+++ b/extensions/obsidian-tasks/package.json
@@ -8,7 +8,8 @@
   "contributors": [
     "elfitaflores",
     "xmok",
-    "ggon"
+    "ggon",
+    "tongy"
   ],
   "license": "MIT",
   "categories": [
@@ -45,6 +46,32 @@
       "title": "Add Task",
       "description": "Add a new task to Obsidian",
       "mode": "view"
+    },
+    {
+      "name": "quick-add-task",
+      "title": "Quick Add Task",
+      "description": "Quickly add a new task to Obsidian",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "description",
+          "placeholder": "Reminder",
+          "type": "text",
+          "required": true
+        },
+        {
+          "name": "date",
+          "placeholder": "Date",
+          "type": "text",
+          "required": false
+        },
+        {
+          "name": "tags",
+          "placeholder": "Tags",
+          "type": "text",
+          "required": false
+        }
+      ]
     },
     {
       "name": "edit-task",
@@ -139,6 +166,7 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.94.3",
+    "chrono-node": "^2.9.1",
     "date-fns": "^2.30.0",
     "fs-extra": "^11.1.0",
     "gray-matter": "^4.0.3"

--- a/extensions/obsidian-tasks/src/quick-add-task.tsx
+++ b/extensions/obsidian-tasks/src/quick-add-task.tsx
@@ -1,0 +1,101 @@
+import { LaunchProps, showToast, Toast } from "@raycast/api";
+import * as chrono from "chrono-node";
+import { addTask } from "./utils/taskOperations";
+
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+const parseIsoDate = (dateText: string): Date | undefined => {
+  const [year, month, day] = dateText.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return undefined;
+  }
+
+  return date;
+};
+
+const toUtcDateOnly = (date: Date): Date => {
+  return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+};
+
+const parseDateArgument = async (dateArgument: string | undefined): Promise<Date | undefined> => {
+  const dateText = dateArgument?.trim();
+
+  if (!dateText) {
+    return undefined;
+  }
+
+  if (ISO_DATE_REGEX.test(dateText)) {
+    const isoDate = parseIsoDate(dateText);
+
+    if (isoDate) {
+      return isoDate;
+    }
+
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Invalid date",
+      message: "Use a valid YYYY-MM-DD date.",
+    });
+    return undefined;
+  }
+
+  const parsedDate = chrono.parseDate(dateText, new Date(), { forwardDate: true });
+
+  if (!parsedDate) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Invalid date",
+      message: "Use YYYY-MM-DD or a natural language date like tomorrow.",
+    });
+    return undefined;
+  }
+
+  return toUtcDateOnly(parsedDate);
+};
+
+const formatInlineTags = (tagsArgument: string | undefined): string => {
+  const tags = tagsArgument
+    ?.split(",")
+    .map((tag) => tag.trim().replace(/^#/, "").replace(/\s+/g, "-"))
+    .filter(Boolean)
+    .map((tag) => `#${tag}`);
+
+  return tags?.length ? ` ${tags.join(" ")}` : "";
+};
+
+export default async function Command(props: LaunchProps<{ arguments: Arguments.QuickAddTask }>) {
+  const description = props.arguments.description.trim();
+
+  if (!description) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Reminder is required",
+    });
+    return;
+  }
+
+  const dateText = props.arguments.date?.trim();
+  const dueDate = await parseDateArgument(dateText);
+
+  if (dateText && !dueDate) {
+    return;
+  }
+
+  const inlineTags = formatInlineTags(props.arguments.tags);
+
+  try {
+    await addTask({
+      description: `${description}${inlineTags}`,
+      completed: false,
+      dueDate,
+    });
+  } catch {
+    return;
+  }
+}


### PR DESCRIPTION
## Description

Adds a new `Quick Add Task` no-view command to the Obsidian Tasks extension.

The command accepts three Raycast Root Search arguments:

- `Reminder` for the task description
- `Date` for an optional due date
- `Tags` for optional comma-separated inline tags

Tasks are still written through the extension's existing `addTask()` pipeline, so file preferences, file writing, toast handling, and menubar refresh behavior remain centralized.

Behavior notes:

- Empty reminders fail before writing.
- Blank dates create tasks without due dates.
- `YYYY-MM-DD` dates are accepted directly and validated as real calendar dates.
- Natural language dates such as `tomorrow` and `next Monday` are parsed with `chrono-node`.
- Parsed dates are normalized to date-only values before writing, matching Obsidian Tasks' date-only `📅 YYYY-MM-DD` format.
- Tags are parsed as comma-separated values, trimmed, stripped of a leading `#`, and appended inline to the description.

Validation performed:

- `npm install`
- `npm run build`
- `npm run lint`
- Manually tested natural language date entry in Raycast.
- Checked early-morning Australia/Brisbane parsing cases to avoid UTC date shift before formatting.

## Screencast

No screencast included. This is a small no-view command addition and was manually tested in Raycast.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
