### PR TITLE
[Kill Process] Prevent background refresh timeout errors

### DIFF
--- a/extensions/kill-process/CHANGELOG.md
+++ b/extensions/kill-process/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kill Process Changelog
 
-## [Bugfix] - {PR_MERGE_DATE}
+## [Bugfix] - 2026-05-27
 
 - Prevented background refreshes from overlapping and surfacing timeout errors while the process list is left open.
 

--- a/extensions/kill-process/CHANGELOG.md
+++ b/extensions/kill-process/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Kill Process Changelog
 
+## [Bugfix] - {PR_MERGE_DATE}
+
+- Prevented background refreshes from overlapping and surfacing timeout errors while the process list is left open.
+
 ## [Added Restart Action] - 2026-04-08
 
 - Added `Restart` and `Force Restart` actions for restartable processes

--- a/extensions/kill-process/src/index.tsx
+++ b/extensions/kill-process/src/index.tsx
@@ -97,6 +97,10 @@ export default function ProcessList() {
 
   const fetchProcesses = (showErrorToast = false) => {
     if (isFetchingProcesses.current) {
+      if (showErrorToast) {
+        showToast({ title: "Refresh already in progress", style: Toast.Style.Animated });
+      }
+
       return;
     }
 

--- a/extensions/kill-process/src/index.tsx
+++ b/extensions/kill-process/src/index.tsx
@@ -16,7 +16,7 @@ import {
   Toast,
 } from "@raycast/api";
 import prettyBytes from "pretty-bytes";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import useInterval from "./hooks/use-interval";
 import { Process } from "./types";
 import { getFileIcon, getPlatformSpecificErrorHelp, hasRestartLaunchPath, isWindows } from "./utils/platform";
@@ -70,6 +70,7 @@ export default function ProcessList() {
   const skipConfirmation = preferences.skipConfirmation;
   const [sortBy, setSortBy] = useState<SortBy>(DEFAULT_SORT_BY);
   const [isAppGroupingEnabled, setIsAppGroupingEnabled] = useState<boolean>(false);
+  const isFetchingProcesses = useRef(false);
 
   // Cache CPU data from WMI queries (persists across refreshes)
   const [cpuCache, setCpuCache] = useState<Map<number, number>>(new Map());
@@ -94,7 +95,12 @@ export default function ProcessList() {
     void loadAppGrouping();
   }, []);
 
-  const fetchProcesses = () => {
+  const fetchProcesses = (showErrorToast = false) => {
+    if (isFetchingProcesses.current) {
+      return;
+    }
+
+    isFetchingProcesses.current = true;
     fetchRunningProcesses()
       .then((processes) => {
         // Apply cached CPU values to new process list
@@ -126,11 +132,16 @@ export default function ProcessList() {
       })
       .catch((err) => {
         console.error("Failed to fetch processes:", err);
-        showToast({
-          title: "Failed to fetch processes",
-          style: Toast.Style.Failure,
-          message: err instanceof Error ? err.message : "Unknown error",
-        });
+        if (showErrorToast) {
+          showToast({
+            title: "Failed to fetch processes",
+            style: Toast.Style.Failure,
+            message: err instanceof Error ? err.message : "Unknown error",
+          });
+        }
+      })
+      .finally(() => {
+        isFetchingProcesses.current = false;
       });
   };
 
@@ -293,7 +304,7 @@ export default function ProcessList() {
         title: `Restarted ${processName}`,
         style: Toast.Style.Success,
       });
-      fetchProcesses();
+      fetchProcesses(true);
     } catch (error) {
       handleRestartError(processName, error);
     }
@@ -547,7 +558,7 @@ export default function ProcessList() {
                       title="Reload"
                       icon={Icon.ArrowClockwise}
                       shortcut={Keyboard.Shortcut.Common.Refresh}
-                      onAction={() => fetchProcesses()}
+                      onAction={() => fetchProcesses(true)}
                     />
                     <Action
                       title={`${isAppGroupingEnabled ? "Disable" : "Enable"} App Grouping`}


### PR DESCRIPTION
## Description

Fixes #27997.

- prevent process-list refreshes from overlapping when the command is left open
- keep automatic refresh failures from surfacing stale timeout toasts
- preserve explicit error feedback for manual reloads and restart refreshes

## Screencast

N/A - code-only stability fix.

## Checklist

- [x] I read the contribution guidelines
- [x] I ran `npm run lint --prefix extensions/kill-process`
- [x] I ran `npm run build --prefix extensions/kill-process`
- [x] I ran `git diff --check`