### PR TITLE
fix(fotmob): repair data fetching after FotMob endpoint changes

### DIFF
--- a/extensions/fotmob/CHANGELOG.md
+++ b/extensions/fotmob/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Fixes] - 2026-05-14
+
+- Fix Match Day, Match Detail, Team Detail, and League Table data fetching after FotMob endpoint changes
+
 ## [Security Fix] - 2026-03-17
 
 - Bump lodash/lodash-es to fix prototype pollution vulnerability (CVE-2025-13465)

--- a/extensions/fotmob/CHANGELOG.md
+++ b/extensions/fotmob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fixes] - 2026-05-14
+## [Fixes] - {PR_MERGE_DATE}
 
 - Fix Match Day, Match Detail, Team Detail, and League Table data fetching after FotMob endpoint changes
 

--- a/extensions/fotmob/CHANGELOG.md
+++ b/extensions/fotmob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-05-14
 
 - Fix Match Day, Match Detail, Team Detail, and League Table data fetching after FotMob endpoint changes
 

--- a/extensions/fotmob/src/hooks/useLeagueDetail.ts
+++ b/extensions/fotmob/src/hooks/useLeagueDetail.ts
@@ -1,19 +1,11 @@
 import { useCachedPromise } from "@raycast/utils";
 import type { LeagueDetailData } from "@/types/league-detail";
