### PR TITLE
Pomodoro: hide menu bar item when timer is inactive

### DIFF
--- a/extensions/pomodoro/CHANGELOG.md
+++ b/extensions/pomodoro/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Pomodoro Changelog
 
-## [Improvement] - {PR_MERGE_DATE}
+## [Improvement] - 2026-05-15
 
 - Added preference to hide the entire menu bar item when the timer is stopped
 

--- a/extensions/pomodoro/CHANGELOG.md
+++ b/extensions/pomodoro/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Pomodoro Changelog
 
+## [Improvement] - {PR_MERGE_DATE}
+
+- Added preference to hide the entire menu bar item when the timer is stopped
+
 ## [Improvement] - 2026-03-08
 
 - Add session label to end of interval notification

--- a/extensions/pomodoro/package.json
+++ b/extensions/pomodoro/package.json
@@ -22,7 +22,8 @@
     "ridemountainpig",
     "meganpearson",
     "alastair_scheuermann",
-    "dangkhoipro"
+    "dangkhoipro",
+    "cblokkeel"
   ],
   "keywords": [
     "pomodoro",
@@ -249,6 +250,15 @@
       "description": "Hide time on the Menu Bar when the timer is stopped",
       "default": true,
       "label": "Hide the time when stopped"
+    },
+    {
+      "name": "hideMenuBarWhenStopped",
+      "type": "checkbox",
+      "required": false,
+      "title": "Hide Menu Bar When Stopped",
+      "description": "Hide the entire menu bar item when the timer is stopped",
+      "default": false,
+      "label": "Hide menu bar when stopped"
     },
     {
       "name": "enableFocusWhileFocused",

--- a/extensions/pomodoro/src/pomodoro-menu-bar.tsx
+++ b/extensions/pomodoro/src/pomodoro-menu-bar.tsx
@@ -65,6 +65,10 @@ export default function TogglePomodoroTimer() {
   const stopedPlaceholder = preferences.hideTimeWhenStopped ? undefined : TimeStoppedPlaceholder;
   const title = currentInterval ? secondsToTime(currentInterval.length - duration(currentInterval)) : stopedPlaceholder;
 
+  if (!currentInterval && preferences.hideMenuBarWhenStopped) {
+    return null;
+  }
+
   return (
     <MenuBarExtra icon={icon} title={preferences.enableTimeOnMenuBar ? title : undefined} tooltip={"Pomodoro"}>
       {preferences.enableTimeOnMenuBar ? null : <MenuBarExtra.Item icon="⏰" title={TimeStoppedPlaceholder} />}


### PR DESCRIPTION
## Description

Added an option in the pomodoro extension to hide the pomodoro item entirely from the menu bar when there is no timer running. The option is set to `false` by default. 

Closes https://github.com/raycast/extensions/issues/27831

## Screencast

<img width="314" height="378" alt="image" src="https://github.com/user-attachments/assets/a2ed91c7-cc91-45af-b194-32577d1b6b6b" />

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [X] I checked that files in the `assets` folder are used by the extension itself
- [X] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
