### PR TITLE
[Todoist] Reduce Menu Bar Tasks sync size

### DIFF
--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -5,6 +5,10 @@
 - **Sort menu bar tasks by priority**: Tasks shown in the menu bar (Today, Upcoming, Inbox, and Filter views) are now ordered by priority first (highest first), then by their existing default order, so the most important tasks surface at the top.
 - **Toggle from preferences**: A new **Sort tasks by priority** checkbox in the menu bar command preferences lets you turn priority sorting off and fall back to the previous default ordering. Enabled by default.
 
+## [Reduce Menu Bar sync size] - {PR_MERGE_DATE}
+
+- Reduced Menu Bar Tasks memory usage by syncing only the Todoist resources used by the menu bar.
+
 ## [Add Keyboard Shortcuts] - 2026-05-16
 
 - Added a shortcut to create Raycast quicklinks from Todoist views.

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -5,7 +5,7 @@
 - **Sort menu bar tasks by priority**: Tasks shown in the menu bar (Today, Upcoming, Inbox, and Filter views) are now ordered by priority first (highest first), then by their existing default order, so the most important tasks surface at the top.
 - **Toggle from preferences**: A new **Sort tasks by priority** checkbox in the menu bar command preferences lets you turn priority sorting off and fall back to the previous default ordering. Enabled by default.
 
-## [Reduce Menu Bar sync size] - {PR_MERGE_DATE}
+## [Reduce Menu Bar sync size] - 2026-05-28
 
 - Reduced Menu Bar Tasks memory usage by syncing only the Todoist resources used by the menu bar.
 

--- a/extensions/todoist/src/api.ts
+++ b/extensions/todoist/src/api.ts
@@ -48,6 +48,18 @@ export type SyncData = {
   user: User;
 };
 
+export type SyncResourceType =
+  | "user"
+  | "projects"
+  | "items"
+  | "sections"
+  | "labels"
+  | "filters"
+  | "collaborators"
+  | "reminders"
+  | "locations"
+  | "notes";
+
 export type CachedDataParams = {
   data: SyncData | undefined;
   setData: Dispatch<SetStateAction<SyncData | undefined>>;
@@ -109,10 +121,10 @@ export async function getFilterTasks(query: string) {
   }
 }
 
-export async function initialSync() {
+export async function initialSync(resourceTypes?: SyncResourceType[]) {
   return syncRequest({
     sync_token: "*",
-    resource_types: [
+    resource_types: resourceTypes ?? [
       "user",
       "projects",
       "items",

--- a/extensions/todoist/src/hooks/useSyncData.ts
+++ b/extensions/todoist/src/hooks/useSyncData.ts
@@ -5,6 +5,18 @@ import { SyncData, SyncResourceType, initialSync } from "../api";
 
 import useCachedData from "./useCachedData";
 
+const EMPTY_SYNC_DATA_FIELDS: Pick<
+  SyncData,
+  "collaborator_states" | "filters" | "locations" | "notes" | "reminders" | "sections"
+> = {
+  collaborator_states: [],
+  filters: [],
+  locations: [],
+  notes: [],
+  reminders: [],
+  sections: [],
+};
+
 export default function useSyncData(shouldSync = true, resourceTypes?: SyncResourceType[]) {
   const { data: syncData, ...rest } = usePromise(
     async (resourceTypes?: SyncResourceType[]) => {
@@ -21,7 +33,9 @@ export default function useSyncData(shouldSync = true, resourceTypes?: SyncResou
 
   useEffect(() => {
     if (syncData) {
-      setCachedData(syncData);
+      setCachedData((cachedData) =>
+        cachedData ? { ...cachedData, ...syncData } : ({ ...EMPTY_SYNC_DATA_FIELDS, ...syncData } as SyncData),
+      );
     }
   }, [syncData, setCachedData]);
 

--- a/extensions/todoist/src/hooks/useSyncData.ts
+++ b/extensions/todoist/src/hooks/useSyncData.ts
@@ -1,19 +1,19 @@
 import { usePromise } from "@raycast/utils";
 import { useEffect } from "react";
 
-import { SyncData, initialSync } from "../api";
+import { SyncData, SyncResourceType, initialSync } from "../api";
 
 import useCachedData from "./useCachedData";
 
-export default function useSyncData(shouldSync = true) {
+export default function useSyncData(shouldSync = true, resourceTypes?: SyncResourceType[]) {
   const { data: syncData, ...rest } = usePromise(
-    async () => {
+    async (resourceTypes?: SyncResourceType[]) => {
       if (shouldSync) {
-        const data = await initialSync();
+        const data = await initialSync(resourceTypes);
         return data as SyncData;
       }
     },
-    [],
+    [resourceTypes],
     { failureToastOptions: { title: "Unable to get Todoist data" } },
   );
 

--- a/extensions/todoist/src/menu-bar.tsx
+++ b/extensions/todoist/src/menu-bar.tsx
@@ -12,7 +12,7 @@ import { addDays, format, isBefore } from "date-fns";
 import { useEffect, useMemo } from "react";
 import removeMarkdown from "remove-markdown";
 
-import { SyncData, Task, getProductivityStats } from "./api";
+import { SyncData, SyncResourceType, Task, getProductivityStats } from "./api";
 import MenuBarTask from "./components/MenubarTask";
 import { getToday } from "./helpers/dates";
 import { groupByDates } from "./helpers/groupBy";
@@ -28,10 +28,12 @@ type MenuBarProps = LaunchProps<{ launchContext: { fromCommand: boolean } }>;
 
 const byPriorityThenDefault = (a: Task, b: Task) => sortByPriority(a, b) || sortByDefault(a, b);
 
+const MENU_BAR_RESOURCE_TYPES: SyncResourceType[] = ["user", "projects", "items", "labels", "collaborators"];
+
 function MenuBar(props: MenuBarProps) {
   const launchedFromWithinCommand = props.launchContext?.fromCommand ?? false;
   // Don't perform a full sync if the command was launched from within another commands
-  const { data, setData, isLoading } = useSyncData(!launchedFromWithinCommand);
+  const { data, setData, isLoading } = useSyncData(!launchedFromWithinCommand, MENU_BAR_RESOURCE_TYPES);
   const { focusedTask, unfocusTask } = useFocusedTask();
   const {
     view,


### PR DESCRIPTION
## Description
Fixes #27858.

The Menu Bar Tasks command used the shared full Todoist sync, which also pulls heavier resources such as notes, reminders, locations, filters, and sections. The menu bar only needs user, projects, items, labels, and collaborators for rendering and menu actions, so this lets the sync hook accept a resource list and uses a smaller sync payload for the menu bar command. Other Todoist commands keep the existing full sync behavior.

## Screencast
N/A; background menu bar memory usage fix.

## Testing
- npm run lint --prefix extensions/todoist
- npm run build --prefix extensions/todoist
- git diff --check
