### PR TITLE
Update spotify-player extension

### DIFF
--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Spotify Player Changelog
 
+## [Add Keyboard Shortcuts] - {PR_MERGE_DATE}
+
+- Added shortcuts for opening Your Library and Search from Now Playing and Add Playing Song to Playlist
+- Added shortcuts for liking, disliking, adding to playlists, connecting devices, and showing related content
+- Added artist action shortcuts for showing albums and popular songs
+
 ## [Fix OAuth PKCE invalid_grant] - 2026-04-04
 
 - Clear corrupted tokens on invalid_grant error so the user is prompted to re-authenticate instead of being stuck

--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Spotify Player Changelog
 
-## [Add Keyboard Shortcuts] - {PR_MERGE_DATE}
+## [Add Keyboard Shortcuts] - 2026-05-17
 
 - Added shortcuts for opening Your Library and Search from Now Playing and Add Playing Song to Playlist
 - Added shortcuts for liking, disliking, adding to playlists, connecting devices, and showing related content

--- a/extensions/spotify-player/package.json
+++ b/extensions/spotify-player/package.json
@@ -42,7 +42,8 @@
     "AdrianKokot",
     "validate",
     "xmok",
-    "hugodemenez"
+    "hugodemenez",
+    "alexi.build"
   ],
   "pastContributors": [
     "bkeys818",

--- a/extensions/spotify-player/src/addPlayingSongToPlaylist.tsx
+++ b/extensions/spotify-player/src/addPlayingSongToPlaylist.tsx
@@ -25,6 +25,7 @@ import { getError } from "./helpers/getError";
 import { CreateQuicklink } from "./components/CreateQuicklink";
 import getAllPlaylistItems from "./helpers/getAllPlaylistItems";
 import addTrackToPlaylistCache from "./helpers/addTrackToPlaylistCache";
+import { Like, OpenLibrary, OpenSearch } from "./shortcuts/shortcuts";
 
 type LaunchContextData = {
   playlistId?: string;
@@ -60,11 +61,13 @@ function AddToPlaylistCommand(props: AddToPlaylistCommandProps) {
                 icon={Icon.Book}
                 title="Your Library"
                 onAction={() => launchCommand({ name: "yourLibrary", type: LaunchType.UserInitiated })}
+                shortcut={OpenLibrary}
               />
               <Action
                 title="Search"
                 icon={Icon.MagnifyingGlass}
                 onAction={() => launchCommand({ name: "search", type: LaunchType.UserInitiated })}
+                shortcut={OpenSearch}
               />
               <Action
                 icon={Icon.Repeat}
@@ -199,6 +202,7 @@ function AddToPlaylistCommand(props: AddToPlaylistCommandProps) {
                         });
                       }
                     }}
