### PR TITLE
Fix Messages chat list memory usage

### DIFF
--- a/extensions/messages/CHANGELOG.md
+++ b/extensions/messages/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Messages Changelog
 
-## [Fix chat list memory usage] - {PR_MERGE_DATE}
+## [Fix chat list memory usage] - 2026-05-28
 
 - Limit the initial chat lookup to the 50 displayed conversations before loading contact details.
 

--- a/extensions/messages/CHANGELOG.md
+++ b/extensions/messages/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Messages Changelog
 
+## [Fix chat list memory usage] - {PR_MERGE_DATE}
+
+- Limit the initial chat lookup to the 50 displayed conversations before loading contact details.
+
 ## [Performance Optimizations] - 2025-11-05
 
 - Added "Load Contact Photos" preference to disable contact photo loading

--- a/extensions/messages/src/api/get-chats.ts
+++ b/extensions/messages/src/api/get-chats.ts
@@ -44,7 +44,7 @@ export async function getChats(searchText: string = ""): Promise<Chat[]> {
       chat.chat_identifier
     ORDER BY
       last_message_date DESC
-    LIMIT 1000;
+    LIMIT ${searchText ? "1000" : "50"};
     `,
   );
 

--- a/extensions/messages/src/hooks/useChats.ts
+++ b/extensions/messages/src/hooks/useChats.ts
@@ -92,7 +92,7 @@ export function useChats(searchText: string = "") {
         chat.chat_identifier
       ORDER BY
         last_message_date DESC
-      LIMIT 1000;
+      LIMIT ${searchText ? "1000" : "50"};
     `;
   };
 


### PR DESCRIPTION
## Description

Limits the initial Messages chat lookup to the 50 conversations shown in the command before loading contact details. This avoids eagerly resolving contacts and contact photos for up to 1000 chats on command load, while keeping the larger lookup for typed searches.

Fixes #27933

## Screencast

N/A

## Checklist

- [x] I read the contribution guidelines
- [x] I ran `npm run build` and `npm run lint` for the extension changed
- [x] I added a changelog entry for my changes