### PR TITLE
[Warp] Windows support

### DIFF
--- a/extensions/warp/CHANGELOG.md
+++ b/extensions/warp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Warp Changelog
 
+## [Windows Support] - {PR_MERGE_DATE}
+
+- Added Windows platform support.
+- Directory search uses PowerShell on Windows (Spotlight on macOS).
+- "Open in Warp" command retrieves the active File Explorer path on Windows.
+
 ## [Improvements] - 2025-04-23
 
 - Added build preference to select between [Warp](https://www.warp.dev) and [Warp Preview](https://www.warp.dev/blog/warp-preview) Releases.

--- a/extensions/warp/CHANGELOG.md
+++ b/extensions/warp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Warp Changelog
 
-## [Windows Support] - {PR_MERGE_DATE}
+## [Windows Support] - 2026-05-12
 
 - Added Windows platform support.
 - Directory search uses PowerShell on Windows (Spotlight on macOS).

--- a/extensions/warp/package.json
+++ b/extensions/warp/package.json
@@ -99,6 +99,7 @@
     "publish": "ray publish"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ]
 }

--- a/extensions/warp/src/launch-config.tsx
+++ b/extensions/warp/src/launch-config.tsx
@@ -20,8 +20,27 @@ interface SearchResult {
   path: string;
 }
 
