### PR TITLE
Fix Capacities space dropdown selection

### DIFF
--- a/extensions/capacities/CHANGELOG.md
+++ b/extensions/capacities/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Capacities Changelog
 
-## [Fix space dropdown selection] - {PR_MERGE_DATE}
+## [Fix space dropdown selection] - 2026-05-20
 
 - Fixed space dropdown selection in the task, weblink, and daily note commands.
 

--- a/extensions/capacities/CHANGELOG.md
+++ b/extensions/capacities/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Capacities Changelog
 
+## [Fix space dropdown selection] - {PR_MERGE_DATE}
+
+- Fixed space dropdown selection in the task, weblink, and daily note commands.
+
 ## [Version 2.0.1] - 2026-01-09
 
 - Fix: Space selection for task, weblink and save to daily note.

--- a/extensions/capacities/src/create-task.tsx
+++ b/extensions/capacities/src/create-task.tsx
@@ -1,6 +1,7 @@
 import { ActionPanel, Action, Form, Icon, closeMainWindow, showToast, Toast, showHUD } from "@raycast/api";
 import { FormValidation, useForm } from "@raycast/utils";
 import { useEffect, useRef } from "react";
+import { getInitialSpaceId, setStoredSpaceId } from "./helpers/spaces";
 import { API_HEADERS, API_URL, handleAPIError, handleUnexpectedError, useCapacitiesStore } from "./helpers/storage";
 
 interface SaveWeblinkBody {
@@ -10,6 +11,8 @@ interface SaveWeblinkBody {
   priority?: string;
   date?: Date;
 }
+
+const SPACE_STORAGE_KEY = "create-task-space-id";
 
 export default function Command() {
   const { store, triggerLoading, isLoading: storeIsLoading } = useCapacitiesStore();
@@ -104,6 +107,26 @@ export default function Command() {
     },
   });
 
