### PR TITLE
Update wrap-unwrap extension

### DIFF
--- a/extensions/wrap-unwrap/CHANGELOG.md
+++ b/extensions/wrap-unwrap/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Wrap Unwrap Changelog
 
-## [Strip Bullet Indentation] - {PR_MERGE_DATE}
+## [Strip Bullet Indentation] - 2026-05-16
 
 - Add **Unwrap Text** preference **Strip Bullet Indentation** — re-indents bullet and numbered lists to a fixed 2-space-per-level step, removing the leading spaces that pasted terminal or rich-text content adds in front of markers. Nesting depth is preserved by relative indent order. Off by default.
 - Recognize common Unicode bullet markers (`•`, `‣`, `▪`, `▸`, `–`, `—`) as list items so pasted rich-text and terminal output reflows correctly.

--- a/extensions/wrap-unwrap/CHANGELOG.md
+++ b/extensions/wrap-unwrap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Wrap Unwrap Changelog
 
+## [Strip Bullet Indentation] - {PR_MERGE_DATE}
+
+- Add **Unwrap Text** preference **Strip Bullet Indentation** — re-indents bullet and numbered lists to a fixed 2-space-per-level step, removing the leading spaces that pasted terminal or rich-text content adds in front of markers. Nesting depth is preserved by relative indent order. Off by default.
+- Recognize common Unicode bullet markers (`•`, `‣`, `▪`, `▸`, `–`, `—`) as list items so pasted rich-text and terminal output reflows correctly.
+- Fix inline-token placeholder restore: a code span immediately followed by digits (e.g. `` `foo`42 ``) no longer drops the span and digits.
+
 ## [Initial Version] - 2026-05-10
 
 - Add **Wrap Text** command — wrap text at a configurable column width with Markdown awareness.

--- a/extensions/wrap-unwrap/README.md
+++ b/extensions/wrap-unwrap/README.md
@@ -37,6 +37,7 @@ Both commands share **Preferred Source**, **Primary Action**, **Hide HUD**, and 
 | --- | --- | --- |
 | Strip Soft Hyphens | on | When joining lines, remove a trailing hyphen if it appears to be a soft line-break hyphen (e.g. `inter-` + `esting` → `interesting`). Compounds like `state-of-the-art` are preserved. |
 | Keep Blank Lines | off | Preserve blank lines between paragraphs instead of collapsing runs. |
+| Strip Bullet Indentation | off | Re-indent bullet and numbered lists to a fixed 2-space-per-level step, removing the leading spaces that pasted terminal or rich-text content adds in front of markers. Nesting depth is preserved by relative indent order, so pasting into an email client produces native bullets. Recognizes Unicode bullets (`•`, `‣`, `▪`, `▸`, `–`, `—`) too. |
 
 ## Suggested hotkeys
 
