### PR TITLE
[Cal.com] Add AI Extension tools (MCP parity) + EU server support

### DIFF
--- a/extensions/cal-com-share-meeting-links/CHANGELOG.md
+++ b/extensions/cal-com-share-meeting-links/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Cal.com Share Meeting Links Changelog
 
+## [AI Tools + EU server support] - {PR_MERGE_DATE}
+
+- **AI tools.** Adds 33 AI Extension tools so Raycast AI can read and manage your Cal.com account via `@cal` — full parity with Cal.com's MCP server surface (event types, bookings, schedules, availability, busy times, conferencing apps, routing forms, organizations). Destructive actions (create/update/delete/cancel/reschedule/etc.) require confirmation.
+- **EU server support.** Adds a "Server Region" preference (Global default, Europe option) so Cal.eu accounts can use the extension. Fixes #27697. All API and link URLs (api/app/public) now route via the selected region.
+- Bumps `@raycast/api` to ^1.104.17 and `@raycast/utils` to ^2.2.4. Removes unused `dayjs` dependency.
+
 ## [Fix + improve View Bookings] - 2026-04-14
 
 - Fix a bug where View Bookings only showed the first 100 bookings (hiding all recent + upcoming bookings for users with longer histories)

--- a/extensions/cal-com-share-meeting-links/CHANGELOG.md
+++ b/extensions/cal-com-share-meeting-links/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Cal.com Share Meeting Links Changelog
 
-## [AI Tools + EU server support] - {PR_MERGE_DATE}
+## [AI Tools + EU server support] - 2026-05-17
 
 - **AI tools.** Adds 33 AI Extension tools so Raycast AI can read and manage your Cal.com account via `@cal` — full parity with Cal.com's MCP server surface (event types, bookings, schedules, availability, busy times, conferencing apps, routing forms, organizations). Destructive actions (create/update/delete/cancel/reschedule/etc.) require confirmation.
 - **EU server support.** Adds a "Server Region" preference (Global default, Europe option) so Cal.eu accounts can use the extension. Fixes #27697. All API and link URLs (api/app/public) now route via the selected region.

--- a/extensions/cal-com-share-meeting-links/package-lock.json
+++ b/extensions/cal-com-share-meeting-links/package-lock.json
@@ -7,10 +7,9 @@
       "name": "cal-com-share-meeting-links",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.12",
-        "@raycast/utils": "^2.2.3",
+        "@raycast/api": "^1.104.17",
+        "@raycast/utils": "^2.2.4",
         "axios": "^1.8.4",
-        "dayjs": "^1.11.11",
         "moment": "^2.30.1"
       },
       "devDependencies": {
@@ -1104,16 +1103,16 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.12",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.12.tgz",
-      "integrity": "sha512-DdrtoksnzLw4q60BgFr/H+PIvIObOfJrW15duTFH7QXVx/0Vxzw9fY7wo+H2gQ2JDDAh9sEMCpc5akP3UxKjTw==",
+      "version": "1.104.17",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.17.tgz",
+      "integrity": "sha512-31yGTbb0HMHKWqxwZZl2rzaUau/Yf+FX6pO1DK6mobpjUMqDb0h0FGkDSwr0MNwsujT4K3DbAYgh3sHhGkxWfw==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
         "@oclif/plugin-autocomplete": "^3.2.40",
         "@oclif/plugin-help": "^6.2.37",
         "@oclif/plugin-not-found": "^3.2.74",
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "esbuild": "^0.27.3",
         "react": "19.0.0"
@@ -1122,10 +1121,10 @@
         "ray": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.14.0"
+        "node": ">=22.22.2"
       },
       "peerDependencies": {
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "react-devtools": "6.1.1"
       },
@@ -1142,24 +1141,24 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@raycast/api/node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.3.tgz",
-      "integrity": "sha512-YwqleVl0Wk/FOq+672gtvswuwMqjNqIr+c63FhouTEHc1LJ3zaohLSkW4+UcfBjPU8HySKQm+kJqZW1iOM9fnA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.4.tgz",
+      "integrity": "sha512-XkxW5bUZACxl2zP4M6Qtkj9a1nbOKcRBm96BLkJ6O4Q7L/vFSnc+3pPJ/i0ZLVOExx5LJMJY0jnNPo91xqJnFQ==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1699,12 +1698,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.12",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
-      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/extensions/cal-com-share-meeting-links/package.json
+++ b/extensions/cal-com-share-meeting-links/package.json
@@ -57,6 +57,333 @@
       "mode": "view"
     }
   ],
