### PR TITLE
Update installed-extensions extension

### DIFF
--- a/extensions/installed-extensions/CHANGELOG.md
+++ b/extensions/installed-extensions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Installed Extensions Changelog
 
+## [Fix Fresh Install Crash] - {PR_MERGE_DATE}
+
+- Treat a missing `~/.config/raycast/extensions` directory as an empty list instead of throwing `ENOENT` on fresh Raycast installs with no extensions yet
+
 ## [Sort by Recently Updated] - 2026-04-24
 
 - Add `Sort By` preference with `Title (A–Z)` (default) and `Recently Updated` options to quickly spot extensions refreshed by "Check for Updates"

--- a/extensions/installed-extensions/CHANGELOG.md
+++ b/extensions/installed-extensions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Fix Fresh Install Crash] - {PR_MERGE_DATE}
 
-- Treat a missing `~/.config/raycast/extensions` directory as an empty list instead of throwing `ENOENT` on fresh Raycast installs with no extensions yet
+- Treat a missing extensions directory (`~/.config/raycast/extensions` on macOS, `~/.config/raycast-x/extensions` on Windows) as an empty list instead of throwing `ENOENT` on fresh Raycast installs with no extensions yet
 
 ## [Sort by Recently Updated] - 2026-04-24
 

--- a/extensions/installed-extensions/CHANGELOG.md
+++ b/extensions/installed-extensions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Installed Extensions Changelog
 
-## [Fix Fresh Install Crash] - {PR_MERGE_DATE}
+## [Fix Fresh Install Crash] - 2026-05-17
 
 - Treat a missing extensions directory (`~/.config/raycast/extensions` on macOS, `~/.config/raycast-x/extensions` on Windows) as an empty list instead of throwing `ENOENT` on fresh Raycast installs with no extensions yet
 

--- a/extensions/installed-extensions/src/helpers/extension-scan.ts
+++ b/extensions/installed-extensions/src/helpers/extension-scan.ts
@@ -49,8 +49,8 @@ export async function parsePackageJson(packageJsonPath: string): Promise<Extensi
 }
 
 export async function getPackageJsonFiles(): Promise<string[]> {
+  const extensionsDir = path.join(os.homedir(), ".config", isWindows ? "raycast-x" : "raycast", "extensions");
   try {
-    const extensionsDir = path.join(os.homedir(), ".config", isWindows ? "raycast-x" : "raycast", "extensions");
     const extensions = await fs.readdir(extensionsDir);
     const packageJsonFiles = await Promise.all(
       extensions.map(async (extension) => {
@@ -65,6 +65,9 @@ export async function getPackageJsonFiles(): Promise<string[]> {
     );
     return packageJsonFiles.filter((file) => file !== null) as string[];
   } catch (e) {
+    if ((e as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return [];
+    }
     if (e instanceof Error) {
       showFailureToast(e.message);
       throw new Error(e.message);


### PR DESCRIPTION
## Description

Fixes #27947.

On a fresh Raycast install with no extensions installed yet, the `~/.config/raycast/extensions` directory does not exist. `getPackageJsonFiles()` called `fs.readdir` on that path unconditionally, which threw `ENOENT` and surfaced as an error toast / empty error state to the user.

This PR treats a missing extensions directory as "no extensions installed" and returns an empty list, so the command renders its normal empty state instead of crashing. Other I/O errors continue to be reported via `showFailureToast` as before.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder