### PR TITLE
[DevUtils] Handle missing app installs

### DIFF
--- a/extensions/devutils/CHANGELOG.md
+++ b/extensions/devutils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DevUtils Changelog
 
+## [Bug Fixes] - {PR_MERGE_DATE}
+
+- Show a Raycast error when the DevUtils app is not installed instead of opening the macOS URL handler dialog.
+
 ## Add Auto Detect command - 2025-01-16
 
 - Add a new command to let the auto-detect feature decide which tool to activate.

--- a/extensions/devutils/CHANGELOG.md
+++ b/extensions/devutils/CHANGELOG.md
@@ -1,6 +1,6 @@
 # DevUtils Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-05-28
 
 - Show a Raycast error when the DevUtils app is not installed instead of opening the macOS URL handler dialog.
 

--- a/extensions/devutils/package.json
+++ b/extensions/devutils/package.json
@@ -362,5 +362,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/devutils/src/auto.tsx
+++ b/extensions/devutils/src/auto.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://auto?clipboard";
-  open(url);
+  await openDevUtilsTool("auto");
 };

--- a/extensions/devutils/src/backslash.tsx
+++ b/extensions/devutils/src/backslash.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://backslash?clipboard";
-  open(url);
+  await openDevUtilsTool("backslash");
 };

--- a/extensions/devutils/src/base64encode.tsx
+++ b/extensions/devutils/src/base64encode.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://base64encode?clipboard";
-  open(url);
+  await openDevUtilsTool("base64encode");
 };

--- a/extensions/devutils/src/base64image.tsx
+++ b/extensions/devutils/src/base64image.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://base64image?clipboard";
-  open(url);
+  await openDevUtilsTool("base64image");
 };

--- a/extensions/devutils/src/colortools.tsx
+++ b/extensions/devutils/src/colortools.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://colortools?clipboard";
-  open(url);
+  await openDevUtilsTool("colortools");
 };

--- a/extensions/devutils/src/cronparser.tsx
+++ b/extensions/devutils/src/cronparser.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://cronparser?clipboard";
-  open(url);
+  await openDevUtilsTool("cronparser");
 };

--- a/extensions/devutils/src/cssformatter.tsx
+++ b/extensions/devutils/src/cssformatter.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://cssformatter?clipboard";
-  open(url);
+  await openDevUtilsTool("cssformatter");
 };

--- a/extensions/devutils/src/csv2json.tsx
+++ b/extensions/devutils/src/csv2json.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://csv2json?clipboard";
-  open(url);
+  await openDevUtilsTool("csv2json");
 };

--- a/extensions/devutils/src/erbformatter.tsx
+++ b/extensions/devutils/src/erbformatter.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://erbformatter?clipboard";
-  open(url);
+  await openDevUtilsTool("erbformatter");
 };

--- a/extensions/devutils/src/hashing.tsx
+++ b/extensions/devutils/src/hashing.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://hashing?clipboard";
-  open(url);
+  await openDevUtilsTool("hashing");
 };

--- a/extensions/devutils/src/html2jsx.tsx
+++ b/extensions/devutils/src/html2jsx.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://html2jsx?clipboard";
-  open(url);
+  await openDevUtilsTool("html2jsx");
 };

--- a/extensions/devutils/src/htmlencode.tsx
+++ b/extensions/devutils/src/htmlencode.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://htmlencode?clipboard";
-  open(url);
+  await openDevUtilsTool("htmlencode");
 };

--- a/extensions/devutils/src/htmlformatter.tsx
+++ b/extensions/devutils/src/htmlformatter.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://htmlformatter?clipboard";
-  open(url);
+  await openDevUtilsTool("htmlformatter");
 };

--- a/extensions/devutils/src/htmlpreview.tsx
+++ b/extensions/devutils/src/htmlpreview.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://htmlpreview?clipboard";
-  open(url);
+  await openDevUtilsTool("htmlpreview");
 };

