### PR TITLE
[JetBrains Toolbox Recent Projects] Show current git branch next to projects

### DIFF
--- a/extensions/jetbrains/CHANGELOG.md
+++ b/extensions/jetbrains/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Jetbrains Changelog
 
+## [Show Git Branch] - {PR_MERGE_DATE}
+
+- Show the current git branch next to projects that live in a git repository
+- Added a "Show Git Branch" preference (default on) to toggle the behavior
+
 ## [Bugfix] - 2025-10-20
 
 - Added support for JetBrains Toolbox version 3 and improved handling of unsupported versions.

--- a/extensions/jetbrains/CHANGELOG.md
+++ b/extensions/jetbrains/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Jetbrains Changelog
 
-## [Show Git Branch] - {PR_MERGE_DATE}
+## [Show Git Branch] - 2026-05-25
 
 - Show the current git branch next to projects that live in a git repository
 - Added a "Show Git Branch" preference (default on) to toggle the behavior

--- a/extensions/jetbrains/package.json
+++ b/extensions/jetbrains/package.json
@@ -10,7 +10,8 @@
     "dima-m711",
     "dgrzedzielski",
     "perasite",
-    "hemang_kinra"
+    "hemang_kinra",
+    "kubarom"
   ],
   "license": "MIT",
   "commands": [
@@ -63,6 +64,15 @@
       "required": false,
       "title": "Use Frecency sorting for projects",
       "description": "Use Raycast's built in frecency sorting to order the list of projects",
+      "default": true,
+      "label": "Enabled"
+    },
+    {
+      "name": "showGitBranch",
+      "type": "checkbox",
+      "required": false,
+      "title": "Show Git Branch",
+      "description": "Show the current git branch next to projects that live in a git repository",
       "default": true,
       "label": "Enabled"
     }

