### PR TITLE
Update habitica-todos extension

### DIFF
--- a/extensions/habitica-todos/CHANGELOG.md
+++ b/extensions/habitica-todos/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Habitica Todos Changelog
 
+## [Add checklists, item usage, and skills] - {PR_MERGE_DATE}
+
+- Add checklist (sub-task) support to To-Dos and Dailies — add, score, edit, delete items, with progress accessory
+- Make inventory items usable: hatch eggs with potions, feed pets, equip pets/mounts, sell eggs/potions/food
+- Add Pets and Mounts categories to the inventory grid with equip/unequip actions
+- Open mystery items directly from the inventory grid when any are pending
+- Add class skills to View Profile with proper level/mana gating and task targeting for damage skills
+- Add tavern rest/wake toggle, revive when dead, and stat point allocation to View Profile
+- Add task attribute selection (STR/INT/PER/CON) on create and edit forms
+- Edit a task's tags inline; clear all completed To-Dos in one action
+- Fix a timezone bug that displayed due dates as the previous day for users west of UTC
+- Cleaner API error toasts (parse the JSON message body) and Today/Tomorrow date labels
+
 ## [Add more commands and improve UI] - 2026-05-12
 
 - Add "View Dailies" command

--- a/extensions/habitica-todos/CHANGELOG.md
+++ b/extensions/habitica-todos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Habitica Todos Changelog
 
-## [Add checklists, item usage, and skills] - {PR_MERGE_DATE}
+## [Add checklists, item usage, and skills] - 2026-06-03
 
 - Add checklist (sub-task) support to To-Dos and Dailies — add, score, edit, delete items, with progress accessory
 - Make inventory items usable: hatch eggs with potions, feed pets, equip pets/mounts, sell eggs/potions/food

--- a/extensions/habitica-todos/package.json
+++ b/extensions/habitica-todos/package.json
@@ -25,7 +25,7 @@
     {
       "name": "view-tasks",
       "title": "View Tasks",
-      "description": "View, check, edit, and delete your Habitica tasks",
+      "description": "View, check, edit, delete, and manage sub-task checklists for your Habitica To-Dos",
       "mode": "view",
       "subtitle": "Habitica"
     },
@@ -53,14 +53,14 @@
     {
       "name": "view-profile",
       "title": "View Profile",
-      "description": "View your Habitica stats and quests",
+      "description": "View stats, cast class skills, allocate stat points, rest in the tavern, and manage quests",
       "mode": "view",
       "subtitle": "Habitica"
     },
     {
       "name": "view-inventory",
       "title": "View Inventory",
-      "description": "View your Habitica eggs, potions, and food",
+      "description": "View, hatch, feed, sell, equip, and open mystery items in your Habitica inventory",
       "mode": "view",
       "subtitle": "Habitica"
     },

--- a/extensions/habitica-todos/src/api.ts
+++ b/extensions/habitica-todos/src/api.ts
@@ -56,7 +56,15 @@ async function habiticaFetch<T>(endpoint: string, options: { method?: string; bo
   });
 
   if (!response.ok) {
-    throw new Error(`Habitica API error: ${response.status} ${response.statusText} - ${await response.text()}`);
+    const text = await response.text();
+    let detail: string | undefined;
+    try {
+      const parsed = JSON.parse(text) as { message?: string; error?: string };
+      detail = parsed.message ?? parsed.error;
+    } catch {
+      // Body wasn't JSON; fall through to generic error.
+    }
+    throw new Error(detail ?? `Habitica API error: ${response.status} ${response.statusText}`);
   }
 
   const json = (await response.json()) as { success: boolean; data: T; message?: string };
@@ -87,7 +95,6 @@ export async function getTags(): Promise<HabiticaTag[]> {
 export async function scoreTask(taskId: string, direction: "up" | "down"): Promise<void> {
   await habiticaFetch(`/api/v3/tasks/${taskId}/score/${direction}`, { method: "POST" });
   invalidateTasksCache();
-  invalidateTagsCache();
   invalidateUserCache();
 }
 
@@ -97,25 +104,39 @@ export async function updateTask(taskId: string, body: UpdateTaskBody): Promise<
     body: JSON.stringify(body),
   });
   invalidateTasksCache();
-  invalidateTagsCache();
   return result;
 }
 
 export async function createTask(body: CreateTaskBody): Promise<void> {
   await habiticaFetch("/api/v3/tasks/user", { method: "POST", body: JSON.stringify(body) });
   invalidateTasksCache();
-  invalidateTagsCache();
 }
 
 export async function deleteTask(taskId: string): Promise<void> {
   await habiticaFetch(`/api/v3/tasks/${taskId}`, { method: "DELETE" });
   invalidateTasksCache();
-  invalidateTagsCache();
+}
+
+export async function clearCompletedTodos(): Promise<void> {
+  await habiticaFetch("/api/v3/tasks/clearCompletedTodos", { method: "POST" });
+  invalidateTasksCache();
+}
+
+export async function addTagToTask(taskId: string, tagId: string): Promise<void> {
+  await habiticaFetch(`/api/v3/tasks/${taskId}/tags/${tagId}`, { method: "POST" });
+  invalidateTasksCache();
+}
+
+export async function removeTagFromTask(taskId: string, tagId: string): Promise<void> {
+  await habiticaFetch(`/api/v3/tasks/${taskId}/tags/${tagId}`, { method: "DELETE" });
+  invalidateTasksCache();
 }
 
 export async function getUser(): Promise<HabiticaUser> {
   if (isFresh(cache.user)) return cache.user.data;
-  const data = await habiticaFetch<HabiticaUser>("/api/v3/user?userFields=stats,party,items,profile,preferences");
+  const data = await habiticaFetch<HabiticaUser>(
+    "/api/v3/user?userFields=stats,party,items,profile,preferences,flags,needsCron,purchased.plan.mysteryItems",
+  );
   cache.user = { data, expiresAt: Date.now() + USER_TTL_MS };
   return data;
 }
