### PR TITLE
Preserve Brew search cache during rebuilds

### DIFF
--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Brew Changelog
 
+## [Fix Search Cache Recovery] - {PR_MERGE_DATE}
+
+- Preserve the last working search cache while rebuilding package indexes.
+
 ## [Add Keyboard Shortcuts] - 2026-05-12
 
 - Added keyboard shortcuts to common Brew actions, including opening package pages, opening homepages, copying URLs, and running terminal commands.

--- a/extensions/brew/src/utils/brew/fetch.ts
+++ b/extensions/brew/src/utils/brew/fetch.ts
@@ -450,6 +450,19 @@ async function ensureChunkedCache<T>(
     // No stale cache available
   }
 
+  const cacheBuildId = `${process.pid}-${Date.now()}`;
+  const nextBaseDir = `${remote.chunkedConfig.baseDir}.next-${cacheBuildId}`;
+  const previousBaseDir = `${remote.chunkedConfig.baseDir}.previous-${cacheBuildId}`;
+  const buildConfig = hasStaleCacheIndex
+    ? {
+        ...remote.chunkedConfig,
+        baseDir: nextBaseDir,
+        indexPath: `${nextBaseDir}/index.json`,
+        metaPath: `${nextBaseDir}/meta.json`,
+      }
+    : remote.chunkedConfig;
+  let previousCacheMoved = false;
+
   try {
     // Need to rebuild - download source JSON to disk WITHOUT parsing into memory
     // This is critical to avoid heap exhaustion on initial load
@@ -460,8 +473,39 @@ async function ensureChunkedCache<T>(
 
     // Now build the chunked cache from the downloaded file
     // This streams through the file and writes chunks incrementally
-    await buildChunkedCache(remote.cachePath, remote.url, remote.chunkedConfig, extractIndex, onProgress, signal);
+    await buildChunkedCache(remote.cachePath, remote.url, buildConfig, extractIndex, onProgress, signal);
+
+    if (buildConfig !== remote.chunkedConfig) {
+      await fs.rm(previousBaseDir, { recursive: true, force: true });
+      await fs.rename(remote.chunkedConfig.baseDir, previousBaseDir);
+      previousCacheMoved = true;
+      try {
+        await fs.rename(buildConfig.baseDir, remote.chunkedConfig.baseDir);
+        await fs.rm(previousBaseDir, { recursive: true, force: true }).catch(() => {});
+        previousCacheMoved = false;
+      } catch (err) {
+        await fs.rename(previousBaseDir, remote.chunkedConfig.baseDir);
+        previousCacheMoved = false;
+        throw err;
+      }
+    }
   } catch (err) {
+    if (buildConfig !== remote.chunkedConfig) {
+      await fs.rm(buildConfig.baseDir, { recursive: true, force: true }).catch(() => {});
+      if (previousCacheMoved) {
+        try {
+          await fs.rename(previousBaseDir, remote.chunkedConfig.baseDir);
+          previousCacheMoved = false;
+        } catch (restoreErr) {
+          brewLogger.warn("Chunked cache rebuild failed and stale cache could not be restored", {
+            type: remote.chunkedConfig.type,
+            error: restoreErr instanceof Error ? restoreErr.message : String(restoreErr),
+          });
+          throw restoreErr;
+        }
+      }
+    }
+
     // Always re-throw abort errors - the caller handles these
     if (err instanceof Error && err.name === "AbortError") throw err;
 

--- a/extensions/brew/src/utils/brew/fetch.ts
+++ b/extensions/brew/src/utils/brew/fetch.ts
@@ -499,7 +499,8 @@ async function ensureChunkedCache<T>(
         } catch (restoreErr) {
           brewLogger.warn("Chunked cache rebuild failed and stale cache could not be restored", {
             type: remote.chunkedConfig.type,
-            error: restoreErr instanceof Error ? restoreErr.message : String(restoreErr),
+            buildError: err instanceof Error ? err.message : String(err),
+            restoreError: restoreErr instanceof Error ? restoreErr.message : String(restoreErr),
           });
           throw restoreErr;
         }


### PR DESCRIPTION
## Description

Fixes Brew search cache rebuilds so the previous working chunked index stays available until the replacement index has been built successfully. If rebuilding fails, the extension can keep using the stale cache instead of leaving search with no usable chunked cache.

Closes #26023

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint`
- [x] I ran `npm run build`