+                    shortcut={Like}
                   />
                   {playlist.id && (
                     <CreateQuicklink

--- a/extensions/spotify-player/src/components/AddToPlaylistAction.tsx
+++ b/extensions/spotify-player/src/components/AddToPlaylistAction.tsx
@@ -2,6 +2,7 @@ import { Action, ActionPanel, getPreferenceValues, Icon, popToRoot, showHUD, sho
 import { addToPlaylist } from "../api/addToPlaylist";
 import { getError } from "../helpers/getError";
 import { PrivateUserObject, SimplifiedPlaylistObject } from "../helpers/spotify.api";
+import { AddToPlaylist } from "../shortcuts/shortcuts";
 
 type AddToPlaylistActionProps = {
   playlists: SimplifiedPlaylistObject[];
@@ -13,7 +14,7 @@ export function AddToPlaylistAction({ playlists, meData, uri }: AddToPlaylistAct
   const { closeWindowOnAction } = getPreferenceValues<{ closeWindowOnAction?: boolean }>();
 
   return (
-    <ActionPanel.Submenu icon={Icon.List} title="Add to Playlist">
+    <ActionPanel.Submenu icon={Icon.List} title="Add to Playlist" shortcut={AddToPlaylist}>
       {playlists
         ?.filter((playlist) => playlist.owner?.id === meData?.id)
         .map((playlist, index) => {

--- a/extensions/spotify-player/src/components/AddToSavedTracksAction.tsx
+++ b/extensions/spotify-player/src/components/AddToSavedTracksAction.tsx
@@ -3,6 +3,7 @@ import { addToMySavedTracks } from "../api/addToMySavedTracks";
 import { getErrorMessage } from "../helpers/getError";
 import { useContainsMyLikedTracks } from "../hooks/useContainsMyLikedTracks";
 import { removeFromMySavedTracks } from "../api/removeFromMySavedTracks";
+import { Dislike, Like } from "../shortcuts/shortcuts";
 
 type AddToSavedTracksActionProps = {
   trackId?: string;
@@ -50,6 +51,7 @@ export function AddToSavedTracksAction({ trackId: trackId }: AddToSavedTracksAct
               toast.message = error;
             }
           }}
+          shortcut={Dislike}
         />
       )}
 
@@ -86,6 +88,7 @@ export function AddToSavedTracksAction({ trackId: trackId }: AddToSavedTracksAct
               toast.message = error;
             }
           }}
+          shortcut={Like}
         />
       )}
     </>

--- a/extensions/spotify-player/src/components/AlbumActionPanel.tsx
+++ b/extensions/spotify-player/src/components/AlbumActionPanel.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Action, ActionPanel, Icon, popToRoot, showHUD } from "@raycast/api";
 import { SimplifiedAlbumObject } from "../helpers/spotify.api";
 import { FooterAction } from "./FooterAction";
@@ -8,6 +7,7 @@ import { getErrorMessage } from "../helpers/getError";
 import { addToMySavedAlbums } from "../api/addToMySavedAlbums";
 import { removeFromMySavedAlbums } from "../api/removeFromMySavedAlbums";
 import { useContainsMySavedAlbum } from "../hooks/useContainsMySavedAlbum";
+import { ShowContent } from "../shortcuts/shortcuts";
 
 type AlbumActionPanelProps = { album: SimplifiedAlbumObject };
 
@@ -20,10 +20,7 @@ export function AlbumActionPanel({ album }: AlbumActionPanelProps) {
       <Action.Push
         icon={Icon.AppWindowList}
         title="Show Songs"
-        shortcut={{
-          macOS: { modifiers: ["cmd", "shift"], key: "a" },
-          Windows: { modifiers: ["ctrl", "shift"], key: "a" },
-        }}
+        shortcut={ShowContent}
         target={<TracksList album={album} showGoToAlbum={false} />}
       />
       <Action

--- a/extensions/spotify-player/src/components/ArtistActionPanel.tsx
+++ b/extensions/spotify-player/src/components/ArtistActionPanel.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Icon } from "@raycast/api";
+import { Action, ActionPanel, Icon, Keyboard } from "@raycast/api";
 import { ArtistObject } from "../helpers/spotify.api";
 import { AlbumsGrid } from "./AlbumsGrid";
 import { useArtistAlbums } from "../hooks/useArtistAlbums";
@@ -7,6 +7,7 @@ import { TracksList } from "./TracksList";
 import { FooterAction } from "./FooterAction";
 import { StartRadioAction } from "./StartRadioAction";
 import { PlayAction } from "./PlayAction";
+import { ShowContent } from "../shortcuts/shortcuts";
 
 type ArtistActionPanelProps = {
   title: string;
@@ -26,6 +27,7 @@ export function ArtistActionPanel({ title, artist }: ArtistActionPanelProps) {
           icon={Icon.AppWindowGrid3x3}
           title="Show Albums"
           target={<AlbumsGrid albums={albums} title={artist.name} />}
+          shortcut={ShowContent}
         />
       )}
       {artistTopTracksData && (
@@ -33,6 +35,7 @@ export function ArtistActionPanel({ title, artist }: ArtistActionPanelProps) {
           icon={Icon.List}
           title="Show Popular Songs"
           target={<TracksList tracks={artistTopTracksData.tracks} />}
+          shortcut={Keyboard.Shortcut.Common.ToggleQuickLook}
         />
       )}
       <StartRadioAction artistId={artist.id} />

--- a/extensions/spotify-player/src/components/PauseAction.tsx
+++ b/extensions/spotify-player/src/components/PauseAction.tsx
@@ -1,5 +1,6 @@
 import { Action, getPreferenceValues, Icon, popToRoot, showHUD, showToast, Toast } from "@raycast/api";
 import { pause } from "../api/pause";
+import { TogglePlayPause } from "../shortcuts/shortcuts";
 
 type PauseActionProps = {
   onPause?: () => void;
@@ -27,6 +28,7 @@ export function PauseAction({ onPause }: PauseActionProps) {
         toast.title = "Paused";
         toast.style = Toast.Style.Success;
       }}
+      shortcut={TogglePlayPause}
     />
   );
 }

