### PR TITLE
[Visual Studio Code] Open Windows projects through editor URLs

### DIFF
--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Visual Studio Code Changelog
 
-## [Fix: Windows project opening] - {PR_MERGE_DATE}
+## [Fix: Windows project opening] - 2026-06-17
 
 - Fixed Windows project opening so recent projects are launched through the selected editor URL handler instead of Explorer.
 

--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Visual Studio Code Changelog
 
+## [Fix: Windows project opening] - {PR_MERGE_DATE}
+
+- Fixed Windows project opening so recent projects are launched through the selected editor URL handler instead of Explorer.
+
 ## [Fix: macOS user Applications path] - 2026-06-05
 
 - Fixed `product.json` resolution when Visual Studio Code is installed in `~/Applications`.

--- a/extensions/visual-studio-code-recent-projects/src/index.tsx
+++ b/extensions/visual-studio-code-recent-projects/src/index.tsx
@@ -37,6 +37,7 @@ import {
   isValidHexColor,
   isWin,
   isWorkspaceEntry,
+  openPathInVSCode,
 } from "./lib/utils";
 import { Shortcut } from "./lib/shortcuts";
 import { getEditorApplication } from "./utils/editor";
@@ -209,7 +210,11 @@ function LocalItem(
         }
       }
 
-      open(isWin ? path : props.uri, editorApp);
+      if (isWin) {
+        await openPathInVSCode(path);
+      } else {
+        open(props.uri, editorApp);
+      }
     };
   };
 

--- a/extensions/visual-studio-code-recent-projects/src/index.tsx
+++ b/extensions/visual-studio-code-recent-projects/src/index.tsx
@@ -211,7 +211,11 @@ function LocalItem(
       }
 
       if (isWin) {
-        await openPathInVSCode(path);
+        if (isWorkspaceEntry(props.entry)) {
+          open(props.uri, editorApp);
+        } else {
+          await openPathInVSCode(path);
+        }
       } else {
         open(props.uri, editorApp);
       }

--- a/extensions/visual-studio-code-recent-projects/src/lib/utils.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/utils.ts
@@ -153,8 +153,29 @@ export function raycastForVSCodeURI(uri: string) {
   return `${getBuildScheme()}://tonka3000.raycast/${uri}`;
 }
 
+export function vscodeFileURI(filePath: string) {
+  const normalizedPath = filePath.replace(/\\/g, "/");
+  const encodedPath = normalizedPath
+    .split("/")
+    .map((segment, index) => {
+      const encodedSegment = encodeURIComponent(segment);
+      return index === 0 && /^[A-Za-z]%3A$/.test(encodedSegment) ? encodedSegment.replace("%3A", ":") : encodedSegment;
+    })
+    .join("/");
+
+  return `${getBuildScheme()}://file/${encodedPath}`;
+}
+
 export async function openURIinVSCode(uri: string) {
   await open(raycastForVSCodeURI(uri));
+}
+
+/**
+ * Opens an unescaped local filesystem path through the selected editor's URL handler.
+ * This avoids Windows shell fallback to Explorer while keeping Raycast aware of launch failures.
+ */
+export async function openPathInVSCode(filePath: string) {
+  await open(vscodeFileURI(filePath));
 }
 
 export function isValidHexColor(color: string): boolean {

--- a/extensions/visual-studio-code-recent-projects/src/lib/utils.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/utils.ts
@@ -155,15 +155,18 @@ export function raycastForVSCodeURI(uri: string) {
 
 export function vscodeFileURI(filePath: string) {
   const normalizedPath = filePath.replace(/\\/g, "/");
-  const encodedPath = normalizedPath
+  const isUncPath = normalizedPath.startsWith("//");
+  const pathToEncode = isUncPath ? normalizedPath.slice(2) : normalizedPath;
+  const encodedPath = pathToEncode
     .split("/")
     .map((segment, index) => {
       const encodedSegment = encodeURIComponent(segment);
       return index === 0 && /^[A-Za-z]%3A$/.test(encodedSegment) ? encodedSegment.replace("%3A", ":") : encodedSegment;
     })
     .join("/");
+  const uriPath = isUncPath ? `/${encodedPath}` : encodedPath;
 
-  return `${getBuildScheme()}://file/${encodedPath}`;
+  return `${getBuildScheme()}://file/${uriPath}`;
 }
 
 export async function openURIinVSCode(uri: string) {

--- a/extensions/visual-studio-code-recent-projects/src/open-with-vscode.ts
+++ b/extensions/visual-studio-code-recent-projects/src/open-with-vscode.ts
@@ -2,7 +2,7 @@ import { closeMainWindow, getFrontmostApplication, getSelectedFinderItems, open,
 import { runAppleScript } from "@raycast/utils";
 import { build } from "./lib/preferences";
 import { getCurrentFinderPath } from "./utils/apple-scripts";
-import { isMac, isWin } from "./lib/utils";
+import { isMac, isWin, openPathInVSCode } from "./lib/utils";
 import { getCurrentExplorerPath } from "./utils/win-scripts";
 import { getEditorApplication } from "./utils/editor";
 
@@ -48,21 +48,14 @@ export default async function main() {
     }
 
     if (isWin) {
-      selectedItems = await getSelectedFinderItems();
+      const currentPath = await getCurrentExplorerPath();
 
-      if (selectedItems.length === 0) {
-        const currentPath = await getCurrentExplorerPath();
-
-        if (currentPath.length === 0) {
-          throw new Error("Not a valid directory.");
-        }
-
-        selectedItems = [{ path: currentPath }];
+      // Raycast does not expose Windows multi-item file manager selection yet.
+      if (currentPath.length === 0) {
+        throw new Error("Could not determine the current Explorer path.");
       }
 
-      for (const item of selectedItems) {
-        open(item.path, editor);
-      }
+      await openPathInVSCode(currentPath);
     }
 
     await closeMainWindow();


### PR DESCRIPTION
## Description
- Launches Windows recent projects through the selected editor URL handler instead of Raycast opening the folder target directly in Explorer.
- Uses the existing VS Code build scheme mapping, so Code, Insiders, Cursor, Windsurf, and other configured builds stay aligned.
- Removes the Windows path through the Finder selection API in the Open With VS Code command.

Fixes #27056
Fixes #27061
Fixes #23628

## Validation
- npm run lint
- npm run build
- git diff --check