### PR TITLE
Fix Mattermost server URL handling

### DIFF
--- a/extensions/mattermost/CHANGELOG.md
+++ b/extensions/mattermost/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mattermost Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-05-18
 
 - Fix authentication when the Mattermost server preference is entered without a URL scheme.
 

--- a/extensions/mattermost/CHANGELOG.md
+++ b/extensions/mattermost/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mattermost Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fix authentication when the Mattermost server preference is entered without a URL scheme.
+
 ## [Maintenance] - 2026-03-16
 
 - Update axios to ^0.30.3 to address CVE for denial of service via `__proto__` key in `mergeConfig`

--- a/extensions/mattermost/src/shared/MattermostClient.tsx
+++ b/extensions/mattermost/src/shared/MattermostClient.tsx
@@ -29,18 +29,23 @@ axios.interceptors.response.use(
 
 export class MattermostClient {
   static baseUrl(): string {
-    return getPreferenceValues<Preferences>().baseUrl + "/api/v4";
+    return this.apiBaseUrl();
   }
 
   static token = "";
 
   static config(): AxiosRequestConfig {
     return {
-      baseURL: getPreferenceValues<Preferences>().baseUrl + "/api/v4",
+      baseURL: this.apiBaseUrl(),
       headers: {
         Authorization: `Bearer ${this.token}`,
       },
     };
+  }
+
+  static apiBaseUrl(): string {
+    const baseUrl = getPreferenceValues<Preferences>().baseUrl.trim().replace(/\/+$/, "");
+    return `${/^https?:\/\//i.test(baseUrl) ? baseUrl : `https://${baseUrl}`}/api/v4`;
   }
 
   static async wakeUpSession(): Promise<boolean> {


### PR DESCRIPTION
## Description
Fixes #27937

Normalizes the Mattermost server URL preference before creating API requests. This keeps full `http://`/`https://` URLs working, trims trailing slashes, and defaults bare hostnames to `https://` so Axios does not treat them as localhost-relative paths.

## Screencast
N/A

## Checklist
- [x] I read the contribution guidelines
- [x] I ran `npm run lint`
- [x] I ran `npm run build`