### PR TITLE
Color Picker: add color favorites

### DIFF
--- a/extensions/color-picker/CHANGELOG.md
+++ b/extensions/color-picker/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Color Picker Changelog
 
+## [Favorites] - 2026-05-18
+
+- Add favorites to the `Organize Colors` command
+- Add actions to reorder favorite colors
+
 ## [Multi-Color Selection] - 2026-04-27
 
 - Add a Single/Multi select mode toggle to the search bar of `Organize Colors` and `Generate Colors`

--- a/extensions/color-picker/src/lib/history.ts
+++ b/extensions/color-picker/src/lib/history.ts
@@ -67,9 +67,8 @@ export function addToHistory(color: HistoryColor) {
 
   const serializedHistory = cache.get("history");
   const previousHistory = serializedHistory ? (JSON.parse(serializedHistory) as HistoryItem[]) : [];
-  const previousHistoryItem = previousHistory.find(
-    (item) => getFormattedColor(item.color) === getFormattedColor(color),
-  );
+  const colorKey = getFormattedColor(color);
+  const previousHistoryItem = previousHistory.find((item) => getFormattedColor(item.color) === colorKey);
 
   const historyItem: HistoryItem = {
     date: new Date().toISOString(),
@@ -77,10 +76,9 @@ export function addToHistory(color: HistoryColor) {
     title: previousHistoryItem?.title,
     isFavorite: previousHistoryItem?.isFavorite,
   };
-  const history = [
-    historyItem,
-    ...previousHistory.filter((item) => getFormattedColor(item.color) !== getFormattedColor(color)),
-  ];
+  const history = previousHistoryItem?.isFavorite
+    ? previousHistory.map((item) => (getFormattedColor(item.color) === colorKey ? historyItem : item))
+    : [historyItem, ...previousHistory.filter((item) => getFormattedColor(item.color) !== colorKey)];
   const persistentItemsCount = history.filter((item) => item.isFavorite).length;
   const maxRegularHistoryLength = Math.max(MAX_HISTORY_LENGTH - persistentItemsCount, 0);
   let regularHistoryCount = 0;

--- a/extensions/color-picker/src/lib/history.ts
+++ b/extensions/color-picker/src/lib/history.ts
@@ -7,6 +7,13 @@ const MAX_HISTORY_LENGTH = 200;
 
 export function useHistory() {
   const [history, setHistory] = useCachedState<HistoryItem[]>("history", []);
+  const update = (color: HistoryColor, updateItem: (item: HistoryItem) => HistoryItem) =>
+    setHistory((previousHistory) => {
+      return previousHistory.map((item) =>
+        getFormattedColor(item.color) === getFormattedColor(color) ? updateItem(item) : item,
+      );
+    });
+
   return {
     history,
     remove: (color: HistoryColor) =>
@@ -19,6 +26,38 @@ export function useHistory() {
           getFormattedColor(item.color) === getFormattedColor(historyItem.color) ? historyItem : item,
         );
       }),
+    addToFavorites: (color: HistoryColor) => update(color, (item) => ({ ...item, isFavorite: true })),
+    removeFromFavorites: (color: HistoryColor) => update(color, (item) => ({ ...item, isFavorite: false })),
+    moveFavorite: (color: HistoryColor, direction: "up" | "down") =>
+      setHistory((previousHistory) => {
+        const colorKey = getFormattedColor(color);
+        const currentIndex = previousHistory.findIndex(
+          (item) => item.isFavorite && getFormattedColor(item.color) === colorKey,
+        );
+
+        if (currentIndex === -1) {
+          return previousHistory;
+        }
+
+        const favoriteIndexes = previousHistory.reduce<number[]>((indexes, item, index) => {
+          if (item.isFavorite) {
+            indexes.push(index);
+          }
+
+          return indexes;
+        }, []);
+        const favoriteIndex = favoriteIndexes.indexOf(currentIndex);
+        const targetFavoriteIndex = favoriteIndex + (direction === "up" ? -1 : 1);
+        const targetIndex = favoriteIndexes[targetFavoriteIndex];
+
+        if (targetIndex === undefined) {
+          return previousHistory;
+        }
+
+        const nextHistory = [...previousHistory];
+        [nextHistory[currentIndex], nextHistory[targetIndex]] = [nextHistory[targetIndex], nextHistory[currentIndex]];
+        return nextHistory;
+      }),
     clear: () => setHistory([]),
   };
 }
