### PR TITLE
[Dia] Fix bookmark opening

### DIFF
--- a/extensions/dia/CHANGELOG.md
+++ b/extensions/dia/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dia Changelog
 
-## [Fix bookmark opening] - {PR_MERGE_DATE}
+## [Fix bookmark opening] - 2026-05-21
 
 - Fixed bookmark results failing to open in Dia on newer Dia versions.
 

--- a/extensions/dia/CHANGELOG.md
+++ b/extensions/dia/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Dia Changelog
 
+## [Fix bookmark opening] - {PR_MERGE_DATE}
+
+- Fixed bookmark results failing to open in Dia on newer Dia versions.
+
 ## [Fixed SQL query escaping] - 2026-03-27
 
 - Fixed single quote escaping in SQL queries to use proper SQL string literals instead of double quotes

--- a/extensions/dia/src/components/BookmarkListItem.tsx
+++ b/extensions/dia/src/components/BookmarkListItem.tsx
@@ -6,6 +6,11 @@ import { BookmarkItem } from "../bookmarks/types";
 
 const DIA_BUNDLE_ID = "company.thebrowser.dia";
 
+async function openInDia(url: string) {
+  await open(url, DIA_BUNDLE_ID);
+  await closeMainWindow();
+}
+
 export function BookmarkListItem({
   item,
   onNavigate,
@@ -54,6 +59,7 @@ export function BookmarkListItem({
 
   // URL bookmark
   if (item.url) {
+    const url = item.url;
     const pathText = item.path.length > 1 ? item.path.slice(0, -1).join(" › ") : undefined;
 
     return (
@@ -64,9 +70,9 @@ export function BookmarkListItem({
         icon={getSafeFavicon(item.url)}
         actions={
           <ActionPanel title={item.name}>
-            <Action.Open icon={Icon.Globe} title="Open Tab" target={item.url} application="company.thebrowser.dia" />
-            <Action.OpenInBrowser url={item.url} shortcut={{ modifiers: ["cmd"], key: "o" }} />
-            <Action.CopyToClipboard title="Copy URL" content={item.url} shortcut={{ modifiers: ["cmd"], key: "c" }} />
+            <Action title="Open in Dia" icon={Icon.Globe} onAction={() => openInDia(url)} />
+            <Action.OpenInBrowser url={url} shortcut={{ modifiers: ["cmd"], key: "o" }} />
+            <Action.CopyToClipboard title="Copy URL" content={url} shortcut={{ modifiers: ["cmd"], key: "c" }} />
             <Action.CopyToClipboard
               title="Copy Title"
               content={item.name}


### PR DESCRIPTION
## Description

Fixes #23340.

The Search Bookmarks command now opens bookmark URLs with Raycast's `open(url, bundleId)` helper instead of `Action.Open`'s application path. This matches the extension's existing folder/open-url behavior and avoids Dia's AppleScript tab-class error on newer Dia versions.

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`

## Screencast

N/A - small command action fix.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build with the local build command
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with the metadata tool