### PR TITLE
Fix Apple Developer Docs search API

### DIFF
--- a/extensions/apple-developer-docs/CHANGELOG.md
+++ b/extensions/apple-developer-docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Apple Developer Docs Changelog
 
-## [Fix Search API] - {PR_MERGE_DATE}
+## [Fix Search API] - 2026-05-18
 - Updated the Apple Developer search request to use the current production endpoint.
 
 ## [Search History] - 2022-08-02

--- a/extensions/apple-developer-docs/CHANGELOG.md
+++ b/extensions/apple-developer-docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Apple Developer Docs Changelog
 
+## [Fix Search API] - {PR_MERGE_DATE}
+- Updated the Apple Developer search request to use the current production endpoint.
+
 ## [Search History] - 2022-08-02
 - Added search history for searched items.
 - Reduced the often-truncated description clutter for list items.

--- a/extensions/apple-developer-docs/package.json
+++ b/extensions/apple-developer-docs/package.json
@@ -36,5 +36,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/apple-developer-docs/src/config.ts
+++ b/extensions/apple-developer-docs/src/config.ts
@@ -1,5 +1,5 @@
 export const config = {
   rootUrl: "https://developer.apple.com",
-  apiBaseUrl: "https://developer.apple.com/search/search_data.php",
+  apiBaseUrl: "https://devintserv.msc.sbz.apple.com/api/v1/search",
   maxResults: 50,
 };

