### PR TITLE
Add Bulk Skills Import and Export to Send to Kindle

### DIFF
--- a/extensions/send-to-kindle/AGENTS.md
+++ b/extensions/send-to-kindle/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+Ce projet est une extension Raycast.
+
+Quand on me demande de modifier le projet, je dois m'appuyer sur la documentation Raycast disponible ici :
+
+https://context7.com/websites/developers_raycast/llms.txt?tokens=10000
+
+Avant d'implémenter un changement lie a l'API Raycast, aux commandes, au manifest, au build, au publish, ou aux patterns d'extension, je dois verifier la documentation pertinente et suivre les conventions Raycast existantes dans le projet.

--- a/extensions/send-to-kindle/CHANGELOG.md
+++ b/extensions/send-to-kindle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Send to Kindle Changelog
 
+## [Skills Import and Export] - {PR_MERGE_DATE}
+
+- Added bulk skills import and export, so you can back up or restore all skills at once instead of managing them one by one.
+
 ## [Smarter Skills, Cleaner Previews] - 2026-02-16
 
 - New CSS selector algorithm: smarter ranking now highlights high-confidence selectors first, so you find the right filter faster with fewer trial-and-error steps.

--- a/extensions/send-to-kindle/CHANGELOG.md
+++ b/extensions/send-to-kindle/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Send to Kindle Changelog
 
-## [Skills Import and Export] - {PR_MERGE_DATE}
+## [Skills Import and Export] - 2026-05-15
 
 - Added bulk skills import and export, so you can back up or restore all skills at once instead of managing them one by one.
 

--- a/extensions/send-to-kindle/README.md
+++ b/extensions/send-to-kindle/README.md
@@ -14,33 +14,32 @@ Send the current browser article to Kindle as a clean EPUB, with domain-based cl
 
 ## Advantages vs Official "Send to Kindle" Chrome Extension
 
-| Feature | This Raycast extension | Official Chrome extension |
-| ------------------------------------------------------ | ---------------------- | ------------------------- |
-| Outdated UX | ❌ | ✅ |
-| Readability.js-based extraction for better results | ✅ | ❌ |
-| Custom per-domain CSS filters | ✅ | ❌ |
-| Manual cover photo selection (`Cover CSS`) | ✅ | ❌ |
-| Guided cover selector picker (`Add Cover Skill`) | ✅ | ❌ |
-| Guided filter selector (`Add Filter Skill`) | ✅ | ❌ |
-| Cover preview before sending | ✅ | ❌ |
-| Edit content before sending | ✅ | ❌ |
-| Faster (in email mode) | ✅ | ❌ |
-| Uses site name instead of article author name | ✅ | ❌ |
-| Import/export filter profiles (JSON) | ✅ | ❌ |
-| Two delivery methods (local app or email) | ✅ | ❌ |
-| Optional removal of all article links before sending | ✅ | ❌ |
-| Sending history | ✅ | ❌ |
+| Feature                                              | This Raycast extension | Official Chrome extension |
+| ---------------------------------------------------- | ---------------------- | ------------------------- |
+| Outdated UX                                          | ❌                     | ✅                        |
+| Readability.js-based extraction for better results   | ✅                     | ❌                        |
+| Custom per-domain CSS filters                        | ✅                     | ❌                        |
+| Manual cover photo selection (`Cover CSS`)           | ✅                     | ❌                        |
+| Guided cover selector picker (`Add Cover Skill`)     | ✅                     | ❌                        |
+| Guided filter selector (`Add Filter Skill`)          | ✅                     | ❌                        |
+| Cover preview before sending                         | ✅                     | ❌                        |
+| Edit content before sending                          | ✅                     | ❌                        |
+| Faster (in email mode)                               | ✅                     | ❌                        |
+| Uses site name instead of article author name        | ✅                     | ❌                        |
+| Import/export filter profiles (JSON)                 | ✅                     | ❌                        |
+| Two delivery methods (local app or email)            | ✅                     | ❌                        |
+| Optional removal of all article links before sending | ✅                     | ❌                        |
+| Sending history                                      | ✅                     | ❌                        |
 
 ## Cover Skill vs Filter Skill
 
