### PR TITLE
Add AI Extension to youtube video summary extension

### DIFF
--- a/extensions/summarize-youtube-video-with-ai/CHANGELOG.md
+++ b/extensions/summarize-youtube-video-with-ai/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Summarize YouTube Video Changelog
 
+## [Feature] - {PR_MERGE_DATE}
+
+- Add a Raycast AI tool to answer questions about YouTube videos from their transcript
+
 ## [Fix] - 2026-03-17
 
 - 🔧 Fix transcript fetching

--- a/extensions/summarize-youtube-video-with-ai/CHANGELOG.md
+++ b/extensions/summarize-youtube-video-with-ai/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Summarize YouTube Video Changelog
 
-## [Feature] - {PR_MERGE_DATE}
+## [Feature] - 2026-05-19
 
 - Add a Raycast AI tool to answer questions about YouTube videos from their transcript
 

--- a/extensions/summarize-youtube-video-with-ai/README.md
+++ b/extensions/summarize-youtube-video-with-ai/README.md
@@ -2,6 +2,10 @@
 
 Summarize any YouTube Video with AI and ask follow up questions to get all the details. Choose between Raycast, OpenAI ChatGPT or Anthropic Claude. You have to either be a [Raycast Pro](https://www.raycast.com/pro) Member, have access to an [OpenAI API Key](https://platform.openai.com/account/api-keys) or [Anthropic API Key](https://www.anthropic.com/api) to use this extension. Alternatively, you can use the extension with [Ollama](https://ollama.com/) to summarize YouTube videos using a local LLM.
 
+## AI Extension
+
+You can mention this extension from Raycast AI with `@summarize-youtube-video-with-ai` and ask questions about a YouTube video. Include a YouTube URL in the prompt or copy one to the clipboard before asking. The AI tool fetches the transcript and answers from the video content.
+
 ## Preferences
 
 ### Commands

--- a/extensions/summarize-youtube-video-with-ai/package.json
+++ b/extensions/summarize-youtube-video-with-ai/package.json
@@ -296,6 +296,32 @@
       "arguments": []
     }
   ],
+  "tools": [
+    {
+      "name": "answer-video-question",
+      "title": "Answer YouTube Video Question",
+      "description": "Answer a user's question about a YouTube video by fetching its transcript. Use this when the user asks about the contents, claims, explanation, or context of a YouTube video. If no URL is provided, the tool can use a YouTube URL from the clipboard.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "question": {
+            "type": "string",
+            "description": "The user's question about the YouTube video. Do not include the YouTube URL unless it is part of the user's original question."
+          },
+          "video": {
+            "type": "string",
+            "description": "Optional YouTube video URL or video ID. Omit this when the user wants the extension to use the YouTube URL from the clipboard."
+          }
+        },
+        "required": [
+          "question"
+        ]
+      }
+    }
+  ],
+  "ai": {
+    "instructions": "Use the answer-video-question tool whenever the user asks a question about a YouTube video. Pass the YouTube URL or video ID when the prompt includes one. If the prompt does not include a URL, call the tool without the video argument so it can inspect the clipboard. Do not answer questions about the video from general knowledge; use the transcript-backed tool result."
+  },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.72.1",
     "@raycast/api": "^1.104.4",

--- a/extensions/summarize-youtube-video-with-ai/package.json
+++ b/extensions/summarize-youtube-video-with-ai/package.json
@@ -296,6 +296,46 @@
       "arguments": []
     }
   ],
