### PR TITLE
Update open link in specific browser extension

### DIFF
--- a/extensions/open-link-in-specific-browser/CHANGELOG.md
+++ b/extensions/open-link-in-specific-browser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Open Link in Specific Browser Changelog
 
-## [Hide Specific Browsers] - {PR_MERGE_DATE}
+## [Hide Specific Browsers] - 2026-05-12
 
 - Add the ability to hide specific browsers from the list and the menu bar
 

--- a/extensions/open-link-in-specific-browser/CHANGELOG.md
+++ b/extensions/open-link-in-specific-browser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Open Link in Specific Browser Changelog
 
+## [Hide Specific Browsers] - {PR_MERGE_DATE}
+
+- Add the ability to hide specific browsers from the list and the menu bar
+
 ## [New Command] - 2025-03-08
 
 - Add new command: Open selected text in default browser

--- a/extensions/open-link-in-specific-browser/package.json
+++ b/extensions/open-link-in-specific-browser/package.json
@@ -6,7 +6,8 @@
   "icon": "open-link.png",
   "author": "koinzhang",
   "contributors": [
-    "ViGeng"
+    "ViGeng",
+    "ridemountainpig"
   ],
   "categories": [
     "Developer Tools",

--- a/extensions/open-link-in-specific-browser/package.json
+++ b/extensions/open-link-in-specific-browser/package.json
@@ -211,5 +211,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/open-link-in-specific-browser/src/components/action-on-browser.tsx
+++ b/extensions/open-link-in-specific-browser/src/components/action-on-browser.tsx
@@ -1,6 +1,6 @@
 import { ItemInput } from "../utils/input-utils";
 import React from "react";
-import { Action, ActionPanel, Application, Icon } from "@raycast/api";
+import { Action, ActionPanel, Application, Alert, confirmAlert, Icon, Keyboard } from "@raycast/api";
 import { actionIcon, actionOnApplicationItem, actionTitle } from "../utils/open-link-utils";
 import { ActionOpenPreferences } from "./action-open-preferences";
 import { ItemType } from "../types/types";
@@ -13,8 +13,31 @@ export function ActionOnBrowser(props: {
   visitItem: (item: Application) => void;
   resetRanking: (item: Application) => Promise<void>;
   mutate: MutatePromise<ItemInput, undefined>;
+  isHidden?: boolean;
+  showHidden?: boolean;
+  hasHiddenBrowsers?: boolean;
+  onToggleShowHidden?: () => void;
+  onHide?: (browser: Application) => Promise<void>;
+  onUnhide?: (browser: Application) => Promise<void>;
+  onUnhideAll?: () => Promise<void>;
 }) {
-  const { browser, itemInput, visitItem, resetRanking, mutate } = props;
+  const {
+    browser,
+    itemInput,
+    visitItem,
+    resetRanking,
+    mutate,
+    isHidden,
+    showHidden,
+    hasHiddenBrowsers,
+    onToggleShowHidden,
+    onHide,
+    onUnhide,
+    onUnhideAll,
+  } = props;
+
+  const hideShortcut: Keyboard.Shortcut = { modifiers: ["cmd"], key: "h" };
+  const toggleShortcut: Keyboard.Shortcut = { modifiers: ["shift", "cmd"], key: "h" };
 
   return (
     <ActionPanel>
@@ -39,6 +62,56 @@ export function ActionOnBrowser(props: {
       )}
       <ActionPanel.Section>
         <Action.ToggleQuickLook shortcut={{ modifiers: ["cmd"], key: "y" }} />
+      </ActionPanel.Section>
+
+      <ActionPanel.Section>
+        {isHidden
+          ? onUnhide && (
+              <Action
+                title={"Unhide Browser"}
+                icon={Icon.Eye}
+                shortcut={hideShortcut}
+                onAction={async () => {
+                  await onUnhide(browser);
+                }}
+              />
+            )
+          : onHide && (
+              <Action
+                title={"Hide Browser"}
+                icon={Icon.EyeDisabled}
+                shortcut={hideShortcut}
+                onAction={async () => {
+                  const confirmed = await confirmAlert({
+                    title: `Hide ${browser.name}?`,
+                    message: "You can show hidden browsers again from the action menu.",
+                    primaryAction: { title: "Hide", style: Alert.ActionStyle.Destructive },
+                  });
+                  if (confirmed) await onHide(browser);
+                }}
+              />
+            )}
+        {hasHiddenBrowsers && onToggleShowHidden && (
+          <Action
+            title={showHidden ? "Hide Hidden Browsers" : "Show Hidden Browsers"}
+            icon={showHidden ? Icon.EyeDisabled : Icon.Eye}
+            shortcut={toggleShortcut}
+            onAction={onToggleShowHidden}
+          />
+        )}
+        {hasHiddenBrowsers && onUnhideAll && (
+          <Action
+            title={"Unhide All Browsers"}
+            icon={Icon.Eye}
+            onAction={async () => {
+              const confirmed = await confirmAlert({
+                title: "Unhide all browsers?",
+                primaryAction: { title: "Unhide All" },
+              });
+              if (confirmed) await onUnhideAll();
+            }}
+          />
+        )}
       </ActionPanel.Section>
 
       <ActionPanel.Section>

--- a/extensions/open-link-in-specific-browser/src/hooks/useHiddenBrowsers.ts
+++ b/extensions/open-link-in-specific-browser/src/hooks/useHiddenBrowsers.ts
@@ -1,0 +1,24 @@
+import { useLocalStorage } from "@raycast/utils";
+
+export const HIDDEN_BROWSERS_KEY = "hidden-browsers";
+
+export function useHiddenBrowsers() {
+  const { value, setValue, isLoading } = useLocalStorage<string[]>(HIDDEN_BROWSERS_KEY, []);
+  const hiddenBundleIds = value ?? [];
+
+  const hideBrowser = async (bundleId: string) => {
+    if (!bundleId || hiddenBundleIds.includes(bundleId)) return;
+    await setValue([...hiddenBundleIds, bundleId]);
+  };
+
+  const unhideBrowser = async (bundleId: string) => {
+    if (!bundleId) return;
+    await setValue(hiddenBundleIds.filter((id) => id !== bundleId));
+  };
+
+  const unhideAll = async () => {
+    await setValue([]);
+  };
+
+  return { hiddenBundleIds, hideBrowser, unhideBrowser, unhideAll, isLoading };
+}

--- a/extensions/open-link-in-specific-browser/src/open-link-from-menubar.tsx
+++ b/extensions/open-link-in-specific-browser/src/open-link-from-menubar.tsx
@@ -11,8 +11,9 @@ import { useHiddenBrowsers } from "./hooks/useHiddenBrowsers";
 
 export default function OpenLinkInSpecificBrowser() {
   const { data: itemInputRaw } = useItemInput();
-  const { data: browsersRaw, isLoading } = useBrowsers();
-  const { hiddenBundleIds } = useHiddenBrowsers();
+  const { data: browsersRaw, isLoading: isBrowsersLoading } = useBrowsers();
+  const { hiddenBundleIds, isLoading: isHiddenLoading } = useHiddenBrowsers();
+  const isLoading = isBrowsersLoading || isHiddenLoading;
 
   const itemInput = useMemo(() => {
     if (!itemInputRaw) return new ItemInput();

--- a/extensions/open-link-in-specific-browser/src/open-link-from-menubar.tsx
+++ b/extensions/open-link-in-specific-browser/src/open-link-from-menubar.tsx
@@ -7,10 +7,12 @@ import { useItemInput } from "./hooks/useItemInput";
 import { useBrowsers } from "./hooks/useBrowsers";
 import { truncate } from "./utils/common-utils";
 import { unsupportedBrowsers } from "./utils/constants";
+import { useHiddenBrowsers } from "./hooks/useHiddenBrowsers";
 
 export default function OpenLinkInSpecificBrowser() {
   const { data: itemInputRaw } = useItemInput();
   const { data: browsersRaw, isLoading } = useBrowsers();
+  const { hiddenBundleIds } = useHiddenBrowsers();
 
   const itemInput = useMemo(() => {
     if (!itemInputRaw) return new ItemInput();
@@ -19,8 +21,13 @@ export default function OpenLinkInSpecificBrowser() {
 
   const browsers = useMemo(() => {
     if (!browsersRaw) return [];
-    return browsersRaw.filter((browser) => browser.bundleId && unsupportedBrowsers.indexOf(browser.bundleId) === -1);
-  }, [browsersRaw]);
+    return browsersRaw.filter(
+      (browser) =>
+        browser.bundleId &&
+        unsupportedBrowsers.indexOf(browser.bundleId) === -1 &&
+        !hiddenBundleIds.includes(browser.bundleId),
+    );
+  }, [browsersRaw, hiddenBundleIds]);
 
   const { data: sortedBrowsers, visitItem } = useFrecencySorting(browsers, { key: (browsers) => browsers.path });
 

--- a/extensions/open-link-in-specific-browser/src/open-link-in-specific-browser.tsx
+++ b/extensions/open-link-in-specific-browser/src/open-link-in-specific-browser.tsx
@@ -15,9 +15,10 @@ import { useHiddenBrowsers } from "./hooks/useHiddenBrowsers";
 
 export default function OpenLinkInSpecificBrowser() {
   const { data: itemInputRaw, mutate } = useItemInput();
-  const { data: browsersRaw, isLoading } = useBrowsers();
+  const { data: browsersRaw, isLoading: isBrowsersLoading } = useBrowsers();
   const { data: defaultBrowserRaw } = useDefaultBrowsers();
-  const { hiddenBundleIds, hideBrowser, unhideBrowser, unhideAll } = useHiddenBrowsers();
+  const { hiddenBundleIds, hideBrowser, unhideBrowser, unhideAll, isLoading: isHiddenLoading } = useHiddenBrowsers();
+  const isLoading = isBrowsersLoading || isHiddenLoading;
   const [showHidden, setShowHidden] = useState(false);
 
   const itemInput = useMemo(() => {

--- a/extensions/open-link-in-specific-browser/src/open-link-in-specific-browser.tsx
+++ b/extensions/open-link-in-specific-browser/src/open-link-in-specific-browser.tsx
@@ -1,7 +1,7 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { columns, itemInset, layout } from "./types/preferences";
 import { useFrecencySorting } from "@raycast/utils";
-import { Color, Grid, Icon, List } from "@raycast/api";
+import { Application, Color, Grid, Icon, List, showToast, Toast } from "@raycast/api";
 import { OpenLinkInEmptyView } from "./components/open-link-in-empty-view";
 import { ActionOnBrowser } from "./components/action-on-browser";
 import { isEmpty } from "./utils/common-utils";
@@ -11,22 +11,34 @@ import { useBrowsers } from "./hooks/useBrowsers";
 import { useItemInput } from "./hooks/useItemInput";
 import { ItemInput } from "./utils/input-utils";
 import { useDefaultBrowsers } from "./hooks/useDefaultBrowsers";
+import { useHiddenBrowsers } from "./hooks/useHiddenBrowsers";
 
 export default function OpenLinkInSpecificBrowser() {
   const { data: itemInputRaw, mutate } = useItemInput();
   const { data: browsersRaw, isLoading } = useBrowsers();
   const { data: defaultBrowserRaw } = useDefaultBrowsers();
+  const { hiddenBundleIds, hideBrowser, unhideBrowser, unhideAll } = useHiddenBrowsers();
+  const [showHidden, setShowHidden] = useState(false);
 
   const itemInput = useMemo(() => {
     if (!itemInputRaw) return new ItemInput();
     return itemInputRaw;
   }, [itemInputRaw]);
 
-  const browsers = useMemo(() => {
+  const allBrowsers = useMemo(() => {
     if (!browsersRaw) return [];
-
     return browsersRaw.filter((browser) => browser.bundleId && unsupportedBrowsers.indexOf(browser.bundleId) === -1);
   }, [browsersRaw]);
+
+  const visibleBrowsers = useMemo(
+    () => allBrowsers.filter((browser) => !hiddenBundleIds.includes(browser.bundleId ?? "")),
+    [allBrowsers, hiddenBundleIds],
+  );
+
+  const hiddenBrowsers = useMemo(
+    () => allBrowsers.filter((browser) => hiddenBundleIds.includes(browser.bundleId ?? "")),
+    [allBrowsers, hiddenBundleIds],
+  );
 
   const defaultBrowser = useMemo(() => {
     if (!defaultBrowserRaw) return undefined;
@@ -37,7 +49,33 @@ export default function OpenLinkInSpecificBrowser() {
     data: sortedBrowsers,
     visitItem,
     resetRanking,
-  } = useFrecencySorting(browsers, { key: (browsers) => browsers.path });
+  } = useFrecencySorting(visibleBrowsers, { key: (browsers) => browsers.path });
+
+  const handleHide = async (browser: Application) => {
+    if (!browser.bundleId) return;
+    await hideBrowser(browser.bundleId);
+    await showToast({ style: Toast.Style.Success, title: `Hid ${browser.name}` });
+  };
+
+  const handleUnhide = async (browser: Application) => {
+    if (!browser.bundleId) return;
+    await unhideBrowser(browser.bundleId);
+    await showToast({ style: Toast.Style.Success, title: `Unhid ${browser.name}` });
+  };
+
+  const handleUnhideAll = async () => {
+    await unhideAll();
+    await showToast({ style: Toast.Style.Success, title: "Unhid all browsers" });
+  };
+
+  const commonActionProps = {
+    hasHiddenBrowsers: hiddenBrowsers.length > 0,
+    showHidden,
+    onToggleShowHidden: () => setShowHidden((v) => !v),
+    onHide: handleHide,
+    onUnhide: handleUnhide,
+    onUnhideAll: handleUnhideAll,
+  };
 
   return layout === "List" ? (
     <List isLoading={isLoading} searchBarPlaceholder={SEARCH_BAR_PLACEHOLDER}>
@@ -57,11 +95,36 @@ export default function OpenLinkInSpecificBrowser() {
                 visitItem={visitItem}
                 resetRanking={resetRanking}
                 mutate={mutate}
+                {...commonActionProps}
               />
             }
           />
         ))}
       </List.Section>
+      {showHidden && hiddenBrowsers.length > 0 && (
+        <List.Section title="Hidden">
+          {hiddenBrowsers.map((browser) => (
+            <List.Item
+              key={browser.path}
+              title={browser.name}
+              icon={{ fileIcon: browser.path }}
+              accessories={[{ icon: Icon.EyeDisabled, tooltip: "Hidden" }]}
+              quickLook={{ path: browser.path, name: browser.name }}
+              actions={
+                <ActionOnBrowser
+                  browser={browser}
+                  itemInput={itemInput}
+                  visitItem={visitItem}
+                  resetRanking={resetRanking}
+                  mutate={mutate}
+                  isHidden
+                  {...commonActionProps}
+                />
+              }
+            />
+          ))}
+        </List.Section>
+      )}
     </List>
   ) : (
     <Grid
@@ -90,11 +153,36 @@ export default function OpenLinkInSpecificBrowser() {
                 visitItem={visitItem}
                 resetRanking={resetRanking}
                 mutate={mutate}
+                {...commonActionProps}
               />
             }
           />
         ))}
       </Grid.Section>
+      {showHidden && hiddenBrowsers.length > 0 && (
+        <Grid.Section title="Hidden">
+          {hiddenBrowsers.map((browser) => (
+            <Grid.Item
+              key={browser.path}
+              title={browser.name}
+              content={{ fileIcon: browser.path }}
+              quickLook={{ path: browser.path, name: browser.name }}
+              accessory={{ icon: { source: Icon.EyeDisabled, tintColor: Color.SecondaryText }, tooltip: "Hidden" }}
+              actions={
+                <ActionOnBrowser
+                  browser={browser}
+                  itemInput={itemInput}
+                  visitItem={visitItem}
+                  resetRanking={resetRanking}
+                  mutate={mutate}
+                  isHidden
+                  {...commonActionProps}
+                />
+              }
+            />
+          ))}
+        </Grid.Section>
+      )}
     </Grid>
   );
 }


### PR DESCRIPTION
## Description
Add the ability to hide specific browsers from the list and the menu bar. Close #27756.
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1000" height="625" alt="open-link-in-specific-browser 2026-05-12 at 09 36 16" src="https://github.com/user-attachments/assets/a0c5ee66-8fd5-42ab-9157-076487af0609" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