+  "tools": [
+    {
+      "name": "get-me",
+      "title": "Get My Profile",
+      "description": "Get the authenticated user's Cal.com profile (id, username, name, email, timezone, default schedule id, organization).",
+      "icon": "logo.png",
+      "keywords": ["me", "profile", "user", "account"]
+    },
+    {
+      "name": "update-me",
+      "title": "Update My Profile",
+      "description": "Update the authenticated user's profile (name, username, bio, timezone, week start, time format, locale). Shows a confirmation before applying.",
+      "icon": "logo.png",
+      "keywords": ["profile", "update", "settings"]
+    },
+    {
+      "name": "get-event-types",
+      "title": "List Event Types",
+      "description": "List event types (booking links) for a user. Each event type has a numeric id, slug, title, lengthInMinutes, locations, and bookingUrl.",
+      "icon": "logo.png",
+      "keywords": ["event", "types", "links", "list"]
+    },
+    {
+      "name": "get-event-type",
+      "title": "Get Event Type",
+      "description": "Get a single event type by numeric id.",
+      "icon": "logo.png",
+      "keywords": ["event", "type"]
+    },
+    {
+      "name": "create-event-type",
+      "title": "Create Event Type",
+      "description": "Create a new event type (booking link). Requires title and lengthInMinutes. Shows a confirmation.",
+      "icon": "logo.png",
+      "keywords": ["event", "type", "create", "new"]
+    },
+    {
+      "name": "update-event-type",
+      "title": "Update Event Type",
+      "description": "Update fields on an event type by id. Shows a confirmation listing the changes.",
+      "icon": "logo.png",
+      "keywords": ["event", "type", "edit", "update"]
+    },
+    {
+      "name": "delete-event-type",
+      "title": "Delete Event Type",
+      "description": "Permanently delete an event type. Shows a confirmation.",
+      "icon": "logo.png",
+      "keywords": ["event", "type", "delete", "remove"]
+    },
+    {
+      "name": "get-bookings",
+      "title": "List Bookings",
+      "description": "List bookings with filters (status, date range, attendee, event type). Returns slim records (uid, title, start, end, hosts, attendees, status, meetingUrl). Use this before any per-booking action to look up the uid.",
+      "icon": "logo.png",
+      "keywords": ["bookings", "meetings", "list", "upcoming", "past"]
+    },
+    {
+      "name": "get-booking",
+      "title": "Get Booking",
+      "description": "Get a single booking by uid (look up via get-bookings if unknown).",
+      "icon": "logo.png",
+      "keywords": ["booking", "meeting", "details"]
+    },
+    {
+      "name": "create-booking",
+      "title": "Create Booking",
+      "description": "Create a booking on an event type. Requires eventTypeId, start (ISO 8601), and the attendee's name, email, and IANA timezone. Shows a confirmation.",
+      "icon": "logo.png",
+      "keywords": ["booking", "create", "schedule", "book"]
+    },
+    {
+      "name": "reschedule-booking",
+      "title": "Reschedule Booking",
+      "description": "Reschedule a booking to a new ISO 8601 start time. Shows a confirmation. Look up the bookingUid via get-bookings first.",
+      "icon": "logo.png",
+      "keywords": ["reschedule", "move", "booking"]
+    },
+    {
+      "name": "cancel-booking",
+      "title": "Cancel Booking",
+      "description": "Cancel a booking by uid with a reason shared with attendees. Shows a confirmation.",
+      "icon": "logo.png",
+      "keywords": ["cancel", "booking"]
+    },
+    {
+      "name": "confirm-booking",
+      "title": "Confirm Booking",
+      "description": "Confirm a pending booking that requires manual confirmation. Shows a confirmation.",
+      "icon": "logo.png",
+      "keywords": ["confirm", "booking", "approve"]
+    },
+    {
+      "name": "mark-booking-absent",
+      "title": "Mark Booking No-Show",
+      "description": "Mark a booking (or specific attendees/host) as no-show. Shows a confirmation.",
+      "icon": "logo.png",
+      "keywords": ["no-show", "absent", "missed"]
+    },
+    {
+      "name": "get-booking-attendees",
+      "title": "List Booking Attendees",
+      "description": "Get all attendees for a booking by uid.",
+      "icon": "logo.png",
+      "keywords": ["attendees", "guests", "booking"]
+    },
+    {
+      "name": "add-booking-attendee",
+      "title": "Add Booking Attendee",
+      "description": "Add an attendee (name, email, IANA timezone) to an existing booking. Shows a confirmation.",
+      "icon": "logo.png",
+      "keywords": ["add", "attendee", "guest", "invite"]
+    },
+    {
+      "name": "get-booking-attendee",
+      "title": "Get Booking Attendee",
+      "description": "Get a specific attendee by id within a booking.",
+      "icon": "logo.png",
+      "keywords": ["attendee", "guest"]
+    },
+    {
+      "name": "get-schedules",
+      "title": "List Schedules",
+      "description": "List all availability schedules. Each schedule has a name, timezone, isDefault flag, weekly availability rules, and date overrides.",
+      "icon": "logo.png",
+      "keywords": ["schedules", "availability", "list"]
+    },
+    {
+      "name": "get-schedule",
+      "title": "Get Schedule",
+      "description": "Get a single availability schedule by id.",
+      "icon": "logo.png",
+      "keywords": ["schedule", "availability"]
+    },
+    {
+      "name": "get-default-schedule",
+      "title": "Get Default Schedule",
+      "description": "Get the user's default availability schedule.",
+      "icon": "logo.png",
+      "keywords": ["default", "schedule", "availability"]
+    },
+    {
+      "name": "create-schedule",
+      "title": "Create Schedule",
+      "description": "Create a new availability schedule (name, IANA timezone, optional weekly availability + overrides). Shows a confirmation.",
+      "icon": "logo.png",
+      "keywords": ["schedule", "create", "availability"]
+    },
+    {
+      "name": "update-schedule",
+      "title": "Update Schedule",
+      "description": "Update fields on a schedule (name, timeZone, isDefault, availability, overrides). Shows a confirmation listing changes.",
+      "icon": "logo.png",
+      "keywords": ["schedule", "update", "edit"]
+    },
+    {
+      "name": "delete-schedule",
+      "title": "Delete Schedule",
+      "description": "Permanently delete a schedule. Shows a confirmation.",
+      "icon": "logo.png",
+      "keywords": ["schedule", "delete", "remove"]
+    },
+    {
+      "name": "get-availability",
+      "title": "Get Available Slots",
+      "description": "Get available time slots for an event type within a window. Requires eventTypeId, start, end (ISO 8601). Optional duration, timeZone (IANA), username.",
+      "icon": "logo.png",
+      "keywords": ["availability", "slots", "free", "open"]
+    },
+    {
+      "name": "get-busy-times",
+      "title": "Get Busy Times",
+      "description": "Get busy intervals across the user's connected calendars within an ISO 8601 window.",
+      "icon": "logo.png",
+      "keywords": ["busy", "calendar", "blocked"]
+    },
+    {
+      "name": "get-conferencing-apps",
+      "title": "List Conferencing Apps",
+      "description": "List connected conferencing apps (Zoom, Google Meet, etc.).",
+      "icon": "logo.png",
+      "keywords": ["zoom", "meet", "conferencing", "video"]
+    },
+    {
+      "name": "calculate-routing-form-slots",
+      "title": "Calculate Routing Form Slots",
+      "description": "Calculate available slots based on a routing form response. Requires routingFormId, response (field-id → value map), start, end.",
+      "icon": "logo.png",
+      "keywords": ["routing", "form", "slots"]
+    },
+    {
+      "name": "get-org-memberships",
+      "title": "List Organization Memberships",
+      "description": "List memberships for an organization (requires admin/owner role).",
+      "icon": "logo.png",
+      "keywords": ["organization", "members", "team"]
+    },
+    {
+      "name": "create-org-membership",
+      "title": "Create Organization Membership",
+      "description": "Add a user to an organization with a role (OWNER/ADMIN/MEMBER). Shows a confirmation.",
+      "icon": "logo.png",
+      "keywords": ["organization", "invite", "add", "member"]
+    },
+    {
+      "name": "get-org-membership",
+      "title": "Get Organization Membership",
+      "description": "Get a single organization membership by id.",
+      "icon": "logo.png",
+      "keywords": ["organization", "member"]
+    },
+    {
+      "name": "delete-org-membership",
+      "title": "Remove Organization Membership",
+      "description": "Remove a user from an organization. Shows a confirmation.",
+      "icon": "logo.png",
+      "keywords": ["organization", "remove", "kick"]
+    },
+    {
+      "name": "get-org-routing-forms",
+      "title": "List Organization Routing Forms",
+      "description": "List routing forms for an organization.",
+      "icon": "logo.png",
+      "keywords": ["routing", "forms", "organization"]
+    },
+    {
+      "name": "get-org-routing-form-responses",
+      "title": "Get Routing Form Responses",
+      "description": "Get responses submitted to an organization's routing form.",
+      "icon": "logo.png",
+      "keywords": ["routing", "form", "responses"]
+    }
+  ],
+  "ai": {
+    "instructions": "This extension exposes Cal.com's v2 API surface — the same surface as Cal.com's official MCP server (mcp.cal.com), but via the user's existing API key so no OAuth handshake is needed.\n\nGeneral rules:\n- ALWAYS look up booking UIDs via get-bookings before calling cancel-booking, reschedule-booking, confirm-booking, mark-booking-absent, get-booking-attendees, add-booking-attendee, or get-booking. Never invent or guess a uid. If the user references a meeting by description (e.g. \"my 2pm tomorrow\", \"meeting with John\"), call get-bookings first with appropriate filters and disambiguate from the results.\n- ALWAYS use the booking `uid` (a string like \"abc123xyz\") for per-booking actions — NOT the numeric `id`. The two are different.\n- ALWAYS pass timezones in IANA format (e.g. \"America/Los_Angeles\", \"Europe/Berlin\"). Never abbreviations like \"PST\".\n- ALWAYS pass datetimes as ISO 8601 with explicit offset or `Z` (e.g. \"2026-06-01T14:00:00-07:00\" or \"2026-06-01T21:00:00Z\"). Never naive local strings.\n\nBooking lookup tips:\n- For \"this week\" / \"next week\" queries, use get-bookings with `status: \"upcoming\"` and filter the results client-side by start range — the API does not need explicit date params for short windows.\n- For \"past meetings with X\" queries, use get-bookings with `status: \"past\"` and `attendeeName` or `attendeeEmail`.\n- For pending approvals, use `status: \"unconfirmed\"`.\n\nAvailability / scheduling:\n- get-availability needs an eventTypeId. Call get-event-types first if the user hasn't named a specific type — pick the best match by length (\"30 min chat\" → 30-min event type).\n- For \"when am I free Monday\", use get-availability with start=Monday 00:00 in the user's timezone and end=Monday 23:59. Default the user's timezone via get-me if not specified.\n\nWrite-tool confirmations:\n- All create/update/delete/cancel/reschedule/mark/add tools show a confirmation dialog before executing. Present the user with the full action context so they can verify (e.g. \"Cancel your 2pm meeting with john@example.com on June 5?\") — do not call the tool blindly.\n\nOrganization tools:\n- Only call org-* tools if the user is in an organization (get-me returns organization.id when applicable). If they aren't, surface a clear message instead of guessing an organizationId.\n\nOOO note:\n- The extension's Raycast commands (Out of Office, Create Out of Office) handle OOO. Out-of-office is not part of Cal.com's MCP server tool surface, so it is not exposed as an AI tool here — direct the user to the OOO commands for those workflows.",
+    "evals": [
+      {
+        "input": "@cal-com-share-meeting-links what bookings do I have this week?",
+        "mocks": {
+          "get-bookings": [
+            {
+              "id": 1,
+              "uid": "abc123",
+              "title": "Demo Call",
+              "start": "2026-05-19T14:00:00Z",
+              "end": "2026-05-19T14:30:00Z",
+              "status": "ACCEPTED",
+              "hosts": [{ "id": 42, "name": "Andrew", "email": "andrew@hill.com" }],
+              "attendees": [{ "name": "John", "email": "john@example.com", "timeZone": "America/Los_Angeles" }]
+            }
+          ]
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "get-bookings",
+              "arguments": { "status": "upcoming" }
+            }
+          }
+        ]
+      },
+      {
+        "input": "@cal-com-share-meeting-links what event types do I have?",
+        "mocks": {
+          "get-me": { "id": 42, "username": "andrew", "name": "Andrew", "email": "andrew@hill.com", "timeZone": "America/Los_Angeles" },
+          "get-event-types": [
+            { "id": 1, "title": "30 Min Meeting", "slug": "30min", "lengthInMinutes": 30 }
+          ]
+        },
+        "expected": [
+          {
+            "callsTool": "get-event-types"
+          }
+        ]
+      },
+      {
+        "input": "@cal-com-share-meeting-links show me my availability schedules",
+        "mocks": {
+          "get-schedules": [
+            { "id": 1, "name": "Working Hours", "timeZone": "America/Los_Angeles", "isDefault": true }
+          ]
+        },
+        "expected": [
+          {
+            "callsTool": "get-schedules"
+          }
+        ]
+      },
+      {
+        "input": "@cal-com-share-meeting-links show me available slots for my 30 minute event type next Monday from 9am to 5pm Pacific time",
+        "mocks": {
+          "get-me": { "id": 42, "username": "andrew", "name": "Andrew", "email": "andrew@hill.com", "timeZone": "America/Los_Angeles" },
+          "get-event-types": [
+            { "id": 42, "title": "30 Min Meeting", "slug": "30min", "lengthInMinutes": 30 }
+          ],
+          "get-availability": { "slots": {} }
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "get-availability",
+              "arguments": {
+                "eventTypeId": 42
+              }
+            }
+          }
+        ]
+      },
+      {
+        "input": "@cal-com-share-meeting-links who am I?",
+        "mocks": {
+          "get-me": {
+            "id": 42,
+            "username": "andrew",
+            "name": "Andrew",
+            "email": "andrew@hill.com",
+            "timeZone": "America/Los_Angeles"
+          }
+        },
+        "expected": [
+          {
+            "callsTool": "get-me"
+          }
+        ]
+      }
+    ]
+  },
   "preferences": [
     {
       "name": "token",
@@ -66,13 +393,30 @@
       "description": "Cal.com API Key",
       "link": "https://app.cal.com/settings/developer",
       "placeholder": "Cal.com API Key"
+    },
+    {
+      "name": "region",
+      "type": "dropdown",
+      "required": false,
+      "title": "Server Region",
+      "description": "Choose your Cal.com server region. Use Europe if your account is on cal.eu.",
+      "default": "global",
+      "data": [
+        {
+          "title": "Global (cal.com)",
+          "value": "global"
+        },
+        {
+          "title": "Europe (cal.eu)",
+          "value": "eu"
+        }
+      ]
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.104.12",
-    "@raycast/utils": "^2.2.3",
+    "@raycast/api": "^1.104.17",
+    "@raycast/utils": "^2.2.4",
     "axios": "^1.8.4",
-    "dayjs": "^1.11.11",
     "moment": "^2.30.1"
   },
   "devDependencies": {

--- a/extensions/cal-com-share-meeting-links/src/api/cal.com.ts
+++ b/extensions/cal-com-share-meeting-links/src/api/cal.com.ts
@@ -122,16 +122,21 @@ export type CalSchedulePatch = Partial<
   Pick<CalSchedule, "name" | "timeZone" | "isDefault" | "availability" | "overrides">
 >;
 
-const { token } = getPreferenceValues<Preferences>();
+const { token, region } = getPreferenceValues<Preferences>();
+
+const isEU = region === "eu";
+export const userBaseUrl = isEU ? "https://api.cal.eu" : "https://api.cal.com";
+export const appBaseUrl = isEU ? "https://app.cal.eu" : "https://app.cal.com";
+export const publicBaseUrl = isEU ? "https://cal.eu" : "https://cal.com";
 
 const api = axios.create({
-  baseURL: "https://api.cal.com/v2/",
+  baseURL: `${userBaseUrl}/v2/`,
   headers: {
     Authorization: `Bearer ${token}`,
   },
 });
 
-async function calAPI<T>({ method = "GET", ...props }: AxiosRequestConfig) {
+export async function calAPI<T>({ method = "GET", ...props }: AxiosRequestConfig) {
   const resp = await api.request<{ status: string; data: T }>({ method, ...props });
   return resp.data.data;
 }
@@ -473,10 +478,10 @@ interface MembershipResponse {
 function normalizeAvatarUrl(url: string | null): string | null {
   if (!url) return null;
   if (url.startsWith("/api/avatar/")) {
-    return `https://app.cal.com${url}?size=32`;
+    return `${appBaseUrl}${url}?size=32`;
   }
   if (url.startsWith("http://") || url.startsWith("https://")) return url;
-  if (url.startsWith("/")) return `https://app.cal.com${url}`;
+  if (url.startsWith("/")) return `${appBaseUrl}${url}`;
   return url;
 }
 

--- a/extensions/cal-com-share-meeting-links/src/components/schedule-detail.tsx
+++ b/extensions/cal-com-share-meeting-links/src/components/schedule-detail.tsx
@@ -1,6 +1,6 @@
 import { Action, ActionPanel, Color, confirmAlert, Icon, List, showToast, Toast } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
-import { updateSchedule, useSchedules } from "@api/cal.com";
+import { appBaseUrl, updateSchedule, useSchedules } from "@api/cal.com";
 import {
   formatDayRanges,
   formatOverrideDate,
@@ -104,7 +104,7 @@ export function ScheduleDetail({ scheduleId }: ScheduleDetailProps) {
   const openScheduleInBrowserAction = (
     <Action.OpenInBrowser
       title="Open Schedule in Browser"
-      url={`https://app.cal.com/availability/${schedule.id}`}
+      url={`${appBaseUrl}/availability/${schedule.id}`}
       shortcut={{ modifiers: ["cmd"], key: "return" }}
     />
   );

--- a/extensions/cal-com-share-meeting-links/src/index.tsx
+++ b/extensions/cal-com-share-meeting-links/src/index.tsx
@@ -11,9 +11,11 @@ import {
   Toast,
 } from "@raycast/api";
 import {
+  appBaseUrl,
   CalEventType,
   createPrivateLinkForEventType,
   formatCurrency,
+  publicBaseUrl,
   useCurrentUser,
   useEventTypes,
 } from "@api/cal.com";
@@ -85,17 +87,17 @@ export default function Command() {
                 <Action.OpenInBrowser
                   title="Open Dashboard"
                   shortcut={{ modifiers: ["cmd"], key: "d" }}
-                  url="https://app.cal.com"
+                  url={appBaseUrl}
                 />
                 <Action.OpenInBrowser
                   title="Open Availability Troubleshooter"
                   shortcut={{ modifiers: ["cmd"], key: "t" }}
-                  url={`https://app.cal.com/availability/troubleshoot?eventType=${item.slug}`}
+                  url={`${appBaseUrl}/availability/troubleshoot?eventType=${item.slug}`}
                 />
                 <Action.CopyToClipboard
                   title="Copy My Link"
                   shortcut={{ modifiers: ["cmd"], key: "m" }}
-                  content={`https://cal.com/${user?.username}`}
+                  content={`${publicBaseUrl}/${user?.username}`}
                 />
                 <GeneratePrivateLinkCommand item={item} aborter={generatePrivateLinkAborter} />
               </ActionPanel.Section>

--- a/extensions/cal-com-share-meeting-links/src/lib/ai-tools.ts
+++ b/extensions/cal-com-share-meeting-links/src/lib/ai-tools.ts
@@ -1,0 +1,48 @@
+import type { CalBooking } from "@api/cal.com";
+
+/**
+ * Throw a clear error if a required tool input is missing or blank. Raycast
+ * surfaces tool errors to the model, so a descriptive message helps it recover
+ * (e.g. by calling get_bookings first to look up a uid).
+ */
+export function assertId(value: unknown, name: string): string {
+  if (value == null) {
+    throw new Error(`${name} is required.`);
+  }
+  const str = typeof value === "number" ? String(value) : String(value).trim();
+  if (str === "") {
+    throw new Error(`${name} is required.`);
+  }
+  return str;
+}
+
+/**
+ * Slim a Cal.com v2 booking object for AI consumption. The raw payload includes
+ * fields like `bookingFieldsResponses` and large nested metadata blobs that
+ * burn context for no benefit; the model only needs ids, timing, status, and
+ * who's involved to reason about the booking.
+ */
+export function formatBookingForAI(b: CalBooking) {
+  return {
+    id: b.id,
+    uid: b.uid,
+    title: b.title,
+    description: b.description,
+    start: b.start,
+    end: b.end,
+    durationMinutes: b.duration,
+    status: b.status,
+    meetingUrl: b.meetingUrl,
+    location: b.location,
+    hosts: b.hosts.map((h) => ({ id: h.id, name: h.name, email: h.email })),
+    attendees: b.attendees.map((a) => ({ name: a.name, email: a.email, timeZone: a.timeZone })),
+    eventTypeId: b.eventType?.id ?? null,
+  };
+}
+
+/**
+ * Standard confirmation payload for destructive tools.
+ */
+export function confirmDestructive(opts: { message: string; image?: string }) {
+  return { message: opts.message, image: opts.image };
+}

--- a/extensions/cal-com-share-meeting-links/src/out-of-office.tsx
+++ b/extensions/cal-com-share-meeting-links/src/out-of-office.tsx
@@ -11,7 +11,7 @@ import {
   Toast,
 } from "@raycast/api";
 import { showFailureToast, useCachedState } from "@raycast/utils";
-import { CalOOOEntry, deleteOOO, useOOOEntries } from "@api/cal.com";
+import { appBaseUrl, CalOOOEntry, deleteOOO, useOOOEntries } from "@api/cal.com";
 import { EditOOO } from "@components/edit-ooo";
 import {
   daysInRange,
@@ -22,8 +22,8 @@ import {
   labelForReason,
 } from "@/lib/ooo";
 
-const OOO_SETTINGS_URL = "https://app.cal.com/settings/my-account/out-of-office";
-const ACCOUNT_SETTINGS_URL = "https://app.cal.com/settings/my-account/general";
+const OOO_SETTINGS_URL = `${appBaseUrl}/settings/my-account/out-of-office`;
+const ACCOUNT_SETTINGS_URL = `${appBaseUrl}/settings/my-account/general`;
 
 export default function OutOfOffice() {
   const { data: entries, isLoading, error, mutate } = useOOOEntries();

--- a/extensions/cal-com-share-meeting-links/src/tools/add-booking-attendee.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/add-booking-attendee.ts
@@ -1,0 +1,34 @@
+import { Tool } from "@raycast/api";
+import { calAPI } from "@api/cal.com";
+import { assertId, confirmDestructive } from "@/lib/ai-tools";
+
+type Input = {
+  bookingUid: string;
+  name: string;
+  email: string;
+  /** IANA timezone. */
+  timeZone: string;
+  /** BCP47 locale. Defaults to "en". */
+  locale?: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  confirmDestructive({
+    message: `Add ${input.name} <${input.email}> as an attendee to booking ${input.bookingUid}?`,
+    image: "➕",
+  });
+
+export default async function tool(input: Input): Promise<unknown> {
+  const uid = assertId(input.bookingUid, "bookingUid");
+  return calAPI({
+    method: "POST",
+    url: `/bookings/${uid}/attendees`,
+    headers: { "cal-api-version": "2026-02-25" },
+    data: {
+      name: input.name,
+      email: input.email,
+      timeZone: input.timeZone,
+      ...(input.locale ? { locale: input.locale } : {}),
+    },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/calculate-routing-form-slots.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/calculate-routing-form-slots.ts
@@ -1,0 +1,38 @@
+import { calAPI } from "@api/cal.com";
+import { assertId } from "@/lib/ai-tools";
+
+type Input = {
+  routingFormId: string;
+  /** Routing form field responses as a JSON-encoded object keyed by field id. */
+  responseJson: string;
+  /** ISO 8601 start of window to search. */
+  start: string;
+  /** ISO 8601 end of window. */
+  end: string;
+  /** IANA timezone for the returned slots. */
+  timeZone?: string;
+};
+
+/**
+ * Calculate available slots for a routing form response — routes the response
+ * to the right event type / host and returns matching availability.
+ */
+export default async function tool(input: Input): Promise<unknown> {
+  const id = assertId(input.routingFormId, "routingFormId");
+  let response: unknown;
+  try {
+    response = JSON.parse(input.responseJson);
+  } catch {
+    throw new Error("responseJson must be valid JSON.");
+  }
+  return calAPI({
+    method: "POST",
+    url: `/routing-forms/${id}/slots`,
+    data: {
+      response,
+      start: input.start,
+      end: input.end,
+      ...(input.timeZone ? { timeZone: input.timeZone } : {}),
+    },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/cancel-booking.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/cancel-booking.ts
@@ -1,0 +1,22 @@
+import { Tool } from "@raycast/api";
+import { cancelBooking } from "@api/cal.com";
+import { assertId, confirmDestructive } from "@/lib/ai-tools";
+
+type Input = {
+  bookingUid: string;
+  /** Reason shared with attendees. */
+  cancellationReason: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  confirmDestructive({
+    message: `Cancel booking ${input.bookingUid}?\n\nReason: ${input.cancellationReason}`,
+    image: "❌",
+  });
+
+export default async function tool(input: Input): Promise<unknown> {
+  const uid = assertId(input.bookingUid, "bookingUid");
+  const reason = input.cancellationReason?.trim();
+  if (!reason) throw new Error("cancellationReason is required.");
+  return cancelBooking(uid, reason);
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/confirm-booking.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/confirm-booking.ts
@@ -1,0 +1,16 @@
+import { Tool } from "@raycast/api";
+import { confirmBooking } from "@api/cal.com";
+import { assertId, confirmDestructive } from "@/lib/ai-tools";
+
+type Input = { bookingUid: string };
+
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  confirmDestructive({
+    message: `Confirm pending booking ${input.bookingUid}?`,
+    image: "✅",
+  });
+
+export default async function tool(input: Input): Promise<unknown> {
+  const uid = assertId(input.bookingUid, "bookingUid");
+  return confirmBooking(uid);
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/create-booking.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/create-booking.ts
@@ -1,0 +1,68 @@
+import { Tool } from "@raycast/api";
+import { calAPI, type CalBooking } from "@api/cal.com";
+import { confirmDestructive, formatBookingForAI } from "@/lib/ai-tools";
+
+function parseJsonArg(s: string, name: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    throw new Error(`${name} must be valid JSON.`);
+  }
+}
+
+type Input = {
+  /** Event type id to book. */
+  eventTypeId: number;
+  /** ISO 8601 start time (must include timezone, e.g. "2026-06-01T14:00:00Z"). */
+  start: string;
+  /** IANA timezone, e.g. "America/Los_Angeles". */
+  attendeeTimeZone: string;
+  /** Attendee's name. */
+  attendeeName: string;
+  /** Attendee's email. */
+  attendeeEmail: string;
+  /** Optional booking title override. */
+  title?: string;
+  /** Optional meeting URL override. */
+  location?: string;
+  /** Phone number for SMS notifications. */
+  attendeePhoneNumber?: string;
+  /** Additional booking-field responses (event type's custom questions) as a JSON-encoded object keyed by field slug. */
+  bookingFieldsResponsesJson?: string;
+  /** Optional metadata as a JSON-encoded object. */
+  metadataJson?: string;
+  /** Cal.com user id to book — defaults to event type owner. */
+  userId?: number;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  confirmDestructive({
+    message: `Create booking on event type ${input.eventTypeId} at ${input.start} for ${input.attendeeName} <${input.attendeeEmail}>?`,
+    image: "📆",
+  });
+
+export default async function tool(input: Input) {
+  const booking = await calAPI<CalBooking>({
+    method: "POST",
+    url: "/bookings",
+    headers: { "cal-api-version": "2026-02-25" },
+    data: {
+      eventTypeId: input.eventTypeId,
+      start: input.start,
+      attendee: {
+        name: input.attendeeName,
+        email: input.attendeeEmail,
+        timeZone: input.attendeeTimeZone,
+        ...(input.attendeePhoneNumber ? { phoneNumber: input.attendeePhoneNumber } : {}),
+      },
+      ...(input.title ? { title: input.title } : {}),
+      ...(input.location ? { location: input.location } : {}),
+      ...(input.bookingFieldsResponsesJson
+        ? { bookingFieldsResponses: parseJsonArg(input.bookingFieldsResponsesJson, "bookingFieldsResponsesJson") }
+        : {}),
+      ...(input.metadataJson ? { metadata: parseJsonArg(input.metadataJson, "metadataJson") } : {}),
+      ...(input.userId ? { userId: input.userId } : {}),
+    },
+  });
+  return formatBookingForAI(booking);
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/create-event-type.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/create-event-type.ts
@@ -1,0 +1,51 @@
+import { Tool } from "@raycast/api";
+import { calAPI, type CalEventType } from "@api/cal.com";
+import { confirmDestructive } from "@/lib/ai-tools";
+
+type Input = {
+  /** Title shown on the booking page. */
+  title: string;
+  /** URL slug (defaults to slugified title). */
+  slug?: string;
+  /** Length in minutes (e.g. 15, 30, 60). */
+  lengthInMinutes: number;
+  /** Description shown to bookers. */
+  description?: string;
+  /** Hidden from your public booking page. */
+  hidden?: boolean;
+  /**
+   * Locations as a JSON-encoded array. Each entry: `{ "type": "integration", "integration": "office365_video" }` or `{ "type": "link", "link": "https://..." }`.
+   * Direct the user to the cal.com web UI for complex location setups; leave blank to use defaults.
+   */
+  locationsJson?: string;
+  /** Disable additional guests. */
+  disableGuests?: boolean;
+  /** Cents per booking (paid events). */
+  price?: number;
+  /** Currency code, e.g. "USD". */
+  currency?: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  confirmDestructive({
+    message: `Create event type "${input.title}" (${input.lengthInMinutes} min)?`,
+    image: "📅",
+  });
+
+export default async function tool(input: Input): Promise<CalEventType> {
+  const { locationsJson, ...rest } = input;
+  const data: Record<string, unknown> = { ...rest };
+  if (locationsJson) {
+    try {
+      data.locations = JSON.parse(locationsJson);
+    } catch {
+      throw new Error("locationsJson must be valid JSON.");
+    }
+  }
+  return calAPI<CalEventType>({
+    method: "POST",
+    url: "/event-types",
+    headers: { "cal-api-version": "2024-06-14" },
+    data,
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/create-org-membership.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/create-org-membership.ts
@@ -1,0 +1,31 @@
+import { Tool } from "@raycast/api";
+import { calAPI } from "@api/cal.com";
+import { assertId, confirmDestructive } from "@/lib/ai-tools";
+
+type Input = {
+  organizationId: number;
+  userId: number;
+  /** "OWNER" | "ADMIN" | "MEMBER". Default "MEMBER". */
+  role?: "OWNER" | "ADMIN" | "MEMBER";
+  accepted?: boolean;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  confirmDestructive({
+    message: `Add user ${input.userId} to organization ${input.organizationId} as ${input.role ?? "MEMBER"}?`,
+    image: "🏢",
+  });
+
+export default async function tool(input: Input): Promise<unknown> {
+  const orgId = assertId(input.organizationId, "organizationId");
+  return calAPI({
+    method: "POST",
+    url: `/organizations/${orgId}/memberships`,
+    headers: { "cal-api-version": "2024-08-13" },
+    data: {
+      userId: input.userId,
+      role: input.role ?? "MEMBER",
+      ...(input.accepted !== undefined ? { accepted: input.accepted } : {}),
+    },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/create-schedule.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/create-schedule.ts
@@ -1,0 +1,49 @@
+import { Tool } from "@raycast/api";
+import { calAPI, type CalSchedule } from "@api/cal.com";
+import { confirmDestructive } from "@/lib/ai-tools";
+
+type Input = {
+  name: string;
+  /** IANA timezone. */
+  timeZone: string;
+  /** If true, set as the user's default schedule. */
+  isDefault?: boolean;
+  /** Weekly availability rules as a JSON-encoded array of `{ "days": ["Monday", ...], "startTime": "09:00", "endTime": "17:00" }`. */
+  availabilityJson?: string;
+  /** Date-specific overrides as a JSON-encoded array of `{ "date": "YYYY-MM-DD", "startTime": "09:00", "endTime": "17:00" }`. */
+  overridesJson?: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  confirmDestructive({
+    message: `Create schedule "${input.name}" (${input.timeZone})${input.isDefault ? " as default" : ""}?`,
+    image: "🗓️",
+  });
+
+export default async function tool(input: Input): Promise<CalSchedule> {
+  const data: Record<string, unknown> = {
+    name: input.name,
+    timeZone: input.timeZone,
+    ...(input.isDefault !== undefined ? { isDefault: input.isDefault } : {}),
+  };
+  if (input.availabilityJson) {
+    try {
+      data.availability = JSON.parse(input.availabilityJson);
+    } catch {
+      throw new Error("availabilityJson must be valid JSON.");
+    }
+  }
+  if (input.overridesJson) {
+    try {
+      data.overrides = JSON.parse(input.overridesJson);
+    } catch {
+      throw new Error("overridesJson must be valid JSON.");
+    }
+  }
+  return calAPI<CalSchedule>({
+    method: "POST",
+    url: "/schedules",
+    headers: { "cal-api-version": "2024-06-11" },
+    data,
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/delete-event-type.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/delete-event-type.ts
@@ -1,0 +1,20 @@
+import { Tool } from "@raycast/api";
+import { calAPI } from "@api/cal.com";
+import { assertId, confirmDestructive } from "@/lib/ai-tools";
+
+type Input = { eventTypeId: number };
+
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  confirmDestructive({
+    message: `Permanently delete event type ${input.eventTypeId}? Existing bookings of this type will be retained but no new bookings will be possible.`,
+    image: "🗑️",
+  });
+
+export default async function tool(input: Input): Promise<unknown> {
+  const id = assertId(input.eventTypeId, "eventTypeId");
+  return calAPI<unknown>({
+    method: "DELETE",
+    url: `/event-types/${id}`,
+    headers: { "cal-api-version": "2024-06-14" },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/delete-org-membership.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/delete-org-membership.ts
@@ -1,0 +1,24 @@
+import { Tool } from "@raycast/api";
+import { calAPI } from "@api/cal.com";
+import { assertId, confirmDestructive } from "@/lib/ai-tools";
+
+type Input = {
+  organizationId: number;
+  membershipId: number;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  confirmDestructive({
+    message: `Remove membership ${input.membershipId} from organization ${input.organizationId}? The user will lose access immediately.`,
+    image: "🗑️",
+  });
+
+export default async function tool(input: Input): Promise<unknown> {
+  const orgId = assertId(input.organizationId, "organizationId");
+  const membershipId = assertId(input.membershipId, "membershipId");
+  return calAPI({
+    method: "DELETE",
+    url: `/organizations/${orgId}/memberships/${membershipId}`,
+    headers: { "cal-api-version": "2024-08-13" },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/delete-schedule.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/delete-schedule.ts
@@ -1,0 +1,20 @@
+import { Tool } from "@raycast/api";
+import { calAPI } from "@api/cal.com";
+import { assertId, confirmDestructive } from "@/lib/ai-tools";
+
+type Input = { scheduleId: number };
+
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  confirmDestructive({
+    message: `Permanently delete schedule ${input.scheduleId}? Event types referencing this schedule will fall back to your default.`,
+    image: "🗑️",
+  });
+
+export default async function tool(input: Input): Promise<unknown> {
+  const id = assertId(input.scheduleId, "scheduleId");
+  return calAPI({
+    method: "DELETE",
+    url: `/schedules/${id}`,
+    headers: { "cal-api-version": "2024-06-11" },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-availability.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-availability.ts
@@ -1,0 +1,36 @@
+import { calAPI } from "@api/cal.com";
+
+type Input = {
+  /** Event type id to check availability for. */
+  eventTypeId: number;
+  /** ISO 8601 start of the search window. */
+  start: string;
+  /** ISO 8601 end of the search window. */
+  end: string;
+  /** Slot length in minutes (defaults to event type duration). */
+  duration?: number;
+  /** IANA timezone to format slots in (e.g. "America/Los_Angeles"). */
+  timeZone?: string;
+  /** Username to scope availability to. Defaults to authenticated user. */
+  username?: string;
+};
+
+/**
+ * Get available time slots for an event type within a window. Returns
+ * timezone-aware slot timestamps the model can offer to the user.
+ */
+export default async function tool(input: Input): Promise<unknown> {
+  const params: Record<string, unknown> = {
+    eventTypeId: input.eventTypeId,
+    start: input.start,
+    end: input.end,
+  };
+  if (input.duration) params.duration = input.duration;
+  if (input.timeZone) params.timeZone = input.timeZone;
+  if (input.username) params.username = input.username;
+  return calAPI({
+    url: "/slots/available",
+    headers: { "cal-api-version": "2024-09-04" },
+    params,
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-booking-attendee.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-booking-attendee.ts
@@ -1,0 +1,16 @@
+import { calAPI } from "@api/cal.com";
+import { assertId } from "@/lib/ai-tools";
+
+type Input = {
+  bookingUid: string;
+  attendeeId: number;
+};
+
+export default async function tool(input: Input): Promise<unknown> {
+  const uid = assertId(input.bookingUid, "bookingUid");
+  const attendeeId = assertId(input.attendeeId, "attendeeId");
+  return calAPI({
+    url: `/bookings/${uid}/attendees/${attendeeId}`,
+    headers: { "cal-api-version": "2026-02-25" },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-booking-attendees.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-booking-attendees.ts
@@ -1,0 +1,12 @@
+import { calAPI } from "@api/cal.com";
+import { assertId } from "@/lib/ai-tools";
+
+type Input = { bookingUid: string };
+
+export default async function tool(input: Input): Promise<unknown> {
+  const uid = assertId(input.bookingUid, "bookingUid");
+  return calAPI({
+    url: `/bookings/${uid}/attendees`,
+    headers: { "cal-api-version": "2026-02-25" },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-booking.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-booking.ts
@@ -1,0 +1,16 @@
+import { calAPI, type CalBooking } from "@api/cal.com";
+import { assertId, formatBookingForAI } from "@/lib/ai-tools";
+
+type Input = {
+  /** Booking UID (NOT numeric id). Look up via get_bookings if unknown. */
+  bookingUid: string;
+};
+
+export default async function tool(input: Input) {
+  const uid = assertId(input.bookingUid, "bookingUid");
+  const booking = await calAPI<CalBooking>({
+    url: `/bookings/${uid}`,
+    headers: { "cal-api-version": "2026-02-25" },
+  });
+  return formatBookingForAI(booking);
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-bookings.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-bookings.ts
@@ -1,0 +1,49 @@
+import { calAPI, type CalBooking } from "@api/cal.com";
+import { formatBookingForAI } from "@/lib/ai-tools";
+
+type Input = {
+  /** "upcoming" | "unconfirmed" | "past" | "cancelled" | "recurring". Default: "upcoming". */
+  status?: "upcoming" | "unconfirmed" | "past" | "cancelled" | "recurring";
+  /** Sort order on start time. */
+  sortStart?: "asc" | "desc";
+  /** Page size (default 100). */
+  take?: number;
+  /** Skip count for pagination. */
+  skip?: number;
+  /** ISO 8601 — only bookings starting after this. */
+  afterStart?: string;
+  /** ISO 8601 — only bookings starting before this. */
+  beforeStart?: string;
+  /** Filter to attendees with this email. */
+  attendeeEmail?: string;
+  /** Filter to attendees with this name. */
+  attendeeName?: string;
+  /** Filter to a specific event type. */
+  eventTypeId?: number;
+};
+
+/**
+ * List bookings. Returns slim records (id, uid, title, start, end, hosts,
+ * attendees, status, meetingUrl) optimized for AI context. Pass uid into
+ * cancel_booking, reschedule_booking, etc.
+ */
+export default async function tool(input: Input) {
+  const params: Record<string, unknown> = {
+    status: input.status ?? "upcoming",
+    sortStart: input.sortStart ?? "asc",
+    take: input.take ?? 100,
+  };
+  if (input.skip !== undefined) params.skip = input.skip;
+  if (input.afterStart) params.afterStart = input.afterStart;
+  if (input.beforeStart) params.beforeStart = input.beforeStart;
+  if (input.attendeeEmail) params.attendeeEmail = input.attendeeEmail;
+  if (input.attendeeName) params.attendeeName = input.attendeeName;
+  if (input.eventTypeId) params.eventTypeId = input.eventTypeId;
+
+  const bookings = await calAPI<CalBooking[]>({
+    url: "/bookings",
+    headers: { "cal-api-version": "2026-02-25" },
+    params,
+  });
+  return bookings.map(formatBookingForAI);
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-busy-times.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-busy-times.ts
@@ -1,0 +1,23 @@
+import { calAPI } from "@api/cal.com";
+
+type Input = {
+  /** ISO 8601 start of window. */
+  start: string;
+  /** ISO 8601 end of window. */
+  end: string;
+  /** Cal.com username (defaults to authenticated user). */
+  username?: string;
+  /** Limit to a specific connected calendar credential id. */
+  credentialId?: number;
+};
+
+/** Get busy times across the user's connected calendars. */
+export default async function tool(input: Input): Promise<unknown> {
+  const params: Record<string, unknown> = { start: input.start, end: input.end };
+  if (input.username) params.username = input.username;
+  if (input.credentialId) params.credentialId = input.credentialId;
+  return calAPI({
+    url: "/calendars/busy-times",
+    params,
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-conferencing-apps.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-conferencing-apps.ts
@@ -1,0 +1,10 @@
+import { calAPI } from "@api/cal.com";
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Input = {};
+
+/** List connected conferencing apps (Zoom, Google Meet, etc.). */
+export default async function tool(input: Input): Promise<unknown> {
+  void input;
+  return calAPI({ url: "/conferencing" });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-default-schedule.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-default-schedule.ts
@@ -1,0 +1,12 @@
+import { calAPI, type CalSchedule } from "@api/cal.com";
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Input = {};
+
+export default async function tool(input: Input): Promise<CalSchedule> {
+  void input;
+  return calAPI<CalSchedule>({
+    url: "/schedules/default",
+    headers: { "cal-api-version": "2024-06-11" },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-event-type.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-event-type.ts
@@ -1,0 +1,15 @@
+import { calAPI, type CalEventType } from "@api/cal.com";
+import { assertId } from "@/lib/ai-tools";
+
+type Input = {
+  /** Numeric event type id. */
+  eventTypeId: number;
+};
+
+export default async function tool(input: Input): Promise<CalEventType> {
+  const id = assertId(input.eventTypeId, "eventTypeId");
+  return calAPI<CalEventType>({
+    url: `/event-types/${id}`,
+    headers: { "cal-api-version": "2024-06-14" },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-event-types.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-event-types.ts
@@ -1,0 +1,15 @@
+import { calAPI, type CalEventType } from "@api/cal.com";
+
+type Input = {
+  /** Filter by user (id or username). Defaults to authenticated user. */
+  username?: string;
+};
+
+/** List event types (booking link configurations) for a user. */
+export default async function tool(input: Input): Promise<CalEventType[]> {
+  return calAPI<CalEventType[]>({
+    url: "/event-types",
+    headers: { "cal-api-version": "2024-06-14" },
+    params: input.username ? { username: input.username } : undefined,
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-me.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-me.ts
@@ -1,0 +1,10 @@
+import { calAPI, type CalUser } from "@api/cal.com";
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Input = {};
+
+/** Get the authenticated user's Cal.com profile. */
+export default async function tool(input: Input): Promise<CalUser> {
+  void input;
+  return calAPI<CalUser>({ url: "/me" });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-org-membership.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-org-membership.ts
@@ -1,0 +1,16 @@
+import { calAPI } from "@api/cal.com";
+import { assertId } from "@/lib/ai-tools";
+
+type Input = {
+  organizationId: number;
+  membershipId: number;
+};
+
+export default async function tool(input: Input): Promise<unknown> {
+  const orgId = assertId(input.organizationId, "organizationId");
+  const membershipId = assertId(input.membershipId, "membershipId");
+  return calAPI({
+    url: `/organizations/${orgId}/memberships/${membershipId}`,
+    headers: { "cal-api-version": "2024-08-13" },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-org-memberships.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-org-memberships.ts
@@ -1,0 +1,15 @@
+import { calAPI } from "@api/cal.com";
+import { assertId } from "@/lib/ai-tools";
+
+type Input = {
+  /** Organization id. Look up via get_me (organization.id) if unknown. */
+  organizationId: number;
+};
+
+export default async function tool(input: Input): Promise<unknown> {
+  const id = assertId(input.organizationId, "organizationId");
+  return calAPI({
+    url: `/organizations/${id}/memberships`,
+    headers: { "cal-api-version": "2024-08-13" },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-org-routing-form-responses.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-org-routing-form-responses.ts
@@ -1,0 +1,24 @@
+import { calAPI } from "@api/cal.com";
+import { assertId } from "@/lib/ai-tools";
+
+type Input = {
+  organizationId: number;
+  routingFormId: string;
+  /** Page size. */
+  take?: number;
+  /** Skip count. */
+  skip?: number;
+};
+
+export default async function tool(input: Input): Promise<unknown> {
+  const orgId = assertId(input.organizationId, "organizationId");
+  const formId = assertId(input.routingFormId, "routingFormId");
+  const params: Record<string, unknown> = {};
+  if (input.take) params.take = input.take;
+  if (input.skip) params.skip = input.skip;
+  return calAPI({
+    url: `/organizations/${orgId}/routing-forms/${formId}/responses`,
+    headers: { "cal-api-version": "2024-08-13" },
+    params,
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-org-routing-form-responses.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-org-routing-form-responses.ts
@@ -14,8 +14,8 @@ export default async function tool(input: Input): Promise<unknown> {
   const orgId = assertId(input.organizationId, "organizationId");
   const formId = assertId(input.routingFormId, "routingFormId");
   const params: Record<string, unknown> = {};
-  if (input.take) params.take = input.take;
-  if (input.skip) params.skip = input.skip;
+  if (input.take !== undefined) params.take = input.take;
+  if (input.skip !== undefined) params.skip = input.skip;
   return calAPI({
     url: `/organizations/${orgId}/routing-forms/${formId}/responses`,
     headers: { "cal-api-version": "2024-08-13" },

--- a/extensions/cal-com-share-meeting-links/src/tools/get-org-routing-forms.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-org-routing-forms.ts
@@ -1,0 +1,12 @@
+import { calAPI } from "@api/cal.com";
+import { assertId } from "@/lib/ai-tools";
+
+type Input = { organizationId: number };
+
+export default async function tool(input: Input): Promise<unknown> {
+  const orgId = assertId(input.organizationId, "organizationId");
+  return calAPI({
+    url: `/organizations/${orgId}/routing-forms`,
+    headers: { "cal-api-version": "2024-08-13" },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-schedule.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-schedule.ts
@@ -1,0 +1,12 @@
+import { calAPI, type CalSchedule } from "@api/cal.com";
+import { assertId } from "@/lib/ai-tools";
+
+type Input = { scheduleId: number };
+
+export default async function tool(input: Input): Promise<CalSchedule> {
+  const id = assertId(input.scheduleId, "scheduleId");
+  return calAPI<CalSchedule>({
+    url: `/schedules/${id}`,
+    headers: { "cal-api-version": "2024-06-11" },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/get-schedules.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/get-schedules.ts
@@ -1,0 +1,12 @@
+import { calAPI, type CalSchedule } from "@api/cal.com";
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Input = {};
+
+export default async function tool(input: Input): Promise<CalSchedule[]> {
+  void input;
+  return calAPI<CalSchedule[]>({
+    url: "/schedules",
+    headers: { "cal-api-version": "2024-06-11" },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/mark-booking-absent.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/mark-booking-absent.ts
@@ -1,0 +1,32 @@
+import { Tool } from "@raycast/api";
+import { calAPI } from "@api/cal.com";
+import { assertId, confirmDestructive } from "@/lib/ai-tools";
+
+type Input = {
+  bookingUid: string;
+  /**
+   * Optional per-attendee no-show list. Pass `attendees: [{ email, noShow: true }, ...]`
+   * to mark specific attendees absent. Pass `host: true` to mark the host absent.
+   */
+  attendees?: Array<{ email: string; noShow: boolean }>;
+  host?: boolean;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  confirmDestructive({
+    message: `Mark booking ${input.bookingUid} no-show?${input.attendees ? `\n\nAttendees: ${input.attendees.map((a) => a.email).join(", ")}` : ""}`,
+    image: "🚫",
+  });
+
+export default async function tool(input: Input): Promise<unknown> {
+  const uid = assertId(input.bookingUid, "bookingUid");
+  return calAPI({
+    method: "POST",
+    url: `/bookings/${uid}/mark-no-show`,
+    headers: { "cal-api-version": "2026-02-25" },
+    data: {
+      ...(input.attendees ? { attendees: input.attendees } : {}),
+      ...(input.host !== undefined ? { host: input.host } : {}),
+    },
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/reschedule-booking.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/reschedule-booking.ts
@@ -1,0 +1,38 @@
+import { Tool } from "@raycast/api";
+import { calAPI, type CalBooking } from "@api/cal.com";
+import { assertId, confirmDestructive, formatBookingForAI } from "@/lib/ai-tools";
+
+type Input = {
+  /** Booking UID to reschedule. */
+  bookingUid: string;
+  /** New ISO 8601 start time. */
+  start: string;
+  /** Optional reschedule reason shown to attendees. */
+  rescheduleReason?: string;
+  /** Cal.com user id rescheduling (defaults to authenticated user). */
+  rescheduledBy?: number;
+  /** Update attendee's timezone for this booking. */
+  attendeeTimeZone?: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  confirmDestructive({
+    message: `Reschedule booking ${input.bookingUid} to ${input.start}?${input.rescheduleReason ? `\n\nReason: ${input.rescheduleReason}` : ""}`,
+    image: "🔄",
+  });
+
+export default async function tool(input: Input) {
+  const uid = assertId(input.bookingUid, "bookingUid");
+  const booking = await calAPI<CalBooking>({
+    method: "POST",
+    url: `/bookings/${uid}/reschedule`,
+    headers: { "cal-api-version": "2026-02-25" },
+    data: {
+      start: input.start,
+      ...(input.rescheduleReason ? { rescheduleReason: input.rescheduleReason } : {}),
+      ...(input.rescheduledBy ? { rescheduledBy: input.rescheduledBy } : {}),
+      ...(input.attendeeTimeZone ? { attendeeTimeZone: input.attendeeTimeZone } : {}),
+    },
+  });
+  return formatBookingForAI(booking);
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/update-event-type.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/update-event-type.ts
@@ -1,0 +1,48 @@
+import { Tool } from "@raycast/api";
+import { calAPI, type CalEventType } from "@api/cal.com";
+import { assertId, confirmDestructive } from "@/lib/ai-tools";
+
+type Input = {
+  eventTypeId: number;
+  title?: string;
+  slug?: string;
+  lengthInMinutes?: number;
+  description?: string;
+  hidden?: boolean;
+  /** Locations as a JSON-encoded array (same shape as create-event-type's locationsJson). */
+  locationsJson?: string;
+  disableGuests?: boolean;
+  price?: number;
+  currency?: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => {
+  const changes = Object.entries(input)
+    .filter(([k, v]) => k !== "eventTypeId" && v !== undefined && v !== null && v !== "")
+    .map(([k, v]) => `${k}: ${typeof v === "object" ? JSON.stringify(v) : String(v)}`)
+    .join("\n");
+  return confirmDestructive({
+    message: `Update event type ${input.eventTypeId}?\n\n${changes || "(no changes)"}`,
+    image: "📅",
+  });
+};
+
+export default async function tool(input: Input): Promise<CalEventType> {
+  const id = assertId(input.eventTypeId, "eventTypeId");
+  const { eventTypeId: _omit, locationsJson, ...patch } = input;
+  void _omit;
+  const data: Record<string, unknown> = { ...patch };
+  if (locationsJson) {
+    try {
+      data.locations = JSON.parse(locationsJson);
+    } catch {
+      throw new Error("locationsJson must be valid JSON.");
+    }
+  }
+  return calAPI<CalEventType>({
+    method: "PATCH",
+    url: `/event-types/${id}`,
+    headers: { "cal-api-version": "2024-06-14" },
+    data,
+  });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/update-me.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/update-me.ts
@@ -1,0 +1,35 @@
+import { Tool } from "@raycast/api";
+import { calAPI, type CalUser } from "@api/cal.com";
+import { confirmDestructive } from "@/lib/ai-tools";
+
+type Input = {
+  /** Display name. */
+  name?: string;
+  /** Cal.com username (the slug after cal.com/). */
+  username?: string;
+  /** Short bio. */
+  bio?: string;
+  /** IANA timezone, e.g. "America/Los_Angeles". */
+  timeZone?: string;
+  /** "Sunday" | "Monday" | ... */
+  weekStart?: string;
+  /** 12 or 24. */
+  timeFormat?: number;
+  /** BCP47, e.g. "en". */
+  locale?: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => {
+  const changes = Object.entries(input)
+    .filter(([, v]) => v !== undefined && v !== null && v !== "")
+    .map(([k, v]) => `${k}: ${String(v)}`)
+    .join("\n");
+  return confirmDestructive({
+    message: `Update your Cal.com profile?\n\n${changes || "(no changes)"}`,
+    image: "👤",
+  });
+};
+
+export default async function tool(input: Input): Promise<CalUser> {
+  return calAPI<CalUser>({ method: "PATCH", url: "/me", data: input });
+}

--- a/extensions/cal-com-share-meeting-links/src/tools/update-schedule.ts
+++ b/extensions/cal-com-share-meeting-links/src/tools/update-schedule.ts
@@ -1,0 +1,51 @@
+import { Tool } from "@raycast/api";
+import { updateSchedule, type CalSchedule, type CalSchedulePatch } from "@api/cal.com";
+import { assertId, confirmDestructive } from "@/lib/ai-tools";
+
+type Input = {
+  scheduleId: number;
+  /** New schedule name. */
+  name?: string;
+  /** IANA timezone, e.g. "America/Los_Angeles". */
+  timeZone?: string;
+  /** Set this schedule as default. */
+  isDefault?: boolean;
+  /** Weekly availability rules as a JSON-encoded array of `{ "days": ["Monday", ...], "startTime": "09:00", "endTime": "17:00" }`. */
+  availabilityJson?: string;
+  /** Date-specific overrides as a JSON-encoded array of `{ "date": "YYYY-MM-DD", "startTime": "09:00", "endTime": "17:00" }`. */
+  overridesJson?: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => {
+  const changes = Object.entries(input)
+    .filter(([k, v]) => k !== "scheduleId" && v !== undefined && v !== null && v !== "")
+    .map(([k, v]) => `${k}: ${String(v)}`)
+    .join("\n");
+  return confirmDestructive({
+    message: `Update schedule ${input.scheduleId}?\n\n${changes || "(no changes)"}`,
+    image: "🗓️",
+  });
+};
+
+export default async function tool(input: Input): Promise<CalSchedule> {
+  const id = Number(assertId(input.scheduleId, "scheduleId"));
+  const patch: CalSchedulePatch = {};
+  if (input.name !== undefined) patch.name = input.name;
+  if (input.timeZone !== undefined) patch.timeZone = input.timeZone;
+  if (input.isDefault !== undefined) patch.isDefault = input.isDefault;
+  if (input.availabilityJson) {
+    try {
+      patch.availability = JSON.parse(input.availabilityJson);
+    } catch {
+      throw new Error("availabilityJson must be valid JSON.");
+    }
+  }
+  if (input.overridesJson) {
+    try {
+      patch.overrides = JSON.parse(input.overridesJson);
+    } catch {
+      throw new Error("overridesJson must be valid JSON.");
+    }
+  }
+  return updateSchedule(id, patch);
+}

--- a/extensions/cal-com-share-meeting-links/src/view-availability.tsx
+++ b/extensions/cal-com-share-meeting-links/src/view-availability.tsx
@@ -1,6 +1,6 @@
 import { Action, ActionPanel, Color, Icon, List, openCommandPreferences, showToast, Toast } from "@raycast/api";
 import { showFailureToast, useCachedState } from "@raycast/utils";
-import { CalSchedule, updateSchedule, useEventTypes, useSchedules } from "@api/cal.com";
+import { appBaseUrl, CalSchedule, updateSchedule, useEventTypes, useSchedules } from "@api/cal.com";
 import { ScheduleDetail } from "@components/schedule-detail";
 import {
   formatDayRanges,
@@ -140,7 +140,7 @@ export default function ViewAvailability() {
               <Action.Push title="View Schedule" icon={Icon.Eye} target={<ScheduleDetail scheduleId={schedule.id} />} />
               <Action.OpenInBrowser
                 title="Open Schedule in Browser"
-                url={`https://app.cal.com/availability/${schedule.id}`}
+                url={`${appBaseUrl}/availability/${schedule.id}`}
                 shortcut={{ modifiers: ["cmd"], key: "return" }}
               />
               <Action
@@ -162,7 +162,7 @@ export default function ViewAvailability() {
               )}
               <Action.OpenInBrowser
                 title="Open All Availabilities in Browser"
-                url="https://app.cal.com/availability"
+                url={`${appBaseUrl}/availability`}
                 shortcut={{ modifiers: ["cmd"], key: "o" }}
               />
             </ActionPanel>

--- a/extensions/cal-com-share-meeting-links/src/view-bookings.tsx
+++ b/extensions/cal-com-share-meeting-links/src/view-bookings.tsx
@@ -1,6 +1,7 @@
 import { Action, ActionPanel, Color, Icon, List, openCommandPreferences, showToast, Toast } from "@raycast/api";
 import { showFailureToast, useCachedState } from "@raycast/utils";
 import {
+  appBaseUrl,
   CalBooking,
   confirmBooking,
   declineBooking,
@@ -109,7 +110,7 @@ export default function viewBookings() {
   const openAllBookingsAction = (
     <Action.OpenInBrowser
       title="Open All Bookings in Browser"
-      url="https://app.cal.com/bookings/upcoming"
+      url={`${appBaseUrl}/bookings/upcoming`}
       shortcut={{ modifiers: ["cmd"], key: "b" }}
     />
   );
@@ -124,7 +125,7 @@ export default function viewBookings() {
           {/* Enter = safe view action; destructive actions live behind explicit shortcuts. */}
           <Action.OpenInBrowser
             title="Open Booking in Browser"
-            url={`https://app.cal.com/bookings/upcoming?uid=${item.uid}`}
+            url={`${appBaseUrl}/bookings/upcoming?uid=${item.uid}`}
           />
           {item.meetingUrl && (
             <Action.OpenInBrowser


### PR DESCRIPTION
## Summary

Adds two cohesive changes to the Cal.com extension:

1. **33 AI Extension tools** that mirror Cal.com's MCP server surface (`mcp.cal.com`), invokable via `@cal-com-share-meeting-links` in Raycast AI chat. Tools wrap the existing v2 API client so they reuse the user's API key — no OAuth handshake or separate auth surface.
2. **EU server support** (fixes #27697). New "Server Region" preference (Global default / Europe) so `cal.eu` accounts no longer hit 401.

## Why one PR for all this

Both changes share the same `src/api/cal.com.ts` axios client. The AI tools route through that client, so wiring the region toggle there makes EU work for the AI tools automatically — splitting into two PRs would force the second to refactor the first's exports. Happy to split if reviewers prefer.

## What's in this PR

### 1. AI Extension tools (33 tools, MCP parity)

Cal.com released an MCP server at `mcp.cal.com` (https://cal.com/docs/mcp-server) that wraps their v2 API and exposes 33 tools. This PR exposes those same 33 tools as native Raycast AI Extension tools so users can invoke Cal.com via `@cal-com-share-meeting-links` in Raycast AI chat. **The implementation calls the existing v2 axios client directly** — Cal.com's MCP server is just a v2 wrapper, so bridging to it (with Streamable HTTP + OAuth 2.1) would add ~300 LOC of plumbing for zero capability gain.

Tool surface (file-per-tool in `src/tools/`):

- **User profile (2):** `get-me`, `update-me`*
- **Event types (5):** `get-event-types`, `get-event-type`, `create-event-type`*, `update-event-type`*, `delete-event-type`*
- **Bookings (10):** `get-bookings`, `get-booking`, `create-booking`*, `reschedule-booking`*, `cancel-booking`*, `confirm-booking`*, `mark-booking-absent`*, `get-booking-attendees`, `add-booking-attendee`*, `get-booking-attendee`
- **Schedules (6):** `get-schedules`, `get-schedule`, `get-default-schedule`, `create-schedule`*, `update-schedule`*, `delete-schedule`*
- **Availability (2):** `get-availability`, `get-busy-times`
- **Conferencing (1):** `get-conferencing-apps`
- **Routing forms (1):** `calculate-routing-form-slots`
- **Organizations (6):** `get-org-memberships`, `create-org-membership`*, `get-org-membership`, `delete-org-membership`*, `get-org-routing-forms`, `get-org-routing-form-responses`

(`*` = requires a Raycast confirmation dialog before executing. 16 of 33 are write-tools.)

`ai.instructions` covers the routing rules: always look up booking UIDs via `get-bookings` before per-booking actions, never invent UIDs, pass IANA timezones (not abbreviations), pass ISO 8601 with offset (not naive local strings), only call org-* tools if the user is in an org, etc.

`ai.evals`: 5 golden-path tests, all passing (`npx ray evals` → 5/5 100%).

Out-of-office is intentionally NOT included — it's not part of Cal.com's MCP server surface, so the strict-parity stance keeps it command-only. Easy to add in a follow-up if requested.

### 2. EU server support — fixes #27697

- New `region` dropdown preference (`global` default, `eu` opt-in).
- `src/api/cal.com.ts` now derives and exports `userBaseUrl` (api.cal.com / api.cal.eu), `appBaseUrl` (app.cal.com / app.cal.eu), and `publicBaseUrl` (cal.com / cal.eu) from the preference.
- All hardcoded URLs across `index.tsx`, `view-bookings.tsx`, `view-availability.tsx`, `out-of-office.tsx`, `components/schedule-detail.tsx`, and `normalizeAvatarUrl` switched to the dynamic exports.
- AI tools route through the same axios instance, so they automatically respect the region — no per-tool wiring.

### Dependency cleanup

- Bumps `@raycast/api` ^1.104.12 → ^1.104.17 and `@raycast/utils` ^2.2.3 → ^2.2.4 (current as of writing).
- Removes unused `dayjs` from `dependencies` (greptile flagged this on the prior PR; the comment was acknowledged but not fixed at the time).

## Implementation notes

- **AI tool inputs avoid TypeScript constructs the Raycast schema extractor rejects.** `Record<*, *>` and `unknown` aren't supported, and cross-file imported types can't be resolved. For complex objects (locations, metadata, booking-field responses, schedule availability/overrides, routing form responses), tools accept a `*Json` parameter that's `JSON.parse`d server-side — keeps the schema extractable while still allowing full v2 API expressiveness. Documented in tool descriptions.
- **Number ids, not unions.** Raycast's extractor only allows string unions, so id parameters are typed as `number` (the helper `assertId` in `src/lib/ai-tools.ts` coerces via `String()` for URL construction).
- **`Tool.Confirmation` payload shape** kept minimal (`message`, `image`) — matches the in-repo pattern in `extensions/superhuman/src/tools/`.
- **`formatBookingForAI`** in `src/lib/ai-tools.ts` slims booking responses for AI consumption (drops large `bookingFieldsResponses` and nested metadata blobs that burn context for no benefit).

## Test plan

- [x] `npm run build` clean across all 38 entry points (5 commands + 33 tool files)
- [x] `npm run lint` clean (only the pre-existing "Create out of Office" title-casing warning from PR #27133, deliberately left as-is)
- [x] `npx ray evals` → **5/5 passing (100%)**
- [x] Verified the existing 5 Raycast commands still work end-to-end with the new dynamic URLs (Global region)
- [ ] EU region: I don't have a cal.eu test account. Verified at code level that all axios + link URLs now route to `api.cal.eu` / `app.cal.eu` / `cal.eu` when the preference is set. Would appreciate a reviewer with a cal.eu account to confirm.

## Breaking changes

None. Existing users keep their API key and cached state. The default region is `global`, which matches the previous hardcoded behavior.

## Open items

- The "Create out of Office" lint title-case warning is pre-existing (from PR #27133). The suggested "Create out of Office" reads oddly, so left as-is — happy to change if reviewers prefer.
- Cal.com's MCP doc page claims 34 tools but the listed surface is exactly 33 (apparent off-by-one in their doc). This PR ships all 33 listed.