+  "preferences": [
+    {
+      "name": "creativity",
+      "title": "Creativity",
+      "description": "Choose how creative the AI should be.",
+      "type": "dropdown",
+      "default": "0.5",
+      "data": [
+        {
+          "value": "0",
+          "title": "None"
+        },
+        {
+          "value": "0.5",
+          "title": "Low"
+        },
+        {
+          "value": "1",
+          "title": "Medium"
+        },
+        {
+          "value": "1.5",
+          "title": "High"
+        },
+        {
+          "value": "2",
+          "title": "Maximum"
+        }
+      ],
+      "required": false
+    },
+    {
+      "name": "language",
+      "title": "Language",
+      "description": "Define the language which Raycast AI should use to answer video questions.",
+      "type": "textfield",
+      "default": "english",
+      "required": false
+    }
+  ],
   "tools": [
     {
       "name": "answer-video-question",

--- a/extensions/summarize-youtube-video-with-ai/src/hooks/useGetVideoUrl.ts
+++ b/extensions/summarize-youtube-video-with-ai/src/hooks/useGetVideoUrl.ts
@@ -5,7 +5,7 @@ import {
   GETTING_VIDEO_URL_FROM_BROWSER,
   GETTING_VIDEO_URL_FROM_CLIPBOARD,
 } from "../const/toast_messages";
-import { getYouTubeVideoUrlFromText } from "../utils/youtubeUrl";
+import { getYouTubeVideoUrl } from "../utils/youtubeUrl";
 
 export const useGetVideoUrl = ({
   input,
@@ -22,7 +22,7 @@ export const useGetVideoUrl = ({
         message: GETTING_VIDEO_URL.message,
       });
 
-      const inputVideoUrl = getYouTubeVideoUrlFromText(input);
+      const inputVideoUrl = getYouTubeVideoUrl(input);
 
       if (inputVideoUrl) {
         setVideoURL(inputVideoUrl);
@@ -30,7 +30,7 @@ export const useGetVideoUrl = ({
       }
 
       const clipboardText = await Clipboard.readText();
-      const clipboardVideoUrl = getYouTubeVideoUrlFromText(clipboardText);
+      const clipboardVideoUrl = getYouTubeVideoUrl(clipboardText);
 
       if (!input && clipboardVideoUrl) {
         showToast({
@@ -45,7 +45,7 @@ export const useGetVideoUrl = ({
       if (!input && environment.canAccess(BrowserExtension)) {
         const tabs = await BrowserExtension.getTabs();
         const activeTabVideoUrl = tabs.find((tab) => tab.active)?.url;
-        const browserVideoUrl = getYouTubeVideoUrlFromText(activeTabVideoUrl);
+        const browserVideoUrl = getYouTubeVideoUrl(activeTabVideoUrl);
         if (browserVideoUrl) {
           showToast({
             style: Toast.Style.Animated,

--- a/extensions/summarize-youtube-video-with-ai/src/hooks/useGetVideoUrl.ts
+++ b/extensions/summarize-youtube-video-with-ai/src/hooks/useGetVideoUrl.ts
@@ -1,11 +1,11 @@
 import { BrowserExtension, Clipboard, environment, popToRoot, showToast, Toast } from "@raycast/api";
 import { useEffect } from "react";
-import ytdl from "ytdl-core";
 import {
   GETTING_VIDEO_URL,
   GETTING_VIDEO_URL_FROM_BROWSER,
   GETTING_VIDEO_URL_FROM_CLIPBOARD,
 } from "../const/toast_messages";
+import { getYouTubeVideoUrlFromText } from "../utils/youtubeUrl";
 
 export const useGetVideoUrl = ({
   input,
@@ -22,34 +22,37 @@ export const useGetVideoUrl = ({
         message: GETTING_VIDEO_URL.message,
       });
 
-      if (input && ytdl.validateURL(input)) {
-        setVideoURL(input);
+      const inputVideoUrl = getYouTubeVideoUrlFromText(input);
+
+      if (inputVideoUrl) {
+        setVideoURL(inputVideoUrl);
         return;
       }
 
       const clipboardText = await Clipboard.readText();
-      const clipboardIsYTUrl = clipboardText && ytdl.validateURL(clipboardText);
+      const clipboardVideoUrl = getYouTubeVideoUrlFromText(clipboardText);
 
-      if (!input && clipboardIsYTUrl) {
+      if (!input && clipboardVideoUrl) {
         showToast({
           style: Toast.Style.Animated,
           title: GETTING_VIDEO_URL_FROM_CLIPBOARD.title,
           message: GETTING_VIDEO_URL_FROM_CLIPBOARD.message,
         });
-        setVideoURL(clipboardText);
+        setVideoURL(clipboardVideoUrl);
         return;
       }
 
       if (!input && environment.canAccess(BrowserExtension)) {
         const tabs = await BrowserExtension.getTabs();
-        const activeTab = tabs.find((tab) => tab.active && ytdl.validateURL(tab.url));
-        if (activeTab) {
+        const activeTabVideoUrl = tabs.find((tab) => tab.active)?.url;
+        const browserVideoUrl = getYouTubeVideoUrlFromText(activeTabVideoUrl);
+        if (browserVideoUrl) {
           showToast({
             style: Toast.Style.Animated,
             title: GETTING_VIDEO_URL_FROM_BROWSER.title,
             message: GETTING_VIDEO_URL_FROM_BROWSER.message,
           });
-          setVideoURL(activeTab.url);
+          setVideoURL(browserVideoUrl);
           return;
         }
       }

--- a/extensions/summarize-youtube-video-with-ai/src/tools/answer-video-question.ts
+++ b/extensions/summarize-youtube-video-with-ai/src/tools/answer-video-question.ts
@@ -1,0 +1,102 @@
+import { AI, BrowserExtension, Clipboard, environment, getPreferenceValues } from "@raycast/api";
+import nodeFetch from "node-fetch";
+import type { VideoDataTypes } from "../utils/getVideoData";
+import { getVideoData } from "../utils/getVideoData";
+import { getVideoQuestionAnswerSnippet } from "../utils/getAiInstructionSnippets";
+import { fetchTranscript } from "../utils/transcriptFetcher";
+import { getYouTubeVideoUrlFromText, removeYouTubeVideoReferenceFromText } from "../utils/youtubeUrl";
+
+(globalThis.fetch as typeof globalThis.fetch) = nodeFetch as never;
+
+type Input = {
+  /**
+   * The user's question about the YouTube video.
+   */
+  question: string;
+  /**
+   * Optional YouTube video URL or video ID. If omitted, the tool reads a YouTube URL from the clipboard.
+   */
+  video?: string;
+};
+
+type Preferences = {
+  creativity?: "0" | "0.5" | "1" | "1.5" | "2";
+  language?: string;
+};
+
+type VideoResolution = {
+  url: string;
+  question: string;
+};
+
+async function getActiveBrowserVideoUrl(): Promise<string | undefined> {
+  if (!environment.canAccess(BrowserExtension)) return undefined;
+
+  const tabs = await BrowserExtension.getTabs();
+  const activeTabUrl = tabs.find((tab) => tab.active)?.url;
+
+  return getYouTubeVideoUrlFromText(activeTabUrl);
+}
+
+async function resolveVideo(input: Input): Promise<VideoResolution> {
+  const clipboardText = await Clipboard.readText();
+  const activeBrowserVideoUrl = await getActiveBrowserVideoUrl();
+  const videoUrl =
+    getYouTubeVideoUrlFromText(input.video) ??
+    getYouTubeVideoUrlFromText(input.question) ??
+    activeBrowserVideoUrl ??
+    getYouTubeVideoUrlFromText(clipboardText);
+
+  if (!videoUrl) {
+    throw new Error("Please provide a YouTube URL in your prompt or copy one to the clipboard.");
+  }
+
+  const question = removeYouTubeVideoReferenceFromText(input.question);
+
+  if (!question) {
+    throw new Error("Please ask a question about the YouTube video.");
+  }
+
+  return { question, url: videoUrl };
+}
+
+function formatAnswer(answer: string, videoData: VideoDataTypes) {
+  return [`# ${videoData.title}`, "", `Source: ${videoData.video_url}`, "", answer.trim()].join("\n");
+}
+
+function formatError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return `I couldn't answer that from the video transcript: ${message}`;
+}
+
+/**
+ * Answer a question about a YouTube video by fetching its transcript and asking Raycast AI to answer from that transcript.
+ */
+export default async function tool(input: Input): Promise<string> {
+  try {
+    if (!environment.canAccess(AI)) {
+      return "Raycast Pro is required to answer questions about YouTube videos with Raycast AI.";
+    }
+
+    const preferences = getPreferenceValues<Preferences>();
+    const language = preferences.language || "english";
+    const creativity = Number.parseFloat(preferences.creativity || "0.5");
+    const { question, url } = await resolveVideo(input);
+    const [videoData, transcript] = await Promise.all([getVideoData(url), fetchTranscript(url)]);
+
+    const answer = await AI.ask(
+      getVideoQuestionAnswerSnippet({
+        channelName: videoData.ownerChannelName,
+        language,
+        question,
+        transcript,
+        videoTitle: videoData.title,
+      }),
+      { creativity },
+    );
+
+    return formatAnswer(answer, videoData);
+  } catch (error) {
+    return formatError(error);
+  }
+}

--- a/extensions/summarize-youtube-video-with-ai/src/tools/answer-video-question.ts
+++ b/extensions/summarize-youtube-video-with-ai/src/tools/answer-video-question.ts
@@ -4,7 +4,11 @@ import type { VideoDataTypes } from "../utils/getVideoData";
 import { getVideoData } from "../utils/getVideoData";
 import { getVideoQuestionAnswerSnippet } from "../utils/getAiInstructionSnippets";
 import { fetchTranscript } from "../utils/transcriptFetcher";
-import { getYouTubeVideoUrlFromText, removeYouTubeVideoReferenceFromText } from "../utils/youtubeUrl";
+import {
+  getYouTubeVideoUrl,
+  getYouTubeVideoUrlFromText,
+  removeYouTubeVideoReferenceFromText,
+} from "../utils/youtubeUrl";
 
 (globalThis.fetch as typeof globalThis.fetch) = nodeFetch as never;
 
@@ -19,11 +23,6 @@ type Input = {
   video?: string;
 };
 
-type Preferences = {
-  creativity?: "0" | "0.5" | "1" | "1.5" | "2";
-  language?: string;
-};
-
 type VideoResolution = {
   url: string;
   question: string;
@@ -35,17 +34,17 @@ async function getActiveBrowserVideoUrl(): Promise<string | undefined> {
   const tabs = await BrowserExtension.getTabs();
   const activeTabUrl = tabs.find((tab) => tab.active)?.url;
 
-  return getYouTubeVideoUrlFromText(activeTabUrl);
+  return getYouTubeVideoUrl(activeTabUrl);
 }
 
 async function resolveVideo(input: Input): Promise<VideoResolution> {
   const clipboardText = await Clipboard.readText();
   const activeBrowserVideoUrl = await getActiveBrowserVideoUrl();
   const videoUrl =
-    getYouTubeVideoUrlFromText(input.video) ??
+    getYouTubeVideoUrl(input.video) ??
     getYouTubeVideoUrlFromText(input.question) ??
     activeBrowserVideoUrl ??
-    getYouTubeVideoUrlFromText(clipboardText);
+    getYouTubeVideoUrl(clipboardText);
 
   if (!videoUrl) {
     throw new Error("Please provide a YouTube URL in your prompt or copy one to the clipboard.");

--- a/extensions/summarize-youtube-video-with-ai/src/utils/getAiInstructionSnippets.ts
+++ b/extensions/summarize-youtube-video-with-ai/src/utils/getAiInstructionSnippets.ts
@@ -88,3 +88,38 @@ ${summary}
 ${previousContext}
 Question: ${question}`;
 }
+
+type VideoQuestionAnswerSnippetParams = {
+  language: string;
+  question: string;
+  transcript: string;
+  videoTitle?: string;
+  channelName?: string;
+};
+
+export function getVideoQuestionAnswerSnippet({
+  language,
+  question,
+  transcript,
+  videoTitle,
+  channelName,
+}: VideoQuestionAnswerSnippetParams): string {
+  const metadata = [
+    videoTitle ? `Title: ${videoTitle}` : undefined,
+    channelName ? `Channel: ${channelName}` : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return `${SYSTEM_PROMPT}
+Use only the transcript below.
+If the transcript does not contain enough information to answer, say that directly.
+Do not invent facts or use outside knowledge.
+Answer in ${language}.
+
+${metadata ? `Video metadata:\n${metadata}\n\n` : ""}Question:
+${question}
+
+Transcript:
+${transcript}`;
+}

--- a/extensions/summarize-youtube-video-with-ai/src/utils/youtubeUrl.ts
+++ b/extensions/summarize-youtube-video-with-ai/src/utils/youtubeUrl.ts
@@ -1,0 +1,39 @@
+import ytdl from "ytdl-core";
+
+const URL_PATTERN = /https?:\/\/[^\s)>\]]+/g;
+
+function trimUrlCandidate(value: string) {
+  return value.trim().replace(/[.,;:!?]+$/, "");
+}
+
+function getYouTubeVideoIdFromText(text: string): string | undefined {
+  return text
+    .split(/\s+/)
+    .map(trimUrlCandidate)
+    .find((part) => ytdl.validateID(part));
+}
+
+export function getYouTubeVideoUrlFromText(text: string | undefined | null): string | undefined {
+  if (!text) return undefined;
+
+  const trimmed = trimUrlCandidate(text);
+
+  if (ytdl.validateURL(trimmed)) return trimmed;
+  if (ytdl.validateID(trimmed)) return `https://www.youtube.com/watch?v=${trimmed}`;
+
+  const url = (text.match(URL_PATTERN) ?? []).map(trimUrlCandidate).find((candidate) => ytdl.validateURL(candidate));
+  if (url) return url;
+
+  const videoId = getYouTubeVideoIdFromText(text);
+  return videoId ? `https://www.youtube.com/watch?v=${videoId}` : undefined;
+}
+
+export function removeYouTubeVideoReferenceFromText(text: string): string {
+  return text
+    .replace(URL_PATTERN, " ")
+    .split(/\s+/)
+    .map(trimUrlCandidate)
+    .filter((part) => part && !ytdl.validateID(part))
+    .join(" ")
+    .trim();
+}

--- a/extensions/summarize-youtube-video-with-ai/src/utils/youtubeUrl.ts
+++ b/extensions/summarize-youtube-video-with-ai/src/utils/youtubeUrl.ts
@@ -6,34 +6,23 @@ function trimUrlCandidate(value: string) {
   return value.trim().replace(/[.,;:!?]+$/, "");
 }
 
-function getYouTubeVideoIdFromText(text: string): string | undefined {
-  return text
-    .split(/\s+/)
-    .map(trimUrlCandidate)
-    .find((part) => ytdl.validateID(part));
+export function getYouTubeVideoUrl(video: string | undefined | null): string | undefined {
+  if (!video) return undefined;
+
+  try {
+    const videoId = ytdl.getVideoID(trimUrlCandidate(video));
+    return `https://www.youtube.com/watch?v=${videoId}`;
+  } catch {
+    return undefined;
+  }
 }
 
 export function getYouTubeVideoUrlFromText(text: string | undefined | null): string | undefined {
   if (!text) return undefined;
 
-  const trimmed = trimUrlCandidate(text);
-
-  if (ytdl.validateURL(trimmed)) return trimmed;
-  if (ytdl.validateID(trimmed)) return `https://www.youtube.com/watch?v=${trimmed}`;
-
-  const url = (text.match(URL_PATTERN) ?? []).map(trimUrlCandidate).find((candidate) => ytdl.validateURL(candidate));
-  if (url) return url;
-
-  const videoId = getYouTubeVideoIdFromText(text);
-  return videoId ? `https://www.youtube.com/watch?v=${videoId}` : undefined;
+  return (text.match(URL_PATTERN) ?? []).map(getYouTubeVideoUrl).find(Boolean);
 }
 
 export function removeYouTubeVideoReferenceFromText(text: string): string {
-  return text
-    .replace(URL_PATTERN, " ")
-    .split(/\s+/)
-    .map(trimUrlCandidate)
-    .filter((part) => part && !ytdl.validateID(part))
-    .join(" ")
-    .trim();
+  return text.replace(URL_PATTERN, " ").replace(/\s+/g, " ").trim();
 }

--- a/extensions/summarize-youtube-video-with-ai/tsconfig.json
+++ b/extensions/summarize-youtube-video-with-ai/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "raycast-env.d.ts"],
   "compilerOptions": {
     "lib": ["ES2023"],
     "module": "commonjs",


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

This enables the AI extension for the YouTube Summarize extension, which allows a user to type a question with a youtube url in clipboard or pasting, and it will be answered instead of summarizing the video for them.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
