### PR TITLE
[codex] Fix stale Skills search results

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Skills Changelog
 
-## [Fix Stale Search Results] - {PR_MERGE_DATE}
+## [Fix Stale Search Results] - 2026-05-12
 
 - Clear stale search results when the current search fails or is superseded by a newer query
 
-## [Standardize Open Actions] - {PR_MERGE_DATE}
+## [Standardize Open Actions] - 2026-05-12
 
 - Standardize **Open on skills.sh** and **Open Repository** actions across Search Skills and Manage Skills
 

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Skills Changelog
 
+## [Fix Stale Search Results] - {PR_MERGE_DATE}
+
+- Clear stale search results when the current search fails or is superseded by a newer query
+
 ## [Standardize Open Actions] - {PR_MERGE_DATE}
 
 - Standardize **Open on skills.sh** and **Open Repository** actions across Search Skills and Manage Skills

--- a/extensions/skills/src/hooks/useDebouncedSearch.ts
+++ b/extensions/skills/src/hooks/useDebouncedSearch.ts
@@ -9,6 +9,7 @@ export function useDebouncedSearch(searchText: string, delay = 300) {
   const [error, setError] = useState<Error | undefined>();
   const abortRef = useRef<AbortController | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestQueryRef = useRef("");
 
   const executeSearch = useCallback(async (query: string) => {
     abortRef.current?.abort();
@@ -17,23 +18,31 @@ export function useDebouncedSearch(searchText: string, delay = 300) {
     setIsLoading(true);
     try {
       const result = await fetchSkillsSearch(query, controller.signal);
-      if (!controller.signal.aborted) {
+      if (!controller.signal.aborted && latestQueryRef.current === query) {
         setData(result);
         setError(undefined);
       }
     } catch (e) {
-      if (!controller.signal.aborted && e instanceof Error && e.name !== "AbortError") {
+      if (
+        !controller.signal.aborted &&
+        latestQueryRef.current === query &&
+        e instanceof Error &&
+        e.name !== "AbortError"
+      ) {
+        setData(undefined);
         setError(e);
       }
     } finally {
-      if (!controller.signal.aborted) setIsLoading(false);
+      if (!controller.signal.aborted && latestQueryRef.current === query) setIsLoading(false);
     }
   }, []);
 
   useEffect(() => {
     if (timerRef.current) clearTimeout(timerRef.current);
+    latestQueryRef.current = searchText;
 
     if (searchText.length < 2) {
+      abortRef.current?.abort();
       setData(undefined);
       setIsLoading(false);
       setError(undefined);


### PR DESCRIPTION
## Summary

- guard debounced Skills search state updates so only the latest query can update results, errors, and loading state
- clear stale results when the current search fails
- abort in-flight search requests when the query becomes too short

## Why

A failed search after a previous successful search could leave the old results in state. The UI would then render stale results under the newer query text instead of showing the error state.

## Validation

- npm run lint
- npm run build