### PR TITLE
Claude/fix figma search extension vi2 cu

### DIFF
--- a/extensions/figma-files/src/api.ts
+++ b/extensions/figma-files/src/api.ts
@@ -102,7 +102,7 @@ async function fetchFiles(): Promise<ProjectFiles[][]> {
               // Update TTL for successfully fetched project
               await updateProjectTTLs([project.id]);
 
-              return { name: project.name, files: result.files ?? [] };
+              return { id: project.id, name: project.name, files: result.files ?? [] };
             }),
           );
           return projects;
@@ -143,7 +143,7 @@ async function fetchFiles(): Promise<ProjectFiles[][]> {
               // Update TTL for successfully fetched project
               await updateProjectTTLs([project.id]);
 
-              return { name: project.name, files: result.files ?? [] };
+              return { id: project.id, name: project.name, files: result.files ?? [] };
             }),
         );
         return projects;
@@ -186,11 +186,14 @@ export async function resolveAllFiles(): Promise<TeamFiles[]> {
       return { name: teamName, files: projectFiles } as TeamFiles;
     }
 
-    // Keep refreshed projects + cached projects that weren't refreshed
+    // Keep refreshed projects + cached projects that weren't refreshed, deduplicating by ID when available
+    const refreshedProjectIds = new Set(projectFiles.map((p) => p.id).filter(Boolean));
     const refreshedProjectNames = new Set(projectFiles.map((p) => p.name));
     const mergedProjects = [
       ...projectFiles,
-      ...cachedTeam.files.filter((p) => !refreshedProjectNames.has(p.name)),
+      ...cachedTeam.files.filter((p) =>
+        p.id ? !refreshedProjectIds.has(p.id) : !refreshedProjectNames.has(p.name),
+      ),
     ];
 
     return { name: teamName, files: mergedProjects } as TeamFiles;

