### PR TITLE
Update github-trending extension

### DIFF
--- a/extensions/github-trending/CHANGELOG.md
+++ b/extensions/github-trending/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitHub Trending Changelog
 
+## [Improve README Rendering] - 2026-05-16
+
+- Convert README HTML to Markdown for better rendering in Raycast
+
 ## [Fix Scraper Iutdated] - 2023-04-24
 
 - Fix outdated scraper Github Trending page

--- a/extensions/github-trending/CHANGELOG.md
+++ b/extensions/github-trending/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Trending Changelog
 
-## [Improve README Rendering] - {PR_MERGE_DATE}
+## [Improve README Rendering] - 2026-05-16
 
 - Convert README HTML to Markdown for better rendering in Raycast
 

--- a/extensions/github-trending/CHANGELOG.md
+++ b/extensions/github-trending/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Trending Changelog
 
-## [Improve README Rendering] - 2026-05-16
+## [Improve README Rendering] - {PR_MERGE_DATE}
 
 - Convert README HTML to Markdown for better rendering in Raycast
 

--- a/extensions/github-trending/README.md
+++ b/extensions/github-trending/README.md
@@ -1,15 +1,22 @@
 # GitHub Trending
 
-This is a Raycast extension that displays the top trending repositories on GitHub. You can filter by language and time period (today, this week, this month).
+Discover what developers are building right now without leaving Raycast. GitHub Trending brings popular repositories into a fast, searchable command so you can track new projects, inspect the README, and jump straight into the code when something looks useful.
 
 ## Features
 
-- View the top trending repositories on GitHub
-- Filter by language and time period
-- Open the repository in your browser on GitHub or GitHub.dev
-- Quick view the repository's README
-
+- Browse trending GitHub repositories for today, this week, or this month
+- Filter by programming language to find projects that match your stack
+- Preview repository details and the project README inside Raycast
+- Open repositories on GitHub or GitHub.dev from the action panel
+- Copy repository names and URLs for quick sharing
 
 ## Usage
+
+1. Open the `Trending Repositories` command in Raycast.
+2. Choose a time range to switch between daily, weekly, and monthly trends.
+3. Filter by language or search the list to narrow the results.
+4. Open a repository, view its README, or jump into GitHub.dev from the action panel.
+
+## Demo
 
 [GitHub Trending](https://user-images.githubusercontent.com/4416419/221431789-615d9e1e-cc5b-4c60-b9f9-9dcb99799fb5.mp4)

--- a/extensions/github-trending/package-lock.json
+++ b/extensions/github-trending/package-lock.json
@@ -10,12 +10,14 @@
         "@raycast/api": "^1.49.3",
         "@raycast/utils": "^1.5.2",
         "cheerio": "^1.0.0-rc.12",
-        "node-fetch": "^3.3.1"
+        "node-fetch": "^3.3.1",
+        "turndown": "^7.2.4"
       },
       "devDependencies": {
         "@types/node": "18.8.3",
         "@types/node-fetch": "^2.6.3",
         "@types/react": "18.0.9",
+        "@types/turndown": "^5.0.6",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint": "^7.32.0",
@@ -201,6 +203,12 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -325,6 +333,13 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.52.0",
@@ -2488,6 +2503,19 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
       }
     },
     "node_modules/type-check": {

--- a/extensions/github-trending/package.json
+++ b/extensions/github-trending/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "github-trending",
   "title": "GitHub Trending",
-  "description": "Quick access to trending repositories on GitHub.",
+  "description": "Discover trending GitHub repositories by language and time range, then preview, open, or jump into code from Raycast.",
   "icon": "icon.png",
   "author": "mikqi",
   "categories": [
@@ -13,7 +13,10 @@
   ],
   "keywords": [
     "github",
-    "trending"
+    "trending",
+    "repositories",
+    "open-source",
+    "developer"
   ],
   "license": "MIT",
   "commands": [
@@ -21,7 +24,7 @@
       "name": "index",
       "title": "Trending Repositories",
       "subtitle": "GitHub",
-      "description": "Quick access to trending repositories on GitHub.",
+      "description": "Explore trending GitHub repositories.",
       "mode": "view"
     }
   ],
@@ -29,12 +32,14 @@
     "@raycast/api": "^1.49.3",
     "@raycast/utils": "^1.5.2",
     "cheerio": "^1.0.0-rc.12",
