### PR TITLE
[Skills] add skills.sh link and audit details in installed skills view

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Show Installed Skill Audit Details] - {PR_MERGE_DATE}
+## [Show Installed Skill Audit Details] - 2026-05-20
 
 - Add an "Open on skills.sh" action and `skills.sh` detail link for published installed skills
 - Show security audit statuses, audit links, and audit actions in installed skill details

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Skills Changelog
 
+## [Show Installed Skill Audit Details] - {PR_MERGE_DATE}
+
+- Add an "Open on skills.sh" action and `skills.sh` detail link for published installed skills
+- Show security audit statuses, audit links, and audit actions in installed skill details
+
 ## [Ask Skills AI Extension] - 2026-05-12
 
 - Add `@skills` support in Raycast AI Chat with five tools: search the marketplace by query, read a skill's full instructions, list installed skills, install a skill for specific agents, and remove a skill

--- a/extensions/skills/package-lock.json
+++ b/extensions/skills/package-lock.json
@@ -7,10 +7,10 @@
       "name": "skills",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "1.104.5",
-        "@raycast/utils": "2.2.3",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
+        "@raycast/api": "^1.104.16",
+        "@raycast/utils": "^2.2.4",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
         "semver": "^7.7.3"
       },
       "devDependencies": {
@@ -25,9 +25,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
       "cpu": [
         "ppc64"
       ],
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
       "cpu": [
         "arm"
       ],
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
       "cpu": [
         "arm64"
       ],
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
       "cpu": [
         "x64"
       ],
@@ -89,7 +89,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
       "cpu": [
         "arm64"
       ],
@@ -103,9 +105,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
       "cpu": [
         "x64"
       ],
@@ -119,9 +121,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
       "cpu": [
         "arm64"
       ],
@@ -135,9 +137,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
       "cpu": [
         "x64"
       ],
@@ -151,9 +153,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
       "cpu": [
         "arm"
       ],
@@ -167,9 +169,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
       "cpu": [
         "arm64"
       ],
@@ -183,9 +185,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
       "cpu": [
         "ia32"
       ],
@@ -199,9 +201,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
       "cpu": [
         "loong64"
       ],
@@ -215,9 +217,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
       "cpu": [
         "mips64el"
       ],
@@ -231,9 +233,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
       "cpu": [
         "ppc64"
       ],
@@ -247,9 +249,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
       "cpu": [
         "riscv64"
       ],
@@ -263,9 +265,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
       "cpu": [
         "s390x"
       ],
@@ -279,9 +281,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
       "cpu": [
         "x64"
       ],
@@ -295,9 +297,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
       "cpu": [
         "arm64"
       ],
@@ -311,9 +313,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
       "cpu": [
         "x64"
       ],
@@ -327,9 +329,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
       "cpu": [
         "arm64"
       ],
@@ -343,9 +345,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
       "cpu": [
         "x64"
       ],
@@ -359,9 +361,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
       "cpu": [
         "arm64"
       ],
@@ -375,9 +377,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
       "cpu": [
         "x64"
       ],
@@ -391,9 +393,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
       "cpu": [
         "arm64"
       ],
@@ -407,9 +409,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
       "cpu": [
         "ia32"
       ],
@@ -423,9 +425,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
       "cpu": [
         "x64"
       ],
@@ -938,7 +940,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.8.0",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.10.3.tgz",
+      "integrity": "sha512-0mD8vcrrX5uRsxzvI8tbWmSVGngvZA/Qo6O0ZGvLPAWEauSf5GFniwgirhY0SkszuHwu0S1J1ivj/jHmqtIDuA==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -951,7 +955,7 @@
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.4",
         "semver": "^7.7.3",
         "string-width": "^4.2.3",
         "supports-color": "^8",
@@ -962,6 +966,42 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@oclif/plugin-autocomplete": {
@@ -1001,26 +1041,28 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.5",
+      "version": "1.104.16",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.16.tgz",
+      "integrity": "sha512-PFUDslQgRGDhoTVJUDvJylezew6medQ2oZBfOk9HMdB7RfyhyQxZSnqihrRPCMin5FCg30W+M6oTOCwdwbRHRA==",
       "license": "MIT",
       "dependencies": {
-        "@oclif/core": "^4.5.4",
-        "@oclif/plugin-autocomplete": "^3.2.35",
-        "@oclif/plugin-help": "^6.2.33",
-        "@oclif/plugin-not-found": "^3.2.68",
-        "@types/node": "22.13.10",
+        "@oclif/core": "^4.8.4",
+        "@oclif/plugin-autocomplete": "^3.2.40",
+        "@oclif/plugin-help": "^6.2.37",
+        "@oclif/plugin-not-found": "^3.2.74",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
-        "esbuild": "^0.25.10",
+        "esbuild": "^0.27.3",
         "react": "19.0.0"
       },
       "bin": {
         "ray": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.14.0"
+        "node": ">=22.22.2"
       },
       "peerDependencies": {
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "react-devtools": "6.1.1"
       },
@@ -1037,10 +1079,12 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@types/node": {
-      "version": "22.13.10",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@raycast/api/node_modules/@types/react": {
@@ -1058,7 +1102,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/undici-types": {
-      "version": "6.20.0",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/@raycast/eslint-config": {
@@ -1237,9 +1283,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.3.tgz",
-      "integrity": "sha512-YwqleVl0Wk/FOq+672gtvswuwMqjNqIr+c63FhouTEHc1LJ3zaohLSkW4+UcfBjPU8HySKQm+kJqZW1iOM9fnA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.4.tgz",
+      "integrity": "sha512-XkxW5bUZACxl2zP4M6Qtkj9a1nbOKcRBm96BLkJ6O4Q7L/vFSnc+3pPJ/i0ZLVOExx5LJMJY0jnNPo91xqJnFQ==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1625,7 +1671,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1635,32 +1683,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2275,6 +2323,7 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -2414,20 +2463,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.6"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/extensions/skills/package.json
+++ b/extensions/skills/package.json
@@ -91,10 +91,10 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "1.104.5",
-    "@raycast/utils": "2.2.3",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
+    "@raycast/api": "^1.104.16",
+    "@raycast/utils": "^2.2.4",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
     "semver": "^7.7.3"
   },
   "devDependencies": {

--- a/extensions/skills/src/components/InstalledSkillListItem.tsx
+++ b/extensions/skills/src/components/InstalledSkillListItem.tsx
@@ -8,7 +8,7 @@ import {
   type Skill,
   AUDIT_PROVIDER_LABELS,
   buildSkillUrl,
-  isPublishedInstalledSkill,
+  isGithubBackedInstalledSkill,
   parseFrontmatter,
 } from "../shared";
 import type { MutateSkills } from "../hooks/useInstalledSkills";
@@ -298,7 +298,7 @@ function SourceBackedInstalledSkillListItem(
 }
 
 export function InstalledSkillListItem({ skill, ...props }: InstalledSkillListItemProps) {
-  if (isPublishedInstalledSkill(skill)) {
+  if (isGithubBackedInstalledSkill(skill)) {
     return <SourceBackedInstalledSkillListItem {...props} skill={skill} />;
   }
 

--- a/extensions/skills/src/components/InstalledSkillListItem.tsx
+++ b/extensions/skills/src/components/InstalledSkillListItem.tsx
@@ -117,8 +117,10 @@ function InlineDetail({ skill, isSelected, skillDetailPageUrl, audits }: InlineD
     ),
   ];
 
+  const sourceAudits = skill.source ? audits : undefined;
+  const shouldShowAuditScopeWarning = skill.hasUpdate && sourceAudits;
   const agentAuditsDetailsSection: MetadataSection = [
-    skill.hasUpdate && audits && (
+    shouldShowAuditScopeWarning && (
       <List.Item.Detail.Metadata.Label
         key="agent-audits-scope"
         title="Audit Scope"
@@ -126,10 +128,9 @@ function InlineDetail({ skill, isSelected, skillDetailPageUrl, audits }: InlineD
         icon={Icon.Warning}
       />
     ),
-    skill.source &&
-      audits &&
-      (audits.results.length > 0 ? (
-        audits.results.map((audit) =>
+    sourceAudits &&
+      (sourceAudits.results.length > 0 ? (
+        sourceAudits.results.map((audit) =>
           audit.url ? (
             <List.Item.Detail.Metadata.Link
               key={`agent-audits-${audit.provider}`}
@@ -149,7 +150,7 @@ function InlineDetail({ skill, isSelected, skillDetailPageUrl, audits }: InlineD
         <List.Item.Detail.Metadata.Label
           key="agent-audits-fallback"
           title="Security Audits"
-          text={getAuditFallbackText(audits.isLoading, audits.availabilityState)}
+          text={getAuditFallbackText(sourceAudits.isLoading, sourceAudits.availabilityState)}
         />
       )),
   ];

--- a/extensions/skills/src/components/InstalledSkillListItem.tsx
+++ b/extensions/skills/src/components/InstalledSkillListItem.tsx
@@ -1,11 +1,22 @@
 import { ActionPanel, Action, Icon, Keyboard, List, Color } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { useCachedPromise } from "@raycast/utils";
-import { type InstalledSkill, parseFrontmatter } from "../shared";
+import { useSkillAudits } from "../hooks/useSkillAudits";
+import {
+  type InstalledSkill,
+  type Skill,
+  AUDIT_PROVIDER_LABELS,
+  buildSkillUrl,
+  isPublishedInstalledSkill,
+  parseFrontmatter,
+} from "../shared";
 import type { MutateSkills } from "../hooks/useInstalledSkills";
+import { formatAuditStatus, getAuditFallbackText } from "../utils/skill-audit-display";
+import { OpenSecurityAuditActions } from "./actions/OpenSecurityAuditActions";
 import { RemoveSkillAction } from "./actions/RemoveSkillAction";
 import { UpdateSkillAction } from "./actions/UpdateSkillAction";
+import { joinMetadataSections, type MetadataSection } from "./_common/metadata";
 
 function formatDate(iso: string): string | undefined {
   const d = new Date(iso);
@@ -13,8 +24,15 @@ function formatDate(iso: string): string | undefined {
   return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
 }
 
-function InlineDetail({ skill, isSelected }: { skill: InstalledSkill; isSelected: boolean }) {
-  const { data: parsed, isLoading } = useCachedPromise(
+interface InlineDetailProps {
+  skill: InstalledSkill;
+  isSelected: boolean;
+  skillDetailPageUrl?: string;
+  audits?: ReturnType<typeof useSkillAudits>;
+}
+
+function InlineDetail({ skill, isSelected, skillDetailPageUrl, audits }: InlineDetailProps) {
+  const { data: parsedSkillMarkdown, isLoading } = useCachedPromise(
     async (path: string) => {
       const raw = await readFile(join(path, "SKILL.md"), "utf-8");
       return parseFrontmatter(raw);
@@ -25,8 +43,116 @@ function InlineDetail({ skill, isSelected }: { skill: InstalledSkill; isSelected
 
   const markdown = isLoading
     ? `# ${skill.name}\n\nLoading...`
-    : (parsed?.body ?? `# ${skill.name}\n\nNo SKILL.md found.`);
-  const frontmatter = parsed?.frontmatter ?? {};
+    : (parsedSkillMarkdown?.body ?? `# ${skill.name}\n\nNo SKILL.md found.`);
+
+  const frontmatter = parsedSkillMarkdown?.frontmatter ?? {};
+
+  const frontmatterDetailsSection: MetadataSection = [
+    frontmatter.description && (
+      <List.Item.Detail.Metadata.Label
+        key="frontmatter-description"
+        title="Description"
+        text={frontmatter.description}
+      />
+    ),
+    frontmatter.license && (
+      <List.Item.Detail.Metadata.Label
+        key="frontmatter-license"
+        title="License"
+        text={frontmatter.license}
+        icon={Icon.Document}
+      />
+    ),
+  ];
+
+  const installedDate = skill.installedAt ? formatDate(skill.installedAt) : undefined;
+  const updatedDate = skill.updatedAt ? formatDate(skill.updatedAt) : undefined;
+  const repositoryUrl = skill.sourceUrl;
+  const repositoryText = skill.source ?? skill.sourceUrl;
+
+  const updateStatusDetailsSection: MetadataSection = [
+    skill.hasUpdate && (
+      <List.Item.Detail.Metadata.TagList key="skill-lock-status" title="Status">
+        <List.Item.Detail.Metadata.TagList.Item text="Update available" color={Color.Orange} />
+      </List.Item.Detail.Metadata.TagList>
+    ),
+  ];
+
+  const localInfoDetailsSection: MetadataSection = [
+    installedDate && (
+      <List.Item.Detail.Metadata.Label
+        key="skill-lock-installed"
+        title="Installed"
+        text={installedDate}
+        icon={Icon.Calendar}
+      />
+    ),
+    updatedDate && (
+      <List.Item.Detail.Metadata.Label key="skill-lock-updated" title="Updated" text={updatedDate} icon={Icon.Clock} />
+    ),
+    <List.Item.Detail.Metadata.TagList key="local-info-agents" title="Agents">
+      {skill.agents.map((agent) => (
+        <List.Item.Detail.Metadata.TagList.Item key={agent} text={agent} color={Color.Blue} />
+      ))}
+    </List.Item.Detail.Metadata.TagList>,
+    <List.Item.Detail.Metadata.Label key="local-info-path" title="Path" text={skill.path} />,
+  ];
+
+  const linkDetailsSection: MetadataSection = [
+    skill.source && skillDetailPageUrl && (
+      <List.Item.Detail.Metadata.Link
+        key="skill-lock-skills"
+        title="skills.sh"
+        text={`${skill.source}/${skill.name}`}
+        target={skillDetailPageUrl}
+      />
+    ),
+    repositoryUrl && repositoryText && (
+      <List.Item.Detail.Metadata.Link
+        key="skill-lock-repository"
+        title="Repository"
+        text={repositoryText}
+        target={repositoryUrl}
+      />
+    ),
+  ];
+
+  const agentAuditsDetailsSection: MetadataSection = [
+    skill.hasUpdate && audits && (
+      <List.Item.Detail.Metadata.Label
+        key="agent-audits-scope"
+        title="Audit Scope"
+        text="Results apply to the latest version available via update."
+        icon={Icon.Warning}
+      />
+    ),
+    skill.source &&
+      audits &&
+      (audits.results.length > 0 ? (
+        audits.results.map((audit) =>
+          audit.url ? (
+            <List.Item.Detail.Metadata.Link
+              key={`agent-audits-${audit.provider}`}
+              title={`${AUDIT_PROVIDER_LABELS[audit.provider]} Audit`}
+              text={formatAuditStatus(audit.status)}
+              target={audit.url}
+            />
+          ) : (
+            <List.Item.Detail.Metadata.Label
+              key={`agent-audits-${audit.provider}`}
+              title={`${AUDIT_PROVIDER_LABELS[audit.provider]} Audit`}
+              text={formatAuditStatus(audit.status)}
+            />
+          ),
+        )
+      ) : (
+        <List.Item.Detail.Metadata.Label
+          key="agent-audits-fallback"
+          title="Security Audits"
+          text={getAuditFallbackText(audits.isLoading, audits.availabilityState)}
+        />
+      )),
+  ];
 
   return (
     <List.Item.Detail
@@ -34,42 +160,16 @@ function InlineDetail({ skill, isSelected }: { skill: InstalledSkill; isSelected
       markdown={markdown}
       metadata={
         <List.Item.Detail.Metadata>
-          {frontmatter.description && (
-            <List.Item.Detail.Metadata.Label title="Description" text={frontmatter.description} />
+          {joinMetadataSections(
+            [
+              updateStatusDetailsSection,
+              frontmatterDetailsSection,
+              localInfoDetailsSection,
+              linkDetailsSection,
+              agentAuditsDetailsSection,
+            ],
+            List.Item.Detail.Metadata.Separator,
           )}
-          <List.Item.Detail.Metadata.Label title="Name" text={skill.name} />
-          {frontmatter.license && (
-            <List.Item.Detail.Metadata.Label title="License" text={frontmatter.license} icon={Icon.Document} />
-          )}
-          {skill.hasUpdate && (
-            <List.Item.Detail.Metadata.TagList title="Status">
-              <List.Item.Detail.Metadata.TagList.Item text="Update available" color={Color.Orange} />
-            </List.Item.Detail.Metadata.TagList>
-          )}
-          {skill.sourceUrl && (
-            <List.Item.Detail.Metadata.Link
-              title="Repository"
-              text={skill.source ?? skill.sourceUrl}
-              target={skill.sourceUrl}
-            />
-          )}
-          {skill.installedAt && formatDate(skill.installedAt) && (
-            <List.Item.Detail.Metadata.Label
-              title="Installed"
-              text={formatDate(skill.installedAt)!}
-              icon={Icon.Calendar}
-            />
-          )}
-          {skill.updatedAt && formatDate(skill.updatedAt) && (
-            <List.Item.Detail.Metadata.Label title="Updated" text={formatDate(skill.updatedAt)!} icon={Icon.Clock} />
-          )}
-          {(skill.sourceUrl || skill.installedAt) && <List.Item.Detail.Metadata.Separator />}
-          <List.Item.Detail.Metadata.TagList title="Agents">
-            {skill.agents.map((agent) => (
-              <List.Item.Detail.Metadata.TagList.Item key={agent} text={agent} color={Color.Blue} />
-            ))}
-          </List.Item.Detail.Metadata.TagList>
-          <List.Item.Detail.Metadata.Label title="Path" text={skill.path} />
         </List.Item.Detail.Metadata>
       }
     />
@@ -85,14 +185,16 @@ interface InstalledSkillListItemProps {
   onRefresh: () => void;
 }
 
-export function InstalledSkillListItem({
+function BaseInstalledSkillListItem({
   skill,
+  skillDetailPageUrl,
+  audits,
   isSelected,
   isShowingDetail,
   mutate,
   onToggleDetail,
   onRefresh,
-}: InstalledSkillListItemProps) {
+}: InstalledSkillListItemProps & { skillDetailPageUrl?: string; audits?: ReturnType<typeof useSkillAudits> }) {
   const extraAgents = skill.agentCount - skill.agents.length;
   const agentsText = extraAgents > 0 ? `${skill.agents.join(", ")} +${extraAgents} more` : skill.agents.join(", ");
 
@@ -118,11 +220,21 @@ export function InstalledSkillListItem({
       }
       keywords={[skill.name, ...skill.agents, ...(skill.source ? [skill.source] : [])]}
       id={skill.name}
-      detail={<InlineDetail skill={skill} isSelected={isSelected} />}
+      detail={
+        <InlineDetail skill={skill} isSelected={isSelected} skillDetailPageUrl={skillDetailPageUrl} audits={audits} />
+      }
       actions={
         <ActionPanel>
           <ActionPanel.Section title="Open">
             <Action.ShowInFinder path={skill.path} icon={Icon.Finder} />
+            {skillDetailPageUrl && (
+              <Action.OpenInBrowser
+                title="Open on skills.sh"
+                url={skillDetailPageUrl}
+                icon={Icon.Globe}
+                shortcut={Keyboard.Shortcut.Common.Open}
+              />
+            )}
             {skill.sourceUrl && (
               <Action.OpenInBrowser
                 title="Open Repository"
@@ -132,6 +244,7 @@ export function InstalledSkillListItem({
               />
             )}
           </ActionPanel.Section>
+          {audits && <OpenSecurityAuditActions audits={audits.results} />}
           <ActionPanel.Section title="Copy">
             <Action.CopyToClipboard
               title="Copy Skill Name"
@@ -165,4 +278,28 @@ export function InstalledSkillListItem({
       }
     />
   );
+}
+
+function SourceBackedInstalledSkillListItem(
+  props: InstalledSkillListItemProps & { skill: InstalledSkill & { source: string } },
+) {
+  const remoteSkill: Skill = {
+    id: `${props.skill.source}/${props.skill.name}`,
+    skillId: props.skill.name,
+    name: props.skill.name,
+    installs: 0,
+    source: props.skill.source,
+  };
+  const skillDetailPageUrl = buildSkillUrl(remoteSkill);
+  const audits = useSkillAudits(remoteSkill, { shouldFetch: props.isSelected });
+
+  return <BaseInstalledSkillListItem {...props} skillDetailPageUrl={skillDetailPageUrl} audits={audits} />;
+}
+
+export function InstalledSkillListItem({ skill, ...props }: InstalledSkillListItemProps) {
+  if (isPublishedInstalledSkill(skill)) {
+    return <SourceBackedInstalledSkillListItem {...props} skill={skill} />;
+  }
+
+  return <BaseInstalledSkillListItem {...props} skill={skill} />;
 }

--- a/extensions/skills/src/components/SkillDetailView.tsx
+++ b/extensions/skills/src/components/SkillDetailView.tsx
@@ -1,7 +1,6 @@
 import { Action, ActionPanel, Color, Detail, Icon, Keyboard } from "@raycast/api";
 import { useCallback, useEffect, useRef } from "react";
 import {
-  type AuditStatus,
   AUDIT_PROVIDER_LABELS,
   buildInstallCommand,
   buildSkillUrl,
@@ -14,28 +13,11 @@ import { useRepoStats } from "../hooks/useRepoStats";
 import { useSkillAudits } from "../hooks/useSkillAudits";
 import { useSkillContent } from "../hooks/useSkillContent";
 import { useInstalledSkillMatches } from "../hooks/useInstalledSkillMatches";
-import { type SkillAuditsAvailabilityState } from "../utils/skill-audits";
+import { formatAuditStatus, getAuditFallbackText } from "../utils/skill-audit-display";
 import { showSkillAuditErrorToast } from "../utils/skill-audit-error-toast";
 import { InstallSkillAction } from "./actions/InstallSkillAction";
 import { OpenSecurityAuditActions } from "./actions/OpenSecurityAuditActions";
-
-const AUDIT_STATUS_META: Record<AuditStatus, { emoji: string; label: string }> = {
-  pass: { emoji: "✅", label: "Pass" },
-  warn: { emoji: "⚠️", label: "Warn" },
-  fail: { emoji: "🛑", label: "Fail" },
-  unknown: { emoji: "", label: "Unknown" },
-};
-
-function formatAuditStatus(status: AuditStatus): string {
-  const { emoji, label } = AUDIT_STATUS_META[status];
-  return emoji ? `${emoji} ${label}` : label;
-}
-
-function getAuditFallbackText(isLoading: boolean, availabilityState?: SkillAuditsAvailabilityState): string {
-  if (isLoading) return "Loading...";
-  if (availabilityState === "parse-error" || availabilityState === "fetch-error") return "Unable to verify";
-  return "Pending";
-}
+import { joinMetadataSections, type MetadataSection } from "./_common/metadata";
 
 interface SkillDetailViewProps {
   skill: Skill;
@@ -53,7 +35,7 @@ export function SkillDetailView({ skill, onSkillInstalled }: SkillDetailViewProp
   const installCommand = buildInstallCommand(skill);
   const allowedTools = normalizeAllowedTools(frontmatter["allowed-tools"]);
   const shownErrorTimestampRef = useRef<string | undefined>(undefined);
-  const skillUrl = buildSkillUrl(skill.source, skill.skillId);
+  const skillUrl = buildSkillUrl(skill);
 
   const refreshSkillStatus = useCallback(async () => {
     await Promise.all([revalidateInstalledSkillMatches(), onSkillInstalled?.()]);
@@ -93,6 +75,138 @@ ${installCommand}
 \`\`\`
 `;
 
+  const installationDetailsSection: MetadataSection = [
+    installedMatch.type === "exact" && (
+      <Detail.Metadata.TagList key="installation-status" title="Installation">
+        <Detail.Metadata.TagList.Item text="Installed" color={Color.Green} />
+      </Detail.Metadata.TagList>
+    ),
+    installedMatch.type === "conflict" && (
+      <Detail.Metadata.TagList key="installation-status" title="Installation">
+        <Detail.Metadata.TagList.Item text="Different Source" color={Color.Orange} />
+      </Detail.Metadata.TagList>
+    ),
+    installedMatch.type === "conflict" && (
+      <Detail.Metadata.Label
+        key="installation-source"
+        title="Installed Source"
+        text={installedMatch.source ?? "Unknown source"}
+      />
+    ),
+    installedMatch.type !== "none" && installedMatch.agents.length > 0 && (
+      <Detail.Metadata.TagList key="installation-agents" title="Agents">
+        {installedMatch.agents.map((agent) => (
+          <Detail.Metadata.TagList.Item key={agent} text={agent} color={Color.Blue} />
+        ))}
+      </Detail.Metadata.TagList>
+    ),
+  ];
+
+  const frontmatterDetailsSection: MetadataSection = [
+    frontmatter.description && (
+      <Detail.Metadata.Label key="frontmatter-description" title="Description" text={frontmatter.description} />
+    ),
+    frontmatter.license && (
+      <Detail.Metadata.Label
+        key="frontmatter-license"
+        title="License"
+        text={frontmatter.license}
+        icon={Icon.Document}
+      />
+    ),
+    frontmatter.compatibility && (
+      <Detail.Metadata.Label
+        key="frontmatter-compatibility"
+        title="Compatibility"
+        text={frontmatter.compatibility}
+        icon={Icon.Checkmark}
+      />
+    ),
+    allowedTools.length > 0 && (
+      <Detail.Metadata.TagList key="frontmatter-allowed-tools" title="Allowed Tools">
+        {allowedTools.map((tool) => (
+          <Detail.Metadata.TagList.Item key={tool} text={tool} color={Color.Blue} />
+        ))}
+      </Detail.Metadata.TagList>
+    ),
+  ];
+
+  const statsDetailsSection: MetadataSection = [
+    <Detail.Metadata.Label
+      key="stats-installs"
+      title="Installs"
+      text={formatInstalls(skill.installs)}
+      icon={Icon.Download}
+    />,
+    stats?.rateLimited ? (
+      <Detail.Metadata.Label key="stats-github-stars" title="GitHub Stars" text="Rate limited" icon={Icon.Warning} />
+    ) : (
+      stats?.stars !== undefined &&
+      stats?.stars !== null && (
+        <Detail.Metadata.Label
+          key="stats-github-stars"
+          title="GitHub Stars"
+          text={formatInstalls(stats.stars)}
+          icon={Icon.Star}
+        />
+      )
+    ),
+    !stats?.rateLimited && stats?.pushedAt && (
+      <Detail.Metadata.Label
+        key="stats-repo-activity"
+        title="Repo Activity"
+        text={formatRelativeDate(stats.pushedAt)}
+        icon={Icon.Calendar}
+      />
+    ),
+  ];
+
+  const repositoryDetailsSection: MetadataSection = [
+    <Detail.Metadata.Link
+      key="repository-skills"
+      title="skills.sh"
+      text={`${skill.source}/${skill.skillId}`}
+      target={skillUrl}
+    />,
+    <Detail.Metadata.Link
+      key="repository-github"
+      title="Repository"
+      text={skill.source}
+      target={`https://github.com/${skill.source}`}
+    />,
+  ];
+
+  const agentAuditsDetailsSection: MetadataSection = [
+    audits.results.length > 0 ? (
+      audits.results.map((audit) =>
+        audit.url ? (
+          <Detail.Metadata.Link
+            key={audit.provider}
+            title={`${AUDIT_PROVIDER_LABELS[audit.provider]} Audit`}
+            text={formatAuditStatus(audit.status)}
+            target={audit.url}
+          />
+        ) : (
+          <Detail.Metadata.Label
+            key={audit.provider}
+            title={`${AUDIT_PROVIDER_LABELS[audit.provider]} Audit`}
+            text={formatAuditStatus(audit.status)}
+          />
+        ),
+      )
+    ) : (
+      <Detail.Metadata.Label
+        key="agent-audits-fallback"
+        title="Security Audits"
+        text={getAuditFallbackText(audits.isLoading, audits.availabilityState)}
+      />
+    ),
+  ];
+
+  const installCommandDetailsSection: MetadataSection = [
+    <Detail.Metadata.Label key="install-command" title="Install Command" text={installCommand} />,
+  ];
+
   return (
     <Detail
       isLoading={isLoading}
@@ -100,87 +214,17 @@ ${installCommand}
       navigationTitle={skill.name}
       metadata={
         <Detail.Metadata>
-          {installedMatch.type === "exact" && (
-            <Detail.Metadata.TagList title="Installation">
-              <Detail.Metadata.TagList.Item text="Installed" color={Color.Green} />
-            </Detail.Metadata.TagList>
+          {joinMetadataSections(
+            [
+              installationDetailsSection,
+              frontmatterDetailsSection,
+              statsDetailsSection,
+              repositoryDetailsSection,
+              agentAuditsDetailsSection,
+              installCommandDetailsSection,
+            ],
+            Detail.Metadata.Separator,
           )}
-          {installedMatch.type === "conflict" && (
-            <Detail.Metadata.TagList title="Installation">
-              <Detail.Metadata.TagList.Item text="Different Source" color={Color.Orange} />
-            </Detail.Metadata.TagList>
-          )}
-          {installedMatch.type === "conflict" && (
-            <Detail.Metadata.Label title="Installed Source" text={installedMatch.source ?? "Unknown source"} />
-          )}
-          {installedMatch.type !== "none" && installedMatch.agents.length > 0 && (
-            <Detail.Metadata.TagList title="Agents">
-              {installedMatch.agents.map((agent) => (
-                <Detail.Metadata.TagList.Item key={agent} text={agent} color={Color.Blue} />
-              ))}
-            </Detail.Metadata.TagList>
-          )}
-          {installedMatch.type !== "none" && <Detail.Metadata.Separator />}
-          {frontmatter.description && <Detail.Metadata.Label title="Description" text={frontmatter.description} />}
-          {frontmatter.description && <Detail.Metadata.Separator />}
-          <Detail.Metadata.Label title="Installs" text={formatInstalls(skill.installs)} icon={Icon.Download} />
-          {stats?.rateLimited ? (
-            <Detail.Metadata.Label title="GitHub Stars" text="Rate limited" icon={Icon.Warning} />
-          ) : (
-            stats?.stars !== undefined &&
-            stats?.stars !== null && (
-              <Detail.Metadata.Label title="GitHub Stars" text={formatInstalls(stats.stars)} icon={Icon.Star} />
-            )
-          )}
-          {!stats?.rateLimited && stats?.pushedAt && (
-            <Detail.Metadata.Label
-              title="Repo Activity"
-              text={formatRelativeDate(stats.pushedAt)}
-              icon={Icon.Calendar}
-            />
-          )}
-          {frontmatter.license && (
-            <Detail.Metadata.Label title="License" text={frontmatter.license} icon={Icon.Document} />
-          )}
-          {frontmatter.compatibility && (
-            <Detail.Metadata.Label title="Compatibility" text={frontmatter.compatibility} icon={Icon.Checkmark} />
-          )}
-          {allowedTools.length > 0 && (
-            <Detail.Metadata.TagList title="Allowed Tools">
-              {allowedTools.map((tool: string) => (
-                <Detail.Metadata.TagList.Item key={tool} text={tool} color={Color.Blue} />
-              ))}
-            </Detail.Metadata.TagList>
-          )}
-          <Detail.Metadata.Separator />
-          <Detail.Metadata.Link title="skills.sh" text={`${skill.source}/${skill.skillId}`} target={skillUrl} />
-          <Detail.Metadata.Link title="Repository" text={skill.source} target={`https://github.com/${skill.source}`} />
-          <Detail.Metadata.Separator />
-          {audits.results.length > 0 ? (
-            audits.results.map((audit) =>
-              audit.url ? (
-                <Detail.Metadata.Link
-                  key={audit.provider}
-                  title={`${AUDIT_PROVIDER_LABELS[audit.provider]} Audit`}
-                  text={formatAuditStatus(audit.status)}
-                  target={audit.url}
-                />
-              ) : (
-                <Detail.Metadata.Label
-                  key={audit.provider}
-                  title={`${AUDIT_PROVIDER_LABELS[audit.provider]} Audit`}
-                  text={formatAuditStatus(audit.status)}
-                />
-              ),
-            )
-          ) : (
-            <Detail.Metadata.Label
-              title="Security Audits"
-              text={getAuditFallbackText(audits.isLoading, audits.availabilityState)}
-            />
-          )}
-          <Detail.Metadata.Separator />
-          <Detail.Metadata.Label title="Install Command" text={installCommand} />
         </Detail.Metadata>
       }
       actions={

--- a/extensions/skills/src/components/SkillListItem.tsx
+++ b/extensions/skills/src/components/SkillListItem.tsx
@@ -23,7 +23,7 @@ export function SkillListItem({
   const isInstalled = installedMatch.type === "exact";
   const hasSourceConflict = installedMatch.type === "conflict";
   const installedSource = installedMatch.type === "conflict" ? (installedMatch.source ?? "Unknown source") : undefined;
-  const skillUrl = buildSkillUrl(skill.source, skill.skillId);
+  const skillUrl = buildSkillUrl(skill);
 
   const iconValue = isInstalled
     ? { source: Icon.CheckCircle, tintColor: Color.Green }

--- a/extensions/skills/src/components/_common/metadata.tsx
+++ b/extensions/skills/src/components/_common/metadata.tsx
@@ -1,0 +1,18 @@
+import type { Detail, List } from "@raycast/api";
+
+type MetadataChild = Detail.Metadata.Props["children"] | List.Item.Detail.Metadata.Props["children"];
+export type MetadataSection = MetadataChild[];
+type MetadataSeparator = typeof Detail.Metadata.Separator | typeof List.Item.Detail.Metadata.Separator;
+
+function isRenderableMetadataNode(node: MetadataChild): boolean {
+  return node !== null && node !== undefined && node !== false;
+}
+
+export function joinMetadataSections(sections: MetadataSection[], Separator: MetadataSeparator): MetadataSection {
+  return sections
+    .map((section) => section.filter(isRenderableMetadataNode))
+    .filter((section) => section.length > 0)
+    .flatMap((section, index) =>
+      index === 0 ? section : [(<Separator key={`separator-${index}`} />) as MetadataChild, ...section],
+    );
+}

--- a/extensions/skills/src/hooks/useSkillAudits.ts
+++ b/extensions/skills/src/hooks/useSkillAudits.ts
@@ -25,9 +25,9 @@ type UseSkillAuditsResult = {
 
 export function useSkillAudits(skill: Skill, options?: UseSkillAuditsOptions): UseSkillAuditsResult {
   const { data, error, isLoading, revalidate } = useCachedPromise(
-    (id: string, skillId: string, name: string, installs: number, source: string) =>
-      fetchSkillAudits({ id, skillId, name, installs, source }),
-    [skill.id, skill.skillId, skill.name, skill.installs, skill.source],
+    (id: string, skillId: string, source: string) =>
+      fetchSkillAudits({ id, skillId, name: skill.name, installs: skill.installs, source }),
+    [skill.id, skill.skillId, skill.source],
     {
       execute: options?.shouldFetch ?? true,
       initialData: options?.initialData,

--- a/extensions/skills/src/hooks/useSkillAudits.ts
+++ b/extensions/skills/src/hooks/useSkillAudits.ts
@@ -25,8 +25,9 @@ type UseSkillAuditsResult = {
 
 export function useSkillAudits(skill: Skill, options?: UseSkillAuditsOptions): UseSkillAuditsResult {
   const { data, error, isLoading, revalidate } = useCachedPromise(
-    (inputSkill: Skill) => fetchSkillAudits(inputSkill),
-    [skill],
+    (id: string, skillId: string, name: string, installs: number, source: string) =>
+      fetchSkillAudits({ id, skillId, name, installs, source }),
+    [skill.id, skill.skillId, skill.name, skill.installs, skill.source],
     {
       execute: options?.shouldFetch ?? true,
       initialData: options?.initialData,

--- a/extensions/skills/src/shared.ts
+++ b/extensions/skills/src/shared.ts
@@ -36,6 +36,7 @@ export type SkillLockEntry = {
   source: string;
   sourceType: string;
   sourceUrl?: string;
+  ref?: string;
   skillPath: string;
   skillFolderHash: string;
   installedAt: string;
@@ -49,7 +50,9 @@ export type InstalledSkill = {
   agentCount: number;
   hasUpdate?: boolean;
   source?: string;
+  sourceType?: string;
   sourceUrl?: string;
+  ref?: string;
   installedAt?: string;
   updatedAt?: string;
 };
@@ -167,12 +170,18 @@ export function stripGitSuffix(url: string): string {
   return url.endsWith(".git") ? url.slice(0, -4) : url;
 }
 
+export function buildSkillUrl({ source, skillId }: Skill): string {
+  return `${SKILLS_BASE_URL}/${source}/${skillId}`;
+}
+
 export function buildInstallCommand(skill: Skill): string {
   return `npx skills add ${skill.source}@${skill.skillId}`;
 }
 
-export function buildSkillUrl(source: string, skillId: string): string {
-  return `${SKILLS_BASE_URL}/${source}/${skillId}`;
+export function isPublishedInstalledSkill(
+  installedSkill: InstalledSkill,
+): installedSkill is InstalledSkill & { source: string } {
+  return Boolean(installedSkill.source && installedSkill.sourceType !== "local" && !installedSkill.ref);
 }
 
 export function deduplicateSkills(skills: Skill[]): Skill[] {

--- a/extensions/skills/src/shared.ts
+++ b/extensions/skills/src/shared.ts
@@ -178,10 +178,10 @@ export function buildInstallCommand(skill: Skill): string {
   return `npx skills add ${skill.source}@${skill.skillId}`;
 }
 
-export function isPublishedInstalledSkill(
+export function isGithubBackedInstalledSkill(
   installedSkill: InstalledSkill,
 ): installedSkill is InstalledSkill & { source: string } {
-  return Boolean(installedSkill.source && installedSkill.sourceType !== "local" && !installedSkill.ref);
+  return Boolean(installedSkill.source && installedSkill.sourceType === "github" && !installedSkill.ref);
 }
 
 export function deduplicateSkills(skills: Skill[]): Skill[] {

--- a/extensions/skills/src/utils/installed-skills.ts
+++ b/extensions/skills/src/utils/installed-skills.ts
@@ -35,7 +35,9 @@ export async function getInstalledSkillsWithLock(): Promise<InstalledSkill[]> {
     return {
       ...skill,
       source: lock.source,
+      sourceType: lock.sourceType,
       sourceUrl: lock.sourceUrl ? stripGitSuffix(lock.sourceUrl) : undefined,
+      ref: lock.ref,
       installedAt: lock.installedAt,
       updatedAt: lock.updatedAt,
     };

--- a/extensions/skills/src/utils/skill-audit-display.ts
+++ b/extensions/skills/src/utils/skill-audit-display.ts
@@ -1,0 +1,20 @@
+import { type AuditStatus } from "../shared";
+import { type SkillAuditsAvailabilityState } from "./skill-audits";
+
+const AUDIT_STATUS_META: Record<AuditStatus, { emoji: string; label: string }> = {
+  pass: { emoji: "✅", label: "Pass" },
+  warn: { emoji: "⚠️", label: "Warn" },
+  fail: { emoji: "🛑", label: "Fail" },
+  unknown: { emoji: "", label: "Unknown" },
+};
+
+export function formatAuditStatus(status: AuditStatus): string {
+  const { emoji, label } = AUDIT_STATUS_META[status];
+  return emoji ? `${emoji} ${label}` : label;
+}
+
+export function getAuditFallbackText(isLoading: boolean, availabilityState?: SkillAuditsAvailabilityState): string {
+  if (isLoading) return "Loading...";
+  if (availabilityState === "parse-error" || availabilityState === "fetch-error") return "Unable to verify";
+  return "Pending";
+}

--- a/extensions/skills/src/utils/skill-audits.ts
+++ b/extensions/skills/src/utils/skill-audits.ts
@@ -1,4 +1,5 @@
 import {
+  buildSkillUrl,
   buildGithubIssueUrl,
   SKILLS_BASE_URL,
   type AuditProvider,
@@ -55,7 +56,7 @@ function buildAuditErrorResult({
       message,
       skillSource: skill.source,
       skillId: skill.skillId,
-      detailUrl: `${SKILLS_BASE_URL}/${skill.source}/${skill.skillId}`,
+      detailUrl: buildSkillUrl(skill),
       timestamp: new Date().toISOString(),
     },
   };
@@ -265,7 +266,7 @@ function parseSecurityAuditsFromHtml(skill: Skill, html: string): SkillAuditsRes
  * @returns The security audits for the skill.
  */
 export async function fetchSkillAudits(skill: Skill): Promise<SkillAuditsResult> {
-  const detailUrl = `${SKILLS_BASE_URL}/${skill.source}/${skill.skillId}`;
+  const detailUrl = buildSkillUrl(skill);
   const timeoutSignal = typeof AbortSignal.timeout === "function" ? AbortSignal.timeout(10_000) : undefined;
 
   let response: Response;


### PR DESCRIPTION
## Description

This change improves the installed skills view under the "Manage Skills" command by giving skills installed from `skills.sh` the same context that is already available when searching skills.

Installed skills now show a direct `skills.sh` link, repository information, security audit statuses, and audit actions from the detail panel. This makes it easier to inspect an installed skill. The extra metadata will only be displayed for skills present in the skills lock.

Changes include:

- Adding an "Open on skills.sh" action and `skills.sh` detail link for published installed skills.
- Showing security audit statuses and links in the metadata view and actions.
- Sharing audit display formatting and metadata section rendering between skill detail views.

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
