### PR TITLE
Support Chrome account bookmark files

### DIFF
--- a/extensions/browser-bookmarks/CHANGELOG.md
+++ b/extensions/browser-bookmarks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Browser Bookmarks Changelog
 
+## [Chrome Account Bookmarks] - {PR_MERGE_DATE}
+
+- Added support for Chrome account-synced bookmarks stored in `AccountBookmarks`
+
 ## [Bug Fix] - 2026-05-19
 
 - Increased the Safari bookmark plist parser limit so large bookmark libraries no longer fail with `maxObjectCount exceeded`

--- a/extensions/browser-bookmarks/CHANGELOG.md
+++ b/extensions/browser-bookmarks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Browser Bookmarks Changelog
 
-## [Chrome Account Bookmarks] - {PR_MERGE_DATE}
+## [Chrome Account Bookmarks] - 2026-05-20
 
 - Added support for Chrome account-synced bookmarks stored in `AccountBookmarks`
 

--- a/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
@@ -25,7 +25,10 @@ type BookmarkFolder = {
 type BookmarkItem = BookmarkURL | BookmarkFolder;
 
 type BookmarksRoot = {
-  roots: Record<string, BookmarkFolder | undefined>;
+  roots: {
+    bookmark_bar: BookmarkFolder;
+    other: BookmarkFolder;
+  } & Record<string, BookmarkFolder | undefined>;
 };
 
 const CHROMIUM_BOOKMARK_FILE_NAMES = ["Bookmarks", "AccountBookmarks"] as const;

--- a/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
@@ -25,10 +25,7 @@ type BookmarkFolder = {
 type BookmarkItem = BookmarkURL | BookmarkFolder;
 
 type BookmarksRoot = {
-  roots: {
-    bookmark_bar: BookmarkFolder;
-    other: BookmarkFolder;
-  };
+  roots: Record<string, BookmarkFolder | undefined>;
 };
 
 const CHROMIUM_BOOKMARK_FILE_NAMES = ["Bookmarks", "AccountBookmarks"] as const;
@@ -55,7 +52,7 @@ function getBookmarks(bookmark: BookmarkFolder | BookmarkItem, hierarchy = "") {
 }
 
 function getBookmarkCount(bookmarksRoot: BookmarksRoot) {
-  return getBookmarks(bookmarksRoot.roots.bookmark_bar).length + getBookmarks(bookmarksRoot.roots.other).length;
+  return Object.values(bookmarksRoot.roots).reduce((count, root) => count + (root ? getBookmarks(root).length : 0), 0);
 }
 
 function hasChromiumBookmarksFile(path: string, profile: string) {

--- a/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
@@ -31,6 +31,8 @@ type BookmarksRoot = {
   };
 };
 
+const CHROMIUM_BOOKMARK_FILE_NAMES = ["Bookmarks", "AccountBookmarks"] as const;
+
 function getBookmarks(bookmark: BookmarkFolder | BookmarkItem, hierarchy = "") {
   const bookmarks = [];
 
@@ -50,6 +52,36 @@ function getBookmarks(bookmark: BookmarkFolder | BookmarkItem, hierarchy = "") {
   }
 
   return bookmarks;
+}
+
+function getBookmarkCount(bookmarksRoot: BookmarksRoot) {
+  return getBookmarks(bookmarksRoot.roots.bookmark_bar).length + getBookmarks(bookmarksRoot.roots.other).length;
+}
+
+function hasChromiumBookmarksFile(path: string, profile: string) {
+  return CHROMIUM_BOOKMARK_FILE_NAMES.some((fileName) => existsSync(join(path, profile, fileName)));
+}
+
+async function readChromiumBookmarks(path: string, profile: string) {
+  const accountBookmarksPath = join(path, profile, "AccountBookmarks");
+
+  if (existsSync(accountBookmarksPath)) {
+    try {
+      const accountBookmarks = JSON.parse((await read(accountBookmarksPath)).toString()) as BookmarksRoot;
+      if (getBookmarkCount(accountBookmarks) > 0) {
+        return accountBookmarks;
+      }
+    } catch {
+      // Fall back to the legacy Bookmarks file below.
+    }
+  }
+
+  const bookmarksPath = join(path, profile, "Bookmarks");
+  if (!existsSync(bookmarksPath)) {
+    return;
+  }
+
+  return JSON.parse((await read(bookmarksPath)).toString()) as BookmarksRoot;
 }
 
 type Folder = {
@@ -88,7 +120,7 @@ async function getChromiumProfilesFallback(path: string): Promise<ChromiumProfil
   let profiles;
   try {
     profiles = readdirSync(path, { withFileTypes: true })
-      .filter((d) => d.isDirectory() && existsSync(join(path, d.name, "Bookmarks")))
+      .filter((d) => d.isDirectory() && hasChromiumBookmarksFile(path, d.name))
       .map((d) => ({ path: d.name, name: d.name }));
   } catch {
     return { profiles: [], defaultProfile: "" };
@@ -126,8 +158,7 @@ async function getChromiumProfiles(path: string): Promise<ChromiumProfilesResult
   const profiles = Object.entries(profileInfoCache)
     .filter(([profilePath]) => {
       try {
-        const profileDirectory = readdirSync(`${path}/${profilePath}`);
-        return profileDirectory.includes("Bookmarks");
+        return hasChromiumBookmarksFile(path, profilePath);
       } catch {
         return false;
       }
@@ -160,6 +191,7 @@ async function getChromiumSourceSignature(path: string, profile: string) {
 
   if (profile) {
     signatures.push(await getFileSignature(join(path, profile, "Bookmarks")));
+    signatures.push(await getFileSignature(join(path, profile, "AccountBookmarks")));
   }
 
   return signatures.join("|");
@@ -216,12 +248,11 @@ export default function useChromiumBookmarks(
     mutate: mutateBookmarks,
   } = useCachedPromise(
     async (profile, isEnabled, currentPath) => {
-      if (!profile || !isEnabled || !existsSync(`${currentPath}/${profile}/Bookmarks`)) {
+      if (!profile || !isEnabled || !hasChromiumBookmarksFile(currentPath, profile)) {
         return;
       }
 
-      const file = await read(`${currentPath}/${profile}/Bookmarks`);
-      return JSON.parse(file.toString()) as BookmarksRoot;
+      return readChromiumBookmarks(currentPath, profile);
     },
     [currentProfile, enabled, path],
   );

--- a/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useChromiumBookmarks.ts
@@ -329,11 +329,14 @@ export default function useChromiumBookmarks(
     };
   }, [currentProfile, enabled, mutate, path]);
 
-  const toolbarBookmarks = data ? getBookmarks(data.roots.bookmark_bar) : [];
-  const toolbarFolders = data ? getFolders(data.roots.bookmark_bar) : [];
+  const toolbarRoot = data?.roots.bookmark_bar;
+  const otherRoot = data?.roots.other;
 
-  const otherBookmarks = data ? getBookmarks(data.roots.other) : [];
-  const otherFolders = data ? getFolders(data.roots.other) : [];
+  const toolbarBookmarks = toolbarRoot ? getBookmarks(toolbarRoot) : [];
+  const toolbarFolders = toolbarRoot ? getFolders(toolbarRoot) : [];
+
+  const otherBookmarks = otherRoot ? getBookmarks(otherRoot) : [];
+  const otherFolders = otherRoot ? getFolders(otherRoot) : [];
 
   const bookmarks = [...toolbarBookmarks, ...otherBookmarks].map((bookmark) => {
     return {

--- a/extensions/google-chrome/CHANGELOG.md
+++ b/extensions/google-chrome/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Chrome Changelog
 
+## [Chrome Account Bookmarks] - {PR_MERGE_DATE}
+
+- Added support for account-synced bookmarks stored in `AccountBookmarks`
+
 ## [Add History Open Action Shortcuts] - 2026-05-13
 
 - Add keyboard shortcuts for opening history items in the current or original profile.

--- a/extensions/google-chrome/CHANGELOG.md
+++ b/extensions/google-chrome/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Chrome Changelog
 
-## [Chrome Account Bookmarks] - {PR_MERGE_DATE}
+## [Chrome Account Bookmarks] - 2026-05-20
 
 - Added support for account-synced bookmarks stored in `AccountBookmarks`
 

--- a/extensions/google-chrome/src/util/index.ts
+++ b/extensions/google-chrome/src/util/index.ts
@@ -10,7 +10,7 @@ import { getPreferenceValues } from "@raycast/api";
 import { Preferences } from "../interfaces";
 import { BookmarkDirectory, HistoryEntry, RawBookmarks } from "../interfaces";
 
-type ChromeFile = "History" | "Bookmarks";
+type ChromeFile = "History" | "Bookmarks" | "AccountBookmarks";
 const userLibraryDirectoryPath = () => {
   if (!process.env.HOME) {
     throw new Error("$HOME environment variable is not set.");
@@ -40,6 +40,7 @@ export const getHistoryDbPath = (profile?: string) => getChromeFilePath("History
 export const getLocalStatePath = () => path.join(userLibraryDirectoryPath(), ...defaultChromeStatePath);
 
 const getBookmarksFilePath = (profile?: string) => getChromeFilePath("Bookmarks", profile);
+const getAccountBookmarksFilePath = (profile?: string) => getChromeFilePath("AccountBookmarks", profile);
 
 function extractBookmarkFromBookmarkDirectory(bookmarkDirectory: BookmarkDirectory): HistoryEntry[] {
   const bookmarks: HistoryEntry[] = [];
@@ -70,6 +71,19 @@ const extractBookmarks = (rawBookmarks: RawBookmarks): HistoryEntry[] => {
 };
 
 export const getBookmarks = async (profile?: string): Promise<HistoryEntry[]> => {
+  const accountBookmarksFilePath = getAccountBookmarksFilePath(profile);
+  if (fs.existsSync(accountBookmarksFilePath)) {
+    try {
+      const fileBuffer = await fs.promises.readFile(accountBookmarksFilePath, { encoding: "utf-8" });
+      const bookmarks = extractBookmarks(JSON.parse(fileBuffer));
+      if (bookmarks.length > 0) {
+        return bookmarks;
+      }
+    } catch {
+      // Fall back to the legacy Bookmarks file below.
+    }
+  }
+
   const bookmarksFilePath = getBookmarksFilePath(profile);
   if (!fs.existsSync(bookmarksFilePath)) {
     throw new Error(NO_BOOKMARKS_MESSAGE);


### PR DESCRIPTION
## Description

Adds support for Chrome account-synced bookmarks stored in `AccountBookmarks`. Browser Bookmarks now discovers profiles with either bookmark file, watches both files for changes, and prefers `AccountBookmarks` only when it contains entries. The Google Chrome extension uses the same fallback behavior for bookmark search.

Closes #26989

## Screencast

N/A

## Checklist

- [x] I read the contribution guidelines
- [x] I ran `npm run build` and tested this distribution locally
- [x] I ran `npm run lint` and fixed lint errors
- [x] I have tested this on the latest Raycast version