### PR TITLE
[iTerm] Fix profile parsing

### DIFF
--- a/extensions/iterm/CHANGELOG.md
+++ b/extensions/iterm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # iTerm Changelog
 
+## [Bug Fixes] - {PR_MERGE_DATE}
+
+- Fixed `Open iTerm Profile` so all saved profiles are listed regardless of plist field order
+
 ## [New Features & Improvements] - 2026-04-14
 
 - Added `Switch iTerm Session` command — unified session switcher listing all open panes grouped by tab, with a window filter dropdown (shown when multiple windows are open), persistent custom tags per session (Cmd+T to assign), and descriptive errors when the `iterm2` Python package is missing

--- a/extensions/iterm/CHANGELOG.md
+++ b/extensions/iterm/CHANGELOG.md
@@ -1,6 +1,6 @@
 # iTerm Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-05-20
 
 - Fixed `Open iTerm Profile` so all saved profiles are listed regardless of plist field order
 

--- a/extensions/iterm/src/core/get-iterm-profiles.tsx
+++ b/extensions/iterm/src/core/get-iterm-profiles.tsx
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { homedir } from "os";
 import { join } from "path";
 
@@ -7,38 +7,44 @@ export interface ItermProfile {
   guid: string;
 }
 
+type ItermPreferences = {
+  "New Bookmarks"?: unknown;
+};
+
+type ItermProfileEntry = {
+  Name?: unknown;
+  Guid?: unknown;
+};
+
+function isItermProfileEntry(entry: unknown): entry is ItermProfileEntry {
+  return typeof entry === "object" && entry !== null;
+}
+
 export function getItermProfiles(): ItermProfile[] {
   const plistPath = join(homedir(), "Library/Preferences/com.googlecode.iterm2.plist");
 
   try {
-    // Get all profile names and GUIDs using PlistBuddy
-    const output = execSync(
-      `/usr/libexec/PlistBuddy -c "Print :New\\ Bookmarks" "${plistPath}" 2>/dev/null | grep -E "Name =|Guid ="`,
-      { encoding: "utf-8" },
-    );
+    const output = execFileSync("/usr/bin/plutil", ["-convert", "json", "-o", "-", plistPath], {
+      encoding: "utf-8",
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    const preferences = JSON.parse(output) as ItermPreferences;
+    const bookmarks = preferences["New Bookmarks"];
 
-    const lines = output.trim().split("\n");
-    const profiles: ItermProfile[] = [];
-
-    // Lines come in pairs: Guid first, then Name. Guid for unique identification
-    for (let i = 0; i < lines.length; i += 2) {
-      const guidLine = lines[i];
-      const nameLine = lines[i + 1];
-
-      if (guidLine && nameLine) {
-        const guidMatch = guidLine.match(/Guid\s*=\s*(.+)/);
-        const nameMatch = nameLine.match(/Name\s*=\s*(.+)/);
-
-        if (nameMatch && guidMatch) {
-          profiles.push({
-            name: nameMatch[1].trim(),
-            guid: guidMatch[1].trim(),
-          });
-        }
-      }
+    if (!Array.isArray(bookmarks)) {
+      return [];
     }
 
-    return profiles;
+    return bookmarks.flatMap((entry) => {
+      if (!isItermProfileEntry(entry)) {
+        return [];
+      }
+
+      const name = typeof entry.Name === "string" ? entry.Name.trim() : "";
+      const guid = typeof entry.Guid === "string" ? entry.Guid.trim() : "";
+
+      return name && guid ? [{ name, guid }] : [];
+    });
   } catch (error) {
     console.error("Failed to read iTerm profiles:", error);
     return [];


### PR DESCRIPTION
## Description

Reads the iTerm preferences plist as JSON and maps each profile object directly instead of pairing filtered `Guid` and `Name` lines from shell output. This keeps profiles visible when plist fields appear in a different order or include additional keys.

Fixes #26822

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint` and `npm run build`