### PR TITLE
Reclaim AI: Don't show declined events in menu bar & My Calendar

### DIFF
--- a/extensions/reclaim-ai/CHANGELOG.md
+++ b/extensions/reclaim-ai/CHANGELOG.md
@@ -1,5 +1,8 @@
 # reclaim Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+- Don't show declined events in the menu bar title or My Calendar when the user has "show declined events" disabled
+
 ## [Update] - 2025-10-30
 - Update to the package.json platforms property to include Windows.
 - Update to Search Tasks to not include tasks that are cancelled.

--- a/extensions/reclaim-ai/src/my-calendar.tsx
+++ b/extensions/reclaim-ai/src/my-calendar.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from "react";
 import { MyCalendarEventListSection } from "./components/MyCalendarEventListSection";
 import { withRAIErrorBoundary } from "./components/RAIErrorBoundary";
 import { useEvents } from "./hooks/useEvent";
+import { useUser } from "./hooks/useUser";
 import { Event } from "./types/event";
 
 type EventSection = { section: string; sectionTitle: string; events: Event[] };
@@ -13,6 +14,9 @@ type EventSection = { section: string; sectionTitle: string; events: Event[] };
 function Command() {
   const [searchText, setSearchText] = useState("");
   const now = new Date();
+
+  const { currentUser } = useUser();
+  const showDeclinedEvents = !!currentUser?.settings.showDeclinedEvents;
 
   const { events, isLoading } = useEvents({
     start: startOfDay(now),
@@ -25,11 +29,15 @@ function Command() {
     const today = startOfDay(now);
     const tomorrow = startOfDay(addDays(now, 1));
 
+    const visibleEvents = showDeclinedEvents
+      ? events
+      : events.filter((event) => event.rsvpStatus !== "Declined");
+
     const eventSectionsUnfiltered: EventSection[] = [
       {
         section: "NOW",
         sectionTitle: "Now",
-        events: events
+        events: visibleEvents
           .filter((event) => {
             const start = new Date(event.eventStart);
             const end = new Date(event.eventEnd);
@@ -42,7 +50,7 @@ function Command() {
       {
         section: "TODAY",
         sectionTitle: "Today",
-        events: events
+        events: visibleEvents
           .filter((event) => {
             const start = new Date(event.eventStart);
             return isAfter(start, now) && isBefore(start, endOfDay(now));
@@ -54,7 +62,7 @@ function Command() {
       {
         section: "EARLIER_TODAY",
         sectionTitle: "Earlier today",
-        events: events
+        events: visibleEvents
           .filter((event) => {
             const end = new Date(event.eventEnd);
             const start = new Date(event.eventStart);
@@ -67,7 +75,7 @@ function Command() {
       {
         section: "TOMORROW",
         sectionTitle: "Tomorrow",
-        events: events
+        events: visibleEvents
           .filter((event) => {
             const start = new Date(event.eventStart);
             return isWithinInterval(start, { start: tomorrow, end: endOfDay(tomorrow) });
@@ -79,7 +87,7 @@ function Command() {
     ];
 
     return eventSectionsUnfiltered.filter((event) => event.events.length > 0);
-  }, [events]);
+  }, [events, showDeclinedEvents]);
 
   return (
     <List

--- a/extensions/reclaim-ai/src/notifications.tsx
+++ b/extensions/reclaim-ai/src/notifications.tsx
@@ -80,23 +80,27 @@ function Command() {
     return !!currentUser?.settings.showDeclinedEvents;
   }, [currentUser]);
 
+  const visibleEvents = useMemo(() => {
+    return showDeclinedEvents
+      ? events
+      : events?.filter((event) => event.rsvpStatus !== "Declined" && event.rsvpStatus !== "NotResponded");
+  }, [events, showDeclinedEvents]);
+
   const eventSections = useMemo<EventSection[]>(() => {
-    if (!events) return [];
+    if (!visibleEvents) return [];
 
     const now = new Date();
     const today = startOfDay(now);
+
+    const nonBufferEvents = visibleEvents.filter((event) => {
+      return event.reclaimEventType !== "CONF_BUFFER" && event.reclaimEventType !== "TRAVEL_BUFFER";
+    });
 
     const eventSectionsUnfiltered: EventSection[] = [
       {
         section: "NOW",
         sectionTitle: "Now",
-        events: events
-          .filter((event) => {
-            return showDeclinedEvents ? true : event.rsvpStatus !== "Declined" && event.rsvpStatus !== "NotResponded";
-          })
-          .filter((event) => {
-            return event.reclaimEventType !== "CONF_BUFFER" && event.reclaimEventType !== "TRAVEL_BUFFER";
-          })
+        events: nonBufferEvents
           .filter((event) => {
             const start = new Date(event.eventStart);
             const end = new Date(event.eventEnd);
@@ -109,13 +113,7 @@ function Command() {
       {
         section: "TODAY",
         sectionTitle: "Upcoming events",
-        events: events
-          .filter((event) => {
-            return showDeclinedEvents ? true : event.rsvpStatus !== "Declined" && event.rsvpStatus !== "NotResponded";
-          })
-          .filter((event) => {
-            return event.reclaimEventType !== "CONF_BUFFER" && event.reclaimEventType !== "TRAVEL_BUFFER";
-          })
+        events: nonBufferEvents
           .filter((event) => {
             const start = new Date(event.eventStart);
             return isWithinInterval(start, { start: now, end: endOfDay(today) });
@@ -128,14 +126,14 @@ function Command() {
     ];
 
     return eventSectionsUnfiltered.filter((event) => event.events.length > 0);
-  }, [events, showDeclinedEvents]);
+  }, [visibleEvents]);
 
   const titleInfo = useMemo<TitleInfo>(() => {
     const now = new Date();
     let eventNextNow;
     const showNowEvent = getPreferenceValues()["showNowEvent"];
     if (showNowEvent) {
-      const nowEvent = events?.filter((event) => {
+      const nowEvent = visibleEvents?.filter((event) => {
         const start = new Date(event.eventStart);
         const end = new Date(event.eventEnd);
         return isWithinInterval(now, { start, end });
@@ -191,7 +189,7 @@ function Command() {
       nowOrNext: "NONE",
       event: null,
     };
-  }, [eventMoment, events]);
+  }, [eventMoment, visibleEvents]);
 
   /********************/
   /*    useCallback   */


### PR DESCRIPTION
## Description

Fixes an issue where declined events were shown in the Raycast menu bar title and My Calendar command even when the user has the "show declined events" setting disabled.

**Changes:**
- **Menu bar (`notifications.tsx`)**: The toolbar title ("Now: ..." / "Next: ...") now respects the user's `showDeclinedEvents` setting. Previously only the dropdown sections filtered declined events — the title itself did not.
- **My Calendar (`my-calendar.tsx`)**: Added declined event filtering to all sections (Now, Today, Earlier today, Tomorrow). This view previously had no RSVP filtering at all.
- Hoisted the declined filter into a shared `visibleEvents` variable so it's computed once and reused, rather than repeated per section.

## Screencast

This is a straightforward bug fix (no new commands or UI). Declined events no longer appear in the menu bar title or calendar list when the setting is off.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)