### PR TITLE
[Apple Reminders] Restore create and close shortcut

### DIFF
--- a/extensions/apple-reminders/CHANGELOG.md
+++ b/extensions/apple-reminders/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Apple Reminders Changelog
 
-## [Fix Create Reminder close shortcut] - {PR_MERGE_DATE}
+## [Fix Create Reminder close shortcut] - 2026-05-19
 
 - Restored the Shift+Command+Enter shortcut for creating a reminder and closing the window.
 

--- a/extensions/apple-reminders/CHANGELOG.md
+++ b/extensions/apple-reminders/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Apple Reminders Changelog
 
+## [Fix Create Reminder close shortcut] - {PR_MERGE_DATE}
+
+- Restored the Shift+Command+Enter shortcut for creating a reminder and closing the window.
+
 ## [Customize Create Reminder Form and Manage Create Actions] - 2026-04-22
 
 - Add a new "Customize Create Reminder Form" command to control which field groups appear in the Create Reminder form.

--- a/extensions/apple-reminders/src/create-reminder.tsx
+++ b/extensions/apple-reminders/src/create-reminder.tsx
@@ -413,6 +413,7 @@ export function CreateReminderForm({ draftValues, listId, mutate }: CreateRemind
           <Action.SubmitForm
             icon={Icon.Window}
             onSubmit={(values) => submitWithOptions(values as CreateReminderValues, { closeWindowAfterCreate: true })}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "enter" }}
             title="Create Reminder and Close Window"
           />
           <Action.Push


### PR DESCRIPTION
## Description
Fixes #27979.

The Create Reminder form already has a Create Reminder and Close Window submit action, but it did not expose the expected Shift+Command+Enter shortcut. This restores that shortcut so the form submits and closes from the keyboard again.

## Screencast
N/A; shortcut wiring only.

## Testing
- npm run lint --prefix extensions/apple-reminders
- git diff --check
- npm run build --prefix extensions/apple-reminders (started locally; stopped after native Swift dependency compilation exceeded 3 minutes)
