### PR TITLE
Handle Forked Extensions git index locks

### DIFF
--- a/extensions/forked-extensions/CHANGELOG.md
+++ b/extensions/forked-extensions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Raycast Fork Extensions Changelog
 
-## [Fix Concurrent Git Operations] - {PR_MERGE_DATE}
+## [Fix Concurrent Git Operations] - 2026-06-02
 
 - Wait for transient Git index locks before running repository commands and show a clear message when another operation is already running.
 

--- a/extensions/forked-extensions/CHANGELOG.md
+++ b/extensions/forked-extensions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Raycast Fork Extensions Changelog
 
+## [Fix Concurrent Git Operations] - {PR_MERGE_DATE}
+
+- Wait for transient Git index locks before running repository commands and show a clear message when another operation is already running.
+
 ## [Improvements] - 2026-04-11
 
 - Optimize clone and fetch behavior with the "tree:0" partial clone filter, "--no-tags", and "upstream/main"-only tracking

--- a/extensions/forked-extensions/src/git.ts
+++ b/extensions/forked-extensions/src/git.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { confirmAlert } from "@raycast/api";
 import spawn from "nano-spawn";
 import * as api from "./api.js";
@@ -63,12 +64,51 @@ const partialCloneFilter = "tree:0";
 const mainBranch = "main";
 
 /**
+ * Maximum time to wait for another Git process to release the repository index lock.
+ */
+const gitIndexLockTimeoutMs = 30_000;
+
+/**
+ * How often to check whether the repository index lock has been released.
+ */
+const gitIndexLockPollMs = 500;
+
+/**
+ * Waits for a transient Git index lock to clear before starting another Git command.
+ * @param cwd The repository directory where the Git command should run.
+ */
+const waitForGitIndexLock = async (cwd: string) => {
+  const lockPath = path.join(cwd, ".git", "index.lock");
+  const startedAt = Date.now();
+  const lockFileExists = async () =>
+    fs
+      .access(lockPath)
+      .then(() => true)
+      .catch(() => false);
+
+  while (true) {
+    if (!(await lockFileExists())) break;
+
+    if (Date.now() - startedAt >= gitIndexLockTimeoutMs) {
+      throw new Error(
+        "Another Git operation is still running in the forked extensions repository. Please wait a moment and try again. If the problem persists, close other Git tools and remove the stale .git/index.lock file.",
+      );
+    }
+
+    await delay(gitIndexLockPollMs);
+  }
+};
+
+/**
  * Executes a git command in a specific repository directory.
  * @param args The arguments to pass to the git command.
  * @param cwd The working directory where the git command should run.
  * @returns The subprocess result of the git command execution.
  */
-const gitAtPath = async (args: string[], cwd: string) => spawn(gitFilePath, args, { cwd, shell: true });
+const gitAtPath = async (args: string[], cwd: string) => {
+  await waitForGitIndexLock(cwd);
+  return spawn(gitFilePath, args, { cwd, shell: true });
+};
 
 /**
  * Normalizes a GitHub remote URL into a `owner/repository` string.

--- a/extensions/forked-extensions/src/operation.ts
+++ b/extensions/forked-extensions/src/operation.ts
@@ -33,7 +33,10 @@ class Operation {
    * Initializes the repository by cloning it if it doesn't exist.
    */
   init = async () => {
-    if (this.isOperating) return;
+    if (this.isOperating) {
+      await this.showOperationBusyToast();
+      return;
+    }
     try {
       this.isOperating = true;
       const gitInstalled = await git.checkIfGitIsValid();
@@ -267,7 +270,10 @@ class Operation {
     loadingMessage: string,
     completedMessage?: string | Toast.Options,
   ) => {
-    if (this.isOperating) return;
+    if (this.isOperating) {
+      await this.showOperationBusyToast();
+      return;
+    }
     try {
       this.isOperating = true;
       await git.checkIfStatusClean();
@@ -318,6 +324,18 @@ class Operation {
    */
   private hideToast = async () => {
     if (this.toast.style === Toast.Style.Animated) this.toast.hide();
+  };
+
+  /**
+   * Shows a failure toast when an operation is already running.
+   */
+  private showOperationBusyToast = async () => {
+    const busyToast = new Toast({
+      title: "Operation Already Running",
+      message: "Please wait for the current Git operation to finish, then try again.",
+      style: Toast.Style.Failure,
+    });
+    await busyToast.show();
   };
 }
 


### PR DESCRIPTION
## Description

Prevents Forked Extensions from failing silently when a Git operation is already running or when a previous sparse-checkout command still holds `.git/index.lock`.

The extension now:
- shows a clear busy toast instead of silently returning when another operation is in progress
- waits briefly for transient Git index locks before starting the next repository command
- reports a clear recovery message if the lock remains stale

Closes #26342

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint` and `npm run build`