### PR TITLE
[ClaudeCast] Preserve session cwd when resolving project paths

### DIFF
--- a/extensions/claudecast/CHANGELOG.md
+++ b/extensions/claudecast/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- **Session Path Resolution**: Session metadata, details, and search results now prefer the session JSONL `cwd` field when present, avoiding lossy fallback decoding for project paths with underscore-prefixed segments.
 - **Cost Calculation: Streaming Chunk Deduplication**: Anthropic streams response chunks where each chunk's `usage` is cumulative. Naive summing inflated session totals by 2x to 4x. Now deduped by `(message.id, requestId)` so per-message totals reflect the final cumulative value once per request.
 - **Cost Calculation: Sonnet 200K Token Tier**: Above 200K input tokens per message, Sonnet rates double across all token types (input, output, cache read, cache write). The pricing now applies a flat per-request high tier keyed off the message's input token count, matching Anthropic's billing.
 - **Cost Calculation: Date-Range Filter Skips Timestampless Entries**: When a date range is active (today/week/month/daily chart), entries without a `timestamp` field are excluded. Previously they passed through the filter and inflated reported costs for users with older session files.

--- a/extensions/claudecast/src/lib/session-parser.ts
+++ b/extensions/claudecast/src/lib/session-parser.ts
@@ -44,6 +44,7 @@ interface JSONLEntry {
   summary?: string;
   leafUuid?: string;
   uuid?: string;
+  cwd?: string;
   // Used as part of the streaming-chunk dedup key.
   requestId?: string;
   message?: {
@@ -478,6 +479,10 @@ async function parseSessionMetadataFast(
           result.id = entry.leafUuid || path.basename(filePath, ".jsonl");
         }
 
+        if (!result.projectPath && entry.cwd) {
+          result.projectPath = sanitizeString(entry.cwd);
+        }
+
         if (entry.type === "user" || entry.type === "human") {
           turnCount++;
           if (!result.permissionMode && entry.permissionMode) {
@@ -584,6 +589,7 @@ async function parseFullSession(
     let id = path.basename(filePath, ".jsonl");
     let model: string | undefined;
     let firstMessage = "";
+    let sessionProjectPath: string | undefined;
 
     const stream = fs.createReadStream(filePath, { encoding: "utf8" });
     const rl = readline.createInterface({ input: stream });
@@ -597,6 +603,10 @@ async function parseFullSession(
         if (entry.type === "summary") {
           summary = sanitizeString(entry.summary || "");
           id = entry.leafUuid || id;
+        }
+
+        if (!sessionProjectPath && entry.cwd) {
+          sessionProjectPath = sanitizeString(entry.cwd);
         }
 
         if (entry.type === "user" || entry.type === "human") {
@@ -654,7 +664,8 @@ async function parseFullSession(
     rl.on("close", async () => {
       try {
         const stat = await fs.promises.stat(filePath);
-        const projectPath = await resolveProjectPath(encodedProjectPath);
+        const projectPath =
+          sessionProjectPath || (await resolveProjectPath(encodedProjectPath));
 
         const totalMessageCount = messages.length;
         const trimmedMessages =
@@ -785,7 +796,8 @@ export async function listAllSessions(options?: {
   for (const { filePath, projectDir, mtime } of filesToParse) {
     try {
       const metadata = await parseSessionMetadataFast(filePath);
-      const projectPath = await resolveProjectPathOnce(projectDir);
+      const projectPath =
+        metadata.projectPath || (await resolveProjectPathOnce(projectDir));
 
       sessions.push({
         id: metadata.id || path.basename(filePath, ".jsonl"),
@@ -826,7 +838,8 @@ export async function listProjectSessions(
       try {
         const stat = await fs.promises.stat(filePath);
         const metadata = await parseSessionMetadataFast(filePath);
-        const resolvedPath = await resolveProjectPath(encodedPath);
+        const resolvedPath =
+          metadata.projectPath || (await resolveProjectPath(encodedPath));
         sessions.push({
           id: metadata.id || path.basename(filePath, ".jsonl"),
           filePath,
@@ -912,7 +925,8 @@ export async function searchSessionContent(
 
     const match = await searchSingleSession(filePath, lowerQuery, signal);
     if (match) {
-      const projectPath = await resolveProjectPath(projectDir);
+      const projectPath =
+        match.projectPath || (await resolveProjectPath(projectDir));
       onMatch({
         id: match.id || path.basename(filePath, ".jsonl"),
         filePath,
@@ -950,6 +964,7 @@ async function searchSingleSession(
   model?: string;
   matchSnippet?: string;
   permissionMode?: PermissionMode;
+  projectPath?: string;
 } | null> {
   type MatchResult = {
     id: string;
@@ -960,6 +975,7 @@ async function searchSingleSession(
     model?: string;
     matchSnippet?: string;
     permissionMode?: PermissionMode;
+    projectPath?: string;
   };
 
   return new Promise<MatchResult | null>((resolve) => {
@@ -971,6 +987,7 @@ async function searchSingleSession(
     let turnCount = 0;
     let model: string | undefined;
     let permissionMode: PermissionMode | undefined;
+    let projectPath: string | undefined;
     let resolved = false;
 
     const safeResolve = (value: MatchResult | null) => {
@@ -1016,6 +1033,10 @@ async function searchSingleSession(
         if (entry.type === "summary") {
           summary = sanitizeString(entry.summary || "");
           id = entry.leafUuid || id;
+        }
+
+        if (!projectPath && entry.cwd) {
+          projectPath = sanitizeString(entry.cwd);
         }
 
         // Extract message content
@@ -1084,6 +1105,7 @@ async function searchSingleSession(
               model,
               matchSnippet,
               permissionMode,
+              projectPath,
             }
           : null,
       );


### PR DESCRIPTION
## Description

Fixes #27904.

Claude session project directory names are lossy: path separators, dots, and underscores can all be encoded as dashes. When a session JSONL entry includes the original `cwd`, use that authoritative path for session metadata/details before falling back to the existing encoded-directory resolver. This prevents paths with underscore-prefixed segments from being displayed or resumed as slash-prefixed paths.

## Screencast

N/A - parser-only bug fix.

## Verification

- `npm run lint`
- `npm run build`
- `git diff --check`

## Checklist

- [ ] I read the extension guidelines
- [ ] I read the documentation about publishing
- [ ] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with the metadata tool

Note: I ran the distribution build successfully, but did not manually load the build in Raycast.