### PR TITLE
Pomodoro: add "sign in to slack" button if user is logged out

### DIFF
--- a/extensions/pomodoro/CHANGELOG.md
+++ b/extensions/pomodoro/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Pomodoro Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Fix Slack menu-bar command erroring when user is logged out, and show a clean "Sign in to Slack" option instead
+
 ## [Improvement] - 2026-05-15
 
 - Added preference to hide the entire menu bar item when the timer is stopped

--- a/extensions/pomodoro/CHANGELOG.md
+++ b/extensions/pomodoro/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Pomodoro Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-05-16
 
 - Fix Slack menu-bar command erroring when user is logged out, and show a clean "Sign in to Slack" option instead
 

--- a/extensions/pomodoro/src/slack-pomodoro-menu-bar.tsx
+++ b/extensions/pomodoro/src/slack-pomodoro-menu-bar.tsx
@@ -25,7 +25,7 @@ const slackClient = OAuthService.slack({
 
 export default function TogglePomodoroTimer() {
   const [currentInterval, setCurrentInterval] = useState<Interval | undefined>(getCurrentInterval());
-  const { isLoading, data: tokenSet } = usePromise(async () => slackClient.client.getTokens(), []);
+  const { isLoading, data: tokenSet, revalidate } = usePromise(async () => slackClient.client.getTokens(), []);
 
   const token = tokenSet && !tokenSet.isExpired() ? tokenSet.accessToken : undefined;
 
@@ -84,6 +84,7 @@ export default function TogglePomodoroTimer() {
   async function onSignIn() {
     try {
       await slackClient.authorize();
+      revalidate();
     } catch (error) {
       console.error("Failed to authorize Slack:", error);
     }

--- a/extensions/pomodoro/src/slack-pomodoro-menu-bar.tsx
+++ b/extensions/pomodoro/src/slack-pomodoro-menu-bar.tsx
@@ -1,10 +1,10 @@
 import { MenuBarExtra, Icon, launchCommand, LaunchType, Image, Color } from "@raycast/api";
 import { useState } from "react";
 import { FocusText, LongBreakText, ShortBreakText, TimeStoppedPlaceholder } from "./lib/constants";
-import { getCurrentInterval, isPaused, duration, preferences, progress } from "./lib/intervals";
+import { getCurrentInterval, isPaused, duration, preferences, progress, resetInterval } from "./lib/intervals";
 import { secondsToTime } from "./lib/secondsToTime";
 import { Interval, IntervalType } from "./lib/types";
-import { OAuthService, getAccessToken, withAccessToken } from "@raycast/utils";
+import { OAuthService, usePromise } from "@raycast/utils";
 import {
   slackContinueInterval,
   slackCreateInterval,
@@ -23,11 +23,11 @@ const slackClient = OAuthService.slack({
   scope: "users.profile:write dnd:write",
 });
 
-export default withAccessToken(slackClient)(TogglePomodoroTimer);
-
-export function TogglePomodoroTimer() {
+export default function TogglePomodoroTimer() {
   const [currentInterval, setCurrentInterval] = useState<Interval | undefined>(getCurrentInterval());
-  const { token } = getAccessToken();
+  const { isLoading, data: tokenSet } = usePromise(async () => slackClient.client.getTokens(), []);
+
+  const token = tokenSet && !tokenSet.isExpired() ? tokenSet.accessToken : undefined;
 
   if (currentInterval && progress(currentInterval) >= 100) {
     try {
@@ -42,28 +42,56 @@ export function TogglePomodoroTimer() {
   }
 
   async function onStart(type: IntervalType) {
+    if (!token) {
+      return;
+    }
     const interval = await slackCreateInterval(type, token);
     setCurrentInterval(interval);
   }
 
   async function onPause() {
+    if (!token) {
+      return;
+    }
     const interval = await slackPauseInterval(token);
     setCurrentInterval(interval);
   }
 
   async function onContinue() {
+    if (!token) {
+      return;
+    }
     const interval = await slackContinueInterval(token);
     setCurrentInterval(interval);
   }
 
   async function onReset() {
+    if (!token) {
+      return;
+    }
     await slackResetInterval(token);
     setCurrentInterval(undefined);
   }
 
   async function onRestart() {
+    if (!token) {
+      return;
+    }
     await slackRestartInterval(token);
     setCurrentInterval(getCurrentInterval());
+  }
+
+  async function onSignIn() {
+    try {
+      await slackClient.authorize();
+    } catch (error) {
+      console.error("Failed to authorize Slack:", error);
+    }
+  }
+
+  function onResetWithoutSlack() {
+    resetInterval();
+    setCurrentInterval(undefined);
   }
 
   let icon: Image.ImageLike;
@@ -76,8 +104,25 @@ export function TogglePomodoroTimer() {
   const stopedPlaceholder = preferences.hideTimeWhenStopped ? undefined : TimeStoppedPlaceholder;
   const title = currentInterval ? secondsToTime(currentInterval.length - duration(currentInterval)) : stopedPlaceholder;
 
+  if (!isLoading && !token) {
+    return (
+      <MenuBarExtra icon={icon} title={preferences.enableTimeOnMenuBar ? title : undefined} tooltip={"Pomodoro"}>
+        {preferences.enableTimeOnMenuBar ? null : <MenuBarExtra.Item icon="⏰" title={TimeStoppedPlaceholder} />}
+        {currentInterval ? (
+          <MenuBarExtra.Item title="Reset Timer" icon={Icon.Stop} onAction={onResetWithoutSlack} />
+        ) : null}
+        <MenuBarExtra.Item title="Sign in to Slack" icon={Icon.Lock} onAction={onSignIn} />
+      </MenuBarExtra>
+    );
+  }
+
   return (
-    <MenuBarExtra icon={icon} title={preferences.enableTimeOnMenuBar ? title : undefined} tooltip={"Pomodoro"}>
+    <MenuBarExtra
+      icon={icon}
+      title={preferences.enableTimeOnMenuBar ? title : undefined}
+      tooltip={"Pomodoro"}
+      isLoading={isLoading}
+    >
       {preferences.enableTimeOnMenuBar ? null : <MenuBarExtra.Item icon="⏰" title={TimeStoppedPlaceholder} />}
       {currentInterval ? (
         <>
@@ -85,27 +130,27 @@ export function TogglePomodoroTimer() {
             <MenuBarExtra.Item
               title="Continue"
               icon={Icon.Play}
-              onAction={async () => onContinue()}
+              onAction={onContinue}
               shortcut={{ modifiers: ["cmd"], key: "c" }}
             />
           ) : (
             <MenuBarExtra.Item
               title="Pause"
               icon={Icon.Pause}
-              onAction={async () => onPause()}
+              onAction={onPause}
               shortcut={{ modifiers: ["cmd"], key: "p" }}
             />
           )}
           <MenuBarExtra.Item
             title="Reset"
             icon={Icon.Stop}
-            onAction={async () => onReset()}
+            onAction={onReset}
             shortcut={{ modifiers: ["cmd"], key: "r" }}
           />
           <MenuBarExtra.Item
             title="Restart Current"
             icon={Icon.Repeat}
-            onAction={async () => onRestart()}
+            onAction={onRestart}
             shortcut={{ modifiers: ["cmd"], key: "t" }}
           />
         </>
@@ -115,21 +160,21 @@ export function TogglePomodoroTimer() {
             title={FocusText}
             subtitle={`${preferences.focusIntervalDuration}:00`}
             icon={`🎯`}
-            onAction={async () => await onStart("focus")}
+            onAction={() => onStart("focus")}
             shortcut={{ modifiers: ["cmd"], key: "f" }}
           />
           <MenuBarExtra.Item
             title={ShortBreakText}
             subtitle={`${preferences.shortBreakIntervalDuration}:00`}
             icon={`🧘‍♂️`}
-            onAction={async () => await onStart("short-break")}
+            onAction={() => onStart("short-break")}
             shortcut={{ modifiers: ["cmd"], key: "s" }}
           />
           <MenuBarExtra.Item
             title={LongBreakText}
             subtitle={`${preferences.longBreakIntervalDuration}:00`}
             icon={`🚶`}
-            onAction={async () => await onStart("long-break")}
+            onAction={() => onStart("long-break")}
             shortcut={{ modifiers: ["cmd"], key: "l" }}
           />
         </>


### PR DESCRIPTION
## Description

We had a bug in the Slack menu-bar command: when users were logged out, the component (wrapped in `withAccessToken`) tried to create an OAuth login flow on every 10-second background refresh. Raycast doesn't permit OAuth in background mode, so users saw a warning triangle and an error screen.

The fix removes `withAccessToken` from the menu-bar command. Instead, we asynchronously check if a Slack token exists. If not, we render a **"Sign in to Slack"** button that opens the proper OAuth UI (which works because it's user-initiated).

I also added a **"Reset Timer"** button for the edge case where a timer is running when the user logs out. Without it, they'd be stuck with an active timer they couldn't stop without re-authenticating.

I also cleaned up redundant wrapper functions in event callbacks.

Fixes https://github.com/raycast/extensions/issues/27211

## Screen

https://github.com/user-attachments/assets/150b56cb-b52f-45aa-b243-c778f9097eec

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [X] I checked that files in the `assets` folder are used by the extension itself
- [X] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