--- a/extensions/devutils/src/jsformatter.tsx
+++ b/extensions/devutils/src/jsformatter.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://jsformatter?clipboard";
-  open(url);
+  await openDevUtilsTool("jsformatter");
 };

--- a/extensions/devutils/src/json2csv.tsx
+++ b/extensions/devutils/src/json2csv.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://json2csv?clipboard";
-  open(url);
+  await openDevUtilsTool("json2csv");
 };

--- a/extensions/devutils/src/json2php.tsx
+++ b/extensions/devutils/src/json2php.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://json2php?clipboard";
-  open(url);
+  await openDevUtilsTool("json2php");
 };

--- a/extensions/devutils/src/json2yaml.tsx
+++ b/extensions/devutils/src/json2yaml.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://json2yaml?clipboard";
-  open(url);
+  await openDevUtilsTool("json2yaml");
 };

--- a/extensions/devutils/src/jsonformatter.tsx
+++ b/extensions/devutils/src/jsonformatter.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://jsonformatter?clipboard";
-  open(url);
+  await openDevUtilsTool("jsonformatter");
 };

--- a/extensions/devutils/src/jwt.tsx
+++ b/extensions/devutils/src/jwt.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://jwt?clipboard";
-  open(url);
+  await openDevUtilsTool("jwt");
 };

--- a/extensions/devutils/src/lessformatter.tsx
+++ b/extensions/devutils/src/lessformatter.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://lessformatter?clipboard";
-  open(url);
+  await openDevUtilsTool("lessformatter");
 };

--- a/extensions/devutils/src/loremipsum.tsx
+++ b/extensions/devutils/src/loremipsum.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://loremipsum?clipboard";
-  open(url);
+  await openDevUtilsTool("loremipsum");
 };

--- a/extensions/devutils/src/markdownpreview.tsx
+++ b/extensions/devutils/src/markdownpreview.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://markdownpreview?clipboard";
-  open(url);
+  await openDevUtilsTool("markdownpreview");
 };

--- a/extensions/devutils/src/numberbase.tsx
+++ b/extensions/devutils/src/numberbase.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://numberbase?clipboard";
-  open(url);
+  await openDevUtilsTool("numberbase");
 };

--- a/extensions/devutils/src/open-devutils.ts
+++ b/extensions/devutils/src/open-devutils.ts
@@ -1,0 +1,29 @@
+import { getApplications, open, showToast, Toast } from "@raycast/api";
+
+const DEVUTILS_BUNDLE_ID = "tonyapp.devutils";
+const DEVUTILS_APP_NAME = "DevUtils";
+const DEVUTILS_DOWNLOAD_URL = "https://devutils.com";
+
+export async function openDevUtilsTool(tool: string) {
+  const app = (await getApplications()).find(
+    (app) => app.bundleId === DEVUTILS_BUNDLE_ID || app.name === DEVUTILS_APP_NAME
+  );
+
+  if (!app) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "DevUtils is not installed",
+      message: "Install the DevUtils app to use these commands.",
+      primaryAction: {
+        title: "Download App",
+        onAction: async (toast) => {
+          await open(DEVUTILS_DOWNLOAD_URL);
+          await toast.hide();
+        },
+      },
+    });
+    return;
+  }
+
+  await open(`devutils://${tool}?clipboard`);
+}

--- a/extensions/devutils/src/php2json.tsx
+++ b/extensions/devutils/src/php2json.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://php2json?clipboard";
-  open(url);
+  await openDevUtilsTool("php2json");
 };

--- a/extensions/devutils/src/phpserializer.tsx
+++ b/extensions/devutils/src/phpserializer.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://phpserializer?clipboard";
-  open(url);
+  await openDevUtilsTool("phpserializer");
 };

--- a/extensions/devutils/src/phpunserializer.tsx
+++ b/extensions/devutils/src/phpunserializer.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://phpunserializer?clipboard";
-  open(url);
+  await openDevUtilsTool("phpunserializer");
 };

