### PR TITLE
[Google Workspace] Guard Drive file list responses

### DIFF
--- a/extensions/google-workspace/CHANGELOG.md
+++ b/extensions/google-workspace/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Workspace Changelog
 
+## [Bug Fix] - {PR_MERGE_DATE}
+
+- Prevent Google Drive search from crashing when the Drive API response does not include a files list.
+
 ## [Add Preferred Browser Preference] - 2026-01-08
 
 - Allow users to specify which browser they want to use.

--- a/extensions/google-workspace/CHANGELOG.md
+++ b/extensions/google-workspace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Workspace Changelog
 
-## [Bug Fix] - {PR_MERGE_DATE}
+## [Bug Fix] - 2026-05-22
 
 - Prevent Google Drive search from crashing when the Drive API response does not include a files list.
 

--- a/extensions/google-workspace/src/api/getFiles.ts
+++ b/extensions/google-workspace/src/api/getFiles.ts
@@ -198,7 +198,7 @@ async function baseGetFiles(params: StandardGetFilesParams | AIGetFilesParams) {
     );
   }
 
-  return { ...data, files: data.files };
+  return data as DriveFilesResponse & { files: File[] };
 }
 
 // Standard search using predefined query types

--- a/extensions/google-workspace/src/api/getFiles.ts
+++ b/extensions/google-workspace/src/api/getFiles.ts
@@ -68,6 +68,13 @@ type FileData = {
   parents: string[];
 };
 
+type DriveFilesResponse = {
+  files?: File[];
+  error?: {
+    message?: string;
+  };
+};
+
 // For the whole list of properties, look at: https://developers.google.com/drive/api/reference/rest/v3/files
 
 const EXTENSION_SEARCH_PARAMS =
@@ -172,7 +179,15 @@ async function baseGetFiles(params: StandardGetFilesParams | AIGetFilesParams) {
       Authorization: `Bearer ${getOAuthToken()}`,
     },
   });
-  const data = (await response.json()) as { files: File[] };
+  const data = (await response.json()) as DriveFilesResponse;
+
+  if (!response.ok) {
+    throw new Error(data.error?.message ?? `Google Drive request failed: ${response.status} ${response.statusText}`);
+  }
+
+  if (!Array.isArray(data.files)) {
+    throw new Error(data.error?.message ?? "Google Drive response did not include files.");
+  }
 
   const { displayFilePath } = getPreferenceValues<Preferences>();
   if (displayFilePath) {
@@ -183,7 +198,7 @@ async function baseGetFiles(params: StandardGetFilesParams | AIGetFilesParams) {
     );
   }
 
-  return data;
+  return { ...data, files: data.files };
 }
 
 // Standard search using predefined query types


### PR DESCRIPTION
## Description

Fixes #22531.

Prevents Search Google Drive from crashing when the Drive API returns an error or another non-file-list JSON response. The file search request now validates the HTTP status and the `files` array before resolving, so Raycast shows the existing failure toast instead of calling `.map` on an undefined file list.

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`

## Screencast

Not included; this is a defensive API response-shape fix for the reported Drive search crash.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)