+  const spaces = store?.spaces ?? [];
+  const spaceIds = spaces.map((space) => space.id).join(",");
+
+  useEffect(() => {
+    if (!spaces.length || itemProps.spaceId.value) {
+      return;
+    }
+    let cancelled = false;
+
+    getInitialSpaceId(SPACE_STORAGE_KEY, spaces).then((spaceId) => {
+      if (!cancelled && spaceId) {
+        setValue("spaceId", spaceId);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [spaceIds, itemProps.spaceId.value, setValue]);
+
   return (
     <Form
       isLoading={storeIsLoading}
@@ -118,8 +141,10 @@ export default function Command() {
           <Form.Dropdown
             title="Space"
             {...itemProps.spaceId}
-            storeValue
-            onChange={(value) => setValue("spaceId", value)}
+            onChange={(value) => {
+              setValue("spaceId", value);
+              setStoredSpaceId(SPACE_STORAGE_KEY, value);
+            }}
             ref={spacesDropdown}
           >
             {store.spaces &&

--- a/extensions/capacities/src/create-weblink.tsx
+++ b/extensions/capacities/src/create-weblink.tsx
@@ -2,6 +2,7 @@ import { ActionPanel, Action, Form, Icon, closeMainWindow, Clipboard, showToast,
 import { FormValidation, useForm } from "@raycast/utils";
 import { useEffect, useRef } from "react";
 import { useActiveTab } from "./helpers/useActiveTab";
+import { getInitialSpaceId, setStoredSpaceId } from "./helpers/spaces";
 import { API_HEADERS, API_URL, handleAPIError, handleUnexpectedError, useCapacitiesStore } from "./helpers/storage";
 
 interface SaveWeblinkBody {
@@ -10,6 +11,8 @@ interface SaveWeblinkBody {
   mdText?: string;
   tags?: string;
 }
+
+const SPACE_STORAGE_KEY = "create-weblink-space-id";
 
 function isValidURL(url: string) {
   try {
@@ -86,6 +89,25 @@ export default function Command() {
   });
 
   const activeTab = useActiveTab();
+  const spaces = store?.spaces ?? [];
+  const spaceIds = spaces.map((space) => space.id).join(",");
+
+  useEffect(() => {
+    if (!spaces.length || itemProps.spaceId.value) {
+      return;
+    }
+    let cancelled = false;
+
+    getInitialSpaceId(SPACE_STORAGE_KEY, spaces).then((spaceId) => {
+      if (!cancelled && spaceId) {
+        setValue("spaceId", spaceId);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [spaceIds, itemProps.spaceId.value, setValue]);
 
   useEffect(() => {
     async function checkClipboard() {
@@ -121,8 +143,10 @@ export default function Command() {
           <Form.Dropdown
             title="Space"
             {...itemProps.spaceId}
-            storeValue
-            onChange={(value) => setValue("spaceId", value)}
+            onChange={(value) => {
+              setValue("spaceId", value);
+              setStoredSpaceId(SPACE_STORAGE_KEY, value);
+            }}
             ref={spacesDropdown}
           >
             {store.spaces &&

--- a/extensions/capacities/src/helpers/spaces.ts
+++ b/extensions/capacities/src/helpers/spaces.ts
@@ -1,0 +1,14 @@
+import { LocalStorage } from "@raycast/api";
+
+type Space = {
+  id: string;
+};
+
+export async function getInitialSpaceId(key: string, spaces: Space[]) {
+  const storedSpaceId = await LocalStorage.getItem<string>(key);
+  return spaces.find((space) => space.id === storedSpaceId)?.id ?? spaces[0]?.id;
+}
+
+export function setStoredSpaceId(key: string, spaceId: string) {
+  return LocalStorage.setItem(key, spaceId);
+}

--- a/extensions/capacities/src/save-to-daily-note.tsx
+++ b/extensions/capacities/src/save-to-daily-note.tsx
@@ -1,12 +1,15 @@
 import { ActionPanel, Action, Form, Icon, showToast, Toast, closeMainWindow, showHUD } from "@raycast/api";
 import { FormValidation, useForm } from "@raycast/utils";
 import { useEffect, useRef } from "react";
+import { getInitialSpaceId, setStoredSpaceId } from "./helpers/spaces";
 import { API_HEADERS, API_URL, handleAPIError, handleUnexpectedError, useCapacitiesStore } from "./helpers/storage";
 
 interface SaveToDailyNoteBody {
   spaceId: string;
   mdText: string;
 }
+
+const SPACE_STORAGE_KEY = "save-to-daily-note-space-id";
 
 export default function Command() {
   const { store, triggerLoading, isLoading: storeIsLoading } = useCapacitiesStore();
@@ -60,6 +63,26 @@ export default function Command() {
     },
   });
 
+  const spaces = store?.spaces ?? [];
+  const spaceIds = spaces.map((space) => space.id).join(",");
+
+  useEffect(() => {
+    if (!spaces.length || itemProps.spaceId.value) {
+      return;
+    }
+    let cancelled = false;
+
+    getInitialSpaceId(SPACE_STORAGE_KEY, spaces).then((spaceId) => {
+      if (!cancelled && spaceId) {
+        setValue("spaceId", spaceId);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [spaceIds, itemProps.spaceId.value, setValue]);
+
   return (
     <Form
       isLoading={storeIsLoading}
@@ -74,8 +97,10 @@ export default function Command() {
           <Form.Dropdown
             title="Space"
             {...itemProps.spaceId}
-            storeValue
-            onChange={(value) => setValue("spaceId", value)}
+            onChange={(value) => {
+              setValue("spaceId", value);
+              setStoredSpaceId(SPACE_STORAGE_KEY, value);
+            }}
             ref={spacesDropdown}
           >
             {store.spaces &&


### PR DESCRIPTION
## Description
- Fixes the Capacities space dropdowns by letting the form state own selection changes.
- Sets the first loaded space as the initial value so submissions still have a space before the user changes it.
- Closes #23328.

## Screencast
N/A

## Checklist
- [x] I ran `npm run lint` and `npm run build`
