### PR TITLE
Fix VS Code shared storage lookup

### DIFF
--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Visual Studio Code Changelog
 
+## [Fix: Recent projects on Windows] - 2026-05-17
+
+- Fixed shared storage lookup for recent projects on Windows.
+
 ## [Fix: Windows app path resolution] - 2026-05-11
 
 - Fixed `product.json` resolution for Windows builds that use VS Code's versioned resources layout.

--- a/extensions/visual-studio-code-recent-projects/src/lib/db.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/db.ts
@@ -5,7 +5,7 @@ import { homedir } from "os";
 import path from "path";
 import { build } from "./preferences";
 import { EntryLike, RecentEntries } from "./types";
-import { isSameEntry, isWin } from "./utils";
+import { isMac, isSameEntry, isWin } from "./utils";
 import { execFilePromise } from "../utils/exec";
 import { getBuildNamePreference, getProductJSONPath } from "./vscode";
 
@@ -110,11 +110,21 @@ function getGlobalStoragePath() {
 function getSharedStoragePath() {
   const sharedDataFolderName = getSharedDataFolderName();
 
-  const sharedPath = sharedDataFolderName
-    ? path.join(homedir(), sharedDataFolderName, "sharedStorage", "state.vscdb")
-    : undefined;
-
-  return sharedPath;
+  if (!sharedDataFolderName) return undefined;
+  if (isWin) {
+    return path.join(homedir(), "AppData", "Roaming", sharedDataFolderName, "User", "sharedStorage", "state.vscdb");
+  }
+  if (isMac) {
+    return path.join(
+      homedir(),
+      "Library",
+      "Application Support",
+      sharedDataFolderName,
+      "User",
+      "sharedStorage",
+      "state.vscdb",
+    );
+  }
 }
 
 function getSharedDataFolderName() {


### PR DESCRIPTION
## Description
Fixes #24035

VS Code now stores recent projects in shared storage for newer builds. The extension was reading the `sharedDataFolderName` database from the user home directory, which misses the actual Windows and macOS app-data locations. This updates the shared storage path lookup to use the platform-specific VS Code data directories before falling back to global storage.

## Screencast
N/A

## Checklist
- [x] I read the contribution guidelines
- [x] I ran `npm run lint`
- [x] I ran `npm run build`