@@ -72,7 +73,7 @@ await launchCommand({
 
 The provider invokes your callback command with `context: { result: "..." }` containing the transformed text. When `callbackLaunchOptions` is present, the provider does not paste, copy, or show a HUD — it just hands the result back.
 
-`UnwrapContext` accepts `text`, `hyphenation`, `keepBlankLines`, and `callbackLaunchOptions`. `WrapContext` accepts `text`, `width`, and `callbackLaunchOptions`.
+`UnwrapContext` accepts `text`, `hyphenation`, `keepBlankLines`, `flattenBullets`, and `callbackLaunchOptions`. `WrapContext` accepts `text`, `width`, and `callbackLaunchOptions`.
 
 ## Acknowledgements
 

--- a/extensions/wrap-unwrap/README.md
+++ b/extensions/wrap-unwrap/README.md
@@ -9,35 +9,35 @@ The classifier recognizes paragraphs, ATX and setext headings, fenced and indent
 
 ## Commands
 
-| Command | Description |
-| --- | --- |
-| Wrap Text | Wrap text at a configurable column width. |
+| Command     | Description                                                                         |
+| ----------- | ----------------------------------------------------------------------------------- |
+| Wrap Text   | Wrap text at a configurable column width.                                           |
 | Unwrap Text | Reflow wrapped text into continuous paragraphs while preserving Markdown structure. |
 
 ## Preferences
 
 Both commands share **Preferred Source**, **Primary Action**, **Hide HUD**, and **Pop to Root After Action**:
 
-| Preference | Default | What it does |
-| --- | --- | --- |
-| Preferred Source | Selected Text | Try the selection first; fall back to the clipboard if none. Choose Clipboard to flip the priority. |
-| Primary Action | Paste | Paste the result into the focused app. Choose Copy to put the result on the clipboard instead. |
-| Hide HUD | off | Suppress the success HUD ("Pasted wrapped text" / "Copied unwrapped text"). |
-| Pop to Root After Action | off | Return to Raycast root after the action completes. (No-op when launched via hotkey.) |
+| Preference               | Default       | What it does                                                                                        |
+| ------------------------ | ------------- | --------------------------------------------------------------------------------------------------- |
+| Preferred Source         | Selected Text | Try the selection first; fall back to the clipboard if none. Choose Clipboard to flip the priority. |
+| Primary Action           | Paste         | Paste the result into the focused app. Choose Copy to put the result on the clipboard instead.      |
+| Hide HUD                 | off           | Suppress the success HUD ("Pasted wrapped text" / "Copied unwrapped text").                         |
+| Pop to Root After Action | off           | Return to Raycast root after the action completes. (No-op when launched via hotkey.)                |
 
 **Wrap Text** also has:
 
-| Preference | Default | What it does |
-| --- | --- | --- |
-| Wrap Column | 80 | The column at which lines are wrapped. The wrap budget is the _full_ line including blockquote and list-item prefixes. Width values below 20 are clamped to 20. |
+| Preference  | Default | What it does                                                                                                                                                    |
+| ----------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Wrap Column | 80      | The column at which lines are wrapped. The wrap budget is the _full_ line including blockquote and list-item prefixes. Width values below 20 are clamped to 20. |
 
 **Unwrap Text** also has:
 
-| Preference | Default | What it does |
-| --- | --- | --- |
-| Strip Soft Hyphens | on | When joining lines, remove a trailing hyphen if it appears to be a soft line-break hyphen (e.g. `inter-` + `esting` → `interesting`). Compounds like `state-of-the-art` are preserved. |
-| Keep Blank Lines | off | Preserve blank lines between paragraphs instead of collapsing runs. |
-| Strip Bullet Indentation | off | Re-indent bullet and numbered lists to a fixed 2-space-per-level step, removing the leading spaces that pasted terminal or rich-text content adds in front of markers. Nesting depth is preserved by relative indent order, so pasting into an email client produces native bullets. Recognizes Unicode bullets (`•`, `‣`, `▪`, `▸`, `–`, `—`) too. |
+| Preference               | Default | What it does                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strip Soft Hyphens       | on      | When joining lines, remove a trailing hyphen if it appears to be a soft line-break hyphen (e.g. `inter-` + `esting` → `interesting`). Compounds like `state-of-the-art` are preserved.                                                                                                                                                              |
+| Keep Blank Lines         | off     | Preserve blank lines between paragraphs instead of collapsing runs.                                                                                                                                                                                                                                                                                 |
+| Strip Bullet Indentation | off     | Re-indent bullet and numbered lists to a fixed 2-space-per-level step, removing the leading spaces that pasted terminal or rich-text content adds in front of markers. Nesting depth is preserved by relative indent order, so pasting into an email client produces native bullets. Recognizes Unicode bullets (`•`, `‣`, `▪`, `▸`, `–`, `—`) too. |
 
 ## Suggested hotkeys
 

--- a/extensions/wrap-unwrap/package-lock.json
+++ b/extensions/wrap-unwrap/package-lock.json
@@ -1215,6 +1215,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1273,6 +1274,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -1477,6 +1479,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1825,6 +1828,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2630,6 +2634,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2653,6 +2658,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2889,6 +2895,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/wrap-unwrap/package.json
+++ b/extensions/wrap-unwrap/package.json
@@ -115,6 +115,15 @@
           "required": false,
           "default": false,
           "label": "Keep Blank Lines"
+        },
+        {
+          "name": "flattenBullets",
+          "title": "Bullet Indentation",
+          "description": "Re-indent bullet and numbered lists to a fixed 2-space-per-level step, removing the leading spaces that pasted terminal or rich-text content adds in front of markers. Nesting depth is preserved by relative indent order.",
+          "type": "checkbox",
+          "required": false,
+          "default": false,
+          "label": "Strip Bullet Indentation"
         }
       ]
     }

--- a/extensions/wrap-unwrap/package.json
+++ b/extensions/wrap-unwrap/package.json
@@ -6,9 +6,22 @@
   "license": "MIT",
   "author": "chrismessina",
   "icon": "extension-icon.png",