--- a/extensions/spotify-player/src/components/PauseAction.tsx
+++ b/extensions/spotify-player/src/components/PauseAction.tsx
@@ -1,6 +1,5 @@
 import { Action, getPreferenceValues, Icon, popToRoot, showHUD, showToast, Toast } from "@raycast/api";
 import { pause } from "../api/pause";
-import { TogglePlayPause } from "../shortcuts/shortcuts";
 
 type PauseActionProps = {
   onPause?: () => void;
@@ -28,7 +27,6 @@ export function PauseAction({ onPause }: PauseActionProps) {
         toast.title = "Paused";
         toast.style = Toast.Style.Success;
       }}
-      shortcut={TogglePlayPause}
     />
   );
 }

--- a/extensions/spotify-player/src/components/PlayAction.tsx
+++ b/extensions/spotify-player/src/components/PlayAction.tsx
@@ -3,7 +3,6 @@ import { play } from "../api/play";
 import { SimplifiedTrackObject } from "../helpers/spotify.api";
 import { getErrorMessage } from "../helpers/getError";
 import { showFailureToast } from "@raycast/utils";
-import { TogglePlayPause } from "../shortcuts/shortcuts";
 
 type PlayActionProps = {
   id?: string;
@@ -56,5 +55,5 @@ export function PlayAction({ id, type, playingContext, onPlay, tracksToQueue }: 
     }
   };
 
-  return <Action icon={Icon.Play} title="Play" onAction={handlePlayAction} shortcut={TogglePlayPause} />;
+  return <Action icon={Icon.Play} title="Play" onAction={handlePlayAction} />;
 }

--- a/extensions/spotify-player/src/components/PlayAction.tsx
+++ b/extensions/spotify-player/src/components/PlayAction.tsx
@@ -3,6 +3,7 @@ import { play } from "../api/play";
 import { SimplifiedTrackObject } from "../helpers/spotify.api";
 import { getErrorMessage } from "../helpers/getError";
 import { showFailureToast } from "@raycast/utils";
+import { TogglePlayPause } from "../shortcuts/shortcuts";
 
 type PlayActionProps = {
   id?: string;
@@ -55,5 +56,5 @@ export function PlayAction({ id, type, playingContext, onPlay, tracksToQueue }: 
     }
   };
 
-  return <Action icon={Icon.Play} title="Play" onAction={handlePlayAction} />;
+  return <Action icon={Icon.Play} title="Play" onAction={handlePlayAction} shortcut={TogglePlayPause} />;
 }

--- a/extensions/spotify-player/src/components/PlaylistActionPanel.tsx
+++ b/extensions/spotify-player/src/components/PlaylistActionPanel.tsx
@@ -3,6 +3,7 @@ import { SimplifiedPlaylistObject } from "../helpers/spotify.api";
 import { FooterAction } from "./FooterAction";
 import { PlayAction } from "./PlayAction";
 import { TracksList } from "./TracksList";
