### PR TITLE
[Gitlab] Fix OOM errors on "My Projects"

### DIFF
--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitLab Changelog
 
-## [Fix OOM crash in My Projects for large GitLab instances] - {PR_MERGE_DATE}
+## [Fix OOM crash in My Projects for large GitLab instances] - 2026-05-16
 
 - Fix out-of-memory crash when fetching thousands of projects by using parallel batch fetching with per-page mapping
 - Replace Fuse.js search with lightweight multi-term substring matching for the project list to reduce memory usage

--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,5 +1,14 @@
 # GitLab Changelog
 
+## [Fix OOM crash in My Projects for large GitLab instances] - {PR_MERGE_DATE}
+
+- Fix out-of-memory crash when fetching thousands of projects by using parallel batch fetching with per-page mapping
+- Replace Fuse.js search with lightweight multi-term substring matching for the project list to reduce memory usage
+- Cap rendered list items to 100 to prevent memory exhaustion from complex ActionPanels
+- Sort projects by last activity date so most relevant projects appear first
+- Add "Search active projects only" preference to My Projects command (consistent with Search Projects)
+- Set background cache refetch interval to 1 day (was 5 minutes)
+
 ## [Merged MR icon in todos] - 2026-04-15
 
 - Show purple merged icon for todos on merged merge requests

--- a/extensions/gitlab/package.json
+++ b/extensions/gitlab/package.json
@@ -107,7 +107,17 @@
       "title": "My Projects",
       "subtitle": "GitLab",
       "description": "My GitLab Projects",
