### PR TITLE
[Spotify Player] Guard podcast episode navigation

### DIFF
--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Spotify Player Changelog
 
-## [Fix Podcast Episode Navigation] - {PR_MERGE_DATE}
+## [Fix Podcast Episode Navigation] - 2026-05-28
 
 - Prevent podcast episode navigation from crashing when Spotify omits show details in search results
 

--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Spotify Player Changelog
 
+## [Fix Podcast Episode Navigation] - {PR_MERGE_DATE}
+
+- Prevent podcast episode navigation from crashing when Spotify omits show details in search results
+
 ## [Add Keyboard Shortcuts] - 2026-05-17
 
 - Added shortcuts for opening Your Library and Search from Now Playing and Add Playing Song to Playlist

--- a/extensions/spotify-player/src/components/EpisodesList.tsx
+++ b/extensions/spotify-player/src/components/EpisodesList.tsx
@@ -5,18 +5,26 @@ import { useShowEpisodes } from "../hooks/useShowEpisodes";
 import EpisodeListItem from "./EpisodeListItem";
 
 type EpisodesListProps = {
-  show: SimplifiedShowObject;
+  show?: SimplifiedShowObject | null;
 };
 
 export function EpisodesList({ show }: EpisodesListProps) {
   const { showEpisodesData, showEpisodesIsLoading } = useShowEpisodes({
     showId: show?.id || "",
     options: {
-      execute: Boolean(show),
+      execute: Boolean(show?.id),
     },
   });
 
   const episodes = showEpisodesData?.items;
+
+  if (!show?.id) {
+    return (
+      <List searchBarPlaceholder="Search episodes">
+        <List.EmptyView title="No Podcast Details" description="Spotify did not return details for this podcast." />
+      </List>
+    );
+  }
 
   return (
     <List searchBarPlaceholder="Search episodes" isLoading={showEpisodesIsLoading}>

--- a/extensions/spotify-player/src/components/ShowActionPanel.tsx
+++ b/extensions/spotify-player/src/components/ShowActionPanel.tsx
@@ -5,9 +5,11 @@ import { FooterAction } from "./FooterAction";
 import { PlayAction } from "./PlayAction";
 import { ShowContent } from "../shortcuts/shortcuts";
 
-type ShowActionPanelProps = { show: SimplifiedShowObject };
+type ShowActionPanelProps = { show?: SimplifiedShowObject | null };
 
 export function ShowActionPanel({ show }: ShowActionPanelProps) {
+  if (!show?.id) return null;
+
   const title = show.name;
 
   return (

--- a/extensions/spotify-player/src/components/ShowsSection.tsx
+++ b/extensions/spotify-player/src/components/ShowsSection.tsx
@@ -4,7 +4,7 @@ import { SimplifiedShowObject } from "../helpers/spotify.api";
 
 type ShowsSectionProps = {
   type: "list" | "grid";
-  shows: SimplifiedShowObject[] | undefined;
+  shows: (SimplifiedShowObject | null | undefined)[] | undefined;
   columns?: number;
   limit?: number;
 };
@@ -12,7 +12,9 @@ type ShowsSectionProps = {
 export function ShowsSection({ type, shows, columns, limit }: ShowsSectionProps) {
   if (!shows) return null;
 
-  const items = shows.slice(0, limit || shows.length);
+  const items = shows.filter((show): show is SimplifiedShowObject => Boolean(show?.id)).slice(0, limit || shows.length);
+
+  if (!items.length) return null;
 
   return (
     <ListOrGridSection type={type} title="Podcasts & Shows" columns={columns}>

--- a/extensions/spotify-player/src/components/ShowsSection.tsx
+++ b/extensions/spotify-player/src/components/ShowsSection.tsx
@@ -12,7 +12,8 @@ type ShowsSectionProps = {
 export function ShowsSection({ type, shows, columns, limit }: ShowsSectionProps) {
   if (!shows) return null;
 
-  const items = shows.filter((show): show is SimplifiedShowObject => Boolean(show?.id)).slice(0, limit || shows.length);
+  const filtered = shows.filter((show): show is SimplifiedShowObject => Boolean(show?.id));
+  const items = filtered.slice(0, limit || filtered.length);
 
   if (!items.length) return null;
 


### PR DESCRIPTION
## Description

Fixes #24061.

Prevents podcast/show navigation from crashing when Spotify search or library results include missing show details. The shows section now filters invalid show entries before rendering, and the episode view avoids fetching episodes until a valid show id is available.

Validation:
- `npm run lint` (passes with the existing package title-case warning)
- `npm run build`
- `git diff --check`

## Screencast

Not included; this is a defensive crash fix for incomplete Spotify show payloads.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and checked that the extension compiles successfully
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)