--- a/extensions/figma-files/src/api.ts
+++ b/extensions/figma-files/src/api.ts
@@ -164,22 +164,39 @@ export async function resolveAllFiles(): Promise<TeamFiles[]> {
   const teamFiles = await fetchFiles();
   const teams = ((await LocalStorage.getItem<string>("teamNames")) ?? "").split(",");
 
-  // If no files were fetched (using cached data), load cached files
+  const { loadFiles, storeFiles } = await import("./cache");
+  const cachedFiles = await loadFiles();
+
+  // If no files were fetched (all projects fresh), return cached data
   if (teamFiles.length === 0 || teamFiles.every((projectFiles) => projectFiles.length === 0)) {
-    const { loadFiles } = await import("./cache");
-    const cachedFiles = await loadFiles();
-    if (cachedFiles && cachedFiles.length > 0) {
-      return cachedFiles;
-    }
+    return cachedFiles ?? [];
   }
 
+  // Merge refreshed data with cached data at project level
   const fi = teamFiles.map((projectFiles, index) => {
-    return { name: teams[index], files: projectFiles } as TeamFiles;
+    const teamName = teams[index];
+    const cachedTeam = cachedFiles?.find((t) => t.name === teamName);
+
+    if (projectFiles.length === 0) {
+      // No projects refreshed for this team — use cached team data
+      return cachedTeam ?? ({ name: teamName, files: [] } as TeamFiles);
+    }
+
+    if (!cachedTeam) {
+      return { name: teamName, files: projectFiles } as TeamFiles;
+    }
+
+    // Keep refreshed projects + cached projects that weren't refreshed
+    const refreshedProjectNames = new Set(projectFiles.map((p) => p.name));
+    const mergedProjects = [
+      ...projectFiles,
+      ...cachedTeam.files.filter((p) => !refreshedProjectNames.has(p.name)),
+    ];
+
+    return { name: teamName, files: mergedProjects } as TeamFiles;
   });
 
-  // Store the fetched files in cache
   if (fi.length > 0) {
-    const { storeFiles } = await import("./cache");
     await storeFiles(fi);
   }
 

--- a/extensions/figma-files/src/components/FileGridItem.tsx
+++ b/extensions/figma-files/src/components/FileGridItem.tsx
@@ -29,7 +29,7 @@ export default function FileGridItem(props: {
     searchkeywords,
   } = props;
   const fileIdentifier = extraKey ? `${file.key}-${extraKey}` : file.key;
-  const isStarred = props.starredFiles.some((item) => item.name === file.name);
+  const isStarred = props.starredFiles.some((item) => item.key === file.key);
 
   const accessory: Grid.Item.Accessory = {};
   accessory.icon = "branch.svg";

--- a/extensions/figma-files/src/index.tsx
+++ b/extensions/figma-files/src/index.tsx
@@ -142,14 +142,10 @@ function Command({ launchContext }: Readonly<LaunchProps<{ launchContext: { quer
 
       {filteredFiles?.map((team: TeamFiles) =>
         team.files.map((project) =>
-          project.files?.length != 0 ? (
+          (project.files?.length ?? 0) > 0 ? (
             <Grid.Section
               key={team.name + project.name + "-project"}
-              title={`${project.name} ${
-                project.files?.length != 0
-                  ? `(${project.files?.length} File${project.files?.length === 1 ? "" : "s"})`
-                  : ""
-              }`}
+              title={`${project.name} (${project.files!.length} File${project.files!.length === 1 ? "" : "s"})`}
               subtitle={team.name}
             >
               {project.files?.map((file) => (

--- a/extensions/figma-files/src/oauth.ts
+++ b/extensions/figma-files/src/oauth.ts
@@ -22,11 +22,15 @@ export const figma = new OAuthService({
   scope: "file_content:read,file_metadata:read,file_versions:read,projects:read",
   personalAccessToken: PERSONAL_ACCESS_TOKEN,
   onAuthorize: async ({ token, type }) => {
-    const headers =
-      type === "oauth" ? { Authorization: `Bearer ${token}` } : { "X-Figma-Token": token };
-    const response = await fetch("https://api.figma.com/v1/me", { headers });
-    if (!response.ok) return;
-    const user = (await response.json()) as { handle: string; img_url: string };
-    setUserInfo({ name: user.handle, icon: user.img_url });
+    try {
+      const headers =
+        type === "oauth" ? { Authorization: `Bearer ${token}` } : { "X-Figma-Token": token };
+      const response = await fetch("https://api.figma.com/v1/me", { headers });
+      if (!response.ok) return;
+      const user = (await response.json()) as { handle: string; img_url: string };
+      setUserInfo({ name: user.handle, icon: user.img_url });
+    } catch {
+      // Non-critical: a transient failure here doesn't affect the OAuth handshake
+    }
   },
 });

--- a/extensions/figma-files/src/oauth.ts
+++ b/extensions/figma-files/src/oauth.ts
@@ -1,4 +1,4 @@
-import { OAuth, getPreferenceValues } from "@raycast/api";
+import { OAuth, getPreferenceValues, setUserInfo } from "@raycast/api";
 import { OAuthService } from "@raycast/utils";
 
 const client = new OAuth.PKCEClient({
@@ -21,4 +21,12 @@ export const figma = new OAuthService({
     "https://oauth.raycast.com/v1/refresh-token/qJfyXOqhjDouaj06_54vl2O3NoIfY36R_-OOExXZNAS073Bih0aeNaHLO9xEpW6lbooqWCpT6zO7zLvbTx1MtXF2dU5d4B_of5d05Yxh27JIAPHG0uBw7fINhej_ViQ-sbE",
   scope: "file_content:read,file_metadata:read,file_versions:read,projects:read",
   personalAccessToken: PERSONAL_ACCESS_TOKEN,
+  onAuthorize: async ({ token, type }) => {
+    const headers =
+      type === "oauth" ? { Authorization: `Bearer ${token}` } : { "X-Figma-Token": token };
+    const response = await fetch("https://api.figma.com/v1/me", { headers });
+    if (!response.ok) return;
+    const user = (await response.json()) as { handle: string; img_url: string };
+    setUserInfo({ name: user.handle, icon: user.img_url });
+  },
 });

--- a/extensions/figma-files/src/types.ts
+++ b/extensions/figma-files/src/types.ts
@@ -19,6 +19,7 @@ export type Project = {
 };
 
 export type ProjectFiles = {
+  id?: string;
   files?: File[];
   name: string;
 };


### PR DESCRIPTION
## Description

Fixed 4 bugs in the Figma File Search extension:

**1. Cache data loss on partial refresh**
When the cache TTL expired for only some projects, `resolveAllFiles()` was overwriting the entire cache with partial data, causing files from other teams/projects to disappear. Fixed by merging refreshed project data with the existing cache at the project level.

**2. Starred file detection by name instead of key**
`FileGridItem` was comparing `item.name === file.name` to check if a file is starred. This caused false matches when multiple files shared the same name. Fixed to use `item.key === file.key`.

**3. Broken project section title when files are undefined**
The condition `project.files?.length != 0` evaluates to `true` when `project.files` is `undefined` (JavaScript quirk: `undefined != 0`), causing sections to render with the title "(undefined Files)" and no items inside. Fixed with `(project.files?.length ?? 0) > 0`.

**4. User profile not shown in Raycast**
`OAuthService` was missing an `onAuthorize` callback, so `setUserInfo` was never called after login. Raycast had no user data to display in extension preferences. Fixed by fetching `/v1/me` from the Figma API on authorize and passing the user's name and avatar to `setUserInfo`.

## Checklist

- [x] Tested the extension locally
- [x] No new dependencies added
- [x] Existing functionality preserved