-      "mode": "view"
+      "mode": "view",
+      "preferences": [
+        {
+          "name": "active",
+          "description": "Limit by projects that are not archived and not marked for deletion",
+          "type": "checkbox",
+          "required": false,
+          "label": "Search active projects only",
+          "default": false
+        }
+      ]
     },
     {
       "name": "group_my",

--- a/extensions/gitlab/src/components/project.tsx
+++ b/extensions/gitlab/src/components/project.tsx
@@ -1,7 +1,7 @@
-import { ActionPanel, Color, Icon, Image, List } from "@raycast/api";
-import { useState } from "react";
+import { ActionPanel, Color, Icon, Image, List, getPreferenceValues } from "@raycast/api";
+import { useRef, useState } from "react";
 import { gitlab } from "../common";
-import { Project, searchData } from "../gitlabapi";
+import { Project } from "../gitlabapi";
 import { daysInSeconds, getFirstChar, hashRecord, projectIconUrl, showErrorToast } from "../utils";
 import {
   CloneProjectInGitPod,
@@ -102,30 +102,46 @@ export function ProjectListEmptyView() {
   return <List.EmptyView title="No Projects" icon={{ source: GitLabIcons.project, tintColor: Color.PrimaryText }} />;
 }
 
+// Cap rendered List.Items to avoid OOM — each item creates ~18 action components in the ActionPanel
+const MAX_RENDERED_PROJECTS = 100;
+
 export function ProjectList({ membership = true, starred = false }: ProjectListProps) {
   const [searchText, setSearchText] = useState<string>();
+  const activeOnly = (getPreferenceValues().active as boolean) || false;
+  const totalCount = useRef(0);
   const { data, error, isLoading } = useCache<Project[]>(
-    hashRecord({ membership: membership, starred: starred }, "projects"),
+    hashRecord({ membership: membership, starred: starred, active: activeOnly }, "projects"),
     async () => {
-      let glProjects: Project[] = [];
-      if (starred) {
-        glProjects = await gitlab.getStarredProjects({ searchText: "", searchIn: "name" }, true);
-      } else {
-        if (membership) {
-          glProjects = await gitlab.getUserProjects({ search: "" }, true);
-        }
+      const params: Record<string, string> = { search: "" };
+      if (activeOnly) {
+        params.archived = "false";
       }
-      return glProjects;
+      if (starred) {
+        return await gitlab.getStarredProjects({ searchText: "", searchIn: "name" }, true);
+      }
+      if (membership) {
+        return await gitlab.getUserProjects(params, true);
+      }
+      return [];
     },
     {
       deps: [searchText, membership, starred],
+      // Substring match instead of Fuse.js — building a Fuse index on thousands of projects exceeds the worker memory limit
       onFilter: async (projects) => {
-        return searchData<Project[]>(projects, {
-          search: searchText || "",
-          keys: ["name_with_namespace"],
-          limit: 50,
-        });
+        totalCount.current = projects.length;
+        if (!searchText || searchText.length === 0) return projects.slice(0, MAX_RENDERED_PROJECTS);
+        const terms = searchText.toLowerCase().split(/\s+/);
+        const filtered: Project[] = [];
+        for (const p of projects) {
+          const name = p.name_with_namespace.toLowerCase();
+          if (terms.every((t) => name.includes(t))) {
+            filtered.push(p);
+            if (filtered.length >= MAX_RENDERED_PROJECTS) break;
+          }
+        }
+        return filtered;
       },
+      secondsToRefetch: daysInSeconds(1),
       secondsToInvalid: daysInSeconds(7),
     },
   );
@@ -142,8 +158,10 @@ export function ProjectList({ membership = true, starred = false }: ProjectListP
       throttle={true}
     >
       <List.Section
-        title={searchText && searchText.length > 0 ? "Search Results" : "Projects"}
-        subtitle={`${data?.length}`}
+        title={searchText && searchText.length > 0 ? "Search Results" : "Recent Projects"}
+        subtitle={
+          data && totalCount.current > data.length ? `${data.length} of ${totalCount.current}` : `${data?.length ?? 0}`
+        }
       >
         {data?.map((project) => (
           <ProjectListItem key={project.id} project={project} />
@@ -163,17 +181,9 @@ export function useMyProjects(): { projects: Project[] | undefined; error?: stri
     error,
     isLoading,
   } = useCache<Project[]>(
-    hashRecord({ membership: membership, starred: starred }, "projects"),
+    hashRecord({ membership: membership, starred: starred, active: false }, "projects"),
     async () => {
-      let glProjects: Project[] = [];
-      if (starred) {
-        glProjects = await gitlab.getStarredProjects({ searchText: "", searchIn: "name" }, true);
-      } else {
-        if (membership) {
-          glProjects = await gitlab.getUserProjects({ search: "" }, true);
-        }
-      }
-      return glProjects;
+      return await gitlab.getUserProjects({ search: "" }, true);
     },
     {
       deps: [],

--- a/extensions/gitlab/src/gitlabapi.ts
+++ b/extensions/gitlab/src/gitlabapi.ts
@@ -172,11 +172,6 @@ function paramString(params: { [key: string]: any }): string {
   return prefix + p.join("&");
 }
 
-function getNextPageNumber(page_response: Response): number | undefined {
-  const header = page_response.headers.get("x-next-page");
-  return header ? parseInt(header) : undefined;
-}
-
 export enum EpicState {
   opened = "opened",
   closed = "closed",
@@ -438,7 +433,12 @@ export class GitLab {
     return new URL(relativeUrl, this.url).href;
   }
 
-  public async fetch(url: string, params: { [key: string]: string } = {}, all = false): Promise<any> {
+  public async fetch(
+    url: string,
+    params: { [key: string]: string } = {},
+    all = false,
+    mapPage?: (items: any[]) => any[],
+  ): Promise<any> {
     const per_page = all ? 100 : 50;
     const fetchPage = async (page: number): Promise<Response> => {
       const pagedParams = { ...params, ...{ per_page: `${per_page}`, page: `${page}` } };
@@ -451,21 +451,47 @@ export class GitLab {
       });
       return response;
     };
+
+    const processPage = async (r: Response): Promise<any[]> => {
+      const items = await toJsonOrError(r);
+      return mapPage ? mapPage(items) : items;
+    };
+
     try {
       const response = await fetchPage(1);
-      let json = await toJsonOrError(response);
+      const json = await processPage(response);
       if (!all) {
         return json;
       }
 
-      let next_page = getNextPageNumber(response);
-      while (next_page) {
-        logAPI(next_page);
-        const page_response = await fetchPage(next_page);
-        const page_content = await toJsonOrError(page_response);
-        json = json.concat(page_content);
-        next_page = getNextPageNumber(page_response);
+      const totalPages = parseInt(response.headers.get("x-total-pages") || "1");
+
+      if (totalPages > 1) {
+        const remainingPages = Array.from({ length: totalPages - 1 }, (_, i) => i + 2);
+        const BATCH_SIZE = 5;
+
+        for (let i = 0; i < remainingPages.length; i += BATCH_SIZE) {
+          const batch = remainingPages.slice(i, i + BATCH_SIZE);
+          const results = await Promise.all(
+            batch.map(async (page) => {
+              try {
+                return await processPage(await fetchPage(page));
+              } catch (firstError) {
+                logAPI(`page ${page} failed, retrying: ${firstError}`);
+                try {
+                  return await processPage(await fetchPage(page));
+                } catch (retryError) {
+                  throw Error(`page ${page} failed after retry: ${retryError} (original: ${firstError})`);
+                }
+              }
+            }),
+          );
+          for (const pageContent of results) {
+            json.push(...pageContent);
+          }
+        }
       }
+
       return json;
     } catch (error: any) {
       throw Error(error); // rethrow error, otherwise raycast could not catch the error
@@ -710,9 +736,12 @@ export class GitLab {
     if (!params.min_access_level) {
       params.min_access_level = "30";
     }
-    return await this.fetch("projects", params, all).then((projects: any[]) => {
-      return projects.map((p: any) => dataToProject(p));
-    });
+    if (!params.order_by) {
+      params.order_by = "last_activity_at";
+      params.sort = "desc";
+    }
+    const mapFn = (items: any[]) => items.map((p: any) => dataToProject(p));
+    return await this.fetch("projects", params, all, mapFn);
   }
 
   async getProjects(args = { searchText: "", searchIn: "", membership: "true", active: false }): Promise<Project[]> {
@@ -746,13 +775,11 @@ export class GitLab {
     if (args.searchIn && args.searchIn.length > 0) {
       params.searchIn = args.searchIn;
     }
+    params.order_by = "last_activity_at";
+    params.sort = "desc";
     const user = await this.getMyself();
-    const projects: Project[] = await this.fetch(`users/${user.id}/starred_projects`, params, all).then(
-      (projects: any[]) => {
-        return projects.map((p: any) => dataToProject(p));
-      },
-    );
-    return projects;
+    const mapFn = (items: any[]) => items.map((p: any) => dataToProject(p));
+    return await this.fetch(`users/${user.id}/starred_projects`, params, all, mapFn);
   }
 
   async getUsers(args = { searchText: "", searchIn: "" }): Promise<User[]> {


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

The My Projects command crashes with `Worker terminated due to reaching memory limit: JS heap out of memory` on GitLab instances with thousands of projects. Our instance has ~3800 projects, and the command has been unusable for me since a week. 

```
Error: Worker terminated due to reaching memory limit: JS heap out of memory

[kOnExit]:worker:316:26
Worker.<computed>.onexit:worker:232:20
```

<img width="1872" height="1320" alt="2026-05-15 at 13 25 10@2x" src="https://github.com/user-attachments/assets/266755fb-a2ae-4010-a033-8d1b37d5b939" />


Additionally, for the past year, when the cache gets invalidated (every 7 days) it would take 3-5min for the list of projects to be refetched again. This was always painfully slow for me, and i couldn't use Raycast meanwhile. 


### Root causes

**1. Sequential API pagination** — All pages were fetched one-by-one, accumulating raw JSON responses in memory before mapping to Project objects. With 39 pages of 100 projects, this took 60+ seconds and held all raw data simultaneously.
**2. Rendering all items** — Every project was rendered as a `<List.Item>` with ~18 action components in the ActionPanel. At 3800+ items, this created ~70,000 React elements, exceeding the worker memory limit.
**3. Fuse.js indexing** — Building a Fuse.js search index on 3800+ items consumed too much memory on top of the data and rendered components.

### What this PR does

**- Parallel batch fetching** — Pages are now fetched in parallel batches of 5, with a mapPage callback that transforms raw API responses to slim Project objects per-page (so raw JSON can be garbage collected between pages). Includes a single retry per failed page. Reduces initial fetch from ~60s to ~10-15s.
**- Render cap** — Only the top 100 matching projects are rendered at a time. The full dataset stays in memory for client-side filtering. The section subtitle shows e.g. "100 of 3847" when the cap is active.
**- Lightweight search** — Replaced Fuse.js with a multi-term case-insensitive substring filter for the project list. Typing data pipeline matches Showpad / Data / Pipeline Service. Zero memory overhead. Other commands (epics, events, labels) still use Fuse.js since their datasets are small.
**- Sort by activity** — Projects are now sorted by `last_activity_at` so the most relevant ones appear first, because of the cap of 100 items before search.
**- "Search active projects only" preference** — New checkbox on the My Projects command (consistent with `Search Projects`) to optionally exclude archived projects.
**- Background refetch interval** — Changed from the 5-minute default to 1 day. With thousands of projects, a background refetch takes 20 seconds — too expensive to trigger every 5 minutes. Users can still force-refresh via the existing "Clear Cache" action.
**- Cleanup** — Removed dead getNextPageNumber function, simplified useMyProjects hook.

**Note:** 
- I think the GitHub extension only allows server-side searching, but I didn't want to revamp going from client-side cached entries to full server-side search in the Gitlab extension. I tried to optimize the fuse.js indexing but i kept getting OOM's so reverted to simple substring search... WDYT?
- Another option would be to switch to the **graphql API** to keep the responses lighter only picking the project fields we need? I tried with the `simple=true` url param on the current API endpoint, but it excludes specific fields we need like the archived status. 

With these fixes in place, it currently works great again for me 👍 

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