+import { ShowContent } from "../shortcuts/shortcuts";
 
 type PlaylistActionPanelProps = {
   title: string;
@@ -16,10 +17,7 @@ export function PlaylistActionPanel({ title, playlist }: PlaylistActionPanelProp
       <Action.Push
         icon={Icon.AppWindowList}
         title="Show Songs"
-        shortcut={{
-          macOS: { modifiers: ["cmd", "shift"], key: "a" },
-          Windows: { modifiers: ["ctrl", "shift"], key: "a" },
-        }}
+        shortcut={ShowContent}
         target={<TracksList playlist={playlist} />}
       />
       <FooterAction url={playlist?.external_urls?.spotify} uri={playlist.uri} title={title} />

--- a/extensions/spotify-player/src/components/PlaylistLikedTracksItem.tsx
+++ b/extensions/spotify-player/src/components/PlaylistLikedTracksItem.tsx
@@ -5,6 +5,7 @@ import { FooterAction } from "./FooterAction";
 import { PlayAction } from "./PlayAction";
 import { TracksList } from "./TracksList";
 import { useYourLibrary } from "../hooks/useYourLibrary";
+import { ShowContent } from "../shortcuts/shortcuts";
 
 type PlaylistLikedTracksItemProps = {
   type: "grid" | "list";
@@ -33,10 +34,7 @@ export default function PlaylistLikedTracksItem({ type }: PlaylistLikedTracksIte
             <Action.Push
               title="Show Songs"
               icon={{ source: Icon.AppWindowList }}
-              shortcut={{
-                macOS: { modifiers: ["cmd", "shift"], key: "a" },
-                Windows: { modifiers: ["ctrl", "shift"], key: "a" },
-              }}
+              shortcut={ShowContent}
               target={<TracksList tracks={myLibraryData.tracks?.items} />}
             />
           )}

--- a/extensions/spotify-player/src/components/ShowActionPanel.tsx
+++ b/extensions/spotify-player/src/components/ShowActionPanel.tsx
@@ -3,6 +3,7 @@ import { SimplifiedShowObject } from "../helpers/spotify.api";
 import { EpisodesList } from "./EpisodesList";
 import { FooterAction } from "./FooterAction";
 import { PlayAction } from "./PlayAction";
+import { ShowContent } from "../shortcuts/shortcuts";
 
 type ShowActionPanelProps = { show: SimplifiedShowObject };
 
@@ -15,10 +16,7 @@ export function ShowActionPanel({ show }: ShowActionPanelProps) {
       <Action.Push
         icon={Icon.AppWindowList}
         title="Show Episodes"
-        shortcut={{
-          macOS: { modifiers: ["cmd", "shift"], key: "a" },
-          Windows: { modifiers: ["ctrl", "shift"], key: "a" },
-        }}
+        shortcut={ShowContent}
         target={<EpisodesList show={show} />}
       />
       <FooterAction url={show?.external_urls?.spotify} uri={show.uri} title={title} />

--- a/extensions/spotify-player/src/components/StartRadioAction.tsx
+++ b/extensions/spotify-player/src/components/StartRadioAction.tsx
@@ -1,6 +1,7 @@
 import { Action, getPreferenceValues, Icon, popToRoot, showHUD, showToast, Toast } from "@raycast/api";
 import { startRadio } from "../api/startRadio";
 import { getError } from "../helpers/getError";
+import { StartRadio } from "../shortcuts/shortcuts";
 
 type StartRadioActionProps = {
   trackId?: string;
@@ -58,6 +59,7 @@ export function StartRadioAction({ trackId, artistId, onRadioStarted }: StartRad
           toast.style = Toast.Style.Failure;
         }
       }}
+      shortcut={StartRadio}
     />
   );
 }

--- a/extensions/spotify-player/src/components/TrackActionPanel.tsx
+++ b/extensions/spotify-player/src/components/TrackActionPanel.tsx
@@ -9,6 +9,7 @@ import { AddToQueueAction } from "./AddtoQueueAction";
 import { StartRadioAction } from "./StartRadioAction";
 import { PlayAction } from "./PlayAction";
 import { AddToSavedTracksAction } from "./AddToSavedTracksAction";
+import { ShowContent } from "../shortcuts/shortcuts";
 
 type TrackActionPanelProps = {
   title: string;
@@ -40,6 +41,7 @@ export function TrackActionPanel({
           icon={Icon.AppWindowList}
           title="Go to Album"
           target={<TracksList album={album} showGoToAlbum={false} />}
+          shortcut={ShowContent}
         />
       )}
       <StartRadioAction trackId={track.id} />

--- a/extensions/spotify-player/src/nowPlaying.tsx
+++ b/extensions/spotify-player/src/nowPlaying.tsx
@@ -35,6 +35,7 @@ import { PlayAction } from "./components/PlayAction";
 import { PauseAction } from "./components/PauseAction";
 import { getErrorMessage } from "./helpers/getError";
 import { triggerMenuBarRefresh } from "./helpers/triggerMenuBarRefresh";
+import { ConnectDevice, Dislike, Like, OpenLibrary, OpenSearch, ShowContent } from "./shortcuts/shortcuts";
 
 function NowPlayingCommand() {
   const { currentlyPlayingData, currentlyPlayingIsLoading, currentlyPlayingRevalidate } = useCurrentlyPlaying();
@@ -67,11 +68,13 @@ function NowPlayingCommand() {
                 icon={Icon.Book}
                 title="Your Library"
                 onAction={() => launchCommand({ name: "yourLibrary", type: LaunchType.UserInitiated })}
+                shortcut={OpenLibrary}
               />
               <Action
                 title="Search"
                 icon={Icon.MagnifyingGlass}
                 onAction={() => launchCommand({ name: "search", type: LaunchType.UserInitiated })}
+                shortcut={OpenSearch}
               />
               <Action
                 icon={Icon.Repeat}
@@ -158,6 +161,7 @@ function NowPlayingCommand() {
                 toast.message = error;
               }
             }}
+            shortcut={Dislike}
           />
         )}
 
