### PR TITLE
Support Antigravity IDE 2.0 paths

### DIFF
--- a/extensions/antigravity/CHANGELOG.md
+++ b/extensions/antigravity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Antigravity Changelog
 
+## [Support Antigravity IDE 2.0] - {PR_MERGE_DATE}
+
+- Prefer the Antigravity IDE 2.0 app and data paths when opening projects, reading recent entries, and managing extensions.
+
 ## [Update] - 2026-01-13
 
 Add a detailed quota usage view

--- a/extensions/antigravity/CHANGELOG.md
+++ b/extensions/antigravity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Antigravity Changelog
 
-## [Support Antigravity IDE 2.0] - {PR_MERGE_DATE}
+## [Support Antigravity IDE 2.0] - 2026-05-28
 
 - Prefer the Antigravity IDE 2.0 app and data paths when opening projects, reading recent entries, and managing extensions.
 

--- a/extensions/antigravity/src/db.ts
+++ b/extensions/antigravity/src/db.ts
@@ -1,10 +1,10 @@
 import { Alert, Icon, Toast, confirmAlert, showToast } from "@raycast/api";
 import { useSQL } from "@raycast/utils";
-import { homedir } from "os";
 import { EntryLike, RecentEntries } from "./types";
 import fs from "fs";
-import { isSameEntry } from "./utils";
+import { getAntigravitySupportPath, isSameEntry } from "./utils";
 import { execFilePromise } from "./utils/exec";
