### PR TITLE
Show Todoist deadlines in Today view

### DIFF
--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Todoist Changelog
 
-## [Include deadlines in Today] - {PR_MERGE_DATE}
+## [Include deadlines in Today] - 2026-05-20
 
 - Show tasks whose deadline is today or overdue in the Today view, even when they do not have a due date.
 

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Todoist Changelog
 
+## [Include deadlines in Today] - {PR_MERGE_DATE}
+
+- Show tasks whose deadline is today or overdue in the Today view, even when they do not have a due date.
+
 ## [Menu bar priority sorting] - 2026-05-18
 
 - **Sort menu bar tasks by priority**: Tasks shown in the menu bar (Today, Upcoming, Inbox, and Filter views) are now ordered by priority first (highest first), then by their existing default order, so the most important tasks surface at the top.

--- a/extensions/todoist/src/helpers/tasks.ts
+++ b/extensions/todoist/src/helpers/tasks.ts
@@ -102,20 +102,24 @@ export function getTasksForUpcomingView(tasks: Task[], userId: string) {
 
 export function getTasksForTodayView(tasks: Task[], userId: string) {
   return getTasksForUpcomingView(tasks, userId).filter((t) => {
-    if (!t.due) return false;
-
-    // Parse the task's due date
-    const taskDate = parseISO(t.due.date);
-
-    // Get today's date at midnight in local timezone
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-
-    // Get the task's due date at midnight in local timezone
-    const taskDateMidnight = new Date(taskDate);
-    taskDateMidnight.setHours(0, 0, 0, 0);
-
-    // Only show tasks due today or overdue
-    return taskDateMidnight <= today;
+    return isTodayOrOverdue(t.due?.date) || isTodayOrOverdue(t.deadline?.date);
   });
+}
+
+function isTodayOrOverdue(date?: string) {
+  if (!date) return false;
+
+  // Parse the task's due or deadline date
+  const taskDate = parseISO(date);
+
+  // Get today's date at midnight in local timezone
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  // Get the task date at midnight in local timezone
+  const taskDateMidnight = new Date(taskDate);
+  taskDateMidnight.setHours(0, 0, 0, 0);
+
+  // Only show tasks due today, deadline today, or overdue
+  return taskDateMidnight <= today;
 }


### PR DESCRIPTION
## Description

Adds deadline-aware filtering to the Todoist Today view so tasks with a deadline today or overdue appear even when they do not have a due date.

## Screencast

N/A - filtering logic change.

## Checklist

- [x] I read the extension guidelines
- [x] I ran `npm run lint`
- [x] I ran `npm run build`

Closes #28089