### PR TITLE
Fix iMessage Time Sensitive code detection

### DIFF
--- a/extensions/imessage-2fa/CHANGELOG.md
+++ b/extensions/imessage-2fa/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Messages 2FA Changelog
 
-## [Fix Time Sensitive iMessage codes] - {PR_MERGE_DATE}
+## [Fix Time Sensitive iMessage codes] - 2026-05-27
 
 - Fixed iMessage code detection when macOS stores notification labels separately from the message body.
 

--- a/extensions/imessage-2fa/CHANGELOG.md
+++ b/extensions/imessage-2fa/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Messages 2FA Changelog
 
+## [Fix Time Sensitive iMessage codes] - {PR_MERGE_DATE}
+
+- Fixed iMessage code detection when macOS stores notification labels separately from the message body.
+
 ## [Update] - 2025-12-17
 
 - Add support for extracting text from binary data in iMessage messages

--- a/extensions/imessage-2fa/src/index.tsx
+++ b/extensions/imessage-2fa/src/index.tsx
@@ -96,7 +96,8 @@ export default function Command() {
       const links: VerificationLink[] = [];
 
       data.forEach((message) => {
-        const linkInfo = extractVerificationLink(message.text);
+        const linkSource = message.source === "imessage" ? message.displayText : message.text;
+        const linkInfo = extractVerificationLink(linkSource);
         if (linkInfo) {
           links.push({
             ...linkInfo,

--- a/extensions/imessage-2fa/src/messages.ts
+++ b/extensions/imessage-2fa/src/messages.ts
@@ -12,6 +12,8 @@ import { calculateLookBackMinutes, escapeSqlLikePattern } from "./utils";
 
 // Path to the iMessage database
 const DB_PATH = resolve(homedir(), "Library/Messages/chat.db");
+const MESSAGE_TEXT_EXPRESSION =
+  "trim(coalesce(message.text, '') || ' ' || coalesce(cast(message.attributedBody as text), ''))";
 
 /**
  * Options for message hook configuration
@@ -39,7 +41,7 @@ function getBaseQuery() {
       ifnull(handle.uncanonicalized_id, chat.chat_identifier) AS sender,
       message.service,
       datetime(message.date / 1000000000 + 978307200, 'unixepoch', 'localtime') AS message_date,
-      coalesce(message.text, message.attributedBody) AS text,
+      ${MESSAGE_TEXT_EXPRESSION} AS text,
       message.is_read
     from message
       left join chat_message_join on chat_message_join.message_id = message.ROWID
@@ -47,7 +49,7 @@ function getBaseQuery() {
       left join handle on message.handle_id = handle.ROWID
     where message.is_from_me = 0
       and (message.text is not null or message.attributedBody is not null)
-      and length(coalesce(message.text, message.attributedBody)) > 0
+      and length(${MESSAGE_TEXT_EXPRESSION}) > 0
       and datetime(message.date / 1000000000 + strftime('%s', '2001-01-01'), 'unixepoch', 'localtime') >= datetime('now', '-${lookBackMinutes} minutes', 'localtime')
 	`;
   if (preferences.ignoreRead) baseQuery += " and message.is_read = 0";
@@ -65,25 +67,25 @@ function getQuery(options: { searchText?: string; searchType: SearchType }) {
   if (options.searchType === "code") {
     baseQuery = `${baseQuery} \nand (
       -- Matches 3 alphanumeric (e.g., 'ABC')
-      coalesce(message.text, message.attributedBody) glob '*[0-9A-Z][0-9A-Z][0-9A-Z]*'
+      ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9A-Z][0-9A-Z][0-9A-Z]*'
       -- Matches 4 alphanumeric (e.g., 'ABCD')
-      or coalesce(message.text, message.attributedBody) glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
+      or ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
       -- Matches 5 alphanumeric (e.g., 'ABCDE')
-      or coalesce(message.text, message.attributedBody) glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
+      or ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
       -- Matches 6 alphanumeric (e.g., 'ABCDEF')
-      or coalesce(message.text, message.attributedBody) glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
+      or ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
       -- Matches format '123-456'
-      or coalesce(message.text, message.attributedBody) glob '*[0-9][0-9][0-9]-[0-9][0-9][0-9]*'
+      or ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9][0-9][0-9]-[0-9][0-9][0-9]*'
       -- Matches 7 alphanumeric (e.g., 'ABCDEFG')
-      or coalesce(message.text, message.attributedBody) glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
+      or ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
       -- Matches 8 alphanumeric (e.g., 'ABCDEFGH')
-      or coalesce(message.text, message.attributedBody) glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
+      or ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
     )`;
   }
 
   if (options.searchText && options.searchText !== "") {
     const escapedSearchText = escapeSqlLikePattern(options.searchText);
-    baseQuery = `${baseQuery} \nand coalesce(message.text, message.attributedBody) like '%${escapedSearchText}%'`;
+    baseQuery = `${baseQuery} \nand ${MESSAGE_TEXT_EXPRESSION} like '%${escapedSearchText}%'`;
   }
 
   return `${baseQuery} \norder by message.date desc limit 100`.trim();

--- a/extensions/imessage-2fa/src/messages.ts
+++ b/extensions/imessage-2fa/src/messages.ts
@@ -35,24 +35,36 @@ function getBaseQuery() {
   const lookBackMinutes = calculateLookBackMinutes(lookBackUnit, lookBackAmount);
 
   let baseQuery = `
+    with message_payload as (
+      select
+        message.guid,
+        message.rowid,
+        ifnull(handle.uncanonicalized_id, chat.chat_identifier) AS sender,
+        message.service,
+        datetime(message.date / 1000000000 + 978307200, 'unixepoch', 'localtime') AS message_date,
+        ${MESSAGE_TEXT_EXPRESSION} AS text,
+        message.is_read,
+        message.date
+      from message
+        left join chat_message_join on chat_message_join.message_id = message.ROWID
+        left join chat on chat.ROWID = chat_message_join.chat_id
+        left join handle on message.handle_id = handle.ROWID
+      where message.is_from_me = 0
+        and (message.text is not null or message.attributedBody is not null)
+    )
     select
-      message.guid,
-      message.rowid,
-      ifnull(handle.uncanonicalized_id, chat.chat_identifier) AS sender,
-      message.service,
-      datetime(message.date / 1000000000 + 978307200, 'unixepoch', 'localtime') AS message_date,
-      ${MESSAGE_TEXT_EXPRESSION} AS text,
-      message.is_read
-    from message
-      left join chat_message_join on chat_message_join.message_id = message.ROWID
-      left join chat on chat.ROWID = chat_message_join.chat_id
-      left join handle on message.handle_id = handle.ROWID
-    where message.is_from_me = 0
-      and (message.text is not null or message.attributedBody is not null)
-      and length(${MESSAGE_TEXT_EXPRESSION}) > 0
-      and datetime(message.date / 1000000000 + strftime('%s', '2001-01-01'), 'unixepoch', 'localtime') >= datetime('now', '-${lookBackMinutes} minutes', 'localtime')
+      guid,
+      rowid,
+      sender,
+      service,
+      message_date,
+      text,
+      is_read
+    from message_payload
+    where length(text) > 0
+      and datetime(date / 1000000000 + strftime('%s', '2001-01-01'), 'unixepoch', 'localtime') >= datetime('now', '-${lookBackMinutes} minutes', 'localtime')
 	`;
-  if (preferences.ignoreRead) baseQuery += " and message.is_read = 0";
+  if (preferences.ignoreRead) baseQuery += " and is_read = 0";
 
   return baseQuery;
 }
@@ -67,28 +79,28 @@ function getQuery(options: { searchText?: string; searchType: SearchType }) {
   if (options.searchType === "code") {
     baseQuery = `${baseQuery} \nand (
       -- Matches 3 alphanumeric (e.g., 'ABC')
-      ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9A-Z][0-9A-Z][0-9A-Z]*'
+      text glob '*[0-9A-Z][0-9A-Z][0-9A-Z]*'
       -- Matches 4 alphanumeric (e.g., 'ABCD')
-      or ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
+      or text glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
       -- Matches 5 alphanumeric (e.g., 'ABCDE')
-      or ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
+      or text glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
       -- Matches 6 alphanumeric (e.g., 'ABCDEF')
-      or ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
+      or text glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
       -- Matches format '123-456'
-      or ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9][0-9][0-9]-[0-9][0-9][0-9]*'
+      or text glob '*[0-9][0-9][0-9]-[0-9][0-9][0-9]*'
       -- Matches 7 alphanumeric (e.g., 'ABCDEFG')
-      or ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
+      or text glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
       -- Matches 8 alphanumeric (e.g., 'ABCDEFGH')
-      or ${MESSAGE_TEXT_EXPRESSION} glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
+      or text glob '*[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]*'
     )`;
   }
 
   if (options.searchText && options.searchText !== "") {
     const escapedSearchText = escapeSqlLikePattern(options.searchText);
-    baseQuery = `${baseQuery} \nand ${MESSAGE_TEXT_EXPRESSION} like '%${escapedSearchText}%'`;
+    baseQuery = `${baseQuery} \nand text like '%${escapedSearchText}%'`;
   }
 
-  return `${baseQuery} \norder by message.date desc limit 100`.trim();
+  return `${baseQuery} \norder by date desc limit 100`.trim();
 }
 
 /**

--- a/extensions/imessage-2fa/src/utils.test.ts
+++ b/extensions/imessage-2fa/src/utils.test.ts
@@ -318,6 +318,15 @@ describe("Testing binary data extraction from iMessage", () => {
     // Should extract codes that contain digits (even without spaces)
     expect(result).toMatch(/ABC123|DEF456|CodeABC123/);
   });
+
+  test("Extract rich text payload when notification label is prepended", () => {
+    const binaryData =
+      "Time Sensitive \x04\x0Bstreamtyped\x81NSMutableAttributedString\x00Your Example verification code is: 246810\x86NSDictionary";
+    const result = extractTextFromBinaryData(binaryData);
+
+    expect(result).toContain("246810");
+    expect(result).not.toContain("NSMutableAttributedString");
+  });
 });
 
 describe("Testing SQL LIKE pattern escaping", () => {


### PR DESCRIPTION
## Description
- Fixes iMessage code detection when macOS stores a notification label in `message.text` and the actual message body in `attributedBody`.
- Searches and displays a combined text payload instead of stopping at the first non-null field.
- Adds a regression test for a Time Sensitive-style rich text payload.
- Closes #23342.

## Screencast
N/A

## Checklist
- [x] I ran `npm test -- --runInBand`
- [x] I ran `npm run lint` and `npm run build`
