### PR TITLE
[Terminal Finder] Improve cmux socket error

### DIFF
--- a/extensions/terminalfinder/CHANGELOG.md
+++ b/extensions/terminalfinder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Terminal Finder Changelog
 
+## [Bugfix] - {PR_MERGE_DATE}
+
+- Show a helpful recovery message when cmux reports a broken automation socket.
+
 ## [Update] - 2026-03-27
 
 - Added support for `cmux`

--- a/extensions/terminalfinder/CHANGELOG.md
+++ b/extensions/terminalfinder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Terminal Finder Changelog
 
-## [Bugfix] - {PR_MERGE_DATE}
+## [Bugfix] - 2026-05-27
 
 - Show a helpful recovery message when cmux reports a broken automation socket.
 

--- a/extensions/terminalfinder/src/cmux-error.ts
+++ b/extensions/terminalfinder/src/cmux-error.ts
@@ -1,0 +1,11 @@
+export function formatCmuxError(message: string) {
+  if (message.includes("Access denied")) {
+    return "cmux denied external control. In cmux, open Settings -> Automation and set Socket Mode to Allow all local processes or Password.";
+  }
+
+  if (message.includes("Broken pipe") || message.includes("Failed to write to socket")) {
+    return "Unable to reach cmux over its automation socket. Make sure cmux is running, then reopen Settings -> Automation and check Socket Mode.";
+  }
+
+  return message || "cmux command failed";
+}

--- a/extensions/terminalfinder/src/utils.ts
+++ b/extensions/terminalfinder/src/utils.ts
@@ -4,6 +4,7 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { findApplication } from "./application";
 import { extractCmuxWorkingDirectory } from "./cmux";
+import { formatCmuxError } from "./cmux-error";
 
 export async function runAppleScript(script: string) {
   if (process.platform !== "darwin") {
@@ -33,14 +34,6 @@ export async function checkApplication(name: Terminal) {
 }
 
 const CMUX_COMMAND_TIMEOUT_MS = 10_000;
-
-function formatCmuxError(message: string) {
-  if (message.includes("Access denied")) {
-    return "cmux denied external control. In cmux, open Settings -> Automation and set Socket Mode to Allow all local processes or Password.";
-  }
-
-  return message || "cmux command failed";
-}
 
 function formatCmuxProcessError(error: NodeJS.ErrnoException) {
   if (error.code === "ETIMEDOUT") {

--- a/extensions/terminalfinder/test/cmux.test.ts
+++ b/extensions/terminalfinder/test/cmux.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { formatCmuxError } from "../src/cmux-error";
 import { extractCmuxWorkingDirectory } from "../src/cmux";
 
 test("returns the cwd for the focused workspace", () => {
@@ -75,5 +76,12 @@ test("throws when the focused workspace has no working directory", () => {
   assert.throws(
     () => extractCmuxWorkingDirectory(sidebarState),
     /cmux did not return a focused workspace with a working directory/,
+  );
+});
+
+test("formats cmux broken pipe socket errors", () => {
+  assert.match(
+    formatCmuxError("Error: Failed to write to socket (Broken pipe, errno 32)"),
+    /Unable to reach cmux over its automation socket/,
   );
 });


### PR DESCRIPTION
## Description

Fixes #27662.

- Moves cmux error formatting into a small testable helper.
- Shows a recovery-oriented message when cmux reports a broken automation socket.
- Adds a regression test for the broken pipe socket error.

## Screencast

N/A - error handling only.

## Checklist

- [x] I ran `npm run lint --prefix extensions/terminalfinder`
- [x] I ran `npm run build --prefix extensions/terminalfinder`
- [x] I ran `npm exec --prefix extensions/terminalfinder -- tsx --test extensions/terminalfinder/test/cmux.test.ts`