### PR TITLE
Fix: Resolve lowerPricePercent API filter and lastPrice division by zero

### DIFF
--- a/extensions/game-scout/CHANGELOG.md
+++ b/extensions/game-scout/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Game Scout Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-05-16
 
 - Fixed an issue where `minDiscount` preference was ignored in Top Deals API requests.
 - Fixed a division-by-zero error in Saved Games when the previous price was free.

--- a/extensions/game-scout/CHANGELOG.md
+++ b/extensions/game-scout/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Game Scout Changelog
 
+## [Update] - {PR_MERGE_DATE}
+
+- Fixed an issue where `minDiscount` preference was ignored in Top Deals API requests.
+- Fixed a division-by-zero error in Saved Games when the previous price was free.
+
 ## [Initial Release] - 2026-05-16
 
-- Initial release
+- Initial release.

--- a/extensions/game-scout/src/saved-games.tsx
+++ b/extensions/game-scout/src/saved-games.tsx
@@ -393,7 +393,11 @@ export default function SavedGames() {
                   if (lastPrice != null && currentPrice !== lastPrice) {
                     const diffAbs = currentPrice - lastPrice;
                     const diffPct =
-                      lastPrice === 0 ? 100 : (diffAbs / lastPrice) * 100;
+                      lastPrice === 0
+                        ? diffAbs > 0
+                          ? 100
+                          : 0
+                        : (diffAbs / lastPrice) * 100;
 
                     if (Math.abs(diffPct) >= 3) {
                       let label = "";

--- a/extensions/game-scout/src/top-deals.tsx
+++ b/extensions/game-scout/src/top-deals.tsx
@@ -116,8 +116,12 @@ export default function TopDeals() {
       }
 
       try {
+        const lowerPricePercent =
+          parseFloat(minDiscount) > 0
+            ? `&lowerPricePercent=${minDiscount}`
+            : "";
         const response = await fetch(
-          `https://www.cheapshark.com/api/1.0/deals?upperPrice=${maxPrice}&onSale=1&sortBy=Deal%20Rating`,
+          `https://www.cheapshark.com/api/1.0/deals?upperPrice=${maxPrice}&onSale=1&sortBy=Deal%20Rating${lowerPricePercent}`,
         );
         const data = (await response.json()) as CheapSharkDeal[];
         data.sort((a, b) => {


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
