### PR TITLE
klack: fix broken GitHub link in README

### DIFF
--- a/extensions/klack/CHANGELOG.md
+++ b/extensions/klack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Klack Changelog
 
+## [Fix README Link] - {PR_MERGE_DATE}
+
+- Fixed broken contributor GitHub link in the README
+
 ## [Stats and Standalone Support] - 2026-05-20
 
 - Added Klack Stats view with live updates, Markdown export, and tracking-since timestamp

--- a/extensions/klack/CHANGELOG.md
+++ b/extensions/klack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Klack Changelog
 
-## [Fix README Link] - {PR_MERGE_DATE}
+## [Fix README Link] - 2026-05-20
 
 - Fixed broken contributor GitHub link in the README
 

--- a/extensions/klack/README.md
+++ b/extensions/klack/README.md
@@ -46,4 +46,4 @@ npm run dev
 ## Credits
 
 - [Henrik Ruscon](https://github.com/henrikruscon) — Klack.app and original extension
-- [Jace](https://github.com/jacepl) — rebuild
+- [Jace](https://github.com/JaceThings) — rebuild


### PR DESCRIPTION
Tiny docs-only fix. The contributor GitHub link in the Klack README pointed to `github.com/jacepl` (404). The correct handle is `github.com/JaceThings`. One-line change.

## Test plan

- [x] `npx ray lint` — passes