### PR TITLE
fix(tuya-smart): Add an optional chain to fix the map error

### DIFF
--- a/extensions/tuya-smart/CHANGELOG.md
+++ b/extensions/tuya-smart/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tuya Smart Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-05-15
 
 Fixed a bug that caused the extension to crash when no older devices were listed
 

--- a/extensions/tuya-smart/CHANGELOG.md
+++ b/extensions/tuya-smart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Tuya Smart Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+Fixed a bug that caused the extension to crash when no older devices were listed
+
 ## [Enhancement] - 2026-01-15
 
 - Added switches in root search

--- a/extensions/tuya-smart/src/components/deviceCommands.tsx
+++ b/extensions/tuya-smart/src/components/deviceCommands.tsx
@@ -8,7 +8,7 @@ export function DeviceCommands(props: { device: Device; onAction: (device: Devic
     case "Switch":
     case "kg":
     case "Socket": {
-      commands = device.status.filter((status) => status.type === "Boolean");
+      commands = (device.status ?? []).filter((status) => status.type === "Boolean");
       break;
     }
     case "cl":
@@ -25,7 +25,7 @@ export function DeviceCommands(props: { device: Device; onAction: (device: Devic
       commands = [
         {
           code: "switch_led",
-          value: device.status.find((status) => status.code === "switch_led")?.value,
+          value: (device.status ?? []).find((status) => status.code === "switch_led")?.value,
           name: "Toggle On/Off",
         },
         { code: "work_mode", value: "white", name: "Workmode: White" },

--- a/extensions/tuya-smart/src/components/list.tsx
+++ b/extensions/tuya-smart/src/components/list.tsx
@@ -142,9 +142,9 @@ export function SwitchListItem(props: {
               return { ...command };
             });
 
-            const statusIndex = props.device.status.findIndex((status) => status.code === command.code);
-            if (statusIndex !== -1) {
-              props.device.status[statusIndex] = command;
+            const statusIndex = props.device.status?.findIndex((status) => status.code === command.code);
+            if (statusIndex !== -1 && statusIndex !== undefined) {
+              props.device.status![statusIndex] = command;
             }
 
             props.onAction({
@@ -239,8 +239,10 @@ export function CommandListItem(props: {
               return { ...command };
             });
 
-            const statusIndex = props.device.status.findIndex((status) => status.code === command.code);
-            props.device.status[statusIndex] = command;
+            const statusIndex = props.device.status?.findIndex((status) => status.code === command.code);
+            if (statusIndex !== -1 && statusIndex !== undefined) {
+              props.device.status![statusIndex] = command;
+            }
 
             props.onAction({
               ...props.device,

--- a/extensions/tuya-smart/src/utils/functions.ts
+++ b/extensions/tuya-smart/src/utils/functions.ts
@@ -1,6 +1,6 @@
+import { showToast, Toast } from "@raycast/api";
 import { Device, DeviceCategories, DeviceCategory } from "./interfaces";
 import { getDeviceFunctionsInfo } from "./tuyaConnector";
-import { showToast, Toast } from "@raycast/api";
 
 export const getCategory = (categories: DeviceCategory[], categoryCode: DeviceCategories): DeviceCategories => {
   const categoryInfo = categories.find((category) => category.code === categoryCode);
@@ -23,8 +23,8 @@ export const isPinned = (device: Device, oldDevices: Device[]) => {
 export const getDeviceFunctions = async (device: Device, oldDeviceInfo?: Device) => {
   const functions = await getDeviceFunctionsInfo(device.id);
 
-  const deviceFunctions = device.status.map((status) => {
-    const oldStatusInfo = oldDeviceInfo?.status.find((oldSatusInfo) => oldSatusInfo.code === status.code);
+  const deviceFunctions = device.status?.map((status) => {
+    const oldStatusInfo = oldDeviceInfo?.status?.find((oldSatusInfo) => oldSatusInfo.code === status.code);
     const functionInfo = functions.find((functionInfo) => functionInfo.code === status.code);
 
     if (functionInfo) {

--- a/extensions/tuya-smart/src/utils/interfaces.ts
+++ b/extensions/tuya-smart/src/utils/interfaces.ts
@@ -15,7 +15,7 @@ export interface Device {
   owner_id: string;
   product_id: string;
   product_name: string;
-  status: FunctionItem[];
+  status?: FunctionItem[];
   sub: boolean;
   time_zone: string;
   uid: string;


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->
Closes #23056
Fixes a Map error when retrieving the list of devices


## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

https://github.com/user-attachments/assets/2de07b39-9d9d-430d-aa61-fd516a464270


## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
