### PR TITLE
[Gmail] Fix browser account selector URLs

### DIFF
--- a/extensions/gmail/CHANGELOG.md
+++ b/extensions/gmail/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Gmail Changelog
 
-## [Fix Gmail browser URLs] - {PR_MERGE_DATE}
+## [Fix Gmail browser URLs] - 2026-05-19
 
 - Fixed Gmail browser links using an email address in the account selector.
 

--- a/extensions/gmail/CHANGELOG.md
+++ b/extensions/gmail/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gmail Changelog
 
+## [Fix Gmail browser URLs] - {PR_MERGE_DATE}
+
+- Fixed Gmail browser links using an email address in the account selector.
+
 ## [Maintenance] - 2026-01-01
 
 - Add support for Windows platform.

--- a/extensions/gmail/src/lib/gmail.ts
+++ b/extensions/gmail/src/lib/gmail.ts
@@ -59,6 +59,8 @@ export function getGMailMessageHeaderValue(msg: gmail_v1.Schema$Message | undefi
 }
 
 export function gmailWebUrlBase(currentProfile: gmail_v1.Schema$Profile | undefined) {
+  // Gmail no longer supports `/mail/u/{email}` selectors. The browser account index
+  // cannot be derived from the Gmail API profile, so use the first browser account.
   return currentProfile?.emailAddress ? "https://mail.google.com/mail/u/0" : undefined;
 }
 

--- a/extensions/gmail/src/lib/gmail.ts
+++ b/extensions/gmail/src/lib/gmail.ts
@@ -59,8 +59,7 @@ export function getGMailMessageHeaderValue(msg: gmail_v1.Schema$Message | undefi
 }
 
 export function gmailWebUrlBase(currentProfile: gmail_v1.Schema$Profile | undefined) {
-  const address = currentProfile?.emailAddress;
-  return address ? `https://mail.google.com/mail/u/${address}` : undefined;
+  return currentProfile?.emailAddress ? "https://mail.google.com/mail/u/0" : undefined;
 }
 
 export function inlineNewMailWebUrl(currentProfile: gmail_v1.Schema$Profile) {


### PR DESCRIPTION
## Description
Fixes #27725.

Gmail browser links were built with `/mail/u/{email}`. Gmail now returns a temporary 404 for that selector format, while numeric selectors such as `/mail/u/0` still work. This changes the shared Gmail web URL base so opening Gmail, compose links, draft links, and message thread links use the numeric selector.

## Screencast
N/A; URL generation fix.

## Testing
- npm run lint --prefix extensions/gmail
- npm run build --prefix extensions/gmail
- git diff --check
