### PR TITLE
[Google Chrome] Add `Close Other Tabs` action to Search Tabs

### DIFF
--- a/extensions/google-chrome/CHANGELOG.md
+++ b/extensions/google-chrome/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## [Close Other Tabs] - 2026-05-13
 
 - Add "Close Other Tabs" action to `Search Tabs` to close every tab in the same window except the selected one (shortcut: `cmd+opt+w`)
+- Note: Pinned tabs are also closed because Chrome's AppleScript interface does not expose the pinned state, so the action cannot distinguish them. This differs from Chrome's built-in "Close other tabs" behavior.
 
 ## [Fixes] - 2026-01-05
 

--- a/extensions/google-chrome/CHANGELOG.md
+++ b/extensions/google-chrome/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Add Name Window command to name the currently active Google Chrome window.
 
+## [Close Other Tabs] - 2026-05-13
+
+- Add "Close Other Tabs" action to `Search Tabs` to close every tab in the same window except the selected one (shortcut: `cmd+opt+w`)
+
 ## [Fixes] - 2026-01-05
 
 - Fix infinite rendering with depth bug in new tab `Action`

--- a/extensions/google-chrome/src/actions/index.tsx
+++ b/extensions/google-chrome/src/actions/index.tsx
@@ -144,6 +144,26 @@ export async function closeActiveTab(tab: Tab): Promise<void> {
   `);
 }
 
+export async function closeOtherTabs(tab: Tab): Promise<void> {
+  // Close every tab in the same window except the given tab.
+  // Iterate from the end so closing earlier tabs doesn't shift the remaining indices.
+  await runAppleScript(`
+    tell application "Google Chrome"
+      activate
+      set _wnd to first window where id is ${tab.windowsId}
+      set index of _wnd to 1
+      set _count to count of tabs of _wnd
+      repeat with i from _count to 1 by -1
+        if i is not ${tab.tabIndex} then
+          close tab i of _wnd
+        end if
+      end repeat
+      set active tab index of _wnd to 1
+    end tell
+    return true
+  `);
+}
+
 export async function reloadTab(tab: Tab): Promise<void> {
   await runAppleScript(`
     tell application "Google Chrome"

--- a/extensions/google-chrome/src/components/ChromeActions.tsx
+++ b/extensions/google-chrome/src/components/ChromeActions.tsx
@@ -1,6 +1,13 @@
 import { ReactElement } from "react";
 import { Action, ActionPanel, closeMainWindow, getPreferenceValues, Icon } from "@raycast/api";
-import { closeActiveTab, openNewTab, reloadTab, setActiveTab, createNewGuestWindowToWebsite } from "../actions";
+import {
+  closeActiveTab,
+  closeOtherTabs,
+  openNewTab,
+  reloadTab,
+  setActiveTab,
+  createNewGuestWindowToWebsite,
+} from "../actions";
 import { Preferences, SettingsProfileOpenBehaviour, Tab } from "../interfaces";
 import { useCachedState } from "@raycast/utils";
 import { CHROME_PROFILE_KEY, DEFAULT_CHROME_PROFILE_ID } from "../constants";
@@ -54,6 +61,7 @@ function TabListItemActions({ tab, onTabClosed }: { tab: Tab; onTabClosed?: () =
         shortcut={{ modifiers: ["cmd", "shift"], key: "enter" }}
       />
       <CloseTab tab={tab} onTabClosed={onTabClosed} />
+      <CloseOtherTabs tab={tab} onTabClosed={onTabClosed} />
       <ActionPanel.Section>
         <Action.CreateQuicklink
           quicklink={{ link: tab.url, name: tab.title, application: "Google Chrome" }}
@@ -146,6 +154,23 @@ function CloseTab(props: { tab: Tab; onTabClosed?: () => void }) {
       icon={{ source: Icon.XMarkCircle }}
       onAction={handleAction}
       shortcut={{ modifiers: ["cmd", "shift"], key: "w" }}
+    />
+  );
+}
+
+function CloseOtherTabs(props: { tab: Tab; onTabClosed?: () => void }) {
+  async function handleAction() {
+    await closeOtherTabs(props.tab);
+    await closeMainWindow();
+    props.onTabClosed?.();
+  }
+
+  return (
+    <Action
+      title="Close Other Tabs"
+      icon={{ source: Icon.XMarkCircleFilled }}
+      onAction={handleAction}
+      shortcut={{ modifiers: ["cmd", "opt"], key: "w" }}
     />
   );
 }


### PR DESCRIPTION
## Description

Add a "Close Other Tabs" action to the `Search Tabs` command in the Google Chrome extension. The action closes every tab in the **same window** as the selected tab, except the selected one — mirroring Chrome's built-in "Close other tabs" menu item.

- Shortcut: `cmd+opt+w` (chosen to avoid conflict with the existing `Close Tab` action's `cmd+shift+w`)
- Scope: same window only — other windows are unaffected
- No confirmation dialog (consistent with the existing `Close Tab` action)
- Internally iterates tab indices from the end so closing earlier tabs doesn't shift the remaining indices

### Known limitation: pinned tabs

Chrome's AppleScript dictionary does **not** expose a `pinned` property on `tab`. Verified empirically:

- `properties of tab 1 of window 1` returns only `URL`, `name`, `loading`, `class`, `id`
- `set pinned of active tab of window 1 to true` fails with "cannot convert the type of 'pinned of active tab of window 1' to a specifier"

As a result, this action also closes pinned tabs, which differs from Chrome's built-in "Close other tabs" behavior (which preserves pinned tabs). This divergence is documented in the CHANGELOG entry.

## Screencast

<!-- TODO: attach a short screencast showing the new action in Search Tabs -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)