### PR TITLE
[GitLab] Keep cached merge requests interactive

### DIFF
--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitLab Changelog
 
-## [Keep cached merge requests interactive] - {PR_MERGE_DATE}
+## [Keep cached merge requests interactive] - 2026-05-18
 
 - Keep cached list results actionable while stale data refreshes in the background
 

--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitLab Changelog
 
+## [Keep cached merge requests interactive] - {PR_MERGE_DATE}
+
+- Keep cached list results actionable while stale data refreshes in the background
+
 ## [Pipeline triggers, My Pipelines & Job controls] - 2026-05-18
 
 - Add top-level `My Pipelines` command listing your recent pipelines across projects

--- a/extensions/gitlab/src/cache.ts
+++ b/extensions/gitlab/src/cache.ts
@@ -178,6 +178,7 @@ export function useCache<T>(
           if (!didUnmount) {
             cacheLog("set cache data");
             setData(await search(cacheData.data));
+            setIsLoading(false);
             cacheLog(`${cacheData.ageInSeconds}  vs  ${secondsToRefetch}`);
             if (cacheData.ageInSeconds > secondsToRefetch) {
               cacheLog("cache is older, start refetch");


### PR DESCRIPTION
## Summary
- Fixes #25340
- Keep cached GitLab list results actionable as soon as valid cached data is rendered
- Continue stale cache refreshes in the background without blocking item actions

## Validation
- npm install --no-audit --no-fund
- npm run lint (passes; existing package title casing warning remains)
- npm run build
- git diff --check