### PR TITLE
[cmux] Improve workspace search

### DIFF
--- a/extensions/cmux/CHANGELOG.md
+++ b/extensions/cmux/CHANGELOG.md
@@ -1,5 +1,9 @@
 # cmux
 
+## [Improve workspace search] - {PR_MERGE_DATE}
+
+- Include workspace descriptions and open surface details when searching workspaces.
+
 ## [Fix PATH resolution] - 2026-04-24
 
 - Fix `spawn cmux ENOENT` errors in Raycast by injecting Homebrew paths into the environment used for CLI calls (covers both Intel `/usr/local/bin` and Apple Silicon `/opt/homebrew/bin`)

--- a/extensions/cmux/CHANGELOG.md
+++ b/extensions/cmux/CHANGELOG.md
@@ -1,6 +1,6 @@
 # cmux
 
-## [Improve workspace search] - {PR_MERGE_DATE}
+## [Improve workspace search] - 2026-05-20
 
 - Include workspace descriptions and open surface details when searching workspaces.
 

--- a/extensions/cmux/src/search-workspaces.tsx
+++ b/extensions/cmux/src/search-workspaces.tsx
@@ -6,7 +6,9 @@ import { Surface, SurfaceList } from "./surfaces";
 interface Workspace {
   ref: string;
   name: string;
+  description?: string | null;
   isSelected: boolean;
+  keywords: string[];
 }
 
 interface Window {
@@ -15,57 +17,88 @@ interface Window {
   workspaces: Workspace[];
 }
 
+interface CmuxTree {
+  windows?: CmuxWindow[];
+}
+
+interface CmuxWindow {
+  ref: string;
+  current?: boolean;
+  workspaces?: CmuxWorkspace[];
+}
+
+interface CmuxWorkspace {
+  ref: string;
+  title: string;
+  description?: string | null;
+  selected?: boolean;
+  panes?: CmuxPane[];
+}
+
+interface CmuxPane {
+  surfaces?: CmuxSurface[];
+}
+
+interface CmuxSurface {
+  ref: string;
+  title: string;
+  selected?: boolean;
+  selected_in_pane?: boolean;
+  active?: boolean;
+  here?: boolean;
+  type?: string;
+  tty?: string | null;
+  url?: string | null;
+}
+
+function compactKeywords(values: Array<string | null | undefined>) {
+  return [...new Set(values.map((value) => value?.replace(/\s+/g, " ").trim()).filter(Boolean))] as string[];
+}
+
+function getWorkspaceSurfaces(workspace: CmuxWorkspace): Surface[] {
+  return (workspace.panes ?? []).flatMap((pane) =>
+    (pane.surfaces ?? []).map((surface) => ({
+      ref: surface.ref,
+      name: surface.title,
+      workspaceRef: workspace.ref,
+      workspaceName: workspace.title,
+      isSelected: Boolean(surface.selected ?? surface.selected_in_pane),
+      isActive: Boolean(surface.active ?? surface.here),
+    })),
+  );
+}
+
+function getWorkspaceKeywords(workspace: CmuxWorkspace, surfaces: Surface[]) {
+  return compactKeywords([
+    workspace.description,
+    ...surfaces.flatMap((surface) => [surface.name, surface.ref, surface.workspaceName]),
+    ...(workspace.panes ?? []).flatMap((pane) =>
+      (pane.surfaces ?? []).flatMap((surface) => [surface.type, surface.tty, surface.url]),
+    ),
+  ]);
+}
+
 async function getTreeData(): Promise<{ windows: Window[]; surfaces: Surface[] }> {
-  const output = await execFileAsync("cmux", ["tree", "--all"]);
-  const lines = output.split("\n");
+  const tree = JSON.parse(await execFileAsync("cmux", ["tree", "--all", "--json"])) as CmuxTree;
 
-  const windows: Window[] = [];
   const surfaces: Surface[] = [];
-  let currentWindow: Window | null = null;
-  let currentWorkspaceRef = "";
-  let currentWorkspaceName = "";
+  const windows =
+    tree.windows?.map((window) => ({
+      ref: window.ref,
+      isCurrent: Boolean(window.current),
+      workspaces: (window.workspaces ?? []).map((workspace) => {
+        const workspaceSurfaces = getWorkspaceSurfaces(workspace);
+        surfaces.push(...workspaceSurfaces);
 
-  for (const line of lines) {
-    const windowMatch = line.match(/^window\s+(window:\d+)(.*)/);
-    if (windowMatch) {
-      currentWindow = {
-        ref: windowMatch[1],
-        isCurrent: windowMatch[2].includes("[current]"),
-        workspaces: [],
-      };
-      windows.push(currentWindow);
-      continue;
-    }
-
-    const workspaceMatch = line.match(/workspace\s+(workspace:\d+)\s+"([^"]+)"(.*)/);
-    if (workspaceMatch && currentWindow) {
-      const ref = workspaceMatch[1];
-      const name = workspaceMatch[2];
-      const meta = workspaceMatch[3];
-      const isSelected = meta.includes("[selected]");
-      currentWorkspaceRef = ref;
-      currentWorkspaceName = name;
-      currentWindow.workspaces.push({ ref, name, isSelected });
-      continue;
-    }
-
-    const surfaceMatch = line.match(/surface\s+(surface:\d+)\s+\[[^\]]+\]\s+"([^"]+)"/);
-    if (surfaceMatch) {
-      const ref = surfaceMatch[1];
-      const name = surfaceMatch[2];
-      const isSelected = line.includes("[selected]");
-      const isActive = line.includes("◀ active");
-
-      surfaces.push({
-        ref,
-        name,
-        workspaceRef: currentWorkspaceRef,
-        workspaceName: currentWorkspaceName,
-        isSelected,
-        isActive,
-      });
-    }
-  }
+        return {
+          ref: workspace.ref,
+          name: workspace.title,
+          description: workspace.description,
+          isSelected: Boolean(workspace.selected),
+          keywords: getWorkspaceKeywords(workspace, workspaceSurfaces),
+        };
+      }),
+    })) ?? [];
 
   return { windows, surfaces };
 }
@@ -127,6 +160,7 @@ export default function Command() {
             <List.Item
               key={workspace.ref}
               title={workspace.name}
+              keywords={workspace.keywords}
               accessories={[...(workspace.isSelected ? [{ tag: { value: "active", color: Color.Green } }] : [])]}
               actions={
                 <ActionPanel>


### PR DESCRIPTION
## Description

Improves the cmux Search Workspaces command so Raycast can match the same context cmux exposes in its own workspace search.

- Reads `cmux tree --all --json` for structured workspace data
- Adds workspace descriptions and open surface details as Raycast item keywords
- Keeps the visible list layout unchanged

Closes #27659.

## Screencast

N/A

## Checklist

- [x] I read the extension guidelines
- [x] I ran `npm run lint` and `npm run build`
- [x] I added a changelog entry