### PR TITLE
[Git Repos] Reduce scan memory usage

### DIFF
--- a/extensions/git-repos/CHANGELOG.md
+++ b/extensions/git-repos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Git Repos Changelog
 
-## [Bug Fix] - {PR_MERGE_DATE}
+## [Bug Fix] - 2026-05-24
 
 - Reduce memory usage while scanning large directory trees for repositories.
 

--- a/extensions/git-repos/CHANGELOG.md
+++ b/extensions/git-repos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Git Repos Changelog
 
+## [Bug Fix] - {PR_MERGE_DATE}
+
+- Reduce memory usage while scanning large directory trees for repositories.
+
 ## [Bug Fix] - 2026-05-05
 
 - Fix out-of-memory crash when searching repositories by replacing glob (which uses worker threads) with a native fs traversal.

--- a/extensions/git-repos/src/hooks/useUsageBasedSort.ts
+++ b/extensions/git-repos/src/hooks/useUsageBasedSort.ts
@@ -32,8 +32,6 @@ export const useUsageBasedSort = <T extends { name: string | number }>(data: T[]
   const { data: usages, set: setUsages } = useLocalStorage<Usages>(USAGE_KEY + localStorageKey);
 
   const recordUsage = (id: string | number) => {
-    console.warn("recordUsage", id);
-    console.warn("usages", usages?.[id]);
     setUsages({
       ...usages,
       [id]: {
@@ -43,14 +41,8 @@ export const useUsageBasedSort = <T extends { name: string | number }>(data: T[]
     });
   };
 
-  const arrayWithScores = data.map((e: T) => {
-    const usage = (usages || {})[e.name];
-    return {
-      ...e,
-      _calculatedScore: getCalculatedScore(usage),
-    };
-  });
-
-  const sortedByScores = [...(arrayWithScores || [])].sort((a, b) => b._calculatedScore - a._calculatedScore);
+  const sortedByScores = [...data].sort(
+    (a, b) => getCalculatedScore((usages || {})[b.name]) - getCalculatedScore((usages || {})[a.name]),
+  );
   return { data: sortedByScores, recordUsage };
 };

--- a/extensions/git-repos/src/utils.tsx
+++ b/extensions/git-repos/src/utils.tsx
@@ -249,43 +249,56 @@ async function findGitEntries(
 ): Promise<{ gitDirs: string[]; gitFiles: string[] }> {
   const gitDirs: string[] = [];
   const gitFiles: string[] = [];
+  const dirsToScan = [{ dir, depth: currentDepth }];
 
-  let entries: fs.Dirent[];
-  try {
-    entries = await fs.promises.readdir(dir, { withFileTypes: true });
-  } catch {
-    return { gitDirs, gitFiles };
-  }
+  while (dirsToScan.length > 0) {
+    const nextDir = dirsToScan.pop();
+    if (!nextDir) {
+      continue;
+    }
 
-  await Promise.all(
-    entries.map(async (entry) => {
-      const fullPath = path.join(dir, entry.name);
-      const stat = await statLink(fullPath, entry);
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(nextDir.dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
 
+    for (const entry of entries) {
+      const fullPath = path.join(nextDir.dir, entry.name);
       if (entry.name === ".git") {
+        const stat = await statLink(fullPath, entry);
         if (entry.isDirectory() || stat?.isDirectory()) {
           gitDirs.push(fullPath);
         } else if (entry.isFile() || stat?.isFile()) {
           gitFiles.push(fullPath);
         }
-        return;
+        continue;
       }
 
-      if (currentDepth < maxDepth && (entry.isDirectory() || stat?.isDirectory())) {
-        const sub = await findGitEntries(fullPath, maxDepth, currentDepth + 1);
-        gitDirs.push(...sub.gitDirs);
-        gitFiles.push(...sub.gitFiles);
+      if (nextDir.depth >= maxDepth) {
+        continue;
       }
-    }),
-  );
+
+      if (entry.isDirectory()) {
+        dirsToScan.push({ dir: fullPath, depth: nextDir.depth + 1 });
+        continue;
+      }
+
+      const stat = await statLink(fullPath, entry);
+      if (stat?.isDirectory()) {
+        dirsToScan.push({ dir: fullPath, depth: nextDir.depth + 1 });
+      }
+    }
+  }
 
   return { gitDirs, gitFiles };
 }
 
 export async function findRepos(paths: string[], maxDepth: number, includeSubmodules: boolean): Promise<GitRepo[]> {
   let foundRepos: GitRepo[] = [];
-  await Promise.allSettled(
-    paths.map(async (scanPath) => {
+  for (const scanPath of paths) {
+    try {
       const { gitDirs, gitFiles } = await findGitEntries(scanPath, maxDepth);
 
       const repos = parseRepoPaths(scanPath, gitDirs, false);
@@ -313,8 +326,10 @@ export async function findRepos(paths: string[], maxDepth: number, includeSubmod
           foundRepos.push(worktree);
         }
       });
-    }),
-  );
+    } catch {
+      continue;
+    }
+  }
   foundRepos.sort((a, b) => {
     const fa = a.name.toLowerCase(),
       fb = b.name.toLowerCase();


### PR DESCRIPTION
## Description

Fixes #27696.

Reworks repository discovery to scan large directory trees iteratively instead of recursively starting work for every entry at once. This keeps the List Repos command from building up a large promise graph while it searches for `.git` entries, and also avoids duplicating repo objects while computing usage-based sort order.

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`

## Screencast

Not included; this is a scan stability fix for large local directory trees.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)