### PR TITLE
[GitHub] Split repository searches by owner

### DIFF
--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Changelog
 
-## [Fix repository search for many organizations] - {PR_MERGE_DATE}
+## [Fix repository search for many organizations] - 2026-05-18
 
 - Split My Repositories loading into smaller owner-specific searches to avoid GitHub 502 errors for users in many organizations.
 

--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitHub Changelog
 
+## [Fix repository search for many organizations] - {PR_MERGE_DATE}
+
+- Split My Repositories loading into smaller owner-specific searches to avoid GitHub 502 errors for users in many organizations.
+
 ## [Fix null pull request nodes crash] - 2026-05-15
 
 - Fixed `TypeError: Cannot read properties of null (reading 'id')` in **My Pull Requests** when the GitHub search API returns edges with a null `node` (e.g. PRs from repositories the user can no longer access).

--- a/extensions/github/src/hooks/useRepositories.ts
+++ b/extensions/github/src/hooks/useRepositories.ts
@@ -9,14 +9,28 @@ export function useMyRepositories() {
   const { github } = getGitHubClient();
   const viewer = useViewer();
 
-  const orgs = viewer?.organizations?.nodes?.map((org) => `org:${org?.login}`).join(" ");
-  const query = `user:@me ${orgs} archived:false sort:updated-desc`;
+  const ownerQueries = [
+    "user:@me",
+    ...(viewer?.organizations?.nodes?.flatMap((org) => (org?.login ? [`org:${org.login}`] : [])) ?? []),
+  ];
+  const ownerQueryKey = ownerQueries.join(" ");
 
-  return useCachedPromise(async () => {
-    const result = await github.searchRepositories({ query, numberOfItems: 100 });
+  return useCachedPromise(
+    async (ownerQueryKey) => {
+      const results = await Promise.all(
+        ownerQueryKey.split(" ").map((ownerQuery: string) =>
+          github.searchRepositories({
+            query: `${ownerQuery} archived:false sort:updated-desc`,
+            numberOfItems: 100,
+          }),
+        ),
+      );
 
-    return result.search.nodes as ExtendedRepositoryFieldsFragment[];
-  });
+      const repositories = results.flatMap((result) => result.search.nodes as ExtendedRepositoryFieldsFragment[]);
+      return [...new Map(repositories.map((repository) => [repository.id, repository])).values()];
+    },
+    [ownerQueryKey],
+  );
 }
 
 export function useReleases(repository: ExtendedRepositoryFieldsFragment) {

--- a/extensions/github/src/hooks/useRepositories.ts
+++ b/extensions/github/src/hooks/useRepositories.ts
@@ -17,7 +17,7 @@ export function useMyRepositories() {
 
   return useCachedPromise(
     async (ownerQueryKey) => {
-      const results = await Promise.all(
+      const results = await Promise.allSettled(
         ownerQueryKey.split(" ").map((ownerQuery: string) =>
           github.searchRepositories({
             query: `${ownerQuery} archived:false sort:updated-desc`,
@@ -26,8 +26,13 @@ export function useMyRepositories() {
         ),
       );
 
-      const repositories = results.flatMap((result) => result.search.nodes as ExtendedRepositoryFieldsFragment[]);
-      return [...new Map(repositories.map((repository) => [repository.id, repository])).values()];
+      const repositories = results.flatMap((result) =>
+        result.status === "fulfilled" ? (result.value.search.nodes as ExtendedRepositoryFieldsFragment[]) : [],
+      );
+
+      return [...new Map(repositories.map((repository) => [repository.id, repository])).values()].sort(
+        (left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime(),
+      );
     },
     [ownerQueryKey],
   );


### PR DESCRIPTION
## Summary
- Fixes #23108
- Split My Repositories loading into owner-specific GitHub searches instead of one large `user:@me org:...` query
- Deduplicate repositories by id after combining user and organization results
- Related to #25410, where the same large repository search can surface while refreshing GitHub views

## Validation
- npm install --no-audit --no-fund
- npm run lint
- npm run build
- git diff --check