### PR TITLE
Update railway extension

### DIFF
--- a/extensions/railway/CHANGELOG.md
+++ b/extensions/railway/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Railway Changelog
 
-## [Add Template Search] - {PR_MERGE_DATE}
+## [Add Template Search] - 2026-05-17
 
 - Added a new `Search Templates` command to browse and search Railway templates
 - List shows template name, creator, image, deployment count, health score, and verified badge

--- a/extensions/railway/CHANGELOG.md
+++ b/extensions/railway/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Railway Changelog
 
+## [Add Template Search] - {PR_MERGE_DATE}
+
+- Added a new `Search Templates` command to browse and search Railway templates
+- List shows template name, creator, image, deployment count, health score, and verified badge
+- Actions: deploy on Railway, view template page, copy URLs
+
 ## [Fix Action Links] - 2024-11-12
 
 - Fixed broken links in the actions, new actions are:

--- a/extensions/railway/package.json
+++ b/extensions/railway/package.json
@@ -11,7 +11,8 @@
   "contributors": [
     "nagauta",
     "xmok",
-    "danieldeichfuss"
+    "danieldeichfuss",
+    "ridemountainpig"
   ],
   "license": "MIT",
   "commands": [
@@ -20,17 +21,24 @@
       "title": "Search Projects",
       "subtitle": "Railway",
       "description": "Search and navigate to your Railway projects",
-      "mode": "view"
-    }
-  ],
-  "preferences": [
+      "mode": "view",
+      "preferences": [
+        {
+          "name": "railwayApiKey",
+          "type": "password",
+          "title": "Railway API Key",
+          "required": true,
+          "description": "type your Railway api key for auth",
+          "placeholder": "xxxxxxxxxx"
+        }
+      ]
+    },
     {
-      "name": "railwayApiKey",
-      "type": "password",
-      "title": "Railway API Key",
-      "required": true,
-      "description": "type your Railway api key for auth",
-      "placeholder": "xxxxxxxxxx"
+      "name": "railway-templates",
+      "title": "Search Templates",
+      "subtitle": "Railway",
+      "description": "Search Railway templates and deploy them with one click",
+      "mode": "view"
     }
   ],
   "dependencies": {

--- a/extensions/railway/package.json
+++ b/extensions/railway/package.json
@@ -63,5 +63,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/railway/src/railway-templates.tsx
+++ b/extensions/railway/src/railway-templates.tsx
@@ -1,0 +1,207 @@
+import { useState } from "react";
+import { ActionPanel, List, Action, Icon, Color } from "@raycast/api";
+import { useCachedPromise, showFailureToast } from "@raycast/utils";
+import { fetchTemplates, fetchTemplateDetail, templatePageUrl, templateDeployUrl, TemplateGQL } from "./railway";
+
+type VerifiedFilter = "all" | "verified";
+
+export default function Command() {
+  const [searchText, setSearchText] = useState("");
+  const [filter, setFilter] = useState<VerifiedFilter>("all");
+  const [isShowingDetail, setIsShowingDetail] = useState(false);
+  const [selectedCode, setSelectedCode] = useState<string | null>(null);
+
+  const {
+    isLoading,
+    data: templates = [],
+    pagination,
+  } = useCachedPromise(
+    (query: string) => async (options: { page: number; cursor?: string }) => {
+      const result = await fetchTemplates(query, options.cursor);
+      return {
+        data: result.templates,
+        hasMore: result.hasNextPage,
+        cursor: result.endCursor ?? undefined,
+      };
+    },
+    [searchText],
+    {
+      keepPreviousData: true,
+      onError: (error) => {
+        showFailureToast(error, { title: "Failed to load templates" });
+      },
+    },
+  );
+
+  const { data: readme } = useCachedPromise(
+    async (code: string | null) => (code && isShowingDetail ? fetchTemplateDetail(code) : null),
+    [selectedCode],
+    {
+      keepPreviousData: false,
+      onError: (error) => {
+        showFailureToast(error, { title: "Failed to load template details" });
+      },
+    },
+  );
+
+  const filtered = filter === "verified" ? templates.filter((t) => t.isVerified) : templates;
+  const seen = new Set<string>();
+  const visible = filtered.filter((t) => {
+    if (seen.has(t.id)) return false;
+    seen.add(t.id);
+    return true;
+  });
+  const sectionTitle = searchText ? "Results" : "Popular Templates";
+
+  return (
+    <List
+      isLoading={isLoading}
+      isShowingDetail={isShowingDetail && visible.length > 0}
+      searchBarPlaceholder="Search Railway templates"
+      onSearchTextChange={setSearchText}
+      pagination={pagination}
+      onSelectionChange={(id) => {
+        const t = templates.find((tpl) => tpl.id === id);
+        setSelectedCode(t?.code ?? null);
+      }}
+      throttle
+      searchBarAccessory={
+        <List.Dropdown tooltip="Filter templates" value={filter} onChange={(v) => setFilter(v as VerifiedFilter)}>
+          <List.Dropdown.Item title="All Templates" value="all" icon={Icon.AppWindowGrid3x3} />
+          <List.Dropdown.Item
+            title="Verified Only"
+            value="verified"
+            icon={{ source: Icon.CheckCircle, tintColor: Color.Blue }}
+          />
+        </List.Dropdown>
+      }
+    >
+      {!isLoading && visible.length === 0 && (
+        <List.EmptyView
+          title="No templates found"
+          description={filter === "verified" ? "Try switching to All Templates" : "Try a different search term"}
+          icon={Icon.MagnifyingGlass}
+        />
+      )}
+      <List.Section title={sectionTitle}>
+        {visible.map((t) => (
+          <List.Item
+            key={t.id}
+            id={t.id}
+            icon={t.image ? { source: t.image, fallback: Icon.Box } : Icon.Box}
+            title={t.name}
+            subtitle={isShowingDetail ? undefined : t.creatorName}
+            keywords={[t.creatorName, t.description].filter((s): s is string => Boolean(s))}
+            accessories={isShowingDetail ? undefined : buildAccessories(t)}
+            detail={
+              <List.Item.Detail
+                markdown={buildMarkdown(t, t.code === selectedCode ? readme : undefined)}
+                metadata={buildMetadata(t)}
+              />
+            }
+            actions={
+              <ActionPanel>
+                <Action.OpenInBrowser title="Deploy on Railway" url={templateDeployUrl(t.code)} />
+                <Action.OpenInBrowser
+                  title="View Template"
+                  url={templatePageUrl(t.code)}
+                  shortcut={{ modifiers: ["cmd"], key: "o" }}
+                />
+                <Action
+                  title={isShowingDetail ? "Hide Details" : "Show Details"}
+                  icon={Icon.Sidebar}
+                  shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
+                  onAction={() => setIsShowingDetail((v) => !v)}
+                />
+                <Action.CopyToClipboard
+                  title="Copy Template URL"
+                  content={templatePageUrl(t.code)}
+                  shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+                />
+                <Action.CopyToClipboard
+                  title="Copy Deploy URL"
+                  content={templateDeployUrl(t.code)}
+                  shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
+                />
+              </ActionPanel>
+            }
+          />
+        ))}
+      </List.Section>
+    </List>
+  );
+}
+
+function buildMarkdown(t: TemplateGQL, readme: string | null | undefined): string {
+  if (readme) return readme;
+  const parts: string[] = [`# ${t.name}`];
+  if (t.image) parts.push(`![${t.name}](${t.image})`);
+  if (t.description) parts.push(t.description);
+  return parts.join("\n\n");
+}
+
+function buildMetadata(t: TemplateGQL) {
+  return (
+    <List.Item.Detail.Metadata>
+      <List.Item.Detail.Metadata.Label title="Creator" text={t.creatorName} />
+      <List.Item.Detail.Metadata.Label
+        title="Verified"
+        icon={
+          t.isVerified
+            ? { source: Icon.CheckCircle, tintColor: Color.Blue }
+            : { source: Icon.Circle, tintColor: Color.SecondaryText }
+        }
+        text={t.isVerified ? "Yes" : "No"}
+      />
+      {t.healthScore != null ? (
+        <List.Item.Detail.Metadata.TagList title="Health Score">
+          <List.Item.Detail.Metadata.TagList.Item text={`${t.healthScore}`} color={healthColor(t.healthScore)} />
+        </List.Item.Detail.Metadata.TagList>
+      ) : (
+        <List.Item.Detail.Metadata.Label title="Health Score" text="No score" />
+      )}
+      <List.Item.Detail.Metadata.Label
+        title="Deployments"
+        text={t.deploymentCount.toLocaleString()}
+        icon={Icon.Download}
+      />
+      <List.Item.Detail.Metadata.Separator />
+      <List.Item.Detail.Metadata.Link title="Template Page" target={templatePageUrl(t.code)} text="Open" />
+    </List.Item.Detail.Metadata>
+  );
+}
+
+function buildAccessories(t: TemplateGQL): List.Item.Accessory[] {
+  const accessories: List.Item.Accessory[] = [];
+
+  if (t.isVerified) {
+    accessories.push({ icon: { source: Icon.CheckCircle, tintColor: Color.Blue }, tooltip: "Verified" });
+  }
+
+  if (t.healthScore != null) {
+    accessories.push({
+      tag: { value: `${t.healthScore}`, color: healthColor(t.healthScore) },
+      tooltip: `Health score: ${t.healthScore}`,
+    });
+  }
+
+  accessories.push({
+    icon: Icon.Download,
+    text: formatCount(t.deploymentCount),
+    tooltip: `${t.deploymentCount.toLocaleString()} deployments`,
+  });
+
+  return accessories;
+}
+
+function healthColor(score: number): Color {
+  if (score >= 90) return Color.Green;
+  if (score >= 70) return Color.Yellow;
+  return Color.Red;
+}
+
+function formatCount(n: number): string {
+  if (n < 1000) return `${n}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}

--- a/extensions/railway/src/railway-templates.tsx
+++ b/extensions/railway/src/railway-templates.tsx
@@ -34,8 +34,8 @@ export default function Command() {
   );
 
   const { data: readme } = useCachedPromise(
-    async (code: string | null) => (code && isShowingDetail ? fetchTemplateDetail(code) : null),
-    [selectedCode],
+    async (code: string | null, showDetail: boolean) => (code && showDetail ? fetchTemplateDetail(code) : null),
+    [selectedCode, isShowingDetail],
     {
       keepPreviousData: false,
       onError: (error) => {

--- a/extensions/railway/src/railway.ts
+++ b/extensions/railway/src/railway.ts
@@ -2,12 +2,15 @@ import { getPreferenceValues } from "@raycast/api";
 import fetch from "node-fetch";
 
 const backboardUrl = "https://backboard.railway.app/graphql/v2";
+const backboardInternalUrl = "https://backboard.railway.com/graphql/internal";
 export const railwayWebUrl = "https://railway.app";
+export const railwayComUrl = "https://railway.com";
 
 export const projectUrl = (projectId: string, page?: string): string =>
   `${railwayWebUrl}/project/${projectId}/${page ?? ""}`;
 
-const token = getPreferenceValues<Preferences>().railwayApiKey;
+export const templatePageUrl = (code: string): string => `${railwayComUrl}/template/${code}`;
+export const templateDeployUrl = (code: string): string => `${railwayComUrl}/new/template/${code}`;
 
 interface ProjectGQL {
   id: string;
@@ -37,6 +40,7 @@ interface Error {
 }
 
 export const gqlRequest = async <T>(query: string): Promise<T | null> => {
+  const token = getPreferenceValues<Preferences.RailwayProjects>().railwayApiKey;
   const res = await fetch(backboardUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
@@ -78,4 +82,109 @@ export const fetchProjects = async (): Promise<ProjectGQL[]> => {
   const projects = [...res.projects.edges.map((p) => p.node)];
 
   return projects;
+};
+
+export interface TemplateGQL {
+  id: string;
+  code: string;
+  name: string;
+  description: string;
+  image: string | null;
+  deploymentCount: number;
+  healthScore: number | null;
+  creatorName: string;
+  isVerified: boolean;
+}
+
+interface TemplateSearchGQL {
+  templateSearch: {
+    edges: Array<{ node: TemplateGQL }>;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+}
+
+const templateSearchQuery = `query templateSearch($query: String!, $first: Int, $after: String) {
+  templateSearch(query: $query, first: $first, after: $after) {
+    edges {
+      node {
+        id
+        code
+        name
+        description
+        image
+        deploymentCount
+        healthScore
+        creatorName
+        isVerified
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}`;
+
+export interface TemplateSearchResult {
+  templates: TemplateGQL[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+interface TemplateDetailGQL {
+  template: {
+    id: string;
+    code: string;
+    name: string;
+    description: string | null;
+    readme: string | null;
+  } | null;
+}
+
+const templateDetailQuery = `query templateDetail($code: String!) {
+  template(code: $code) {
+    id
+    code
+    name
+    description
+    readme
+  }
+}`;
+
+export const fetchTemplateDetail = async (code: string): Promise<string | null> => {
+  const res = await fetch(backboardInternalUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      operationName: "templateDetail",
+      query: templateDetailQuery,
+      variables: { code },
+    }),
+  });
+
+  const json = (await res.json()) as { errors?: Error[]; data?: TemplateDetailGQL };
+  if (json.errors) throw new Error(json.errors[0].message);
+  return json.data?.template?.readme ?? null;
+};
+
+export const fetchTemplates = async (query: string, after?: string): Promise<TemplateSearchResult> => {
+  const res = await fetch(backboardInternalUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      operationName: "templateSearch",
+      query: templateSearchQuery,
+      variables: { query, first: 50, after },
+    }),
+  });
+
+  const json = (await res.json()) as { errors?: Error[]; data?: TemplateSearchGQL };
+  if (json.errors) throw new Error(json.errors[0].message);
+  if (!json.data) return { templates: [], hasNextPage: false, endCursor: null };
+
+  return {
+    templates: json.data.templateSearch.edges.map((e) => e.node),
+    hasNextPage: json.data.templateSearch.pageInfo.hasNextPage,
+    endCursor: json.data.templateSearch.pageInfo.endCursor,
+  };
 };


### PR DESCRIPTION
## Description
- Added a new `Search Templates` command to browse and search Railway templates
- List shows template name, creator, image, deployment count, health score, and verified badge
- Actions: deploy on Railway, view template page, copy URLs
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1000" height="625" alt="railway 2026-05-17 at 10 57 14" src="https://github.com/user-attachments/assets/749457a6-d338-4960-8868-ef6ce3cc8ae6" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
