### PR TITLE
Add Dia support to Incognito Clone

### DIFF
--- a/extensions/incognito-clone/CHANGELOG.md
+++ b/extensions/incognito-clone/CHANGELOG.md
@@ -1,4 +1,8 @@
-# MUI Documentation Search Changelog
+# Incognito Clone Changelog
+
+## [Add Dia support] - {PR_MERGE_DATE}
+
+- Added Dia support when cloning tabs into a private window.
 
 ## [Initial Version] - 2023-05-23
 

--- a/extensions/incognito-clone/CHANGELOG.md
+++ b/extensions/incognito-clone/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Incognito Clone Changelog
 
-## [Add Dia support] - {PR_MERGE_DATE}
+## [Add Dia support] - 2026-05-20
 
 - Added Dia support when cloning tabs into a private window.
 

--- a/extensions/incognito-clone/src/utils.ts
+++ b/extensions/incognito-clone/src/utils.ts
@@ -47,6 +47,34 @@ const cloneTab = async (closeTab = false) => {
           tell front window to make new tab with properties {URL:theURL}
         end if
       end tell
+    else if frontmostApp is "Dia"
+      tell application "Dia"
+        if (count every tab of front window) > 0 then
+          set theURL to ""
+
+          repeat with t in every tab of front window
+            try
+              if isFocused of t is true then
+                set theURL to URL of t
+                if ${closeTab} then close t
+                exit repeat
+              end if
+            end try
+          end repeat
+
+          if theURL is "" then
+            set theURL to URL of active tab of front window
+            if ${closeTab} then close active tab of front window
+          end if
+
+          activate
+          tell application "System Events"
+            keystroke "n" using {command down, shift down}
+          end tell
+          delay 0.2
+          set URL of active tab of front window to theURL
+        end if
+      end tell
     else
       error "You need a supported browser as your frontmost app."
     end if


### PR DESCRIPTION
## Description

Adds Dia support to Incognito Clone.

## Changes

- Detects Dia as a supported frontmost browser
- Reads the focused Dia tab URL and opens it in a private Dia window
- Preserves the existing clone-and-close behavior for Dia tabs
- Adds a changelog entry

## Screencast

N/A

## Checklist

- [x] I read the [contribution guidelines](https://developers.raycast.com/basics/contribute-to-an-extension)
- [x] I ran `npm run build` and `npm run lint`

Fixes #27151
