### PR TITLE
[Incident.io] Guard on-call shifts without user details

### DIFF
--- a/extensions/incident-io/CHANGELOG.md
+++ b/extensions/incident-io/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Incident.io Changelog
 
+## [Bug Fix] - {PR_MERGE_DATE}
+
+- Prevent the on-call schedule list from crashing when a shift has no user details.
+
 ## [v0.0.3] - 2025-06-13
 
 - Add AI-powered incident search functionality

--- a/extensions/incident-io/CHANGELOG.md
+++ b/extensions/incident-io/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Incident.io Changelog
 
-## [Bug Fix] - {PR_MERGE_DATE}
+## [Bug Fix] - 2026-05-18
 
 - Prevent the on-call schedule list from crashing when a shift has no user details.
 

--- a/extensions/incident-io/package.json
+++ b/extensions/incident-io/package.json
@@ -68,5 +68,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/incident-io/src/oncall.tsx
+++ b/extensions/incident-io/src/oncall.tsx
@@ -7,19 +7,23 @@ interface Preferences {
 }
 
 interface User {
-  id: string;
-  name: string;
-  email: string;
+  id?: string;
+  name?: string;
+  email?: string;
 }
 
 interface CurrentShift {
-  user: User;
+  user?: User | null;
 }
 
 interface Schedule {
   id: string;
   name: string;
-  current_shifts: CurrentShift[];
+  current_shifts?: CurrentShift[] | null;
+}
+
+function isString(value: string | undefined): value is string {
+  return Boolean(value);
 }
 
 export default function CurrentOnCallCommand() {
@@ -59,8 +63,21 @@ export default function CurrentOnCallCommand() {
     fetchSchedules();
   }, [preferences.apiKey]);
 
+  function getCurrentShifts(schedule: Schedule): CurrentShift[] {
+    return Array.isArray(schedule.current_shifts) ? schedule.current_shifts : [];
+  }
+
+  function getCurrentResponderEmails(schedule: Schedule): string[] {
+    return getCurrentShifts(schedule)
+      .map((shift) => shift.user?.email)
+      .filter(isString);
+  }
+
   function getCurrentResponders(schedule: Schedule): string {
-    const responders = schedule.current_shifts.map((shift) => shift.user.name);
+    const responders = getCurrentShifts(schedule)
+      .map((shift) => shift.user?.name || shift.user?.email)
+      .filter(isString);
+
     return responders.length > 0 ? responders.join(", ") : "No one currently on-call";
   }
 
@@ -68,18 +85,17 @@ export default function CurrentOnCallCommand() {
     <List isLoading={loading} searchBarPlaceholder="Search schedules...">
       {schedules.map((schedule) => {
         const currentResponders = getCurrentResponders(schedule);
+        const currentResponderEmails = getCurrentResponderEmails(schedule);
+
         return (
           <List.Item
             key={schedule.id}
             title={schedule.name}
             subtitle={`On-call: ${currentResponders}`}
             actions={
-              schedule.current_shifts.length > 0 && (
+              currentResponderEmails.length > 0 && (
                 <ActionPanel>
-                  <Action.CopyToClipboard
-                    title="Copy On-Call Email(s)"
-                    content={schedule.current_shifts.map((shift) => shift.user.email).join(", ")}
-                  />
+                  <Action.CopyToClipboard title="Copy On-Call Email(s)" content={currentResponderEmails.join(", ")} />
                 </ActionPanel>
               )
             }


### PR DESCRIPTION
## Description

Fixes #26691.

Prevents the current on-call list from crashing when an incident.io schedule shift is missing user details. The command now skips missing users, falls back to email when a name is unavailable, and only shows the copy-email action when there are emails to copy.

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`

## Screencast

Not included; this is a null-safety fix for an API response shape reported in the issue.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)