### PR TITLE
[Jira Search] Surface issue search auth errors

### DIFF
--- a/extensions/jira-search/CHANGELOG.md
+++ b/extensions/jira-search/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Jira Search Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Show Jira authentication and authorization failures instead of silently returning empty issue results.
+
 ## [Fixes] - 2025-09-09
 
 - Fixed issue search to work again

--- a/extensions/jira-search/CHANGELOG.md
+++ b/extensions/jira-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Jira Search Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-05-28
 
 - Show Jira authentication and authorization failures instead of silently returning empty issue results.
 

--- a/extensions/jira-search/package.json
+++ b/extensions/jira-search/package.json
@@ -87,5 +87,8 @@
     "lint": "ray lint",
     "lint-fix": "ray lint --fix",
     "publish": "node publish.mjs"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/jira-search/src/issue.ts
+++ b/extensions/jira-search/src/issue.ts
@@ -1,8 +1,8 @@
 import { jiraFetchObject, jiraUrl } from "./jira"
 import { jiraImage } from "./image"
 import { ResultItem, SearchCommand } from "./command"
-import { Color, Icon, Image } from "@raycast/api"
-import { ErrorText } from "./exception"
+import { Color, Icon, Image, showToast, Toast } from "@raycast/api"
+import { ErrorText, PresentableError } from "./exception"
 
 interface IssueType {
   id: string
@@ -29,6 +29,9 @@ interface Issue {
 
 interface Issues {
   issues?: Issue[]
+  warningMessages?: string[]
+  errorMessages?: string[]
+  errors?: Record<string, string>
 }
 
 type IssueFilter = "allIssues" | "issuesInOpenSprints" | "myIssues" | "myIssuesInOpenSprints"
@@ -112,6 +115,23 @@ async function searchIssues(query: string, filter?: IssueFilter): Promise<Result
     { jql, fields },
     { 400: ErrorText("Invalid Query", "Unknown project, issue type or assignee") },
   )
+  const firstError = [...(result.errorMessages ?? []), ...Object.values(result.errors ?? {})][0]
+  if (firstError) {
+    throw new PresentableError("Jira Error", firstError)
+  }
+
+  const firstWarning = result.warningMessages?.[0]
+  if (firstWarning) {
+    if ((result.issues?.length ?? 0) === 0) {
+      throw new PresentableError("Jira Search Warning", firstWarning)
+    }
+    showToast({
+      style: Toast.Style.Failure,
+      title: "Jira Search Warning",
+      message: firstWarning,
+    })
+  }
+
   const mapResult = async (issue: Issue): Promise<ResultItem> => ({
     id: issue.id,
     title: issue.fields.summary,

--- a/extensions/jira-search/src/jira.ts
+++ b/extensions/jira-search/src/jira.ts
@@ -72,6 +72,7 @@ export async function jiraFetch(
 
 const defaultStatusErrors: StatusErrors = {
   401: ErrorText("Jira Authentication failed", "Check your Jira credentials in the preferences."),
+  403: ErrorText("Jira Authorization failed", "Check that your API token has access to this Jira site."),
 }
 
 function throwIfResponseNotOkay(response: Response, statusErrors?: StatusErrors) {


### PR DESCRIPTION
## Description

Fixes #27550.

Issue search now surfaces Jira authentication and authorization failures instead of presenting a successful empty result. It also forwards Jira error payloads and no-result warning messages so users can see when access or token scope problems are blocking search.

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`

## Screencast

Not included; this is an error handling fix for credential and permission failures.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)