### PR TITLE
Buildkite: Build graph view and unblock steps

### DIFF
--- a/extensions/buildkite/CHANGELOG.md
+++ b/extensions/buildkite/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Buildkite Changelog
 
-## [Build Graph & Unblock Steps] - {PR_MERGE_DATE}
+## [Build Graph & Unblock Steps] - 2026-05-22
 
 - Added a "Show Build Graph" action on each build that renders the build's steps grouped by dependency stage, with state icons and step dependencies.
 - Added an "Unblock Step" action for blocked manual steps so pipelines can be unblocked without leaving Raycast.

--- a/extensions/buildkite/CHANGELOG.md
+++ b/extensions/buildkite/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Buildkite Changelog
 
+## [Build Graph & Unblock Steps] - {PR_MERGE_DATE}
+
+- Added a "Show Build Graph" action on each build that renders the build's steps grouped by dependency stage, with state icons and step dependencies.
+- Added an "Unblock Step" action for blocked manual steps so pipelines can be unblocked without leaving Raycast.
+- Added an "Unblock All Steps" action (⌘⇧U) that iterates and unblocks every blocked step in the build.
+
 ## [Fix potentially undefined data] - 2023-12-12
 
 - Fixes GraphQL data that is potentially undefined

--- a/extensions/buildkite/CHANGELOG.md
+++ b/extensions/buildkite/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added a "Show Build Graph" action on each build that renders the build's steps grouped by dependency stage, with state icons and step dependencies.
 - Added an "Unblock Step" action for blocked manual steps so pipelines can be unblocked without leaving Raycast.
 - Added an "Unblock All Steps" action (⌘⇧U) that iterates and unblocks every blocked step in the build.
+- Added a ⌘⇧G keyboard shortcut to "Show Build Graph".
 
 ## [Fix potentially undefined data] - 2023-12-12
 

--- a/extensions/buildkite/package.json
+++ b/extensions/buildkite/package.json
@@ -78,5 +78,8 @@
     "dev": "concurrently \"ray develop\" \"npm run generate -- --watch\"",
     "lint": "ray lint",
     "generate": "graphql-codegen --config codegen.ts"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/buildkite/src/buildkite.graphql
