### PR TITLE
Update powertoys-tool-runner extension

### DIFF
--- a/extensions/powertoys-tool-runner/CHANGELOG.md
+++ b/extensions/powertoys-tool-runner/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PowerToys Tool Runner Changelog
 
+## [Added Auto-Start PowerToys funcitionality] - {PR_MERGE_DATE}
+
+- Added functionality to automatically start PowerToys when a tool is triggered
+- Added auto-start setting to control the auto-start functionality
+
 ## [Added Awake Command] - 2026-04-04
 
 - Added Awake command to open PowerToys Awake settings

--- a/extensions/powertoys-tool-runner/CHANGELOG.md
+++ b/extensions/powertoys-tool-runner/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerToys Tool Runner Changelog
 
-## [Added Auto-Start PowerToys functionality] - {PR_MERGE_DATE}
+## [Added Auto-Start PowerToys functionality] - 2026-05-20
 
 - Added functionality to automatically start PowerToys when a tool is triggered
 - Added auto-start setting to control the auto-start functionality

--- a/extensions/powertoys-tool-runner/CHANGELOG.md
+++ b/extensions/powertoys-tool-runner/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerToys Tool Runner Changelog
 
-## [Added Auto-Start PowerToys funcitionality] - {PR_MERGE_DATE}
+## [Added Auto-Start PowerToys functionality] - {PR_MERGE_DATE}
 
 - Added functionality to automatically start PowerToys when a tool is triggered
 - Added auto-start setting to control the auto-start functionality

--- a/extensions/powertoys-tool-runner/README.md
+++ b/extensions/powertoys-tool-runner/README.md
@@ -19,6 +19,11 @@ Launch any PowerToys tool instantly:
 - **Workspaces** - Launch workspace configurations
 - **Environment Variables** - Edit system environment variables
 - **Crop and Lock** - Reparent and Thumbnail modes
+- **Awake** - Keep your computer awake
+
+## Settings
+
+- **Auto-start PowerToys** - Attempt to start PowerToys before executing a tool
 
 ## Usage
 

--- a/extensions/powertoys-tool-runner/package.json
+++ b/extensions/powertoys-tool-runner/package.json
@@ -111,6 +111,17 @@
       "icon": "Awake.png"
     }
   ],
+  "preferences": [
+    {
+      "name": "autoStartPowerToys",
+      "type": "checkbox",
+      "required": false,
+      "title": "Auto-start settings",
+      "label": "Auto-start PowerToys",
+      "description": "Attempt to start PowerToys before executing a tool",
+      "default": true
+    }
+  ],
   "dependencies": {
     "@raycast/api": "^1.103.0",
     "@raycast/utils": "^2.2.1"
@@ -132,7 +143,9 @@
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1"
   },
   "author": "LostViking09",
-  "contributors": ["Logan-8f"],
+  "contributors": [
+    "Logan-8f"
+  ],
   "platforms": [
     "Windows"
   ],

--- a/extensions/powertoys-tool-runner/src/utils/openSettings.ts
+++ b/extensions/powertoys-tool-runner/src/utils/openSettings.ts
@@ -1,20 +1,17 @@
 import { runPowerShellScript, showFailureToast } from "@raycast/utils";
 import { showToast, Toast } from "@raycast/api";
