### PR TITLE
[Diskutil] Avoid timeouts on large disk lists

### DIFF
--- a/extensions/diskutil-mac/CHANGELOG.md
+++ b/extensions/diskutil-mac/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [1.3.0] - Performance Improvements - 2026-05-19
 
   
+## [Bugfix] - {PR_MERGE_DATE}
+
+- Limit concurrent disk detail loading so large disk lists do not all time out at once.
 
 ## [Bugfix] - 2026-05-17
 

--- a/extensions/diskutil-mac/src/features/disk/components/DiskSection.tsx
+++ b/extensions/diskutil-mac/src/features/disk/components/DiskSection.tsx
@@ -35,6 +35,10 @@ export default class DiskSection {
     await Promise.allSettled(initPromises);
   }
 
+  /**
+   * Create DiskSection from section string
+   * Parses section name and disk strings, then creates Disk instances
+   */
   static createFromString(sectionString: string): DiskSection {
     const sectionNameMatches = sectionString.match(/(\/.+:)/gm);
     const sectionName = sectionNameMatches ? sectionNameMatches[0] : "";

--- a/extensions/diskutil-mac/src/index.tsx
+++ b/extensions/diskutil-mac/src/index.tsx
@@ -5,6 +5,8 @@ import { SizesView, cycleSizesView, loadSizesView, saveSizesView } from "./utils
 import { execDiskCommand } from "./utils/diskUtils";
 import DiskListItem from "./features/disk/components/DiskListItem";
 
+const DISK_INIT_CONCURRENCY = 4;
+
 export default function ListDisks(): JSX.Element {
   const [diskSections, setDisksSections] = useState<DiskSection[]>([]);
   const [showingDetail, setShowingDetail] = useState({ show: false, detail: 0 });
@@ -102,32 +104,57 @@ export default function ListDisks(): JSX.Element {
       completedInBatch = 0;
     };
 
-    const sectionInitPromises = sections.map((section) =>
-      section.initDisks(() => {
-        completedDisks++;
-        completedInBatch++;
+    const disks = sections.flatMap((section) => section.disks);
+    let nextDiskIndex = 0;
 
-        if (isProgressiveLoad) {
-          if (completedInBatch >= BATCH_SIZE) {
-            triggerBatchUpdate();
-            return;
-          }
+    const handleDiskInitialized = () => {
+      completedDisks++;
+      completedInBatch++;
 
-          if (completedDisks === totalDisks) {
-            triggerBatchUpdate();
-            return;
-          }
-
-          if (!updateTimer) {
-            updateTimer = setTimeout(() => {
-              triggerBatchUpdate();
-            }, BATCH_TIMEOUT_MS);
-          }
+      if (isProgressiveLoad) {
+        if (completedInBatch >= BATCH_SIZE) {
+          triggerBatchUpdate();
+          return;
         }
-      }),
-    );
 
-    await Promise.allSettled(sectionInitPromises);
+        if (completedDisks === totalDisks) {
+          triggerBatchUpdate();
+          return;
+        }
+
+        if (!updateTimer) {
+          updateTimer = setTimeout(() => {
+            triggerBatchUpdate();
+          }, BATCH_TIMEOUT_MS);
+        }
+      }
+    };
+
+    const initializeNextDisk = async () => {
+      while (nextDiskIndex < disks.length) {
+        const disk = disks[nextDiskIndex];
+        nextDiskIndex++;
+
+        try {
+          disk.startInit();
+          await disk.init();
+          disk.finishInit(true);
+        } catch (error) {
+          disk.finishInit(false);
+          console.error(`Failed to initialize ${disk.identifier}:`, error);
+        } finally {
+          handleDiskInitialized();
+        }
+      }
+    };
+
+    const workers = Array.from({ length: Math.min(DISK_INIT_CONCURRENCY, disks.length) }, initializeNextDisk);
+
+    await Promise.allSettled(workers);
+
+    if (totalDisks === 0 && isProgressiveLoad) {
+      setDiskUpdateTrigger((prev) => prev + 1);
+    }
 
     if (updateTimer) {
       clearTimeout(updateTimer);


### PR DESCRIPTION
## Description

Fixes #28040.

Limits disk detail initialization to four disks at a time. The extension still renders progressively, but it no longer starts every `diskutil info` process at once for large disk lists, which could make each disk hit the existing timeout and show `Timed Out`.

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`

## Screencast

Not included; this is a data-loading stability fix for large local disk lists.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)