@@ -155,5 +176,99 @@ export async function buyHealthPotion(): Promise<void> {
 
 export async function buyArmoire(): Promise<void> {
   await habiticaFetch("/api/v3/user/buy-armoire", { method: "POST" });
+  invalidateUserCache();
+}
+
+// ---------------------------------------------------------------------------
+// Checklist
+// ---------------------------------------------------------------------------
+
+export async function addChecklistItem(taskId: string, text: string): Promise<void> {
+  await habiticaFetch(`/api/v3/tasks/${taskId}/checklist`, {
+    method: "POST",
+    body: JSON.stringify({ text }),
+  });
+  invalidateTasksCache();
+}
+
+export async function scoreChecklistItem(taskId: string, itemId: string): Promise<void> {
+  await habiticaFetch(`/api/v3/tasks/${taskId}/checklist/${itemId}/score`, { method: "POST" });
+  invalidateTasksCache();
+}
+
+export async function updateChecklistItem(taskId: string, itemId: string, text: string): Promise<void> {
+  await habiticaFetch(`/api/v3/tasks/${taskId}/checklist/${itemId}`, {
+    method: "PUT",
+    body: JSON.stringify({ text }),
+  });
+  invalidateTasksCache();
+}
+
+export async function deleteChecklistItem(taskId: string, itemId: string): Promise<void> {
+  await habiticaFetch(`/api/v3/tasks/${taskId}/checklist/${itemId}`, { method: "DELETE" });
+  invalidateTasksCache();
+}
+
+// ---------------------------------------------------------------------------
+// Inventory actions
+// ---------------------------------------------------------------------------
+
+export async function hatchPet(eggKey: string, potionKey: string): Promise<void> {
+  await habiticaFetch(`/api/v3/user/hatch/${eggKey}/${potionKey}`, { method: "POST" });
+  invalidateUserCache();
+}
+
+export async function feedPet(petKey: string, foodKey: string, amount = 1): Promise<void> {
+  await habiticaFetch(`/api/v3/user/feed/${petKey}/${foodKey}?amount=${amount}`, { method: "POST" });
+  invalidateUserCache();
+}
+
+export async function equipItem(type: "mount" | "pet" | "equipped" | "costume", key: string): Promise<void> {
+  await habiticaFetch(`/api/v3/user/equip/${type}/${key}`, { method: "POST" });
+  invalidateUserCache();
+}
+
+export async function sellItem(type: "eggs" | "hatchingPotions" | "food", key: string, amount = 1): Promise<void> {
+  await habiticaFetch(`/api/v3/user/sell/${type}/${key}?amount=${amount}`, { method: "POST" });
+  invalidateUserCache();
+}
+
+export async function openMysteryItem(): Promise<void> {
+  await habiticaFetch("/api/v3/user/open-mystery-item", { method: "POST" });
+  invalidateUserCache();
+}
+
+// ---------------------------------------------------------------------------
+// Class / skills / stats
+// ---------------------------------------------------------------------------
+
+export async function castSpell(spellId: string, targetId?: string): Promise<void> {
+  const query = targetId ? `?targetId=${encodeURIComponent(targetId)}` : "";
+  await habiticaFetch(`/api/v3/user/class/cast/${spellId}${query}`, { method: "POST" });
+  invalidateUserCache();
+  invalidateTasksCache();
+}
+
+export async function allocateStat(stat: "str" | "con" | "int" | "per"): Promise<void> {
+  await habiticaFetch(`/api/v3/user/allocate?stat=${stat}`, { method: "POST" });
+  invalidateUserCache();
+}
+
+export async function allocateNow(): Promise<void> {
+  await habiticaFetch("/api/v3/user/allocate-now", { method: "POST" });
+  invalidateUserCache();
+}
+
+// ---------------------------------------------------------------------------
+// User state
+// ---------------------------------------------------------------------------
+
+export async function toggleSleep(): Promise<void> {
+  await habiticaFetch("/api/v3/user/sleep", { method: "POST" });
+  invalidateUserCache();
+}
+
+export async function reviveUser(): Promise<void> {
+  await habiticaFetch("/api/v3/user/revive", { method: "POST" });
   invalidateUserCache();
 }

--- a/extensions/habitica-todos/src/checklist-form.tsx
+++ b/extensions/habitica-todos/src/checklist-form.tsx
@@ -1,0 +1,87 @@
+import { Form, ActionPanel, Action, showToast, Toast, useNavigation } from "@raycast/api";
+import { useState } from "react";
+
+interface ChecklistFormProps {
+  taskId: string;
+  taskText: string;
+  /** Existing item being edited — when omitted, the form adds a new item. */
+  existingItemId?: string;
+  existingItemText?: string;
+  onSubmitted: () => void;
+  /** Add a new item to the task. Required when existingItemId is omitted. */
+  onAdd?: (taskId: string, text: string) => Promise<void>;
+  /** Update an existing item. Required when existingItemId is provided. */
+  onUpdate?: (taskId: string, itemId: string, text: string) => Promise<void>;
+}
+
+interface FormValues {
+  text: string;
+}
+
+export default function ChecklistForm({
+  taskId,
+  taskText,
+  existingItemId,
+  existingItemText,
+  onSubmitted,
+  onAdd,
+  onUpdate,
+}: ChecklistFormProps) {
+  const { pop } = useNavigation();
+  const [submitting, setSubmitting] = useState(false);
+  const isEdit = Boolean(existingItemId);
+
+  async function handleSubmit(values: FormValues) {
+    const trimmed = values.text.trim();
+    if (!trimmed) {
+      await showToast({ style: Toast.Style.Failure, title: "Item text is required" });
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      await showToast({
+        style: Toast.Style.Animated,
+        title: isEdit ? "Updating item…" : "Adding item…",
+      });
+      if (isEdit) {
+        if (!onUpdate || !existingItemId) throw new Error("Missing update handler");
+        await onUpdate(taskId, existingItemId, trimmed);
+      } else {
+        if (!onAdd) throw new Error("Missing add handler");
+        await onAdd(taskId, trimmed);
+      }
+      await showToast({ style: Toast.Style.Success, title: isEdit ? "Item updated" : "Item added" });
+      onSubmitted();
+      pop();
+    } catch (error) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: isEdit ? "Failed to update item" : "Failed to add item",
+        message: String(error),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Form
+      navigationTitle={`${isEdit ? "Edit Item" : "Add Item"}: ${taskText}`}
+      isLoading={submitting}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title={isEdit ? "Save Item" : "Add Item"} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField
+        id="text"
+        title="Checklist Item"
+        placeholder="Sub-task description"
+        defaultValue={existingItemText ?? ""}
+        autoFocus
+      />
+    </Form>
+  );
+}

--- a/extensions/habitica-todos/src/components/TaskList.tsx
+++ b/extensions/habitica-todos/src/components/TaskList.tsx
@@ -11,19 +11,40 @@ import {
   useNavigation,
 } from "@raycast/api";
 import { useEffect, useState, useCallback } from "react";
-import { getTasks, getTags, scoreTask, deleteTask } from "../api";
-import { HabiticaTask, HabiticaTag } from "../types";
-import { PRIORITY_LABELS, TAG_FILTER_ALL } from "../constants";
+import {
+  getTasks,
+  getTags,
+  scoreTask,
+  deleteTask,
+  scoreChecklistItem,
+  deleteChecklistItem,
+  addChecklistItem,
+  updateChecklistItem,
+  clearCompletedTodos,
+} from "../api";
+import { HabiticaTask, HabiticaTag, CreateTaskBody } from "../types";
+import { PRIORITY_LABELS, STAT_LABELS, TAG_FILTER_ALL } from "../constants";
+import { parseHabiticaDate } from "../date-utils";
 import EditTaskForm from "../edit-task";
+import ChecklistForm from "../checklist-form";
+import { CreateTaskForm } from "../create-task";
 
 interface TaskListProps {
   type: "todos" | "dailys" | "habits" | "rewards";
   navigationTitle: string;
 }
 
+const LIST_TYPE_TO_TASK_TYPE: Record<TaskListProps["type"], CreateTaskBody["type"] | undefined> = {
+  todos: "todo",
+  dailys: "daily",
+  habits: "habit",
+  rewards: undefined,
+};
+
 function isTaskExpired(task: HabiticaTask): boolean {
   if (task.completed || !task.date) return false;
-  const dueDate = new Date(task.date);
+  const dueDate = parseHabiticaDate(task.date);
+  if (!dueDate) return false;
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   dueDate.setHours(0, 0, 0, 0);
@@ -31,10 +52,15 @@ function isTaskExpired(task: HabiticaTask): boolean {
 }
 
 function formatTaskDate(date: string | null | undefined): string | undefined {
-  if (!date) return undefined;
-  const taskDate = new Date(date);
-  if (Number.isNaN(taskDate.getTime())) return undefined;
+  const taskDate = parseHabiticaDate(date);
+  if (!taskDate) return undefined;
   const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const dayMs = 86_400_000;
+  const diffDays = Math.round((taskDate.getTime() - now.getTime()) / dayMs);
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Tomorrow";
+  if (diffDays === -1) return "Yesterday";
   const isCurrentYear = taskDate.getFullYear() === now.getFullYear();
   return taskDate.toLocaleDateString("en-US", {
     month: "short",
@@ -84,7 +110,10 @@ export default function TaskList({ type, navigationTitle }: TaskListProps) {
     fetchData();
   }, [fetchData]);
 
-  const filteredTasks = tagFilter === TAG_FILTER_ALL ? tasks : tasks.filter((t) => t.tags.includes(tagFilter));
+  const filteredTasks = (tagFilter === TAG_FILTER_ALL ? tasks : tasks.filter((t) => t.tags.includes(tagFilter)))
+    .slice()
+    // Habitica's web UI floats completed todos/dailies to the bottom; do the same.
+    .sort((a, b) => (a.completed === b.completed ? 0 : a.completed ? 1 : -1));
 
   async function handleScore(task: HabiticaTask, direction: "up" | "down" = "up") {
     let actionName = "Completing";
@@ -116,6 +145,51 @@ export default function TaskList({ type, navigationTitle }: TaskListProps) {
     }
   }
 
+  async function handleChecklistScore(task: HabiticaTask, item: { id: string; text: string }) {
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Updating checklist…" });
+      await scoreChecklistItem(task.id, item.id);
+      await showToast({ style: Toast.Style.Success, title: "Checklist updated" });
+      await fetchData();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Failed", message: String(error) });
+    }
+  }
+
+  async function handleChecklistDelete(task: HabiticaTask, item: { id: string; text: string }) {
+    const confirmed = await confirmAlert({
+      title: "Delete Checklist Item",
+      message: `Remove "${item.text}"?`,
+      primaryAction: { title: "Delete", style: Alert.ActionStyle.Destructive },
+    });
+    if (!confirmed) return;
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Removing…" });
+      await deleteChecklistItem(task.id, item.id);
+      await showToast({ style: Toast.Style.Success, title: "Removed" });
+      await fetchData();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Failed", message: String(error) });
+    }
+  }
+
+  async function handleClearCompleted() {
+    const confirmed = await confirmAlert({
+      title: "Clear Completed To-Dos",
+      message: "Permanently delete all completed To-Dos? This cannot be undone.",
+      primaryAction: { title: "Clear", style: Alert.ActionStyle.Destructive },
+    });
+    if (!confirmed) return;
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Clearing…" });
+      await clearCompletedTodos();
+      await showToast({ style: Toast.Style.Success, title: "Cleared" });
+      await fetchData();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Failed", message: String(error) });
+    }
+  }
+
   async function handleDelete(task: HabiticaTask) {
     const confirmed = await confirmAlert({
       title: "Delete Task",
@@ -140,6 +214,16 @@ export default function TaskList({ type, navigationTitle }: TaskListProps) {
   }
 
   const tagNameMap = new Map(tags.map((t) => [t.id, t.name]));
+  const defaultCreateType = LIST_TYPE_TO_TASK_TYPE[type];
+
+  const createTaskAction = defaultCreateType ? (
+    <Action
+      title="Create New Task"
+      icon={Icon.Plus}
+      shortcut={{ modifiers: ["cmd"], key: "n" }}
+      onAction={() => push(<CreateTaskForm defaultType={defaultCreateType} onCreated={fetchData} />)}
+    />
+  ) : null;
 
   return (
     <List
@@ -157,7 +241,11 @@ export default function TaskList({ type, navigationTitle }: TaskListProps) {
       }
     >
       {filteredTasks.length === 0 && !isLoading ? (
-        <List.EmptyView title="No tasks found" description="Create a new one to get started!" />
+        <List.EmptyView
+          title="No tasks found"
+          description="Create a new one to get started!"
+          actions={createTaskAction ? <ActionPanel>{createTaskAction}</ActionPanel> : undefined}
+        />
       ) : (
         filteredTasks.map((task) => {
           const icon = taskIcon(task);
@@ -165,20 +253,42 @@ export default function TaskList({ type, navigationTitle }: TaskListProps) {
           const taskTagNames = task.tags.map((tid) => tagNameMap.get(tid)).filter(Boolean) as string[];
           const difficultyLabel = PRIORITY_LABELS[task.priority] ?? "Unknown";
 
-          const detailMarkdown = task.notes || "*No description*";
+          const checklist = task.checklist ?? [];
+          const checklistDone = checklist.filter((c) => c.completed).length;
+          const checklistMarkdown =
+            checklist.length > 0
+              ? "\n\n### Checklist\n\n" + checklist.map((c) => `- ${c.completed ? "[x]" : "[ ]"} ${c.text}`).join("\n")
+              : "";
+          const detailMarkdown = (task.notes || "*No description*") + checklistMarkdown;
+          const accessories: { text?: string; icon?: { source: Icon; tintColor?: Color }; tooltip?: string }[] = [];
+          if (checklist.length > 0) {
+            accessories.push({
+              icon: {
+                source: Icon.BulletPoints,
+                tintColor: checklistDone === checklist.length ? Color.Green : Color.SecondaryText,
+              },
+              text: `${checklistDone}/${checklist.length}`,
+              tooltip: "Checklist progress",
+            });
+          }
+          if (formattedDate) accessories.push({ text: formattedDate });
 
           return (
             <List.Item
               key={task.id}
               icon={icon}
               title={task.text}
-              accessories={formattedDate ? [{ text: formattedDate }] : undefined}
+              accessories={accessories.length > 0 ? accessories : undefined}
               detail={
                 <List.Item.Detail
                   markdown={detailMarkdown}
                   metadata={
                     <List.Item.Detail.Metadata>
                       <List.Item.Detail.Metadata.Label title="Difficulty" text={difficultyLabel} />
+                      <List.Item.Detail.Metadata.Label
+                        title="Attribute"
+                        text={STAT_LABELS[task.attribute] ?? "Strength"}
+                      />
                       {task.type === "habit" && (
                         <>
                           <List.Item.Detail.Metadata.Separator />
@@ -198,6 +308,16 @@ export default function TaskList({ type, navigationTitle }: TaskListProps) {
                           <List.Item.Detail.Metadata.Label title="Due Date" text={formattedDate} />
                         </>
                       )}
+                      {checklist.length > 0 && (
+                        <>
+                          <List.Item.Detail.Metadata.Separator />
+                          <List.Item.Detail.Metadata.Label
+                            title="Checklist"
+                            text={`${checklistDone} / ${checklist.length} done`}
+                            icon={Icon.BulletPoints}
+                          />
+                        </>
+                      )}
                       <List.Item.Detail.Metadata.Separator />
                       <List.Item.Detail.Metadata.TagList title="Tags">
                         {taskTagNames.length > 0 ? (
@@ -208,12 +328,34 @@ export default function TaskList({ type, navigationTitle }: TaskListProps) {
                           <List.Item.Detail.Metadata.TagList.Item text="No tags" color={Color.SecondaryText} />
                         )}
                       </List.Item.Detail.Metadata.TagList>
-                      <List.Item.Detail.Metadata.Separator />
-                      <List.Item.Detail.Metadata.Label
-                        title="Status"
-                        text={task.completed ? "Completed" : "Pending"}
-                        icon={task.completed ? Icon.CheckCircle : Icon.Circle}
-                      />
+                      {(task.type === "todo" || task.type === "daily") && (
+                        <>
+                          <List.Item.Detail.Metadata.Separator />
+                          <List.Item.Detail.Metadata.Label
+                            title="Status"
+                            text={
+                              task.completed
+                                ? task.type === "daily"
+                                  ? "Done today"
+                                  : "Completed"
+                                : task.type === "daily"
+                                  ? "Pending today"
+                                  : "Pending"
+                            }
+                            icon={task.completed ? Icon.CheckCircle : Icon.Circle}
+                          />
+                        </>
+                      )}
+                      {task.type === "reward" && (
+                        <>
+                          <List.Item.Detail.Metadata.Separator />
+                          <List.Item.Detail.Metadata.Label
+                            title="Cost"
+                            text={`${task.value} GP`}
+                            icon={{ source: Icon.Coins, tintColor: Color.Yellow }}
+                          />
+                        </>
+                      )}
                     </List.Item.Detail.Metadata>
                   }
                 />
@@ -261,7 +403,84 @@ export default function TaskList({ type, navigationTitle }: TaskListProps) {
                       onAction={() => handleDelete(task)}
                     />
                   </ActionPanel.Section>
+                  {(task.type === "todo" || task.type === "daily") && (
+                    <ActionPanel.Section title="Checklist">
+                      <Action
+                        title="Add Checklist Item"
+                        icon={Icon.PlusCircle}
+                        shortcut={{ modifiers: ["cmd", "shift"], key: "k" }}
+                        onAction={() =>
+                          push(
+                            <ChecklistForm
+                              taskId={task.id}
+                              taskText={task.text}
+                              onSubmitted={fetchData}
+                              onAdd={addChecklistItem}
+                            />,
+                          )
+                        }
+                      />
+                      {checklist.length > 0 && (
+                        <ActionPanel.Submenu title="Toggle Item" icon={Icon.CheckCircle}>
+                          {checklist.map((item) => (
+                            <Action
+                              key={item.id}
+                              title={item.text}
+                              icon={item.completed ? Icon.Checkmark : Icon.Circle}
+                              onAction={() => handleChecklistScore(task, item)}
+                            />
+                          ))}
+                        </ActionPanel.Submenu>
+                      )}
+                      {checklist.length > 0 && (
+                        <ActionPanel.Submenu title="Edit Item" icon={Icon.Pencil}>
+                          {checklist.map((item) => (
+                            <Action
+                              key={`edit-${item.id}`}
+                              title={item.text}
+                              icon={Icon.Pencil}
+                              onAction={() =>
+                                push(
+                                  <ChecklistForm
+                                    taskId={task.id}
+                                    taskText={task.text}
+                                    existingItemId={item.id}
+                                    existingItemText={item.text}
+                                    onSubmitted={fetchData}
+                                    onUpdate={updateChecklistItem}
+                                  />,
+                                )
+                              }
+                            />
+                          ))}
+                        </ActionPanel.Submenu>
+                      )}
+                      {checklist.length > 0 && (
+                        <ActionPanel.Submenu title="Delete Item" icon={Icon.Trash}>
+                          {checklist.map((item) => (
+                            <Action
+                              key={`del-${item.id}`}
+                              title={item.text}
+                              icon={Icon.Trash}
+                              style={Action.Style.Destructive}
+                              onAction={() => handleChecklistDelete(task, item)}
+                            />
+                          ))}
+                        </ActionPanel.Submenu>
+                      )}
+                    </ActionPanel.Section>
+                  )}
                   <ActionPanel.Section>
+                    {createTaskAction}
+                    {type === "todos" && tasks.some((t) => t.completed) && (
+                      <Action
+                        title="Clear Completed To-Dos"
+                        icon={Icon.Eraser}
+                        style={Action.Style.Destructive}
+                        shortcut={{ modifiers: ["cmd", "shift"], key: "delete" }}
+                        onAction={handleClearCompleted}
+                      />
+                    )}
                     <Action
                       title="Refresh"
                       icon={Icon.ArrowClockwise}

--- a/extensions/habitica-todos/src/constants.ts
+++ b/extensions/habitica-todos/src/constants.ts
@@ -19,3 +19,84 @@ export const TAG_FILTER_ALL = "all";
 
 /** Shared S3 asset base URL used by avatar and inventory. */
 export const ASSET_BASE_URL = "https://habitica-assets.s3.amazonaws.com/mobileApp/images/";
+
+/** Skill definitions per class, sourced from habitica/website/common/script/content/spells.js. */
+export interface SkillDefinition {
+  key: string;
+  name: string;
+  description: string;
+  mana: number;
+  level: number;
+  /** When true, the skill expects a task targetId. */
+  targetsTask?: boolean;
+  /** When true, the skill expects a party member targetId. */
+  targetsParty?: boolean;
+}
+
+export const SKILLS_BY_CLASS: Record<string, SkillDefinition[]> = {
+  warrior: [
+    {
+      key: "smash",
+      name: "Brutal Smash",
+      description: "Deals damage to a task & boss.",
+      mana: 10,
+      level: 11,
+      targetsTask: true,
+    },
+    { key: "defensiveStance", name: "Defensive Stance", description: "Reduces incoming damage.", mana: 25, level: 12 },
+    {
+      key: "valorousPresence",
+      name: "Valorous Presence",
+      description: "Boosts STR for the party.",
+      mana: 20,
+      level: 13,
+    },
+    { key: "intimidate", name: "Intimidating Gaze", description: "Boosts CON for the party.", mana: 15, level: 14 },
+  ],
+  wizard: [
+    {
+      key: "fireball",
+      name: "Burst of Flames",
+      description: "Deals damage to a task & boss.",
+      mana: 10,
+      level: 11,
+      targetsTask: true,
+    },
+    { key: "mpheal", name: "Ethereal Surge", description: "Restores mana for the party.", mana: 30, level: 12 },
+    { key: "earth", name: "Earthquake", description: "Boosts INT for the party.", mana: 35, level: 13 },
+    { key: "frost", name: "Chilling Frost", description: "Removes daily streaks for re-rolling.", mana: 40, level: 14 },
+  ],
+  rogue: [
+    { key: "pickPocket", name: "Pickpocket", description: "Steals gold.", mana: 10, level: 11, targetsTask: true },
+    {
+      key: "backStab",
+      name: "Backstab",
+      description: "Deals damage & gives EXP.",
+      mana: 15,
+      level: 12,
+      targetsTask: true,
+    },
+    { key: "toolsOfTrade", name: "Tools of the Trade", description: "Boosts PER for the party.", mana: 25, level: 13 },
+    { key: "stealth", name: "Stealth", description: "Avoid Daily damage tonight.", mana: 45, level: 14 },
+  ],
+  healer: [
+    { key: "heal", name: "Healing Light", description: "Restores health.", mana: 15, level: 11 },
+    { key: "brightness", name: "Searing Brightness", description: "Boosts task values.", mana: 15, level: 12 },
+    { key: "protectAura", name: "Protective Aura", description: "Boosts CON for the party.", mana: 30, level: 13 },
+    { key: "healAll", name: "Blessing", description: "Restores health for the party.", mana: 25, level: 14 },
+  ],
+};
+
+export const STAT_LABELS: Record<string, string> = {
+  str: "Strength",
+  con: "Constitution",
+  int: "Intelligence",
+  per: "Perception",
+};
+
+export const ATTRIBUTE_OPTIONS: { value: string; title: string }[] = [
+  { value: "str", title: "Strength" },
+  { value: "int", title: "Intelligence" },
+  { value: "per", title: "Perception" },
+  { value: "con", title: "Constitution" },
+];

--- a/extensions/habitica-todos/src/create-task.tsx
+++ b/extensions/habitica-todos/src/create-task.tsx
@@ -1,17 +1,19 @@
-import { Form, ActionPanel, Action, showToast, Toast, launchCommand, LaunchType } from "@raycast/api";
+import { Form, ActionPanel, Action, showToast, Toast, launchCommand, LaunchType, useNavigation } from "@raycast/api";
 import { useEffect, useState } from "react";
 import { createTask, getTags } from "./api";
-import { HabiticaTag, CreateTaskBody } from "./types";
+import { HabiticaTag, CreateTaskBody, TaskAttribute } from "./types";
 import { toHabiticaDate } from "./date-utils";
-import { PRIORITY_OPTIONS } from "./constants";
+import { PRIORITY_OPTIONS, ATTRIBUTE_OPTIONS } from "./constants";
 
 interface FormValues {
   text: string;
   type: string;
   notes: string;
   priority: string;
+  attribute: string;
   date: Date | null;
   tags: string[];
+  checklist: string;
 }
 
 const TYPE_TO_COMMAND: Record<string, string> = {
@@ -20,9 +22,16 @@ const TYPE_TO_COMMAND: Record<string, string> = {
   daily: "view-dailies",
 };
 
-export default function Command() {
+interface CreateTaskFormProps {
+  defaultType?: CreateTaskBody["type"];
+  onCreated?: () => void;
+}
+
+export function CreateTaskForm({ defaultType = "todo", onCreated }: CreateTaskFormProps) {
+  const { pop } = useNavigation();
   const [tags, setTags] = useState<HabiticaTag[]>([]);
   const [isLoadingTags, setIsLoadingTags] = useState(true);
+  const [type, setType] = useState<string>(defaultType);
 
   useEffect(() => {
     loadTags();
@@ -55,18 +64,36 @@ export default function Command() {
 
     if (values.notes?.trim()) body.notes = values.notes.trim();
     if (values.priority) body.priority = parseFloat(values.priority);
+    if (values.attribute) body.attribute = values.attribute as TaskAttribute;
 
-    const dueDate = toHabiticaDate(values.date);
-    if (dueDate) body.date = dueDate;
+    if (taskType === "todo") {
+      const dueDate = toHabiticaDate(values.date);
+      if (dueDate) body.date = dueDate;
+    }
 
     if (values.tags?.length > 0) body.tags = values.tags;
+
+    if (values.checklist?.trim()) {
+      const items = values.checklist
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .map((text) => ({ text }));
+      if (items.length > 0) body.checklist = items;
+    }
 
     try {
       await showToast({ style: Toast.Style.Animated, title: "Creating task…" });
       await createTask(body);
       await showToast({ style: Toast.Style.Success, title: "Task created!" });
-      const targetCommand = TYPE_TO_COMMAND[taskType] ?? "view-tasks";
-      await launchCommand({ name: targetCommand, type: LaunchType.UserInitiated });
+
+      if (onCreated) {
+        onCreated();
+        pop();
+      } else {
+        const targetCommand = TYPE_TO_COMMAND[taskType] ?? "view-tasks";
+        await launchCommand({ name: targetCommand, type: LaunchType.UserInitiated });
+      }
     } catch (error) {
       await showToast({
         style: Toast.Style.Failure,
@@ -87,13 +114,22 @@ export default function Command() {
     >
       <Form.TextField id="text" title="Title" placeholder="What do you need to do?" autoFocus />
 
-      <Form.Dropdown id="type" title="Type" defaultValue="todo">
+      <Form.Dropdown id="type" title="Type" value={type} onChange={setType}>
         <Form.Dropdown.Item value="todo" title="To-Do" />
         <Form.Dropdown.Item value="habit" title="Habit" />
         <Form.Dropdown.Item value="daily" title="Daily" />
       </Form.Dropdown>
 
       <Form.TextArea id="notes" title="Notes" placeholder="Additional details (optional)" />
+
+      {(type === "todo" || type === "daily") && (
+        <Form.TextArea
+          id="checklist"
+          title="Checklist"
+          placeholder="One sub-task per line (optional)"
+          info="Each line becomes a checklist item."
+        />
+      )}
 
       <Form.Separator />
 
@@ -103,7 +139,18 @@ export default function Command() {
         ))}
       </Form.Dropdown>
 
-      <Form.DatePicker id="date" title="Due Date" type={Form.DatePicker.Type.Date} />
+      <Form.Dropdown
+        id="attribute"
+        title="Attribute"
+        defaultValue="str"
+        info="Stat this task trains. Auto-allocate uses this to distribute level-up points."
+      >
+        {ATTRIBUTE_OPTIONS.map((opt) => (
+          <Form.Dropdown.Item key={opt.value} value={opt.value} title={opt.title} />
+        ))}
+      </Form.Dropdown>
+
+      {type === "todo" && <Form.DatePicker id="date" title="Due Date" type={Form.DatePicker.Type.Date} />}
 
       <Form.Separator />
 
@@ -114,4 +161,8 @@ export default function Command() {
       </Form.TagPicker>
     </Form>
   );
+}
+
+export default function Command() {
+  return <CreateTaskForm />;
 }

--- a/extensions/habitica-todos/src/date-utils.ts
+++ b/extensions/habitica-todos/src/date-utils.ts
@@ -1,10 +1,10 @@
 /**
  * Converts any date-like value to a YYYY-MM-DD string for the Habitica API.
  *
- * Raycast provides a real Date object from Form.DatePicker, but other
- * runtimes may pass a string or number instead.
- * This helper normalises all cases so the rest of the codebase never
- * needs to call .toISOString() directly.
+ * Uses local date components rather than .toISOString() so a Date picked in
+ * the user's local timezone serializes to the same calendar day. Otherwise
+ * a date picked just before midnight local time can round forward a day
+ * (e.g. picking Oct 15 in UTC+9 would otherwise serialize as Oct 14 UTC).
  *
  * Returns undefined when the value is absent or not parseable.
  */
@@ -20,5 +20,25 @@ export function toHabiticaDate(value: unknown): string | undefined {
 
   if (!date || Number.isNaN(date.getTime())) return undefined;
 
-  return date.toISOString().split("T")[0];
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Parses a Habitica task date (ISO string at UTC midnight, e.g. 2025-10-15T00:00:00.000Z)
+ * into a local-midnight Date. We treat the UTC calendar day as the intended day so the
+ * displayed date matches what the user picked, regardless of timezone offset.
+ */
+export function parseHabiticaDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  // For "YYYY-MM-DD" strings, use the calendar components directly.
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (!match) {
+    const fallback = new Date(value);
+    return Number.isNaN(fallback.getTime()) ? null : fallback;
+  }
+  const [, y, m, d] = match;
+  return new Date(Number(y), Number(m) - 1, Number(d));
 }

--- a/extensions/habitica-todos/src/edit-task.tsx
+++ b/extensions/habitica-todos/src/edit-task.tsx
@@ -51,29 +51,43 @@ export default function EditTaskForm({ task, onUpdated }: EditTaskFormProps) {
       }
     }
 
+    await showToast({ style: Toast.Style.Animated, title: "Updating task…" });
+
     try {
-      await showToast({ style: Toast.Style.Animated, title: "Updating task…" });
       await updateTask(task.id, body);
-
-      const desired = new Set(values.tags ?? []);
-      const current = new Set(task.tags ?? []);
-      const toAdd = [...desired].filter((id) => !current.has(id));
-      const toRemove = [...current].filter((id) => !desired.has(id));
-      await Promise.all([
-        ...toAdd.map((id) => addTagToTask(task.id, id)),
-        ...toRemove.map((id) => removeTagFromTask(task.id, id)),
-      ]);
-
-      await showToast({ style: Toast.Style.Success, title: "Task updated!" });
-      onUpdated();
-      pop();
     } catch (error) {
       await showToast({
         style: Toast.Style.Failure,
         title: "Failed to update task",
         message: String(error),
       });
+      return;
     }
+
+    const desired = new Set(values.tags ?? []);
+    const current = new Set(task.tags ?? []);
+    const toAdd = [...desired].filter((id) => !current.has(id));
+    const toRemove = [...current].filter((id) => !desired.has(id));
+
+    try {
+      await Promise.all([
+        ...toAdd.map((id) => addTagToTask(task.id, id)),
+        ...toRemove.map((id) => removeTagFromTask(task.id, id)),
+      ]);
+    } catch (error) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Task saved, but tag sync failed",
+        message: String(error),
+      });
+      onUpdated();
+      pop();
+      return;
+    }
+
+    await showToast({ style: Toast.Style.Success, title: "Task updated!" });
+    onUpdated();
+    pop();
   }
 
   return (

--- a/extensions/habitica-todos/src/edit-task.tsx
+++ b/extensions/habitica-todos/src/edit-task.tsx
@@ -1,8 +1,9 @@
 import { Form, ActionPanel, Action, showToast, Toast, useNavigation } from "@raycast/api";
-import { HabiticaTask, UpdateTaskBody } from "./types";
-import { updateTask } from "./api";
-import { toHabiticaDate } from "./date-utils";
-import { PRIORITY_OPTIONS } from "./constants";
+import { useEffect, useState } from "react";
+import { HabiticaTask, HabiticaTag, TaskAttribute, UpdateTaskBody } from "./types";
+import { updateTask, getTags, addTagToTask, removeTagFromTask } from "./api";
+import { toHabiticaDate, parseHabiticaDate } from "./date-utils";
+import { PRIORITY_OPTIONS, ATTRIBUTE_OPTIONS } from "./constants";
 
 interface EditTaskFormProps {
   task: HabiticaTask;
@@ -13,11 +14,22 @@ interface FormValues {
   text: string;
   notes: string;
   priority: string;
+  attribute: string;
   date: Date | null;
+  tags: string[];
 }
 
 export default function EditTaskForm({ task, onUpdated }: EditTaskFormProps) {
   const { pop } = useNavigation();
+  const [tags, setTags] = useState<HabiticaTag[]>([]);
+  const [isLoadingTags, setIsLoadingTags] = useState(true);
+
+  useEffect(() => {
+    getTags()
+      .then(setTags)
+      .catch((error) => showToast({ style: Toast.Style.Failure, title: "Failed to load tags", message: String(error) }))
+      .finally(() => setIsLoadingTags(false));
+  }, []);
 
   async function handleSubmit(values: FormValues) {
     if (!values.text.trim()) {
@@ -28,14 +40,13 @@ export default function EditTaskForm({ task, onUpdated }: EditTaskFormProps) {
     const body: UpdateTaskBody = { text: values.text.trim(), notes: values.notes.trim() };
 
     if (values.priority) body.priority = parseFloat(values.priority);
+    if (values.attribute) body.attribute = values.attribute as TaskAttribute;
 
-    // Only apply date changes for task types that expose the DatePicker
     if (task.type === "todo") {
       const dueDate = toHabiticaDate(values.date);
       if (dueDate) {
         body.date = dueDate;
       } else if (task.date) {
-        // Explicitly clear the date if the user removed it
         body.date = "";
       }
     }
@@ -43,6 +54,16 @@ export default function EditTaskForm({ task, onUpdated }: EditTaskFormProps) {
     try {
       await showToast({ style: Toast.Style.Animated, title: "Updating task…" });
       await updateTask(task.id, body);
+
+      const desired = new Set(values.tags ?? []);
+      const current = new Set(task.tags ?? []);
+      const toAdd = [...desired].filter((id) => !current.has(id));
+      const toRemove = [...current].filter((id) => !desired.has(id));
+      await Promise.all([
+        ...toAdd.map((id) => addTagToTask(task.id, id)),
+        ...toRemove.map((id) => removeTagFromTask(task.id, id)),
+      ]);
+
       await showToast({ style: Toast.Style.Success, title: "Task updated!" });
       onUpdated();
       pop();
@@ -76,14 +97,31 @@ export default function EditTaskForm({ task, onUpdated }: EditTaskFormProps) {
         ))}
       </Form.Dropdown>
 
+      <Form.Dropdown id="attribute" title="Attribute" defaultValue={task.attribute ?? "str"}>
+        {ATTRIBUTE_OPTIONS.map((opt) => (
+          <Form.Dropdown.Item key={opt.value} value={opt.value} title={opt.title} />
+        ))}
+      </Form.Dropdown>
+
       {task.type === "todo" && (
         <Form.DatePicker
           id="date"
           title="Due Date"
           type={Form.DatePicker.Type.Date}
-          defaultValue={task.date ? new Date(task.date) : undefined}
+          defaultValue={parseHabiticaDate(task.date) ?? undefined}
         />
       )}
+
+      <Form.TagPicker
+        id="tags"
+        title="Tags"
+        defaultValue={task.tags ?? []}
+        placeholder={isLoadingTags ? "Loading tags…" : "Select tags"}
+      >
+        {tags.map((tag) => (
+          <Form.TagPicker.Item key={tag.id} value={tag.id} title={tag.name} />
+        ))}
+      </Form.TagPicker>
     </Form>
   );
 }

--- a/extensions/habitica-todos/src/feed-form.tsx
+++ b/extensions/habitica-todos/src/feed-form.tsx
@@ -1,0 +1,70 @@
+import { Form, ActionPanel, Action, showToast, Toast, useNavigation } from "@raycast/api";
+import { useState } from "react";
+import { feedPet } from "./api";
+
+type InventoryEntry = [key: string, count: number];
+
+interface FeedFormProps {
+  foodKey: string;
+  pets: InventoryEntry[];
+  onSubmitted: () => void;
+}
+
+export default function FeedForm({ foodKey, pets, onSubmitted }: FeedFormProps) {
+  const { pop } = useNavigation();
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(values: { pet: string; amount: string }) {
+    const pet = values.pet;
+    const amount = Math.max(1, Math.min(50, parseInt(values.amount, 10) || 1));
+    if (!pet) {
+      await showToast({ style: Toast.Style.Failure, title: "Pick a pet" });
+      return;
+    }
+    try {
+      setSubmitting(true);
+      await showToast({ style: Toast.Style.Animated, title: `Feeding ${pet}…` });
+      await feedPet(pet, foodKey, amount);
+      await showToast({ style: Toast.Style.Success, title: "Pet fed!" });
+      onSubmitted();
+      pop();
+    } catch (error) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Failed to feed pet",
+        message: String(error),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Form
+      navigationTitle={`Feed With ${foodKey}`}
+      isLoading={submitting}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Feed Pet" onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.Description title="Food" text={foodKey} />
+      {pets.length === 0 ? (
+        <Form.Description title="Pet" text="You have no pets to feed. Hatch one first!" />
+      ) : (
+        <Form.Dropdown id="pet" title="Pet">
+          {pets.map(([k, c]) => (
+            <Form.Dropdown.Item key={k} value={k} title={`${k} (×${c})`} />
+          ))}
+        </Form.Dropdown>
+      )}
+      <Form.TextField
+        id="amount"
+        title="Amount"
+        defaultValue="1"
+        info="Pets eat 50 units before becoming mounts. Preferred food: 5 units. Other: 2 units."
+      />
+    </Form>
+  );
+}

--- a/extensions/habitica-todos/src/hatch-form.tsx
+++ b/extensions/habitica-todos/src/hatch-form.tsx
@@ -1,0 +1,80 @@
+import { Form, ActionPanel, Action, showToast, Toast, useNavigation } from "@raycast/api";
+import { useState } from "react";
+import { hatchPet } from "./api";
+
+type InventoryEntry = [key: string, count: number];
+
+interface HatchFormProps {
+  /** When provided, the egg side is pinned and only the potion is selectable. */
+  eggKey?: string;
+  /** When provided, the potion side is pinned and only the egg is selectable. */
+  potionKey?: string;
+  eggs?: InventoryEntry[];
+  potions?: InventoryEntry[];
+  onSubmitted: () => void;
+}
+
+export default function HatchForm({ eggKey, potionKey, eggs, potions, onSubmitted }: HatchFormProps) {
+  const { pop } = useNavigation();
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(values: { egg: string; potion: string }) {
+    const egg = eggKey ?? values.egg;
+    const potion = potionKey ?? values.potion;
+    if (!egg || !potion) {
+      await showToast({ style: Toast.Style.Failure, title: "Pick both an egg and a potion" });
+      return;
+    }
+    try {
+      setSubmitting(true);
+      await showToast({ style: Toast.Style.Animated, title: "Hatching…" });
+      await hatchPet(egg, potion);
+      await showToast({ style: Toast.Style.Success, title: `Hatched ${egg}-${potion}!` });
+      onSubmitted();
+      pop();
+    } catch (error) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Failed to hatch",
+        message: String(error),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Form
+      navigationTitle="Hatch Pet"
+      isLoading={submitting}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Hatch Pet" onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      {eggKey ? (
+        <Form.Description title="Egg" text={eggKey} />
+      ) : (eggs ?? []).length === 0 ? (
+        <Form.Description title="Egg" text="No eggs in inventory" />
+      ) : (
+        <Form.Dropdown id="egg" title="Egg">
+          {(eggs ?? []).map(([k, c]) => (
+            <Form.Dropdown.Item key={k} value={k} title={`${k} (×${c})`} />
+          ))}
+        </Form.Dropdown>
+      )}
+      {potionKey ? (
+        <Form.Description title="Hatching Potion" text={potionKey} />
+      ) : (potions ?? []).length === 0 ? (
+        <Form.Description title="Hatching Potion" text="No hatching potions in inventory" />
+      ) : (
+        <Form.Dropdown id="potion" title="Hatching Potion">
+          {(potions ?? []).map(([k, c]) => (
+            <Form.Dropdown.Item key={k} value={k} title={`${k} (×${c})`} />
+          ))}
+        </Form.Dropdown>
+      )}
+    </Form>
+  );
+}

--- a/extensions/habitica-todos/src/skill-cast-form.tsx
+++ b/extensions/habitica-todos/src/skill-cast-form.tsx
@@ -1,0 +1,68 @@
+import { List, ActionPanel, Action, Icon, showToast, Toast, useNavigation } from "@raycast/api";
+import { useEffect, useState } from "react";
+import { castSpell, getTasks } from "./api";
+import { HabiticaTask } from "./types";
+
+interface SkillCastFormProps {
+  spellId: string;
+  spellName: string;
+  /** Filters to a subset of tasks. Defaults to all non-rewards. */
+  taskTypes?: ("todo" | "daily" | "habit")[];
+  onCast: () => void;
+}
+
+export default function SkillCastForm({ spellId, spellName, taskTypes, onCast }: SkillCastFormProps) {
+  const { pop } = useNavigation();
+  const [tasks, setTasks] = useState<HabiticaTask[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const allowedTypes = taskTypes ?? ["todo", "daily", "habit"];
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const all = await getTasks();
+        setTasks(all.filter((t) => allowedTypes.includes(t.type as "todo" | "daily" | "habit") && !t.completed));
+      } catch (error) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Failed to load tasks",
+          message: String(error),
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, []);
+
+  async function handleCast(task: HabiticaTask) {
+    try {
+      await showToast({ style: Toast.Style.Animated, title: `Casting ${spellName}…` });
+      await castSpell(spellId, task.id);
+      await showToast({ style: Toast.Style.Success, title: `${spellName} cast on ${task.text}` });
+      onCast();
+      pop();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Cast failed", message: String(error) });
+    }
+  }
+
+  return (
+    <List isLoading={isLoading} navigationTitle={`Cast ${spellName} On…`} searchBarPlaceholder="Search tasks…">
+      {tasks.length === 0 && !isLoading && (
+        <List.EmptyView title="No targets available" description="Add a task first." />
+      )}
+      {tasks.map((task) => (
+        <List.Item
+          key={task.id}
+          title={task.text}
+          icon={Icon.Circle}
+          actions={
+            <ActionPanel>
+              <Action title="Cast on This Task" icon={Icon.Wand} onAction={() => handleCast(task)} />
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
+  );
+}

--- a/extensions/habitica-todos/src/types.ts
+++ b/extensions/habitica-todos/src/types.ts
@@ -37,7 +37,24 @@ export interface HabiticaUser {
     lvl: number;
     gp: number;
     maxHealth?: number;
+    maxMP?: number;
     class?: string;
+    points?: number;
+    str?: number;
+    con?: number;
+    int?: number;
+    per?: number;
+  };
+  /** Death buff. Active when user died and must revive. */
+  needsCron?: boolean;
+  flags?: {
+    classSelected?: boolean;
+    rebirthEnabled?: boolean;
+  };
+  purchased?: {
+    plan?: {
+      mysteryItems?: string[];
+    };
   };
   party?: {
     quest?: {
@@ -61,8 +78,10 @@ export interface HabiticaUser {
       costume: Record<string, string>;
       owned: Record<string, boolean>;
     };
+    /** Pets store feed progress (5–50); -1 indicates a released pet. */
     pets: Record<string, number>;
-    mounts: Record<string, number>;
+    /** Mounts store boolean ownership; false indicates a released mount. */
+    mounts: Record<string, boolean>;
     currentPet?: string;
     currentMount?: string;
   };
@@ -78,6 +97,12 @@ export interface HabiticaUser {
     /** When true, render costume gear instead of equipped gear. */
     costume?: boolean;
   };
+}
+
+export interface HabiticaChecklistItem {
+  id: string;
+  text: string;
+  completed: boolean;
 }
 
 export interface HabiticaTask {
@@ -96,6 +121,7 @@ export interface HabiticaTask {
   streak?: number;
   up?: boolean;
   down?: boolean;
+  checklist?: HabiticaChecklistItem[];
 }
 
 export interface HabiticaTag {
@@ -110,6 +136,8 @@ export interface CreateTaskBody {
   priority?: number;
   date?: string;
   tags?: string[];
+  attribute?: TaskAttribute;
+  checklist?: { text: string; completed?: boolean }[];
 }
 
 export interface UpdateTaskBody {
@@ -117,6 +145,7 @@ export interface UpdateTaskBody {
   notes?: string;
   priority?: number;
   date?: string;
+  attribute?: TaskAttribute;
 }
 
 /** Only the gear subset is fetched from /api/v3/content (fields=gear). */

--- a/extensions/habitica-todos/src/view-inventory.tsx
+++ b/extensions/habitica-todos/src/view-inventory.tsx
@@ -1,8 +1,10 @@
-import { ActionPanel, Action, Icon, Grid, showToast, Toast } from "@raycast/api";
+import { ActionPanel, Action, Icon, Grid, showToast, Toast, Alert, confirmAlert, useNavigation } from "@raycast/api";
 import { useEffect, useState, useCallback } from "react";
-import { getUser } from "./api";
+import { getUser, equipItem, sellItem, openMysteryItem } from "./api";
 import { HabiticaUser } from "./types";
 import { ASSET_BASE_URL } from "./constants";
+import HatchForm from "./hatch-form";
+import FeedForm from "./feed-form";
 
 type InventoryEntry = [key: string, count: number];
 
@@ -16,6 +18,7 @@ export default function Command() {
   const [user, setUser] = useState<HabiticaUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [category, setCategory] = useState("all");
+  const { push } = useNavigation();
 
   const fetchData = useCallback(async () => {
     setIsLoading(true);
@@ -32,19 +35,93 @@ export default function Command() {
     fetchData();
   }, [fetchData]);
 
-  const items = user?.items;
+  async function handleSell(type: "eggs" | "hatchingPotions" | "food", key: string) {
+    const confirmed = await confirmAlert({
+      title: `Sell ${key}?`,
+      message: `Selling exchanges items for a small amount of gold.`,
+      primaryAction: { title: "Sell One", style: Alert.ActionStyle.Destructive },
+    });
+    if (!confirmed) return;
 
-  const categories: { key: string; label: string; entries: InventoryEntry[]; imageUrl: (k: string) => string }[] = [
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Selling…" });
+      await sellItem(type, key);
+      await showToast({ style: Toast.Style.Success, title: "Item sold" });
+      await fetchData();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Failed to sell", message: String(error) });
+    }
+  }
+
+  async function handleEquipPet(petKey: string) {
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Equipping pet…" });
+      await equipItem("pet", petKey);
+      await showToast({ style: Toast.Style.Success, title: "Pet equipped" });
+      await fetchData();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Failed", message: String(error) });
+    }
+  }
+
+  async function handleEquipMount(mountKey: string) {
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Equipping mount…" });
+      await equipItem("mount", mountKey);
+      await showToast({ style: Toast.Style.Success, title: "Mount equipped" });
+      await fetchData();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Failed", message: String(error) });
+    }
+  }
+
+  async function handleOpenMystery() {
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Opening mystery item…" });
+      await openMysteryItem();
+      await showToast({ style: Toast.Style.Success, title: "Mystery item opened!" });
+      await fetchData();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Failed", message: String(error) });
+    }
+  }
+
+  const items = user?.items;
+  const ownedPets = items?.pets ?? {};
+  const ownedMounts = items?.mounts ?? {};
+  const eggEntries = buildInventoryEntries(items?.eggs);
+  const potionEntries = buildInventoryEntries(items?.hatchingPotions);
+
+  type CategoryKind = "eggs" | "potions" | "food" | "special" | "quests" | "pets" | "mounts";
+
+  interface InventoryCategory {
+    key: CategoryKind;
+    label: string;
+    entries: InventoryEntry[];
+    imageUrl: (k: string) => string;
+  }
+
+  const petEntries: InventoryEntry[] = Object.entries(ownedPets)
+    .filter(([, count]) => count > 0)
+    .sort(([a], [b]) => a.localeCompare(b)) as InventoryEntry[];
+  // Mounts are stored as booleans (true = owned). Convert to 1/0 so the inventory grid
+  // can share the same `InventoryEntry` shape (count is purely informational for mounts).
+  const mountEntries: InventoryEntry[] = Object.entries(ownedMounts)
+    .filter(([, owned]) => owned === true)
+    .map(([key]) => [key, 1] as InventoryEntry)
+    .sort((a, b) => a[0].localeCompare(b[0]));
+
+  const categories: InventoryCategory[] = [
     {
       key: "eggs",
       label: "Eggs",
-      entries: buildInventoryEntries(items?.eggs),
+      entries: eggEntries,
       imageUrl: (k) => `${ASSET_BASE_URL}Pet_Egg_${k}.png`,
     },
     {
       key: "potions",
       label: "Hatching Potions",
-      entries: buildInventoryEntries(items?.hatchingPotions),
+      entries: potionEntries,
       imageUrl: (k) => `${ASSET_BASE_URL}Pet_HatchingPotion_${k}.png`,
     },
     {
@@ -65,13 +142,35 @@ export default function Command() {
       entries: buildInventoryEntries(items?.quests),
       imageUrl: (k) => `${ASSET_BASE_URL}inventory_quest_scroll_${k}.png`,
     },
+    {
+      key: "pets",
+      label: "Pets",
+      entries: petEntries,
+      imageUrl: (k) => `${ASSET_BASE_URL}Pet-${k}.png`,
+    },
+    {
+      key: "mounts",
+      label: "Mounts",
+      entries: mountEntries,
+      imageUrl: (k) => `${ASSET_BASE_URL}Mount_Icon_${k}.png`,
+    },
   ];
 
   const visibleCategories = category === "all" ? categories : categories.filter((c) => c.key === category);
   const isEmpty = visibleCategories.every((c) => c.entries.length === 0);
 
-  const inventoryActions = (
-    <ActionPanel>
+  const pendingMystery = user?.purchased?.plan?.mysteryItems?.length ?? 0;
+
+  const baseActions = (
+    <>
+      {pendingMystery > 0 && (
+        <Action
+          title={`Open Mystery Item (${pendingMystery} Pending)`}
+          icon={Icon.Gift}
+          shortcut={{ modifiers: ["cmd"], key: "m" }}
+          onAction={handleOpenMystery}
+        />
+      )}
       <Action
         title="Refresh"
         icon={Icon.ArrowClockwise}
@@ -83,8 +182,90 @@ export default function Command() {
         url="https://habitica.com/inventory/items"
         shortcut={{ modifiers: ["cmd"], key: "o" }}
       />
-    </ActionPanel>
+    </>
   );
+
+  function itemActions(c: InventoryCategory, key: string) {
+    switch (c.key) {
+      case "eggs":
+        return (
+          <ActionPanel>
+            <Action
+              title="Hatch Pet"
+              icon={Icon.NewDocument}
+              onAction={() => push(<HatchForm eggKey={key} potions={potionEntries} onSubmitted={fetchData} />)}
+            />
+            <Action
+              title="Sell Egg"
+              icon={Icon.Coins}
+              style={Action.Style.Destructive}
+              onAction={() => handleSell("eggs", key)}
+            />
+            {baseActions}
+          </ActionPanel>
+        );
+      case "potions":
+        return (
+          <ActionPanel>
+            <Action
+              title="Hatch Egg"
+              icon={Icon.NewDocument}
+              onAction={() => push(<HatchForm potionKey={key} eggs={eggEntries} onSubmitted={fetchData} />)}
+            />
+            <Action
+              title="Sell Potion"
+              icon={Icon.Coins}
+              style={Action.Style.Destructive}
+              onAction={() => handleSell("hatchingPotions", key)}
+            />
+            {baseActions}
+          </ActionPanel>
+        );
+      case "food":
+        return (
+          <ActionPanel>
+            <Action
+              title="Feed a Pet"
+              icon={Icon.Heart}
+              onAction={() => push(<FeedForm foodKey={key} pets={petEntries} onSubmitted={fetchData} />)}
+            />
+            <Action
+              title="Sell Food"
+              icon={Icon.Coins}
+              style={Action.Style.Destructive}
+              onAction={() => handleSell("food", key)}
+            />
+            {baseActions}
+          </ActionPanel>
+        );
+      case "special":
+        return <ActionPanel>{baseActions}</ActionPanel>;
+      case "pets":
+        return (
+          <ActionPanel>
+            <Action
+              title={items?.currentPet === key ? "Unequip Pet" : "Equip Pet"}
+              icon={items?.currentPet === key ? Icon.Circle : Icon.CheckCircle}
+              onAction={() => handleEquipPet(key)}
+            />
+            {baseActions}
+          </ActionPanel>
+        );
+      case "mounts":
+        return (
+          <ActionPanel>
+            <Action
+              title={items?.currentMount === key ? "Unequip Mount" : "Equip Mount"}
+              icon={items?.currentMount === key ? Icon.Circle : Icon.CheckCircle}
+              onAction={() => handleEquipMount(key)}
+            />
+            {baseActions}
+          </ActionPanel>
+        );
+      default:
+        return <ActionPanel>{baseActions}</ActionPanel>;
+    }
+  }
 
   return (
     <Grid
@@ -99,6 +280,8 @@ export default function Command() {
           <Grid.Dropdown.Item title="Pet Food and Saddles" value="food" />
           <Grid.Dropdown.Item title="Special" value="special" />
           <Grid.Dropdown.Item title="Quests" value="quests" />
+          <Grid.Dropdown.Item title="Pets" value="pets" />
+          <Grid.Dropdown.Item title="Mounts" value="mounts" />
         </Grid.Dropdown>
       }
     >
@@ -109,15 +292,21 @@ export default function Command() {
           .filter((c) => c.entries.length > 0)
           .map((c) => (
             <Grid.Section key={c.key} title={`${c.label} (${c.entries.length})`}>
-              {c.entries.map(([key, count]) => (
-                <Grid.Item
-                  key={`${c.key}-${key}`}
-                  title={key}
-                  subtitle={`×${count}`}
-                  content={c.imageUrl(key)}
-                  actions={inventoryActions}
-                />
-              ))}
+              {c.entries.map(([key, count]) => {
+                const equippedSuffix =
+                  (c.key === "pets" && items?.currentPet === key) || (c.key === "mounts" && items?.currentMount === key)
+                    ? " (equipped)"
+                    : "";
+                return (
+                  <Grid.Item
+                    key={`${c.key}-${key}`}
+                    title={key + equippedSuffix}
+                    subtitle={c.key === "pets" || c.key === "mounts" ? undefined : `×${count}`}
+                    content={c.imageUrl(key)}
+                    actions={itemActions(c, key)}
+                  />
+                );
+              })}
             </Grid.Section>
           ))
       )}

--- a/extensions/habitica-todos/src/view-profile.tsx
+++ b/extensions/habitica-todos/src/view-profile.tsx
@@ -170,7 +170,7 @@ export default function Command() {
               onAction={handleToggleSleep}
             />
           </ActionPanel.Section>
-          {userLevel >= 10 && skills.length > 0 && (
+          {skills.length > 0 && userLevel >= Math.min(...skills.map((s) => s.level)) && (
             <ActionPanel.Section title="Skills">
               {skills.map((skill) => {
                 const canCast = userLevel >= skill.level && userMp >= skill.mana;

--- a/extensions/habitica-todos/src/view-profile.tsx
+++ b/extensions/habitica-todos/src/view-profile.tsx
@@ -1,8 +1,31 @@
-import { ActionPanel, Action, Icon, Detail, showToast, Toast, Color, confirmAlert, Alert } from "@raycast/api";
+import {
+  ActionPanel,
+  Action,
+  Icon,
+  Detail,
+  showToast,
+  Toast,
+  Color,
+  confirmAlert,
+  Alert,
+  useNavigation,
+} from "@raycast/api";
 import { useEffect, useState, useCallback, useRef } from "react";
-import { getUser, forceCompleteQuest, acceptQuest, abortQuest } from "./api";
+import {
+  getUser,
+  forceCompleteQuest,
+  acceptQuest,
+  abortQuest,
+  castSpell,
+  allocateStat,
+  allocateNow,
+  toggleSleep,
+  reviveUser,
+} from "./api";
 import { getAvatarSvg } from "./avatar";
 import { HabiticaUser } from "./types";
+import { SKILLS_BY_CLASS, STAT_LABELS } from "./constants";
+import SkillCastForm from "./skill-cast-form";
 
 const AVATAR_PLACEHOLDER = `data:image/svg+xml;base64,${Buffer.from(
   `<svg width="140" height="140" viewBox="0 0 140 140" xmlns="http://www.w3.org/2000/svg"><rect width="140" height="140" rx="12" fill="#2d2c2a"/><circle cx="70" cy="52" r="22" fill="#444"/><ellipse cx="70" cy="110" rx="34" ry="24" fill="#444"/></svg>`,
@@ -13,6 +36,7 @@ export default function Command() {
   const [avatarUri, setAvatarUri] = useState<string>(AVATAR_PLACEHOLDER);
   const [isLoading, setIsLoading] = useState(true);
   const avatarGenRef = useRef(0); // incremented on each fetch to cancel stale avatar updates
+  const { push } = useNavigation();
 
   const fetchData = useCallback(async () => {
     setIsLoading(true);
@@ -42,6 +66,13 @@ export default function Command() {
 
   const stats = user?.stats;
   const quest = user?.party?.quest;
+  const userClass = stats?.class;
+  const userLevel = stats?.lvl ?? 0;
+  const userMp = stats?.mp ?? 0;
+  const skills = userClass ? (SKILLS_BY_CLASS[userClass] ?? []) : [];
+  const unallocatedPoints = stats?.points ?? 0;
+  const isSleeping = user?.preferences?.sleep ?? false;
+  const isDead = stats ? stats.hp <= 0 : false;
 
   let questMarkdown = "### No Active Quest\n\nYou are not currently on a quest.";
   if (quest?.key) {
@@ -72,7 +103,7 @@ export default function Command() {
           />
           <Detail.Metadata.Label
             title="Mana"
-            text={(stats?.mp ?? 0).toFixed(1)}
+            text={`${(stats?.mp ?? 0).toFixed(1)}${stats?.maxMP ? ` / ${stats.maxMP}` : ""}`}
             icon={{ source: Icon.Star, tintColor: Color.Blue }}
           />
           <Detail.Metadata.Label
@@ -85,6 +116,27 @@ export default function Command() {
             text={(stats?.gp ?? 0).toFixed(2)}
             icon={{ source: Icon.Coins, tintColor: Color.Yellow }}
           />
+          {userClass && (
+            <Detail.Metadata.Label
+              title="Class"
+              text={userClass.charAt(0).toUpperCase() + userClass.slice(1)}
+              icon={Icon.Person}
+            />
+          )}
+          {unallocatedPoints > 0 && (
+            <Detail.Metadata.Label
+              title="Stat Points"
+              text={`${unallocatedPoints} unspent`}
+              icon={{ source: Icon.Plus, tintColor: Color.Green }}
+            />
+          )}
+          {isSleeping && (
+            <Detail.Metadata.Label
+              title="Resting"
+              text="At the Tavern"
+              icon={{ source: Icon.Moon, tintColor: Color.Blue }}
+            />
+          )}
           {quest?.key && (
             <Detail.Metadata.TagList title="Quest Status">
               <Detail.Metadata.TagList.Item
@@ -104,7 +156,71 @@ export default function Command() {
               shortcut={{ modifiers: ["cmd"], key: "r" }}
               onAction={fetchData}
             />
+            {isDead && (
+              <Action
+                title="Revive Character"
+                icon={{ source: Icon.Heart, tintColor: Color.Red }}
+                onAction={handleRevive}
+              />
+            )}
+            <Action
+              title={isSleeping ? "Wake up" : "Rest in Tavern"}
+              icon={isSleeping ? Icon.Sun : Icon.Moon}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "s" }}
+              onAction={handleToggleSleep}
+            />
           </ActionPanel.Section>
+          {userLevel >= 10 && skills.length > 0 && (
+            <ActionPanel.Section title="Skills">
+              {skills.map((skill) => {
+                const canCast = userLevel >= skill.level && userMp >= skill.mana;
+                const title = `${skill.name}${skill.targetsTask ? "…" : ""} (${skill.mana} MP)`;
+                return (
+                  <Action
+                    key={skill.key}
+                    title={title}
+                    icon={{ source: Icon.Wand, tintColor: canCast ? Color.Blue : Color.SecondaryText }}
+                    onAction={() => {
+                      if (skill.targetsTask) {
+                        if (userLevel < skill.level) {
+                          showToast({
+                            style: Toast.Style.Failure,
+                            title: "Level too low",
+                            message: `${skill.name} unlocks at level ${skill.level}`,
+                          });
+                          return;
+                        }
+                        if (userMp < skill.mana) {
+                          showToast({
+                            style: Toast.Style.Failure,
+                            title: "Not enough mana",
+                            message: `Needs ${skill.mana} MP — have ${userMp.toFixed(1)}`,
+                          });
+                          return;
+                        }
+                        push(<SkillCastForm spellId={skill.key} spellName={skill.name} onCast={fetchData} />);
+                      } else {
+                        handleCastSkill(skill.key, skill.name, skill.mana, skill.level);
+                      }
+                    }}
+                  />
+                );
+              })}
+            </ActionPanel.Section>
+          )}
+          {unallocatedPoints > 0 && (
+            <ActionPanel.Section title={`Allocate Stat Point (${unallocatedPoints} left)`}>
+              {(["str", "con", "int", "per"] as const).map((stat) => (
+                <Action
+                  key={stat}
+                  title={`+1 ${STAT_LABELS[stat]}`}
+                  icon={Icon.Plus}
+                  onAction={() => handleAllocate(stat)}
+                />
+              ))}
+              <Action title="Auto-Allocate All" icon={Icon.Stars} onAction={handleAllocateNow} />
+            </ActionPanel.Section>
+          )}
           {quest?.key && (
             <ActionPanel.Section title="Quest Actions">
               {!quest.active && (
@@ -136,6 +252,92 @@ export default function Command() {
       }
     />
   );
+
+  async function handleCastSkill(spellId: string, name: string, mana: number, level: number) {
+    if (userLevel < level) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Level too low",
+        message: `${name} unlocks at level ${level}`,
+      });
+      return;
+    }
+    if (userMp < mana) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Not enough mana",
+        message: `Needs ${mana} MP — have ${userMp.toFixed(1)}`,
+      });
+      return;
+    }
+    try {
+      await showToast({ style: Toast.Style.Animated, title: `Casting ${name}…` });
+      await castSpell(spellId);
+      await showToast({ style: Toast.Style.Success, title: `Cast ${name}` });
+      await fetchData();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Cast failed", message: String(error) });
+    }
+  }
+
+  async function handleAllocate(stat: "str" | "con" | "int" | "per") {
+    try {
+      await showToast({ style: Toast.Style.Animated, title: `Allocating to ${STAT_LABELS[stat]}…` });
+      await allocateStat(stat);
+      await showToast({ style: Toast.Style.Success, title: "Stat allocated" });
+      await fetchData();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Failed", message: String(error) });
+    }
+  }
+
+  async function handleAllocateNow() {
+    const confirmed = await confirmAlert({
+      title: "Auto-Allocate All Points",
+      message: "Spend all unallocated stat points using your chosen automatic strategy?",
+      primaryAction: { title: "Allocate" },
+    });
+    if (!confirmed) return;
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Allocating…" });
+      await allocateNow();
+      await showToast({ style: Toast.Style.Success, title: "Stats allocated" });
+      await fetchData();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Failed", message: String(error) });
+    }
+  }
+
+  async function handleToggleSleep() {
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Toggling tavern…" });
+      await toggleSleep();
+      await showToast({
+        style: Toast.Style.Success,
+        title: isSleeping ? "Woke up" : "Resting in the tavern",
+      });
+      await fetchData();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Failed", message: String(error) });
+    }
+  }
+
+  async function handleRevive() {
+    const confirmed = await confirmAlert({
+      title: "Revive Character",
+      message: "Revive your character? You lose a level and a piece of equipment.",
+      primaryAction: { title: "Revive", style: Alert.ActionStyle.Destructive },
+    });
+    if (!confirmed) return;
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Reviving…" });
+      await reviveUser();
+      await showToast({ style: Toast.Style.Success, title: "Revived" });
+      await fetchData();
+    } catch (error) {
+      await showToast({ style: Toast.Style.Failure, title: "Failed", message: String(error) });
+    }
+  }
 
   async function handleQuestAction(action: "accept" | "abort" | "force-complete") {
     if (action === "abort") {

--- a/extensions/habitica-todos/src/view-shop.tsx
+++ b/extensions/habitica-todos/src/view-shop.tsx
@@ -336,7 +336,7 @@ export default function Command() {
                       />
                       <Action.OpenInBrowser
                         title="Open Habitica Equipment"
-                        url="https://habitica.com/shops/market"
+                        url="https://habitica.com/inventory/equipment"
                         shortcut={{ modifiers: ["cmd"], key: "o" }}
                       />
                     </ActionPanel>

--- a/extensions/habitica-todos/src/view-shop.tsx
+++ b/extensions/habitica-todos/src/view-shop.tsx
@@ -269,6 +269,16 @@ export default function Command() {
       isShowingDetail
       searchBarAccessory={filterDropdown}
     >
+      {!showMarket && !showGear && !showRewards && !isLoading && (
+        <List.EmptyView
+          title="Nothing to show"
+          description={
+            filter === "affordable"
+              ? "You don't have enough gold for anything in the shop right now."
+              : "No items match this filter."
+          }
+        />
+      )}
       {showMarket && (
         <List.Section title="Market" subtitle={goldLabel}>
           {filteredItems
@@ -283,7 +293,17 @@ export default function Command() {
                 actions={
                   <ActionPanel>
                     <Action title="Buy Item" icon={Icon.Cart} onAction={() => handleBuy(item)} />
-                    <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={fetchData} />
+                    <Action
+                      title="Refresh"
+                      icon={Icon.ArrowClockwise}
+                      shortcut={{ modifiers: ["cmd"], key: "r" }}
+                      onAction={fetchData}
+                    />
+                    <Action.OpenInBrowser
+                      title="Open Habitica Market"
+                      url="https://habitica.com/shops/market"
+                      shortcut={{ modifiers: ["cmd"], key: "o" }}
+                    />
                   </ActionPanel>
                 }
               />
@@ -308,7 +328,17 @@ export default function Command() {
                   actions={
                     <ActionPanel>
                       <Action title="Buy Gear" icon={Icon.Cart} onAction={() => handleBuy(item)} />
-                      <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={fetchData} />
+                      <Action
+                        title="Refresh"
+                        icon={Icon.ArrowClockwise}
+                        shortcut={{ modifiers: ["cmd"], key: "r" }}
+                        onAction={fetchData}
+                      />
+                      <Action.OpenInBrowser
+                        title="Open Habitica Equipment"
+                        url="https://habitica.com/shops/market"
+                        shortcut={{ modifiers: ["cmd"], key: "o" }}
+                      />
                     </ActionPanel>
                   }
                 />
@@ -331,7 +361,17 @@ export default function Command() {
                 actions={
                   <ActionPanel>
                     <Action title="Buy Reward" icon={Icon.Cart} onAction={() => handleBuy(item)} />
-                    <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={fetchData} />
+                    <Action
+                      title="Refresh"
+                      icon={Icon.ArrowClockwise}
+                      shortcut={{ modifiers: ["cmd"], key: "r" }}
+                      onAction={fetchData}
+                    />
+                    <Action.OpenInBrowser
+                      title="Open Habitica"
+                      url="https://habitica.com/"
+                      shortcut={{ modifiers: ["cmd"], key: "o" }}
+                    />
                   </ActionPanel>
                 }
               />


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->
- Add checklist (sub-task) support to To-Dos and Dailies — add, score, edit, delete items, with progress accessory
- Make inventory items usable: hatch eggs with potions, feed pets, equip pets/mounts, sell eggs/potions/food
- Add Pets and Mounts categories to the inventory grid with equip/unequip actions
- Open mystery items directly from the inventory grid when any are pending
- Add class skills to View Profile with proper level/mana gating and task targeting for damage skills
- Add tavern rest/wake toggle, revive when dead, and stat point allocation to View Profile
- Add task attribute selection (STR/INT/PER/CON) on create and edit forms
- Edit a task's tags inline; clear all completed To-Dos in one action
- Fix a timezone bug that displayed due dates as the previous day for users west of UTC
- Cleaner API error toasts (parse the JSON message body) and Today/Tomorrow date labels

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
