### PR TITLE
Handle missing DEVONthink property order preference

### DIFF
--- a/extensions/devonthink/CHANGELOG.md
+++ b/extensions/devonthink/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DEVONthink Changelog
 
+## [Fix missing property order preference] - {PR_MERGE_DATE}
+
+- Fixed search results crashing when the optional property order preference is missing.
+
 ## [Update] - 2025-05-24
 
 - Recognize DEVONthink 4 (search for another app name)

--- a/extensions/devonthink/CHANGELOG.md
+++ b/extensions/devonthink/CHANGELOG.md
@@ -1,6 +1,6 @@
 # DEVONthink Changelog
 
-## [Fix missing property order preference] - {PR_MERGE_DATE}
+## [Fix missing property order preference] - 2026-05-21
 
 - Fixed search results crashing when the optional property order preference is missing.
 

--- a/extensions/devonthink/src/components/SearchResultItem.tsx
+++ b/extensions/devonthink/src/components/SearchResultItem.tsx
@@ -196,7 +196,9 @@ const searchResultMetadataItems = (result: SearchResult) => {
     />,
   ].concat(createMetadataLabels({ propKey: "propertyMetaData", record: result.metaData }));
 
-  const orderKeys = preferences.orderSearchResultItemProperties.split(",").map((key) => key.trim().toLowerCase());
+  const orderKeys = (preferences.orderSearchResultItemProperties ?? "")
+    .split(",")
+    .map((key) => key.trim().toLowerCase());
   const ordered = [] as JSX.Element[];
 
   orderKeys.forEach((key) => {


### PR DESCRIPTION
## Description

- guard the optional property order preference before splitting it
- preserve the default metadata ordering when the preference is missing

Fixes #28106

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint`
- [x] I ran `npm run build`