### PR TITLE
[Apple Notes] Clarify full disk access error

### DIFF
--- a/extensions/apple-notes/CHANGELOG.md
+++ b/extensions/apple-notes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Apple Notes Changelog
 
+## [Bugfix] - {PR_MERGE_DATE}
+
+- Clarify that searching notes requires Full Disk Access when Raycast cannot open the Apple Notes database.
+
 ## [Bug Fix Update] - 2026-02-26
 
 - Fix `get-note-content` and `update-note` timing out when Notes is not already running by using a longer AppleScript timeout.

--- a/extensions/apple-notes/src/hooks/useNotes.ts
+++ b/extensions/apple-notes/src/hooks/useNotes.ts
@@ -118,7 +118,8 @@ const tagsQuery = `
 
 export const useNotes = () => {
   const { data, ...rest } = useSQL<NoteItem>(NOTES_DB, query, {
-    permissionPriming: "This is required to search your Apple Notes.",
+    permissionPriming:
+      "Raycast needs Full Disk Access to search Apple Notes. Open System Settings > Privacy & Security > Full Disk Access and enable Raycast.",
   });
 
   // Split the query into two to avoid a SQL error if the zcinivitation table doesn't exist


### PR DESCRIPTION
## Description

Fixes #27918.

- Updates the Apple Notes database permission message to explicitly mention Full Disk Access.
- Points users to System Settings > Privacy & Security > Full Disk Access when Raycast cannot open the Notes database.

## Screencast

N/A - copy-only permission message update.

## Checklist

- [x] I ran `npm run lint --prefix extensions/apple-notes`
- [x] I ran `npm run build --prefix extensions/apple-notes`