### PR TITLE
Update youtube-thumbnail extension

### DIFF
--- a/extensions/youtube-thumbnail/CHANGELOG.md
+++ b/extensions/youtube-thumbnail/CHANGELOG.md
@@ -1,6 +1,6 @@
 # YouTube Thumbnail Grabber Changelog
 
-## [1.1.2] - {PR_MERGE_DATE}
+## [1.1.2] - 2026-05-18
 
 - Fixed memory leak in history thumbnail loader that could exhaust the extension memory limit
 

--- a/extensions/youtube-thumbnail/CHANGELOG.md
+++ b/extensions/youtube-thumbnail/CHANGELOG.md
@@ -1,10 +1,14 @@
 # YouTube Thumbnail Grabber Changelog
 
+## [1.1.2] - {PR_MERGE_DATE}
+
+- Fixed memory leak in history thumbnail loader that could exhaust the extension memory limit
+
 ## [1.1.1] - 2026-03-12
 
 - Added thumbnail dimensions to list items
 
-## [1.1.0] - 2024-03-12
+## [1.1.0] - 2026-03-12
 
 ### Added
 

--- a/extensions/youtube-thumbnail/src/get-thumbnail.tsx
+++ b/extensions/youtube-thumbnail/src/get-thumbnail.tsx
@@ -127,12 +127,7 @@ export default function Command() {
     let cancelled = false;
 
     async function loadHistoryThumbnails() {
-      if (urlHistory.length === 0) {
-        setHistoryThumbnailUrls({});
-        return;
-      }
-
-      const missingEntries = urlHistory.filter((entry) => !historyThumbnailUrls[entry.url]);
+      const missingEntries = urlHistory.filter((entry) => !(entry.url in historyThumbnailUrls));
       if (missingEntries.length === 0) {
         return;
       }
@@ -150,7 +145,7 @@ export default function Command() {
 
       setHistoryThumbnailUrls((currentUrls) => ({
         ...currentUrls,
-        ...Object.fromEntries(entries.filter((entry): entry is readonly [string, string] => entry[1].length > 0)),
+        ...Object.fromEntries(entries),
       }));
     }
 


### PR DESCRIPTION
## Description

- Fixed memory leak in history thumbnail loader that could exhaust the extension memory limit

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
