### PR TITLE
Add task snooze actions to Reclaim

### DIFF
--- a/extensions/reclaim-ai/CHANGELOG.md
+++ b/extensions/reclaim-ai/CHANGELOG.md
@@ -1,6 +1,6 @@
 # reclaim Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-05-27
 - Add snooze actions to Search Tasks.
 
 ## [Update] - 2025-10-30

--- a/extensions/reclaim-ai/CHANGELOG.md
+++ b/extensions/reclaim-ai/CHANGELOG.md
@@ -1,5 +1,8 @@
 # reclaim Changelog
 
+## [Update] - {PR_MERGE_DATE}
+- Add snooze actions to Search Tasks.
+
 ## [Update] - 2025-10-30
 - Update to the package.json platforms property to include Windows.
 - Update to Search Tasks to not include tasks that are cancelled.

--- a/extensions/reclaim-ai/src/consts/tasks.consts.tsx
+++ b/extensions/reclaim-ai/src/consts/tasks.consts.tsx
@@ -1,12 +1,12 @@
-type SnoozeOption = { title: string; value: string };
+export type SnoozeOption = { title: string; value: string; minutes?: number; days?: number; startOfDay?: boolean };
 
 export const SNOOZE_OPTIONS: SnoozeOption[] = [
-  { title: "15 min", value: "FROM_NOW_15M" },
-  { title: "30 min", value: "FROM_NOW_30M" },
-  { title: "1 hr", value: "FROM_NOW_1H" },
-  { title: "2 hrs", value: "FROM_NOW_2H" },
-  { title: "4 hrs", value: "FROM_NOW_4H" },
-  { title: "1 day", value: "TOMORROW" },
-  { title: "2 days", value: "IN_TWO_DAYS" },
-  { title: "1 week", value: "NEXT_WEEK" },
+  { title: "15 min", value: "FROM_NOW_15M", minutes: 15 },
+  { title: "30 min", value: "FROM_NOW_30M", minutes: 30 },
+  { title: "1 hr", value: "FROM_NOW_1H", minutes: 60 },
+  { title: "2 hrs", value: "FROM_NOW_2H", minutes: 120 },
+  { title: "4 hrs", value: "FROM_NOW_4H", minutes: 240 },
+  { title: "1 day", value: "TOMORROW", days: 1, startOfDay: true },
+  { title: "2 days", value: "IN_TWO_DAYS", days: 2, startOfDay: true },
+  { title: "1 week", value: "NEXT_WEEK", days: 7, startOfDay: true },
 ];

--- a/extensions/reclaim-ai/src/list-tasks.tsx
+++ b/extensions/reclaim-ai/src/list-tasks.tsx
@@ -8,6 +8,7 @@ import { useTaskActions, useTasks } from "./hooks/useTask";
 import { useUser } from "./hooks/useUser";
 import { Task, TaskStatus } from "./types/task";
 import { formatPriority, formatPriorityIcon, formatStrDuration, TIME_BLOCK_IN_MINUTES } from "./utils/dates";
+import { SNOOZE_OPTIONS, SnoozeOption } from "./consts/tasks.consts";
 
 type DropdownStatus = "OPEN" | "DONE";
 
@@ -23,6 +24,23 @@ const TASK_GROUP_LABEL: Record<TaskStatus, string> = {
   CANCELLED: "Cancelled",
   NEW: "New",
   SCHEDULED: "Scheduled",
+};
+
+const getSnoozeUntil = (snoozeOption: SnoozeOption) => {
+  const date = new Date();
+
+  if (snoozeOption.minutes) {
+    date.setMinutes(date.getMinutes() + snoozeOption.minutes);
+  } else if (snoozeOption.days) {
+    date.setDate(date.getDate() + snoozeOption.days);
+    if (snoozeOption.startOfDay) {
+      date.setHours(0, 0, 0, 0);
+    }
+  } else {
+    return undefined;
+  }
+
+  return date.toISOString();
 };
 
 type StatusDropdownProps = {
@@ -54,7 +72,7 @@ function TaskList() {
 
   const { currentUser } = useUser();
   const { tasks: sourceTasks, isLoading } = useTasks();
-  const { addTime, updateTask, doneTask, incompleteTask } = useTaskActions();
+  const { addTime, updateTask, doneTask, incompleteTask, rescheduleTask } = useTaskActions();
 
   /********************/
   /*     useState     */
@@ -152,6 +170,21 @@ function TaskList() {
     // optimistic update
     setTasks((prevTasks) => prevTasks.map((t) => (t.id === task.id ? { ...t, ...payload } : t)));
     showToast(Toast.Style.Success, `Updated '${task.title}'!`);
+  });
+
+  const handleSnoozeTask = useCallbackSafeRef(async (task: Task, snoozeOption: SnoozeOption) => {
+    await showToast(Toast.Style.Animated, `Snoozing '${task.title}'...`);
+    try {
+      await rescheduleTask(String(task.id), snoozeOption.value);
+    } catch (error) {
+      showToast({ style: Toast.Style.Failure, title: `Error while snoozing '${task.title}'`, message: String(error) });
+      return;
+    }
+    const snoozeUntil = getSnoozeUntil(snoozeOption);
+    if (snoozeUntil) {
+      setTasks((prevTasks) => prevTasks.map((t) => (t.id === task.id ? { ...t, snoozeUntil } : t)));
+    }
+    showToast(Toast.Style.Success, `Snoozed '${task.title}' for ${snoozeOption.title}`);
   });
 
   const getListAccessories = useCallbackSafeRef((task: Task) => {
@@ -395,6 +428,21 @@ function TaskList() {
                               }
                             }}
                           />
+                          <ActionPanel.Submenu
+                            title="Snooze Task"
+                            icon={Icon.ArrowClockwise}
+                            shortcut={{ modifiers: ["cmd"], key: "s" }}
+                          >
+                            {SNOOZE_OPTIONS.map((option) => (
+                              <Action
+                                key={option.value}
+                                title={option.title}
+                                onAction={() => {
+                                  handleSnoozeTask(task, option);
+                                }}
+                              />
+                            ))}
+                          </ActionPanel.Submenu>
                           {task.onDeck ? (
                             <Action
                               icon={{ source: Icon.ArrowDown, tintColor: Color.Red }}


### PR DESCRIPTION
## Description

Adds snooze actions to the Reclaim Search Tasks command.

## Changes

- Reuses the existing Reclaim snooze options from the calendar action panel
- Adds a Snooze Task submenu for open tasks in Search Tasks
- Calls the existing task reschedule endpoint through `rescheduleTask`
- Adds success and failure toasts for the action

## Screencast

N/A

## Checklist

- [x] I read the [contribution guidelines](https://developers.raycast.com/basics/contribute-to-an-extension)
- [x] I ran `npm run build` and `npm run lint`

Fixes #28137