--- a/extensions/jetbrains/src/components/RecentProject.tsx
+++ b/extensions/jetbrains/src/components/RecentProject.tsx
@@ -203,6 +203,16 @@ export function RecentProject({
               tooltip: `Last opened ${new Date(recent.opened).toLocaleString()}`,
             }
           : {},
+        recent.branch
+          ? {
+              icon: Icon.Code,
+              tag: {
+                value: recent.branch,
+                color: Color.Green,
+              },
+              tooltip: `Git branch: ${recent.branch}`,
+            }
+          : {},
         {
           tag: {
             value: app.name,

--- a/extensions/jetbrains/src/git.ts
+++ b/extensions/jetbrains/src/git.ts
@@ -1,0 +1,46 @@
+import { readFile, stat } from "fs/promises";
+import { dirname, isAbsolute, resolve } from "path";
+import { homedir } from "os";
+
+async function findGitDir(startDir: string): Promise<string | undefined> {
+  const stopAt = new Set([homedir(), "/"]);
+  let current = startDir;
+  while (true) {
+    const candidate = resolve(current, ".git");
+    try {
+      const stats = await stat(candidate);
+      if (stats.isDirectory()) {
+        return candidate;
+      }
+      if (stats.isFile()) {
+        const contents = await readFile(candidate, "utf8");
+        const match = contents.match(/^gitdir:\s*(.+?)\s*$/m);
+        if (!match) return undefined;
+        const gitdir = match[1];
+        return isAbsolute(gitdir) ? gitdir : resolve(current, gitdir);
+      }
+    } catch {
+      // .git not at this level — continue walking up
+    }
+    if (stopAt.has(current)) return undefined;
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+export async function getGitBranch(projectPath: string): Promise<string | undefined> {
+  try {
+    const stats = await stat(projectPath);
+    const startDir = stats.isDirectory() ? projectPath : dirname(projectPath);
+    const gitDir = await findGitDir(startDir);
+    if (!gitDir) return undefined;
+    const head = await readFile(resolve(gitDir, "HEAD"), "utf8");
+    const refMatch = head.match(/^ref:\s*refs\/heads\/(.+?)\s*$/m);
+    if (refMatch) return refMatch[1];
+    const sha = head.trim();
+    return /^[0-9a-f]{40}$/i.test(sha) ? sha.slice(0, 7) : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/extensions/jetbrains/src/recentMenu.tsx
+++ b/extensions/jetbrains/src/recentMenu.tsx
@@ -16,6 +16,10 @@ const menuIcon = {
 function buildSubtitle(entry: recentEntry): string {
   const branchSuffix = entry.branch ? `  ⎇ ${entry.branch}` : "";
   const budget = maxTitleLength - entry.title.length - branchSuffix.length;
+  if (entry.branch && budget < 2) {
+    // Branch suffix would leave no room for the path — drop the branch instead.
+    return buildSubtitle({ ...entry, branch: undefined });
+  }
   const truncatedParts = entry.parts.length < budget ? entry.parts : entry.parts.substring(0, budget - 2) + "…";
   return `← ${truncatedParts}${branchSuffix}`;
 }

--- a/extensions/jetbrains/src/recentMenu.tsx
+++ b/extensions/jetbrains/src/recentMenu.tsx
@@ -13,6 +13,13 @@ const menuIcon = {
   },
 };
 
+function buildSubtitle(entry: recentEntry): string {
+  const branchSuffix = entry.branch ? `  ⎇ ${entry.branch}` : "";
+  const budget = maxTitleLength - entry.title.length - branchSuffix.length;
+  const truncatedParts = entry.parts.length < budget ? entry.parts : entry.parts.substring(0, budget - 2) + "…";
+  return `← ${truncatedParts}${branchSuffix}`;
+}
+
 export default function ProjectList(): React.JSX.Element {
   const { isLoading, toolboxApp, appHistory, myFavs, recent, visitActions } = useAppHistory();
   if (toolboxApp === undefined || toolboxApp === false) {
@@ -57,11 +64,7 @@ export default function ProjectList(): React.JSX.Element {
                   title={`Open ${
                     fav.title.length < maxTitleLength ? fav.title : fav.title.substring(0, maxTitleLength - 1) + "…"
                   }`}
-                  subtitle={`← ${
-                    fav.title.length + fav.parts.length < maxTitleLength
-                      ? fav.parts
-                      : fav.parts.substring(0, maxTitleLength - fav.title.length - 2) + "…"
-                  }`}
+                  subtitle={buildSubtitle(fav)}
                   onAction={openInApp(
                     appHistory.find((history) => history.title === fav.appName) || appHistory[0],
                     fav,
@@ -82,11 +85,7 @@ export default function ProjectList(): React.JSX.Element {
                       ? recent.title
                       : recent.title.substring(0, maxTitleLength - 1) + "…"
                   }`}
-                  subtitle={`← ${
-                    recent.title.length + recent.parts.length < maxTitleLength
-                      ? recent.parts
-                      : recent.parts.substring(0, maxTitleLength - recent.title.length - 2) + "…"
-                  }`}
+                  subtitle={buildSubtitle(recent)}
                   onAction={openInApp(
                     appHistory.find((history) => history.title === recent.appName) || appHistory[0],
                     recent,
@@ -125,11 +124,7 @@ export default function ProjectList(): React.JSX.Element {
                                     ? recent.title
                                     : recent.title.substring(0, maxTitleLength - 1) + "…"
                                 }`}
-                                subtitle={`← ${
-                                  recent.title.length + recent.parts.length < maxTitleLength
-                                    ? recent.parts
-                                    : recent.parts.substring(0, maxTitleLength - recent.title.length - 2) + "…"
-                                }`}
+                                subtitle={buildSubtitle(recent)}
                                 tooltip={`Open ${recent.path} in ${app.title}`}
                                 onAction={openInApp(app, recent, visitActions.visit)}
                               />

--- a/extensions/jetbrains/src/util.ts
+++ b/extensions/jetbrains/src/util.ts
@@ -21,6 +21,7 @@ import { Options } from "fast-glob/out/settings";
 import Channel, { ChannelDetail, Extension, Tool } from "./.channel.json";
 import { exec } from "child_process";
 import { promisify } from "util";
+import { getGitBranch } from "./git";
 
 export const execPromise = promisify(exec);
 
@@ -31,6 +32,7 @@ interface prefs {
   toolsInstall: PreferenceValues;
   fallback: PreferenceValues;
   frecencySorting: PreferenceValues;
+  showGitBranch: PreferenceValues;
 }
 
 const preferences = getPreferenceValues<prefs>();
@@ -44,6 +46,7 @@ export const toolsInstall = String(preferences["toolsInstall"]).replace("~", hom
 export const toolsSupportDir = "~/Library/Application Support/JetBrains/Toolbox".replace("~", homedir());
 export const useUrl = Boolean(preferences["fallback"]);
 export const frecencySorting = Boolean(preferences["frecencySorting"]);
+export const showGitBranch = Boolean(preferences["showGitBranch"]);
 
 const CHANNEL_GLOB = resolve(toolsSupportDir, "channels/*.json");
 const SETTINGS_GLOB = resolve(toolsSupportDir, ".settings.json");
@@ -66,6 +69,7 @@ export interface recentEntry {
   opened: number;
   appName: string;
   exists?: boolean;
+  branch?: string;
   filter?: number;
   app: AppHistory;
   xmlFile: file;
@@ -165,11 +169,16 @@ export async function getRecentEntries(xmlFile: file, app: AppHistory): Promise<
             )
             // check if the file actually exists to prevent breaking open with actions
             .map(async (recent: recentEntry) => {
-              return {
-                ...recent,
-                exists: await stat(recent.path)
+              const [exists, branch] = await Promise.all([
+                stat(recent.path)
                   .then(() => true)
                   .catch(() => false),
+                showGitBranch ? getGitBranch(recent.path) : Promise.resolve(undefined),
+              ]);
+              return {
+                ...recent,
+                exists,
+                branch,
               } as recentEntry;
             })
         );


### PR DESCRIPTION
## Description

Shows the current git branch next to each recent project that lives in a git repository. Useful for quickly distinguishing multiple worktrees / checkouts of the same repo that all share the same project name (e.g. several `Younium.sln` entries under different `monolith-api` worktrees).

## Screencast / Screenshots

The branch appears as a green accessory tag with a code glyph between the date tag and the IDE tag in the list view. In the menu bar, it's appended to the subtitle as ` ⎇ branch`.

## How it works

- Walks up from the project path looking for a `.git` entry; falls back gracefully when none is found.
- Reads `.git/HEAD` directly — no `git` subprocess.
- Supports linked worktrees (`.git` as a file pointing at a `gitdir:` location).
- Detached HEAD shows a 7-char short SHA.
- All file-system errors are swallowed; the row simply renders without a branch tag.
- Gated by a new `Show Git Branch` preference (default **on**) so users can opt out.

## Files changed

- `src/git.ts` (new) — small helper exporting `getGitBranch(path)`.
- `src/util.ts` — extended `recentEntry` with `branch?: string`, resolved in parallel with the existing `exists` check inside `getRecentEntries`.
- `src/components/RecentProject.tsx` — added the branch accessory tag.
- `src/recentMenu.tsx` — appended branch to subtitle, extracted a `buildSubtitle` helper.
- `package.json` — added the `showGitBranch` preference.
- `CHANGELOG.md` — entry added.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] Added a CHANGELOG entry
- [x] Made sure that my changes do not lead to performance issues (branch resolution runs in parallel per entry, no `git` subprocess)

🤖 Generated with [Claude Code](https://claude.com/claude-code)