### PR TITLE
Update github extension

### DIFF
--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Changelog
 
-## [Fix null pull request nodes crash] - {PR_MERGE_DATE}
+## [Fix null pull request nodes crash] - 2026-05-15
 
 - Fixed `TypeError: Cannot read properties of null (reading 'id')` in **My Pull Requests** when the GitHub search API returns edges with a null `node` (e.g. PRs from repositories the user can no longer access).
 - Applied the same defensive null-filtering to **Search Pull Requests** and the per-repository pull request list to prevent the same crash from surfacing there.

--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,5 +1,10 @@
 # GitHub Changelog
 
+## [Fix null pull request nodes crash] - {PR_MERGE_DATE}
+
+- Fixed `TypeError: Cannot read properties of null (reading 'id')` in **My Pull Requests** when the GitHub search API returns edges with a null `node` (e.g. PRs from repositories the user can no longer access).
+- Applied the same defensive null-filtering to **Search Pull Requests** and the per-repository pull request list to prevent the same crash from surfacing there.
+
 ## [My Stats Menu Bar Enhancements] - 2026-05-12
 
 - Added a `What's New` section to the **My GitHub Stats Menu Bar** that surfaces repositories which received new stars since the last visit.

--- a/extensions/github/src/components/RepositoryPullRequest.tsx
+++ b/extensions/github/src/components/RepositoryPullRequest.tsx
@@ -26,7 +26,9 @@ export function RepositoryPullRequestList(props: { repo: string }): JSX.Element 
         query: `is:pr ${repoFilter} ${sortTxt} archived:false ${query}`,
         numberOfItems: 20,
       });
-      return result.search.edges?.map((edge) => edge?.node as PullRequestFieldsFragment);
+      return result.search.edges
+        ?.map((edge) => edge?.node as PullRequestFieldsFragment | null | undefined)
+        .filter((node): node is PullRequestFieldsFragment => node != null);
     },
     [query, sortQuery],
   );

--- a/extensions/github/src/hooks/useMyPullRequests.ts
+++ b/extensions/github/src/hooks/useMyPullRequests.ts
@@ -89,7 +89,11 @@ export function useMyPullRequests({
         ),
       );
 
-      return results.map((result) => result.search.edges?.map((edge) => edge?.node as PullRequestFieldsFragment));
+      return results.map((result) =>
+        result.search.edges
+          ?.map((edge) => edge?.node as PullRequestFieldsFragment | null | undefined)
+          .filter((node): node is PullRequestFieldsFragment => node != null),
+      );
     },
     [
       repository,

--- a/extensions/github/src/search-pull-requests.tsx
+++ b/extensions/github/src/search-pull-requests.tsx
@@ -37,7 +37,9 @@ function SearchPullRequests() {
         query: `is:pr archived:false ${sortTxt} ${searchFilter} ${searchText}`,
       });
 
-      return result.search.edges?.map((edge) => edge?.node as PullRequestFieldsFragment);
+      return result.search.edges
+        ?.map((edge) => edge?.node as PullRequestFieldsFragment | null | undefined)
+        .filter((node): node is PullRequestFieldsFragment => node != null);
     },
     [searchText, searchFilter, sortQuery],
     { keepPreviousData: true },


### PR DESCRIPTION
### Description

Fixes #27901.

`useMyPullRequests` was crashing with `TypeError: Cannot read properties of null (reading 'id')` on `useMyPullRequests.ts:154` whenever the GitHub search API returned an edge with a `null` `node` — for example a PR whose repository the authenticated user can no longer access.

The mapping at the source cast `edge?.node as PullRequestFieldsFragment`, which silenced the nullable type and let `null` flow into the deduplication step (`pullRequests.filter((pr) => !prIds.includes(pr.id))`), where `pr.id` then threw.

Fix:
- Filter out `null`/`undefined` nodes immediately after `result.search.edges?.map(...)` so the downstream code keeps its non-null invariant.
- Applied the same defensive null-filtering to the other two call sites that share the exact same pattern (`search-pull-requests.tsx`, `components/RepositoryPullRequest.tsx`) — they don't crash today only because the affected accounts haven't hit a null-node PR there yet, but the bug is latent.

No behavior change for the happy path: only previously-crashing or invisible-null cases are now silently skipped (which matches what users would expect — they couldn't open those PRs anyway).

### Screencast

N/A — backend-only crash fix, no UI changes.

### Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran \`npm run build\` and tested this distribution build in Raycast
- [x] I checked that files in the \`assets\` folder are used by the extension itself
- [x] I checked that assets used by the \`README\` are placed outside of the \`metadata\` folder