### PR TITLE
[TogglTrack] Fixed Resume Entry on recent entries in Raycast v2

### DIFF
--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Toggl Track Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-05-15
 
 - Fixed "Resume Time Entry" on recent entries: use `Action` with `onAction` instead of `Action.SubmitForm`, which is for form submission and was incorrect in the list action panel
 

--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Toggl Track Changelog
 
+## [Bug Fixes] - 2026-05-14
+
+- Fixed "Resume Time Entry" on recent entries: use `Action` with `onAction` instead of `Action.SubmitForm`, which is for form submission and was incorrect in the list action panel
+
 ## [Fix] - 2026-04-17
 
 - Clarified Low Data Mode documentation in README — activation takes effect on next command launch, and framed sync behavior as a user contract (up to 1 hour delay) rather than implementation details

--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Toggl Track Changelog
 
-## [Bug Fixes] - 2026-05-14
+## [Bug Fixes] - {PR_MERGE_DATE}
 
 - Fixed "Resume Time Entry" on recent entries: use `Action` with `onAction` instead of `Action.SubmitForm`, which is for form submission and was incorrect in the list action panel
 

--- a/extensions/toggl-track/src/index.tsx
+++ b/extensions/toggl-track/src/index.tsx
@@ -3,7 +3,7 @@ import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import { useEffect, useRef } from "react";
 
-import { liteModeSync, isLiteModeColdStart, isLiteModeSyncDue } from "@/api";
+import { isLiteModeColdStart, isLiteModeSyncDue, liteModeSync } from "@/api";
 import { removeTimeEntry } from "@/api/timeEntries";
 import TimeEntryForm from "@/components/CreateTimeEntryForm";
 import RunningTimeEntry from "@/components/RunningTimeEntry";
@@ -123,6 +123,7 @@ function ListView() {
           revalidateTimeEntries={revalidateTimeEntries}
         />
       )}
+
       <List.Section title="Actions">
         <List.Item
           title="Create a new time entry"
@@ -149,6 +150,7 @@ function ListView() {
           }
         />
       </List.Section>
+
       {timeEntriesWithUniqueProjectAndDescription.length > 0 && (
         <List.Section title="Recent time entries">
           {timeEntriesWithUniqueProjectAndDescription.map((timeEntry) => (
@@ -165,11 +167,12 @@ function ListView() {
               icon={{ source: Icon.Circle, tintColor: timeEntry.project_color }}
               actions={
                 <ActionPanel>
-                  <Action.SubmitForm
+                  <Action
                     title="Resume Time Entry"
-                    onSubmit={() => resumeTimeEntry(timeEntry)}
+                    onAction={() => resumeTimeEntry(timeEntry)}
                     icon={{ source: Icon.Clock }}
                   />
+
                   <Action.Push
                     title="Edit Time Entry"
                     icon={Icon.Pencil}
@@ -183,6 +186,7 @@ function ListView() {
                       </ExtensionContextProvider>
                     }
                   />
+
                   <Action.Push
                     title="Create Similar Time Entry"
                     icon={{ source: Icon.Plus }}
@@ -197,11 +201,13 @@ function ListView() {
                       </ExtensionContextProvider>
                     }
                   />
+
                   <ActionPanel.Section>
                     <SyncAction
                       revalidateRunningTimeEntry={revalidateRunningTimeEntry}
                       revalidateTimeEntries={revalidateTimeEntries}
                     />
+
                     <Action
                       title="Delete Time Entry"
                       icon={Icon.Trash}


### PR DESCRIPTION
## Description

 In Raycast v2, **Resume Time Entry** on recent time entries stopped working. The action was implemented with `Action.SubmitForm` and `onSubmit`, which is for form submission, not list actions. That pattern no longer behaved correctly in v2. It is replaced with `Action` and `onAction`, which is the right API for this case and restores resume behavior.
 
 Fixes https://github.com/raycast/extensions/issues/27862

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [X] I checked that files in the `assets` folder are used by the extension itself
- [X] I checked that assets used by the `README` are placed outside of the `metadata` folder
