### PR TITLE
[Trello] Guard member lists in Create a Card

### DIFF
--- a/extensions/trello/CHANGELOG.md
+++ b/extensions/trello/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Trello Changelog
 
+## [Bug Fix] - {PR_MERGE_DATE}
+
+- Prevent the Create a Card form from crashing when board members cannot be loaded as a list.
+
 ## [Update] - 2026-03-25
 
 - Rebuilt extension with Trello REST client

--- a/extensions/trello/CHANGELOG.md
+++ b/extensions/trello/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Trello Changelog
 
-## [Bug Fix] - {PR_MERGE_DATE}
+## [Bug Fix] - 2026-05-18
 
 - Prevent the Create a Card form from crashing when board members cannot be loaded as a list.
 

--- a/extensions/trello/src/createTodo.tsx
+++ b/extensions/trello/src/createTodo.tsx
@@ -20,6 +20,10 @@ function toArray<T>(value: unknown): T[] {
   return Array.isArray(value) ? value : [];
 }
 
+function isArray<T>(value: unknown): value is T[] {
+  return Array.isArray(value);
+}
+
 export default function Command() {
   const [boardResults, setBoards] = useState<Board[]>([]);
   const [listResults, setLists] = useState<List[]>([]);
@@ -33,7 +37,13 @@ export default function Command() {
     async function fetchBoards() {
       try {
         setLoading(true);
-        const response = toArray<Board>(await trelloClient.getBoards(false));
+        const response = await trelloClient.getBoards(false);
+        if (!isArray<Board>(response)) {
+          showToast(Toast.Style.Failure, "Failed loading boards", "Unexpected Trello response.");
+          setBoards([]);
+          setLoading(false);
+          return;
+        }
         setBoards(response);
         if (response[0]?.id) {
           setSelectedBoard(response[0].id);
@@ -51,7 +61,14 @@ export default function Command() {
   async function loadListsAndMembers(boardId: string) {
     try {
       setLoading(true);
-      const listsResponse = toArray<List>(await trelloClient.getLists(boardId));
+      const listsResponse = await trelloClient.getLists(boardId);
+      if (!isArray<List>(listsResponse)) {
+        showToast(Toast.Style.Failure, "Failed loading lists", "Unexpected Trello response.");
+        setLists([]);
+        setMembers([]);
+        setLoading(false);
+        return;
+      }
       const membersResponse = toArray<Member>(await trelloClient.getBoardMembers(boardId));
       setLists(listsResponse);
       setMembers(membersResponse);

--- a/extensions/trello/src/createTodo.tsx
+++ b/extensions/trello/src/createTodo.tsx
@@ -16,6 +16,10 @@ type Values = {
   idMember?: string[];
 };
 
+function toArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
 export default function Command() {
   const [boardResults, setBoards] = useState<Board[]>([]);
   const [listResults, setLists] = useState<List[]>([]);
@@ -29,7 +33,7 @@ export default function Command() {
     async function fetchBoards() {
       try {
         setLoading(true);
-        const response = await trelloClient.getBoards(false);
+        const response = toArray<Board>(await trelloClient.getBoards(false));
         setBoards(response);
         if (response[0]?.id) {
           setSelectedBoard(response[0].id);
@@ -47,8 +51,8 @@ export default function Command() {
   async function loadListsAndMembers(boardId: string) {
     try {
       setLoading(true);
-      const listsResponse = await trelloClient.getLists(boardId);
-      const membersResponse = await trelloClient.getBoardMembers(boardId);
+      const listsResponse = toArray<List>(await trelloClient.getLists(boardId));
+      const membersResponse = toArray<Member>(await trelloClient.getBoardMembers(boardId));
       setLists(listsResponse);
       setMembers(membersResponse);
       if (listsResponse[0]?.id) setSelectedList(listsResponse[0].id);


### PR DESCRIPTION
## Description

Fixes #22894.

Prevents the Create a Card form from crashing when the Trello API returns a non-list response for boards, lists, or board members. The form now normalizes those responses before rendering member, board, and list pickers, so card creation can still load safely when members are unavailable.

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`

Note: `npm run lint` exits successfully with an existing title-case warning for the `Fetch all Cards` command title.

## Screencast

Not included; this is a defensive fix for an API response shape reported in the issue.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)