### PR TITLE
Update default-web-browser-manager extension

### DIFF
--- a/extensions/default-web-browser-manager/CHANGELOG.md
+++ b/extensions/default-web-browser-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Default Web Browser Manager Changelog
 
-## [Add Open Default Browser Command] - {PR_MERGE_DATE}
+## [Add Open Default Browser Command] - 2026-05-11
 
 - Add "Open Default Browser" command to quickly open the current default browser
 

--- a/extensions/default-web-browser-manager/CHANGELOG.md
+++ b/extensions/default-web-browser-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Default Web Browser Manager Changelog
 
+## [Add Open Default Browser Command] - {PR_MERGE_DATE}
+
+- Add "Open Default Browser" command to quickly open the current default browser
+
 ## [Rename Command] - 2025-12-17
 
 - Rename "Choose" to "Set" so it better aligns with the default "System" setting commands

--- a/extensions/default-web-browser-manager/package.json
+++ b/extensions/default-web-browser-manager/package.json
@@ -6,7 +6,8 @@
   "icon": "browser-icon.png",
   "author": "clins1994",
   "contributors": [
-    "pernielsentikaer"
+    "pernielsentikaer",
+    "elfitaflores"
   ],
   "platforms": [
     "macOS"
@@ -21,6 +22,12 @@
       "title": "Set Default Browser",
       "description": "Set your default browser",
       "mode": "view"
+    },
+    {
+      "name": "open-default",
+      "title": "Open Default Browser",
+      "description": "Open your default browser",
+      "mode": "no-view"
     }
   ],
   "dependencies": {

--- a/extensions/default-web-browser-manager/src/open-default.ts
+++ b/extensions/default-web-browser-manager/src/open-default.ts
@@ -1,0 +1,14 @@
+import { getDefaultApplication, showToast, Toast, open } from "@raycast/api";
+
+export default async function Command() {
+  try {
+    const browser = await getDefaultApplication("https://raycast.com");
+    await open(browser.path);
+  } catch (error) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Could not open browser",
+      message: String(error),
+    });
+  }
+}

--- a/extensions/default-web-browser-manager/src/open-default.ts
+++ b/extensions/default-web-browser-manager/src/open-default.ts
@@ -1,14 +1,11 @@
-import { getDefaultApplication, showToast, Toast, open } from "@raycast/api";
+import { getDefaultApplication, open } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
 
 export default async function Command() {
   try {
     const browser = await getDefaultApplication("https://raycast.com");
     await open(browser.path);
   } catch (error) {
-    await showToast({
-      style: Toast.Style.Failure,
-      title: "Could not open browser",
-      message: String(error),
-    });
+    await showFailureToast(error, { title: "Could not open browser" });
   }
 }


### PR DESCRIPTION
## Description

Add `Open Default Browser` command. The purpose of this command is to centralize Raycast configurations in the default browser, for example to assign hotkeys.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