-The extension uses 2 complementary skill types per domain. 
+The extension uses 2 complementary skill types per domain.
 
 When a skill is added, it is applied to all the future articles you will send from that domain.
 
 - `Filter Skill`
   - Removes unwanted page blocks before extraction (ads, sidebars, popups, cookie walls, related-content blocks).
   - Goal: cleaner article body and better readability output.
-  
 - `Cover Skill`
   - Targets the best image to use as the Kindle cover.
   - Goal: consistent, high-quality cover image instead of random inline article images (or no image at all with the official "Send to Kindle Chrome extension").

--- a/extensions/send-to-kindle/package-lock.json
+++ b/extensions/send-to-kindle/package-lock.json
@@ -1274,6 +1274,7 @@
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1332,6 +1333,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1536,6 +1538,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2003,6 +2006,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2861,6 +2865,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2884,6 +2889,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3120,6 +3126,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/send-to-kindle/package-lock.json
+++ b/extensions/send-to-kindle/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.5.0",
-        "@raycast/api": "^1.104.4",
+        "@raycast/api": "^1.104.16",
         "@raycast/utils": "^1.17.0",
         "linkedom": "^0.18.12",
         "turndown": "^7.1.2"
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -151,9 +151,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -167,9 +167,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -183,9 +183,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -199,9 +199,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -215,9 +215,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -247,9 +247,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -263,9 +263,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -295,9 +295,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -343,9 +343,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -359,9 +359,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -375,9 +375,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -407,9 +407,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -423,9 +423,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -1046,9 +1046,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.0.tgz",
-      "integrity": "sha512-jteNUQKgJHLHFbbz806aGZqf+RJJ7t4gwF4MYa8fCwCxQ8/klJNWc0MvaJiBebk7Mc+J39mdlsB4XraaCKznFw==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.2.tgz",
+      "integrity": "sha512-LWDalCgy+hYyAkLa9sMIXMXk6ws5RzQhVnkmfXtVIIyEEYigbXQ/9/x+s76p53MiXxNc6SJB7lfwkPF+SdzfMQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -1061,8 +1061,8 @@
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
-        "minimatch": "^9.0.5",
-        "semver": "^7.7.3",
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.0",
         "string-width": "^4.2.3",
         "supports-color": "^8",
         "tinyglobby": "^0.2.14",
@@ -1072,6 +1072,42 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@oclif/plugin-autocomplete": {
@@ -1117,28 +1153,28 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.4",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.4.tgz",
-      "integrity": "sha512-Pz6qmLVfHp1OLKGyzDhFN9IPczG6EiGFIE6pq23SVsYB6lRpfABSVsscnjioa5NAX3cI5/6cz+/nk142ZncupA==",
+      "version": "1.104.16",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.16.tgz",
+      "integrity": "sha512-PFUDslQgRGDhoTVJUDvJylezew6medQ2oZBfOk9HMdB7RfyhyQxZSnqihrRPCMin5FCg30W+M6oTOCwdwbRHRA==",
       "license": "MIT",
       "dependencies": {
-        "@oclif/core": "^4.5.4",
-        "@oclif/plugin-autocomplete": "^3.2.35",
-        "@oclif/plugin-help": "^6.2.33",
-        "@oclif/plugin-not-found": "^3.2.68",
-        "@types/node": "22.13.10",
+        "@oclif/core": "^4.8.4",
+        "@oclif/plugin-autocomplete": "^3.2.40",
+        "@oclif/plugin-help": "^6.2.37",
+        "@oclif/plugin-not-found": "^3.2.74",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
-        "esbuild": "^0.25.10",
+        "esbuild": "^0.27.3",
         "react": "19.0.0"
       },
       "bin": {
         "ray": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.14.0"
+        "node": ">=22.22.2"
       },
       "peerDependencies": {
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "react-devtools": "6.1.1"
       },
@@ -1153,6 +1189,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@raycast/api/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@raycast/api/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@raycast/eslint-config": {
       "version": "2.1.1",
@@ -1221,6 +1272,7 @@
       "version": "22.13.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -1893,9 +1945,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1905,32 +1957,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2633,6 +2685,7 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -2877,9 +2930,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3109,6 +3162,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {

