### PR TITLE
[Browser Bookmarks] Handle large Safari bookmark files

### DIFF
--- a/extensions/browser-bookmarks/CHANGELOG.md
+++ b/extensions/browser-bookmarks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Browser Bookmarks Changelog
 
+## [Bug Fix] - {PR_MERGE_DATE}
+
+- Increased the Safari bookmark plist parser limit so large bookmark libraries no longer fail with `maxObjectCount exceeded`
+
 ## [Windows Support for Chromium Browsers] - 2026-04-30
 
 - Added Windows support for Chrome, Edge, and Brave bookmarks

--- a/extensions/browser-bookmarks/CHANGELOG.md
+++ b/extensions/browser-bookmarks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Browser Bookmarks Changelog
 
-## [Bug Fix] - {PR_MERGE_DATE}
+## [Bug Fix] - 2026-05-19
 
 - Increased the Safari bookmark plist parser limit so large bookmark libraries no longer fail with `maxObjectCount exceeded`
 

--- a/extensions/browser-bookmarks/src/hooks/useSafariBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useSafariBookmarks.ts
@@ -2,13 +2,16 @@ import { homedir } from "os";
 import { promisify } from "util";
 
 import { useCachedPromise } from "@raycast/utils";
-import { readFile } from "simple-plist";
+import { bplistParser, readFile } from "simple-plist";
 
 import { BROWSERS_BUNDLE_ID } from "./useAvailableBrowsers";
 
 const PLIST_PATH = `${homedir()}/Library/Safari/Bookmarks.plist`;
+const SAFARI_BOOKMARKS_MAX_OBJECT_COUNT = 250_000;
 
 const readPlist = promisify(readFile);
+const safariBplistParser = bplistParser as typeof bplistParser & { maxObjectCount: number };
+safariBplistParser.maxObjectCount = SAFARI_BOOKMARKS_MAX_OBJECT_COUNT;
 
 export type BookmarkFolder = {
   WebBookmarkUUID: string;


### PR DESCRIPTION
## Description

Fixes #8640.

Prevents Safari bookmark loading from failing with `maxObjectCount exceeded` for users with very large `Bookmarks.plist` files. Safari bookmarks now raise the binary plist parser object limit before reading the local Safari bookmark file, while leaving bookmark traversal and browser integration unchanged.

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`

## Screencast

Not included; this is a defensive parser-limit fix for large local Safari bookmark files.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and checked that the extension compiles successfully
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)