### PR TITLE
Fix Windows Terminal SSH profile launch

### DIFF
--- a/extensions/windows-terminal/CHANGELOG.md
+++ b/extensions/windows-terminal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Windows Terminal Changelog
 
+## [Fix SSH Profiles] - {PR_MERGE_DATE}
+
+- Fixed SSH profiles by preserving the Windows OpenSSH path when launching Windows Terminal
+
 ## [Quake Window Preference] - 2026-05-22
 
 - Added the `Open profiles in quake window` preference. When enabled, the primary "Open Profile" action and the "Open as Administrator" action both route into Windows Terminal's quake (drop-down) window via `wt.exe -w _quake`.

--- a/extensions/windows-terminal/CHANGELOG.md
+++ b/extensions/windows-terminal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Windows Terminal Changelog
 
-## [Fix SSH Profiles] - {PR_MERGE_DATE}
+## [Fix SSH Profiles] - 2026-06-15
 
 - Fixed SSH profiles by preserving the Windows OpenSSH path when launching Windows Terminal
 

--- a/extensions/windows-terminal/src/open-profile.tsx
+++ b/extensions/windows-terminal/src/open-profile.tsx
@@ -23,6 +23,25 @@ const PROFILES = JSON.parse(
   ),
 ) as WindowsTerminalSettings;
 
+function getWindowsTerminalEnv() {
+  const env = { ...process.env };
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "Path";
+  const systemRoot = env.SystemRoot ?? "C:\\Windows";
+  const pathParts = (env[pathKey] ?? "").split(";").filter(Boolean);
+  const requiredPathParts = [`${systemRoot}\\System32\\OpenSSH`, `${systemRoot}\\System32`, systemRoot];
+  const normalizePathPart = (pathPart: string) => pathPart.toLowerCase().replace(/\\+$/, "");
+
+  env[pathKey] = [
+    ...pathParts,
+    ...requiredPathParts.filter(
+      (requiredPathPart) =>
+        !pathParts.some((pathPart) => normalizePathPart(pathPart) === normalizePathPart(requiredPathPart)),
+    ),
+  ].join(";");
+
+  return env;
+}
+
 function Actions(props: { name: string; quake: boolean }) {
   return (
     <ActionPanel title={props.name}>
@@ -31,7 +50,7 @@ function Actions(props: { name: string; quake: boolean }) {
         title={props.quake ? "Open in Quake Window" : "Open in New Tab"}
         onAction={async () => {
           const args = props.quake ? ["-w", "_quake", "new-tab", "-p", props.name] : ["new-tab", "-p", props.name];
-          execFile("wt.exe", args);
+          execFile("wt.exe", args, { env: getWindowsTerminalEnv() });
           await closeMainWindow();
         }}
       />
@@ -39,7 +58,7 @@ function Actions(props: { name: string; quake: boolean }) {
         icon={Icon.PlusTopRightSquare}
         title="Open in New Window"
         onAction={async () => {
-          execFile("wt.exe", ["-p", props.name]);
+          execFile("wt.exe", ["-p", props.name], { env: getWindowsTerminalEnv() });
           await closeMainWindow();
         }}
       />


### PR DESCRIPTION
## Description

Preserves the Windows OpenSSH/system paths when launching Windows Terminal profiles from Raycast so SSH profiles can resolve `ssh.exe` without requiring elevated launch.

Closes #27321

## Screencast

N/A

## Checklist

- [x] I read the contribution guidelines
- [x] I ran `npm run build` and tested this distribution locally
- [x] I ran `npm run lint` and fixed lint errors
- [x] I have tested this on the latest Raycast version