### PR TITLE
[Installed Extensions] Scan beta extension folder on macOS

### DIFF
--- a/extensions/installed-extensions/CHANGELOG.md
+++ b/extensions/installed-extensions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Installed Extensions Changelog
 
+## [Fix Beta Extension Folder] - {PR_MERGE_DATE}
+
+- Include the Raycast beta extension folder on macOS when scanning installed extensions.
+
 ## [Fix Fresh Install Crash] - 2026-05-17
 
 - Treat a missing extensions directory (`~/.config/raycast/extensions` on macOS, `~/.config/raycast-x/extensions` on Windows) as an empty list instead of throwing `ENOENT` on fresh Raycast installs with no extensions yet

--- a/extensions/installed-extensions/CHANGELOG.md
+++ b/extensions/installed-extensions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Installed Extensions Changelog
 
-## [Fix Beta Extension Folder] - {PR_MERGE_DATE}
+## [Fix Beta Extension Folder] - 2026-05-21
 
 - Include the Raycast beta extension folder on macOS when scanning installed extensions.
 

--- a/extensions/installed-extensions/src/helpers/extension-scan.ts
+++ b/extensions/installed-extensions/src/helpers/extension-scan.ts
@@ -49,7 +49,13 @@ export async function parsePackageJson(packageJsonPath: string): Promise<Extensi
 }
 
 export async function getPackageJsonFiles(): Promise<string[]> {
-  const extensionsDir = path.join(os.homedir(), ".config", isWindows ? "raycast-x" : "raycast", "extensions");
+  const configDirs = isWindows ? ["raycast-x"] : ["raycast", "raycast-x"];
+  const extensionDirs = configDirs.map((dir) => path.join(os.homedir(), ".config", dir, "extensions"));
+  const packageJsonFiles = await Promise.all(extensionDirs.map(getPackageJsonFilesFromDirectory));
+  return packageJsonFiles.flat();
+}
+
+async function getPackageJsonFilesFromDirectory(extensionsDir: string): Promise<string[]> {
   try {
     const extensions = await fs.readdir(extensionsDir);
     const packageJsonFiles = await Promise.all(

--- a/extensions/installed-extensions/src/helpers/extension-scan.ts
+++ b/extensions/installed-extensions/src/helpers/extension-scan.ts
@@ -48,11 +48,33 @@ export async function parsePackageJson(packageJsonPath: string): Promise<Extensi
   }
 }
 
+function storeExtensionIdFromPath(packageJsonPath: string): string | null {
+  const folderName = path.basename(path.dirname(packageJsonPath));
+  const match = folderName.match(LOCAL_EXTENSION_UUID_PATTERN);
+  return match ? match[0].toLowerCase() : null;
+}
+
+function dedupePackageJsonPaths(paths: string[]): string[] {
+  const seenStoreIds = new Set<string>();
+  const deduped: string[] = [];
+
+  for (const packageJsonPath of paths) {
+    const storeId = storeExtensionIdFromPath(packageJsonPath);
+    if (storeId) {
+      if (seenStoreIds.has(storeId)) continue;
+      seenStoreIds.add(storeId);
+    }
+    deduped.push(packageJsonPath);
+  }
+
+  return deduped;
+}
+
 export async function getPackageJsonFiles(): Promise<string[]> {
   const configDirs = isWindows ? ["raycast-x"] : ["raycast", "raycast-x"];
   const extensionDirs = configDirs.map((dir) => path.join(os.homedir(), ".config", dir, "extensions"));
   const packageJsonFiles = await Promise.all(extensionDirs.map(getPackageJsonFilesFromDirectory));
-  return packageJsonFiles.flat();
+  return dedupePackageJsonPaths(packageJsonFiles.flat());
 }
 
 async function getPackageJsonFilesFromDirectory(extensionsDir: string): Promise<string[]> {


### PR DESCRIPTION
## Summary
- include the Raycast beta extension folder when scanning installed extensions on macOS
- keep missing extension folders treated as an empty list

## Validation
- npm run lint
- npm run build
- ./node_modules/.bin/tsc -p tsconfig.json --noEmit
- git diff --check

Fixes #28101