### PR TITLE
[Finder File Actions] Add custom names for pinned folders

### DIFF
--- a/extensions/finder-file-actions/CHANGELOG.md
+++ b/extensions/finder-file-actions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Finder File Actions Changelog
 
-## [Pinned folder custom names] - 2026-05-20
+## [Pinned folder custom names] - {PR_MERGE_DATE}
 
 - Added custom names for pinned folders
 

--- a/extensions/finder-file-actions/CHANGELOG.md
+++ b/extensions/finder-file-actions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Finder File Actions Changelog
 
+## [Pinned folder custom names] - 2026-05-20
+
+- Added custom names for pinned folders
+
 ## [New commands, search fix, icon refresh] - 2026-04-12
 
 - Added "Create Folder" command that creates a new folder in the current Finder directory

--- a/extensions/finder-file-actions/CHANGELOG.md
+++ b/extensions/finder-file-actions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Finder File Actions Changelog
 
-## [Pinned folder custom names] - {PR_MERGE_DATE}
+## [Pinned folder custom names] - 2026-05-28
 
 - Added custom names for pinned folders
 

--- a/extensions/finder-file-actions/src/common/cache-manager.ts
+++ b/extensions/finder-file-actions/src/common/cache-manager.ts
@@ -57,11 +57,13 @@ export class CacheManager {
     return this.pinnedFolders.has(path);
   }
 
