### PR TITLE
(zen) :bug: migrate workspace storage from SQLite to zen-sessions.jsonlz4

### DIFF
--- a/extensions/zen-browser/CHANGELOG.md
+++ b/extensions/zen-browser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zen Changelog
 
-## [Fix Open Workspace Command for Recent Zen Versions] - {PR_MERGE_DATE}
+## [Fix Open Workspace Command for Recent Zen Versions] - 2026-06-05
 
 - Fixed the **Open Workspace** command crashing with `no such table: zen_workspaces`. Zen Browser migrated workspace storage from the `zen_workspaces` SQLite table in `places.sqlite` to a dedicated `zen-sessions.jsonlz4` file (see [zen-browser/desktop#6469](https://github.com/zen-browser/desktop/pull/6469)). The extension now reads workspace data directly from `zen-sessions.jsonlz4` using a pure-TypeScript mozLz40/LZ4 decompressor — no new runtime dependencies required.
 

--- a/extensions/zen-browser/CHANGELOG.md
+++ b/extensions/zen-browser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zen Changelog
 
+## [Fix Open Workspace Command for Recent Zen Versions] - {PR_MERGE_DATE}
+
+- Fixed the **Open Workspace** command crashing with `no such table: zen_workspaces`. Zen Browser migrated workspace storage from the `zen_workspaces` SQLite table in `places.sqlite` to a dedicated `zen-sessions.jsonlz4` file (see [zen-browser/desktop#6469](https://github.com/zen-browser/desktop/pull/6469)). The extension now reads workspace data directly from `zen-sessions.jsonlz4` using a pure-TypeScript mozLz40/LZ4 decompressor — no new runtime dependencies required.
+
 ## [Fix Bookmark and History Search When Zen Is Running] - {PR-MERGE-DATE}
 
 - Bumped `@raycast/utils` from `^2.2.0` to `^2.2.3` to pick up the fix for `useSQL` not falling back to a DB copy when `node:sqlite` reports `errcode: 5` ("database is locked"). Previously, searching bookmarks or history while Zen was running surfaced "Cannot query the data — database is locked" because the lock detector only matched error message text containing `(5)`/`(14)`, which the native `node:sqlite` path does not produce.

--- a/extensions/zen-browser/package.json
+++ b/extensions/zen-browser/package.json
@@ -18,7 +18,8 @@
     "Zheckan",
     "Diwanshumidha",
     "vmrjnvc",
-    "gareth_price"
+    "gareth_price",
+    "CaffeineCat"
   ],
   "categories": [
     "Applications",

--- a/extensions/zen-browser/src/hooks/useWorkspaces.tsx
+++ b/extensions/zen-browser/src/hooks/useWorkspaces.tsx
@@ -15,7 +15,7 @@ export const useWorkspaces = () => {
 
   const workspaceEntries = workspaces
     .map((ws) => {
-      const sc = shortcuts.find((s) => s.id === `zen-workspace-switch-${ws.position / 1000}`);
+      const sc = shortcuts.find((s) => s.id === `zen-workspace-switch-${ws.position / 1000 + 1}`);
 
       return {
         ...ws,

--- a/extensions/zen-browser/src/hooks/useWorkspaces.tsx
+++ b/extensions/zen-browser/src/hooks/useWorkspaces.tsx
@@ -1,17 +1,14 @@
-import { useSQL } from "@raycast/utils";
 import { existsSync } from "fs";
 import { ReactElement } from "react";
-import { NotInstalledError } from "../components";
-import { WorkspaceModel } from "../interfaces";
-import { getPlacesDbPath } from "../util";
-import { useRetrySQLError } from "./useRetrySQLError";
+import { NotInstalledError, UnknownError } from "../components";
+import { getZenSessionsPath, readZenWorkspacesFromSession } from "../util";
 import { useShortcuts } from "./useShortcuts";
 
 export const useWorkspaces = () => {
   const { shortcuts, errorView: shortcutsErrorView } = useShortcuts();
-  const { data: workspaces, isLoading, permissionView } = useListWorkspaces();
+  const { data: workspaces, isLoading, errorView: listErrorView } = useListWorkspaces();
 
-  const errorView = shortcutsErrorView || permissionView;
+  const errorView = shortcutsErrorView || listErrorView;
   if (!workspaces) {
     return { data: workspaces, isLoading, errorView: errorView as ReactElement };
   }
@@ -31,21 +28,17 @@ export const useWorkspaces = () => {
 };
 
 export const useListWorkspaces = () => {
-  const dbPath = getPlacesDbPath();
-  const inQuery = getAllWorkspacesQuery();
+  const sessionPath = getZenSessionsPath();
 
-  if (!existsSync(dbPath)) {
-    return { data: [], isLoading: false, permissionView: <NotInstalledError /> };
+  if (!existsSync(sessionPath)) {
+    return { data: undefined, isLoading: false, errorView: <NotInstalledError /> };
   }
 
-  const { data, isLoading, error, permissionView, revalidate } = useSQL<WorkspaceModel>(dbPath, inQuery);
-  useRetrySQLError({ error, onRetry: revalidate });
-
-  return { data, isLoading, permissionView: permissionView as ReactElement };
-};
-
-const getAllWorkspacesQuery = () => {
-  return `
-  SELECT * FROM zen_workspaces;
-  `;
+  try {
+    const data = readZenWorkspacesFromSession();
+    return { data, isLoading: false, errorView: undefined };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { data: undefined, isLoading: false, errorView: <UnknownError message={message} /> };
+  }
 };

--- a/extensions/zen-browser/src/interfaces/index.ts
+++ b/extensions/zen-browser/src/interfaces/index.ts
@@ -66,4 +66,11 @@ export interface WorkspaceModel {
   is_default: boolean;
 }
 
+export interface SessionSpace {
+  uuid: string;
+  name: string;
+  icon?: string;
+  position?: number;
+}
+
 export type GroupedEntries = Map<string, HistoryEntry[]>;

--- a/extensions/zen-browser/src/util/index.ts
+++ b/extensions/zen-browser/src/util/index.ts
@@ -144,52 +144,9 @@ export const getZenSessionsPath = (): string => {
   return path.join(userDirectoryPath, getProfileName(userDirectoryPath), "zen-sessions.jsonlz4");
 };
 
-// Mozilla's mozLz40 format: 8-byte magic + 4-byte uncompressed size (LE) + LZ4 block data
-const MOZ_LZ4_MAGIC = Buffer.from([0x6d, 0x6f, 0x7a, 0x4c, 0x7a, 0x34, 0x30, 0x00]);
-
-function decompressMozLz4(data: Buffer): string {
-  if (!data.subarray(0, 8).equals(MOZ_LZ4_MAGIC)) {
-    throw new Error("Not a valid mozLz40 file");
-  }
-  const originalSize = data.readUInt32LE(8);
-  const output = Buffer.alloc(originalSize);
-  let sPos = 12;
-  let dPos = 0;
-  while (sPos < data.length) {
-    const token = data[sPos++];
-    let litLen = (token >>> 4) & 0xf;
-    if (litLen === 15) {
-      let extra: number;
-      do {
-        extra = data[sPos++];
-        litLen += extra;
-      } while (extra === 255);
-    }
-    data.copy(output, dPos, sPos, sPos + litLen);
-    dPos += litLen;
-    sPos += litLen;
-    if (sPos >= data.length) break;
-    const offset = data.readUInt16LE(sPos);
-    sPos += 2;
-    let matchLen = (token & 0xf) + 4;
-    if ((token & 0xf) === 15) {
-      let extra: number;
-      do {
-        extra = data[sPos++];
-        matchLen += extra;
-      } while (extra === 255);
-    }
-    let matchPos = dPos - offset;
-    for (let i = 0; i < matchLen; i++) {
-      output[dPos++] = output[matchPos++];
-    }
-  }
-  return output.toString("utf8");
-}
-
 export const readZenWorkspacesFromSession = (): WorkspaceModel[] => {
   const raw = fs.readFileSync(getZenSessionsPath());
-  const session: { spaces?: SessionSpace[] } = JSON.parse(decompressMozLz4(raw));
+  const session: { spaces?: SessionSpace[] } = decodeLZ4(raw);
   return (session.spaces ?? []).map((space, index) => ({
     uuid: space.uuid,
     name: space.name,

--- a/extensions/zen-browser/src/util/index.ts
+++ b/extensions/zen-browser/src/util/index.ts
@@ -1,6 +1,6 @@
 import { getPreferenceValues } from "@raycast/api";
 import { executeSQL } from "@raycast/utils";
-import { HistoryEntry } from "../interfaces";
+import { HistoryEntry, WorkspaceModel, SessionSpace } from "../interfaces";
 import fs from "fs";
 import path from "path";
 
@@ -137,6 +137,66 @@ export const getSessionManagerExtensionPath = (extensionId: string) => {
 export const getSessionInactivePath = async () => {
   const userDirectoryPath = userDataDirectoryPath();
   return path.join(userDirectoryPath, getProfileName(userDirectoryPath), "sessionstore.jsonlz4");
+};
+
+export const getZenSessionsPath = (): string => {
+  const userDirectoryPath = userDataDirectoryPath();
+  return path.join(userDirectoryPath, getProfileName(userDirectoryPath), "zen-sessions.jsonlz4");
+};
+
+// Mozilla's mozLz40 format: 8-byte magic + 4-byte uncompressed size (LE) + LZ4 block data
+const MOZ_LZ4_MAGIC = Buffer.from([0x6d, 0x6f, 0x7a, 0x4c, 0x7a, 0x34, 0x30, 0x00]);
+
+function decompressMozLz4(data: Buffer): string {
+  if (!data.subarray(0, 8).equals(MOZ_LZ4_MAGIC)) {
+    throw new Error("Not a valid mozLz40 file");
+  }
+  const originalSize = data.readUInt32LE(8);
+  const output = Buffer.alloc(originalSize);
+  let sPos = 12;
+  let dPos = 0;
+  while (sPos < data.length) {
+    const token = data[sPos++];
+    let litLen = (token >>> 4) & 0xf;
+    if (litLen === 15) {
+      let extra: number;
+      do {
+        extra = data[sPos++];
+        litLen += extra;
+      } while (extra === 255);
+    }
+    data.copy(output, dPos, sPos, sPos + litLen);
+    dPos += litLen;
+    sPos += litLen;
+    if (sPos >= data.length) break;
+    const offset = data.readUInt16LE(sPos);
+    sPos += 2;
+    let matchLen = (token & 0xf) + 4;
+    if ((token & 0xf) === 15) {
+      let extra: number;
+      do {
+        extra = data[sPos++];
+        matchLen += extra;
+      } while (extra === 255);
+    }
+    let matchPos = dPos - offset;
+    for (let i = 0; i < matchLen; i++) {
+      output[dPos++] = output[matchPos++];
+    }
+  }
+  return output.toString("utf8");
+}
+
+export const readZenWorkspacesFromSession = (): WorkspaceModel[] => {
+  const raw = fs.readFileSync(getZenSessionsPath());
+  const session: { spaces?: SessionSpace[] } = JSON.parse(decompressMozLz4(raw));
+  return (session.spaces ?? []).map((space, index) => ({
+    uuid: space.uuid,
+    name: space.name,
+    icon: space.icon ?? "",
+    position: space.position ?? index * 1000,
+    is_default: index === 0,
+  }));
 };
 
 export const getSessionActivePath = async () => {


### PR DESCRIPTION
## Description

### Summary

Zen Browser removed the `zen_workspaces` table from `places.sqlite` in favor of storing workspace data in a dedicated `zen-sessions.jsonlz4` file (see upstream changes in [zen-browser/desktop#6469](https://github.com/zen-browser/desktop/pull/6469) and related session refactor commits). This caused the **Open Workspace** command to crash with `no such table: zen_workspaces`.

### Changes

- **`src/hooks/useWorkspaces.tsx`**: Replaced `useSQL` / `executeSQL` approach with synchronous file-based read from `zen-sessions.jsonlz4`; added file-existence check that falls back to `NotInstalledError` when the file is missing
- **`src/util/index.ts`**:
  - Added `getZenSessionsPath()` to resolve the `zen-sessions.jsonlz4` path under the active profile directory
  - Implemented `decompressMozLz4()` — a pure-TypeScript LZ4 block decompressor that handles Mozilla's `mozLz40\0` container format (8-byte magic + 4-byte LE uncompressed size + LZ4 block payload) — no new runtime dependencies required
  - Added `readZenWorkspacesFromSession()` to parse the decompressed JSON and map `spaces[]` entries to `WorkspaceModel`
- **`src/interfaces/index.ts`**: Added `SessionSpace` interface representing a workspace entry as stored in `zen-sessions.jsonlz4`

### References

- Zen Browser session storage migration: https://github.com/zen-browser/desktop/issues/6469
- mozLz40 file format: https://github.com/nicowillis/mozlz4

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

Before:
<img width="777" height="493" alt="image" src="https://github.com/user-attachments/assets/8410c081-8f0b-49af-85c8-aeda1281d5cc" />
After:
<img width="815" height="554" alt="image" src="https://github.com/user-attachments/assets/605ffc1d-e2cc-4ae9-991a-7664a7216e19" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
