### PR TITLE
[1Password] Reduce memory usage for large item lists

### DIFF
--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 1Password Changelog
 
+## [Bug Fix] - {PR_MERGE_DATE}
+
+- Reduce memory usage when loading large item lists.
+
 ## [Enhancements] - 2026-04-16
 
 - Improved search: queries now match across all item fields (title, username/email, URLs, vault name). For example, searching "m@ goo" now finds a Google login with email "m@example.com".

--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Bug Fix] - {PR_MERGE_DATE}
 
-- Reduce memory usage when loading large item lists while preserving list subtitles and search metadata.
+- Reduce memory usage when loading large item lists by avoiding the full item payload until it is needed.
 
 ## [Enhancements] - 2026-04-16
 

--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [Bug Fix] - {PR_MERGE_DATE}
 
-- Reduce memory usage when loading large item lists by avoiding the full item payload until it is needed.
-- The item list now uses the summary payload, so username/email subtitles and username/email search are unavailable until full item details are fetched by an action.
+- Reduce memory usage when loading large item lists by avoiding the full item payload until it is needed. Opt in via **Reduce item list memory usage** in extension preferences.
+- When enabled, the item list uses the summary payload, so username/email subtitles and username/email search are unavailable until full item details are fetched by an action.
 
 ## [Enhancements] - 2026-04-16
 

--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Bug Fix] - {PR_MERGE_DATE}
 
 - Reduce memory usage when loading large item lists by avoiding the full item payload until it is needed.
+- The item list now uses the summary payload, so username/email subtitles and username/email search are unavailable until full item details are fetched by an action.
 
 ## [Enhancements] - 2026-04-16
 

--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Bug Fix] - {PR_MERGE_DATE}
 
-- Reduce memory usage when loading large item lists.
+- Reduce memory usage when loading large item lists while preserving list subtitles and search metadata.
 
 ## [Enhancements] - 2026-04-16
 

--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Reduce memory usage when loading large item lists by avoiding the full item payload until it is needed. Opt in via **Reduce item list memory usage** in extension preferences.
 - When enabled, the item list uses the summary payload, so username/email subtitles and username/email search are unavailable until full item details are fetched by an action.
+- When enabled, the list renders the first 200 matching items to avoid Raycast worker memory limits on very large vaults.
 
 ## [Enhancements] - 2026-04-16
 

--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1Password Changelog
 
-## [Bug Fix] - {PR_MERGE_DATE}
+## [Bug Fix] - 2026-06-15
 
 - Reduce memory usage when loading large item lists by avoiding the full item payload until it is needed. Opt in via **Reduce item list memory usage** in extension preferences.
 - When enabled, the item list uses the summary payload, so username/email subtitles and username/email search are unavailable until full item details are fetched by an action.

--- a/extensions/1password/package.json
+++ b/extensions/1password/package.json
@@ -189,6 +189,14 @@
       "description": "Close Raycast window after copying a username or password."
     },
     {
+      "name": "reduceItemListMemoryUsage",
+      "type": "checkbox",
+      "required": false,
+      "default": false,
+      "label": "Reduce item list memory usage",
+      "description": "Load a lightweight summary when listing passwords instead of full item details. Uses less memory with large vaults, but username/email subtitles and search may be limited until an action fetches full details."
+    },
+    {
       "description": "Enter the CLI binary path",
       "name": "cliPath",
       "placeholder": "e.g., /usr/local/bin/op",

--- a/extensions/1password/src/v8/components/ItemActionPanel.tsx
+++ b/extensions/1password/src/v8/components/ItemActionPanel.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Icon, open, showToast, Toast } from "@raycast/api";
+import { Action, ActionPanel, getPreferenceValues, Icon, open, showToast, Toast } from "@raycast/api";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
@@ -141,7 +141,7 @@ function OpenInBrowser(account: undefined | User, item: Item) {
     );
   }
 
