### PR TITLE
[Safari] Clarify history permission errors

### DIFF
--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Safari Changelog
 
+## [Bugfix] - {PR_MERGE_DATE}
+
+- Clarify the Full Disk Access requirement when Safari history cannot be opened.
+
 ## [Fix] - 2026-05-06
 
 - Fix `Search History` command failing with `no such column: "%...%"` by using single-quoted string literals for search terms in the SQL query.

--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Safari Changelog
 
-## [Bugfix] - {PR_MERGE_DATE}
+## [Bugfix] - 2026-05-22
 
 - Clarify the Full Disk Access requirement when Safari history cannot be opened.
 

--- a/extensions/safari/src/hooks/useHistorySearch.ts
+++ b/extensions/safari/src/hooks/useHistorySearch.ts
@@ -34,7 +34,13 @@ export const getHistoryQuery = (searchText?: string) => {
 
 const useHistorySearch = (searchText?: string) => {
   const query = getHistoryQuery(searchText);
-  return useSQL<HistoryItem>(HISTORY_DB, query);
+  return useSQL<HistoryItem>(HISTORY_DB, query, {
+    permissionPriming: "This is required to search your Safari history.",
+    failureToastOptions: {
+      title: "Cannot search Safari history",
+      message: "Grant Raycast Full Disk Access, then try again.",
+    },
+  });
 };
 
 export default useHistorySearch;


### PR DESCRIPTION
## Description
- Add Full Disk Access permission priming to Safari history SQL reads.
- Replace the raw database open failure with a clearer failure toast when history cannot be opened.

Fixes #27884
Fixes #28124

## Screencast
N/A

## Checklist
- [x] I read the contribution guidelines
- [x] I ran `npm run lint --prefix extensions/safari`
- [x] I ran `npm run build --prefix extensions/safari`
- [x] I ran `git diff --check`