-const configPath = ".warp/launch_configurations";
-const fullPath = path.join(os.homedir(), configPath);
+const isWindows = process.platform === "win32";
+
+function getConfigDir(): string {
+  if (isWindows) {
+    const appData = process.env.APPDATA ?? path.join(os.homedir(), "AppData", "Roaming");
+    return path.join(appData, "Warp", "Warp", "data", "tab_configs");
+  }
+  return path.join(os.homedir(), ".warp", "launch_configurations");
+}
+
+const fullPath = getConfigDir();
+const configFilePattern = isWindows ? /\.toml$/i : /\.ya?ml$/i;
+
+function parseConfigName(contents: string, filePath: string): string | null {
+  if (isWindows) {
+    const match = contents.match(/^name\s*=\s*"(.+)"/m);
+    return match ? match[1] : null;
+  }
+  const yaml = YAML.parse(contents);
+  return yaml?.name ?? path.basename(filePath, path.extname(filePath));
+}
 
 export default function Command() {
   const [searchText, setSearchText] = useState("");
@@ -48,7 +67,7 @@ export default function Command() {
     const exists = await fs.stat(fullPath).catch(() => false);
 
     if (exists === false) {
-      return showError("Launch Configuration directory missing", `~/${configPath} wasn't found on your computer!`);
+      return showError("Launch Configuration directory missing", `${fullPath} wasn't found on your computer!`);
     }
 
     const files = await fs.readdir(fullPath).catch(() => null);
@@ -60,16 +79,18 @@ export default function Command() {
       );
     }
 
-    const fileList = await Promise.all(
-      files
-        .filter((file) => file.match(/.y(a)?ml$/g))
-        .map(async (file) => {
-          const contents = await fs.readFile(path.join(fullPath, file), "utf-8");
-          const yaml = YAML.parse(contents);
+    const fileList = (
+      await Promise.all(
+        files
+          .filter((file) => configFilePattern.test(file))
+          .map(async (file) => {
+            const contents = await fs.readFile(path.join(fullPath, file), "utf-8");
+            const name = parseConfigName(contents, file);
 
-          return { name: yaml.name, path: path.join(fullPath, file) };
-        })
-    );
+            return name ? { name, path: path.join(fullPath, file) } : null;
+          })
+      )
+    ).filter((item): item is SearchResult => item !== null);
 
     if (fileList.length === 0) {
       return showError(NO_LAUNCH_CONFIGS_TITLE, NO_LAUNCH_CONFIGS_MESSAGE);
@@ -175,7 +196,7 @@ function SearchListItem({
   return (
     <List.Item
       title={searchResult.name}
-      subtitle={searchResult.path.replace(fullPath + "/", "")}
+      subtitle={searchResult.path.replace(fullPath + path.sep, "")}
       actions={
         <ActionPanel>
           <ActionPanel.Section>
@@ -187,7 +208,7 @@ function SearchListItem({
           </ActionPanel.Section>
           <ActionPanel.Section>
             <Action.ShowInFinder
-              title="Reveal in Finder"
+              title={isWindows ? "Reveal in File Explorer" : "Reveal in Finder"}
               path={searchResult.path}
               shortcut={{ modifiers: ["cmd"], key: "." }}
             />

--- a/extensions/warp/src/launch-config.tsx
+++ b/extensions/warp/src/launch-config.tsx
@@ -35,7 +35,7 @@ const configFilePattern = isWindows ? /\.toml$/i : /\.ya?ml$/i;
 
 function parseConfigName(contents: string, filePath: string): string | null {
   if (isWindows) {
-    const match = contents.match(/^name\s*=\s*"(.+)"/m);
+    const match = contents.match(/^name\s*=\s*["'](.+?)["']/m);
     return match ? match[1] : null;
   }
   const yaml = YAML.parse(contents);

--- a/extensions/warp/src/open-directory.tsx
+++ b/extensions/warp/src/open-directory.tsx
@@ -1,5 +1,5 @@
 import os from "node:os";
-import spotlight from "node-spotlight";
+import { execFile } from "node:child_process";
 import { useRef, useState } from "react";
 import { ActionPanel, Action, List, Icon, showToast, Toast, Keyboard } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
@@ -7,6 +7,27 @@ import { Category, SearchResult } from "./types";
 import useLocalStorage from "./hooks/useLocalStorage";
 import { getNewTabUri, getNewWindowUri } from "./uri";
 import { getAppName } from "./constants";
+
+const isWindows = process.platform === "win32";
+
+function searchDirectoriesWindows(query: string, maxResults: number): Promise<SearchResult[]> {
+  return new Promise((resolve) => {
+    const psCommand = `Get-ChildItem -Path $env:USERPROFILE -Directory -Recurse -Depth 5 -ErrorAction SilentlyContinue | Where-Object { $_.Name -like ('*' + $env:WARP_SEARCH_QUERY + '*') } | Select-Object -First ${maxResults} -ExpandProperty FullName`;
+    const env = { ...process.env, WARP_SEARCH_QUERY: query };
+    execFile("powershell", ["-NoProfile", "-Command", psCommand], { timeout: 15000, env }, (error, stdout) => {
+      if (error || !stdout) {
+        resolve([]);
+        return;
+      }
+      const results = stdout
+        .trim()
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map((p) => ({ name: p.trim().replace(os.homedir(), "~"), path: p.trim() }));
+      resolve(results);
+    });
+  });
+}
 
 export default function Command() {
   const [searchText, setSearchText] = useState("");
@@ -24,24 +45,30 @@ export default function Command() {
         return [];
       }
 
-      const results = await spotlight(query);
+      if (isWindows) {
+        const windowsResults = await searchDirectoriesWindows(searchText, maxResults);
+        setResults(windowsResults);
+      } else {
+        const spotlight = (await import("node-spotlight")).default;
+        const results = await spotlight(query);
 
-      setResults([]);
+        setResults([]);
 
-      let resultsCount = 0;
+        let resultsCount = 0;
 
-      for await (const result of results) {
-        setResults((state) => [...state, { name: result.path.replace(os.homedir(), "~"), path: result.path }]);
+        for await (const result of results) {
+          setResults((state) => [...state, { name: result.path.replace(os.homedir(), "~"), path: result.path }]);
 
-        resultsCount++;
+          resultsCount++;
 
-        if (resultsCount >= maxResults) {
-          abortable?.current?.abort();
-          break;
+          if (resultsCount >= maxResults) {
+            abortable?.current?.abort();
+            break;
+          }
         }
       }
     },
-    [`kind:folders ${searchText}`],
+    [isWindows ? searchText : `kind:folders ${searchText}`],
     {
       abortable,
     }

--- a/extensions/warp/src/open-directory.tsx
+++ b/extensions/warp/src/open-directory.tsx
@@ -46,7 +46,10 @@ export default function Command() {
       }
 
       if (isWindows) {
+        setResults([]);
+        const thisAbort = abortable.current;
         const windowsResults = await searchDirectoriesWindows(searchText, maxResults);
+        if (thisAbort?.signal.aborted) return;
         setResults(windowsResults);
       } else {
         const spotlight = (await import("node-spotlight")).default;

--- a/extensions/warp/src/open-selected-finder-item.tsx
+++ b/extensions/warp/src/open-selected-finder-item.tsx
@@ -1,9 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { execFile } from "node:child_process";
 import { getSelectedFinderItems, showToast, Toast, open, getFrontmostApplication } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
 import { getNewTabUri } from "./uri";
 import { getAppName } from "./constants";
+
+const isWindows = process.platform === "win32";
 
 const getSelectedPathFinderItems = async () => {
   const script = `
@@ -40,7 +43,50 @@ const fallback = async (): Promise<boolean> => {
   return true;
 };
 
-export default async function Command() {
+function getActiveExplorerPath(): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      "powershell",
+      [
+        "-NoProfile",
+        "-Command",
+        `(New-Object -ComObject Shell.Application).Windows() | ForEach-Object { $_.Document.Folder.Self.Path } | Select-Object -First 1`,
+      ],
+      { timeout: 5000 },
+      (error, stdout) => {
+        const p = stdout?.trim();
+        resolve(!error && p ? p : null);
+      }
+    );
+  });
+}
+
+async function windowsCommand() {
+  try {
+    const explorerPath = await getActiveExplorerPath();
+
+    if (explorerPath) {
+      const info = await fs.stat(explorerPath);
+      const dirPath = info.isDirectory() ? explorerPath : path.dirname(explorerPath);
+      await open(getNewTabUri(dirPath));
+      return;
+    }
+
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "No directory found",
+      message: `Please open a folder in File Explorer to open in ${getAppName()}`,
+    });
+  } catch (error) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: `Cannot open selected item in ${getAppName()}`,
+      message: String(error),
+    });
+  }
+}
+
+async function macOSCommand() {
   try {
     let selectedItems: { path: string }[] = [];
 
@@ -80,4 +126,11 @@ export default async function Command() {
       message: String(error),
     });
   }
+}
+
+export default async function Command() {
+  if (isWindows) {
+    return windowsCommand();
+  }
+  return macOSCommand();
 }


### PR DESCRIPTION
## Description

Add Windows platform support to the Warp extension.

### Changes

- **`package.json`**: Added `"windows"` to the `platforms` array.
- **`launch-config.tsx`**: On Windows, Launch Configurations are read from `%APPDATA%\Warp\Warp\data\tab_configs\` (`.toml` files) instead of `~/.warp/launch_configurations/` (`.yaml` files on macOS). The config name is extracted via regex from TOML format.
- **`open-directory.tsx`**: Replaced the static `node-spotlight` import (macOS-only) with a dynamic import. On Windows, directory search uses PowerShell `Get-ChildItem` with the search query passed via environment variable to prevent command injection.
- **`open-selected-finder-item.tsx`**: Split into platform-specific code paths. On Windows, the active File Explorer window path is retrieved via the `Shell.Application` COM object through PowerShell.
- **`new-tab.tsx` / `new-window.tsx`**: No changes needed — `warp://` URI scheme is registered on Windows and works as-is.
- **`CHANGELOG.md`**: Added entry for Windows support.

### Notes

- Warp for Windows stores its Launch Configurations in a different location and format (TOML vs YAML) compared to macOS. This is handled transparently.
- `Action.ShowInFinder` works cross-platform (opens File Explorer on Windows), titles are adapted per platform.

## Screencast

<!-- TODO: Add a screencast showing the extension working on Windows -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)