### PR TITLE
Fix Sonos listener port conflicts

### DIFF
--- a/extensions/sonos/CHANGELOG.md
+++ b/extensions/sonos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Sonos Changelog
 
-## [Bug fix] - {PR_MERGE_DATE}
+## [Bug fix] - 2026-05-20
 
 - Fix an error when setting the active group while another Sonos command is using the event listener port
 

--- a/extensions/sonos/CHANGELOG.md
+++ b/extensions/sonos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sonos Changelog
 
+## [Bug fix] - {PR_MERGE_DATE}
+
+- Fix an error when setting the active group while another Sonos command is using the event listener port
+
 ## [Improvement] - 2024-05-10
 
 - Display the volume change after executing increase and decrease volume commands

--- a/extensions/sonos/package.json
+++ b/extensions/sonos/package.json
@@ -114,5 +114,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/sonos/src/core/sonos.ts
+++ b/extensions/sonos/src/core/sonos.ts
@@ -4,6 +4,10 @@ import { SonosState } from "@svrooij/sonos/lib/models/sonos-state";
 import * as storage from "./storage";
 import { isDefined } from "./utils";
 
+// Raycast commands can run in separate processes, so disable the SDK's service
+// event subscriptions before SonosManager adds listeners in @svrooij/sonos.
+process.env.SONOS_DISABLE_EVENTS = "true";
+
 export async function formatPlayingState(state: SonosState | null): Promise<string | null> {
   const playing = await isPlaying();
   const icon = playing ? `▶︎` : `⏸︎`;


### PR DESCRIPTION
## Description
- Disable Sonos SDK event subscriptions for the extension so separate Raycast command processes don't compete for the default listener port
- Keep the existing discovery-based group lookup flow for Set Active Group

## Screencast
N/A

## Checklist
- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store) and followed them
- [x] I tested the extension as best as I could
- [x] I ran  and  and they passed

Fixes #28112