### PR TITLE
Reclaim: Fix error boundary to use proper Raycast List component

### DIFF
--- a/extensions/reclaim-ai/CHANGELOG.md
+++ b/extensions/reclaim-ai/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Update] - 2025-06-04
 - Update to the package.json description to include Outlook as a valid calendar provider.
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-05-19
 - Fix error boundary fallback to use proper Raycast List component
 
 ## [Fixes] - 2025-04-02

--- a/extensions/reclaim-ai/CHANGELOG.md
+++ b/extensions/reclaim-ai/CHANGELOG.md
@@ -8,6 +8,9 @@
 ## [Update] - 2025-06-04
 - Update to the package.json description to include Outlook as a valid calendar provider.
 
+## [Fixes] - {PR_MERGE_DATE}
+- Fix error boundary fallback to use proper Raycast List component
+
 ## [Fixes] - 2025-04-02
 - Don't split surrogate pairs
 

--- a/extensions/reclaim-ai/src/components/RAIErrorBoundary.tsx
+++ b/extensions/reclaim-ai/src/components/RAIErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { captureException } from "@sentry/node";
+import { List } from "@raycast/api";
 import { ComponentType, FC } from "react";
 import { ErrorBoundary, ErrorBoundaryProps } from "react-error-boundary";
 import { useCallbackSafeRef } from "../hooks/useCallbackSafeRef";
@@ -28,7 +29,11 @@ export const withRAIErrorBoundary = <P extends Record<string, unknown>>(
 
   const Wrapped: React.FC<P> = (props: P) => (
     <RAIErrorBoundary
-      fallbackRender={() => <>Something went wrong! Please contact support.</>}
+      fallbackRender={() => (
+        <List>
+          <List.EmptyView title="Something went wrong!" description="Please contact support." />
+        </List>
+      )}
       {...errorBoundaryOptions}
     >
       <WrappedComponent {...props} />


### PR DESCRIPTION
## Summary

Fixes the error boundary fallback component to use Raycast's proper `List` and `List.EmptyView` components instead of a plain React fragment. This ensures consistent UI rendering and follows Raycast's component patterns when errors occur.

**Changes:**
- Updated `RAIErrorBoundary.tsx` fallback from fragment to `List.EmptyView`
- Maintains the same error message: "Something went wrong! Please contact support."

## Testing

Tested locally by triggering error boundary conditions in the extension. The error state now renders properly with Raycast's standard empty view UI instead of rendering raw text.