@@ -28,12 +67,31 @@ export function addToHistory(color: HistoryColor) {
 
   const serializedHistory = cache.get("history");
   const previousHistory = serializedHistory ? (JSON.parse(serializedHistory) as HistoryItem[]) : [];
+  const previousHistoryItem = previousHistory.find(
+    (item) => getFormattedColor(item.color) === getFormattedColor(color),
+  );
 
-  const historyItem: HistoryItem = { date: new Date().toISOString(), color };
-  const newHistory = [
+  const historyItem: HistoryItem = {
+    date: new Date().toISOString(),
+    color,
+    title: previousHistoryItem?.title,
+    isFavorite: previousHistoryItem?.isFavorite,
+  };
+  const history = [
     historyItem,
     ...previousHistory.filter((item) => getFormattedColor(item.color) !== getFormattedColor(color)),
-  ].slice(0, MAX_HISTORY_LENGTH);
+  ];
+  const persistentItemsCount = history.filter((item) => item.isFavorite).length;
+  const maxRegularHistoryLength = Math.max(MAX_HISTORY_LENGTH - persistentItemsCount, 0);
+  let regularHistoryCount = 0;
+  const newHistory = history.filter((item) => {
+    if (item.isFavorite) {
+      return true;
+    }
+
+    regularHistoryCount += 1;
+    return regularHistoryCount <= maxRegularHistoryLength;
+  });
 
   cache.set("history", JSON.stringify(newHistory));
 }

--- a/extensions/color-picker/src/lib/types.ts
+++ b/extensions/color-picker/src/lib/types.ts
@@ -22,6 +22,7 @@ export type HistoryItem = {
   date: string;
   color: HistoryColor;
   title?: string;
+  isFavorite?: boolean;
 };
 
 export type LaunchOptions = Parameters<typeof launchCommand>[0];