-import { isPowerToysRunning } from "./triggerEvent";
+import { ensurePowerToysIsRunning } from "./triggerEvent";
 import { getPowerToysInstallPath } from "./getPowerToysInstallPath";
 
 export async function openPowerToysSettings(moduleName: string): Promise<void> {
   try {
-    const [isRunning, installPath] = await Promise.all([isPowerToysRunning(), getPowerToysInstallPath()]);
+    const isRunning = await ensurePowerToysIsRunning();
 
     if (!isRunning) {
-      await showToast({
-        style: Toast.Style.Failure,
-        title: "PowerToys is not running",
-        message: "Please ensure PowerToys is installed and running",
-      });
       return;
     }
+
+    const installPath = await getPowerToysInstallPath();
 
     if (!installPath) {
       await showToast({

--- a/extensions/powertoys-tool-runner/src/utils/triggerEvent.ts
+++ b/extensions/powertoys-tool-runner/src/utils/triggerEvent.ts
@@ -2,10 +2,6 @@ import { runPowerShellScript, showFailureToast } from "@raycast/utils";
 import { getPreferenceValues, showToast, Toast } from "@raycast/api";
 import { getPowerToysInstallPath } from "./getPowerToysInstallPath";
 
-interface Preferences {
-  autoStartPowerToys: boolean;
-}
-
 export async function isPowerToysRunning(): Promise<boolean> {
   try {
     const psCommand = `(Get-Process -Name 'PowerToys' -ErrorAction SilentlyContinue) -ne $null`;

--- a/extensions/powertoys-tool-runner/src/utils/triggerEvent.ts
+++ b/extensions/powertoys-tool-runner/src/utils/triggerEvent.ts
@@ -1,5 +1,10 @@
 import { runPowerShellScript, showFailureToast } from "@raycast/utils";
-import { showToast, Toast } from "@raycast/api";
+import { getPreferenceValues, showToast, Toast } from "@raycast/api";
+import { getPowerToysInstallPath } from "./getPowerToysInstallPath";
+
+interface Preferences {
+  autoStartPowerToys: boolean;
+}
 
 export async function isPowerToysRunning(): Promise<boolean> {
   try {
@@ -14,16 +19,71 @@ export async function isPowerToysRunning(): Promise<boolean> {
   }
 }
 
+export async function ensurePowerToysIsRunning(): Promise<boolean> {
+  const isRunning = await isPowerToysRunning();
+  if (isRunning) return true;
+
+  const preferences = getPreferenceValues<Preferences>();
+  if (!preferences.autoStartPowerToys) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "PowerToys is not running",
+      message: "Please ensure PowerToys is installed and running",
+    });
+    return false;
+  }
+
+  await showToast({
+    style: Toast.Style.Animated,
+    title: "Starting PowerToys...",
+  });
+
+  const installPath = await getPowerToysInstallPath();
+  if (!installPath) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Failed to auto-start PowerToys",
+      message: "Could not locate PowerToys install directory.",
+    });
+    return false;
+  }
+
+  try {
+    const escapedPath = installPath.replace(/'/g, "''");
+    const psCommand = `Start-Process '${escapedPath}\\PowerToys.exe'`;
+    await runPowerShellScript(psCommand, { timeout: 5000 });
+
+    let attempts = 0;
+    while (attempts < 10) {
+      await new Promise((r) => setTimeout(r, 2000));
+      if (await isPowerToysRunning()) {
+        return true;
+      }
+      attempts++;
+    }
+
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Failed to auto-start PowerToys",
+      message: "PowerToys did not start in time. Please ensure PowerToys is installed.",
+    });
+    return false;
+  } catch (error) {
+    console.error("Failed to auto-start PowerToys:", error);
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Failed to auto-start PowerToys",
+      message: "Please ensure PowerToys is installed.",
+    });
+    return false;
+  }
+}
+
 export async function triggerPowerToysEvent(eventName: string, toolName: string): Promise<void> {
   try {
-    const isRunning = await isPowerToysRunning();
+    const isRunning = await ensurePowerToysIsRunning();
 
     if (!isRunning) {
-      await showToast({
-        style: Toast.Style.Failure,
-        title: "PowerToys is not running",
-        message: "Please ensure PowerToys is installed and running",
-      });
       return;
     }
 
@@ -31,9 +91,27 @@ export async function triggerPowerToysEvent(eventName: string, toolName: string)
 
     console.log(`Triggering ${toolName}...`);
 
-    await runPowerShellScript(psCommand, {
-      timeout: 5000,
-    });
+    let attempts = 0;
+    let success = false;
+    let lastError: unknown = null;
+
+    while (attempts < 15) {
+      try {
+        await runPowerShellScript(psCommand, {
+          timeout: 5000,
+        });
+        success = true;
+        break;
+      } catch (error) {
+        lastError = error;
+        attempts++;
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
+
+    if (!success) {
+      throw lastError;
+    }
 
     console.log(`${toolName} triggered successfully`);
   } catch (error) {


### PR DESCRIPTION
## Description

**New functionality:**
The extension can now attempt to start PowerToys, if it is not already running, upon running a tool call command.
Configurable in the settings.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
