### PR TITLE
Update Portless: add custom executable path preference

### DIFF
--- a/extensions/portless/CHANGELOG.md
+++ b/extensions/portless/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Portless Changelog
 
+## [Add custom executable path preference] - {PR_MERGE_DATE}
+
+- Add a "Custom Portless Executable Path" preference so users on Node version managers other than nvm (e.g. fnm, volta, asdf, mise) can point at the binary explicitly.
+
 ## [Initial Version] - 2026-04-13
 
 Initial version code

--- a/extensions/portless/package.json
+++ b/extensions/portless/package.json
@@ -21,6 +21,15 @@
       "mode": "view"
     }
   ],
+  "preferences": [
+    {
+      "name": "customPortlessPath",
+      "type": "textfield",
+      "required": false,
+      "title": "Custom Portless Executable Path",
+      "description": "Set this if your portless executable is in a non-standard location (e.g. installed via a Node version manager like fnm, volta, asdf, or mise). Run `which portless` in your terminal to find the path."
+    }
+  ],
   "dependencies": {
     "@raycast/api": "^1.104.10",
     "@raycast/utils": "^1.17.0"

--- a/extensions/portless/src/list.tsx
+++ b/extensions/portless/src/list.tsx
@@ -1,7 +1,11 @@
 import { existsSync, readdirSync } from "fs";
 import { join } from "path";
-import { ActionPanel, Action, Icon, List } from "@raycast/api";
+import { ActionPanel, Action, getPreferenceValues, Icon, List } from "@raycast/api";
 import { useExec } from "@raycast/utils";
+
+interface Preferences {
+  customPortlessPath?: string;
+}
 
 function parsePortlessListOutput(stdout: string): string[] {
   const urls: string[] = [];
@@ -48,7 +52,10 @@ function getExtendedPath(): string {
 }
 
 export default function Command() {
-  const { data, isLoading } = useExec("portless", ["list"], {
+  const { customPortlessPath } = getPreferenceValues<Preferences>();
+  const binary = customPortlessPath?.trim() || "portless";
+
+  const { data, isLoading } = useExec(binary, ["list"], {
     env: { PATH: getExtendedPath() },
     parseOutput: ({ stdout, error }) => (error ? [] : parsePortlessListOutput(stdout)),
   });


### PR DESCRIPTION
## Description

The extension's `getExtendedPath` only knows how to find Node binaries installed under `~/.nvm`. Users on other version managers (fnm, volta, asdf, mise, …) see "No active routes" even though `portless list` works fine in their terminal — Raycast spawns commands with a minimal PATH that doesn't include the version manager's bin dir, so the `portless` binary can't be located.

I hit this on fnm. Rather than add per-tool detection logic, this PR mirrors the [`brew` extension's `customBrewPath` pattern](https://github.com/raycast/extensions/blob/main/extensions/brew/package.json#L26-L32) and adds a simple textfield preference for an explicit binary path. The description tells users to run `which portless` to find it.

Existing nvm + homebrew auto-detection in `getExtendedPath` is unchanged, so this is purely additive — users on supported setups see no change.

## Changes

- **`package.json`**: add `customPortlessPath` textfield preference.
- **`src/list.tsx`**: read the preference; if set (and non-empty after trim), use it as the binary path in `useExec`; otherwise call `"portless"` as before.

3 files changed, 22 insertions(+), 2 deletions(-).

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with the metadata tool