### PR TITLE
Ignore Raycast windows when tiling layouts

### DIFF
--- a/extensions/window-layouts/CHANGELOG.md
+++ b/extensions/window-layouts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Window Layouts Changelog
 
+## [Fix Raycast Beta windows] - {PR_MERGE_DATE}
+
+- Fixed layout commands trying to tile Raycast's own windows on Raycast v2 beta.
+
 ## [Improvements] - 2026-05-06
 
 - Improved the error message shown when the Raycast `WindowManagement` API is not available, clarifying that the extension requires both Raycast Pro and Accessibility permission

--- a/extensions/window-layouts/CHANGELOG.md
+++ b/extensions/window-layouts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Window Layouts Changelog
 
-## [Fix Raycast Beta windows] - {PR_MERGE_DATE}
+## [Fix Raycast Beta windows] - 2026-05-20
 
 - Fixed layout commands trying to tile Raycast's own windows on Raycast v2 beta.
 

--- a/extensions/window-layouts/src/utils/get-desktop-context.ts
+++ b/extensions/window-layouts/src/utils/get-desktop-context.ts
@@ -7,6 +7,11 @@ export type DesktopContext = Readonly<{
   windows: WindowManagement.Window[];
 }>;
 
+function isRaycastWindow(window: WindowManagement.Window) {
+  const appName = window.application?.name?.toLowerCase();
+  return appName === "raycast" || appName === "raycast beta";
+}
+
 export async function getDesktopContext(): Promise<DesktopContext | null> {
   if (!environment.canAccess(WindowManagement)) {
     await showFailureToast("WindowManagement Not Available", {
@@ -33,6 +38,7 @@ export async function getDesktopContext(): Promise<DesktopContext | null> {
   const { excludedApps } = getUserPreferences();
 
   const resizableWindows = windows?.filter((window) => {
+    if (isRaycastWindow(window)) return false;
     if (!window.resizable || !window.positionable) return false;
     if (excludedApps.length > 0) {
       const appName = (window.application?.name ?? "").toLowerCase();


### PR DESCRIPTION
## Description

- exclude Raycast and Raycast Beta windows from the tiling window set
- avoid sending layout bounds to Raycast's own extension/webview windows, which can reject window-management updates on v2 beta

Fixes #28032
Fixes #28130

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint`
- [x] I ran `npm run build`