### PR TITLE
Reduce OneNote search list memory usage

### DIFF
--- a/extensions/onenote/CHANGELOG.md
+++ b/extensions/onenote/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OneNote Changelog
 
-## [Fix search memory usage] - {PR_MERGE_DATE}
+## [Fix search memory usage] - 2026-05-20
 
 - Reduced search list memory usage by loading full page content only when a page detail is opened.
 

--- a/extensions/onenote/CHANGELOG.md
+++ b/extensions/onenote/CHANGELOG.md
@@ -1,3 +1,7 @@
 # OneNote Changelog
 
+## [Fix search memory usage] - {PR_MERGE_DATE}
+
+- Reduced search list memory usage by loading full page content only when a page detail is opened.
+
 ## [Initial Version] - 2023-02-14

--- a/extensions/onenote/src/directory.tsx
+++ b/extensions/onenote/src/directory.tsx
@@ -144,7 +144,9 @@ function PageDetail({ item }: { item: OneNoteItem }) {
     `SELECT Content FROM Entities WHERE GOID = '${quoteSql(item.GOID)}' LIMIT 1;`
   );
   const content =
-    data === undefined ? item.Content : (data[0]?.Content ?? (data.length > 0 ? item.Content : "*Full content could not be loaded.*"));
+    data === undefined
+      ? item.Content
+      : data[0]?.Content ?? (data.length > 0 ? item.Content : "*Full content could not be loaded.*");
 
   return (
     <Detail

--- a/extensions/onenote/src/directory.tsx
+++ b/extensions/onenote/src/directory.tsx
@@ -51,6 +51,13 @@ export function getListItems(query: string, elt: OneNoteItem | undefined = undef
   );
 }
 
+const LIST_COLUMNS =
+  "Type, GOID, GUID, GOSID, ParentGOID, GrandparentGOIDs, ContentRID, RootRevGenCount, LastModifiedTime, RecentTime, PinTime, Color, Title, EnterpriseIdentity, substr(Content, 1, 1000) AS Content";
+
+function quoteSql(value: string) {
+  return value.replaceAll("'", "''");
+}
+
 function Items(props: { items: OneNoteItem[]; type: number; elt: OneNoteItem | undefined }): JSX.Element {
   return (
     <>
@@ -117,24 +124,37 @@ export function Directory(props: { elt?: OneNoteItem }) {
     if (props.elt) {
       const item = props.elt;
       if (props.elt.Type == PAGE) {
-        return (
-          <Detail
-            navigationTitle={getAncestorsStr(props.elt, " > ", false)}
-            markdown={"# " + props.elt.Content}
-            actions={
-              <ActionPanel>
-                <Action title="Open in OneNote" icon={Icon.Receipt} onAction={() => openNote(item)} />
-              </ActionPanel>
-            }
-          />
-        );
+        return <PageDetail item={item} />;
       } else {
-        const query = `SELECT * FROM Entities WHERE ParentGOID = "${props.elt.GOID}" ORDER BY RecentTime DESC;`;
+        const query = `SELECT ${LIST_COLUMNS} FROM Entities WHERE ParentGOID = '${quoteSql(
+          props.elt.GOID
+        )}' ORDER BY RecentTime DESC;`;
         return getListItems(query, props.elt);
       }
     }
   }
   // const query = `SELECT * FROM Entities WHERE ParentGOID is NULL ORDER BY RecentTime DESC;`;
-  const query = "SELECT * FROM Entities ORDER BY RecentTime DESC;";
+  const query = `SELECT ${LIST_COLUMNS} FROM Entities ORDER BY RecentTime DESC;`;
   return getListItems(query);
+}
+
+function PageDetail({ item }: { item: OneNoteItem }) {
+  const { data, isLoading } = useSQL<{ Content: string }>(
+    ONENOTE_MERGED_DB,
+    `SELECT Content FROM Entities WHERE GOID = '${quoteSql(item.GOID)}' LIMIT 1;`
+  );
+  const content = data?.[0]?.Content ?? item.Content;
+
+  return (
+    <Detail
+      navigationTitle={getAncestorsStr(item, " > ", false)}
+      isLoading={isLoading}
+      markdown={"# " + content}
+      actions={
+        <ActionPanel>
+          <Action title="Open in OneNote" icon={Icon.Receipt} onAction={() => openNote(item)} />
+        </ActionPanel>
+      }
+    />
+  );
 }

--- a/extensions/onenote/src/directory.tsx
+++ b/extensions/onenote/src/directory.tsx
@@ -143,7 +143,8 @@ function PageDetail({ item }: { item: OneNoteItem }) {
     ONENOTE_MERGED_DB,
     `SELECT Content FROM Entities WHERE GOID = '${quoteSql(item.GOID)}' LIMIT 1;`
   );
-  const content = data?.[0]?.Content ?? item.Content;
+  const content =
+    data === undefined ? item.Content : (data[0]?.Content ?? (data.length > 0 ? item.Content : "*Full content could not be loaded.*"));
 
   return (
     <Detail

--- a/extensions/onenote/src/utils.ts
+++ b/extensions/onenote/src/utils.ts
@@ -40,7 +40,7 @@ export async function openNote(item: OneNoteItem) {
   let cmd = await getUrl(item);
   cmd = "open " + cmd?.replaceAll(" ", "%20").replaceAll("&", "%26").replaceAll("{", "%7B").replaceAll("}", "%7D");
   console.log(cmd);
-  exec(cmd, (_err, _sdtout, _stderr) => {
+  exec(cmd, () => {
     closeMainWindow();
   });
 }


### PR DESCRIPTION
## Description

- avoid loading full note bodies into the search list query
- keep lightweight content previews in list rows
- load the full page content only when opening a page detail

Fixes #27802

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint`
- [x] I ran `npm run build`