--- a/extensions/apple-developer-docs/src/index.tsx
+++ b/extensions/apple-developer-docs/src/index.tsx
@@ -8,13 +8,24 @@ import DevOnlyActionPanel from "./DevOnlyActionPanel";
 
 export default function Command() {
   const [searchText, setSearchText] = useState("");
+  const query = searchText.length === 0 ? "SwiftUI" : searchText;
 
-  const params = new URLSearchParams();
-  params.append("q", searchText.length === 0 ? "SwiftUI" : searchText);
-  params.append("results", config.maxResults.toString());
+  // Keep q in the URL so useFetch re-runs when the search text changes; the API reads text from the POST body.
+  const { data, isLoading } = useFetch(`${config.apiBaseUrl}?q=${encodeURIComponent(query)}`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "User-Agent": "Raycast Apple Developer Docs",
+    },
+    body: JSON.stringify({ text: query, targetResultLocale: "en", results: config.maxResults }),
+    parseResponse: async (response) => {
+      if (!response.ok) {
+        throw new Error(`Apple Developer search request failed with status ${response.status}`);
+      }
 
-  const { data, isLoading } = useFetch(config.apiBaseUrl + "?" + params.toString(), {
-    parseResponse: async (response) => (await response.json()) as PayloadResponse,
+      return normalizeResponse((await response.json()) as AppleSearchResponse);
+    },
     keepPreviousData: true,
     initialData: { results: [], featuredResult: "", suggested_query: "", uuid: "" },
   });
@@ -47,7 +58,7 @@ export default function Command() {
       return searchedResults;
     }
 
-    const filteredResults = searchedResults?.filter((result) => result.type === typeFilter.toLowerCase());
+    const filteredResults = searchedResults?.filter((result) => result.type.toLowerCase() === typeFilter.toLowerCase());
 
     return filteredResults?.filter(
       (result) => searchText.trim() === "" || result.title.toLowerCase().includes(searchText.toLowerCase())
@@ -83,6 +94,118 @@ export default function Command() {
       </List.Section>
     </List>
   );
+}
+
+function normalizeResponse(payload: AppleSearchResponse): PayloadResponse {
+  return {
+    results: (payload.results ?? []).slice(0, config.maxResults).map(normalizeResult),
+    featuredResult: "",
+    suggested_query: "",
+    uuid: "",
+  };
+}
+
+function normalizeResult(result: AppleSearchResult, order: number): SearchResult {
+  if ("documentation" in result) {
+    const metadata = result.documentation.metadata;
+    const type = metadata.kind === "sampleCode" ? "sample_code" : "documentation";
+
+    return createSearchResult({
+      title: metadata.title,
+      description: metadata.description,
+      url: metadata.permalink,
+      type,
+      order,
+      platform: platformsFromAvailability(metadata.availability),
+      breadcrumbs: breadcrumbsFromHierarchy(metadata.hierarchy),
+    });
+  }
+
+  if ("devsite" in result) {
+    const metadata = result.devsite.metadata;
+
+    return createSearchResult({
+      title: metadata.title,
+      description: metadata.description,
+      url: metadata.sourceURL,
+      type: "general",
+      order,
+    });
+  }
+
+  const metadata = result.developer.metadata;
+  const itemType = first(metadata.itemTypes);
+
+  return createSearchResult({
+    title: first(metadata.titles),
+    description: first(metadata.descriptions),
+    url: first(metadata.permalinks),
+    type: isVideoResult(itemType) ? "video" : "general",
+    order,
+    date: first(metadata.availabilityDates),
+    event_name: first(metadata.projectNames),
+    session_id: first(metadata.ids),
+    tile_image: first(metadata.thumbnailLinks),
+    language: first(metadata.deliveryLanguageCodes),
+    duration: metadata.mediaDurations?.[0]?.toString(),
+  });
+}
+
+function createSearchResult({
+  title,
+  description,
+  url,
+  type,
+  order,
+  platform = [],
+  breadcrumbs = [],
+  date = "",
+  event_name = "",
+  session_id = "",
+  tile_image = "",
+  language = "",
+  duration,
+}: Partial<SearchResult> & Pick<SearchResult, "type" | "order">): SearchResult {
+  return {
+    title: title ?? "Untitled",
+    description: description ?? "",
+    url: url ?? config.rootUrl,
+    type,
+    order,
+    platform,
+    breadcrumbs,
+    date,
+    event_name,
+    session_id,
+    tile_image,
+    relevance: 0,
+    is_beta: 0,
+    language,
+    lang_children: [],
+    duration,
+  };
+}
+
+function first(values?: string[]) {
+  return values?.[0] ?? undefined;
+}
+
+function isVideoResult(type?: string) {
+  return ["session", "video"].includes(type?.toLowerCase() ?? "");
+}
+
+function platformsFromAvailability(availability?: string) {
+  return (availability ?? "")
+    .split("|")
+    .map((platform) => platform.trim().split(" ")[0])
+    .filter(Boolean);
+}
+
+function breadcrumbsFromHierarchy(hierarchy?: string) {
+  return (hierarchy ?? "")
+    .split(">")
+    .map((breadcrumb) => breadcrumb.trim())
+    .filter(Boolean);
 }
 
 function ItemActionPanel({ result, onVisit }: { result: ResultLike } & Visitable) {

--- a/extensions/apple-developer-docs/src/types.d.ts
+++ b/extensions/apple-developer-docs/src/types.d.ts
@@ -1,5 +1,5 @@
 type AllResultType = "all";
-type ResultType = "General" | "documentation" | "video" | "sample_code" | string;
+type ResultType = "general" | "documentation" | "video" | "sample_code" | string;
 
 type SearchResult = {
   title: string;
@@ -38,6 +38,55 @@ type PayloadResponse = {
   featuredResult: FeaturedResult | "";
   suggested_query: SuggestedQuery | "";
   uuid: string;
+};
+
+type AppleSearchResponse = {
+  results?: AppleSearchResult[];
+};
+
+type AppleSearchResult =
+  | {
+      documentation: {
+        metadata: AppleDocumentationMetadata;
+      };
+    }
+  | {
+      devsite: {
+        metadata: AppleDevsiteMetadata;
+      };
+    }
+  | {
+      developer: {
+        metadata: AppleDeveloperMetadata;
+      };
+    };
+
+type AppleDocumentationMetadata = {
+  title?: string;
+  description?: string;
+  permalink?: string;
+  hierarchy?: string;
+  availability?: string;
+  kind?: string;
+};
+
+type AppleDevsiteMetadata = {
+  title?: string;
+  description?: string;
+  sourceURL?: string;
+};
+
+type AppleDeveloperMetadata = {
+  titles?: string[];
+  descriptions?: string[];
+  permalinks?: string[];
+  thumbnailLinks?: string[];
+  projectNames?: string[];
+  ids?: string[];
+  itemTypes?: string[];
+  availabilityDates?: string[];
+  deliveryLanguageCodes?: string[];
+  mediaDurations?: number[];
 };
 
 interface Visitable {


### PR DESCRIPTION
## Description

- replace the deprecated Apple Developer search_data.php endpoint with the current search API
- normalize documentation, devsite, and developer search results into the existing Raycast result shape
- keep the existing result type filter support for documentation, sample code, video, and general results

## Validation

- npm run build
- npm run lint