### PR TITLE
[Espanso] Reduce Search Matches memory usage

### DIFF
--- a/extensions/espanso/CHANGELOG.md
+++ b/extensions/espanso/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Espanso Changelog
 
-## [Fix Search Matches memory usage] - {PR_MERGE_DATE}
+## [Fix Search Matches memory usage] - 2026-05-28
 
 - Reduced Search Matches memory usage by loading replacement previews only for the selected match.
 

--- a/extensions/espanso/CHANGELOG.md
+++ b/extensions/espanso/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Espanso Changelog
 
+## [Fix Search Matches memory usage] - {PR_MERGE_DATE}
+
+- Reduced Search Matches memory usage by loading replacement previews only for the selected match.
+
 ## [1.1.0] - 2026-04-16
 
 ### What's Changed

--- a/extensions/espanso/src/components/match-item/index.tsx
+++ b/extensions/espanso/src/components/match-item/index.tsx
@@ -27,7 +27,7 @@ export default function MatchItem({
   onEdited,
 }: MatchItemProps) {
   const { triggers, replace, image_path, form, label, filePath, profile, vars, isRegex } = match;
-  const [expandedReplace, setExpandedReplace] = useState(replace ?? "");
+  const [expandedReplace, setExpandedReplace] = useState("");
   const [resolvedImagePath, setResolvedImagePath] = useState<string | undefined>(undefined);
 
   const isDynamic = !!vars?.length;
@@ -41,8 +41,10 @@ export default function MatchItem({
 
     if (isImage) {
       setResolvedImagePath(resolveImagePath(image_path, configPath));
-    } else {
+    } else if (isDynamic) {
       refresh();
+    } else {
+      setExpandedReplace(replace ?? "");
     }
   }, [isSelected]);
 
@@ -52,11 +54,11 @@ export default function MatchItem({
     <List.Item
       id={id}
       title={label ?? triggers.join(", ")}
-      keywords={replace ? [replace] : undefined}
+      keywords={replace && replace.length <= 200 ? [replace] : undefined}
       subtitle={profile ? formatCategoryName(profile, separator) : ""}
       detail={
         <List.Item.Detail
-          markdown={form ? "`form` is not supported yet." : isImage ? imageMarkdown : expandedReplace}
+          markdown={form ? "`form` is not supported yet." : isImage ? imageMarkdown : isSelected ? expandedReplace : ""}
           metadata={
             <List.Item.Detail.Metadata>
               <List.Item.Detail.Metadata.TagList title="Triggers">


### PR DESCRIPTION
## Description
Fixes #27892.

Search Matches rendered every match with its full replacement text already stored in item state and indexed as a keyword. Large Espanso configs can push the extension over the 100 MB JS heap limit. This keeps replacement previews lazy: only the selected item gets its replacement text loaded into detail state, and very large replacement text is no longer duplicated into list keywords.

## Screencast
N/A; memory usage fix.

## Testing
- npm run lint --prefix extensions/espanso
- npm test --prefix extensions/espanso -- --run
- npm run build --prefix extensions/espanso
- git diff --check
