### PR TITLE
[Quit Applications] Handle app discovery timeouts

### DIFF
--- a/extensions/quit-applications/CHANGELOG.md
+++ b/extensions/quit-applications/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quit Applications Changelog
 
-## [Bugfix] - {PR_MERGE_DATE}
+## [Bugfix] - 2026-05-28
 
 - Added timeout handling and fallback app discovery when loading running applications.
 

--- a/extensions/quit-applications/CHANGELOG.md
+++ b/extensions/quit-applications/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Quit Applications Changelog
 
+## [Bugfix] - {PR_MERGE_DATE}
+
+- Added timeout handling and fallback app discovery when loading running applications.
+
 ## [Bug fix] - 2026-04-04
 
 - Fixed error when a foreground process has no file property (error -1728)

--- a/extensions/quit-applications/src/index.tsx
+++ b/extensions/quit-applications/src/index.tsx
@@ -14,6 +14,7 @@ import { runAppleScript } from "@raycast/utils";
 import { execSync } from "child_process";
 
 const APPLESCRIPT_TIMEOUT_MS = 5000;
+const RESTART_APPLESCRIPT_TIMEOUT_MS = 15000;
 
 function applicationNameFromPath(path: string): string {
   /* Example:
@@ -107,7 +108,7 @@ function restartApp(app: string) {
 	                          end repeat
 	                          activate
                         end tell`,
-    { timeout: APPLESCRIPT_TIMEOUT_MS },
+    { timeout: RESTART_APPLESCRIPT_TIMEOUT_MS },
   );
 }
 
@@ -295,7 +296,12 @@ export default function Command({ launchContext }: CommandProps) {
                   }
                 }}
               />
-              <Action title="Restart" onAction={() => restartAppWithToast(app.name)} />
+              <Action
+                title="Restart"
+                onAction={async () => {
+                  await restartAppWithToast(app.name);
+                }}
+              />
               <Action.CreateQuicklink
                 title="Create Quit Quicklink"
                 quicklink={{ link: getQuickLinkForApp(app.name, "quit"), name: `Quit ${app.name}` }}

--- a/extensions/quit-applications/src/index.tsx
+++ b/extensions/quit-applications/src/index.tsx
@@ -13,6 +13,8 @@ import {
 import { runAppleScript } from "@raycast/utils";
 import { execSync } from "child_process";
 
+const APPLESCRIPT_TIMEOUT_MS = 5000;
+
 function applicationNameFromPath(path: string): string {
   /* Example:
    * '/Applications/Visual Studio Code.app' -> 'Visual Studio Code'
@@ -27,8 +29,26 @@ function applicationNameFromPath(path: string): string {
 }
 
 async function getRunningAppsPaths(): Promise<string[]> {
+  const getRunningAppsPathsWithPs = () => {
+    const outputLines = execSync("/bin/ps -axo comm | /usr/bin/grep -E '.app/Contents/MacOS/' || true")
+      .toString()
+      .split("\n")
+      .filter(Boolean);
+
+    const appSet = new Set<string>();
+    for (const line of outputLines) {
+      const match = line.match(/(.+\.app)\/Contents\/MacOS\//);
+      if (match && match[1]) {
+        appSet.add(match[1]);
+      }
+    }
+
+    return Array.from(appSet);
+  };
+
   try {
-    const result = await runAppleScript(`
+    const result = await runAppleScript(
+      `
       set appPaths to {}
       tell application "System Events"
         repeat with aProcess in (every process whose background only is false)
@@ -40,27 +60,16 @@ async function getRunningAppsPaths(): Promise<string[]> {
       end tell
 
       return appPaths
-    `);
+    `,
+      { timeout: APPLESCRIPT_TIMEOUT_MS },
+    );
 
     return result.split(", ").map((appPath: string) => appPath.trim());
   } catch (error: unknown) {
     const message = typeof error === "string" ? error : (error as Error)?.message ?? "";
-    if (message.includes("Not authorized to send Apple events")) {
+    if (message.includes("Not authorized to send Apple events") || message.includes("Timed out")) {
       try {
-        // Use `ps` to list running executables and derive their .app bundle paths.
-        const outputLines = execSync("/bin/ps -axo comm | /usr/bin/grep -E '.app/Contents/MacOS/' || true")
-          .toString()
-          .split("\n")
-          .filter(Boolean);
-
-        const appSet = new Set<string>();
-        for (const line of outputLines) {
-          const match = line.match(/(.+\.app)\/Contents\/MacOS\//);
-          if (match && match[1]) {
-            appSet.add(match[1]);
-          }
-        }
-        const fallbackPaths = Array.from(appSet);
+        const fallbackPaths = getRunningAppsPathsWithPs();
         if (fallbackPaths.length > 0) {
           return fallbackPaths;
         }
@@ -75,7 +84,8 @@ async function getRunningAppsPaths(): Promise<string[]> {
 }
 
 function quitApp(app: string) {
-  return runAppleScript(`try
+  return runAppleScript(
+    `try
   tell application "${app}" to quit
   on error error_message number error_number
       if error_number is equal to -128 then
@@ -83,22 +93,27 @@ function quitApp(app: string) {
       else
           display dialog error_message
       end if
-end try`);
+end try`,
+    { timeout: APPLESCRIPT_TIMEOUT_MS },
+  );
 }
 
 function restartApp(app: string) {
-  return runAppleScript(`tell application "${app}"
+  return runAppleScript(
+    `tell application "${app}"
                             repeat while its running
                               quit
                               delay 0.5
 	                          end repeat
 	                          activate
-                        end tell`);
+                        end tell`,
+    { timeout: APPLESCRIPT_TIMEOUT_MS },
+  );
 }
 
-function quitAppWithToast(app: string): boolean {
+async function quitAppWithToast(app: string): Promise<boolean> {
   try {
-    quitApp(app);
+    await quitApp(app);
     showToast({
       style: Toast.Style.Success,
       title: `Quit ${app}`,
@@ -113,9 +128,9 @@ function quitAppWithToast(app: string): boolean {
   }
 }
 
-function restartAppWithToast(app: string): boolean {
+async function restartAppWithToast(app: string): Promise<boolean> {
   try {
-    restartApp(app);
+    await restartApp(app);
     showToast({
       style: Toast.Style.Success,
       title: `Restarted ${app}`,
@@ -156,42 +171,53 @@ export default function Command({ launchContext }: CommandProps) {
       const { appName, action } = launchContext;
 
       if (action === "quit") {
-        quitAppWithToast(appName);
+        void quitAppWithToast(appName);
       } else if (action === "restart") {
-        restartAppWithToast(appName);
+        void restartAppWithToast(appName);
       }
       return;
     }
 
-    getRunningAppsPaths().then((appCandidatePaths) => {
-      const mappedApps = appCandidatePaths
-        .filter((path) => path.endsWith(".app"))
-        .map((path) => ({ name: applicationNameFromPath(path), path }));
+    const loadApps = async () => {
+      try {
+        const appCandidatePaths = await getRunningAppsPaths();
+        const mappedApps = appCandidatePaths
+          .filter((path) => path.endsWith(".app"))
+          .map((path) => ({ name: applicationNameFromPath(path), path }));
 
-      const excludedNames = preferences.excludeApplications
-        ? preferences.excludeApplications.split(",").map((name: string) => name.trim().toLowerCase())
-        : [];
+        const excludedNames = preferences.excludeApplications
+          ? preferences.excludeApplications.split(",").map((name: string) => name.trim().toLowerCase())
+          : [];
 
-      const filteredApps = mappedApps.filter((app) => !excludedNames.includes(app.name.toLowerCase()));
+        const filteredApps = mappedApps.filter((app) => !excludedNames.includes(app.name.toLowerCase()));
 
-      const uniqueApps: { name: string; path: string }[] = [];
-      const seenPaths = new Set<string>();
+        const uniqueApps: { name: string; path: string }[] = [];
+        const seenPaths = new Set<string>();
 
-      for (const app of filteredApps) {
-        if (!seenPaths.has(app.path)) {
-          seenPaths.add(app.path);
-          uniqueApps.push(app);
+        for (const app of filteredApps) {
+          if (!seenPaths.has(app.path)) {
+            seenPaths.add(app.path);
+            uniqueApps.push(app);
+          }
         }
+
+        setApps(uniqueApps);
+
+        if (uniqueApps && uniqueApps[0]) {
+          setSelectedId(uniqueApps[0].path);
+        }
+      } catch (error) {
+        showToast({
+          style: Toast.Style.Failure,
+          title: "Unable to load applications",
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
+      } finally {
+        setIsLoading(false);
       }
+    };
 
-      setApps(uniqueApps);
-
-      if (uniqueApps && uniqueApps[0]) {
-        setSelectedId(uniqueApps[0].path);
-      }
-
-      setIsLoading(false);
-    });
+    void loadApps();
   }, []);
 
   return (
@@ -256,8 +282,8 @@ export default function Command({ launchContext }: CommandProps) {
             <ActionPanel>
               <Action
                 title="Quit"
-                onAction={() => {
-                  const success = quitAppWithToast(app.name);
+                onAction={async () => {
+                  const success = await quitAppWithToast(app.name);
 
                   if (success) {
                     const removedAppIndex = apps.findIndex((a) => a.name === app.name);

--- a/extensions/quit-applications/src/index.tsx
+++ b/extensions/quit-applications/src/index.tsx
@@ -68,7 +68,12 @@ async function getRunningAppsPaths(): Promise<string[]> {
     return result.split(", ").map((appPath: string) => appPath.trim());
   } catch (error: unknown) {
     const message = typeof error === "string" ? error : (error as Error)?.message ?? "";
-    if (message.includes("Not authorized to send Apple events") || message.includes("Timed out")) {
+    const isTimedOut =
+      typeof error === "object" &&
+      error !== null &&
+      "timedOut" in error &&
+      (error as { timedOut: unknown }).timedOut === true;
+    if (message.includes("Not authorized to send Apple events") || isTimedOut) {
       try {
         const fallbackPaths = getRunningAppsPathsWithPs();
         if (fallbackPaths.length > 0) {


### PR DESCRIPTION
## Description

Fixes #27689.

- add an explicit timeout to AppleScript app discovery and quit/restart calls
- fall back to process-list based app discovery when System Events times out or is not authorized
- await quit/restart AppleScript calls so failures show the existing error toast instead of escaping asynchronously

## Screencast

N/A - timeout/error handling fix.

## Checklist

- [x] I read the contribution guidelines
- [x] I ran `npm run lint --prefix extensions/quit-applications`
- [x] I ran `npm run build --prefix extensions/quit-applications`
- [x] I ran `git diff --check`