-  "platforms": ["macOS"],
-  "categories": ["Productivity"],
-  "keywords": ["markdown", "reflow", "wrap", "unwrap", "format", "text", "prose", "fold"],
+  "platforms": [
+    "macOS"
+  ],
+  "categories": [
+    "Productivity"
+  ],
+  "keywords": [
+    "markdown",
+    "reflow",
+    "wrap",
+    "unwrap",
+    "format",
+    "text",
+    "prose",
+    "fold"
+  ],
   "scripts": {
     "dev": "ray develop",
     "lint": "ray lint",
@@ -39,8 +52,14 @@
       "required": false,
       "default": "selection",
       "data": [
-        { "title": "Selected Text", "value": "selection" },
-        { "title": "Clipboard", "value": "clipboard" }
+        {
+          "title": "Selected Text",
+          "value": "selection"
+        },
+        {
+          "title": "Clipboard",
+          "value": "clipboard"
+        }
       ]
     },
     {
@@ -51,8 +70,14 @@
       "required": false,
       "default": "paste",
       "data": [
-        { "title": "Paste", "value": "paste" },
-        { "title": "Copy", "value": "copy" }
+        {
+          "title": "Paste",
+          "value": "paste"
+        },
+        {
+          "title": "Copy",
+          "value": "copy"
+        }
       ]
     },
     {

--- a/extensions/wrap-unwrap/src/lib/classify.ts
+++ b/extensions/wrap-unwrap/src/lib/classify.ts
@@ -96,6 +96,9 @@ function isBlank(content: string): boolean {
 }
 
 type FenceState = { char: "`" | "~"; len: number } | null;
+type ClassifyOptions = {
+  recognizeDashBullets?: boolean;
+};
 
 function classifyFenceBoundary(
   content: string,
@@ -149,7 +152,10 @@ function classifyHtmlBlockStart(content: string): boolean {
   return HTML_BLOCK_TAGS.has(m[1].toLowerCase());
 }
 
-function classifyListItem(content: string): {
+function classifyListItem(
+  content: string,
+  opts: Required<ClassifyOptions>,
+): {
   listMarker: string;
   hangIndent: number;
   listIndent: string;
@@ -161,6 +167,9 @@ function classifyListItem(content: string): {
   if (!m) return null;
   const indent = m[1];
   const marker = m[2];
+  if ((marker === "–" || marker === "—") && !opts.recognizeDashBullets) {
+    return null;
+  }
   const gap = m[3];
   const hangIndent = indent.length + marker.length + gap.length;
   const afterMarker = content.slice(hangIndent);
@@ -244,7 +253,11 @@ function applyHardBreakPass(records: Classified[]): void {
   }
 }
 
-export function classify(text: string): Classified[] {
+export function classify(
+  text: string,
+  opts: ClassifyOptions = {},
+): Classified[] {
+  const classifyOpts = { recognizeDashBullets: false, ...opts };
   const lines = text.replace(/\r\n?/g, "\n").split("\n");
   const out: Classified[] = [];
   let fence: FenceState = null;
@@ -306,7 +319,7 @@ export function classify(text: string): Classified[] {
       continue;
     }
 
-    const li = classifyListItem(content);
+    const li = classifyListItem(content, classifyOpts);
     if (li) {
       out.push({
         prefixes,

--- a/extensions/wrap-unwrap/src/lib/inline.ts
+++ b/extensions/wrap-unwrap/src/lib/inline.ts
@@ -23,10 +23,11 @@ const INLINE_PATTERNS = [
  * Placeholder sentinel — U+E000, a Unicode Private Use Area character that
  * (a) is a single code point with no whitespace semantics, so reflow won't
  * split inside a placeholder, and (b) is exceedingly unlikely to appear in
- * user input. Followed by the token's index.
+ * user input. The index is wrapped in a trailing sentinel too, so a literal
+ * digit immediately after a token in the source can't bleed into the index.
  */
 const PLACEHOLDER = String.fromCodePoint(0xe000);
-const RESTORE_PATTERN = new RegExp(`${PLACEHOLDER}(\\d+)`, "g");
+const RESTORE_PATTERN = new RegExp(`${PLACEHOLDER}(\\d+)${PLACEHOLDER}`, "g");
 
 export type Protected = {
   protected: string;
@@ -40,7 +41,7 @@ export function protectInline(input: string): Protected {
     working = working.replace(pattern, (match) => {
       const idx = tokens.length;
       tokens.push(match);
-      return `${PLACEHOLDER}${idx}`;
+      return `${PLACEHOLDER}${idx}${PLACEHOLDER}`;
     });
   }
   return { protected: working, tokens };

--- a/extensions/wrap-unwrap/src/lib/regex.ts
+++ b/extensions/wrap-unwrap/src/lib/regex.ts
@@ -21,10 +21,14 @@ export const HR = /^ {0,3}([-*_])(?:\s*\1){2,}\s*$/;
 /**
  * List-item start. Captures:
  *   group 1: leading indent
- *   group 2: marker (`-` `*` `+` or `\d{1,9}[.)]` per CommonMark 9-digit cap)
+ *   group 2: marker — CommonMark `-` `*` `+` / `\d{1,9}[.)]` (9-digit cap),
+ *            plus common Unicode bullets pasted from rich text or terminals
+ *            (•, ‣, ▪, ▸, –, —). The Unicode set is recognized so pasted
+ *            content can be reflowed and (optionally) re-indented; it is
+ *            emitted back verbatim, never rewritten to an ASCII marker.
  *   group 3: trailing whitespace (defines hang indent column)
  */
-export const LIST_ITEM = /^(\s*)([-*+]|\d{1,9}[.)])(\s+)/;
+export const LIST_ITEM = /^(\s*)([-*+]|[•‣▪▸–—]|\d{1,9}[.)])(\s+)/;
 
 /** Task-item marker, applied to list-item content (after stripping the list marker). */
 export const TASK_MARKER = /^\[[ xX]\]\s/;

--- a/extensions/wrap-unwrap/src/lib/unwrap.ts
+++ b/extensions/wrap-unwrap/src/lib/unwrap.ts
@@ -63,7 +63,9 @@ function emitGroup(g: Group): string {
 
 export function unwrap(text: string, opts: UnwrapOptions): string {
   if (text === "") return "";
-  const records = classify(text);
+  const records = classify(text, {
+    recognizeDashBullets: opts.flattenBullets,
+  });
 
   type Output =
     | { kind: "group"; group: Group }

--- a/extensions/wrap-unwrap/src/lib/unwrap.ts
+++ b/extensions/wrap-unwrap/src/lib/unwrap.ts
@@ -5,7 +5,16 @@ import { HYPHEN_BREAK_END } from "./regex.js";
 export type UnwrapOptions = {
   hyphenation: boolean;
   keepBlankLines: boolean;
+  /**
+   * Re-indent list items to a fixed 2-space-per-level step, deriving each
+   * item's level from the rank of its original indent width within its
+   * contiguous list block. Strips the leading spaces that pasted terminal
+   * or rich-text content carries in front of bullet markers.
+   */
+  flattenBullets: boolean;
 };
+
+const INDENT_STEP = "  ";
 
 const REFLOWABLE_ROLES = new Set<Classified["role"]>(["prose", "list-item"]);
 
@@ -132,6 +141,44 @@ export function unwrap(text: string, opts: UnwrapOptions): string {
     }
   }
   flush();
+
+  // Normalize bullet indentation per contiguous list block. A block breaks on
+  // a blank, a passthrough, or a non-list-item group. Within a block, the
+  // distinct original indent widths are ranked ascending and each list item is
+  // re-indented to rank * INDENT_STEP.
+  if (opts.flattenBullets) {
+    let blockStart = 0;
+    const reindentBlock = (start: number, end: number) => {
+      const headers: Classified[] = [];
+      for (let k = start; k < end; k++) {
+        const item = output[k];
+        if (item.kind === "group" && item.group.header.role === "list-item") {
+          headers.push(item.group.header);
+        }
+      }
+      if (headers.length === 0) return;
+      const widths = [
+        ...new Set(headers.map((h) => (h.listIndent ?? "").length)),
+      ].sort((a, b) => a - b);
+      const rankOf = new Map(widths.map((w, rank) => [w, rank]));
+      for (const h of headers) {
+        const rank = rankOf.get((h.listIndent ?? "").length) ?? 0;
+        h.listIndent = INDENT_STEP.repeat(rank);
+      }
+    };
+    for (let i = 0; i < output.length; i++) {
+      const o = output[i];
+      const isListGroup =
+        o.kind === "group" &&
+        !o.group.passthrough &&
+        o.group.header.role === "list-item";
+      if (!isListGroup) {
+        reindentBlock(blockStart, i);
+        blockStart = i + 1;
+      }
+    }
+    reindentBlock(blockStart, output.length);
+  }
 
   // Render output.
   const lines: string[] = [];

--- a/extensions/wrap-unwrap/src/lib/wrap.ts
+++ b/extensions/wrap-unwrap/src/lib/wrap.ts
@@ -64,7 +64,7 @@ export function wrap(text: string, opts: WrapOptions): string {
     Number.isFinite(opts.width) && opts.width > 0 ? opts.width : 80;
   const width = Math.max(MIN_WIDTH, widthRaw);
 
-  const records = classify(text);
+  const records = classify(text, { recognizeDashBullets: false });
   const out: string[] = [];
 
   let i = 0;

--- a/extensions/wrap-unwrap/src/unwrap-text.ts
+++ b/extensions/wrap-unwrap/src/unwrap-text.ts
@@ -12,6 +12,7 @@ import { unwrap } from "./lib/unwrap.js";
 type UnwrapContext = BaseLaunchContext & {
   hyphenation?: boolean;
   keepBlankLines?: boolean;
+  flattenBullets?: boolean;
 };
 
 export default async function Command(
@@ -25,7 +26,13 @@ export default async function Command(
     const hyphenation = props.launchContext?.hyphenation ?? prefs.hyphenation;
     const keepBlankLines =
       props.launchContext?.keepBlankLines ?? prefs.keepBlankLines;
-    const result = unwrap(input, { hyphenation, keepBlankLines });
+    const flattenBullets =
+      props.launchContext?.flattenBullets ?? prefs.flattenBullets;
+    const result = unwrap(input, {
+      hyphenation,
+      keepBlankLines,
+      flattenBullets,
+    });
     await deliver({
       launchContext: props.launchContext,
       prefs,

--- a/extensions/wrap-unwrap/test-fixtures/02-headings.md
+++ b/extensions/wrap-unwrap/test-fixtures/02-headings.md
@@ -11,12 +11,10 @@ Some prose under the heading that may need to be reflowed depending on width.
 
 ## Another ATX heading
 
-A Setext H1
-===========
+# A Setext H1
 
 Body of setext h1.
 
-A Setext H2
------------
+## A Setext H2
 
 Body of setext h2.

--- a/extensions/wrap-unwrap/test-fixtures/03-bullets-and-lists.md
+++ b/extensions/wrap-unwrap/test-fixtures/03-bullets-and-lists.md
@@ -10,15 +10,17 @@ Expected on Unwrap: continuation lines merge into the parent item
   with a continuation line
 
 * Asterisk bullets
-+ Plus bullets
+
+- Plus bullets
 
 1. First ordered
 2. Second ordered
+
 10) Tenth ordered with paren style
 
 - [ ] An unchecked task
 - [x] A checked task
-- [X] Capital X also works
+- [x] Capital X also works
 
 - Outer
   - Nested under outer

--- a/extensions/wrap-unwrap/test-fixtures/04-blockquotes.md
+++ b/extensions/wrap-unwrap/test-fixtures/04-blockquotes.md
@@ -9,6 +9,7 @@ Expected on Unwrap: lines within the same quote depth merge; depth changes break
 > Continues here.
 
 > Outer quote
+>
 > > Nested quote with its own paragraph
 > > continuing here.
 

--- a/extensions/wrap-unwrap/test-fixtures/05-fenced-code.md
+++ b/extensions/wrap-unwrap/test-fixtures/05-fenced-code.md
@@ -15,10 +15,10 @@ function thisIsAVeryLongFunctionNameThatShouldNotBeWrappedNoMatterWhat() {
 
 between fences
 
-~~~
+```
 - this looks like a list but is inside a fence
 1. and so is this
 | not | a | table |
-~~~
+```
 
 after

--- a/extensions/wrap-unwrap/test-fixtures/06-indented-code.md
+++ b/extensions/wrap-unwrap/test-fixtures/06-indented-code.md
@@ -13,5 +13,5 @@ para before
 para after
 
 - list item
-    continuation under the bullet (4 spaces)
+  continuation under the bullet (4 spaces)
 - next item

--- a/extensions/wrap-unwrap/test-fixtures/08-tables.md
+++ b/extensions/wrap-unwrap/test-fixtures/08-tables.md
@@ -8,8 +8,8 @@ Expected on Unwrap: same
 before
 
 | Column A | Column B |
-| --- | --- |
-| 1 | 2 |
-| 3 | 4 |
+| -------- | -------- |
+| 1        | 2        |
+| 3        | 4        |
 
 after

--- a/extensions/wrap-unwrap/test-fixtures/13-mixed-realistic.md
+++ b/extensions/wrap-unwrap/test-fixtures/13-mixed-realistic.md
@@ -24,7 +24,7 @@ Then configure it:
 
 > Note: see [the docs](https://example.com/docs) for advanced setup.
 
-| Option | Default |
-| --- | --- |
+| Option | Default        |
+| ------ | -------------- |
 | `mode` | `"production"` |
-| `port` | `8080` |
+| `port` | `8080`         |

--- a/extensions/wrap-unwrap/test-fixtures/14-edge-cases.md
+++ b/extensions/wrap-unwrap/test-fixtures/14-edge-cases.md
@@ -4,8 +4,6 @@ Input: empty paragraphs, single blank lines, whitespace-only lines, no trailing 
 Expected on Wrap/Unwrap: graceful handling, no crashes, no infinite loops
 -->
 
-   
-
 A_single_extremely_long_token_with_no_spaces_that_definitely_exceeds_any_reasonable_wrap_width_limit_set_by_the_user
 
 After the long token.

--- a/extensions/wrap-unwrap/test/inline.test.ts
+++ b/extensions/wrap-unwrap/test/inline.test.ts
@@ -20,10 +20,15 @@ test("protectInline handles double-backtick spans", () => {
 });
 
 test("protectInline replaces inline links", () => {
-  const { protected: p, tokens } = protectInline("see [the docs](https://example.com/a b) now");
+  const { protected: p, tokens } = protectInline(
+    "see [the docs](https://example.com/a b) now",
+  );
   assert.equal(tokens.length, 1);
   assert.equal(tokens[0], "[the docs](https://example.com/a b)");
-  assert.equal(restoreInline(p, tokens), "see [the docs](https://example.com/a b) now");
+  assert.equal(
+    restoreInline(p, tokens),
+    "see [the docs](https://example.com/a b) now",
+  );
 });
 
 test("protectInline replaces reference links", () => {
@@ -34,7 +39,9 @@ test("protectInline replaces reference links", () => {
 });
 
 test("protectInline replaces autolinks", () => {
-  const { protected: p, tokens } = protectInline("ping <https://example.com> please");
+  const { protected: p, tokens } = protectInline(
+    "ping <https://example.com> please",
+  );
   assert.equal(tokens.length, 1);
   assert.equal(tokens[0], "<https://example.com>");
   assert.equal(restoreInline(p, tokens), "ping <https://example.com> please");

--- a/extensions/wrap-unwrap/test/inline.test.ts
+++ b/extensions/wrap-unwrap/test/inline.test.ts
@@ -47,6 +47,24 @@ test("protectInline handles multiple tokens in one string", () => {
   assert.equal(restoreInline(p, tokens), input);
 });
 
+test("restoreInline handles a token immediately followed by digits", () => {
+  // Regression: a greedy placeholder index regex would absorb the trailing
+  // digits ("042" parsed as index 42), dropping both the span and the digits.
+  const input = "`foo`42 and `bar`9";
+  const { protected: p, tokens } = protectInline(input);
+  assert.equal(tokens.length, 2);
+  assert.equal(restoreInline(p, tokens), input);
+});
+
+test("restoreInline handles ten-plus tokens with digits adjacent", () => {
+  // Two-digit indices must not be truncated by an adjacent literal digit.
+  const spans = Array.from({ length: 12 }, (_, n) => `\`s${n}\`${n}`);
+  const input = spans.join(" ");
+  const { protected: p, tokens } = protectInline(input);
+  assert.equal(tokens.length, 12);
+  assert.equal(restoreInline(p, tokens), input);
+});
+
 test("protected output contains no spaces from token bodies", () => {
   // This is the load-bearing property: a wrapper joining on whitespace
   // must never see a space that came from inside a token.

--- a/extensions/wrap-unwrap/test/unwrap.test.ts
+++ b/extensions/wrap-unwrap/test/unwrap.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { unwrap } from "../src/lib/unwrap.js";
 
-const dflt = { hyphenation: true, keepBlankLines: false };
+const dflt = { hyphenation: true, keepBlankLines: false, flattenBullets: false };
 
 test("unwrap joins consecutive prose lines with a single space", () => {
   const input = "alpha\nbeta\ngamma";
@@ -111,4 +111,54 @@ test("unwrap preserves multi-space gap after list marker", () => {
   // A 3-space gap between marker and content is intentional alignment.
   const input = "-   item one\n-   item two";
   assert.equal(unwrap(input, dflt), "-   item one\n-   item two");
+});
+
+test("flattenBullets normalizes leading-space bullets to a 2-space step", () => {
+  // The Harvest-email case: top-level ordered items at col 0, sub-bullets
+  // pasted with 3 leading spaces. Without the option they round-trip
+  // verbatim; with it the sub-bullets normalize to depth 1 (2 spaces).
+  const input = "1. ITC details\n   - cost basis?\n   - pass-through?";
+  assert.equal(
+    unwrap(input, { ...dflt, flattenBullets: true }),
+    "1. ITC details\n  - cost basis?\n  - pass-through?",
+  );
+});
+
+test("flattenBullets is off by default (indentation preserved)", () => {
+  const input = "1. ITC details\n   - cost basis?";
+  assert.equal(unwrap(input, dflt), "1. ITC details\n   - cost basis?");
+});
+
+test("flattenBullets maps three indent levels to 0/2/4 spaces", () => {
+  const input = "- a\n   - b\n      - c";
+  assert.equal(
+    unwrap(input, { ...dflt, flattenBullets: true }),
+    "- a\n  - b\n    - c",
+  );
+});
+
+test("flattenBullets recomputes depth per contiguous list block", () => {
+  // Two blocks separated by a blank line; the second uses different raw
+  // indentation but its shallowest item must still land at column 0.
+  const input = "- a\n   - b\n\n     - c\n        - d";
+  assert.equal(
+    unwrap(input, { ...dflt, flattenBullets: true }),
+    "- a\n  - b\n\n- c\n  - d",
+  );
+});
+
+test("flattenBullets handles Unicode bullet markers", () => {
+  const input = "  • alpha\n  • beta";
+  assert.equal(
+    unwrap(input, { ...dflt, flattenBullets: true }),
+    "• alpha\n• beta",
+  );
+});
+
+test("flattenBullets flattens an over-indented single-level list to col 0", () => {
+  const input = "     - only\n     - level";
+  assert.equal(
+    unwrap(input, { ...dflt, flattenBullets: true }),
+    "- only\n- level",
+  );
 });

--- a/extensions/wrap-unwrap/test/unwrap.test.ts
+++ b/extensions/wrap-unwrap/test/unwrap.test.ts
@@ -2,7 +2,11 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { unwrap } from "../src/lib/unwrap.js";
 
-const dflt = { hyphenation: true, keepBlankLines: false, flattenBullets: false };
+const dflt = {
+  hyphenation: true,
+  keepBlankLines: false,
+  flattenBullets: false,
+};
 
 test("unwrap joins consecutive prose lines with a single space", () => {
   const input = "alpha\nbeta\ngamma";
@@ -21,7 +25,10 @@ test("unwrap collapses multiple blank lines by default", () => {
 
 test("unwrap preserves blank-line runs when keepBlankLines is on", () => {
   const input = "alpha\n\n\nbeta";
-  assert.equal(unwrap(input, { ...dflt, keepBlankLines: true }), "alpha\n\n\nbeta");
+  assert.equal(
+    unwrap(input, { ...dflt, keepBlankLines: true }),
+    "alpha\n\n\nbeta",
+  );
 });
 
 test("unwrap leaves fenced code untouched", () => {
@@ -51,30 +58,45 @@ test("unwrap merges list-item continuation lines", () => {
 
 test("unwrap strips soft hyphens when enabled", () => {
   const input = "an inter-\nesting word";
-  assert.equal(unwrap(input, { ...dflt, hyphenation: true }), "an interesting word");
+  assert.equal(
+    unwrap(input, { ...dflt, hyphenation: true }),
+    "an interesting word",
+  );
 });
 
 test("unwrap leaves single-line compounds alone (not split, no hyphenation runs)", () => {
   const input = "state-of-the-art";
-  assert.equal(unwrap(input, { ...dflt, hyphenation: true }), "state-of-the-art");
+  assert.equal(
+    unwrap(input, { ...dflt, hyphenation: true }),
+    "state-of-the-art",
+  );
 });
 
 test("unwrap preserves capital-led split words (no strip, but joined with space)", () => {
   // The hyphen rule excludes capital-led runs. The hyphen stays; lines join with a space.
   const input = "A State-\nwide policy";
-  assert.equal(unwrap(input, { ...dflt, hyphenation: true }), "A State- wide policy");
+  assert.equal(
+    unwrap(input, { ...dflt, hyphenation: true }),
+    "A State- wide policy",
+  );
 });
 
 test("unwrap mid-compound break — known v1 limitation: gains a space", () => {
   // The hyphen rule excludes mid-compound breaks (lowercase run preceded by `-`).
   // The hyphen stays; lines join with a space. Documented limitation.
   const input = "the state-of-the-\nart";
-  assert.equal(unwrap(input, { ...dflt, hyphenation: true }), "the state-of-the- art");
+  assert.equal(
+    unwrap(input, { ...dflt, hyphenation: true }),
+    "the state-of-the- art",
+  );
 });
 
 test("unwrap with hyphenation off keeps the hyphen verbatim", () => {
   const input = "an inter-\nesting word";
-  assert.equal(unwrap(input, { ...dflt, hyphenation: false }), "an inter- esting word");
+  assert.equal(
+    unwrap(input, { ...dflt, hyphenation: false }),
+    "an inter- esting word",
+  );
 });
 
 test("unwrap protects inline code from joins", () => {
@@ -84,7 +106,10 @@ test("unwrap protects inline code from joins", () => {
 
 test("unwrap protects inline links", () => {
   const input = "go to [the docs](https://x.test/a b)\nplease";
-  assert.equal(unwrap(input, dflt), "go to [the docs](https://x.test/a b) please");
+  assert.equal(
+    unwrap(input, dflt),
+    "go to [the docs](https://x.test/a b) please",
+  );
 });
 
 test("unwrap preserves hard-break-terminated lines", () => {
@@ -160,5 +185,14 @@ test("flattenBullets flattens an over-indented single-level list to col 0", () =
   assert.equal(
     unwrap(input, { ...dflt, flattenBullets: true }),
     "- only\n- level",
+  );
+});
+
+test("em-dash lines stay prose unless flattenBullets is enabled", () => {
+  const input = "— first\n— second";
+  assert.equal(unwrap(input, dflt), "— first — second");
+  assert.equal(
+    unwrap(input, { ...dflt, flattenBullets: true }),
+    "— first\n— second",
   );
 });

--- a/extensions/wrap-unwrap/test/wrap.test.ts
+++ b/extensions/wrap-unwrap/test/wrap.test.ts
@@ -41,7 +41,10 @@ test("wrap respects width INCLUDING blockquote prefix", () => {
   const out = wrap(input, W(20));
   for (const line of out.split("\n")) {
     assert.ok(line.length <= 20, `line too long: ${JSON.stringify(line)}`);
-    assert.ok(line.startsWith("> "), `lost quote prefix: ${JSON.stringify(line)}`);
+    assert.ok(
+      line.startsWith("> "),
+      `lost quote prefix: ${JSON.stringify(line)}`,
+    );
   }
 });
 


### PR DESCRIPTION
## Description

Follow-up to #27655 (merged). Three changes to the **Wrap Unwrap** extension:

1. **New `Unwrap Text` preference: Strip Bullet Indentation** (checkbox, off by default). Re-indents bullet and numbered lists to a fixed 2-space-per-level step, deriving each item's level from the rank of its original indent width within its contiguous list block. This strips the leading spaces that pasted terminal or rich-text content carries in front of markers, so pasting reflowed text into an email client produces native bullets instead of indented literal text. Nesting depth is preserved by relative indent order.

2. **Unicode bullet recognition.** `•`, `‣`, `▪`, `▸`, `–`, `—` are now recognized as list-item markers (in addition to CommonMark `-` `*` `+` and ordered `1.`/`1)`), so rich-text/terminal paste reflows correctly. Markers are emitted back verbatim — never rewritten to ASCII.

3. **Bug fix: greedy inline-placeholder restore.** Addresses the review thread https://github.com/raycast/extensions/pull/27655#discussion_r3214120848 — a code span (or other protected inline token) immediately followed by digits in the source (e.g. `` `foo`42 ``) bled those digits into the placeholder-index match, restoring the wrong token (`undefined`) and silently dropping both the span and the literal digits. The placeholder index is now terminated with a closing sentinel so the boundary is unambiguous. Two regression tests added.

All pure-function changes are TDD-covered: 98 tests passing (`npm test`), `npm run build` and `npm run lint` clean.

## Screencast

No UI changes (both commands are `no-view`). Behavior example — input with terminal-style indented sub-bullets:

```
2. Commercial ITC details — ... Can you confirm:
   - What is the total system cost basis ...?
   - How much does the ITC pass-through reduce ...?
```

With **Strip Bullet Indentation** on, Unwrap Text produces:

```
2. Commercial ITC details — ... Can you confirm:
  - What is the total system cost basis ...?
  - How much does the ITC pass-through reduce ...?
```

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)