### PR TITLE
Update keyraycast extension

### DIFF
--- a/extensions/keyraycast/CHANGELOG.md
+++ b/extensions/keyraycast/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Keystroke Visualizer Extension Changelog
+
+## [Fixes] - {PR_MERGE_DATE}
+
+- Fixed helper startup failures after installing the extension ([#27817](https://github.com/raycast/extensions/issues/27817)).
+- Fixed cases where toggling the overlay off could leave the helper process running.
+- Added checks for the packaged helper binary so missing or non-executable helper files now show a clear error.
+- Improved helper launch behavior by starting the native helper directly instead of through a shell command.
+- Added HyperKey display support so Hyper shortcuts render as ✦ in the overlay.
+
 ## [Initial Release] - 2026-05-11
 
 - Shows keystrokes on screen with floating overlay pills.

--- a/extensions/keyraycast/CHANGELOG.md
+++ b/extensions/keyraycast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Keystroke Visualizer Extension Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-05-12
 
 - Fixed helper startup failures after installing the extension ([#27817](https://github.com/raycast/extensions/issues/27817)).
 - Fixed cases where toggling the overlay off could leave the helper process running.

--- a/extensions/keyraycast/package.json
+++ b/extensions/keyraycast/package.json
@@ -5,6 +5,9 @@
   "description": "Show keystrokes on screen — a modern KeyCastr alternative as a Raycast extension",
   "icon": "command-icon.png",
   "author": "benostein",
+  "contributors": [
+    "0xdhrv"
+  ],
   "license": "MIT",
   "categories": [
     "Productivity",
@@ -210,8 +213,8 @@
   },
   "scripts": {
     "build": "npm run build-helper-universal && ray build -e dist",
-    "build-helper": "cd swift/keyraycast-helper && swift build -c release && cp .build/release/KeyraycastHelper ../../assets/KeyraycastHelper",
-    "build-helper-universal": "cd swift/keyraycast-helper && swift build -c release --arch arm64 --arch x86_64 && cp .build/apple/Products/Release/KeyraycastHelper ../../assets/KeyraycastHelper",
+    "build-helper": "cd swift/keyraycast-helper && swift build -c release --scratch-path ../../.raycast-swift-build/keyraycast-helper && cp ../../.raycast-swift-build/keyraycast-helper/release/KeyraycastHelper ../../assets/KeyraycastHelper",
+    "build-helper-universal": "cd swift/keyraycast-helper && swift build -c release --arch arm64 --arch x86_64 --scratch-path ../../.raycast-swift-build/keyraycast-helper && cp ../../.raycast-swift-build/keyraycast-helper/apple/Products/Release/KeyraycastHelper ../../assets/KeyraycastHelper",
     "predev": "npm run build-helper",
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",

--- a/extensions/keyraycast/src/helper.ts
+++ b/extensions/keyraycast/src/helper.ts
@@ -146,7 +146,7 @@ export async function startOverlay(config: {
 
   // Launch helper as a fully independent background process
   try {
-    const out = fs.openSync(LOG_FILE, "a");
+    const out = fs.openSync(LOG_FILE, "w");
     const child = spawn(
       helperPath,
       ["--config", CONFIG_FILE, "--pid", PID_FILE, "--log", LOG_FILE],

--- a/extensions/keyraycast/src/helper.ts
+++ b/extensions/keyraycast/src/helper.ts
@@ -145,8 +145,9 @@ export async function startOverlay(config: {
   fs.writeFileSync(CONFIG_FILE, JSON.stringify(config));
 
   // Launch helper as a fully independent background process
+  let out: number | null = null;
   try {
-    const out = fs.openSync(LOG_FILE, "w");
+    out = fs.openSync(LOG_FILE, "w");
     const child = spawn(
       helperPath,
       ["--config", CONFIG_FILE, "--pid", PID_FILE, "--log", LOG_FILE],
@@ -156,12 +157,13 @@ export async function startOverlay(config: {
       },
     );
     child.unref();
-    fs.closeSync(out);
   } catch (error) {
     return {
       success: false,
       error: `Helper failed to launch: ${error instanceof Error ? error.message : String(error)}`,
     };
+  } finally {
+    if (out !== null) fs.closeSync(out);
   }
 
   // Poll for helper to start and write its PID (check every 100ms, timeout after 3s)

--- a/extensions/keyraycast/src/helper.ts
+++ b/extensions/keyraycast/src/helper.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync, spawn } from "child_process";
 import { environment } from "@raycast/api";
 import path from "path";
 import fs from "fs";
@@ -10,6 +10,32 @@ const LOG_FILE = path.join(os.tmpdir(), "keyraycast-helper.log");
 
 function getHelperPath(): string {
   return path.join(environment.assetsPath, "KeyraycastHelper");
+}
+
+function prepareHelper(
+  helperPath: string,
+): { success: true } | { success: false; error: string } {
+  if (!fs.existsSync(helperPath)) {
+    return {
+      success: false,
+      error: `Helper binary is missing at ${helperPath}. Rebuild or reinstall the extension.`,
+    };
+  }
+
+  try {
+    fs.accessSync(helperPath, fs.constants.X_OK);
+  } catch {
+    try {
+      fs.chmodSync(helperPath, 0o755);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Helper is not executable: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  return { success: true };
 }
 
 function readPid(): number | null {
@@ -33,7 +59,67 @@ function readPid(): number | null {
 }
 
 export function isRunning(): boolean {
-  return readPid() !== null;
+  return readPid() !== null || findHelperPids().length > 0;
+}
+
+function findHelperPids(): number[] {
+  try {
+    return execFileSync("/usr/bin/pgrep", ["-f", "KeyraycastHelper( |$)"], {
+      encoding: "utf8",
+    })
+      .split("\n")
+      .map((line) => parseInt(line.trim(), 10))
+      .filter((pid) => Number.isInteger(pid) && pid > 0 && pid !== process.pid);
+  } catch {
+    return [];
+  }
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntilStopped(
+  pid: number,
+  attempts: number,
+  delayMs: number,
+): Promise<boolean> {
+  for (let i = 0; i < attempts; i++) {
+    if (!isAlive(pid)) {
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  return !isAlive(pid);
+}
+
+async function terminatePid(pid: number): Promise<void> {
+  if (!isAlive(pid)) {
+    return;
+  }
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    // ignore
+  }
+
+  if (await waitUntilStopped(pid, 50, 40)) {
+    return;
+  }
+
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // ignore
+  }
+
+  await waitUntilStopped(pid, 25, 40);
 }
 
 export async function startOverlay(config: {
@@ -49,18 +135,33 @@ export async function startOverlay(config: {
   await stopOverlay();
 
   const helperPath = getHelperPath();
+  const helperStatus = prepareHelper(helperPath);
+
+  if (!helperStatus.success) {
+    return helperStatus;
+  }
 
   // Write config to temp file
   fs.writeFileSync(CONFIG_FILE, JSON.stringify(config));
 
   // Launch helper as a fully independent background process
   try {
-    execSync(
-      `"${helperPath}" --config "${CONFIG_FILE}" --pid "${PID_FILE}" --log "${LOG_FILE}" &`,
-      { shell: "/bin/zsh", timeout: 2000, stdio: "ignore" },
+    const out = fs.openSync(LOG_FILE, "a");
+    const child = spawn(
+      helperPath,
+      ["--config", CONFIG_FILE, "--pid", PID_FILE, "--log", LOG_FILE],
+      {
+        detached: true,
+        stdio: ["ignore", out, out],
+      },
     );
-  } catch {
-    // Safety net: zsh should exit 0 immediately after backgrounding; catch covers spawn/shell failures.
+    child.unref();
+    fs.closeSync(out);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Helper failed to launch: ${error instanceof Error ? error.message : String(error)}`,
+    };
   }
 
   // Poll for helper to start and write its PID (check every 100ms, timeout after 3s)
@@ -101,26 +202,22 @@ export async function startOverlay(config: {
 }
 
 export async function stopOverlay(): Promise<void> {
+  const pids = new Set<number>();
   const pid = readPid();
   if (pid !== null) {
-    try {
-      process.kill(pid, "SIGTERM");
-    } catch {
-      // ignore
-    }
-    // Wait until the process is gone so restart does not briefly run two helpers.
-    for (let i = 0; i < 100; i++) {
-      try {
-        process.kill(pid, 0);
-      } catch {
-        break;
-      }
-      await new Promise((r) => setTimeout(r, 20));
-    }
-    try {
-      fs.unlinkSync(PID_FILE);
-    } catch {
-      // ignore
-    }
+    pids.add(pid);
+  }
+  for (const helperPid of findHelperPids()) {
+    pids.add(helperPid);
+  }
+
+  for (const helperPid of pids) {
+    await terminatePid(helperPid);
+  }
+
+  try {
+    fs.unlinkSync(PID_FILE);
+  } catch {
+    // ignore
   }
 }

--- a/extensions/keyraycast/swift/keyraycast-helper/Sources/EventTap.swift
+++ b/extensions/keyraycast/swift/keyraycast-helper/Sources/EventTap.swift
@@ -138,12 +138,37 @@ class EventTap {
     private var activeModifiers: CGEventFlags = []
     private var pendingModifierID: UInt64 = 0  // increments to cancel stale modifier displays
 
+    private func isHyper(control: Bool, option: Bool, shift: Bool, command: Bool) -> Bool {
+        // Raycast can emit Hyper as Ctrl+Opt+Cmd, with Shift optional depending on the user's Hyper Key setup.
+        _ = shift
+        return control && option && command
+    }
+
+    private func formatModifiers(control: Bool, option: Bool, shift: Bool, command: Bool) -> String {
+        if isHyper(control: control, option: option, shift: shift, command: command) {
+            return "✦"
+        }
+
+        var modifiers = ""
+        if control { modifiers += "⌃" }
+        if option { modifiers += "⌥" }
+        if shift { modifiers += "⇧" }
+        if command { modifiers += "⌘" }
+        return modifiers
+    }
+
     private func handleEvent(type: CGEventType, event: CGEvent) {
         let flags = event.flags
 
         if type == .flagsChanged {
             let newMods = flags.intersection([.maskCommand, .maskControl, .maskAlternate, .maskShift, .maskSecondaryFn])
             let prevMods = activeModifiers
+            let isHyperNow = isHyper(
+                control: newMods.contains(.maskControl),
+                option: newMods.contains(.maskAlternate),
+                shift: newMods.contains(.maskShift),
+                command: newMods.contains(.maskCommand)
+            )
 
             var pressed: [String] = []
             if newMods.contains(.maskControl) && !prevMods.contains(.maskControl) { pressed.append("⌃") }
@@ -154,10 +179,17 @@ class EventTap {
 
             activeModifiers = newMods
 
-            if !pressed.isEmpty && displayMode == .allKeys {
+            // Show modifier-only events in allKeys mode.
+            // Hyper is a meaningful standalone chord, so always show it.
+            if !pressed.isEmpty && (displayMode == .allKeys || isHyperNow) {
                 pendingModifierID &+= 1
                 let thisID = pendingModifierID
-                let modText = pressed.joined()
+                let modText = formatModifiers(
+                    control: newMods.contains(.maskControl),
+                    option: newMods.contains(.maskAlternate),
+                    shift: newMods.contains(.maskShift),
+                    command: newMods.contains(.maskCommand)
+                )
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
                     // Only show if no keyDown cancelled this
                     if self?.pendingModifierID == thisID {
@@ -179,11 +211,7 @@ class EventTap {
             // Only show clicks that have modifiers (plain clicks are too noisy)
             // Exception: right-click is always shown since it's intentional
             if hasAnyModifier || type == .rightMouseDown {
-                var mods = ""
-                if hasControl { mods += "⌃" }
-                if hasOption { mods += "⌥" }
-                if hasShift { mods += "⇧" }
-                if hasCommand { mods += "⌘" }
+                let mods = formatModifiers(control: hasControl, option: hasOption, shift: hasShift, command: hasCommand)
 
                 let clickName: String
                 if type == .rightMouseDown { clickName = "Right Click" }
@@ -234,12 +262,14 @@ class EventTap {
         let keyString = keyCodeToString(keyCode: keyCode, event: event, withShift: shiftForTranslate, uppercase: shouldUppercase)
         guard !keyString.isEmpty else { return }
 
-        var modifiers = ""
-        if hasControl { modifiers += "⌃" }
-        if hasOption { modifiers += "⌥" }
         // Omit ⇧ when shift is already reflected in the translated character (allKeys / shift-only allModified).
-        if hasShift && !shiftForTranslate && (hasModifier || displayMode != .allKeys) { modifiers += "⇧" }
-        if hasCommand { modifiers += "⌘" }
+        let shouldShowShiftModifier = hasShift && !shiftForTranslate && (hasModifier || displayMode != .allKeys)
+        let modifiers = formatModifiers(
+            control: hasControl,
+            option: hasOption,
+            shift: shouldShowShiftModifier,
+            command: hasCommand
+        )
 
         let isCommand = hasCommand || hasControl
         let displayText = modifiers.isEmpty ? keyString : "\(modifiers)\(keyString)"

--- a/extensions/keyraycast/swift/keyraycast-helper/Sources/EventTap.swift
+++ b/extensions/keyraycast/swift/keyraycast-helper/Sources/EventTap.swift
@@ -146,7 +146,7 @@ class EventTap {
 
     private func formatModifiers(control: Bool, option: Bool, shift: Bool, command: Bool) -> String {
         if isHyper(control: control, option: option, shift: shift, command: command) {
-            return "✦"
+            return shift ? "✦⇧" : "✦"
         }
 
         var modifiers = ""


### PR DESCRIPTION
## Description

Improves KeyRaycast’s helper reliability and publishing flow.

This change fixes helper startup failures after installing the extension by validating the packaged `KeyraycastHelper` binary before launch, ensuring it is executable, and returning clearer errors when the helper is missing or cannot start. It also launches the helper directly with `spawn` instead of shelling out, and improves toggle-off behavior by finding and terminating any lingering helper processes.

Closes https://github.com/raycast/extensions/issues/27817

The native helper now also supports Raycast Hyper Key shortcuts by rendering Hyper as `✦` in modifier-only events, keyboard shortcuts, and mouse-click overlays.

Finally, the Swift build scripts now use the extension-level `.raycast-swift-build/keyraycast-helper` scratch path instead of `swift/keyraycast-helper/.build`, which prevents Raycast publish from trying to copy SwiftPM build artifacts.

## Screencast

Not applicable. This is primarily a helper reliability, shortcut-display, and build/publish fix. The visible behavior change is that Hyper shortcuts now appear as `✦` in the overlay.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder