### PR TITLE
Fix JWT Decoder React peer versions

### DIFF
--- a/extensions/jwt-decoder/CHANGELOG.md
+++ b/extensions/jwt-decoder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # JWT-Decoder Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-05-28
 
 - Fixed runtime React version mismatch by pinning React peer versions
 

--- a/extensions/jwt-decoder/CHANGELOG.md
+++ b/extensions/jwt-decoder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # JWT-Decoder Changelog
 
+## [Fix] - 2026-05-17
+
+- Fixed runtime React version mismatch by pinning React peer versions
+
 ## [Fix] - 2026-04-15
 
 - Pinned `react` and `react-dom` to `19.0.0` to avoid runtime React version mismatch errors

--- a/extensions/jwt-decoder/CHANGELOG.md
+++ b/extensions/jwt-decoder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # JWT-Decoder Changelog
 
-## [Fix] - 2026-05-17
+## [Fix] - {PR_MERGE_DATE}
 
 - Fixed runtime React version mismatch by pinning React peer versions
 

--- a/extensions/jwt-decoder/package-lock.json
+++ b/extensions/jwt-decoder/package-lock.json
@@ -24,8 +24,8 @@
         "typescript": "^5.8.2"
       },
       "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react": "19.0.0",
+        "react-dom": "19.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/extensions/jwt-decoder/package.json
+++ b/extensions/jwt-decoder/package.json
@@ -39,8 +39,8 @@
     "raycast-hooks": "^1.0.4"
   },
   "peerDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",


### PR DESCRIPTION
## Description

Closes #28021.

JWT Decoder imports `react-dom/server`, and the extension already pins `react` and `react-dom` dev dependencies to `19.0.0`. The peer dependency ranges still allowed Raycast to provide a newer React host version, which can pair React 19.2.x with the extension's React DOM 19.0.0 and trigger the runtime version mismatch.

This pins the peer dependency contract to the same React version used by the extension bundle.

## Screencast

N/A - dependency/runtime compatibility fix.

## Checklist

- [x] I ran `npm run lint`
- [x] I ran `npm run build`