### PR TITLE
[Jira] Fix attachment image URLs in issue details

### DIFF
--- a/extensions/jira/CHANGELOG.md
+++ b/extensions/jira/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Jira Changelog
 
-## [Bug Fix] - {PR_MERGE_DATE}
+## [Bug Fix] - 2026-05-18
 
 - Fixed issue details failing to load when descriptions include absolute Jira attachment image URLs
 

--- a/extensions/jira/CHANGELOG.md
+++ b/extensions/jira/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Jira Changelog
 
+## [Bug Fix] - {PR_MERGE_DATE}
+
+- Fixed issue details failing to load when descriptions include absolute Jira attachment image URLs
+
 ## [Bug Fix] - 2026-05-18
 
 - Loaded all saved filters in the My Filters command instead of stopping after the first 100 results

--- a/extensions/jira/src/components/IssueDetail.tsx
+++ b/extensions/jira/src/components/IssueDetail.tsx
@@ -17,6 +17,25 @@ type IssueDetailProps = {
   issueKey: string;
 };
 
+function resolveAuthenticatedImageUri(uri: string, baseUrl: string) {
+  if (uri.startsWith("data:")) {
+    return uri;
+  }
+
+  if (uri.startsWith("http://") || uri.startsWith("https://")) {
+    const url = new URL(uri);
+    const restPathIndex = url.pathname.indexOf("/rest/");
+
+    if (baseUrl.includes("api.atlassian.com/ex/jira/") && restPathIndex >= 0) {
+      return `${baseUrl}${url.pathname.slice(restPathIndex)}${url.search}`;
+    }
+
+    return uri;
+  }
+
+  return `${baseUrl}${uri.startsWith("/") ? uri : `/${uri}`}`;
+}
+
 export default function IssueDetail({ initialIssue, issueKey }: IssueDetailProps) {
   const {
     data: issue,
@@ -32,9 +51,9 @@ export default function IssueDetail({ initialIssue, issueKey }: IssueDetailProps
       const baseUrl = getBaseUrl();
       const description = issue.renderedFields?.description ?? "";
       // Resolve all the image URLs to data URIs in the cached promise for better performance
-      // Jira images use partial URLs, so we need to prepend the base URL
+      // Jira can return partial URLs or tenant URLs; OAuth requests must go through the API base.
       const resolvedDescription = await replaceAsync(description, /src="(.*?)"/g, async (_, uri) => {
-        const dataUri = await getAuthenticatedUri(`${baseUrl}${uri}`, "image/jpeg");
+        const dataUri = await getAuthenticatedUri(resolveAuthenticatedImageUri(uri, baseUrl), "image/jpeg");
         return `src="${dataUri}"`;
       });
       issue.renderedFields.description = resolvedDescription;

--- a/extensions/jira/src/components/IssueDetail.tsx
+++ b/extensions/jira/src/components/IssueDetail.tsx
@@ -30,10 +30,14 @@ function resolveAuthenticatedImageUri(uri: string, baseUrl: string) {
       return null;
     }
 
-    const restPathIndex = url.pathname.indexOf("/rest/");
+    if (baseUrl.includes("api.atlassian.com/ex/jira/")) {
+      if (url.hostname === "api.atlassian.com") {
+        return uri;
+      }
 
-    if (baseUrl.includes("api.atlassian.com/ex/jira/") && restPathIndex >= 0) {
-      return `${baseUrl}${url.pathname.slice(restPathIndex)}${url.search}`;
+      const restPathIndex = url.pathname.indexOf("/rest/");
+      const path = restPathIndex >= 0 ? url.pathname.slice(restPathIndex) : url.pathname;
+      return `${baseUrl}${path}${url.search}`;
     }
 
     return uri;

--- a/extensions/jira/src/components/IssueDetail.tsx
+++ b/extensions/jira/src/components/IssueDetail.tsx
@@ -36,8 +36,11 @@ function resolveAuthenticatedImageUri(uri: string, baseUrl: string) {
       }
 
       const restPathIndex = url.pathname.indexOf("/rest/");
-      const path = restPathIndex >= 0 ? url.pathname.slice(restPathIndex) : url.pathname;
-      return `${baseUrl}${path}${url.search}`;
+      if (restPathIndex >= 0) {
+        return `${baseUrl}${url.pathname.slice(restPathIndex)}${url.search}`;
+      }
+
+      return null;
     }
 
     return uri;

--- a/extensions/jira/src/components/IssueDetail.tsx
+++ b/extensions/jira/src/components/IssueDetail.tsx
@@ -39,8 +39,6 @@ function resolveAuthenticatedImageUri(uri: string, baseUrl: string) {
       if (restPathIndex >= 0) {
         return `${baseUrl}${url.pathname.slice(restPathIndex)}${url.search}`;
       }
-
-      return null;
     }
 
     return uri;
@@ -71,8 +69,12 @@ export default function IssueDetail({ initialIssue, issueKey }: IssueDetailProps
           return `src="${uri}"`;
         }
 
-        const dataUri = await getAuthenticatedUri(authenticatedUri, "image/jpeg");
-        return `src="${dataUri}"`;
+        try {
+          const dataUri = await getAuthenticatedUri(authenticatedUri, "image/jpeg");
+          return `src="${dataUri}"`;
+        } catch {
+          return `src="${uri}"`;
+        }
       });
       issue.renderedFields.description = resolvedDescription;
 

--- a/extensions/jira/src/components/IssueDetail.tsx
+++ b/extensions/jira/src/components/IssueDetail.tsx
@@ -19,11 +19,17 @@ type IssueDetailProps = {
 
 function resolveAuthenticatedImageUri(uri: string, baseUrl: string) {
   if (uri.startsWith("data:")) {
-    return uri;
+    return null;
   }
 
   if (uri.startsWith("http://") || uri.startsWith("https://")) {
     const url = new URL(uri);
+    const isAtlassianUrl = url.hostname === "api.atlassian.com" || url.hostname.endsWith(".atlassian.net");
+
+    if (!isAtlassianUrl) {
+      return null;
+    }
+
     const restPathIndex = url.pathname.indexOf("/rest/");
 
     if (baseUrl.includes("api.atlassian.com/ex/jira/") && restPathIndex >= 0) {
@@ -53,7 +59,12 @@ export default function IssueDetail({ initialIssue, issueKey }: IssueDetailProps
       // Resolve all the image URLs to data URIs in the cached promise for better performance
       // Jira can return partial URLs or tenant URLs; OAuth requests must go through the API base.
       const resolvedDescription = await replaceAsync(description, /src="(.*?)"/g, async (_, uri) => {
-        const dataUri = await getAuthenticatedUri(resolveAuthenticatedImageUri(uri, baseUrl), "image/jpeg");
+        const authenticatedUri = resolveAuthenticatedImageUri(uri, baseUrl);
+        if (!authenticatedUri) {
+          return `src="${uri}"`;
+        }
+
+        const dataUri = await getAuthenticatedUri(authenticatedUri, "image/jpeg");
         return `src="${dataUri}"`;
       });
       issue.renderedFields.description = resolvedDescription;


### PR DESCRIPTION
## Summary
- Fixes #27521
- Handle absolute Jira attachment image URLs in rendered issue descriptions
- Preserve OAuth requests through the Atlassian API proxy while keeping site/API-token URLs unchanged

## Validation
- npm install --no-audit --no-fund
- npm run lint
- npm run build
- git diff --check