### PR TITLE
[Downloads Manager] Add "Copy Path" action to Manage Downloads

### DIFF
--- a/extensions/downloads-manager/CHANGELOG.md
+++ b/extensions/downloads-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Downloads Manager Changelog
 
-## [Add Copy Path action] - {PR_MERGE_DATE}
+## [Add Copy Path action] - 2026-05-18
 
 - Added a "Copy Path" action to the Manage Downloads command that copies the focused download's absolute path as text (shortcut: `⌘⇧.` on macOS, `Ctrl+Shift+.` on Windows).
 

--- a/extensions/downloads-manager/CHANGELOG.md
+++ b/extensions/downloads-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Downloads Manager Changelog
 
+## [Add Copy Path action] - {PR_MERGE_DATE}
+
+- Added a "Copy Path" action to the Manage Downloads command that copies the focused download's absolute path as text (shortcut: `⌘⇧.` on macOS, `Ctrl+Shift+.` on Windows).
+
 ## [Upgrade Delete Latest Download Command] - 2026-04-27
 
 - Address [#26296](https://github.com/raycast/extensions/issues/26296) by upgrading Delete Latest Download Command to support background deeplinks without focusing Raycast.

--- a/extensions/downloads-manager/src/manage-downloads.tsx
+++ b/extensions/downloads-manager/src/manage-downloads.tsx
@@ -213,6 +213,11 @@ function Command({ currentFolderPath = downloadsFolder }: { currentFolderPath?: 
           content={{ file: download.path }}
           shortcut={Keyboard.Shortcut.Common.Copy}
         />
+        <Action.CopyToClipboard
+          title="Copy Path"
+          content={download.path}
+          shortcut={{ macOS: { modifiers: ["cmd", "shift"], key: "." }, Windows: { modifiers: ["ctrl", "shift"], key: "." } }}
+        />
         <Action
           title="Reload Downloads"
           icon={Icon.RotateAntiClockwise}

--- a/extensions/downloads-manager/src/manage-downloads.tsx
+++ b/extensions/downloads-manager/src/manage-downloads.tsx
@@ -216,7 +216,10 @@ function Command({ currentFolderPath = downloadsFolder }: { currentFolderPath?: 
         <Action.CopyToClipboard
           title="Copy Path"
           content={download.path}
-          shortcut={{ macOS: { modifiers: ["cmd", "shift"], key: "." }, Windows: { modifiers: ["ctrl", "shift"], key: "." } }}
+          shortcut={{
+            macOS: { modifiers: ["cmd", "shift"], key: "." },
+            Windows: { modifiers: ["ctrl", "shift"], key: "." },
+          }}
         />
         <Action
           title="Reload Downloads"


### PR DESCRIPTION
## Summary
Adds a "Copy Path" action to the Manage Downloads command. It copies the focused download's absolute path as plain text, separate from the existing "Copy File" action (which puts the file itself on the clipboard).

Shortcut: `⌘⇧.` on macOS, `Ctrl+Shift+.` on Windows.

Resolves #28048

## Screencast / Screenshots
_n/a — text-only action change_

## Test plan
- [ ] Focus a file in Manage Downloads, run "Copy Path" → clipboard contains the absolute path as a string
- [ ] Focus a folder, run "Copy Path" → clipboard contains the folder path
- [ ] `⌘⇧.` triggers the action
- [ ] Existing "Copy File" still copies the file itself (regression check)