### PR TITLE
[Beeper Desktop] Limit chat message page size

### DIFF
--- a/extensions/beeper/CHANGELOG.md
+++ b/extensions/beeper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Beeper Changelog
 
-## [Bug Fix] - {PR_MERGE_DATE}
+## [Bug Fix] - 2026-05-18
 
 - Limited chat message loading to one page at a time to avoid memory pressure in large conversations
 

--- a/extensions/beeper/CHANGELOG.md
+++ b/extensions/beeper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Beeper Changelog
 
+## [Bug Fix] - {PR_MERGE_DATE}
+
+- Limited chat message loading to one page at a time to avoid memory pressure in large conversations
+
 ## [Windows Support] - 2026-04-13
 
 ### Added

--- a/extensions/beeper/src/api.ts
+++ b/extensions/beeper/src/api.ts
@@ -408,18 +408,23 @@ export const createChat = async (body: {
   return getBeeperDesktop().chats.create(body);
 };
 
+const DEFAULT_MESSAGE_PAGE_LIMIT = 50;
+
 export const listChatMessages = async (
   chatID: string,
-  params?: { cursor?: string | null; direction?: "after" | "before" },
+  params?: { cursor?: string | null; direction?: "after" | "before"; limit?: number },
 ): Promise<CursorResponse<BeeperDesktop.Message>> => {
+  const limit = params?.limit ?? DEFAULT_MESSAGE_PAGE_LIMIT;
+
   if (useMockData()) {
     const items = MOCK_MESSAGES.filter((m) => m.chatId === chatID)
       .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+      .slice(0, limit)
       .map(mockMessageToBeeperMessage);
     return { items, hasMore: false };
   }
   const response = await getBeeperDesktop().get(`/v1/chats/${encodeURIComponent(chatID)}/messages`, {
-    query: params,
+    query: { ...params, limit },
   });
   return normalizeUnknownCursorResponse<BeeperDesktop.Message>(response);
 };


### PR DESCRIPTION
## Description

Fixes #27353.

Prevents large Beeper chat threads from loading an unbounded message list at once. Chat message loading now requests one 50-message page by default, matching the search path and keeping the existing Load older messages pagination path in place.

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`

## Screencast

Not included; this is a defensive pagination fix for large local chat histories.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and checked that the extension compiles successfully
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)