@@ -194,6 +198,7 @@ function NowPlayingCommand() {
                 toast.message = error;
               }
             }}
+            shortcut={Like}
           />
         )}
         <Action
@@ -260,6 +265,7 @@ function NowPlayingCommand() {
           icon={Icon.AppWindowGrid3x3}
           title="Go to Album"
           target={<TracksList album={album} showGoToAlbum={false} />}
+          shortcut={ShowContent}
         />
       </>
     );
@@ -300,7 +306,7 @@ function NowPlayingCommand() {
           {myPlaylistsData?.items && meData && uri && (
             <AddToPlaylistAction playlists={myPlaylistsData.items} meData={meData} uri={uri} />
           )}
-          <ActionPanel.Submenu icon={Icon.Mobile} title="Connect Device">
+          <ActionPanel.Submenu icon={Icon.Mobile} title="Connect Device" shortcut={ConnectDevice}>
             {myDevicesData?.devices
               ?.filter((device) => !device.is_restricted)
               .map((device) => (

--- a/extensions/spotify-player/src/shortcuts/shortcuts.ts
+++ b/extensions/spotify-player/src/shortcuts/shortcuts.ts
@@ -1,0 +1,46 @@
+import { Keyboard } from "@raycast/api";
+
+export const ShowContent: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd", "shift"], key: "a" },
+  Windows: { modifiers: ["ctrl", "shift"], key: "a" },
+};
+
+export const AddToPlaylist: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd"], key: "a" },
+  Windows: { modifiers: ["ctrl"], key: "a" },
+};
+
+export const TogglePlayPause: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd"], key: "p" },
+  Windows: { modifiers: ["ctrl"], key: "p" },
+};
+
+export const Like: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd"], key: "l" },
+  Windows: { modifiers: ["ctrl"], key: "l" },
+};
+
+export const Dislike: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd"], key: "d" },
+  Windows: { modifiers: ["ctrl"], key: "d" },
+};
+
+export const StartRadio: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd", "shift"], key: "r" },
+  Windows: { modifiers: ["ctrl", "shift"], key: "r" },
+};
+
+export const ConnectDevice: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd", "shift"], key: "k" },
+  Windows: { modifiers: ["ctrl", "shift"], key: "k" },
+};
+
+export const OpenSearch: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd", "shift"], key: "f" },
+  Windows: { modifiers: ["ctrl", "shift"], key: "f" },
+};
+
+export const OpenLibrary: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd", "shift"], key: "l" },
+  Windows: { modifiers: ["ctrl", "shift"], key: "l" },
+};

--- a/extensions/spotify-player/src/shortcuts/shortcuts.ts
+++ b/extensions/spotify-player/src/shortcuts/shortcuts.ts
@@ -10,11 +10,6 @@ export const AddToPlaylist: Keyboard.Shortcut = {
   Windows: { modifiers: ["ctrl"], key: "a" },
 };
 
-export const TogglePlayPause: Keyboard.Shortcut = {
-  macOS: { modifiers: ["cmd"], key: "p" },
-  Windows: { modifiers: ["ctrl"], key: "p" },
-};
-
 export const Like: Keyboard.Shortcut = {
   macOS: { modifiers: ["cmd"], key: "l" },
   Windows: { modifiers: ["ctrl"], key: "l" },


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->
### [Add Keyboard Shortcuts] 

- Added shortcuts for opening Your Library and Search from Now Playing and Add Playing Song to Playlist
- Added shortcuts for liking, disliking, adding to playlists, connecting devices, and showing related content
- Added artist action shortcuts for showing albums and popular songs
## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