--- a/extensions/devutils/src/qrcode.tsx
+++ b/extensions/devutils/src/qrcode.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://qrcode?clipboard";
-  open(url);
+  await openDevUtilsTool("qrcode");
 };

--- a/extensions/devutils/src/querystringparser.tsx
+++ b/extensions/devutils/src/querystringparser.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://querystringparser?clipboard";
-  open(url);
+  await openDevUtilsTool("querystringparser");
 };

--- a/extensions/devutils/src/randomstringgenerator.tsx
+++ b/extensions/devutils/src/randomstringgenerator.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://randomstringgenerator?clipboard";
-  open(url);
+  await openDevUtilsTool("randomstringgenerator");
 };

--- a/extensions/devutils/src/regextester.tsx
+++ b/extensions/devutils/src/regextester.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://regextester?clipboard";
-  open(url);
+  await openDevUtilsTool("regextester");
 };

--- a/extensions/devutils/src/scssformatter.tsx
+++ b/extensions/devutils/src/scssformatter.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://scssformatter?clipboard";
-  open(url);
+  await openDevUtilsTool("scssformatter");
 };

--- a/extensions/devutils/src/sqlformatter.tsx
+++ b/extensions/devutils/src/sqlformatter.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://sqlformatter?clipboard";
-  open(url);
+  await openDevUtilsTool("sqlformatter");
 };

--- a/extensions/devutils/src/stringcaseconverter.tsx
+++ b/extensions/devutils/src/stringcaseconverter.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://stringcaseconverter?clipboard";
-  open(url);
+  await openDevUtilsTool("stringcaseconverter");
 };

--- a/extensions/devutils/src/stringinspect.tsx
+++ b/extensions/devutils/src/stringinspect.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://stringinspect?clipboard";
-  open(url);
+  await openDevUtilsTool("stringinspect");
 };

--- a/extensions/devutils/src/textdiff.tsx
+++ b/extensions/devutils/src/textdiff.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://textdiff?clipboard";
-  open(url);
+  await openDevUtilsTool("textdiff");
 };

--- a/extensions/devutils/src/unixtime.tsx
+++ b/extensions/devutils/src/unixtime.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://unixtime?clipboard";
-  open(url);
+  await openDevUtilsTool("unixtime");
 };

--- a/extensions/devutils/src/urlencode.tsx
+++ b/extensions/devutils/src/urlencode.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://urlencode?clipboard";
-  open(url);
+  await openDevUtilsTool("urlencode");
 };

--- a/extensions/devutils/src/uuidtool.tsx
+++ b/extensions/devutils/src/uuidtool.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://uuidtool?clipboard";
-  open(url);
+  await openDevUtilsTool("uuidtool");
 };

--- a/extensions/devutils/src/xmlformatter.tsx
+++ b/extensions/devutils/src/xmlformatter.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://xmlformatter?clipboard";
-  open(url);
+  await openDevUtilsTool("xmlformatter");
 };

--- a/extensions/devutils/src/yaml2json.tsx
+++ b/extensions/devutils/src/yaml2json.tsx
@@ -1,6 +1,5 @@
-import { open } from "@raycast/api";
+import { openDevUtilsTool } from "./open-devutils";
 
 export default async () => {
-  const url = "devutils://yaml2json?clipboard";
-  open(url);
+  await openDevUtilsTool("yaml2json");
 };


### PR DESCRIPTION
## Description
- Add a shared DevUtils launcher that checks whether the native DevUtils app is installed before opening `devutils://` URLs
- Show a Raycast failure toast with a download action when the app is missing instead of letting macOS show the URL handler dialog
- Route all DevUtils commands through the shared launcher

## Screencast
N/A

## Checklist
- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store) and followed them
- [x] I tested the extension as best as I could
- [x] I ran `npm run build` and `npm run lint` and they passed

Fixes #28162
