### PR TITLE
Fix SteamGridDB image type fallback

### DIFF
--- a/extensions/steamgriddb/CHANGELOG.md
+++ b/extensions/steamgriddb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # SteamGridDB
 
-## [Fix image type fallback] - {PR_MERGE_DATE}
+## [Fix image type fallback] - 2026-05-20
 
 - Prevent a crash when the selected image type is missing or unexpected.
 

--- a/extensions/steamgriddb/CHANGELOG.md
+++ b/extensions/steamgriddb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SteamGridDB
 
+## [Fix image type fallback] - {PR_MERGE_DATE}
+
+- Prevent a crash when the selected image type is missing or unexpected.
+
 ## [Maintenance] - 2025-07-11
 
 - Change the default Enter key behavior to Download Image

--- a/extensions/steamgriddb/src/components.tsx
+++ b/extensions/steamgriddb/src/components.tsx
@@ -11,6 +11,9 @@ import { useEffect, useState } from "react";
 import { ImageType, SGDBGame, SGDBImage } from "./types.js";
 import { db, downloadImage, imageTypes, imageTypeSpecs } from "./utils.js";
 
+const isImageType = (value: string): value is ImageType =>
+  imageTypes.includes(value as ImageType);
+
 export const ImageDetail = ({ image }: { image: SGDBImage }) => {
   return <Detail markdown={`![](${image.url})`} />;
 };
@@ -35,16 +38,21 @@ export const ImagePreview = ({ game }: { game: SGDBGame }) => {
 
   if (isLoading) return <Grid isLoading />;
 
+  const currentImageType = isImageType(imageType) ? imageType : ImageType.Grids;
+  const imageTypeSpec = imageTypeSpecs[currentImageType];
+
   return (
     <Grid
-      columns={imageTypeSpecs[imageType].gridColumns}
+      columns={imageTypeSpec.gridColumns}
       isLoading={isLoading}
-      aspectRatio={imageTypeSpecs[imageType].aspectRatio}
-      fit={imageTypeSpecs[imageType].imageFit}
+      aspectRatio={imageTypeSpec.aspectRatio}
+      fit={imageTypeSpec.imageFit}
       searchBarAccessory={
         <Grid.Dropdown
           tooltip="Select Grid Type"
-          onChange={(value) => setImageType(value as ImageType)}
+          onChange={(value) =>
+            setImageType(isImageType(value) ? value : ImageType.Grids)
+          }
         >
           {imageTypes.map((t) => (
             <Grid.Dropdown.Item key={t} value={t} title={t} />
@@ -92,7 +100,7 @@ export const ImagePreview = ({ game }: { game: SGDBGame }) => {
               />
               <Action.OpenInBrowser
                 shortcut={{ modifiers: ["shift"], key: "enter" }}
-                url={`https://www.steamgriddb.com/${imageTypeSpecs[imageType].websitePathname}/${image.id}`}
+                url={`https://www.steamgriddb.com/${imageTypeSpec.websitePathname}/${image.id}`}
               />
             </ActionPanel>
           }


### PR DESCRIPTION
## Description

Fixes a crash in SteamGridDB when the selected image type is missing or unexpected at render time. The preview now falls back to the default Grids type before reading layout specs or building the SteamGridDB image URL.

Fixes #27562

## Screencast

N/A

## Checklist

- [x] I read the contribution guidelines
- [x] I ran `npm run build` and `npm run lint` for the extension changed
- [x] I added a changelog entry for my changes