+import path from "path";
 
 export type RemoveMethods = {
   removeEntry: (entry: EntryLike) => Promise<void>;
@@ -82,7 +82,7 @@ export function useRecentEntries() {
 }
 
 function getPath() {
-  return `${homedir()}/Library/Application Support/Antigravity/User/globalStorage/state.vscdb`;
+  return path.join(getAntigravitySupportPath(), "User/globalStorage/state.vscdb");
 }
 
 async function saveEntries(entries: EntryLike[]) {

--- a/extensions/antigravity/src/index.tsx
+++ b/extensions/antigravity/src/index.tsx
@@ -17,6 +17,8 @@ import {
   isRemoteWorkspaceEntry,
   isValidHexColor,
   isWorkspaceEntry,
+  getAntigravityProcessName,
+  openInAntigravity,
 } from "./utils";
 import {
   ListOrGrid,
@@ -123,9 +125,10 @@ function EntryItem(props: { entry: EntryLike; pinned?: boolean } & PinMethods & 
 async function openProject(uri: string, closeOtherWindows: boolean) {
   try {
     if (closeOtherWindows) {
+      const processName = getAntigravityProcessName();
       runAppleScriptSync(`
           tell application "System Events"
-            tell process "Antigravity"
+            tell process "${processName}"
               repeat while window 1 exists
                 click button 1 of window 1
               end repeat
@@ -133,7 +136,7 @@ async function openProject(uri: string, closeOtherWindows: boolean) {
           end tell
           `);
     }
-    await open(uri, "Antigravity");
+    await openInAntigravity(uri);
   } catch (error) {
     console.error("Error opening project:", error);
     await showToast(Toast.Style.Failure, "Failed to open project");

--- a/extensions/antigravity/src/lib/antigravity.ts
+++ b/extensions/antigravity/src/lib/antigravity.ts
@@ -1,6 +1,5 @@
-import { fileExists } from "../utils";
+import { fileExists, getAntigravityCLIPath, getAntigravityExtensionsPath } from "../utils";
 import * as afs from "fs/promises";
-import * as os from "os";
 import path from "path";
 import * as child_process from "child_process";
 
@@ -66,7 +65,7 @@ function getNLSVariable(text: string | undefined): string | undefined {
 }
 
 export function getAntigravityCLIFilename(): string {
-  return "/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity";
+  return getAntigravityCLIPath();
 }
 
 export class AntigravityCLI {
@@ -128,7 +127,7 @@ async function getPackageJSONInfo(filename: string): Promise<PackageJSONInfo | u
 }
 
 export async function getLocalExtensions(): Promise<Extension[] | undefined> {
-  const extensionsRootFolder = path.join(os.homedir(), ".antigravity/extensions");
+  const extensionsRootFolder = getAntigravityExtensionsPath();
   const extensionsManifrestFilename = path.join(extensionsRootFolder, "extensions.json");
   if (await fileExists(extensionsManifrestFilename)) {
     const data = await afs.readFile(extensionsManifrestFilename, {

--- a/extensions/antigravity/src/open-new-window.ts
+++ b/extensions/antigravity/src/open-new-window.ts
@@ -1,18 +1,22 @@
 import { Toast, closeMainWindow, showToast } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
+import { getAntigravityApplicationName, getAntigravityProcessName } from "./utils";
 
 const makeNewWindow = async () => {
+  const appName = getAntigravityApplicationName();
+  const processName = getAntigravityProcessName();
+
   await runAppleScript(`
-    tell application "Antigravity"
+    tell application "${appName}"
 	    activate
     end tell
     delay(0.5)
-    tell application "Antigravity"
+    tell application "${appName}"
 	    activate
     end tell
 
     tell application "System Events"
-	    tell process "Antigravity"
+	    tell process "${processName}"
 		    click menu item "New Window" of menu "File" of menu bar 1
 	    end tell
     end tell

--- a/extensions/antigravity/src/open-with-antigravity.ts
+++ b/extensions/antigravity/src/open-with-antigravity.ts
@@ -1,6 +1,7 @@
-import { showToast, Toast, open, closeMainWindow, getSelectedFinderItems, getFrontmostApplication } from "@raycast/api";
+import { showToast, Toast, closeMainWindow, getSelectedFinderItems, getFrontmostApplication } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
 import { getCurrentFinderPath } from "./utils/apple-scripts";
+import { openInAntigravity } from "./utils";
 
 // Function to get selected Path Finder items
 const getSelectedPathFinderItems = async () => {
@@ -33,10 +34,10 @@ export default async function main() {
     if (selectedItems.length === 0) {
       const currentPath = await getCurrentFinderPath();
       if (currentPath.length === 0) throw new Error("Not a valid directory");
-      await open(currentPath, "Antigravity");
+      await openInAntigravity(currentPath);
     } else {
       for (const item of selectedItems) {
-        await open(item.path, "Antigravity");
+        await openInAntigravity(item.path);
       }
     }
 

--- a/extensions/antigravity/src/utils.ts
+++ b/extensions/antigravity/src/utils.ts
@@ -23,6 +23,10 @@ const ANTIGRAVITY_IDE_APP_PATHS = [
 ];
 const ANTIGRAVITY_APP_PATHS = ["/Applications/Antigravity.app", path.join(homedir(), "Applications/Antigravity.app")];
 
+function hasAntigravityIdeApp(): boolean {
+  return ANTIGRAVITY_IDE_APP_PATHS.some((appPath) => existsSync(appPath));
+}
+
 // Type Guards
 
 export function isFileEntry(entry: EntryLike): entry is FileEntry {
@@ -161,7 +165,7 @@ export async function waitForFileExists(filename: string, timeoutMs = 2000) {
 }
 
 export function getAntigravityApplicationName(): string {
-  if (ANTIGRAVITY_IDE_APP_PATHS.some((appPath) => existsSync(appPath))) {
+  if (hasAntigravityIdeApp()) {
     return ANTIGRAVITY_IDE_APP_NAME;
   }
 
@@ -177,18 +181,16 @@ export async function openInAntigravity(target: string): Promise<void> {
 }
 
 export function getAntigravitySupportPath(): string {
-  const idePath = path.join(homedir(), "Library/Application Support/Antigravity IDE");
-  if (existsSync(idePath)) {
-    return idePath;
+  if (hasAntigravityIdeApp()) {
+    return path.join(homedir(), "Library/Application Support/Antigravity IDE");
   }
 
   return path.join(homedir(), "Library/Application Support/Antigravity");
 }
 
 export function getAntigravityExtensionsPath(): string {
-  const idePath = path.join(homedir(), ".antigravity-ide/extensions");
-  if (existsSync(idePath)) {
-    return idePath;
+  if (hasAntigravityIdeApp()) {
+    return path.join(homedir(), ".antigravity-ide/extensions");
   }
 
   return path.join(homedir(), ".antigravity/extensions");

--- a/extensions/antigravity/src/utils.ts
+++ b/extensions/antigravity/src/utils.ts
@@ -161,10 +161,7 @@ export async function waitForFileExists(filename: string, timeoutMs = 2000) {
 }
 
 export function getAntigravityApplicationName(): string {
-  if (
-    ANTIGRAVITY_IDE_APP_PATHS.some((appPath) => existsSync(appPath)) ||
-    existsSync(path.join(homedir(), "Library/Application Support/Antigravity IDE"))
-  ) {
+  if (ANTIGRAVITY_IDE_APP_PATHS.some((appPath) => existsSync(appPath))) {
     return ANTIGRAVITY_IDE_APP_NAME;
   }
 

--- a/extensions/antigravity/src/utils.ts
+++ b/extensions/antigravity/src/utils.ts
@@ -1,4 +1,6 @@
 import { existsSync } from "fs";
+import { homedir } from "os";
+import path from "path";
 import { URL } from "url";
 import { isDeepStrictEqual } from "util";
 import {
@@ -12,6 +14,14 @@ import {
 } from "./types";
 import { open } from "@raycast/api";
 import * as fs from "fs";
+
+const ANTIGRAVITY_IDE_APP_NAME = "Antigravity IDE";
+const ANTIGRAVITY_APP_NAME = "Antigravity";
+const ANTIGRAVITY_IDE_APP_PATHS = [
+  "/Applications/Antigravity IDE.app",
+  path.join(homedir(), "Applications/Antigravity IDE.app"),
+];
+const ANTIGRAVITY_APP_PATHS = ["/Applications/Antigravity.app", path.join(homedir(), "Applications/Antigravity.app")];
 
 // Type Guards
 
@@ -148,6 +158,61 @@ export async function waitForFileExists(filename: string, timeoutMs = 2000) {
     }
   }
   return false;
+}
+
+export function getAntigravityApplicationName(): string {
+  if (
+    ANTIGRAVITY_IDE_APP_PATHS.some((appPath) => existsSync(appPath)) ||
+    existsSync(path.join(homedir(), "Library/Application Support/Antigravity IDE"))
+  ) {
+    return ANTIGRAVITY_IDE_APP_NAME;
+  }
+
+  return ANTIGRAVITY_APP_NAME;
+}
+
+export function getAntigravityProcessName(): string {
+  return getAntigravityApplicationName();
+}
+
+export async function openInAntigravity(target: string): Promise<void> {
+  await open(target, getAntigravityApplicationName());
+}
+
+export function getAntigravitySupportPath(): string {
+  const idePath = path.join(homedir(), "Library/Application Support/Antigravity IDE");
+  if (existsSync(idePath)) {
+    return idePath;
+  }
+
+  return path.join(homedir(), "Library/Application Support/Antigravity");
+}
+
+export function getAntigravityExtensionsPath(): string {
+  const idePath = path.join(homedir(), ".antigravity-ide/extensions");
+  if (existsSync(idePath)) {
+    return idePath;
+  }
+
+  return path.join(homedir(), ".antigravity/extensions");
+}
+
+export function getAntigravityCLIPath(): string {
+  for (const appPath of ANTIGRAVITY_IDE_APP_PATHS) {
+    const cliPath = path.join(appPath, "Contents/Resources/app/bin/antigravity");
+    if (existsSync(cliPath)) {
+      return cliPath;
+    }
+  }
+
+  for (const appPath of ANTIGRAVITY_APP_PATHS) {
+    const cliPath = path.join(appPath, "Contents/Resources/app/bin/antigravity");
+    if (existsSync(cliPath)) {
+      return cliPath;
+    }
+  }
+
+  return path.join(ANTIGRAVITY_APP_PATHS[0], "Contents/Resources/app/bin/antigravity");
 }
 
 export function raycastForAntigravityURI(uri: string) {


### PR DESCRIPTION
## Description

- prefer the Antigravity IDE 2.0 app when opening projects and new windows
- read recent projects and installed extensions from the IDE-specific support folders when present
- resolve the CLI path from both system and user Applications folders before falling back to the older app path

Fixes #28148

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint`
- [x] I ran `npm run build`