### PR TITLE
[MarkMarks] Fix Safari bookmark opening

### DIFF
--- a/extensions/markmarks/CHANGELOG.md
+++ b/extensions/markmarks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # MarkMarks Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-05-20
 
 - Fixed opening bookmarks from Safari so links target Safari directly
 

--- a/extensions/markmarks/CHANGELOG.md
+++ b/extensions/markmarks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MarkMarks Changelog
 
+## [Bug Fixes] - {PR_MERGE_DATE}
+
+- Fixed opening bookmarks from Safari so links target Safari directly
+
 ## [1.1.0] - 2026-05-19
 
 - Add Dia browser support

--- a/extensions/markmarks/src/lib/browser.ts
+++ b/extensions/markmarks/src/lib/browser.ts
@@ -13,6 +13,10 @@ const BROWSER_ALIASES: Record<string, SupportedBrowser> = {
 
 const RAYCAST_APPS = new Set(["Raycast", "Raycast Beta"]);
 
+const BROWSER_OPEN_TARGETS: Partial<Record<SupportedBrowser, string>> = {
+  Safari: "com.apple.Safari",
+};
+
 /**
  * Get the frontmost application name
  */
@@ -144,6 +148,10 @@ function getSupportedBrowser(appName: string): SupportedBrowser | undefined {
   return BROWSER_ALIASES[appName];
 }
 
+function getBrowserOpenTarget(browser: SupportedBrowser): string {
+  return BROWSER_OPEN_TARGETS[browser] ?? browser;
+}
+
 function isValidTab(tab: ActiveTab): boolean {
   return Boolean(tab.title && tab.url);
 }
@@ -197,7 +205,12 @@ export async function getActiveSupportedBrowser(): Promise<SupportedBrowser | un
 
 export async function openUrlInActiveBrowser(url: string): Promise<SupportedBrowser | undefined> {
   const browser = await getActiveSupportedBrowser();
-  await open(url, browser);
+  if (!browser) {
+    await open(url);
+    return undefined;
+  }
+
+  await open(url, getBrowserOpenTarget(browser));
   return browser;
 }
 


### PR DESCRIPTION
## Description

Targets Safari by bundle identifier when opening a bookmark from an active Safari window. This avoids resolving the `Safari` application name to a companion app and keeps links opening in Safari.

Fixes #28146

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint` and `npm run build`