### PR TITLE
Update craft-cms-docs extension

### DIFF
--- a/extensions/craft-cms-docs/CHANGELOG.md
+++ b/extensions/craft-cms-docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Craft CMS Changelog
 
+## [Craft CMS 6.x Docs] - {PR_MERGE_DATE}
+
+- Craft CMS 6.x option now available for docs version
+
 ## [Add Plugin Store Search] - 2026-03-26
 
 ### Added

--- a/extensions/craft-cms-docs/CHANGELOG.md
+++ b/extensions/craft-cms-docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Craft CMS Changelog
 
-## [Craft CMS 6.x Docs] - {PR_MERGE_DATE}
+## [Craft CMS 6.x Docs] - 2026-05-18
 
 - Craft CMS 6.x option now available for docs version
 

--- a/extensions/craft-cms-docs/package.json
+++ b/extensions/craft-cms-docs/package.json
@@ -34,7 +34,12 @@
           "description": "Craft CMS docs version",
           "type": "dropdown",
           "required": true,
+          "default": "5.x",
           "data": [
+            {
+              "title": "6.x",
+              "value": "6.x"
+            },
             {
               "title": "5.x",
               "value": "5.x"

--- a/extensions/craft-cms-docs/src/api.tsx
+++ b/extensions/craft-cms-docs/src/api.tsx
@@ -100,7 +100,7 @@ export function deriveDocsCategoryFromUrl(url: string): string | undefined {
   }
 
   if (docsSegments.length === 0) return undefined;
-  if (/^[1-5]\.x$/i.test(docsSegments[0])) {
+  if (/^[1-6]\.x$/i.test(docsSegments[0])) {
     docsSegments = docsSegments.slice(1);
   }
 
@@ -257,17 +257,17 @@ function firstString(...values: Array<unknown>): string | undefined {
 }
 
 function inferCraftVersion(url: string, type?: string): DocsSearchResult["craftVersion"] | undefined {
-  const urlMatch = url.toLowerCase().match(/(?:^|\/)([1-5])\.x(?:\/|$)/);
+  const urlMatch = url.toLowerCase().match(/(?:^|\/)([1-6])\.x(?:\/|$)/);
   if (urlMatch && isVersionNumber(urlMatch[1])) return `${urlMatch[1]}.x`;
 
   if (!type) return undefined;
-  const typeMatch = type.toLowerCase().match(/(?:craft[\s-]*)?([1-5])(?:\b|\.|x)/);
+  const typeMatch = type.toLowerCase().match(/(?:craft[\s-]*)?([1-6])(?:\b|\.|x)/);
   if (typeMatch && isVersionNumber(typeMatch[1])) return `${typeMatch[1]}.x`;
   return undefined;
 }
 
-function isVersionNumber(value: string): value is "1" | "2" | "3" | "4" | "5" {
-  return value === "1" || value === "2" || value === "3" || value === "4" || value === "5";
+function isVersionNumber(value: string): value is "1" | "2" | "3" | "4" | "5" | "6" {
+  return value === "1" || value === "2" || value === "3" || value === "4" || value === "5" || value === "6";
 }
 
 function extractGlossarySlug(url: string): string | undefined {

--- a/extensions/craft-cms-docs/src/search-docs.tsx
+++ b/extensions/craft-cms-docs/src/search-docs.tsx
@@ -994,19 +994,19 @@ function getSelectedVersion(
 
 function toApiVersion(version: DocsSearchResult["craftVersion"] | undefined): string | undefined {
   if (!version) return undefined;
-  const match = version.match(/^([1-5])\.x$/);
+  const match = version.match(/^([1-6])\.x$/);
   return match?.[1];
 }
 
 function normalizeVersionValue(value: string | undefined): DocsSearchResult["craftVersion"] | undefined {
   if (!value) return undefined;
-  if (/^[1-5]\.x$/.test(value)) return value as DocsSearchResult["craftVersion"];
-  if (/^[1-5]$/.test(value)) return `${value}.x` as DocsSearchResult["craftVersion"];
+  if (/^[1-6]\.x$/.test(value)) return value as DocsSearchResult["craftVersion"];
+  if (/^[1-6]$/.test(value)) return `${value}.x` as DocsSearchResult["craftVersion"];
   return undefined;
 }
 
 function extractVersionFromUrl(url: string): DocsSearchResult["craftVersion"] | undefined {
-  const match = url.toLowerCase().match(/(?:^|\/)([1-5])\.x(?:\/|$|[?#])/);
+  const match = url.toLowerCase().match(/(?:^|\/)([1-6])\.x(?:\/|$|[?#])/);
   if (!match) return undefined;
   return `${match[1]}.x` as DocsSearchResult["craftVersion"];
 }

--- a/extensions/craft-cms-docs/src/types.tsx
+++ b/extensions/craft-cms-docs/src/types.tsx
@@ -95,5 +95,5 @@ export interface DocsSearchResult {
   type?: string;
   docsLinks?: DocsLink[];
   relatedTerms?: RelatedTerm[];
-  craftVersion?: "1.x" | "2.x" | "3.x" | "4.x" | "5.x";
+  craftVersion?: "1.x" | "2.x" | "3.x" | "4.x" | "5.x" | "6.x";
 }


### PR DESCRIPTION
## Description

- Added Craft CMS 6.x option to docs version dropdown in settings

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