-    "node-fetch": "^3.3.1"
+    "node-fetch": "^3.3.1",
+    "turndown": "^7.2.4"
   },
   "devDependencies": {
     "@types/node": "18.8.3",
     "@types/node-fetch": "^2.6.3",
     "@types/react": "18.0.9",
+    "@types/turndown": "^5.0.6",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^7.32.0",

--- a/extensions/github-trending/package.json
+++ b/extensions/github-trending/package.json
@@ -53,5 +53,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/github-trending/src/components/RepoDetail.tsx
+++ b/extensions/github-trending/src/components/RepoDetail.tsx
@@ -1,31 +1,40 @@
 import { Action, ActionPanel, Detail, Icon } from '@raycast/api'
 import { useFetch } from '@raycast/utils'
+import { useMemo } from 'react'
 import { PROGRAMMING_LANGUAGES_COLORS } from '../constants'
+import { formatReadmeMarkdown } from '../lib/readme-markdown'
 import { RepoType } from '../type'
 import { formatNumber } from '../utils'
 
 export const RepoDetail = ({ repo }: { repo: RepoType }) => {
   const READMEUrl = `https://raw.githubusercontent.com/${repo.author}/${repo.name}/master/README.md`
+  const readmeAssetBaseUrl = `https://raw.githubusercontent.com/${repo.author}/${repo.name}/master/`
   const authorUrl = `https://github.com/${repo.author}`
   const languageColor =
     PROGRAMMING_LANGUAGES_COLORS?.[repo.language as keyof typeof PROGRAMMING_LANGUAGES_COLORS] ?? '#fff'
   const githubDevUrl = `https://github.dev/${repo.author}/${repo.name}`
+  const repoName = `${repo.author}/${repo.name}`
 
   const { data: README, isLoading } = useFetch(READMEUrl, { method: 'GET' })
+  const markdown = useMemo(
+    () => formatReadmeMarkdown(README, { rawBaseUrl: readmeAssetBaseUrl }),
+    [README, readmeAssetBaseUrl],
+  )
+
   return (
     <Detail
-      navigationTitle={repo.author + '/' + repo.name}
+      navigationTitle={repoName}
       isLoading={isLoading}
-      markdown={README as string}
+      markdown={markdown}
       metadata={
         <Detail.Metadata>
-          <Detail.Metadata.Link title="Repository" target={repo.href} text={repo.author + '/' + repo.name} />
+          <Detail.Metadata.Link title="Repository" target={repo.href} text={repoName} />
           <Detail.Metadata.Label title="Stars" icon={Icon.Star} text={`${formatNumber(repo.stars)}`} />
           <Detail.Metadata.TagList title="Language">
-            <Detail.Metadata.TagList.Item color={languageColor} text={repo.language} />
+            <Detail.Metadata.TagList.Item color={languageColor} text={repo.language || 'Unknown'} />
           </Detail.Metadata.TagList>
           <Detail.Metadata.Separator />
-          <Detail.Metadata.Label title="Description" text={`${repo.description}`} />
+          <Detail.Metadata.Label title="Description" text={repo.description || 'No description'} />
           <Detail.Metadata.Link title="Author" target={authorUrl} text={repo.author} />
         </Detail.Metadata>
       }
@@ -34,6 +43,8 @@ export const RepoDetail = ({ repo }: { repo: RepoType }) => {
           <Action.OpenInBrowser url={repo.href} title="Open in Browser" />
           <Action.OpenInBrowser url={authorUrl} title="Open Author in Browser" />
           <Action.OpenInBrowser icon="github-dev.png" url={githubDevUrl} title="Open in GitHub.dev" />
+          <Action.CopyToClipboard title="Copy Repository URL" content={repo.href} />
+          <Action.CopyToClipboard title="Copy Repository Name" content={repoName} />
         </ActionPanel>
       }
     />

--- a/extensions/github-trending/src/components/RepoDetail.tsx
+++ b/extensions/github-trending/src/components/RepoDetail.tsx
@@ -17,8 +17,8 @@ export const RepoDetail = ({ repo }: { repo: RepoType }) => {
 
   const { data: README, isLoading } = useFetch(READMEUrl, { method: 'GET' })
   const markdown = useMemo(
-    () => formatReadmeMarkdown(README, { rawBaseUrl: readmeAssetBaseUrl }),
-    [README, readmeAssetBaseUrl],
+    () => (isLoading ? '' : formatReadmeMarkdown(README, { rawBaseUrl: readmeAssetBaseUrl })),
+    [README, isLoading, readmeAssetBaseUrl],
   )
 
   return (

--- a/extensions/github-trending/src/lib/readme-markdown.ts
+++ b/extensions/github-trending/src/lib/readme-markdown.ts
@@ -1,0 +1,71 @@
+import TurndownService from 'turndown'
+
+const htmlTagPattern = /<\/?[a-z][\s\S]*>/i
+const htmlBlockPattern = /^\s*<\/?[a-z][^>]*>/i
+const quotedImageSrcPattern = /(<img\b[^>]*\bsrc\s*=\s*)(["'])([^"']+)(\2)/gi
+const unquotedImageSrcPattern = /(<img\b[^>]*\bsrc\s*=\s*)([^"'\s>]+)/gi
+const absoluteUrlPattern = /^[a-z][a-z\d+.-]*:/i
+
+type FormatReadmeMarkdownOptions = {
+  rawBaseUrl?: string
+}
+
+const turndownService = new TurndownService({
+  bulletListMarker: '-',
+  codeBlockStyle: 'fenced',
+  headingStyle: 'atx',
+})
+
+turndownService.remove(['script', 'style'])
+
+const normalizeMarkdown = (markdown: string) =>
+  markdown
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/\u00a0/g, ' ')
+    .replace(/[ \t]+•[ \t]+/g, ' • ')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+
+const resolveReadmeAssetUrl = (src: string, rawBaseUrl?: string) => {
+  if (!rawBaseUrl || absoluteUrlPattern.test(src) || src.startsWith('//') || src.startsWith('#')) {
+    return src
+  }
+
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl : `${rawBaseUrl}/`
+
+  try {
+    return src.startsWith('/') ? `${baseUrl}${src.replace(/^\/+/, '')}` : new URL(src, baseUrl).toString()
+  } catch (error) {
+    return src
+  }
+}
+
+const absolutizeRelativeImageSources = (html: string, rawBaseUrl?: string) =>
+  html
+    .replace(quotedImageSrcPattern, (match, prefix: string, quote: string, src: string) => {
+      return `${prefix}${quote}${resolveReadmeAssetUrl(src, rawBaseUrl)}${quote}`
+    })
+    .replace(unquotedImageSrcPattern, (match, prefix: string, src: string) => {
+      return `${prefix}"${resolveReadmeAssetUrl(src, rawBaseUrl)}"`
+    })
+
+const formatHtmlBlock = (block: string, options: FormatReadmeMarkdownOptions) =>
+  normalizeMarkdown(turndownService.turndown(absolutizeRelativeImageSources(block, options.rawBaseUrl)))
+
+export const formatReadmeMarkdown = (readme: unknown, options: FormatReadmeMarkdownOptions = {}) => {
+  if (typeof readme !== 'string' || readme.trim() === '') {
+    return 'README is empty or unavailable.'
+  }
+
+  if (!htmlTagPattern.test(readme)) {
+    return readme
+  }
+
+  return normalizeMarkdown(
+    readme
+      .split(/\n{2,}/)
+      .map((block) => (htmlBlockPattern.test(block) ? formatHtmlBlock(block, options) : block))
+      .join('\n\n'),
+  )
+}


### PR DESCRIPTION
## Description

This pull request improves the GitHub Trending Raycast extension by enhancing how repository READMEs are displayed, updating documentation, and refining the user experience. The most significant update is the conversion of HTML-based READMEs to Markdown for better rendering within Raycast, which also ensures that images and assets display correctly. Additionally, the README and extension metadata have been updated for clarity and discoverability, and new actions have been added for easier repository sharing.

## Screencast

| Before | After |
|--------|--------|
| <img width="1000" height="625" alt="github-trending-1" src="https://github.com/user-attachments/assets/2b0df577-2002-450c-bff9-316cd643aff6" /> | <img width="1000" height="625" alt="github-trending-7" src="https://github.com/user-attachments/assets/eabdfd71-678d-4ce1-83a4-78364033818e" /> | 

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
