### PR TITLE
zed-recent-projects: Fix non-POSIX shell detection

### DIFF
--- a/extensions/zed-recent-projects/CHANGELOG.md
+++ b/extensions/zed-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zed Recent Projects Changelog
 
-## [Fix Non-POSIX Shell Support] - {PR_MERGE_DATE}
+## [Fix Non-POSIX Shell Support] - 2026-05-17
 
 - Fix projects silently failing to open when the user's default shell is non-POSIX (nushell, elvish, xonsh, pwsh, ...) by falling back to `/bin/zsh` for the `env -i ... -lc` invocation. Previously only fish was handled this way.
 - Surface CLI launch failures via a toast in the single-folder open action so future regressions don't fail silently.

--- a/extensions/zed-recent-projects/CHANGELOG.md
+++ b/extensions/zed-recent-projects/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Zed Recent Projects Changelog
 
+## [Fix Non-POSIX Shell Support] - {PR_MERGE_DATE}
+
+- Fix projects silently failing to open when the user's default shell is non-POSIX (nushell, elvish, xonsh, pwsh, ...) by falling back to `/bin/zsh` for the `env -i ... -lc` invocation. Previously only fish was handled this way.
+- Surface CLI launch failures via a toast in the single-folder open action so future regressions don't fail silently.
+
 ## [Fix Environment Inheritance] - 2026-02-23
 
 - Fix Zed inheriting Raycast environment variables when launched via extension

--- a/extensions/zed-recent-projects/package.json
+++ b/extensions/zed-recent-projects/package.json
@@ -12,7 +12,8 @@
     "tm.wrnr",
     "true-real-michael",
     "xmorse",
