### PR TITLE
Fix ccusage v19 session output parsing

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [v2.3.3] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Session usage now parses the singular `session` key emitted by ccusage v19 while keeping the previous `sessions` format working.
+
 ## [v2.3.2] - 2026-04-24
 
 ### Added

--- a/extensions/ccusage/src/types/usage-types.test.ts
+++ b/extensions/ccusage/src/types/usage-types.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "@jest/globals";
+import { SessionUsageCommandResponseSchema } from "./usage-types";
+
+const session = {
+  sessionId: "00d27b82",
+  inputTokens: 100,
+  outputTokens: 50,
+  cacheCreationTokens: 10,
+  cacheReadTokens: 5,
+  totalTokens: 165,
+  totalCost: 0.12,
+  lastActivity: "2026-05-17T14:00:00.000Z",
+  modelsUsed: ["sonnet"],
+  modelBreakdowns: [
+    {
+      modelName: "sonnet",
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheCreationTokens: 10,
+      cacheReadTokens: 5,
+      cost: 0.12,
+    },
+  ],
+};
+
+const totals = {
+  inputTokens: 100,
+  outputTokens: 50,
+  cacheCreationTokens: 10,
+  cacheReadTokens: 5,
+  totalCost: 0.12,
+  totalTokens: 165,
+};
+
+describe("SessionUsageCommandResponseSchema", () => {
+  it("parses ccusage v19 session output", () => {
+    const result = SessionUsageCommandResponseSchema.parse({
+      session: [session],
+      totals,
+    });
+
+    expect(result.sessions).toEqual([session]);
+  });
+
+  it("keeps the previous sessions output format working", () => {
+    const result = SessionUsageCommandResponseSchema.parse({
+      sessions: [session],
+      totals,
+    });
+
+    expect(result.sessions).toEqual([session]);
+  });
+});

--- a/extensions/ccusage/src/types/usage-types.ts
+++ b/extensions/ccusage/src/types/usage-types.ts
@@ -106,7 +106,7 @@ export const MonthlyUsageCommandResponseSchema = z.object({
   monthly: z.array(MonthlyUsageResponseSchema),
 });
 
-export const SessionUsageCommandResponseSchema = z.object({
+const SessionUsageCommandResponseBaseSchema = z.object({
   sessions: z.array(SessionResponseSchema),
   totals: z.object({
     inputTokens: z.number(),
@@ -117,6 +117,19 @@ export const SessionUsageCommandResponseSchema = z.object({
     totalTokens: z.number(),
   }),
 });
+
+export const SessionUsageCommandResponseSchema = z.preprocess((value) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+
+  const response = value as Record<string, unknown>;
+  if (!("sessions" in response) && Array.isArray(response.session)) {
+    return { ...response, sessions: response.session };
+  }
+
+  return value;
+}, SessionUsageCommandResponseBaseSchema);
 
 export const LimitWindowSchema = z.object({
   utilization: z.number(),


### PR DESCRIPTION
## Description

Fixes #28037.

The ccusage extension now accepts the `session` key emitted by ccusage v19 and normalizes it to the existing `sessions` shape before validation. The previous `sessions` response format remains supported.

Validation run:
- `npm test -- usage-types.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

## Screencast

Not applicable; this is a parser compatibility fix covered by tests.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran `npm run build` and tested this distribution build with the local build command
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with the metadata tool