### PR TITLE
[Audio Device] Restore enforce command notifications

### DIFF
--- a/extensions/audio-device/CHANGELOG.md
+++ b/extensions/audio-device/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Audio Device Changelog
 
+## [Bugfix] - {PR_MERGE_DATE}
+
+- Show a confirmation when manually running the enforce device commands.
+
 ## [Add Keyboard Shortcuts] - 2026-05-16
 
 - Add Save shortcut for creating device quicklinks

--- a/extensions/audio-device/CHANGELOG.md
+++ b/extensions/audio-device/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Audio Device Changelog
 
-## [Bugfix] - {PR_MERGE_DATE}
+## [Bugfix] - 2026-05-27
 
 - Show a confirmation when manually running the enforce device commands.
 

--- a/extensions/audio-device/src/auto-switcher.ts
+++ b/extensions/audio-device/src/auto-switcher.ts
@@ -1,4 +1,4 @@
-import { updateCommandMetadata } from "@raycast/api";
+import { LaunchType, Toast, environment, showToast, updateCommandMetadata } from "@raycast/api";
 import {
   type IOType,
   getDefaultInputDevice,
@@ -82,11 +82,18 @@ async function buildSubtitle(type: IOType): Promise<string> {
 
 export async function runAutoSwitch(type: IOType) {
   await migrateFromPriorityOrder(getInputDevices, getOutputDevices);
-  await updateCommandMetadata({ subtitle: await buildSubtitle(type) });
+  const subtitle = await buildSubtitle(type);
+  await updateCommandMetadata({ subtitle });
 
   try {
     await runEnforcement(type);
-  } catch {
-    // Silently ignore errors in background
+    if (environment.launchType === LaunchType.UserInitiated) {
+      const label = type === "input" ? "Enforce Input Device" : "Enforce Output Device";
+      await showToast(Toast.Style.Success, `${label} is running`, subtitle);
+    }
+  } catch (error) {
+    if (environment.launchType === LaunchType.UserInitiated) {
+      await showToast(Toast.Style.Failure, `Failed to enforce ${type} device`, String(error));
+    }
   }
 }


### PR DESCRIPTION
## Description
- Show a success toast when Enforce Input/Output Device is started manually.
- Keep scheduled background runs silent so the 10s interval does not show repeated notifications.
- Surface failures only for manual runs.

Fixes #27959

## Screencast
N/A

## Checklist
- [x] I read the contribution guidelines
- [x] I ran `npm run lint --prefix extensions/audio-device`
- [x] I ran `npm run build --prefix extensions/audio-device`
- [x] I ran `git diff --check`