### PR TITLE
[Warp] Add Tab Config support

### DIFF
--- a/extensions/warp/CHANGELOG.md
+++ b/extensions/warp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Warp Changelog
 
-## [Tab Config Support] - {PR_MERGE_DATE}
+## [Tab Config Support] - 2026-05-28
 
 - Added Tab Config support to the config launcher, with legacy Launch Configurations as a fallback.
 

--- a/extensions/warp/CHANGELOG.md
+++ b/extensions/warp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Warp Changelog
 
+## [Tab Config Support] - {PR_MERGE_DATE}
+
+- Added Tab Config support to the config launcher, with legacy Launch Configurations as a fallback.
+
 ## [Windows Support] - 2026-05-12
 
 - Added Windows platform support.

--- a/extensions/warp/package.json
+++ b/extensions/warp/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "warp",
   "title": "Warp",
-  "description": "Open Warp tabs/windows and Launch Configurations.",
+  "description": "Open Warp tabs, windows, and Tab Configs.",
   "icon": "warp-icon.png",
   "author": "joetannenbaum",
   "contributors": [
@@ -25,8 +25,8 @@
   "commands": [
     {
       "name": "launch-config",
-      "title": "Open Launch Configuration",
-      "description": "Open a Warp Launch Configuration.",
+      "title": "Open Tab Config",
+      "description": "Open a Warp Tab Config or legacy Launch Configuration.",
       "mode": "view"
     },
     {

--- a/extensions/warp/src/constants.ts
+++ b/extensions/warp/src/constants.ts
@@ -9,13 +9,13 @@ export const getAppName = (): string => {
   return warpApp === "preview" ? "Warp Preview" : "Warp";
 };
 
-// URL for Warp Launch Configurations Docs
-export const LAUNCH_CONFIGS_URL = "https://docs.warp.dev/features/sessions/launch-configurations";
+// URL for Warp Tab Configs Docs
+export const CONFIGS_URL = "https://docs.warp.dev/terminal/windows/tab-configs/";
 
 // Error and information messages
-export const NO_LAUNCH_CONFIGS_TITLE = "No Launch Configurations found";
-export const NO_LAUNCH_CONFIGS_MESSAGE = "You need to create at least one Launch Configuration before launching.";
+export const NO_CONFIGS_TITLE = "No Tab Configs found";
+export const NO_CONFIGS_MESSAGE = "You need to create at least one Tab Config before launching.";
 
 // Action titles
-export const VIEW_DOCS_ACTION_TITLE = "View Launch Configuration Docs";
-export const OPEN_CONFIGS_DIR_ACTION_TITLE = "Open Launch Configurations Directory";
+export const VIEW_DOCS_ACTION_TITLE = "View Tab Config Docs";
+export const OPEN_CONFIGS_DIR_ACTION_TITLE = "Open Tab Configs Directory";

--- a/extensions/warp/src/launch-config.tsx
+++ b/extensions/warp/src/launch-config.tsx
@@ -5,46 +5,76 @@ import YAML from "yaml";
 import { useEffect, useState } from "react";
 import { ActionPanel, Action, List, showToast, Toast, Icon, Keyboard } from "@raycast/api";
 import useLocalStorage from "./hooks/useLocalStorage";
-import { getLaunchConfigUri } from "./uri";
+import { getLaunchConfigUri, getTabConfigUri } from "./uri";
 import {
-  LAUNCH_CONFIGS_URL,
-  NO_LAUNCH_CONFIGS_TITLE,
+  CONFIGS_URL,
+  NO_CONFIGS_TITLE,
   VIEW_DOCS_ACTION_TITLE,
   OPEN_CONFIGS_DIR_ACTION_TITLE,
-  NO_LAUNCH_CONFIGS_MESSAGE,
+  NO_CONFIGS_MESSAGE,
   getAppName,
 } from "./constants";
+
+type ConfigKind = "tab" | "launch";
 
 interface SearchResult {
   name: string;
   path: string;
+  directory: string;
+  kind: ConfigKind;
 }
 
 const isWindows = process.platform === "win32";
 
-function getConfigDir(): string {
+function getAppDataDir(): string {
   if (isWindows) {
-    const appData = process.env.APPDATA ?? path.join(os.homedir(), "AppData", "Roaming");
-    return path.join(appData, "Warp", "Warp", "data", "tab_configs");
+    return process.env.APPDATA ?? path.join(os.homedir(), "AppData", "Roaming");
   }
-  return path.join(os.homedir(), ".warp", "launch_configurations");
+
+  return path.join(os.homedir(), ".warp");
 }
 
-const fullPath = getConfigDir();
-const configFilePattern = isWindows ? /\.toml$/i : /\.ya?ml$/i;
+function getConfigSources(): Array<{ directory: string; kind: ConfigKind; pattern: RegExp }> {
+  const configDir = getAppDataDir();
 
-function parseConfigName(contents: string, filePath: string): string | null {
   if (isWindows) {
-    const match = contents.match(/^name\s*=\s*["'](.+?)["']/m);
-    return match ? match[1] : null;
+    const warpDataDir = path.join(configDir, "Warp", "Warp", "data");
+    return [
+      { directory: path.join(warpDataDir, "tab_configs"), kind: "tab", pattern: /\.toml$/i },
+      { directory: path.join(warpDataDir, "launch_configurations"), kind: "launch", pattern: /\.ya?ml$/i },
+    ];
   }
+
+  return [
+    { directory: path.join(configDir, "tab_configs"), kind: "tab", pattern: /\.toml$/i },
+    { directory: path.join(configDir, "launch_configurations"), kind: "launch", pattern: /\.ya?ml$/i },
+  ];
+}
+
+const configSources = getConfigSources();
+const primaryConfigDir = configSources[0].directory;
+
+function parseConfigName(contents: string, filePath: string, kind: ConfigKind): string | null {
+  if (kind === "tab") {
+    const match = contents.match(/^name\s*=\s*["'](.+?)["']/m);
+    return match ? match[1] : path.basename(filePath, path.extname(filePath));
+  }
+
   const yaml = YAML.parse(contents);
   return yaml?.name ?? path.basename(filePath, path.extname(filePath));
+}
+
+function getConfigUri(searchResult: SearchResult): string {
+  const configName =
+    searchResult.kind === "tab" ? path.basename(searchResult.path, path.extname(searchResult.path)) : searchResult.name;
+
+  return searchResult.kind === "tab" ? getTabConfigUri(configName) : getLaunchConfigUri(configName);
 }
 
 export default function Command() {
   const [searchText, setSearchText] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
+  const [configDir, setConfigDir] = useState(primaryConfigDir);
   const {
     data: resultsOrderList,
     setData: setResultsOrderList,
@@ -64,53 +94,60 @@ export default function Command() {
   };
 
   const init = async () => {
-    const exists = await fs.stat(fullPath).catch(() => false);
+    for (const source of configSources) {
+      const exists = await fs.stat(source.directory).catch(() => false);
 
-    if (exists === false) {
-      return showError("Launch Configuration directory missing", `${fullPath} wasn't found on your computer!`);
-    }
+      if (exists === false) {
+        continue;
+      }
 
-    const files = await fs.readdir(fullPath).catch(() => null);
+      const files = await fs.readdir(source.directory).catch(() => null);
 
-    if (files === null || typeof files === "undefined") {
-      return showError(
-        "Error reading Launch Configuration directory",
-        "Something went wrong while reading the Launch Configuration directory."
+      if (files === null || typeof files === "undefined") {
+        return showError(
+          "Error reading Tab Config directory",
+          "Something went wrong while reading the config directory."
+        );
+      }
+
+      const fileList = (
+        await Promise.all(
+          files
+            .filter((file) => source.pattern.test(file))
+            .map(async (file) => {
+              const filePath = path.join(source.directory, file);
+              const contents = await fs.readFile(filePath, "utf-8");
+              const name = parseConfigName(contents, file, source.kind);
+
+              return name ? { name, path: filePath, directory: source.directory, kind: source.kind } : null;
+            })
+        )
+      ).filter((item): item is SearchResult => item !== null);
+
+      if (fileList.length === 0) {
+        continue;
+      }
+
+      setConfigDir(source.directory);
+      const allFileNames = fileList.map(({ name }) => name);
+      const resultsOrderListFilteredFromStaleFiles = resultsOrderList.filter(
+        (fileName) => allFileNames.indexOf(fileName) !== -1
       );
+      const newFileNamesNotPresentOnResultsOrderList = allFileNames.filter(
+        (fileName) => resultsOrderList.indexOf(fileName) === -1
+      );
+
+      const currentOrderList = [...resultsOrderListFilteredFromStaleFiles, ...newFileNamesNotPresentOnResultsOrderList];
+      setResultsOrderList(currentOrderList);
+      setResults(
+        [...fileList].sort((fileA, fileB) => {
+          return currentOrderList.indexOf(fileA.name) - currentOrderList.indexOf(fileB.name);
+        })
+      );
+      return;
     }
 
-    const fileList = (
-      await Promise.all(
-        files
-          .filter((file) => configFilePattern.test(file))
-          .map(async (file) => {
-            const contents = await fs.readFile(path.join(fullPath, file), "utf-8");
-            const name = parseConfigName(contents, file);
-
-            return name ? { name, path: path.join(fullPath, file) } : null;
-          })
-      )
-    ).filter((item): item is SearchResult => item !== null);
-
-    if (fileList.length === 0) {
-      return showError(NO_LAUNCH_CONFIGS_TITLE, NO_LAUNCH_CONFIGS_MESSAGE);
-    }
-
-    const allFileNames = fileList.map(({ name }) => name);
-    const resultsOrderListFilteredFromStaleFiles = resultsOrderList.filter(
-      (fileName) => allFileNames.indexOf(fileName) !== -1
-    );
-    const newFileNamesNotPresentOnResultsOrderList = allFileNames.filter(
-      (fileName) => resultsOrderList.indexOf(fileName) === -1
-    );
-
-    const currentOrderList = [...resultsOrderListFilteredFromStaleFiles, ...newFileNamesNotPresentOnResultsOrderList];
-    setResultsOrderList(currentOrderList);
-    setResults(
-      [...fileList].sort((fileA, fileB) => {
-        return currentOrderList.indexOf(fileA.name) - currentOrderList.indexOf(fileB.name);
-      })
-    );
+    return showError(NO_CONFIGS_TITLE, NO_CONFIGS_MESSAGE);
   };
 
   let initialized = false;
@@ -143,18 +180,18 @@ export default function Command() {
     <List
       isLoading={results.length === 0 && !error}
       onSearchTextChange={setSearchText}
-      searchBarPlaceholder="Searching for Launch Configurations..."
+      searchBarPlaceholder="Searching for Tab Configs..."
       throttle
     >
       <List.EmptyView
-        title={NO_LAUNCH_CONFIGS_TITLE}
-        description={NO_LAUNCH_CONFIGS_MESSAGE}
+        title={NO_CONFIGS_TITLE}
+        description={NO_CONFIGS_MESSAGE}
         icon={Icon.Terminal}
         actions={
           <ActionPanel>
             <ActionPanel.Section>
-              <Action.ShowInFinder title={OPEN_CONFIGS_DIR_ACTION_TITLE} path={fullPath} icon={Icon.Folder} />
-              <Action.OpenInBrowser title={VIEW_DOCS_ACTION_TITLE} url={LAUNCH_CONFIGS_URL} icon={Icon.Document} />
+              <Action.ShowInFinder title={OPEN_CONFIGS_DIR_ACTION_TITLE} path={configDir} icon={Icon.Folder} />
+              <Action.OpenInBrowser title={VIEW_DOCS_ACTION_TITLE} url={CONFIGS_URL} icon={Icon.Document} />
             </ActionPanel.Section>
           </ActionPanel>
         }
@@ -196,14 +233,14 @@ function SearchListItem({
   return (
     <List.Item
       title={searchResult.name}
-      subtitle={searchResult.path.replace(fullPath + path.sep, "")}
+      subtitle={searchResult.path.replace(searchResult.directory + path.sep, "")}
       actions={
         <ActionPanel>
           <ActionPanel.Section>
             <Action.OpenInBrowser
               title={`Launch in ${getAppName()}`}
               icon={Icon.Terminal}
-              url={getLaunchConfigUri(searchResult.name)}
+              url={getConfigUri(searchResult)}
             />
           </ActionPanel.Section>
           <ActionPanel.Section>
@@ -213,16 +250,20 @@ function SearchListItem({
               shortcut={{ modifiers: ["cmd"], key: "." }}
             />
             <Action.Open
-              title="Edit Launch Configuration"
+              title={searchResult.kind === "tab" ? "Edit Tab Config" : "Edit Launch Configuration"}
               target={searchResult.path}
               shortcut={Keyboard.Shortcut.Common.Open}
             />
             <Action.CreateQuicklink
               title="Save as Quicklink"
-              quicklink={{ link: getLaunchConfigUri(searchResult.name), name: searchResult.name }}
+              quicklink={{ link: getConfigUri(searchResult), name: searchResult.name }}
             />
-            <Action.ShowInFinder title={OPEN_CONFIGS_DIR_ACTION_TITLE} path={fullPath} icon={Icon.Folder} />
-            <Action.OpenInBrowser title={VIEW_DOCS_ACTION_TITLE} url={LAUNCH_CONFIGS_URL} icon={Icon.Document} />
+            <Action.ShowInFinder
+              title={OPEN_CONFIGS_DIR_ACTION_TITLE}
+              path={searchResult.directory}
+              icon={Icon.Folder}
+            />
+            <Action.OpenInBrowser title={VIEW_DOCS_ACTION_TITLE} url={CONFIGS_URL} icon={Icon.Document} />
             {!isSearching && (
               <>
                 <Action

--- a/extensions/warp/src/uri.ts
+++ b/extensions/warp/src/uri.ts
@@ -9,3 +9,4 @@ const getWarpUri = (path: string) => {
 export const getNewTabUri = (path: string) => getWarpUri(`action/new_tab?path=${encodeURIComponent(path)}`);
 export const getNewWindowUri = (path: string) => getWarpUri(`action/new_window?path=${encodeURIComponent(path)}`);
 export const getLaunchConfigUri = (path: string) => getWarpUri(`launch/${encodeURIComponent(path)}`);
+export const getTabConfigUri = (path: string) => getWarpUri(`tab_config/${encodeURIComponent(path)}`);


### PR DESCRIPTION
## Description

Updates Warp's config launcher to prefer Tab Configs and fall back to legacy Launch Configurations when no Tab Configs are available. Tab Configs are read from the `tab_configs` directory and opened with Warp's `tab_config` deeplink, while legacy Launch Configurations keep the existing `launch` deeplink behavior.

Fixes #27824

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint` and `npm run build`