-    "ivens_joris"
+    "ivens_joris",
+    "FollowTheProcess"
   ],
   "categories": [
     "Developer Tools"

--- a/extensions/zed-recent-projects/src/lib/utils.test.ts
+++ b/extensions/zed-recent-projects/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { shellEscape } from "./utils";
+import { shellEscape, isPosixShell } from "./utils";
 
 describe("shellEscape", () => {
   it("should wrap simple strings in single quotes", () => {
@@ -38,5 +38,40 @@ describe("shellEscape", () => {
   it("should handle unicode characters", () => {
     expect(shellEscape("/Users/test/日本語")).toBe("'/Users/test/日本語'");
     expect(shellEscape("emoji-folder-🚀")).toBe("'emoji-folder-🚀'");
+  });
+});
+
+describe("isPosixShell", () => {
+  it("recognises common POSIX shells by absolute path", () => {
+    expect(isPosixShell("/bin/sh")).toBe(true);
+    expect(isPosixShell("/bin/bash")).toBe(true);
+    expect(isPosixShell("/bin/zsh")).toBe(true);
+    expect(isPosixShell("/bin/dash")).toBe(true);
+    expect(isPosixShell("/bin/ksh")).toBe(true);
+    expect(isPosixShell("/bin/ash")).toBe(true);
+  });
+
+  it("recognises POSIX shells installed in non-standard locations", () => {
+    expect(isPosixShell("/usr/local/bin/bash")).toBe(true);
+    expect(isPosixShell("/opt/homebrew/bin/zsh")).toBe(true);
+  });
+
+  it("rejects non-POSIX shells", () => {
+    expect(isPosixShell("/usr/local/bin/fish")).toBe(false);
+    expect(isPosixShell("/opt/homebrew/bin/fish")).toBe(false);
+    expect(isPosixShell("/opt/homebrew/bin/nu")).toBe(false);
+    expect(isPosixShell("/usr/local/bin/elvish")).toBe(false);
+    expect(isPosixShell("/opt/homebrew/bin/xonsh")).toBe(false);
+    expect(isPosixShell("/usr/local/bin/pwsh")).toBe(false);
+  });
+
+  it("matches on the basename, not substring of the path", () => {
+    expect(isPosixShell("/opt/catfish/bin/nu")).toBe(false);
+    expect(isPosixShell("/opt/bash-experiments/bin/fish")).toBe(false);
+  });
+
+  it("treats unknown or empty shells as non-POSIX", () => {
+    expect(isPosixShell("")).toBe(false);
+    expect(isPosixShell("/some/unknown/shell")).toBe(false);
   });
 });

--- a/extensions/zed-recent-projects/src/lib/utils.ts
+++ b/extensions/zed-recent-projects/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import util from "util";
+import path from "path";
 import { existsSync } from "fs";
 import { execFile, execFileSync } from "child_process";
 import { homedir, userInfo } from "os";
@@ -10,6 +11,21 @@ export const isMac = process.platform === "darwin";
 
 export function shellEscape(arg: string): string {
   return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+const POSIX_SHELL_NAMES = new Set(["sh", "bash", "zsh", "dash", "ksh", "ash", "mksh"]);
+
+/**
+ * Returns true when the given shell path's basename is a known POSIX shell
+ * whose `-lc` invocation accepts the POSIX-style command produced by
+ * `shellEscape`. Non-POSIX shells (fish, nu, elvish, xonsh, pwsh, ...) need
+ * to be replaced with a POSIX shell before running such a command.
+ */
+export function isPosixShell(shellPath: string): boolean {
+  if (!shellPath) {
+    return false;
+  }
+  return POSIX_SHELL_NAMES.has(path.basename(shellPath));
 }
 
 /**
@@ -43,19 +59,18 @@ function getUserShell(): string {
  * 2. Only HOME is passed (required for login shell to find profile files)
  * 3. A POSIX-compatible login shell (zsh or bash) sources the user's profile,
  *    then execs the target command directly — avoiding shell-escaping issues
- *    with non-POSIX shells like fish.
+ *    with non-POSIX shells like fish, nushell, etc.
  *
  * This gives the command the same environment as a fresh terminal window.
  */
 export async function execWithCleanEnv(command: string, args: string[]): Promise<void> {
   const userShell = getUserShell();
 
-  // If the user's shell is fish (or any other non-POSIX shell), fall back to
-  // /bin/zsh for the -lc invocation. Fish does not support POSIX-style quoting
-  // or the `-c` flag in the same way, so we must use a POSIX shell to source
-  // the profile and then exec the real command.
-  const isFish = userShell.endsWith("fish");
-  const posixShell = isFish ? "/bin/zsh" : userShell;
+  // Non-POSIX shells (fish, nushell, elvish, xonsh, pwsh, ...) don't accept
+  // the POSIX-style quoted command we build below, so fall back to /bin/zsh
+  // for the -lc invocation. The user's profile still gets sourced, just by a
+  // POSIX shell instead of their interactive shell.
+  const posixShell = isPosixShell(userShell) ? userShell : "/bin/zsh";
 
   const escapedArgs = args.map(shellEscape).join(" ");
   const shellCommand = `${shellEscape(command)} ${escapedArgs}`;

--- a/extensions/zed-recent-projects/src/search.tsx
+++ b/extensions/zed-recent-projects/src/search.tsx
@@ -220,9 +220,17 @@ function OpenInZedAction({ entry, revalidate }: { entry: Entry; revalidate: () =
   // If CLI available, use it for consistency (handles revalidation)
   if (cliPath) {
     const openSingleFolder = async () => {
-      setTimeout(revalidate, 200);
-      await closeMainWindow();
-      await openWithZedCli(cliPath!, [entry.paths[0]]);
+      try {
+        setTimeout(revalidate, 200);
+        await closeMainWindow();
+        await openWithZedCli(cliPath!, [entry.paths[0]]);
+      } catch (error) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Failed to open project",
+          message: String(error),
+        });
+      }
     };
     return <Action title="Open in Zed" icon={zedIcon} onAction={openSingleFolder} />;
   }


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Fixes the non-POSIX shell detection in the `zed-recent-projects` to correctly classify more than just `fish` as non POSIX. I use [nushell](https://www.nushell.sh) and this extension doesn't open Zed when I hit enter on the project in the picker.

It didn't open Zed but also didn't flag an error or anything so I just assumed it must just not work or maybe Zed changed since this was released or something but I got curious and on looking into it, it's easily fixable :)

I also added an explicit error when it fails to open in the `openSingleFolder` case, mirroring the same approach as the `openMultiFolder` above

## Screencast

### Build and Run

<img width="274" height="80" alt="image" src="https://github.com/user-attachments/assets/a516e6da-9337-4e5b-8be3-cfe4fc32afff" />

<img width="756" height="213" alt="image" src="https://github.com/user-attachments/assets/1892558d-5ba4-426f-a80d-a99d0b8867e7" />

### Picking the Extensions Repo

<img width="793" height="171" alt="image" src="https://github.com/user-attachments/assets/51573566-b69a-4ede-91fe-9fa55c9ccee4" />

### And here it is!

<img width="1091" height="192" alt="image" src="https://github.com/user-attachments/assets/a7336a6d-e399-4bc9-be9d-39e285efa70b" />


<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
