### PR TITLE
Add Edge support to Linkding browser tab capture

### DIFF
--- a/extensions/linkding/CHANGELOG.md
+++ b/extensions/linkding/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Linkding Changelog
 
-## [Fix Save Browser Tab] - {PR_MERGE_DATE}
+## [Fix Save Browser Tab] - 2026-05-20
 
 - Add Microsoft Edge support to Save Browser Tab.
 

--- a/extensions/linkding/CHANGELOG.md
+++ b/extensions/linkding/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Linkding Changelog
 
+## [Fix Save Browser Tab] - {PR_MERGE_DATE}
+
+- Add Microsoft Edge support to Save Browser Tab.
+
 ## [Frecency + Refactor] - 2026-01-26
 
 - chore: npm audit fix

--- a/extensions/linkding/src/hooks/use-browser-link.tsx
+++ b/extensions/linkding/src/hooks/use-browser-link.tsx
@@ -21,6 +21,8 @@ export const useBrowserLink = ({ ignoreErrors }: Props = {}) => {
           return runAppleScript(`tell application "Google Chrome" to return URL of active tab of front window`);
         case "com.brave.Browser":
           return runAppleScript(`tell application "Brave Browser" to return URL of active tab of front window`);
+        case "com.microsoft.edgemac":
+          return runAppleScript(`tell application "Microsoft Edge" to return URL of active tab of front window`);
         case "com.apple.Safari":
           return runAppleScript(`tell application "Safari" to return URL of front document`);
         case "com.kagi.kagimacOS":


### PR DESCRIPTION
## Description

Adds Microsoft Edge to Linkding's Save Browser Tab browser detection so it can read the active tab URL through the same Chromium AppleScript path used by Chrome and Brave.

Closes #27028

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint`
- [x] I ran `npm run build`