-  async pinFolder(folder: SpotlightSearchResult): Promise<void> {
+  async pinFolder(folder: SpotlightSearchResult, customName?: string): Promise<void> {
     await this.init();
 
+    const trimmedCustomName = customName?.trim();
     const pinnedFolder: PinnedFolder = {
       ...folder,
+      ...(trimmedCustomName ? { customName: trimmedCustomName } : {}),
       pinnedAt: new Date(),
       lastVerified: new Date(),
     };
@@ -73,6 +75,24 @@ export class CacheManager {
   async unpinFolder(path: string): Promise<void> {
     await this.init();
     this.pinnedFolders.delete(path);
+    await this.save();
+  }
+
+  async renamePinnedFolder(path: string, customName?: string): Promise<void> {
+    await this.init();
+
+    const folder = this.pinnedFolders.get(path);
+    if (!folder) {
+      return;
+    }
+
+    const trimmedCustomName = customName?.trim();
+    if (trimmedCustomName) {
+      folder.customName = trimmedCustomName;
+    } else {
+      delete folder.customName;
+    }
+
     await this.save();
   }
 

--- a/extensions/finder-file-actions/src/common/types.ts
+++ b/extensions/finder-file-actions/src/common/types.ts
@@ -18,6 +18,7 @@ export interface SpotlightSearchResult {
 }
 
 export interface PinnedFolder extends SpotlightSearchResult {
+  customName?: string;
   pinnedAt: Date;
   lastVerified: Date;
 }

--- a/extensions/finder-file-actions/src/common/utils.tsx
+++ b/extensions/finder-file-actions/src/common/utils.tsx
@@ -1,7 +1,7 @@
 import { Alert, Icon, closeMainWindow, confirmAlert, trash, showToast, popToRoot } from "@raycast/api";
 
 import { runAppleScript } from "run-applescript";
-import { SpotlightSearchResult } from "./types";
+import { PinnedFolder, SpotlightSearchResult } from "./types";
 import path from "path";
 
 const safeSearchScope = (searchScope: string | undefined) => {
@@ -67,6 +67,10 @@ const folderName = (result: SpotlightSearchResult) => {
   return path.basename(result.path) || "Untitled";
 };
 
+const pinnedFolderName = (result: PinnedFolder) => {
+  return result.customName?.trim() || folderName(result);
+};
+
 const enclosingFolderName = (result: SpotlightSearchResult) => {
   return [...result.path.split("/")]
     .filter((_, pathPartIndex) => pathPartIndex < [...result.path.split("/")].length - 1)
@@ -129,6 +133,7 @@ const fixDoubleConcat = (text: string): string => {
 export {
   safeSearchScope,
   folderName,
+  pinnedFolderName,
   enclosingFolderName,
   showFolderInfoInFinder,
   copyFolderToClipboard,

--- a/extensions/finder-file-actions/src/move-to-folder.tsx
+++ b/extensions/finder-file-actions/src/move-to-folder.tsx
@@ -1,6 +1,7 @@
 import {
   Action,
   ActionPanel,
+  Form,
   Icon,
   List,
   LocalStorage,
@@ -14,6 +15,7 @@ import {
   showHUD,
   confirmAlert,
   LaunchProps,
+  useNavigation,
 } from "@raycast/api";
 
 import { usePromise } from "@raycast/utils";
@@ -23,13 +25,54 @@ import path from "path";
 
 import { searchSpotlight } from "./common/search-spotlight";
 import { SpotlightSearchPreferences, SpotlightSearchResult, PinnedFolder } from "./common/types";
-import { folderName, lastUsedSort, fixDoubleConcat } from "./common/utils";
+import { folderName, lastUsedSort, fixDoubleConcat, pinnedFolderName } from "./common/utils";
 import { fsAsync } from "./common/fs-async";
 import { CacheManager } from "./common/cache-manager";
 import { isFinderFrontmost } from "./common/finder";
 
 interface RecentFolder extends SpotlightSearchResult {
   lastUsed: Date;
+}
+
+interface PinnedFolderNameFormValues {
+  customName?: string;
+}
+
+function PinnedFolderNameForm({
+  folder,
+  defaultCustomName,
+  submitTitle,
+  onSubmit,
+}: {
+  folder: SpotlightSearchResult;
+  defaultCustomName?: string;
+  submitTitle: string;
+  onSubmit: (folder: SpotlightSearchResult, customName?: string) => Promise<void>;
+}) {
+  const { pop } = useNavigation();
+
+  async function handleSubmit(values: PinnedFolderNameFormValues) {
+    await onSubmit(folder, values.customName);
+    pop();
+  }
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title={submitTitle} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField
+        id="customName"
+        title="Custom Name"
+        defaultValue={defaultCustomName}
+        placeholder={folderName(folder)}
+      />
+      <Form.Description text={folder.path} />
+    </Form>
+  );
 }
 
 export default function Command(props: LaunchProps) {
@@ -51,6 +94,16 @@ export default function Command(props: LaunchProps) {
   const preferences = getPreferenceValues<SpotlightSearchPreferences>();
   const maxRecentFolders = parseInt(preferences.maxRecentFolders || "10");
   const cacheManager = CacheManager.getInstance();
+  const normalizedSearchText = searchText.trim().toLowerCase();
+  const filteredPinnedFolders = pinnedFolders.filter((folder) => {
+    if (!normalizedSearchText) {
+      return true;
+    }
+
+    return [pinnedFolderName(folder), folderName(folder), folder.path].some((value) =>
+      value.toLowerCase().includes(normalizedSearchText),
+    );
+  });
 
   // Function to get selected files from Finder
   async function getSelectedFinderFiles() {
@@ -666,14 +719,14 @@ export default function Command(props: LaunchProps) {
     }
   }
 
-  async function pinFolder(folder: SpotlightSearchResult) {
+  async function pinFolder(folder: SpotlightSearchResult, customName?: string) {
     try {
-      await cacheManager.pinFolder(folder);
+      await cacheManager.pinFolder(folder, customName);
       await loadPinnedFolders();
       showToast({
         style: Toast.Style.Success,
         title: "Folder Pinned",
-        message: folderName(folder),
+        message: customName?.trim() || folderName(folder),
       });
     } catch (error) {
       console.error("Error pinning folder:", error);
@@ -700,6 +753,25 @@ export default function Command(props: LaunchProps) {
         style: Toast.Style.Failure,
         title: "Error",
         message: "Failed to unpin folder",
+      });
+    }
+  }
+
+  async function renamePinnedFolder(folder: SpotlightSearchResult, customName?: string) {
+    try {
+      await cacheManager.renamePinnedFolder(folder.path, customName);
+      await loadPinnedFolders();
+      showToast({
+        style: Toast.Style.Success,
+        title: "Pinned Folder Renamed",
+        message: customName?.trim() || folderName(folder),
+      });
+    } catch (error) {
+      console.error("Error renaming pinned folder:", error);
+      showToast({
+        style: Toast.Style.Failure,
+        title: "Error",
+        message: "Failed to rename pinned folder",
       });
     }
   }
@@ -760,7 +832,7 @@ export default function Command(props: LaunchProps) {
                 icon={Icon.ArrowUp}
                 actions={
                   <ActionPanel>
-                    <Action title="Go Up" onAction={navigateUp} />
+                    <Action title="Go up" onAction={navigateUp} />
                   </ActionPanel>
                 }
               />
@@ -877,21 +949,27 @@ export default function Command(props: LaunchProps) {
                       onAction={() => pinFolder(folder)}
                       shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
                     />
+                    <Action.Push
+                      icon={Icon.Pencil}
+                      title="Pin with Custom Name"
+                      target={<PinnedFolderNameForm folder={folder} submitTitle="Pin Folder" onSubmit={pinFolder} />}
+                    />
                   </ActionPanel>
                 }
               />
             ))}
           </List.Section>
 
-          {!searchText && pinnedFolders.length > 0 && (
+          {filteredPinnedFolders.length > 0 && (
             <List.Section title="Pinned Folders">
-              {pinnedFolders.map((folder, index) => (
+              {filteredPinnedFolders.map((folder, index) => (
                 <List.Item
                   key={`pinned-${folder.path}-${index}`}
                   id={`pinned-${folder.path}-${index}`}
-                  title={folderName(folder)}
+                  title={pinnedFolderName(folder)}
                   subtitle={folder.path}
                   icon={Icon.Star}
+                  keywords={[folderName(folder), folder.path]}
                   accessories={[
                     {
                       text: folder.pinnedAt ? `Pinned: ${folder.pinnedAt.toLocaleDateString()}` : "",
@@ -904,6 +982,9 @@ export default function Command(props: LaunchProps) {
                         <List.Item.Detail.Metadata>
                           <List.Item.Detail.Metadata.Label title="Metadata" />
                           <List.Item.Detail.Metadata.Label title="Name" text={folder.kMDItemFSName} />
+                          {folder.customName && (
+                            <List.Item.Detail.Metadata.Label title="Custom Name" text={folder.customName} />
+                          )}
                           <List.Item.Detail.Metadata.Separator />
                           <List.Item.Detail.Metadata.Label title="Where" text={folder.path} />
                           <List.Item.Detail.Metadata.Separator />
@@ -956,6 +1037,18 @@ export default function Command(props: LaunchProps) {
                         icon={Icon.Sidebar}
                         shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
                         onAction={() => setIsShowingDetail(!isShowingDetail)}
+                      />
+                      <Action.Push
+                        icon={Icon.Pencil}
+                        title="Rename Pinned Folder"
+                        target={
+                          <PinnedFolderNameForm
+                            folder={folder}
+                            defaultCustomName={folder.customName}
+                            submitTitle="Rename Folder"
+                            onSubmit={renamePinnedFolder}
+                          />
+                        }
                       />
                       <Action
                         icon={Icon.StarDisabled}
@@ -1045,6 +1138,11 @@ export default function Command(props: LaunchProps) {
                         title="Pin This Folder"
                         onAction={() => pinFolder(folder)}
                         shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
+                      />
+                      <Action.Push
+                        icon={Icon.Pencil}
+                        title="Pin with Custom Name"
+                        target={<PinnedFolderNameForm folder={folder} submitTitle="Pin Folder" onSubmit={pinFolder} />}
                       />
                       <Action
                         icon={Icon.Trash}


### PR DESCRIPTION
## Description

Adds optional custom names for pinned folders in Finder File Actions. Pinned folders can be saved or renamed with a custom label, and the pinned section now remains searchable by the custom name, original folder name, or path so similarly named folders are easier to tell apart.

Fixes #28103

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint` and `npm run build`
