### PR TITLE
[Jira] Load all saved filters

### DIFF
--- a/extensions/jira/CHANGELOG.md
+++ b/extensions/jira/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Jira Changelog
 
+## [Bug Fix] - {PR_MERGE_DATE}
+
+- Loaded all saved filters in the My Filters command instead of stopping after the first 100 results
+
 ## [Open Issues sprint/backlog split config] - 2026-04-16
 
 - Added new `Open Issues` checkboxes to choose which sections to show: `Active Sprint`, `All Sprints`, and `Backlog`.

--- a/extensions/jira/CHANGELOG.md
+++ b/extensions/jira/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Jira Changelog
 
-## [Bug Fix] - {PR_MERGE_DATE}
+## [Bug Fix] - 2026-05-18
 
 - Loaded all saved filters in the My Filters command instead of stopping after the first 100 results
 

--- a/extensions/jira/src/api/filters.ts
+++ b/extensions/jira/src/api/filters.ts
@@ -10,18 +10,40 @@ export type Filter = {
 
 type GetFiltersResponse = {
   values: Filter[];
+  isLast?: boolean;
+  total?: number;
 };
 
 export async function getFilters(query: string) {
   const { sortByFavourite } = getPreferenceValues<Preferences.MyFilters>();
+  const maxResults = 100;
+  let startAt = 0;
+  let hasMore = true;
+  const filters: Filter[] = [];
 
-  const params = {
-    maxResults: "100",
-    expand: "jql",
-    filterName: query,
-    ...(sortByFavourite === true && { orderBy: "-IS_FAVOURITE" }),
-  };
+  while (hasMore) {
+    const params = {
+      maxResults: String(maxResults),
+      startAt: String(startAt),
+      expand: "jql",
+      filterName: query,
+      ...(sortByFavourite === true && { orderBy: "-IS_FAVOURITE" }),
+    };
 
-  const result = await request<GetFiltersResponse>(`/filter/search`, { params });
-  return result?.values;
+    const result = await request<GetFiltersResponse>(`/filter/search`, { params });
+    const values = result?.values ?? [];
+    filters.push(...values);
+
+    if (
+      result?.isLast === true ||
+      values.length < maxResults ||
+      (result?.total !== undefined && filters.length >= result.total)
+    ) {
+      hasMore = false;
+    } else {
+      startAt += values.length;
+    }
+  }
+
+  return filters;
 }


### PR DESCRIPTION
## Description

Fixes #27307.

Loads Jira saved filters across all `/filter/search` result pages instead of stopping at the first 100 results. The My Filters dropdown now keeps requesting pages until Jira reports the last page, the total has been reached, or the returned page is shorter than the requested page size.

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`

## Screencast

Not included; this is a pagination fix for Jira workspaces with more than 100 saved filters.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and checked that the extension compiles successfully
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)