--- a/extensions/send-to-kindle/package.json
+++ b/extensions/send-to-kindle/package.json
@@ -73,7 +73,7 @@
   ],
   "dependencies": {
     "@mozilla/readability": "^0.5.0",
-    "@raycast/api": "^1.104.4",
+    "@raycast/api": "^1.104.16",
     "@raycast/utils": "^1.17.0",
     "linkedom": "^0.18.12",
     "turndown": "^7.1.2"

--- a/extensions/send-to-kindle/src/filters.ts
+++ b/extensions/send-to-kindle/src/filters.ts
@@ -28,6 +28,13 @@ export type FilterTransferPayload = {
   filter: Pick<DomainFilter, "domain" | "selector" | "coverSelector">;
 };
 
+export type FiltersTransferPayload = {
+  format: "send-to-kindle-skills";
+  version: 1;
+  exportedAt: string;
+  filters: Pick<DomainFilter, "domain" | "selector" | "coverSelector">[];
+};
+
 const STORAGE_KEY = "domain-filters";
 const MULTI_PART_TLDS = new Set([
   "co.uk",
@@ -398,6 +405,31 @@ export async function exportFilterToPath(
   await writeFile(filePath, JSON.stringify(payload, null, 2), "utf8");
 }
 
+export async function exportFiltersToPath(
+  filePath: string,
+  filters: Pick<DomainFilter, "domain" | "selector" | "coverSelector">[],
+): Promise<number> {
+  const sanitized = filters.map(sanitizeFilter).filter((filter): filter is DomainFilter => Boolean(filter));
+
+  if (sanitized.length === 0) {
+    throw new Error("No skills to export.");
+  }
+
+  const payload: FiltersTransferPayload = {
+    format: "send-to-kindle-skills",
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    filters: sanitized.map((filter) => ({
+      domain: filter.domain,
+      selector: filter.selector,
+      coverSelector: filter.coverSelector,
+    })),
+  };
+
+  await writeFile(filePath, JSON.stringify(payload, null, 2), "utf8");
+  return payload.filters.length;
+}
+
 export async function importFilterFromPath(
   filePath: string,
 ): Promise<Pick<DomainFilter, "domain" | "selector" | "coverSelector">> {
@@ -416,4 +448,38 @@ export async function importFilterFromPath(
     selector: sanitized.selector,
     coverSelector: sanitized.coverSelector,
   };
+}
+
+export async function importFiltersFromPath(
+  filePath: string,
+): Promise<Pick<DomainFilter, "domain" | "selector" | "coverSelector">[]> {
+  const raw = await readFile(filePath, "utf8");
+  const parsed = JSON.parse(raw) as { filter?: unknown; filters?: unknown } | unknown;
+
+  const maybeFilters =
+    parsed && typeof parsed === "object" && "filters" in parsed
+      ? (parsed as { filters?: unknown }).filters
+      : parsed && typeof parsed === "object" && "filter" in parsed
+        ? [(parsed as { filter?: unknown }).filter]
+        : parsed;
+
+  if (!Array.isArray(maybeFilters)) {
+    throw new Error("Invalid JSON format. Expected a list of skills.");
+  }
+
+  const sanitized = maybeFilters.map(sanitizeFilter).filter((filter): filter is DomainFilter => Boolean(filter));
+
+  if (sanitized.length === 0) {
+    throw new Error("Invalid JSON format. Expected at least one skill with domain and CSS fields.");
+  }
+
+  if (sanitized.length !== maybeFilters.length) {
+    throw new Error("Invalid JSON format. Every imported skill needs a domain and at least one CSS field.");
+  }
+
+  return sanitized.map((filter) => ({
+    domain: filter.domain,
+    selector: filter.selector,
+    coverSelector: filter.coverSelector,
+  }));
 }

--- a/extensions/send-to-kindle/src/my-filters.tsx
+++ b/extensions/send-to-kindle/src/my-filters.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import AddFilterCommand from "./add-filter";
 import FilterForm from "./filter-form";
 import { deleteFilter, DomainFilter, listFilters } from "./filters";
-import { ExportSkillForm } from "./skill-transfer";
+import { ExportAllSkillsForm, ExportSkillForm, ImportAllSkillsForm } from "./skill-transfer";
 
 export default function MyFiltersCommand() {
   const [filters, setFilters] = useState<DomainFilter[]>([]);
@@ -53,6 +53,12 @@ export default function MyFiltersCommand() {
               icon={Icon.Plus}
               target={<AddFilterCommand shouldPop onSaved={loadFilters} />}
             />
+            <Action.Push
+              title="Import All Skills JSON"
+              icon={Icon.Download}
+              shortcut={{ modifiers: ["opt"], key: "i" }}
+              target={<ImportAllSkillsForm onImported={loadFilters} />}
+            />
           </ActionPanel>
         }
       />
@@ -91,6 +97,12 @@ export default function MyFiltersCommand() {
                 target={<AddFilterCommand shouldPop onSaved={loadFilters} />}
               />
               <Action.Push
+                title="Import All Skills JSON"
+                icon={Icon.Download}
+                shortcut={{ modifiers: ["opt"], key: "i" }}
+                target={<ImportAllSkillsForm onImported={loadFilters} />}
+              />
+              <Action.Push
                 title="Export Skill JSON"
                 icon={Icon.Upload}
                 target={
@@ -102,6 +114,12 @@ export default function MyFiltersCommand() {
                     }}
                   />
                 }
+              />
+              <Action.Push
+                title="Export All Skills JSON"
+                icon={Icon.Upload}
+                shortcut={{ modifiers: ["opt"], key: "e" }}
+                target={<ExportAllSkillsForm filters={filters} />}
               />
             </ActionPanel>
           }

--- a/extensions/send-to-kindle/src/my-filters.tsx
+++ b/extensions/send-to-kindle/src/my-filters.tsx
@@ -97,12 +97,6 @@ export default function MyFiltersCommand() {
                 target={<AddFilterCommand shouldPop onSaved={loadFilters} />}
               />
               <Action.Push
-                title="Import All Skills JSON"
-                icon={Icon.Download}
-                shortcut={{ modifiers: ["opt"], key: "i" }}
-                target={<ImportAllSkillsForm onImported={loadFilters} />}
-              />
-              <Action.Push
                 title="Export Skill JSON"
                 icon={Icon.Upload}
                 target={
@@ -120,6 +114,12 @@ export default function MyFiltersCommand() {
                 icon={Icon.Upload}
                 shortcut={{ modifiers: ["opt"], key: "e" }}
                 target={<ExportAllSkillsForm filters={filters} />}
+              />
+              <Action.Push
+                title="Import All Skills JSON"
+                icon={Icon.Download}
+                shortcut={{ modifiers: ["opt"], key: "i" }}
+                target={<ImportAllSkillsForm onImported={loadFilters} />}
               />
             </ActionPanel>
           }

--- a/extensions/send-to-kindle/src/skill-transfer.tsx
+++ b/extensions/send-to-kindle/src/skill-transfer.tsx
@@ -1,6 +1,13 @@
 import { Action, ActionPanel, Form, Icon, showToast, Toast, useNavigation } from "@raycast/api";
 import path from "path";
-import { DomainFilter, exportFilterToPath, importFilterFromPath } from "./filters";
+import {
+  addFilter,
+  DomainFilter,
+  exportFiltersToPath,
+  exportFilterToPath,
+  importFiltersFromPath,
+  importFilterFromPath,
+} from "./filters";
 
 type FilterDraft = Pick<DomainFilter, "domain" | "selector" | "coverSelector">;
 
@@ -8,8 +15,16 @@ type ImportSkillFormProps = {
   onImported: (filter: FilterDraft) => void;
 };
 
+type ImportAllSkillsFormProps = {
+  onImported: (count: number) => void;
+};
+
 type ExportSkillFormProps = {
   filter: FilterDraft;
+};
+
+type ExportAllSkillsFormProps = {
+  filters: FilterDraft[];
 };
 
 type ImportSkillFormValues = {
@@ -20,6 +35,8 @@ type ExportSkillFormValues = {
   directory: string[];
   fileName: string;
 };
+
+type ExportAllSkillsFormValues = ExportSkillFormValues;
 
 export function ImportSkillForm({ onImported }: ImportSkillFormProps) {
   const { pop } = useNavigation();
@@ -59,6 +76,57 @@ export function ImportSkillForm({ onImported }: ImportSkillFormProps) {
       actions={
         <ActionPanel>
           <Action.SubmitForm title="Import Skill" icon={Icon.Download} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.FilePicker id="files" title="JSON file" allowMultipleSelection={false} canChooseDirectories={false} />
+    </Form>
+  );
+}
+
+export function ImportAllSkillsForm({ onImported }: ImportAllSkillsFormProps) {
+  const { pop } = useNavigation();
+
+  async function handleSubmit(values: ImportSkillFormValues) {
+    const filePath = values.files[0];
+    if (!filePath) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Missing file",
+        message: "Select a JSON file to import.",
+      });
+      return;
+    }
+
+    try {
+      const imported = await importFiltersFromPath(filePath);
+      for (const filter of imported) {
+        await addFilter(filter.domain, filter.selector, filter.coverSelector);
+      }
+
+      onImported(imported.length);
+      await showToast({
+        style: Toast.Style.Success,
+        title: "Skills imported",
+        message: `${imported.length} skill${imported.length === 1 ? "" : "s"} imported.`,
+      });
+      pop();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Import failed",
+        message,
+      });
+    }
+  }
+
+  return (
+    <Form
+      navigationTitle="Import All Skills JSON"
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Import All Skills" icon={Icon.Download} onSubmit={handleSubmit} />
         </ActionPanel>
       }
     >
@@ -131,6 +199,73 @@ export function ExportSkillForm({ filter }: ExportSkillFormProps) {
         canChooseFiles={false}
       />
       <Form.TextField id="fileName" title="Filename" defaultValue={suggestedFileName} />
+    </Form>
+  );
+}
+
+export function ExportAllSkillsForm({ filters }: ExportAllSkillsFormProps) {
+  const { pop } = useNavigation();
+
+  async function handleSubmit(values: ExportAllSkillsFormValues) {
+    const directoryPath = values.directory[0];
+    const rawFileName = values.fileName.trim();
+
+    if (!directoryPath) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Missing folder",
+        message: "Select an output folder.",
+      });
+      return;
+    }
+
+    if (!rawFileName) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Missing filename",
+        message: "Enter a filename.",
+      });
+      return;
+    }
+
+    const finalFileName = rawFileName.toLowerCase().endsWith(".json") ? rawFileName : `${rawFileName}.json`;
+    const filePath = path.join(directoryPath, finalFileName);
+
+    try {
+      const exportedCount = await exportFiltersToPath(filePath, filters);
+      await showToast({
+        style: Toast.Style.Success,
+        title: "Skills exported",
+        message: `${exportedCount} skill${exportedCount === 1 ? "" : "s"} exported.`,
+      });
+      pop();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Export failed",
+        message,
+      });
+    }
+  }
+
+  return (
+    <Form
+      navigationTitle="Export All Skills JSON"
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Export All Skills" icon={Icon.Upload} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.FilePicker
+        id="directory"
+        title="Output folder"
+        allowMultipleSelection={false}
+        canChooseDirectories
+        canChooseFiles={false}
+      />
+      <Form.TextField id="fileName" title="Filename" defaultValue="send-to-kindle-skills.json" />
     </Form>
   );
 }


### PR DESCRIPTION
## Description

Adds bulk import and export for Send to Kindle skills from the `My Skills` command.

- Add an `Import All Skills JSON` action to import multiple skills at once.
- Add an `Export All Skills JSON` action to back up all configured skills in one JSON file.
- Keep single-skill import/export support intact, while accepting bulk payloads and legacy single-skill payloads during import.
- Update the changelog with the Raycast `{PR_MERGE_DATE}` placeholder.
- Update `@raycast/api` from `^1.104.4` to `^1.104.16`.

## Screencast

N/A - this is a small update to existing skill management actions.

Build verification: `npm run build` passes locally.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder

Note: `npm run build` has been run successfully; manual testing of the distribution build in Raycast is still pending.