### PR TITLE
[Diskutil] Include ejectable disks in removable filter

### DIFF
--- a/extensions/diskutil-mac/CHANGELOG.md
+++ b/extensions/diskutil-mac/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Diskutil Changelog
 
-## [Bugfix] - {PR_MERGE_DATE}
+## [Bugfix] - 2026-05-17
 
 - Include ejectable external disks in the removable disk filter.
 

--- a/extensions/diskutil-mac/CHANGELOG.md
+++ b/extensions/diskutil-mac/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Diskutil Changelog
 
+## [Bugfix] - {PR_MERGE_DATE}
+
+- Include ejectable external disks in the removable disk filter.
+
 ## [Initial Private Version] - 2023-05-11
 
 ## [Public Release Version] - 2025-02-28

--- a/extensions/diskutil-mac/src/index.tsx
+++ b/extensions/diskutil-mac/src/index.tsx
@@ -143,6 +143,20 @@ export default function ListDisks(): JSX.Element {
     setFilter(value);
   }
 
+  function matchesFilter(disk: DiskSection["disks"][number]) {
+    const isEjectable = disk.removable === true || disk.details.Ejectable === true;
+
+    if (filter === "removable") {
+      return isEjectable;
+    }
+
+    if (filter === "fixed") {
+      return !isEjectable;
+    }
+
+    return true;
+  }
+
   async function toggleSizesView() {
     const nextView = cycleSizesView(sizesView);
     setSizesView(nextView);
@@ -150,9 +164,7 @@ export default function ListDisks(): JSX.Element {
   }
 
   const hasDisks = diskSections.length > 0;
-  const hasFilteredDisks = diskSections.some((section) =>
-    section.disks.some((disk) => filter === "all" || disk.removable === (filter === "removable"))
-  );
+  const hasFilteredDisks = diskSections.some((section) => section.disks.some(matchesFilter));
 
   return (
     <List
@@ -162,7 +174,7 @@ export default function ListDisks(): JSX.Element {
         <List.Dropdown tooltip="Filter Disks" onChange={handleFilterChange} value={filter}>
           <List.Dropdown.Item title="All" value="all" />
           <List.Dropdown.Item title="Fixed" value="fixed" />
-          <List.Dropdown.Item title="Removable" value="removable" />
+          <List.Dropdown.Item title="Removable or Ejectable" value="removable" />
         </List.Dropdown>
       }
     >
@@ -193,19 +205,17 @@ export default function ListDisks(): JSX.Element {
       ) : (
         diskSections.map((section, index) => (
           <List.Section key={index} title={section.sectionName}>
-            {section.disks
-              .filter((disk) => filter === "all" || disk.removable === (filter === "removable"))
-              .map((disk, diskIndex) => (
-                <DiskListItem
-                  key={diskIndex}
-                  disk={disk}
-                  showingDetail={showingDetail}
-                  sizesView={sizesView}
-                  onToggleDetail={(detailType) => setShowingDetail({ show: !showingDetail.show, detail: detailType })}
-                  onRefresh={(type) => fetchDisks(type)}
-                  onToggleSizesView={toggleSizesView}
-                />
-              ))}
+            {section.disks.filter(matchesFilter).map((disk, diskIndex) => (
+              <DiskListItem
+                key={diskIndex}
+                disk={disk}
+                showingDetail={showingDetail}
+                sizesView={sizesView}
+                onToggleDetail={(detailType) => setShowingDetail({ show: !showingDetail.show, detail: detailType })}
+                onRefresh={(type) => fetchDisks(type)}
+                onToggleSizesView={toggleSizesView}
+              />
+            ))}
           </List.Section>
         ))
       )}


### PR DESCRIPTION
## Description
- Treat disks with either `Removable` or `Ejectable` set in `diskutil info -plist` as removable for filtering.
- Clarify the dropdown label to cover ejectable external drives that macOS reports as non-removable.

Fixes #27896

## Screencast
N/A

## Checklist
- [x] I read the contribution guidelines
- [x] I ran `npm run lint --prefix extensions/diskutil-mac`
- [x] I ran `npm run build --prefix extensions/diskutil-mac`
- [x] I ran `git diff --check`