### PR TITLE
[Sentry] Guard issue details without stack frames

### DIFF
--- a/extensions/sentry/CHANGELOG.md
+++ b/extensions/sentry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sentry Changelog
 
+## [Bug Fix] - {PR_MERGE_DATE}
+
+- Prevent issue details from crashing when the latest event has no stack frames.
+
 ## [List Latest Releases] - 2026-03-31
 
 - Added new command to list latest releases per project.

--- a/extensions/sentry/CHANGELOG.md
+++ b/extensions/sentry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Sentry Changelog
 
-## [Bug Fix] - {PR_MERGE_DATE}
+## [Bug Fix] - 2026-05-28
 
 - Prevent issue details from crashing when the latest event has no stack frames.
 

--- a/extensions/sentry/src/IssueDetails.tsx
+++ b/extensions/sentry/src/IssueDetails.tsx
@@ -96,7 +96,9 @@ function formatException(lastEvent?: Event) {
     return "";
   }
 
-  const exception = lastEvent.entries.find((entry) => entry.type === "threads") as Exception | undefined;
+  const exception = lastEvent.entries.find((entry) => entry.type === "exception" || entry.type === "threads") as
+    | Exception
+    | undefined;
   if (!exception) {
     return "";
   }
@@ -106,7 +108,12 @@ function formatException(lastEvent?: Event) {
     return "";
   }
 
-  const fomattedException = lastException.stacktrace.frames
+  const frames = lastException.stacktrace?.frames;
+  if (!frames?.length) {
+    return "";
+  }
+
+  const fomattedException = frames
     .filter((frame) => frame.inApp)
     .map((frame) => `- ${frame.function} _(${frame.filename}:${frame.lineNo})_`)
     .reverse()

--- a/extensions/sentry/src/types.ts
+++ b/extensions/sentry/src/types.ts
@@ -88,33 +88,35 @@ export type Message = {
 };
 
 export type Exception = {
-  type: "exception";
+  type: "exception" | "threads";
   data: {
     excOmitted: number[];
     hasSystemFrames: boolean;
     values: {
-      stacktrace: {
-        frames: {
-          function: string;
-          errors: string;
-          colNo: number;
-          package: string;
-          absPath: string;
-          inApp: boolean;
-          lineNo: number;
-          module: string;
-          filename: string;
-          platform: string;
-          instructionAddr: string;
-          context: (number | string)[][];
-          symbolAddr: string;
-          trust: string;
-          symbol: string;
-        }[];
+      stacktrace?: {
+        frames:
+          | {
+              function: string;
+              errors: string;
+              colNo: number;
+              package: string;
+              absPath: string;
+              inApp: boolean;
+              lineNo: number;
+              module: string;
+              filename: string;
+              platform: string;
+              instructionAddr: string;
+              context: (number | string)[][];
+              symbolAddr: string;
+              trust: string;
+              symbol: string;
+            }[]
+          | null;
         framesOmitted: string;
         registers: string;
         hasSystemFrames: boolean;
-      };
+      } | null;
       module: string;
       rawStacktrace: {
         [k: string]: unknown;


### PR DESCRIPTION
## Description

Fixes #25150.

Prevents the issue detail view from crashing when Sentry returns a latest event whose exception/thread entry has no stacktrace frames. The detail page now skips the exception section for frame-less events and continues rendering the rest of the issue metadata and event details.

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`

## Screencast

Not included; this is a null-safety fix for an API response shape reported in the issue.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)