### PR TITLE
Fix starred repository request batching

### DIFF
--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitHub Changelog
 
+## [Fix starred repositories loading] - {PR_MERGE_DATE}
+
+- Load starred repositories in smaller GitHub GraphQL batches to avoid 502 errors with larger result preferences.
+
 ## [Fix repository search for many organizations] - 2026-05-18
 
 - Split My Repositories loading into smaller owner-specific searches to avoid GitHub 502 errors for users in many organizations.

--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Changelog
 
-## [Fix starred repositories loading] - {PR_MERGE_DATE}
+## [Fix starred repositories loading] - 2026-05-20
 
 - Load starred repositories in smaller GitHub GraphQL batches to avoid 502 errors with larger result preferences.
 

--- a/extensions/github/src/my-starred-repositories.tsx
+++ b/extensions/github/src/my-starred-repositories.tsx
@@ -9,6 +9,8 @@ import { ExtendedRepositoryFieldsFragment, OrderDirection, StarOrderField } from
 import { STARRED_REPO_DEFAULT_SORT_QUERY, STARRED_REPO_SORT_TYPES_TO_QUERIES, useHistory } from "./helpers/repository";
 import { withGitHubClient } from "./helpers/withGithubClient";
 
+const STARRED_REPOSITORIES_BATCH_SIZE = 25;
+
 function MyStarredRepositories() {
   const { github } = getGitHubClient();
 
@@ -27,17 +29,32 @@ function MyStarredRepositories() {
     async (sort: string, afterCursor: string | null) => {
       const orderByField = sort.split(":")[0].toUpperCase() as StarOrderField;
       const orderByDirection = sort.split(":")[1].toUpperCase() as OrderDirection;
-      const perPage = getBoundedPreferenceNumber({ name: "numberOfResults", default: 50 });
+      const requestedCount = getBoundedPreferenceNumber({ name: "numberOfResults", default: 50 });
+      const repos: ExtendedRepositoryFieldsFragment[] = [];
+      let pageInfo: { hasNextPage: boolean; endCursor?: string | null } = {
+        hasNextPage: false,
+        endCursor: afterCursor,
+      };
+      let nextCursor = afterCursor;
 
-      const result = await github.myStarredRepositories({
-        numberOfItems: perPage,
-        after: afterCursor,
-        orderByField,
-        orderByDirection,
-      });
+      while (repos.length < requestedCount) {
+        const result = await github.myStarredRepositories({
+          numberOfItems: Math.min(STARRED_REPOSITORIES_BATCH_SIZE, requestedCount - repos.length),
+          after: nextCursor,
+          orderByField,
+          orderByDirection,
+        });
 
-      const repos = result.viewer.starredRepositories.nodes as ExtendedRepositoryFieldsFragment[];
-      const pageInfo = result.viewer.starredRepositories.pageInfo;
+        const starredRepositories = result.viewer.starredRepositories;
+        repos.push(...(starredRepositories.nodes as ExtendedRepositoryFieldsFragment[]));
+        pageInfo = starredRepositories.pageInfo;
+
+        if (!pageInfo.hasNextPage || !pageInfo.endCursor) {
+          break;
+        }
+
+        nextCursor = pageInfo.endCursor;
+      }
 
       return {
         repositories: repos,


### PR DESCRIPTION
## Description

Fixes My Starred Repositories failing when a larger result count asks GitHub for 100 starred repositories in one GraphQL request. The command now keeps the configured result count but loads starred repositories in smaller 25-item batches, reducing the chance of GitHub returning a 502 while preserving pagination behavior.

Fixes #26937

## Screencast

N/A

## Checklist

- [x] I read the contribution guidelines
- [x] I ran `npm run lint` and `npm run build` for the extension changed
- [x] I added a changelog entry for my changes