### PR TITLE
[Toggle Desktop Visibility] Fix Tahoe icon toggling

### DIFF
--- a/extensions/toggle-desktop-visibility/CHANGELOG.md
+++ b/extensions/toggle-desktop-visibility/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Toggle Desktop Visibility Changelog
 
+## [Bugfix] - {PR_MERGE_DATE}
+- Fixed desktop icon visibility commands on macOS Tahoe
+
 ## [Support Tahoe] - 2025-07-10
 - Added support for macOS Tahoe (version 26)
 

--- a/extensions/toggle-desktop-visibility/CHANGELOG.md
+++ b/extensions/toggle-desktop-visibility/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Toggle Desktop Visibility Changelog
 
-## [Bugfix] - {PR_MERGE_DATE}
+## [Bugfix] - 2026-05-28
 - Fixed desktop icon visibility commands on macOS Tahoe
 
 ## [Support Tahoe] - 2025-07-10

--- a/extensions/toggle-desktop-visibility/package.json
+++ b/extensions/toggle-desktop-visibility/package.json
@@ -49,7 +49,7 @@
       "name": "show-desktop-widgets",
       "title": "Show Widgets",
       "subtitle": "Desktop",
-      "description": "Show Desktop widgets",  
+      "description": "Show Desktop widgets",
       "mode": "no-view",
       "disabledByDefault": true
     },
@@ -79,5 +79,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/toggle-desktop-visibility/src/utils/tahoe.ts
+++ b/extensions/toggle-desktop-visibility/src/utils/tahoe.ts
@@ -1,7 +1,10 @@
 import { spawnSync } from "child_process";
 
 function restartFinder() {
-  spawnSync("killall", ["Finder"]);
+  const result = spawnSync("killall", ["Finder"]);
+  if (result.status !== 0) {
+    throw new Error(`Failed to restart Finder: ${result.stderr?.toString().trim() || "unknown error"}`);
+  }
 }
 
 export function areDesktopIconsHidden() {

--- a/extensions/toggle-desktop-visibility/src/utils/tahoe.ts
+++ b/extensions/toggle-desktop-visibility/src/utils/tahoe.ts
@@ -7,6 +7,13 @@ function restartFinder() {
   }
 }
 
+function writeDesktopPref(value: boolean) {
+  const result = spawnSync("defaults", ["write", "com.apple.finder", "CreateDesktop", "-bool", value.toString()]);
+  if (result.status !== 0) {
+    throw new Error(`Failed to write CreateDesktop preference: ${result.stderr?.toString().trim() || "unknown error"}`);
+  }
+}
+
 export function areDesktopIconsHidden() {
   const { stdout } = spawnSync("defaults", ["read", "com.apple.finder", "CreateDesktop"], {
     encoding: "utf-8",
@@ -15,12 +22,12 @@ export function areDesktopIconsHidden() {
 }
 
 export function hideDesktopIcons() {
-  spawnSync("defaults", ["write", "com.apple.finder", "CreateDesktop", "-bool", "false"]);
+  writeDesktopPref(false);
   restartFinder();
 }
 
 export function showDesktopIcons() {
-  spawnSync("defaults", ["write", "com.apple.finder", "CreateDesktop", "-bool", "true"]);
+  writeDesktopPref(true);
   restartFinder();
 }
 

--- a/extensions/toggle-desktop-visibility/src/utils/tahoe.ts
+++ b/extensions/toggle-desktop-visibility/src/utils/tahoe.ts
@@ -18,7 +18,7 @@ export function areDesktopIconsHidden() {
   const { stdout } = spawnSync("defaults", ["read", "com.apple.finder", "CreateDesktop"], {
     encoding: "utf-8",
   });
-  return stdout.trim() === "0";
+  return stdout.trim() === "1";
 }
 
 export function hideDesktopIcons() {

--- a/extensions/toggle-desktop-visibility/src/utils/tahoe.ts
+++ b/extensions/toggle-desktop-visibility/src/utils/tahoe.ts
@@ -1,18 +1,24 @@
 import { spawnSync } from "child_process";
 
+function restartFinder() {
+  spawnSync("killall", ["Finder"]);
+}
+
 export function areDesktopIconsHidden() {
-  const { stdout } = spawnSync("defaults", ["read", "com.apple.WindowManager", "StandardHideDesktopIcons"], {
+  const { stdout } = spawnSync("defaults", ["read", "com.apple.finder", "CreateDesktop"], {
     encoding: "utf-8",
   });
   return stdout.trim() === "0";
 }
 
 export function hideDesktopIcons() {
-  spawnSync("defaults", ["write", "com.apple.WindowManager", "StandardHideDesktopIcons", "-bool", "true"]);
+  spawnSync("defaults", ["write", "com.apple.finder", "CreateDesktop", "-bool", "false"]);
+  restartFinder();
 }
 
 export function showDesktopIcons() {
-  spawnSync("defaults", ["write", "com.apple.WindowManager", "StandardHideDesktopIcons", "-bool", "false"]);
+  spawnSync("defaults", ["write", "com.apple.finder", "CreateDesktop", "-bool", "true"]);
+  restartFinder();
 }
 
 export function areDesktopWidgetsHidden() {


### PR DESCRIPTION
## Description

Uses the Finder `CreateDesktop` preference for macOS Tahoe desktop icon visibility and restarts Finder after changing it. The previous Tahoe path wrote `StandardHideDesktopIcons`, which can report success without changing the visible Desktop icons.

Fixes #27691

## Screencast

N/A; macOS preference command fix.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [contribution guidelines](https://github.com/raycast/extensions/blob/main/CONTRIBUTING.md)
- [x] I ran `npm run lint --prefix extensions/toggle-desktop-visibility`
- [x] I ran `npm run build --prefix extensions/toggle-desktop-visibility`
- [x] I ran `git diff --check`

## Verification

- Verified on macOS 26.4.1 that `com.apple.finder CreateDesktop` reads `0` after writing `false` and `1` after writing `true`, then restored the previous preference state
- `npm run lint --prefix extensions/toggle-desktop-visibility`
- `npm run build --prefix extensions/toggle-desktop-visibility`
- `git diff --check`