### PR TITLE
[Hide Files] Fix path handling for visibility toggles

### DIFF
--- a/extensions/hide-files/CHANGELOG.md
+++ b/extensions/hide-files/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Hide Files Changelog
 
-## [Bugfix] - {PR_MERGE_DATE}
+## [Bugfix] - 2026-05-27
 
 - Fixed hiding and unhiding files whose paths need shell escaping
 

--- a/extensions/hide-files/CHANGELOG.md
+++ b/extensions/hide-files/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hide Files Changelog
 
+## [Bugfix] - {PR_MERGE_DATE}
+
+- Fixed hiding and unhiding files whose paths need shell escaping
+
 ## [New Icon Style] - 2025-07-07
 
 - Optimize extension icons for macOS Tahoe

--- a/extensions/hide-files/src/manage-hidden-files.tsx
+++ b/extensions/hide-files/src/manage-hidden-files.tsx
@@ -85,6 +85,7 @@ export default function Command() {
                       title={`Unhide File`}
                       shortcut={{ modifiers: ["cmd"], key: "u" }}
                       onAction={async () => {
+                        showHiddenFiles(value.path);
                         const _localDirectory = [...localHiddenDirectory];
                         _localDirectory.splice(index, 1);
                         await LocalStorage.setItem(
@@ -92,7 +93,6 @@ export default function Command() {
                           JSON.stringify(_localDirectory),
                         );
                         setRefresh(refreshNumber());
-                        showHiddenFiles(value.path);
 
                         const options: Toast.Options = {
                           style: Toast.Style.Success,

--- a/extensions/hide-files/src/manage-hidden-files.tsx
+++ b/extensions/hide-files/src/manage-hidden-files.tsx
@@ -1,6 +1,7 @@
 import {
   Action,
   ActionPanel,
+  captureException,
   Clipboard,
   Icon,
   List,
@@ -85,35 +86,40 @@ export default function Command() {
                       title={`Unhide File`}
                       shortcut={{ modifiers: ["cmd"], key: "u" }}
                       onAction={async () => {
-                        showHiddenFiles(value.path);
-                        const _localDirectory = [...localHiddenDirectory];
-                        _localDirectory.splice(index, 1);
-                        await LocalStorage.setItem(
-                          LocalStorageKey.LOCAL_HIDE_DIRECTORY,
-                          JSON.stringify(_localDirectory),
-                        );
-                        setRefresh(refreshNumber());
+                        try {
+                          showHiddenFiles(value.path);
+                          const _localDirectory = [...localHiddenDirectory];
+                          _localDirectory.splice(index, 1);
+                          await LocalStorage.setItem(
+                            LocalStorageKey.LOCAL_HIDE_DIRECTORY,
+                            JSON.stringify(_localDirectory),
+                          );
+                          setRefresh(refreshNumber());
 
-                        const options: Toast.Options = {
-                          style: Toast.Style.Success,
-                          title: `Success!`,
-                          message: `${value.name} has been unhidden.`,
-                          primaryAction: {
-                            title: "Open in Finder",
-                            onAction: (toast) => {
-                              open(value.path);
-                              toast.hide();
+                          const options: Toast.Options = {
+                            style: Toast.Style.Success,
+                            title: `Success!`,
+                            message: `${value.name} has been unhidden.`,
+                            primaryAction: {
+                              title: "Open in Finder",
+                              onAction: (toast) => {
+                                open(value.path);
+                                toast.hide();
+                              },
                             },
-                          },
-                          secondaryAction: {
-                            title: "Show in Finder",
-                            onAction: (toast) => {
-                              showInFinder(value.path);
-                              toast.hide();
+                            secondaryAction: {
+                              title: "Show in Finder",
+                              onAction: (toast) => {
+                                showInFinder(value.path);
+                                toast.hide();
+                              },
                             },
-                          },
-                        };
-                        await showToast(options);
+                          };
+                          await showToast(options);
+                        } catch (error) {
+                          captureException(error);
+                          await showToast(Toast.Style.Failure, "Failed to unhide file", String(error));
+                        }
                       }}
                     />
                     <Action
@@ -127,11 +133,16 @@ export default function Command() {
                           "Are you sure you want to unhide all files?",
                           "Unhide All",
                           async () => {
-                            const filePaths = localHiddenDirectory.map((file) => file.path);
-                            showHiddenFiles(filePaths);
-                            await LocalStorage.clear();
-                            setRefresh(refreshNumber());
-                            await showToast(Toast.Style.Success, "Success!", "All files have been unhidden.");
+                            try {
+                              const filePaths = localHiddenDirectory.map((file) => file.path);
+                              showHiddenFiles(filePaths);
+                              await LocalStorage.clear();
+                              setRefresh(refreshNumber());
+                              await showToast(Toast.Style.Success, "Success!", "All files have been unhidden.");
+                            } catch (error) {
+                              captureException(error);
+                              await showToast(Toast.Style.Failure, "Failed to unhide files", String(error));
+                            }
                           },
                         );
                       }}

--- a/extensions/hide-files/src/manage-hidden-files.tsx
+++ b/extensions/hide-files/src/manage-hidden-files.tsx
@@ -92,7 +92,7 @@ export default function Command() {
                           JSON.stringify(_localDirectory),
                         );
                         setRefresh(refreshNumber());
-                        showHiddenFiles(value.path.replaceAll(" ", `" "`));
+                        showHiddenFiles(value.path);
 
                         const options: Toast.Options = {
                           style: Toast.Style.Success,
@@ -127,8 +127,8 @@ export default function Command() {
                           "Are you sure you want to unhide all files?",
                           "Unhide All",
                           async () => {
-                            const filePaths = localHiddenDirectory.map((file) => file.path.replaceAll(" ", `" "`));
-                            showHiddenFiles(filePaths.join(" "));
+                            const filePaths = localHiddenDirectory.map((file) => file.path);
+                            showHiddenFiles(filePaths);
                             await LocalStorage.clear();
                             setRefresh(refreshNumber());
                             await showToast(Toast.Style.Success, "Success!", "All files have been unhidden.");

--- a/extensions/hide-files/src/utils/hide-files-utils.ts
+++ b/extensions/hide-files/src/utils/hide-files-utils.ts
@@ -2,10 +2,23 @@ import { captureException, getSelectedFinderItems, LocalStorage, showHUD } from 
 import { checkDuplicatePath, getFilesInDirectory, getLocalStorage, isDirectoryOrFile, isEmpty } from "./common-utils";
 import { DirectoryInfo } from "./directory-info";
 import { parse } from "path";
-import { spawn } from "child_process";
 import { LocalStorageKey } from "./constants";
 import { spawnSync } from "node:child_process";
 import fse from "fs-extra";
+
+const runChflags = (flag: "hidden" | "nohidden", paths: string[]) => {
+  if (paths.length === 0) {
+    return;
+  }
+
+  const result = spawnSync("chflags", [flag, ...paths], { encoding: "utf-8" });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `chflags ${flag} failed`);
+  }
+};
 
 export const putFileOnHidePanel = async (fileSystemItems: string[]) => {
   try {
@@ -75,10 +88,10 @@ export const removeFilesFromPanelBySelected = async (directory: string[]) => {
 
 /**
  *
- * @param path If there are multiple paths, please separate them with spaces
+ * @param path One path or an array of paths to unhide
  */
-export const showHiddenFiles = (path: string) => {
-  spawn("chflags", ["nohidden", path], { shell: true });
+export const showHiddenFiles = (path: string | string[]) => {
+  runChflags("nohidden", Array.isArray(path) ? path : [path]);
 };
 
 // Judging by the hidden attribute of the first file
@@ -109,15 +122,16 @@ export const hideFilesInFolder = async (path: string) => {
     }
 
     if (isHidden) {
+      const fileSystemItems = getFilesInDirectory(pathStr);
+      runChflags("nohidden", fileSystemItems);
       await showHUD(`🐵 Unhiding files in ${name}`);
-      spawn("chflags", ["nohidden", `${pathStr.replaceAll(" ", `" "`)}*`], { shell: true });
       //remove files from hide panel
       await removeFilesFromPanel(pathStr);
     } else {
-      await showHUD(`🙈 Hiding files in ${name}`);
-      spawn("chflags", ["hidden", `${pathStr.replaceAll(" ", `" "`)}*`], { shell: true });
       //add files to hide panel
       const fileSystemItems = getFilesInDirectory(pathStr);
+      runChflags("hidden", fileSystemItems);
+      await showHUD(`🙈 Hiding files in ${name}`);
       await putFileOnHidePanel(fileSystemItems);
     }
     return isHidden;
@@ -138,31 +152,20 @@ export const hideFilesSelected = async () => {
     }
     const isHidden = isFileHidden(fileSystemItems[0].path);
 
-    let hiddenFilesStr = "";
-    fileSystemItems.forEach((value) => {
-      const parsedPath = parse(value.path);
-      hiddenFilesStr =
-        hiddenFilesStr + " " + parsedPath.dir.replaceAll(" ", `" "`) + "/" + parsedPath.base.replaceAll(" ", `" "`);
-    });
+    const filePaths = fileSystemItems.map((value) => value.path);
 
     if (isHidden) {
+      runChflags("nohidden", filePaths);
       await showHUD(`🐵 Unhiding selected files`);
-      spawn("chflags", ["nohidden", `${hiddenFilesStr}`], { shell: true });
 
       //add files to hide panel
-      const _fileSystemItems = fileSystemItems.map((value) => {
-        return value.path;
-      });
-      await removeFilesFromPanelBySelected(_fileSystemItems);
+      await removeFilesFromPanelBySelected(filePaths);
     } else {
+      runChflags("hidden", filePaths);
       await showHUD(`🙈 Hiding selected files`);
-      spawn("chflags", ["hidden", hiddenFilesStr], { shell: true });
 
       //add files to hide panel
-      const _fileSystemItems = fileSystemItems.map((value) => {
-        return value.path;
-      });
-      await putFileOnHidePanel(_fileSystemItems);
+      await putFileOnHidePanel(filePaths);
     }
   } catch (e) {
     captureException(e);


### PR DESCRIPTION
## Description

Replaces shell-escaped `chflags` calls with direct path arguments so hiding and unhiding works for files whose paths require escaping. This also keeps success HUDs behind successful `chflags` calls.

Fixes #27690

## Screencast

N/A; command path handling fix.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [contribution guidelines](https://github.com/raycast/extensions/blob/main/CONTRIBUTING.md)
- [x] I ran `npm run lint --prefix extensions/hide-files`
- [x] I ran `npm run build --prefix extensions/hide-files`
- [x] I ran `git diff --check`

## Verification

- Confirmed `chflags hidden` and `chflags nohidden` work with multiple direct path arguments, including a filename with spaces
- `npm run lint --prefix extensions/hide-files`
- `npm run build --prefix extensions/hide-files`
- `git diff --check`