-  if (item.category !== "LOGIN") {
+  if (!getPreferenceValues<ExtensionPreferences>().reduceItemListMemoryUsage || item.category !== "LOGIN") {
     return null;
   }
 

--- a/extensions/1password/src/v8/components/ItemActionPanel.tsx
+++ b/extensions/1password/src/v8/components/ItemActionPanel.tsx
@@ -30,7 +30,7 @@ export function ItemActionPanel({
           case "open-in-1password":
             return OpenIn1Password(account, item);
           case "open-in-browser":
-            return OpenInBrowser(item);
+            return OpenInBrowser(account, item);
           case "paste-one-time-password":
             return PasteOneTimePassword(item);
           case "paste-password":
@@ -124,7 +124,7 @@ function OpenIn1Password(account: undefined | User, item: Item) {
   return null;
 }
 
-function OpenInBrowser(item: Item) {
+function OpenInBrowser(account: undefined | User, item: Item) {
   const href = hrefToOpenInBrowser(item);
 
   if (href) {
@@ -151,8 +151,16 @@ function OpenInBrowser(item: Item) {
         try {
           const stdout = execFileSync(
             getCliPath(),
-            ["item", "get", item.id, "--vault", item.vault.id, "--format=json"],
-            windowsEnv ? { env: windowsEnv } : {},
+            [
+              ...(account ? ["--account", account.account_uuid] : []),
+              "item",
+              "get",
+              item.id,
+              "--vault",
+              item.vault.id,
+              "--format=json",
+            ],
+            { maxBuffer: 4096 * 1024, ...(windowsEnv ? { env: windowsEnv } : {}) },
           );
           const detailedItem = JSON.parse(stdout.toString()) as Item;
           const detailedHref = hrefToOpenInBrowser(detailedItem);

--- a/extensions/1password/src/v8/components/ItemActionPanel.tsx
+++ b/extensions/1password/src/v8/components/ItemActionPanel.tsx
@@ -1,8 +1,9 @@
-import { Action, ActionPanel, Icon } from "@raycast/api";
+import { Action, ActionPanel, Icon, open, showToast, Toast } from "@raycast/api";
+import { execFileSync } from "node:child_process";
 
 import resetCache from "../../reset-cache";
 import { Item, User } from "../types";
-import { ActionID, hrefToOpenInBrowser } from "../utils";
+import { ActionID, getCliPath, handleErrors, hrefToOpenInBrowser, windowsEnv } from "../utils";
 import { CopyToClipboard } from "./ActionCopyToClipboard";
 import { ShareItem } from "./ActionShareItem";
 import { SwitchAccount } from "./ActionSwitchAccount";
@@ -137,7 +138,51 @@ function OpenInBrowser(item: Item) {
     );
   }
 
-  return null;
+  if (item.category !== "LOGIN") {
+    return null;
+  }
+
+  return (
+    <Action
+      key="open-in-browser"
+      onAction={async () => {
+        const toast = await showToast({ style: Toast.Style.Animated, title: "Opening in browser..." });
+
+        try {
+          const stdout = execFileSync(
+            getCliPath(),
+            ["item", "get", item.id, "--vault", item.vault.id, "--format=json"],
+            windowsEnv ? { env: windowsEnv } : {},
+          );
+          const detailedItem = JSON.parse(stdout.toString()) as Item;
+          const detailedHref = hrefToOpenInBrowser(detailedItem);
+
+          if (!detailedHref) {
+            toast.style = Toast.Style.Failure;
+            toast.title = "No website URL found";
+            return;
+          }
+
+          await open(detailedHref);
+          toast.style = Toast.Style.Success;
+          toast.title = "Opened in browser";
+        } catch (error) {
+          toast.style = Toast.Style.Failure;
+          toast.title = "Failed to open in browser";
+
+          if (error instanceof Error) {
+            try {
+              handleErrors(error.message);
+            } catch (err) {
+              toast.message = err instanceof Error ? err.message : error.message;
+            }
+          }
+        }
+      }}
+      shortcut={{ key: "return", modifiers: ["opt"] }}
+      title="Open in Browser"
+    />
+  );
 }
 
 function PasteOneTimePassword(item: Item) {

--- a/extensions/1password/src/v8/components/ItemActionPanel.tsx
+++ b/extensions/1password/src/v8/components/ItemActionPanel.tsx
@@ -1,5 +1,6 @@
 import { Action, ActionPanel, Icon, open, showToast, Toast } from "@raycast/api";
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
 import resetCache from "../../reset-cache";
 import { Item, User } from "../types";
@@ -7,6 +8,8 @@ import { ActionID, getCliPath, handleErrors, hrefToOpenInBrowser, windowsEnv } f
 import { CopyToClipboard } from "./ActionCopyToClipboard";
 import { ShareItem } from "./ActionShareItem";
 import { SwitchAccount } from "./ActionSwitchAccount";
+
+const execFileAsync = promisify(execFile);
 
 export function ItemActionPanel({
   account,
@@ -149,7 +152,7 @@ function OpenInBrowser(account: undefined | User, item: Item) {
         const toast = await showToast({ style: Toast.Style.Animated, title: "Opening in browser..." });
 
         try {
-          const stdout = execFileSync(
+          const { stdout } = await execFileAsync(
             getCliPath(),
             [
               ...(account ? ["--account", account.account_uuid] : []),
@@ -160,9 +163,9 @@ function OpenInBrowser(account: undefined | User, item: Item) {
               item.vault.id,
               "--format=json",
             ],
-            { maxBuffer: 4096 * 1024, ...(windowsEnv ? { env: windowsEnv } : {}) },
+            { encoding: "utf8", maxBuffer: 4096 * 1024, ...(windowsEnv ? { env: windowsEnv } : {}) },
           );
-          const detailedItem = JSON.parse(stdout.toString()) as Item;
+          const detailedItem = JSON.parse(stdout) as Item;
           const detailedHref = hrefToOpenInBrowser(detailedItem);
 
           if (!detailedHref) {

--- a/extensions/1password/src/v8/components/Items.tsx
+++ b/extensions/1password/src/v8/components/Items.tsx
@@ -42,7 +42,6 @@ function matchesSearch(item: Item, query: string): boolean {
 export function Items({ flags }: { flags?: string[] }) {
   const [category, setCategory] = useCachedState<string>("selected_category", DEFAULT_CATEGORY);
   const [searchText, setSearchText] = useState("");
-  const [passwords, setPasswords] = useState<Item[]>([]);
   const { data: account, error: accountError, isLoading: accountIsLoading } = useAccount();
   const {
     data: items,
@@ -50,13 +49,13 @@ export function Items({ flags }: { flags?: string[] }) {
     isLoading: itemsIsLoading,
   } = usePasswords2({ account: account?.account_uuid ?? "", execute: !accountError && !accountIsLoading, flags });
 
-  useMemo(() => {
-    if (!items) return;
+  const passwords = useMemo(() => {
+    if (!items) return [];
     const byCategory =
       category === DEFAULT_CATEGORY
         ? items
         : items.filter((item) => item.category === category.replaceAll(" ", "_").toUpperCase());
-    setPasswords(byCategory.filter((item) => matchesSearch(item, searchText)));
+    return byCategory.filter((item) => matchesSearch(item, searchText));
   }, [items, category, searchText]);
 
   const onCategoryChange = (newCategory: string) => {
@@ -90,8 +89,8 @@ export function Items({ flags }: { flags?: string[] }) {
         icon="1password-noview.png"
         title="No items found"
       />
-      <List.Section subtitle={`${passwords?.length}`} title="Items">
-        {passwords?.length
+      <List.Section subtitle={`${passwords.length}`} title="Items">
+        {passwords.length
           ? passwords.map((item) => (
               <List.Item
                 accessories={[

--- a/extensions/1password/src/v8/components/Items.tsx
+++ b/extensions/1password/src/v8/components/Items.tsx
@@ -1,4 +1,4 @@
-import { Color, Icon, List } from "@raycast/api";
+import { Color, getPreferenceValues, Icon, List } from "@raycast/api";
 import { useCachedState } from "@raycast/utils";
 import { useMemo, useState } from "react";
 
@@ -16,32 +16,46 @@ import { Categories, DEFAULT_CATEGORY } from "./Categories";
 import { Error as ErrorGuide } from "./Error";
 import { ItemActionPanel } from "./ItemActionPanel";
 
-function getSearchableStrings(item: Item): string[] {
-  const strings = [item.title];
-  if (item.additional_information) strings.push(item.additional_information);
-  if (item.urls) {
-    for (const url of item.urls) {
-      try {
-        strings.push(new URL(url.href).hostname);
-      } catch {
-        strings.push(url.href);
-      }
-    }
+const MAX_LIGHTWEIGHT_RENDERED_ITEMS = 200;
+const URL_HOSTNAME_REGEX = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:/\n?]+)/i;
+const preferences = getPreferenceValues<ExtensionPreferences>();
+
+function getHostname(href: string, useLightweightParser: boolean): string {
+  if (useLightweightParser) {
+    return href.match(URL_HOSTNAME_REGEX)?.[1] ?? href;
   }
-  if (item.vault?.name) strings.push(item.vault.name);
-  return strings;
+
+  try {
+    return new URL(href).hostname;
+  } catch {
+    return href;
+  }
 }
 
-function matchesSearch(item: Item, query: string): boolean {
+function matchesValue(value: string | undefined, token: string): boolean {
+  return value?.toLowerCase().includes(token) ?? false;
+}
+
+function matchesSearch(item: Item, query: string, useLightweightUrlParser: boolean): boolean {
   if (!query) return true;
   const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
-  const searchable = getSearchableStrings(item).map((s) => s.toLowerCase());
-  return tokens.every((token) => searchable.some((s) => s.includes(token)));
+  return tokens.every((token) => {
+    if (
+      matchesValue(item.title, token) ||
+      matchesValue(item.additional_information, token) ||
+      matchesValue(item.vault?.name, token)
+    ) {
+      return true;
+    }
+
+    return item.urls?.some((url) => matchesValue(getHostname(url.href, useLightweightUrlParser), token)) ?? false;
+  });
 }
 
 export function Items({ flags }: { flags?: string[] }) {
   const [category, setCategory] = useCachedState<string>("selected_category", DEFAULT_CATEGORY);
   const [searchText, setSearchText] = useState("");
+  const reduceItemListMemoryUsage = preferences.reduceItemListMemoryUsage;
   const { data: account, error: accountError, isLoading: accountIsLoading } = useAccount();
   const {
     data: items,
@@ -55,8 +69,17 @@ export function Items({ flags }: { flags?: string[] }) {
       category === DEFAULT_CATEGORY
         ? items
         : items.filter((item) => item.category === category.replaceAll(" ", "_").toUpperCase());
-    return byCategory.filter((item) => matchesSearch(item, searchText));
-  }, [items, category, searchText]);
+    return byCategory.filter((item) => matchesSearch(item, searchText, reduceItemListMemoryUsage));
+  }, [items, category, searchText, reduceItemListMemoryUsage]);
+
+  const visiblePasswords = useMemo(
+    () => (reduceItemListMemoryUsage ? passwords.slice(0, MAX_LIGHTWEIGHT_RENDERED_ITEMS) : passwords),
+    [passwords, reduceItemListMemoryUsage],
+  );
+  const itemCountSubtitle =
+    visiblePasswords.length < passwords.length
+      ? `${visiblePasswords.length} of ${passwords.length}`
+      : `${passwords.length}`;
 
   const onCategoryChange = (newCategory: string) => {
     if (category !== newCategory) setCategory(newCategory);
@@ -89,9 +112,9 @@ export function Items({ flags }: { flags?: string[] }) {
         icon="1password-noview.png"
         title="No items found"
       />
-      <List.Section subtitle={`${passwords.length}`} title="Items">
-        {passwords.length
-          ? passwords.map((item) => (
+      <List.Section subtitle={itemCountSubtitle} title="Items">
+        {visiblePasswords.length
+          ? visiblePasswords.map((item) => (
               <List.Item
                 accessories={[
                   item?.favorite

--- a/extensions/1password/src/v8/types.ts
+++ b/extensions/1password/src/v8/types.ts
@@ -32,7 +32,7 @@ export type Field = {
   value: string;
 };
 export type Item = {
-  additional_information: string;
+  additional_information?: string;
   category: CategoryName;
   created_at: string;
   favorite?: boolean;

--- a/extensions/1password/src/v8/types.ts
+++ b/extensions/1password/src/v8/types.ts
@@ -32,7 +32,7 @@ export type Field = {
   value: string;
 };
 export type Item = {
-  additional_information?: string;
+  additional_information: string;
   category: CategoryName;
   created_at: string;
   favorite?: boolean;

--- a/extensions/1password/src/v8/utils.ts
+++ b/extensions/1password/src/v8/utils.ts
@@ -174,38 +174,34 @@ export const usePasswords2 = ({
   execute: boolean;
   flags?: string[];
 }) =>
-  useExec<Item[], ExtensionError>(
-    getCliPath(),
-    ["--account", account, "items", "list", "--long", "--format=json", ...flags],
-    {
-      env: windowsEnv,
-      execute,
-      onError: async (e) => {
-        await showToast({
-          style: Toast.Style.Failure,
-          title: e.message,
-        });
-      },
-      parseOutput: ({ error, exitCode, stderr, stdout }) => {
-        if (error) handleErrors(error.message);
-        if (stderr) handleErrors(stderr);
-        if (exitCode != 0) handleErrors(stdout);
-        const items = JSON.parse(stdout) as Item[];
-
-        return items.sort((a, b) => {
-          if (a.favorite && !b.favorite) {
-            return -1;
-          } else if (!a.favorite && b.favorite) {
-            return 1;
-          }
-
-          return a.title.localeCompare(b.title);
-        });
-      },
+  useExec<Item[], ExtensionError>(getCliPath(), ["--account", account, "items", "list", "--format=json", ...flags], {
+    env: windowsEnv,
+    execute,
+    onError: async (e) => {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: e.message,
+      });
     },
-  );
+    parseOutput: ({ error, exitCode, stderr, stdout }) => {
+      if (error) handleErrors(error.message);
+      if (stderr) handleErrors(stderr);
+      if (exitCode != 0) handleErrors(stdout);
+      const items = JSON.parse(stdout) as Item[];
+
+      return items.sort((a, b) => {
+        if (a.favorite && !b.favorite) {
+          return -1;
+        } else if (!a.favorite && b.favorite) {
+          return 1;
+        }
+
+        return a.title.localeCompare(b.title);
+      });
+    },
+  });
 export const usePasswords = (flags: string[] = []) =>
-  useOp<Item[], ExtensionError>(["items", "list", "--long", ...flags], (data) =>
+  useOp<Item[], ExtensionError>(["items", "list", ...flags], (data) =>
     data.sort((a, b) => a.title.localeCompare(b.title)),
   );
 export const useVaults = () =>

--- a/extensions/1password/src/v8/utils.ts
+++ b/extensions/1password/src/v8/utils.ts
@@ -165,6 +165,8 @@ export const useOp = <T = Buffer, U = undefined>(args: string[], callback?: (dat
     },
   });
 };
+const itemListFlags = () => (preferences.reduceItemListMemoryUsage ? [] : ["--long"]);
+
 export const usePasswords2 = ({
   account,
   execute = true,
@@ -174,34 +176,38 @@ export const usePasswords2 = ({
   execute: boolean;
   flags?: string[];
 }) =>
-  useExec<Item[], ExtensionError>(getCliPath(), ["--account", account, "items", "list", "--format=json", ...flags], {
-    env: windowsEnv,
-    execute,
-    onError: async (e) => {
-      await showToast({
-        style: Toast.Style.Failure,
-        title: e.message,
-      });
-    },
-    parseOutput: ({ error, exitCode, stderr, stdout }) => {
-      if (error) handleErrors(error.message);
-      if (stderr) handleErrors(stderr);
-      if (exitCode != 0) handleErrors(stdout);
-      const items = JSON.parse(stdout) as Item[];
+  useExec<Item[], ExtensionError>(
+    getCliPath(),
+    ["--account", account, "items", "list", "--format=json", ...itemListFlags(), ...flags],
+    {
+      env: windowsEnv,
+      execute,
+      onError: async (e) => {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: e.message,
+        });
+      },
+      parseOutput: ({ error, exitCode, stderr, stdout }) => {
+        if (error) handleErrors(error.message);
+        if (stderr) handleErrors(stderr);
+        if (exitCode != 0) handleErrors(stdout);
+        const items = JSON.parse(stdout) as Item[];
 
-      return items.sort((a, b) => {
-        if (a.favorite && !b.favorite) {
-          return -1;
-        } else if (!a.favorite && b.favorite) {
-          return 1;
-        }
+        return items.sort((a, b) => {
+          if (a.favorite && !b.favorite) {
+            return -1;
+          } else if (!a.favorite && b.favorite) {
+            return 1;
+          }
 
-        return a.title.localeCompare(b.title);
-      });
+          return a.title.localeCompare(b.title);
+        });
+      },
     },
-  });
+  );
 export const usePasswords = (flags: string[] = []) =>
-  useOp<Item[], ExtensionError>(["items", "list", ...flags], (data) =>
+  useOp<Item[], ExtensionError>(["items", "list", ...itemListFlags(), ...flags], (data) =>
     data.sort((a, b) => a.title.localeCompare(b.title)),
   );
 export const useVaults = () =>


### PR DESCRIPTION
## Description

Fixes #27540.

Adds an opt-in **Reduce item list memory usage** path for 1Password item lists with very large vaults. When enabled, the list uses the smaller summary payload from `op item list` instead of `--long`, avoids keeping an extra derived item-list state array, filters across the full result set, and renders the first 200 matching items to keep Raycast worker memory bounded.

Full item details are still fetched lazily when an action needs them. For example, **Open in Browser** fetches the full login item before opening the website if the lightweight list item does not include a URL.

In reduced-memory mode, username/email subtitles and username/email search are unavailable until a full item is fetched by an action. The changelog calls out that tradeoff.

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`
- Latest extension CI job is green

## Screencast

Not included; this is a memory-usage fix for large local item lists.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