-import { getHeaderToken } from "@/utils/token";
+import { fetchLeaguePageData } from "@/utils/fotmob-client";
 
 export function useLeagueDetail(leagueId: string) {
   const { data, error, isLoading } = useCachedPromise(
     async (leagueId: string): Promise<LeagueDetailData> => {
-      const url = `https://www.fotmob.com/api/leagues?id=${leagueId}`;
-      const token = await getHeaderToken();
-
-      const response = await fetch(url, { headers: token });
-      if (!response.ok) {
-        throw new Error("Failed to fetch league details");
-      }
-      const leagueDetailData = (await response.json()) as LeagueDetailData;
-      return leagueDetailData;
+      return fetchLeaguePageData<LeagueDetailData>(leagueId);
     },
     [leagueId],
     {

--- a/extensions/fotmob/src/hooks/useMatchDay.ts
+++ b/extensions/fotmob/src/hooks/useMatchDay.ts
@@ -1,21 +1,11 @@
 import { useCachedPromise } from "@raycast/utils";
 import type { MatchDayResponse } from "@/types/match-day";
-import { getHeaderToken } from "@/utils/token";
+import { fetchMatchDayJson } from "@/utils/fotmob-client";
 
 export function useMatchDay(date: Date) {
   const { data, error, isLoading } = useCachedPromise(
     async (date): Promise<MatchDayResponse> => {
-      const dateStr = date.toISOString().split("T")[0].replace(/-/g, "");
-      const url = `https://www.fotmob.com/api/data/matches?date=${dateStr}`;
-      const headers = await getHeaderToken();
-      const searchResponse = await fetch(url, { headers });
-
-      if (!searchResponse.ok) {
-        throw new Error("Failed to fetch search results");
-      }
-
-      const response: MatchDayResponse = (await searchResponse.json()) as MatchDayResponse;
-      return response;
+      return fetchMatchDayJson<MatchDayResponse>(date);
     },
     [date],
   );

--- a/extensions/fotmob/src/hooks/useMatchDetail.ts
+++ b/extensions/fotmob/src/hooks/useMatchDetail.ts
@@ -1,82 +1,213 @@
 import { useCachedPromise } from "@raycast/utils";
-import type { MatchDetailData } from "@/types/match-detail";
-import { getHeaderToken } from "@/utils/token";
+import type { MatchDetailData, MatchEvent, MatchStats } from "@/types/match-detail";
+import {
+  type JsonRecord,
+  fetchFotmobPageProps,
+  getBoolean,
+  getNumber,
+  getRecord,
+  getString,
+  isRecord,
+} from "@/utils/fotmob-client";
+import { buildMatchDetailUrl } from "@/utils/url-builder";
+
+function getStatPair(value: unknown) {
+  if (!Array.isArray(value) || value.length < 2) return undefined;
+  return {
+    home: getNumber(value[0]),
+    away: getNumber(value[1]),
+  };
+}
+
+function normalizeKey(value: unknown) {
+  return getString(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}
+
+const STAT_MATCHERS: { field: keyof MatchStats; matches: (key: string, title: string) => boolean }[] = [
+  { field: "possession", matches: (key, title) => key.includes("ballpossesion") || title.includes("possession") },
+  { field: "shots", matches: (key, title) => key === "totalshots" || title === "totalshots" },
+  { field: "shotsOnTarget", matches: (key, title) => key.includes("shotsontarget") || title.includes("shotsontarget") },
+  { field: "corners", matches: (key, title) => key.includes("corner") || title.includes("corner") },
+  { field: "fouls", matches: (key, title) => key.includes("foul") || title.includes("foul") },
+  { field: "yellowCards", matches: (key, title) => key.includes("yellow") || title.includes("yellowcards") },
+  { field: "redCards", matches: (key, title) => key.includes("red") || title.includes("redcards") },
+  { field: "passes", matches: (key, title) => key === "passes" || title === "passes" },
+  { field: "passAccuracy", matches: (key, title) => title.includes("passaccuracy") || key.includes("accuratepasses") },
+];
+
+function transformStats(content: JsonRecord | undefined): MatchStats | undefined {
+  const stats = content ? getRecord(content, "stats") : undefined;
+  const periods = stats ? getRecord(stats, "Periods") : undefined;
+  const all = periods ? getRecord(periods, "All") : undefined;
+  const groups = all?.stats;
+
+  if (!Array.isArray(groups)) return undefined;
+
+  const result: MatchStats = {};
+
+  groups.forEach((group) => {
+    if (!isRecord(group) || !Array.isArray(group.stats)) return;
+
+    group.stats.forEach((stat) => {
+      if (!isRecord(stat)) return;
+
+      const key = normalizeKey(stat.key);
+      const title = normalizeKey(stat.title);
+      const pair = getStatPair(stat.stats);
+      if (!pair) return;
+
+      const matcher = STAT_MATCHERS.find((entry) => entry.matches(key, title));
+      if (matcher) {
+        result[matcher.field] = pair;
+      }
+    });
+  });
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function mapEventType(rawType: unknown, ownGoal: unknown): MatchEvent["type"] | undefined {
+  const type = getString(rawType).toLowerCase();
+
+  if (ownGoal === true) return "own_goal";
+  if (type.includes("goal")) return "goal";
+  if (type.includes("card")) return "card";
+  if (type.includes("substitution") || type.includes("sub")) return "substitution";
+  if (type.includes("penalty")) return "penalty";
+  if (type.includes("var")) return "var";
+
+  return undefined;
+}
+
+function getEventsArray(matchFacts: JsonRecord | undefined): unknown[] {
+  const rawEvents = matchFacts?.events;
+  if (Array.isArray(rawEvents)) return rawEvents;
+  if (isRecord(rawEvents) && Array.isArray(rawEvents.events)) return rawEvents.events;
+  return [];
+}
+
+function transformEvents(content: JsonRecord | undefined): MatchEvent[] {
+  const matchFacts = content ? getRecord(content, "matchFacts") : undefined;
+
+  return getEventsArray(matchFacts).flatMap((event, index): MatchEvent[] => {
+    if (!isRecord(event)) return [];
+
+    const type = mapEventType(event.type, event.ownGoal);
+    if (!type) return [];
+
+    const player = getRecord(event, "player");
+    const assist = getRecord(event, "assistInput") ?? getRecord(event, "assistPlayer");
+    const card = normalizeKey(event.type).includes("red") ? "red" : "yellow";
+
+    return [
+      {
+        id: getString(event.eventId, getString(event.reactKey, `${index}`)),
+        type,
+        minute: getNumber(event.time ?? event.timeStr),
+        minuteExtra: event.overloadTime ? getNumber(event.overloadTime) : undefined,
+        playerId: getNumber(event.playerId ?? player?.id),
+        playerName: getString(event.nameStr, getString(event.fullName, getString(player?.name, "Unknown Player"))),
+        assistPlayerId: assist ? getNumber(assist.id) : undefined,
+        assistPlayerName: assist ? getString(assist.name) : undefined,
+        cardType: type === "card" ? card : undefined,
+      },
+    ];
+  });
+}
+
+function buildTeam(
+  general: JsonRecord,
+  header: JsonRecord | undefined,
+  fallbackName: string,
+  fallbackShortName: string,
+) {
+  return {
+    id: getNumber(general.id ?? header?.id),
+    name: getString(general.name, getString(header?.name, fallbackName)),
+    shortName: getString(general.shortName, getString(header?.shortName, getString(header?.name, fallbackShortName))),
+    score: getNumber(header?.score),
+    formation: getString(general.formation, undefined),
+  };
+}
+
+function transformMatchDetail(rawData: JsonRecord, matchId: string): MatchDetailData {
+  const general = getRecord(rawData, "general") ?? {};
+  const header = getRecord(rawData, "header") ?? {};
+  const content = getRecord(rawData, "content");
+  const status = getRecord(header, "status") ?? {};
+  const teams = Array.isArray(header.teams) ? header.teams : [];
+  const headerHome = isRecord(teams[0]) ? teams[0] : undefined;
+  const headerAway = isRecord(teams[1]) ? teams[1] : undefined;
+  const generalHome = getRecord(general, "homeTeam") ?? {};
+  const generalAway = getRecord(general, "awayTeam") ?? {};
+  const venue = getRecord(general, "venue");
+  const referee = getRecord(general, "referee");
+  const started = getBoolean(status.started, getBoolean(general.started));
+  const finished = getBoolean(status.finished, getBoolean(general.finished));
+  const cancelled = getBoolean(status.cancelled);
+
+  return {
+    id: getNumber(general.matchId, parseInt(matchId, 10)),
+    home: buildTeam(generalHome, headerHome, "Home Team", "HOME"),
+    away: buildTeam(generalAway, headerAway, "Away Team", "AWAY"),
+    status: {
+      utcTime: getString(status.utcTime, getString(general.matchTimeUTC, new Date().toISOString())),
+      started,
+      cancelled,
+      finished,
+      ongoing: getBoolean(status.ongoing, started && !finished && !cancelled),
+      postponed: getBoolean(status.postponed),
+      abandoned: getBoolean(status.abandoned),
+      liveTime: isRecord(status.liveTime)
+        ? {
+            short: getString(status.liveTime.short),
+            long: getString(status.liveTime.long),
+            maxTime: getNumber(status.liveTime.maxTime),
+          }
+        : null,
+      reason: isRecord(status.reason)
+        ? {
+            short: getString(status.reason.short),
+            long: getString(status.reason.long),
+          }
+        : null,
+    },
+    tournament: {
+      id: getNumber(general.leagueId),
+      name: getString(general.leagueName, "Tournament"),
+      leagueId: getNumber(general.parentLeagueId, getNumber(general.leagueId)),
+      round: getString(general.leagueRoundName, undefined),
+      season: getString(general.season, undefined),
+    },
+    venue: venue
+      ? {
+          id: getNumber(venue.id),
+          name: getString(venue.name),
+          city: getString(venue.city),
+          country: isRecord(venue.country) ? getString(venue.country.name) : getString(venue.country),
+          capacity: venue.capacity === undefined ? undefined : getNumber(venue.capacity),
+        }
+      : undefined,
+    referee: referee
+      ? {
+          id: getNumber(referee.id),
+          name: getString(referee.name),
+          country: getString(referee.country, undefined),
+        }
+      : undefined,
+    events: transformEvents(content),
+    stats: transformStats(content),
+    attendance: general.attendance === undefined ? undefined : getNumber(general.attendance),
+  };
+}
 
 export function useMatchDetail(matchId: string) {
   const { data, error, isLoading } = useCachedPromise(
     async (matchId: string): Promise<MatchDetailData> => {
-      const url = `https://www.fotmob.com/api/matchDetails?matchId=${matchId}`;
-      const headers = await getHeaderToken();
-
-      const response = await fetch(url, { headers });
-      if (!response.ok) {
-        throw new Error(`Failed to fetch match details: ${response.status} ${response.statusText}`);
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const rawData = (await response.json()) as any; // Use type assertion for complex nested data structure
-
-      if (!rawData) {
-        throw new Error("No match data received from API");
-      }
-
-      // Transform the response to match our expected structure
-      const transformedData: MatchDetailData = {
-        id: rawData.general?.matchId || rawData.matchId || parseInt(matchId),
-        home: {
-          id: rawData.general?.homeTeam?.id || rawData.home?.id || 0,
-          name: rawData.general?.homeTeam?.name || rawData.home?.name || "Home Team",
-          shortName: rawData.general?.homeTeam?.shortName || rawData.home?.shortName || rawData.home?.name || "HOME",
-          score: rawData.header?.teams?.[0]?.score || rawData.home?.score || 0,
-          formation: rawData.general?.homeTeam?.formation,
-        },
-        away: {
-          id: rawData.general?.awayTeam?.id || rawData.away?.id || 0,
-          name: rawData.general?.awayTeam?.name || rawData.away?.name || "Away Team",
-          shortName: rawData.general?.awayTeam?.shortName || rawData.away?.shortName || rawData.away?.name || "AWAY",
-          score: rawData.header?.teams?.[1]?.score || rawData.away?.score || 0,
-          formation: rawData.general?.awayTeam?.formation,
-        },
-        status: {
-          utcTime: rawData.general?.matchTimeUTC || rawData.status?.utcTime || new Date().toISOString(),
-          started: rawData.header?.status?.started || false,
-          cancelled: rawData.header?.status?.cancelled || false,
-          finished: rawData.header?.status?.finished || false,
-          ongoing: rawData.header?.status?.ongoing || null,
-          postponed: rawData.header?.status?.postponed || false,
-          abandoned: rawData.header?.status?.abandoned || false,
-          liveTime: rawData.header?.status?.liveTime || null,
-          reason: rawData.header?.status?.reason || null,
-        },
-        tournament: {
-          id: rawData.general?.leagueId || 0,
-          name: rawData.general?.leagueName || rawData.tournament?.name || "Tournament",
-          leagueId: rawData.general?.leagueId || 0,
-          round: rawData.general?.leagueRoundName,
-          season: rawData.general?.season,
-        },
-        venue: rawData.general?.venue
-          ? {
-              id: rawData.general.venue.id || 0,
-              name: rawData.general.venue.name,
-              city: rawData.general.venue.city || "",
-              country: rawData.general.venue.country || "",
-              capacity: rawData.general.venue.capacity,
-            }
-          : undefined,
-        referee: rawData.general?.referee
-          ? {
-              id: rawData.general.referee.id || 0,
-              name: rawData.general.referee.name,
-              country: rawData.general.referee.country,
-            }
-          : undefined,
-        events: Array.isArray(rawData.content?.matchFacts?.events) ? rawData.content.matchFacts.events : [],
-        stats: rawData.content?.stats?.Periods?.All || undefined,
-        attendance: rawData.general?.attendance,
-      };
-
-      return transformedData;
+      const rawData = await fetchFotmobPageProps(buildMatchDetailUrl(matchId));
+      return transformMatchDetail(rawData, matchId);
     },
     [matchId],
     {

--- a/extensions/fotmob/src/hooks/useTeamDetail.ts
+++ b/extensions/fotmob/src/hooks/useTeamDetail.ts
@@ -1,19 +1,11 @@
 import { useCachedPromise } from "@raycast/utils";
 import type { ExtendedTeamDetailData, MatchFixture, TeamDetailData } from "@/types/team-detail";
-import { getHeaderToken } from "@/utils/token";
+import { fetchTeamPageData } from "@/utils/fotmob-client";
 
 export function useTeamDetail(teamId: string) {
   const { data, error, isLoading } = useCachedPromise(
     async (teamId: string): Promise<TeamDetailData> => {
-      const url = `https://www.fotmob.com/api/teams?id=${teamId}`;
-      const token = await getHeaderToken();
-
-      const response = await fetch(url, { headers: token });
-      if (!response.ok) {
-        throw new Error("Failed to fetch team details");
-      }
-      const teamDetailData = (await response.json()) as TeamDetailData;
-      return teamDetailData;
+      return fetchTeamPageData<TeamDetailData>(teamId);
     },
     [teamId],
     {

--- a/extensions/fotmob/src/utils/fotmob-client.ts
+++ b/extensions/fotmob/src/utils/fotmob-client.ts
@@ -1,7 +1,6 @@
 import { buildLeagueDetailUrl, buildTeamDetailUrl } from "@/utils/url-builder";
 
 const FOTMOB_BASE_URL = "https://www.fotmob.com";
-const DEFAULT_COUNTRY_CODE = "USA";
 
 export type JsonRecord = Record<string, unknown>;
 
@@ -81,10 +80,11 @@ export async function fetchMatchDayJson<T>(date: Date) {
   return fetchFotmobJson<T>("/api/data/matches", {
     date: formatFotmobDate(date),
     timezone: getTimezone(),
-    ccode3: DEFAULT_COUNTRY_CODE,
   });
 }
 
+// FotMob no longer exposes a usable public JSON API for these pages, so data is
+// read from the Next.js `__NEXT_DATA__` payload embedded in the page HTML.
 export async function fetchFotmobPageProps(pathOrUrl: string) {
   const response = await fetch(toFotmobUrl(pathOrUrl), { headers: getRequestHeaders() });
 

--- a/extensions/fotmob/src/utils/fotmob-client.ts
+++ b/extensions/fotmob/src/utils/fotmob-client.ts
@@ -1,0 +1,129 @@
+import { buildLeagueDetailUrl, buildTeamDetailUrl } from "@/utils/url-builder";
+
+const FOTMOB_BASE_URL = "https://www.fotmob.com";
+const DEFAULT_COUNTRY_CODE = "USA";
+
+export type JsonRecord = Record<string, unknown>;
+
+export function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function getRecord(record: JsonRecord, key: string) {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+export function getString(value: unknown, fallback = "") {
+  return typeof value === "string" ? value : fallback;
+}
+
+export function getNumber(value: unknown, fallback = 0) {
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value.replace("%", ""));
+    return Number.isNaN(parsed) ? fallback : parsed;
+  }
+  return fallback;
+}
+
+export function getBoolean(value: unknown, fallback = false) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function getRequestHeaders(): Record<string, string> {
+  return {
+    Accept: "application/json, text/html;q=0.9, */*;q=0.8",
+    "User-Agent":
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+  };
+}
+
+function getTimezone() {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}
+
+function toFotmobUrl(pathOrUrl: string) {
+  if (pathOrUrl.startsWith("http")) return pathOrUrl;
+  return `${FOTMOB_BASE_URL}${pathOrUrl.startsWith("/") ? pathOrUrl : `/${pathOrUrl}`}`;
+}
+
+export function formatFotmobDate(date: Date) {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}${month}${day}`;
+}
+
+export function buildFotmobApiUrl(path: string, params?: Record<string, string | number | boolean | undefined>) {
+  const url = new URL(toFotmobUrl(path));
+
+  Object.entries(params ?? {}).forEach(([key, value]) => {
+    if (value !== undefined) {
+      url.searchParams.set(key, `${value}`);
+    }
+  });
+
+  return url.toString();
+}
+
+export async function fetchFotmobJson<T>(path: string, params?: Record<string, string | number | boolean | undefined>) {
+  const response = await fetch(buildFotmobApiUrl(path, params), { headers: getRequestHeaders() });
+
+  if (!response.ok) {
+    throw new Error(`FotMob request failed: ${response.status} ${response.statusText}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function fetchMatchDayJson<T>(date: Date) {
+  return fetchFotmobJson<T>("/api/data/matches", {
+    date: formatFotmobDate(date),
+    timezone: getTimezone(),
+    ccode3: DEFAULT_COUNTRY_CODE,
+  });
+}
+
+export async function fetchFotmobPageProps(pathOrUrl: string) {
+  const response = await fetch(toFotmobUrl(pathOrUrl), { headers: getRequestHeaders() });
+
+  if (!response.ok) {
+    throw new Error(`FotMob page request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const html = await response.text();
+  const match = html.match(/<script id="__NEXT_DATA__" type="application\/json">(.*?)<\/script>/s);
+
+  if (!match?.[1]) {
+    throw new Error("FotMob page data was not found");
+  }
+
+  const nextData = JSON.parse(match[1]) as unknown;
+
+  if (!isRecord(nextData)) {
+    throw new Error("FotMob page data is invalid");
+  }
+
+  const props = nextData.props;
+  if (!isRecord(props) || !isRecord(props.pageProps)) {
+    throw new Error("FotMob page props are invalid");
+  }
+
+  return props.pageProps;
+}
+
+export async function fetchTeamPageData<T>(teamId: string) {
+  const pageProps = await fetchFotmobPageProps(buildTeamDetailUrl(teamId));
+  const fallback = pageProps.fallback;
+
+  if (isRecord(fallback) && isRecord(fallback[`team-${teamId}`])) {
+    return fallback[`team-${teamId}`] as T;
+  }
+
+  return pageProps as T;
+}
+
+export async function fetchLeaguePageData<T>(leagueId: string) {
+  return (await fetchFotmobPageProps(buildLeagueDetailUrl(leagueId))) as T;
+}

--- a/extensions/fotmob/src/utils/token.ts
+++ b/extensions/fotmob/src/utils/token.ts
@@ -1,9 +1,0 @@
-export async function getHeaderToken(): Promise<Record<string, string>> {
-  // This URL endpoint came from this fix https://github.com/probberechts/soccerdata/issues/742
-  const url = "http://46.101.91.154:6006/";
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error("Failed to fetch header token");
-  }
-  return (await response.json()) as Record<string, string>;
-}


### PR DESCRIPTION
## Description

FotMob's API changed and the previous token-based access (`src/utils/token.ts`, which fetched headers from a hard-coded third-party IP) no longer works. This broke Match Day, Match Detail, Team Detail, and League Table.

This PR replaces it with a shared `src/utils/fotmob-client.ts` that:
- Reads data from FotMob page props (`__NEXT_DATA__`) for match/team/league pages
- Uses the public match-day endpoint with `timezone`/`ccode3` params for Match Day
- Removes the hard-coded third-party token server dependency

`useMatchDetail` now transforms the page-prop payload into the existing `MatchDetailData` shape with defensive coercion helpers, since the new source is less structured than the old API response.

Fixes #27878

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` / lint and tested the changes locally
- [x] I checked that the extension's CHANGELOG is updated