--- a/extensions/color-picker/src/organize-colors.tsx
+++ b/extensions/color-picker/src/organize-colors.tsx
@@ -54,6 +54,8 @@ export default function Command() {
   // (e.g. legacy data with duplicate picks) get distinct selection keys.
   const getItemKey = useCallback((item: HistoryItem) => `${item.date}-${getFormattedColor(item.color)}`, []);
   const { selection } = useColorsSelection<HistoryItem>(history ?? [], getItemKey);
+  const favoriteHistory = history?.filter((item) => item.isFavorite) ?? [];
+  const regularHistory = history?.filter((item) => !item.isFavorite) ?? [];
 
   if (selectMode === "multi") {
     return (
@@ -79,24 +81,8 @@ export default function Command() {
             </ActionPanel>
           }
         />
-        {history?.map((historyItem) => {
-          const formattedColor = getFormattedColor(historyItem.color);
-          const previewColor = getPreviewColor(historyItem.color);
-          const isSelected = selection.helpers.getIsItemSelected(historyItem);
-
-          return (
-            <List.Item
-              key={`${historyItem.date}-${formattedColor}`}
-              icon={getIcon(previewColor)}
-              title={`${isSelected ? "✓ " : ""}${formattedColor}${historyItem.title ? ` ${historyItem.title}` : ""}`}
-              subtitle={new Date(historyItem.date).toLocaleString(undefined, {
-                dateStyle: "medium",
-                timeStyle: "short",
-              })}
-              actions={<Actions historyItem={historyItem} selectMode={selectMode} selection={selection} />}
-            />
-          );
-        })}
+        <ListHistorySection title="Favorites" history={favoriteHistory} selectMode={selectMode} selection={selection} />
+        <ListHistorySection title="History" history={regularHistory} selectMode={selectMode} selection={selection} />
       </List>
     );
   }
@@ -120,14 +106,34 @@ export default function Command() {
           </ActionPanel>
         }
       />
-      {history?.map((historyItem) => {
+      <GridHistorySection title="Favorites" history={favoriteHistory} selectMode={selectMode} selection={selection} />
+      <GridHistorySection title="History" history={regularHistory} selectMode={selectMode} selection={selection} />
+    </Grid>
+  );
+}
+
+type HistorySectionProps = {
+  title: string;
+  history: HistoryItem[];
+  selectMode: SelectMode;
+  selection: UseColorsSelectionObject<HistoryItem>;
+};
+
+function GridHistorySection({ title, history, selectMode, selection }: HistorySectionProps) {
+  if (history.length === 0) {
+    return null;
+  }
+
+  return (
+    <Grid.Section title={title} subtitle={String(history.length)}>
+      {history.map((historyItem) => {
         const formattedColor = getFormattedColor(historyItem.color);
         const previewColor = getPreviewColor(historyItem.color);
         const color = { light: previewColor, dark: previewColor, adjustContrast: false };
 
         return (
           <Grid.Item
-            key={`${historyItem.date}-${formattedColor}`}
+            key={`${title}-${historyItem.date}-${formattedColor}`}
             content={historyItem.title ? { value: { color }, tooltip: historyItem.title } : { color }}
             title={`${formattedColor} ${historyItem.title ?? ""}`}
             subtitle={new Date(historyItem.date).toLocaleString(undefined, {
@@ -138,7 +144,36 @@ export default function Command() {
           />
         );
       })}
-    </Grid>
+    </Grid.Section>
+  );
+}
+
+function ListHistorySection({ title, history, selectMode, selection }: HistorySectionProps) {
+  if (history.length === 0) {
+    return null;
+  }
+
+  return (
+    <List.Section title={title} subtitle={String(history.length)}>
+      {history.map((historyItem) => {
+        const formattedColor = getFormattedColor(historyItem.color);
+        const previewColor = getPreviewColor(historyItem.color);
+        const isSelected = selection.helpers.getIsItemSelected(historyItem);
+
+        return (
+          <List.Item
+            key={`${title}-${historyItem.date}-${formattedColor}`}
+            icon={getIcon(previewColor)}
+            title={`${isSelected ? "✓ " : ""}${formattedColor}${historyItem.title ? ` ${historyItem.title}` : ""}`}
+            subtitle={new Date(historyItem.date).toLocaleString(undefined, {
+              dateStyle: "medium",
+              timeStyle: "short",
+            })}
+            actions={<Actions historyItem={historyItem} selectMode={selectMode} selection={selection} />}
+          />
+        );
+      })}
+    </List.Section>
   );
 }
 
@@ -149,7 +184,7 @@ type ActionsProps = {
 };
 
 function Actions({ historyItem, selectMode, selection }: ActionsProps) {
-  const { remove, clear, edit } = useHistory();
+  const { history, remove, clear, edit, addToFavorites, removeFromFavorites, moveFavorite } = useHistory();
   const { data: frontmostApp } = usePromise(async () => {
     try {
       return await getFrontmostApplication();
@@ -164,6 +199,10 @@ function Actions({ historyItem, selectMode, selection }: ActionsProps) {
 
   const color = historyItem.color;
   const formattedColor = getFormattedColor(color);
+  const favoriteHistory = history?.filter((item) => item.isFavorite) ?? [];
+  const favoriteIndex = favoriteHistory.findIndex((item) => getFormattedColor(item.color) === formattedColor);
+  const canMoveFavoriteUp = favoriteIndex > 0;
+  const canMoveFavoriteDown = favoriteIndex !== -1 && favoriteIndex < favoriteHistory.length - 1;
 
   return (
     <ActionPanel>
@@ -194,6 +233,45 @@ function Actions({ historyItem, selectMode, selection }: ActionsProps) {
           icon={Icon.Pencil}
           shortcut={Keyboard.Shortcut.Common.Edit}
         />
+      </ActionPanel.Section>
+
+      <ActionPanel.Section title="Organize">
+        <Action
+          icon={historyItem.isFavorite ? Icon.StarDisabled : Icon.Star}
+          title={historyItem.isFavorite ? "Remove from Favorites" : "Add to Favorites"}
+          shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
+          onAction={async () => {
+            if (historyItem.isFavorite) {
+              removeFromFavorites(historyItem.color);
+              await showToast({ title: "Removed from favorites" });
+            } else {
+              addToFavorites(historyItem.color);
+              await showToast({ title: "Added to favorites" });
+            }
+          }}
+        />
+        {canMoveFavoriteUp && (
+          <Action
+            icon={Icon.ArrowUp}
+            title="Move Favorite up"
+            shortcut={{ modifiers: ["cmd", "opt"], key: "arrowUp" }}
+            onAction={async () => {
+              moveFavorite(historyItem.color, "up");
+              await showToast({ title: "Moved favorite up" });
+            }}
+          />
+        )}
+        {canMoveFavoriteDown && (
+          <Action
+            icon={Icon.ArrowDown}
+            title="Move Favorite Down"
+            shortcut={{ modifiers: ["cmd", "opt"], key: "arrowDown" }}
+            onAction={async () => {
+              moveFavorite(historyItem.color, "down");
+              await showToast({ title: "Moved favorite down" });
+            }}
+          />
+        )}
       </ActionPanel.Section>
 
       {selectMode === "multi" && (


### PR DESCRIPTION
Addresses some suggestion on [𝕏](https://x.com/jacoblo/status/2056270617607868834).

## Summary
- Adds a Favorites section to the Color Picker Organize Colors command.
- Adds actions to add/remove favorites and move favorites up or down.
- Keeps favorited colors out of the regular History section so each color appears in only one section.
- Preserves favorite/title metadata when a color is picked again and keeps favorite items from being trimmed out of cached history.

<img width="2000" height="1250" alt="Raycast 2026-05-18 08 49 43" src="https://github.com/user-attachments/assets/33390a98-206e-4d29-8601-1b969dee5b4e" />

## Validation
- `npm run lint`
- `npm run build`
- `pnpm dev:xray` reached Vite ready and node-backend watch built successfully in `/Users/mann/Developer/raycast-clients`.