### PR TITLE
Fix Copy Path for VS Code active files

### DIFF
--- a/extensions/copy-path/CHANGELOG.md
+++ b/extensions/copy-path/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Copy Path Changelog
 
-## [Fix VS Code active file copy] - {PR_MERGE_DATE}
+## [Fix VS Code active file copy] - 2026-05-28
 
 - Fixed copying the active file path from VS Code when AppleScript document lookup stalls.
 

--- a/extensions/copy-path/CHANGELOG.md
+++ b/extensions/copy-path/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Copy Path Changelog
 
+## [Fix VS Code active file copy] - {PR_MERGE_DATE}
+
+- Fixed copying the active file path from VS Code when AppleScript document lookup stalls.
+
 ## [Support QSpace Pro] - 2026-05-11
 
 - Support copying selected item paths and the current location from QSpace Pro.

--- a/extensions/copy-path/src/utils/applescript-utils.ts
+++ b/extensions/copy-path/src/utils/applescript-utils.ts
@@ -2,6 +2,8 @@ import { runAppleScript } from "@raycast/utils";
 import * as os from "node:os";
 import { Application } from "@raycast/api";
 
+const APPLESCRIPT_TIMEOUT_MS = 5000;
+
 export const scriptFinderPath = `
 if application "Finder" is not running then
     return "Finder not running"
@@ -15,7 +17,7 @@ end tell
 // finder path, with / at the end
 export const getFocusFinderPath = async () => {
   try {
-    return await runAppleScript(scriptFinderPath);
+    return await runAppleScript(scriptFinderPath, { timeout: APPLESCRIPT_TIMEOUT_MS });
   } catch (e) {
     return os.homedir();
   }
@@ -54,7 +56,7 @@ end tell
 
 export const getQSpacePathUrls = async () => {
   try {
-    return await runAppleScript(scriptQSpacePath);
+    return await runAppleScript(scriptQSpacePath, { timeout: APPLESCRIPT_TIMEOUT_MS });
   } catch (e) {
     return "";
   }
@@ -78,7 +80,7 @@ return windowPath
 
 export const getFocusWindowPath = async (app: Application) => {
   try {
-    let path = await runAppleScript(scriptWindowPath(app));
+    let path = await runAppleScript(scriptWindowPath(app), { timeout: APPLESCRIPT_TIMEOUT_MS });
     if (path == "missing value" || path == "") {
       return "";
     }
@@ -93,6 +95,49 @@ export const getFocusWindowPath = async (app: Application) => {
     } catch {
       return path;
     }
+  } catch (e) {
+    return "";
+  }
+};
+
+export const scriptVSCodeActiveFilePath = (app: Application) => `
+set previousClipboard to the clipboard
+set sentinelClipboard to "__raycast_copy_path_no_active_file__"
+set the clipboard to sentinelClipboard
+
+try
+  tell application id "${app.bundleId}" to activate
+  delay 0.1
+  tell application "System Events"
+    keystroke "c" using {option down, command down}
+  end tell
+  delay 0.2
+  set activeFilePath to the clipboard
+  if activeFilePath is sentinelClipboard then
+    set the clipboard to previousClipboard
+    return ""
+  end if
+  return activeFilePath
+on error
+  set the clipboard to previousClipboard
+  return ""
+end try
+`;
+
+export const getVSCodeActiveFilePath = async (app: Application) => {
+  if (!app.bundleId) {
+    return "";
+  }
+
+  try {
+    const path = (await runAppleScript(scriptVSCodeActiveFilePath(app), { timeout: APPLESCRIPT_TIMEOUT_MS })).trim();
+    if (path.startsWith("file://")) {
+      return decodeURIComponent(path.replace("file://", ""));
+    }
+    if (path.startsWith("/") || path.startsWith("~")) {
+      return path;
+    }
+    return "";
   } catch (e) {
     return "";
   }
@@ -117,7 +162,7 @@ return windowTitle
 
 export const getFocusWindowTitle = async (app: Application) => {
   try {
-    return await runAppleScript(scriptWindowTitle(app));
+    return await runAppleScript(scriptWindowTitle(app), { timeout: APPLESCRIPT_TIMEOUT_MS });
   } catch (e) {
     return "";
   }
@@ -132,7 +177,7 @@ return currentURL`;
 
 export const getWebkitBrowserPath = async (app: string) => {
   try {
-    return await runAppleScript(scriptWebkitBrowserPath(app));
+    return await runAppleScript(scriptWebkitBrowserPath(app), { timeout: APPLESCRIPT_TIMEOUT_MS });
   } catch (e) {
     return "";
   }
@@ -147,7 +192,7 @@ return currentURL`;
 
 export const getChromiumBrowserPath = async (app: string) => {
   try {
-    return await runAppleScript(scriptChromiumBrowserPath(app));
+    return await runAppleScript(scriptChromiumBrowserPath(app), { timeout: APPLESCRIPT_TIMEOUT_MS });
   } catch (e) {
     return "";
   }
@@ -172,7 +217,7 @@ end tell`;
 
 export const copyFirefoxBrowserPath = async (app: string) => {
   try {
-    return await runAppleScript(scriptFirefoxBrowserPath(app));
+    return await runAppleScript(scriptFirefoxBrowserPath(app), { timeout: APPLESCRIPT_TIMEOUT_MS });
   } catch (e) {
     return "";
   }
@@ -192,7 +237,7 @@ end tell`;
 
 export const copySafariWebAppPath = async (app: string) => {
   try {
-    return await runAppleScript(scriptSafariWebAppPath(app));
+    return await runAppleScript(scriptSafariWebAppPath(app), { timeout: APPLESCRIPT_TIMEOUT_MS });
   } catch (e) {
     return "";
   }

--- a/extensions/copy-path/src/utils/applescript-utils.ts
+++ b/extensions/copy-path/src/utils/applescript-utils.ts
@@ -128,7 +128,7 @@ export const getVSCodeActiveFilePath = async (app: Application) => {
   } catch (e) {
     path = "";
   } finally {
-    if (path === "" || path === VSCODE_SENTINEL_CLIPBOARD) {
+    if (!isVSCodeFilePath(path)) {
       await restoreClipboard(previousClipboard);
     }
   }
@@ -137,13 +137,17 @@ export const getVSCodeActiveFilePath = async (app: Application) => {
     if (path.startsWith("file://")) {
       return decodeURIComponent(path.replace("file://", ""));
     }
-    if (path.startsWith("/") || path.startsWith("~")) {
+    if (isVSCodeFilePath(path)) {
       return path;
     }
     return "";
   } catch (e) {
     return "";
   }
+};
+
+const isVSCodeFilePath = (path: string) => {
+  return path.startsWith("file://") || path.startsWith("/") || path.startsWith("~");
 };
 
 const restoreClipboard = async (content: Clipboard.ReadContent) => {

--- a/extensions/copy-path/src/utils/applescript-utils.ts
+++ b/extensions/copy-path/src/utils/applescript-utils.ts
@@ -142,7 +142,7 @@ export const getVSCodeActiveFilePath = async (app: Application) => {
 const normalizeVSCodeFilePath = (path: string) => {
   try {
     if (path.startsWith("file://")) {
-      return decodeURIComponent(path.replace("file://", ""));
+      return decodeURIComponent(new URL(path).pathname);
     }
   } catch {
     return "";

--- a/extensions/copy-path/src/utils/applescript-utils.ts
+++ b/extensions/copy-path/src/utils/applescript-utils.ts
@@ -1,8 +1,9 @@
 import { runAppleScript } from "@raycast/utils";
 import * as os from "node:os";
-import { Application } from "@raycast/api";
+import { Application, Clipboard } from "@raycast/api";
 
 const APPLESCRIPT_TIMEOUT_MS = 5000;
+const VSCODE_SENTINEL_CLIPBOARD = "__raycast_copy_path_no_active_file__";
 
 export const scriptFinderPath = `
 if application "Finder" is not running then
@@ -101,10 +102,6 @@ export const getFocusWindowPath = async (app: Application) => {
 };
 
 export const scriptVSCodeActiveFilePath = (app: Application) => `
-set previousClipboard to the clipboard
-set sentinelClipboard to "__raycast_copy_path_no_active_file__"
-set the clipboard to sentinelClipboard
-
 try
   tell application id "${app.bundleId}" to activate
   delay 0.1
@@ -112,14 +109,8 @@ try
     keystroke "c" using {option down, command down}
   end tell
   delay 0.2
-  set activeFilePath to the clipboard
-  if activeFilePath is sentinelClipboard then
-    set the clipboard to previousClipboard
-    return ""
-  end if
-  return activeFilePath
+  return the clipboard
 on error
-  set the clipboard to previousClipboard
   return ""
 end try
 `;
@@ -129,8 +120,24 @@ export const getVSCodeActiveFilePath = async (app: Application) => {
     return "";
   }
 
+  const previousClipboard = await Clipboard.readText();
+  let path = "";
   try {
-    const path = (await runAppleScript(scriptVSCodeActiveFilePath(app), { timeout: APPLESCRIPT_TIMEOUT_MS })).trim();
+    await Clipboard.copy(VSCODE_SENTINEL_CLIPBOARD);
+    path = (await runAppleScript(scriptVSCodeActiveFilePath(app), { timeout: APPLESCRIPT_TIMEOUT_MS })).trim();
+  } catch (e) {
+    path = "";
+  } finally {
+    if (path === "" || path === VSCODE_SENTINEL_CLIPBOARD) {
+      if (previousClipboard === undefined) {
+        await Clipboard.clear();
+      } else {
+        await Clipboard.copy(previousClipboard);
+      }
+    }
+  }
+
+  try {
     if (path.startsWith("file://")) {
       return decodeURIComponent(path.replace("file://", ""));
     }

--- a/extensions/copy-path/src/utils/applescript-utils.ts
+++ b/extensions/copy-path/src/utils/applescript-utils.ts
@@ -124,30 +124,30 @@ export const getVSCodeActiveFilePath = async (app: Application) => {
   let path = "";
   try {
     await Clipboard.copy(VSCODE_SENTINEL_CLIPBOARD);
-    path = (await runAppleScript(scriptVSCodeActiveFilePath(app), { timeout: APPLESCRIPT_TIMEOUT_MS })).trim();
+    const clipboardPath = (
+      await runAppleScript(scriptVSCodeActiveFilePath(app), { timeout: APPLESCRIPT_TIMEOUT_MS })
+    ).trim();
+    path = normalizeVSCodeFilePath(clipboardPath);
   } catch (e) {
     path = "";
   } finally {
-    if (!isVSCodeFilePath(path)) {
+    if (path === "") {
       await restoreClipboard(previousClipboard);
     }
   }
 
+  return path;
+};
+
+const normalizeVSCodeFilePath = (path: string) => {
   try {
     if (path.startsWith("file://")) {
       return decodeURIComponent(path.replace("file://", ""));
     }
-    if (isVSCodeFilePath(path)) {
-      return path;
-    }
-    return "";
-  } catch (e) {
+  } catch {
     return "";
   }
-};
-
-const isVSCodeFilePath = (path: string) => {
-  return path.startsWith("file://") || path.startsWith("/") || path.startsWith("~");
+  return path.startsWith("/") || path.startsWith("~") ? path : "";
 };
 
 const restoreClipboard = async (content: Clipboard.ReadContent) => {

--- a/extensions/copy-path/src/utils/applescript-utils.ts
+++ b/extensions/copy-path/src/utils/applescript-utils.ts
@@ -120,7 +120,7 @@ export const getVSCodeActiveFilePath = async (app: Application) => {
     return "";
   }
 
-  const previousClipboard = await Clipboard.readText();
+  const previousClipboard = await Clipboard.read();
   let path = "";
   try {
     await Clipboard.copy(VSCODE_SENTINEL_CLIPBOARD);
@@ -129,11 +129,7 @@ export const getVSCodeActiveFilePath = async (app: Application) => {
     path = "";
   } finally {
     if (path === "" || path === VSCODE_SENTINEL_CLIPBOARD) {
-      if (previousClipboard === undefined) {
-        await Clipboard.clear();
-      } else {
-        await Clipboard.copy(previousClipboard);
-      }
+      await restoreClipboard(previousClipboard);
     }
   }
 
@@ -147,6 +143,18 @@ export const getVSCodeActiveFilePath = async (app: Application) => {
     return "";
   } catch (e) {
     return "";
+  }
+};
+
+const restoreClipboard = async (content: Clipboard.ReadContent) => {
+  if (content.file) {
+    await Clipboard.copy({ file: content.file });
+  } else if (content.html) {
+    await Clipboard.copy({ html: content.html, text: content.text });
+  } else if (content.text) {
+    await Clipboard.copy(content.text);
+  } else {
+    await Clipboard.clear();
   }
 };
 

--- a/extensions/copy-path/src/utils/applescript-utils.ts
+++ b/extensions/copy-path/src/utils/applescript-utils.ts
@@ -106,7 +106,9 @@ try
   tell application id "${app.bundleId}" to activate
   delay 0.1
   tell application "System Events"
-    keystroke "c" using {option down, command down}
+    tell process "${app.name}"
+      keystroke "c" using {option down, command down}
+    end tell
   end tell
   delay 0.2
   return the clipboard

--- a/extensions/copy-path/src/utils/common-utils.ts
+++ b/extensions/copy-path/src/utils/common-utils.ts
@@ -6,6 +6,7 @@ import {
   getFocusWindowPath,
   getFocusWindowTitle,
   getQSpacePathUrls,
+  getVSCodeActiveFilePath,
   getWebkitBrowserPath,
 } from "./applescript-utils";
 import {
@@ -31,7 +32,7 @@ import {
 } from "../types/preferences";
 import parseUrl from "parse-url";
 import * as os from "node:os";
-import { firefoxBrowsers } from "./constants";
+import { firefoxBrowsers, vsCodeBundleIds } from "./constants";
 
 export const isEmpty = (string: string | null | undefined) => {
   return !(string != null && String(string).length > 0);
@@ -119,7 +120,10 @@ export const copyFinderPath = async () => {
 
 export const copyWindowPath = async (app: Application) => {
   const { useTildeForHome } = await getPreferenceValues();
-  let path = await getFocusWindowPath(app);
+  let path = vsCodeBundleIds.includes(app.bundleId ?? "") ? await getVSCodeActiveFilePath(app) : "";
+  if (isEmpty(path)) {
+    path = await getFocusWindowPath(app);
+  }
   if (useTildeForHome) {
     path = path.replace(os.homedir(), "~");
   }

--- a/extensions/copy-path/src/utils/constants.ts
+++ b/extensions/copy-path/src/utils/constants.ts
@@ -1,4 +1,10 @@
 export const finderBundleId = "com.apple.finder";
 export const qSpaceBundleId = "com.jinghaoshe.qspace.pro";
+export const vsCodeBundleIds = [
+  "com.microsoft.VSCode",
+  "com.microsoft.VSCodeInsiders",
+  "com.visualstudio.code.oss",
+  "com.vscodium",
+];
 
 export const firefoxBrowsers = ["firefox", "zen"];


### PR DESCRIPTION
## Description

- add a VS Code-specific active file path fallback using the default copy-path shortcut
- add timeouts to AppleScript path and URL lookups so the command can recover instead of staying on Copying
- keep the existing document-window and unsupported-app fallbacks for other apps

Fixes #28075

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint`
- [x] I ran `npm run build`