+++ b/extensions/buildkite/src/buildkite.graphql
@@ -1,5 +1,6 @@
 fragment Build on Build {
   id
+  uuid
   branch
   createdAt
   message
@@ -8,6 +9,93 @@ fragment Build on Build {
   url
   pipeline {
     name
+    slug
+  }
+}
+
+fragment JobStep on Step {
+  key
+  dependencies(first: 100) {
+    edges {
+      node {
+        key
+      }
+    }
+  }
+}
+
+fragment BuildJob on JobInterface {
+  __typename
+  ... on JobTypeCommand {
+    id
+    uuid
+    label
+    state
+    url
+    step {
+      ...JobStep
+    }
+  }
+  ... on JobTypeBlock {
+    id
+    uuid
+    label
+    state
+    isUnblockable
+    step {
+      ...JobStep
+    }
+  }
+  ... on JobTypeWait {
+    id
+    uuid
+    label
+    state
+    step {
+      ...JobStep
+    }
+  }
+  ... on JobTypeTrigger {
+    id
+    uuid
+    label
+    state
+    step {
+      ...JobStep
+    }
+  }
+}
+
+query getBuild($uuid: ID!) {
+  build(uuid: $uuid) {
+    id
+    uuid
+    number
+    state
+    message
+    branch
+    url
+    createdAt
+    pipeline {
+      name
+      slug
+    }
+    jobs(first: 100) {
+      edges {
+        node {
+          ...BuildJob
+        }
+      }
+    }
+  }
+}
+
+mutation unblockJob($id: ID!) {
+  jobTypeBlockUnblock(input: { id: $id }) {
+    jobTypeBlock {
+      id
+      state
+    }
   }
 }
 

--- a/extensions/buildkite/src/buildkite.graphql
+++ b/extensions/buildkite/src/buildkite.graphql
@@ -81,6 +81,10 @@ query getBuild($uuid: ID!) {
       slug
     }
     jobs(first: 100) {
+      count
+      pageInfo {
+        hasNextPage
+      }
       edges {
         node {
           ...BuildJob

--- a/extensions/buildkite/src/components/BuildDetails.tsx
+++ b/extensions/buildkite/src/components/BuildDetails.tsx
@@ -3,7 +3,7 @@ import { useCachedPromise } from "@raycast/utils";
 import { useMemo } from "react";
 import { getBuildkiteClient } from "../api/withBuildkiteClient";
 import { BuildFragment, BuildJobFragment } from "../generated/graphql";
-import { getJobStateGlyph, getJobStateIcon } from "../utils/states";
+import { getJobStateIcon } from "../utils/states";
 import { truthy } from "../utils/truthy";
 
 type JobNode = BuildJobFragment;
@@ -32,8 +32,6 @@ function jobDeps(job: JobNode): string[] {
 interface Derived {
   jobs: JobNode[];
   byLevel: Map<number, JobNode[]>;
-  baseGraphLines: string[];
-  lineIndexById: Map<string, number>;
   blockedJobs: { id: string; label: string }[];
 }
 
@@ -76,38 +74,12 @@ function deriveFromJobs(rawJobs: JobNode[]): Derived {
     if (bucket) bucket.push(job);
     else byLevel.set(d, [job]);
   }
-  const levels = Array.from(byLevel.keys()).sort((a, b) => a - b);
-  const maxLevel = levels.length ? levels[levels.length - 1] : 0;
-
-  const baseGraphLines: string[] = ["```", "Pipeline graph", ""];
-  const lineIndexById = new Map<string, number>();
-  for (const level of levels) {
-    const levelJobs = byLevel.get(level)!;
-    baseGraphLines.push(`Stage ${level + 1}`);
-    for (const job of levelJobs) {
-      const deps = jobDeps(job);
-      const depStr = deps.length ? `  ← ${deps.join(", ")}` : "";
-      lineIndexById.set(job.id, baseGraphLines.length);
-      baseGraphLines.push(`  ${getJobStateGlyph(job.state)} ${jobLabel(job)}${depStr}`);
-    }
-    if (level < maxLevel) baseGraphLines.push("  │");
-  }
-  baseGraphLines.push("```");
-
   const blockedJobs = jobs
     .filter((j): j is Extract<JobNode, { __typename: "JobTypeBlock" }> => j.__typename === "JobTypeBlock")
     .filter((j) => j.state === "BLOCKED" && j.isUnblockable !== false)
     .map((j) => ({ id: j.id, label: jobLabel(j) }));
 
-  return { jobs, byLevel, baseGraphLines, lineIndexById, blockedJobs };
-}
-
-function graphForJob(derived: Derived, highlightId: string): string {
-  const idx = derived.lineIndexById.get(highlightId);
-  if (idx === undefined) return derived.baseGraphLines.join("\n");
-  const lines = derived.baseGraphLines.slice();
-  lines[idx] = lines[idx].replace(/^ {2}/, "▶ ");
-  return lines.join("\n");
+  return { jobs, byLevel, blockedJobs };
 }
 
 export function BuildDetails({ build }: BuildDetailsProps) {
@@ -231,7 +203,6 @@ export function BuildDetails({ build }: BuildDetailsProps) {
                   ]}
                   detail={
                     <List.Item.Detail
-                      markdown={graphForJob(derived, job.id)}
                       metadata={
                         <List.Item.Detail.Metadata>
                           <List.Item.Detail.Metadata.Label title="Label" text={label} />

--- a/extensions/buildkite/src/components/BuildDetails.tsx
+++ b/extensions/buildkite/src/components/BuildDetails.tsx
@@ -1,0 +1,267 @@
+import { Action, ActionPanel, Alert, confirmAlert, Icon, List, showToast, Toast } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { useMemo } from "react";
+import { getBuildkiteClient } from "../api/withBuildkiteClient";
+import { BuildFragment, BuildJobFragment } from "../generated/graphql";
+import { getJobStateGlyph, getJobStateIcon } from "../utils/states";
+import { truthy } from "../utils/truthy";
+
+type JobNode = BuildJobFragment;
+type JobTypename = JobNode["__typename"];
+
+const JOB_TYPE_LABEL: Record<JobTypename, string> = {
+  JobTypeCommand: "Command",
+  JobTypeBlock: "Block",
+  JobTypeWait: "Wait",
+  JobTypeTrigger: "Trigger",
+};
+
+interface BuildDetailsProps {
+  build: BuildFragment;
+}
+
+function jobLabel(job: JobNode): string {
+  return job.label?.trim() || job.step?.key || JOB_TYPE_LABEL[job.__typename].toLowerCase();
+}
+
+function jobDeps(job: JobNode): string[] {
+  const edges = job.step?.dependencies?.edges ?? [];
+  return edges.map((e) => e?.node?.key).filter(truthy);
+}
+
+interface Derived {
+  jobs: JobNode[];
+  byLevel: Map<number, JobNode[]>;
+  baseGraphLines: string[];
+  lineIndexById: Map<string, number>;
+  blockedJobs: { id: string; label: string }[];
+}
+
+function deriveFromJobs(rawJobs: JobNode[]): Derived {
+  const jobs = rawJobs;
+
+  // DAG keyed by step.key; keyless jobs can't be referenced as deps, so they
+  // anchor at depth 0. job.id is the unique identity used for rendering/highlight.
+  const byKey = new Map<string, JobNode>();
+  for (const job of jobs) {
+    const key = job.step?.key;
+    if (key) byKey.set(key, job);
+  }
+
+  const depths = new Map<string, number>();
+  const visiting = new Set<string>();
+  function depth(job: JobNode): number {
+    const id = job.id;
+    const cached = depths.get(id);
+    if (cached !== undefined) return cached;
+    if (visiting.has(id)) {
+      depths.set(id, 0);
+      return 0;
+    }
+    visiting.add(id);
+    const deps = jobDeps(job)
+      .map((k) => byKey.get(k))
+      .filter(truthy);
+    const d = deps.length === 0 ? 0 : 1 + Math.max(...deps.map(depth));
+    visiting.delete(id);
+    depths.set(id, d);
+    return d;
+  }
+  for (const job of jobs) depth(job);
+
+  const byLevel = new Map<number, JobNode[]>();
+  for (const job of jobs) {
+    const d = depths.get(job.id) ?? 0;
+    const bucket = byLevel.get(d);
+    if (bucket) bucket.push(job);
+    else byLevel.set(d, [job]);
+  }
+  const levels = Array.from(byLevel.keys()).sort((a, b) => a - b);
+  const maxLevel = levels.length ? levels[levels.length - 1] : 0;
+
+  const baseGraphLines: string[] = ["```", "Pipeline graph", ""];
+  const lineIndexById = new Map<string, number>();
+  for (const level of levels) {
+    const levelJobs = byLevel.get(level)!;
+    baseGraphLines.push(`Stage ${level + 1}`);
+    for (const job of levelJobs) {
+      const deps = jobDeps(job);
+      const depStr = deps.length ? `  ← ${deps.join(", ")}` : "";
+      lineIndexById.set(job.id, baseGraphLines.length);
+      baseGraphLines.push(`  ${getJobStateGlyph(job.state)} ${jobLabel(job)}${depStr}`);
+    }
+    if (level < maxLevel) baseGraphLines.push("  │");
+  }
+  baseGraphLines.push("```");
+
+  const blockedJobs = jobs
+    .filter((j): j is Extract<JobNode, { __typename: "JobTypeBlock" }> => j.__typename === "JobTypeBlock")
+    .filter((j) => j.state === "BLOCKED" && j.isUnblockable !== false)
+    .map((j) => ({ id: j.id, label: jobLabel(j) }));
+
+  return { jobs, byLevel, baseGraphLines, lineIndexById, blockedJobs };
+}
+
+function graphForJob(derived: Derived, highlightId: string): string {
+  const idx = derived.lineIndexById.get(highlightId);
+  if (idx === undefined) return derived.baseGraphLines.join("\n");
+  const lines = derived.baseGraphLines.slice();
+  lines[idx] = lines[idx].replace(/^ {2}/, "▶ ");
+  return lines.join("\n");
+}
+
+export function BuildDetails({ build }: BuildDetailsProps) {
+  const buildkite = getBuildkiteClient();
+  const { data, isLoading, revalidate } = useCachedPromise(
+    async (uuid: string) => {
+      const result = await buildkite.getBuild({ uuid });
+      return result.build;
+    },
+    [build.uuid],
+    { keepPreviousData: true },
+  );
+
+  const derived = useMemo<Derived>(() => {
+    const rawJobs = (data?.jobs?.edges ?? []).map((e) => e?.node).filter(truthy);
+    return deriveFromJobs(rawJobs);
+  }, [data]);
+
+  const pipelineName = build.pipeline?.name;
+  const title = pipelineName ? `${pipelineName} #${build.number}` : `Build #${build.number}`;
+  const buildLabel = pipelineName ? `${pipelineName} #${build.number}` : `build #${build.number}`;
+
+  async function unblock(jobId: string, label: string) {
+    const confirmed = await confirmAlert({
+      title: "Unblock step?",
+      message: label,
+      primaryAction: { title: "Unblock" },
+    });
+    if (!confirmed) return;
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Unblocking…", message: label });
+    try {
+      await buildkite.unblockJob({ id: jobId });
+      toast.style = Toast.Style.Success;
+      toast.title = "Unblocked";
+      revalidate();
+    } catch (err) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Failed to unblock step";
+      toast.message = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  async function unblockAll() {
+    const targets = derived.blockedJobs;
+    if (!targets.length) {
+      await showToast({ style: Toast.Style.Success, title: "No blocked steps" });
+      return;
+    }
+    const confirmed = await confirmAlert({
+      title: `Unblock ${targets.length} step${targets.length === 1 ? "" : "s"} on ${buildLabel}?`,
+      message: targets.map((t) => `• ${t.label}`).join("\n"),
+      primaryAction: { title: "Unblock All", style: Alert.ActionStyle.Destructive },
+    });
+    if (!confirmed) return;
+
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: `Unblocking ${targets.length} step${targets.length === 1 ? "" : "s"}…`,
+    });
+    const results = await Promise.allSettled(targets.map((t) => buildkite.unblockJob({ id: t.id })));
+    const failures = results
+      .map((r, i) => (r.status === "rejected" ? { label: targets[i].label, error: String(r.reason) } : null))
+      .filter(truthy);
+    const succeeded = targets.length - failures.length;
+    revalidate();
+    if (failures.length === 0) {
+      toast.style = Toast.Style.Success;
+      toast.title = `Unblocked ${succeeded} step${succeeded === 1 ? "" : "s"}`;
+      toast.message = undefined;
+    } else {
+      toast.style = Toast.Style.Failure;
+      toast.title = `Unblocked ${succeeded} / ${targets.length}, ${failures.length} failed`;
+      toast.message = failures.map((f) => `${f.label}: ${f.error}`).join("\n");
+    }
+  }
+
+  const hasBlocked = derived.blockedJobs.length > 0;
+
+  return (
+    <List isLoading={isLoading} navigationTitle={title} searchBarPlaceholder="Filter steps…" isShowingDetail>
+      {Array.from(derived.byLevel.entries())
+        .sort((a, b) => a[0] - b[0])
+        .map(([level, levelJobs]) => (
+          <List.Section
+            key={level}
+            title={`Stage ${level + 1}`}
+            subtitle={`${levelJobs.length} step${levelJobs.length === 1 ? "" : "s"}`}
+          >
+            {levelJobs.map((job) => {
+              const label = jobLabel(job);
+              const deps = jobDeps(job);
+              const typeLabel = JOB_TYPE_LABEL[job.__typename];
+              const canUnblock =
+                job.__typename === "JobTypeBlock" && job.state === "BLOCKED" && job.isUnblockable !== false;
+              const url = job.__typename === "JobTypeCommand" ? job.url : undefined;
+              return (
+                <List.Item
+                  key={job.id}
+                  title={label}
+                  icon={getJobStateIcon(job.state)}
+                  accessories={[
+                    { text: typeLabel.toLowerCase() },
+                    ...(deps.length ? [{ text: `← ${deps.join(", ")}` }] : []),
+                  ]}
+                  detail={
+                    <List.Item.Detail
+                      markdown={graphForJob(derived, job.id)}
+                      metadata={
+                        <List.Item.Detail.Metadata>
+                          <List.Item.Detail.Metadata.Label title="Label" text={label} />
+                          <List.Item.Detail.Metadata.Label title="Type" text={typeLabel} />
+                          <List.Item.Detail.Metadata.Label title="State" text={job.state} />
+                          {job.step?.key ? <List.Item.Detail.Metadata.Label title="Key" text={job.step.key} /> : null}
+                          {deps.length ? (
+                            <List.Item.Detail.Metadata.Label title="Depends on" text={deps.join(", ")} />
+                          ) : null}
+                          {url ? (
+                            <List.Item.Detail.Metadata.Link title="Job" target={url} text="Open in Buildkite" />
+                          ) : null}
+                        </List.Item.Detail.Metadata>
+                      }
+                    />
+                  }
+                  actions={
+                    <ActionPanel>
+                      {canUnblock ? (
+                        <Action title="Unblock Step" icon={Icon.LockUnlocked} onAction={() => unblock(job.id, label)} />
+                      ) : null}
+                      {url ? <Action.OpenInBrowser url={url} title="Open Job in Browser" /> : null}
+                      <Action.OpenInBrowser url={build.url} title="Open Build in Browser" />
+                      <Action
+                        title="Refresh"
+                        icon={Icon.ArrowClockwise}
+                        onAction={revalidate}
+                        shortcut={{ modifiers: ["cmd"], key: "r" }}
+                      />
+                      {hasBlocked ? (
+                        <ActionPanel.Section title="Danger Zone">
+                          <Action
+                            title={`Unblock All Steps (${derived.blockedJobs.length})`}
+                            icon={Icon.LockUnlocked}
+                            style={Action.Style.Destructive}
+                            shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
+                            onAction={unblockAll}
+                          />
+                        </ActionPanel.Section>
+                      ) : null}
+                    </ActionPanel>
+                  }
+                />
+              );
+            })}
+          </List.Section>
+        ))}
+    </List>
+  );
+}

--- a/extensions/buildkite/src/components/BuildDetails.tsx
+++ b/extensions/buildkite/src/components/BuildDetails.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Alert, confirmAlert, Icon, List, showToast, Toast } from "@raycast/api";
+import { Action, ActionPanel, Alert, Color, confirmAlert, Icon, List, showToast, Toast } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { useMemo } from "react";
 import { getBuildkiteClient } from "../api/withBuildkiteClient";
@@ -126,6 +126,9 @@ export function BuildDetails({ build }: BuildDetailsProps) {
     return deriveFromJobs(rawJobs);
   }, [data]);
 
+  const totalJobs = data?.jobs?.count ?? derived.jobs.length;
+  const truncated = data?.jobs?.pageInfo?.hasNextPage === true;
+
   const pipelineName = build.pipeline?.name;
   const title = pipelineName ? `${pipelineName} #${build.number}` : `Build #${build.number}`;
   const buildLabel = pipelineName ? `${pipelineName} #${build.number}` : `build #${build.number}`;
@@ -188,6 +191,20 @@ export function BuildDetails({ build }: BuildDetailsProps) {
 
   return (
     <List isLoading={isLoading} navigationTitle={title} searchBarPlaceholder="Filter steps…" isShowingDetail>
+      {truncated ? (
+        <List.Section title="Notice">
+          <List.Item
+            title={`Showing first ${derived.jobs.length} of ${totalJobs} steps`}
+            subtitle="Open this build in Buildkite to see the rest"
+            icon={{ source: Icon.ExclamationMark, tintColor: Color.Orange }}
+            actions={
+              <ActionPanel>
+                <Action.OpenInBrowser url={build.url} title="Open Build in Browser" />
+              </ActionPanel>
+            }
+          />
+        </List.Section>
+      ) : null}
       {Array.from(derived.byLevel.entries())
         .sort((a, b) => a[0] - b[0])
         .map(([level, levelJobs]) => (

--- a/extensions/buildkite/src/components/BuildListItem.tsx
+++ b/extensions/buildkite/src/components/BuildListItem.tsx
@@ -21,7 +21,12 @@ export function BuildListItem({ build }: BuildListItemProps) {
         <ActionPanel>
           <Action.OpenInBrowser url={build.url} />
           <Action.CopyToClipboard content={build.url} title="Copy URL" />
-          <Action.Push title="Show Build Graph" icon={Icon.AppWindowGrid3x3} target={<BuildDetails build={build} />} />
+          <Action.Push
+            title="Show Build Graph"
+            icon={Icon.AppWindowGrid3x3}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "g" }}
+            target={<BuildDetails build={build} />}
+          />
         </ActionPanel>
       }
     />

--- a/extensions/buildkite/src/components/BuildListItem.tsx
+++ b/extensions/buildkite/src/components/BuildListItem.tsx
@@ -1,7 +1,8 @@
-import { ActionPanel, List, Action } from "@raycast/api";
+import { ActionPanel, List, Action, Icon } from "@raycast/api";
 import { BuildFragment } from "../generated/graphql";
 import { timeAgo } from "../utils/format";
 import { getStateIcon } from "../utils/states";
+import { BuildDetails } from "./BuildDetails";
 
 interface BuildListItemProps {
   build: BuildFragment;
@@ -18,6 +19,7 @@ export function BuildListItem({ build }: BuildListItemProps) {
       accessories={[{ text: timeAgo(build.createdAt) }]}
       actions={
         <ActionPanel>
+          <Action.Push title="Show Build Graph" icon={Icon.AppWindowGrid3x3} target={<BuildDetails build={build} />} />
           <Action.OpenInBrowser url={build.url} />
           <Action.CopyToClipboard content={build.url} title="Copy URL" />
         </ActionPanel>

--- a/extensions/buildkite/src/components/BuildListItem.tsx
+++ b/extensions/buildkite/src/components/BuildListItem.tsx
@@ -19,9 +19,9 @@ export function BuildListItem({ build }: BuildListItemProps) {
       accessories={[{ text: timeAgo(build.createdAt) }]}
       actions={
         <ActionPanel>
-          <Action.Push title="Show Build Graph" icon={Icon.AppWindowGrid3x3} target={<BuildDetails build={build} />} />
           <Action.OpenInBrowser url={build.url} />
           <Action.CopyToClipboard content={build.url} title="Copy URL" />
+          <Action.Push title="Show Build Graph" icon={Icon.AppWindowGrid3x3} target={<BuildDetails build={build} />} />
         </ActionPanel>
       }
     />

--- a/extensions/buildkite/src/generated/graphql.ts
+++ b/extensions/buildkite/src/generated/graphql.ts
@@ -6157,7 +6157,7 @@ export type GetBuildQueryVariables = Exact<{
 }>;
 
 
-export type GetBuildQuery = { build: { id: string, uuid: string, number: number, state: BuildStates, message: string | null, branch: string, url: string, createdAt: any | null, pipeline: { name: string, slug: string }, jobs: { edges: Array<{ node: { __typename: 'JobTypeBlock', id: string, uuid: string, label: string | null, state: JobStates, isUnblockable: boolean | null, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null } | { __typename: 'JobTypeCommand', id: string, uuid: string, label: string | null, state: JobStates, url: string, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null } | { __typename: 'JobTypeTrigger', id: string, uuid: string, label: string | null, state: JobStates, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null } | { __typename: 'JobTypeWait', id: string, uuid: string, label: string | null, state: JobStates, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null } | null } | null> | null } | null } | null };
+export type GetBuildQuery = { build: { id: string, uuid: string, number: number, state: BuildStates, message: string | null, branch: string, url: string, createdAt: any | null, pipeline: { name: string, slug: string }, jobs: { count: number, pageInfo: { hasNextPage: boolean } | null, edges: Array<{ node: { __typename: 'JobTypeBlock', id: string, uuid: string, label: string | null, state: JobStates, isUnblockable: boolean | null, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null } | { __typename: 'JobTypeCommand', id: string, uuid: string, label: string | null, state: JobStates, url: string, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null } | { __typename: 'JobTypeTrigger', id: string, uuid: string, label: string | null, state: JobStates, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null } | { __typename: 'JobTypeWait', id: string, uuid: string, label: string | null, state: JobStates, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null } | null } | null> | null } | null } | null };
 
 export type UnblockJobMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -6291,6 +6291,10 @@ export const GetBuildDocument = gql`
       slug
     }
     jobs(first: 100) {
+      count
+      pageInfo {
+        hasNextPage
+      }
       edges {
         node {
           ...BuildJob

--- a/extensions/buildkite/src/generated/graphql.ts
+++ b/extensions/buildkite/src/generated/graphql.ts
@@ -1,5 +1,4 @@
-import { GraphQLClient } from 'graphql-request';
-import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
+import { GraphQLClient, RequestOptions } from 'graphql-request';
 import gql from 'graphql-tag';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
@@ -8,6 +7,7 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: 
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: { input: string; output: string; }
@@ -6130,19 +6130,53 @@ export type ViewerPermissions = {
   totpConfigure: Permission;
 };
 
-export type BuildFragment = { id: string, branch: string, createdAt: any | null, message: string | null, number: number, state: BuildStates, url: string, pipeline: { name: string } };
+export type BuildFragment = { id: string, uuid: string, branch: string, createdAt: any | null, message: string | null, number: number, state: BuildStates, url: string, pipeline: { name: string, slug: string } };
+
+type JobStep_StepCommand_Fragment = { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null };
+
+type JobStep_StepInput_Fragment = { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null };
+
+type JobStep_StepTrigger_Fragment = { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null };
+
+type JobStep_StepWait_Fragment = { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null };
+
+export type JobStepFragment = JobStep_StepCommand_Fragment | JobStep_StepInput_Fragment | JobStep_StepTrigger_Fragment | JobStep_StepWait_Fragment;
+
+type BuildJob_JobTypeBlock_Fragment = { __typename: 'JobTypeBlock', id: string, uuid: string, label: string | null, state: JobStates, isUnblockable: boolean | null, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null };
+
+type BuildJob_JobTypeCommand_Fragment = { __typename: 'JobTypeCommand', id: string, uuid: string, label: string | null, state: JobStates, url: string, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null };
+
+type BuildJob_JobTypeTrigger_Fragment = { __typename: 'JobTypeTrigger', id: string, uuid: string, label: string | null, state: JobStates, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null };
+
+type BuildJob_JobTypeWait_Fragment = { __typename: 'JobTypeWait', id: string, uuid: string, label: string | null, state: JobStates, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null };
+
+export type BuildJobFragment = BuildJob_JobTypeBlock_Fragment | BuildJob_JobTypeCommand_Fragment | BuildJob_JobTypeTrigger_Fragment | BuildJob_JobTypeWait_Fragment;
+
+export type GetBuildQueryVariables = Exact<{
+  uuid: Scalars['ID']['input'];
+}>;
+
+
+export type GetBuildQuery = { build: { id: string, uuid: string, number: number, state: BuildStates, message: string | null, branch: string, url: string, createdAt: any | null, pipeline: { name: string, slug: string }, jobs: { edges: Array<{ node: { __typename: 'JobTypeBlock', id: string, uuid: string, label: string | null, state: JobStates, isUnblockable: boolean | null, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null } | { __typename: 'JobTypeCommand', id: string, uuid: string, label: string | null, state: JobStates, url: string, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null } | { __typename: 'JobTypeTrigger', id: string, uuid: string, label: string | null, state: JobStates, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null } | { __typename: 'JobTypeWait', id: string, uuid: string, label: string | null, state: JobStates, step: { key: string | null, dependencies: { edges: Array<{ node: { key: string | null } | null } | null> | null } | null } | null } | null } | null> | null } | null } | null };
+
+export type UnblockJobMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type UnblockJobMutation = { jobTypeBlockUnblock: { jobTypeBlock: { id: string, state: JobStates } } | null };
 
 export type MyBuildsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MyBuildsQuery = { viewer: { user: { builds: { edges: Array<{ node: { id: string, branch: string, createdAt: any | null, message: string | null, number: number, state: BuildStates, url: string, pipeline: { name: string } } | null } | null> | null } | null } | null } | null };
+export type MyBuildsQuery = { viewer: { user: { builds: { edges: Array<{ node: { id: string, uuid: string, branch: string, createdAt: any | null, message: string | null, number: number, state: BuildStates, url: string, pipeline: { name: string, slug: string } } | null } | null> | null } | null } | null } | null };
 
 export type ListBuildsQueryVariables = Exact<{
   pipeline: Scalars['ID']['input'];
 }>;
 
 
-export type ListBuildsQuery = { pipeline: { builds: { edges: Array<{ node: { id: string, branch: string, createdAt: any | null, message: string | null, number: number, state: BuildStates, url: string, pipeline: { name: string } } | null } | null> | null } | null } | null };
+export type ListBuildsQuery = { pipeline: { builds: { edges: Array<{ node: { id: string, uuid: string, branch: string, createdAt: any | null, message: string | null, number: number, state: BuildStates, url: string, pipeline: { name: string, slug: string } } | null } | null> | null } | null } | null };
 
 export type PipelineFragment = { slug: string, name: string, description: string | null, favorite: boolean, url: string, builds: { edges: Array<{ node: { state: BuildStates } | null } | null> | null } | null };
 
@@ -6157,6 +6191,7 @@ export type SearchPipelinesQuery = { organization: { pipelines: { edges: Array<{
 export const BuildFragmentDoc = gql`
     fragment Build on Build {
   id
+  uuid
   branch
   createdAt
   message
@@ -6165,9 +6200,65 @@ export const BuildFragmentDoc = gql`
   url
   pipeline {
     name
+    slug
   }
 }
     `;
+export const JobStepFragmentDoc = gql`
+    fragment JobStep on Step {
+  key
+  dependencies(first: 100) {
+    edges {
+      node {
+        key
+      }
+    }
+  }
+}
+    `;
+export const BuildJobFragmentDoc = gql`
+    fragment BuildJob on JobInterface {
+  __typename
+  ... on JobTypeCommand {
+    id
+    uuid
+    label
+    state
+    url
+    step {
+      ...JobStep
+    }
+  }
+  ... on JobTypeBlock {
+    id
+    uuid
+    label
+    state
+    isUnblockable
+    step {
+      ...JobStep
+    }
+  }
+  ... on JobTypeWait {
+    id
+    uuid
+    label
+    state
+    step {
+      ...JobStep
+    }
+  }
+  ... on JobTypeTrigger {
+    id
+    uuid
+    label
+    state
+    step {
+      ...JobStep
+    }
+  }
+}
+    ${JobStepFragmentDoc}`;
 export const PipelineFragmentDoc = gql`
     fragment Pipeline on Pipeline {
   slug
@@ -6180,6 +6271,41 @@ export const PipelineFragmentDoc = gql`
       node {
         state
       }
+    }
+  }
+}
+    `;
+export const GetBuildDocument = gql`
+    query getBuild($uuid: ID!) {
+  build(uuid: $uuid) {
+    id
+    uuid
+    number
+    state
+    message
+    branch
+    url
+    createdAt
+    pipeline {
+      name
+      slug
+    }
+    jobs(first: 100) {
+      edges {
+        node {
+          ...BuildJob
+        }
+      }
+    }
+  }
+}
+    ${BuildJobFragmentDoc}`;
+export const UnblockJobDocument = gql`
+    mutation unblockJob($id: ID!) {
+  jobTypeBlockUnblock(input: {id: $id}) {
+    jobTypeBlock {
+      id
+      state
     }
   }
 }
@@ -6231,21 +6357,27 @@ export const SearchPipelinesDocument = gql`
 }
     ${PipelineFragmentDoc}`;
 
-export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
 
 
-const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType) => action();
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action();
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    myBuilds(variables?: MyBuildsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<MyBuildsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<MyBuildsQuery>(MyBuildsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'myBuilds', 'query');
+    getBuild(variables: GetBuildQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<GetBuildQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetBuildQuery>({ document: GetBuildDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'getBuild', 'query', variables);
     },
-    listBuilds(variables: ListBuildsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ListBuildsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ListBuildsQuery>(ListBuildsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'listBuilds', 'query');
+    unblockJob(variables: UnblockJobMutationVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<UnblockJobMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<UnblockJobMutation>({ document: UnblockJobDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'unblockJob', 'mutation', variables);
     },
-    searchPipelines(variables: SearchPipelinesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SearchPipelinesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<SearchPipelinesQuery>(SearchPipelinesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'searchPipelines', 'query');
+    myBuilds(variables?: MyBuildsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<MyBuildsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<MyBuildsQuery>({ document: MyBuildsDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'myBuilds', 'query', variables);
+    },
+    listBuilds(variables: ListBuildsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<ListBuildsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ListBuildsQuery>({ document: ListBuildsDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'listBuilds', 'query', variables);
+    },
+    searchPipelines(variables: SearchPipelinesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<SearchPipelinesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<SearchPipelinesQuery>({ document: SearchPipelinesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'searchPipelines', 'query', variables);
     }
   };
 }

--- a/extensions/buildkite/src/utils/states.ts
+++ b/extensions/buildkite/src/utils/states.ts
@@ -1,5 +1,5 @@
 import { Color, Icon, Image } from "@raycast/api";
-import { BuildStates } from "../generated/graphql";
+import type { BuildStates, JobStates } from "../generated/graphql";
 
 export function getStateIcon(state: BuildStates | undefined): Image.ImageLike | undefined {
   switch (state) {
@@ -19,5 +19,63 @@ export function getStateIcon(state: BuildStates | undefined): Image.ImageLike | 
     case "SCHEDULED":
     default:
       return Icon.Circle;
+  }
+}
+
+export function getJobStateIcon(state: JobStates | undefined): Image.ImageLike {
+  switch (state) {
+    case "FINISHED":
+    case "UNBLOCKED":
+      return { source: Icon.CheckCircle, tintColor: Color.Green };
+    case "BROKEN":
+    case "TIMED_OUT":
+    case "TIMING_OUT":
+    case "EXPIRED":
+    case "UNBLOCKED_FAILED":
+    case "WAITING_FAILED":
+      return { source: Icon.XMarkCircle, tintColor: Color.Red };
+    case "BLOCKED":
+    case "BLOCKED_FAILED":
+      return { source: Icon.LockUnlocked, tintColor: Color.Orange };
+    case "RUNNING":
+    case "ACCEPTED":
+    case "ASSIGNED":
+      return { source: Icon.CircleProgress50, tintColor: Color.Yellow };
+    case "CANCELED":
+    case "CANCELING":
+      return { source: Icon.MinusCircle, tintColor: Color.SecondaryText };
+    case "SKIPPED":
+      return { source: Icon.Forward, tintColor: Color.SecondaryText };
+    default:
+      return { source: Icon.Circle, tintColor: Color.SecondaryText };
+  }
+}
+
+export function getJobStateGlyph(state: JobStates | undefined): string {
+  switch (state) {
+    case "FINISHED":
+    case "UNBLOCKED":
+      return "✅";
+    case "BROKEN":
+    case "TIMED_OUT":
+    case "TIMING_OUT":
+    case "EXPIRED":
+    case "UNBLOCKED_FAILED":
+    case "WAITING_FAILED":
+      return "❌";
+    case "BLOCKED":
+    case "BLOCKED_FAILED":
+      return "⏸️";
+    case "RUNNING":
+    case "ACCEPTED":
+    case "ASSIGNED":
+      return "🟡";
+    case "CANCELED":
+    case "CANCELING":
+      return "⊘";
+    case "SKIPPED":
+      return "⤳";
+    default:
+      return "⚪";
   }
 }

--- a/extensions/buildkite/src/utils/states.ts
+++ b/extensions/buildkite/src/utils/states.ts
@@ -36,7 +36,7 @@ export function getJobStateIcon(state: JobStates | undefined): Image.ImageLike {
       return { source: Icon.XMarkCircle, tintColor: Color.Red };
     case "BLOCKED":
     case "BLOCKED_FAILED":
-      return { source: Icon.LockUnlocked, tintColor: Color.Orange };
+      return { source: Icon.Lock, tintColor: Color.Orange };
     case "RUNNING":
     case "ACCEPTED":
     case "ASSIGNED":

--- a/extensions/buildkite/src/utils/states.ts
+++ b/extensions/buildkite/src/utils/states.ts
@@ -50,32 +50,3 @@ export function getJobStateIcon(state: JobStates | undefined): Image.ImageLike {
       return { source: Icon.Circle, tintColor: Color.SecondaryText };
   }
 }
-
-export function getJobStateGlyph(state: JobStates | undefined): string {
-  switch (state) {
-    case "FINISHED":
-    case "UNBLOCKED":
-      return "✅";
-    case "BROKEN":
-    case "TIMED_OUT":
-    case "TIMING_OUT":
-    case "EXPIRED":
-    case "UNBLOCKED_FAILED":
-    case "WAITING_FAILED":
-      return "❌";
-    case "BLOCKED":
-    case "BLOCKED_FAILED":
-      return "⏸️";
-    case "RUNNING":
-    case "ACCEPTED":
-    case "ASSIGNED":
-      return "🟡";
-    case "CANCELED":
-    case "CANCELING":
-      return "⊘";
-    case "SKIPPED":
-      return "⤳";
-    default:
-      return "⚪";
-  }
-}


### PR DESCRIPTION
## Description

Extends the Buildkite extension with two new capabilities, both accessible from the existing **My Builds** and **Search Pipelines** commands via a new **Show Build Graph** action on each build:

1. **Visual build graph** — a list view that groups every job in the build by computed dependency stage (topological depth), with state icons, a markdown DAG in the detail pane, and metadata for each step (label, type, state, key, dependencies, link).
2. **Unblock blocked steps** without leaving Raycast:
   - **Unblock Step** action on any blocked manual (`block`) step.
   - **Unblock All Steps** (⌘⇧U) bulk action in a *Danger Zone* section, with a destructive-styled confirmation listing every step to be unblocked. Runs the mutations in parallel via `Promise.allSettled` and reports per-step success/failure in the final toast.

Implementation notes:
- Adds a shared `JobStep` GraphQL fragment to keep the new `BuildJob` fragment compact.
- New `getBuild(uuid)` query and `unblockJob(id)` mutation (uses `jobTypeBlockUnblock`).
- New `getJobStateIcon` / `getJobStateGlyph` helpers in `src/utils/states.ts`.
- All new keying uses `job.id` (unique), with `step.key` used only for dependency resolution — safe against duplicate `step.key` (e.g. matrix steps / retries) and missing keys.
- Depth computation is cycle-safe (caches a 0 for cycle-broken nodes).
- No new commands, no new preferences, no version bump.

## Screencast

<!-- Screenshots to follow once captured against a real org. The new view reuses the existing token preference so no extra setup is needed. -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with the metadata tool