### PR TITLE
[Day One] Resolve CLI from common macOS paths

### DIFF
--- a/extensions/day-one/CHANGELOG.md
+++ b/extensions/day-one/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Day One Changelog
 
+## [Bug fix] - 2026-05-19
+
+- Fixed CLI detection when Raycast does not inherit the terminal PATH.
+
 ## [Bug fix] - 2025-03-17
 
 - Fixed an issue where adding an entry when the journal name contains a space character causes an error.

--- a/extensions/day-one/CHANGELOG.md
+++ b/extensions/day-one/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Day One Changelog
 
-## [Bug fix] - {PR_MERGE_DATE}
+## [Bug fix] - 2026-05-19
 
 - Fixed CLI detection when Raycast does not inherit the terminal PATH.
 

--- a/extensions/day-one/CHANGELOG.md
+++ b/extensions/day-one/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Day One Changelog
 
-## [Bug fix] - 2026-05-19
+## [Bug fix] - {PR_MERGE_DATE}
 
 - Fixed CLI detection when Raycast does not inherit the terminal PATH.
 

--- a/extensions/day-one/package.json
+++ b/extensions/day-one/package.json
@@ -36,5 +36,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/day-one/src/utils.ts
+++ b/extensions/day-one/src/utils.ts
@@ -1,4 +1,10 @@
 import child_process from "child_process";
 import { promisify } from "util";
 
-export const exec = promisify(child_process.exec);
+const execAsync = promisify(child_process.exec);
+
+const commandPath = [process.env.PATH, "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+  .filter(Boolean)
+  .join(":");
+
+export const exec = (command: string) => execAsync(command, { env: { ...process.env, PATH: commandPath } });


### PR DESCRIPTION
## Description

Fixes #28113.

Raycast does not always inherit the same PATH as an interactive terminal, so the Day One extension can report the `dayone2` CLI as missing even when it is installed and works in a shell. This keeps the existing command flow but adds common macOS binary locations when running Day One CLI commands.

## Screencast

N/A - small CLI lookup fix.

## Checklist

- [x] I ran `npm run lint`
- [x] I ran `npm run build`

Türkiye’den sevgiler