### PR TITLE
Update git extension

### DIFF
--- a/extensions/git/.cursor/rules/code-style.mdc
+++ b/extensions/git/.cursor/rules/code-style.mdc
@@ -26,7 +26,8 @@ alwaysApply: true
 ### State Management and Data Fetching
 - **Use `useCachedPromise` for Git Data**: All hooks that fetch data from Git (e.g., `useGitBranches`, `useGitStatus`) must use `useCachedPromise` from `@raycast/utils`. The repository path (`gitManager.repoPath`) must be part of the dependency array to ensure a separate cache for each repository.
 - **Revalidate Data After Mutations**: After any Git operation that changes repository state (e.g., checkout, commit, push), call the `.revalidate()` function on the relevant data hooks (`branches.revalidate()`, `status.revalidate()`) to refresh the UI.
-- **Use `useCachedState` for UI State**: For simple, persistent UI state (like filters or dropdown selections), use `useCachedState`.
+- **Use `useStorage` for Persistent User Data**: Repository lists, AI presets, issue tracker configs, and other user data that must survive across commands must use `useStorage` from `/src/hooks/useStorage.ts` (LocalStorage with Cache migration). Do not use `useCachedState` or `useLocalStorage` directly for this data.
+- **Use `useCachedState` for UI State**: For simple, persistent UI state (like filters, dropdown selections, or draft text), use `useCachedState`.
 
 ### Error Handling and Toast Notifications
 - **`GitManager` Handles Errors**: The `GitManager` class is responsible for catching errors from `simple-git` and displaying a failure toast.
@@ -67,6 +68,7 @@ alwaysApply: true
 - ❌ Do not create separate `toast-utils` or similar helpers.
 - ❌ Do not use emojis instead of built-in or custom SVG icons.
 - ❌ Do not create separate storage managers for frecency data; use `useCachedPromise` or `useCachedState`.
+- ❌ Do not use `useCachedState` or `useLocalStorage` directly for persistent user data; use `useStorage`.
 - ❌ Do not create config files for preferences (use the API).
 - ❌ Do not create `NavigationActions` (they are available in the Raycast API).
 - ❌ Do not use non-English localization in the code; use only English with commonly accepted Git GUI client terminology.

--- a/extensions/git/.gitignore
+++ b/extensions/git/.gitignore
@@ -11,4 +11,6 @@ compiled_raycast_swift
 
 # misc
 .DS_Store
+AGENTS.md
 .cursor/hooks/state/continual-learning.json
+.cursor/hooks/state/continual-learning-index.json

--- a/extensions/git/CHANGELOG.md
+++ b/extensions/git/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-05-25
 
 ### Added
 - **Manage Repositories**: Add "Clear Cache" action for clearing the extension cache

--- a/extensions/git/CHANGELOG.md
+++ b/extensions/git/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [Update] - 2026-05-20
+## [Update] - {PR_MERGE_DATE}
+
+### Added
+- **Manage Repositories**: Add "Clear Cache" action for clearing the extension cache
+
+### Changed
+- **Storage**: Move stable data from `Cache` to `LocalStorage`
 
 ### Fixed
 - **Diff**: Show raw Git diff output without stripping leading whitespace from added/removed lines, so indented code changes display correctly

--- a/extensions/git/CHANGELOG.md
+++ b/extensions/git/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Update] - 2026-05-20
+
+### Fixed
+- **Diff**: Show raw Git diff output without stripping leading whitespace from added/removed lines, so indented code changes display correctly
+- **Commit Details**: Load changed files with `--first-parent` when fetching a commit by hash, matching the commits history view for merge commits
+
+## [Update] - 2026-05-11
+
+### Added
+- **Remotes**: Add "Host Provider" dropdown to `RemoteEditorForm` for manually selecting the provider for unknown host URLs
+
+### Fixed
+- **Remote Host Parser**: Fix SSH URL parsing with port (e.g. `git@host:2224/org/repo.git`)
+- **Azure DevOps**: Fix logo icon path
+
 ## [Update] - 2026-04-13
 
 ### Added

--- a/extensions/git/package-lock.json
+++ b/extensions/git/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.102.7",
-        "@raycast/utils": "^2.2.1",
+        "@raycast/utils": "^2.2.5",
         "fast-fuzzy": "^1.12.0",
         "file-type": "^21.0.0",
         "nanoid": "^5.1.5",
@@ -1236,9 +1236,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.2.tgz",
-      "integrity": "sha512-tZcyWCHZvz4L/i1CGEnSZkBoK6wwX1pzlTKjcWWugbrQyG0QCMOxjKJfRC/iNkD+hHaqhMWUj4Y0LNo/NknvFw==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.5.tgz",
+      "integrity": "sha512-1o6zGRECh1KNe6CBx68iMPOrNYbV56opqs4zUtDr6Wmq4F7Ww3d8uLTXKVzXlGyJmpAys/Eliw6cKIP7dPdFfw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -93,12 +93,12 @@
   ],
   "preferences": [
     {
-    "name": "binaryPath",
-    "required": false,
-    "type": "textfield",
-    "title": "Binary Path",
-    "default": "git",
-    "description": "The path to the git binary to use for git commands"
+      "name": "binaryPath",
+      "required": false,
+      "type": "textfield",
+      "title": "Binary Path",
+      "default": "git",
+      "description": "The path to the git binary to use for git commands"
     },
     {
       "name": "defaultTerminal",
@@ -223,7 +223,7 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.102.7",
-    "@raycast/utils": "^2.2.1",
+    "@raycast/utils": "^2.2.5",
     "fast-fuzzy": "^1.12.0",
     "file-type": "^21.0.0",
     "nanoid": "^5.1.5",

--- a/extensions/git/src/components/actions/RemoteActions.tsx
+++ b/extensions/git/src/components/actions/RemoteActions.tsx
@@ -185,7 +185,7 @@ export function RemoteEditorForm(context: RemoteEditorFormProps) {
         await context.gitManager.addRemote(values.name.trim(), values.fetchUrl.trim(), values.pushUrl.trim());
       }
 
-      if (values.hostProvider !== undefined) {
+      if (values.hostProvider) {
         context.remotes.addProviderOverride(values.hostProvider, values.fetchUrl.trim());
       }
 

--- a/extensions/git/src/components/actions/RemoteActions.tsx
+++ b/extensions/git/src/components/actions/RemoteActions.tsx
@@ -155,12 +155,8 @@ export function RemoteEditorForm(context: RemoteEditorFormProps) {
 
   const { data: needsManualProvider } = usePromise(
     async (url: string) => {
-      if (!validateGitUrl(url)) return false;
+      if (validateGitUrl(url) !== undefined) return false;
       const parsed = remoteHostParser(url);
-
-      if (context.initialRemote?.provider !== undefined && !context.initialRemote?.isOverridedProvider) {
-        return parsed.provider === undefined;
-      }
 
       return parsed.provider === undefined;
     },

--- a/extensions/git/src/components/actions/RemoteActions.tsx
+++ b/extensions/git/src/components/actions/RemoteActions.tsx
@@ -155,7 +155,7 @@ export function RemoteEditorForm(context: RemoteEditorFormProps) {
 
   const { data: needsManualProvider } = usePromise(
     async (url: string) => {
-      if (context.initialRemote?.provider === undefined) {
+      if (context.initialRemote?.provider === undefined || context.initialRemote?.isOverridedProvider) {
         return true;
       }
 

--- a/extensions/git/src/components/actions/RemoteActions.tsx
+++ b/extensions/git/src/components/actions/RemoteActions.tsx
@@ -155,15 +155,13 @@ export function RemoteEditorForm(context: RemoteEditorFormProps) {
 
   const { data: needsManualProvider } = usePromise(
     async (url: string) => {
-      if (context.initialRemote?.provider === undefined || context.initialRemote?.isOverridedProvider) {
-        return true;
-      }
-
-      if (!validateGitUrl(url)) {
-        return false;
-      }
-
+      if (!validateGitUrl(url)) return false;
       const parsed = remoteHostParser(url);
+
+      if (context.initialRemote?.provider !== undefined && !context.initialRemote?.isOverridedProvider) {
+        return parsed.provider === undefined;
+      }
+
       return parsed.provider === undefined;
     },
     [fetchUrl.trim()],
@@ -262,12 +260,12 @@ export function RemoteEditorForm(context: RemoteEditorFormProps) {
 
 /**
  * Action submenu for opening the remote repository in github.dev or vscode.dev.
- * Only rendered when remote.provider is "GitHub".
+ * Only rendered when remote.provider is GitHub.
  */
 export function RemoteOpenInDevAction(context: { remote: Remote }) {
   const { remote } = context;
 
-  if (remote.provider !== "GitHub" || !remote.organizationName || !remote.repositoryName) {
+  if (remote.provider !== RemoteProvider.GitHub || !remote.organizationName || !remote.repositoryName) {
     return null;
   }
 

--- a/extensions/git/src/components/actions/RemoteActions.tsx
+++ b/extensions/git/src/components/actions/RemoteActions.tsx
@@ -12,12 +12,14 @@ import {
   useNavigation,
 } from "@raycast/api";
 import { RemotesHosts } from "../../hooks/useGitRemotes";
-import { RemoteHostIcon } from "../icons/RemoteHostIcons";
+import { RemoteHostIcon, RemoteHostProviderIcon } from "../icons/RemoteHostIcons";
 import { NavigationContext, RepositoryContext } from "../../open-repository";
-import { Commit, Remote } from "../../types";
+import { Commit, Remote, RemoteProvider } from "../../types";
 import { useState } from "react";
 import { basename } from "path";
 import { validateGitUrl } from "../../utils/url-utils";
+import { usePromise } from "@raycast/utils";
+import { remoteHostParser } from "../../utils/remote-host-parser";
 
 /**
  * Global fetch action that can be reused across different views.
@@ -149,14 +151,46 @@ export function RemoteEditorForm(context: RemoteEditorFormProps) {
   const [name, setName] = useState(context.initialRemote?.name ?? context.defaultRemoteName ?? "");
   const [fetchUrl, setFetchUrl] = useState(context.initialRemote?.fetchUrl ?? context.defaultFetchUrl ?? "");
   const [pushUrl, setPushUrl] = useState(context.initialRemote?.pushUrl ?? context.defaultPushUrl ?? "");
+  const [manualProvider, setManualProvider] = useState<RemoteProvider | undefined>(context.initialRemote?.provider);
 
-  const handleSubmit = async (_values: { name: string; fetchUrl: string; pushUrl: string }) => {
+  const { data: needsManualProvider } = usePromise(
+    async (url: string) => {
+      if (context.initialRemote?.provider === undefined) {
+        return true;
+      }
+
+      if (!validateGitUrl(url)) {
+        return false;
+      }
+
+      const parsed = remoteHostParser(url);
+      return parsed.provider === undefined;
+    },
+    [fetchUrl.trim()],
+  );
+
+  const handleSubmit = async (values: {
+    name: string;
+    fetchUrl: string;
+    pushUrl: string;
+    hostProvider: RemoteProvider | undefined;
+  }) => {
     try {
       if (context.initialRemote) {
-        await context.gitManager.updateRemote(context.initialRemote.name, fetchUrl.trim(), pushUrl.trim(), name.trim());
+        await context.gitManager.updateRemote(
+          context.initialRemote.name,
+          values.fetchUrl.trim(),
+          values.pushUrl.trim(),
+          values.name.trim(),
+        );
       } else {
-        await context.gitManager.addRemote(name.trim(), fetchUrl.trim(), pushUrl.trim());
+        await context.gitManager.addRemote(values.name.trim(), values.fetchUrl.trim(), values.pushUrl.trim());
       }
+
+      if (values.hostProvider !== undefined) {
+        context.remotes.addProviderOverride(values.hostProvider, values.fetchUrl.trim());
+      }
+
       await context.remotes.revalidate();
       pop();
     } catch {
@@ -199,6 +233,29 @@ export function RemoteEditorForm(context: RemoteEditorFormProps) {
         info={"Optional"}
         onChange={setPushUrl}
       />
+
+      {needsManualProvider && (
+        <>
+          <Form.Separator />
+          <Form.Dropdown
+            id="hostProvider"
+            title="Host Provider"
+            info="The fetch URL does not match any known host provider; pick the provider manually to provide respective provider integrations."
+            value={manualProvider ?? ""}
+            onChange={(value) => setManualProvider(value ? (value as RemoteProvider) : undefined)}
+          >
+            <Form.Dropdown.Item value="" title="Select provider…" />
+            {Object.values(RemoteProvider).map((provider) => (
+              <Form.Dropdown.Item
+                key={provider}
+                value={provider}
+                title={provider}
+                icon={RemoteHostProviderIcon(provider)}
+              />
+            ))}
+          </Form.Dropdown>
+        </>
+      )}
     </Form>
   );
 }

--- a/extensions/git/src/components/icons/RemoteHostIcons.tsx
+++ b/extensions/git/src/components/icons/RemoteHostIcons.tsx
@@ -23,15 +23,15 @@ export function RemoteHostProviderIcon(provider: RemoteProvider | undefined): Im
   }
 
   switch (provider) {
-    case "GitHub":
+    case RemoteProvider.GitHub:
       return { source: "github.svg", tintColor: Color.PrimaryText };
-    case "GitLab":
+    case RemoteProvider.GitLab:
       return { source: "gitlab.svg", tintColor: Color.Red };
-    case "Bitbucket":
+    case RemoteProvider.Bitbucket:
       return { source: "bitbucket.svg", tintColor: Color.Blue };
-    case "Azure DevOps":
-      return { source: "azure-devops.svg", tintColor: Color.Blue };
-    case "Gitea":
+    case RemoteProvider.AzureDevOps:
+      return { source: "azuredevops.svg", tintColor: Color.Blue };
+    case RemoteProvider.Gitea:
       return { source: "gitea.svg", tintColor: Color.Green };
     default:
       return { source: Icon.Globe, tintColor: Color.SecondaryText };

--- a/extensions/git/src/components/views/RemotesView.tsx
+++ b/extensions/git/src/components/views/RemotesView.tsx
@@ -117,7 +117,9 @@ function RemoteListItem(
       actions={
         <ActionPanel>
           <ActionPanel.Section title={context.remote.name}>
-            <Action.OpenInBrowser title="Open in Browser" url={context.remote.fetchUrl} icon={Icon.Link} />
+            {context.remote.type == "http" && (
+              <Action.OpenInBrowser title="Open in Browser" url={context.remote.fetchUrl} icon={Icon.Link} />
+            )}
             <RemoteOpenInDevAction remote={context.remote} />
             <RemoteEditAction initialRemote={context.remote} {...context} />
 

--- a/extensions/git/src/hooks/useAiPromptPresets.ts
+++ b/extensions/git/src/hooks/useAiPromptPresets.ts
@@ -1,5 +1,5 @@
-import { useCachedState } from "@raycast/utils";
 import { nanoid } from "nanoid";
+import { useStorage } from "./useStorage";
 
 /**
  * Represents an AI commit message prompt preset.
@@ -112,11 +112,11 @@ Output only the commit message, no markdown or extra text.
 };
 
 /**
- * Hook for managing AI commit message prompt presets in cached state.
+ * Hook for managing AI commit message prompt presets in persistent storage.
  * Presets are global for the extension (not per repository).
  */
 export function useAiPromptPresets() {
-  const [data, setData] = useCachedState<AiPromptPresetsData>("ai-prompt-presets", {
+  const [data, setData] = useStorage<AiPromptPresetsData>("ai-prompt-presets", {
     presets: [CONVENTIONAL_MESSAGE_PROMPT, GITMOJI_MESSAGE_PROMPT, MINIMALIST_MESSAGE_PROMPT],
     defaultPresetId: CONVENTIONAL_MESSAGE_PROMPT.id,
   });

--- a/extensions/git/src/hooks/useGitDiff.ts
+++ b/extensions/git/src/hooks/useGitDiff.ts
@@ -37,10 +37,10 @@ export function useGitDiff({ gitManager, options, execute = true }: UseGitDiffPr
         }
       }
 
-      let rawDiff = await gitManager.getDiff({ file, commitHash, status });
+      const rawDiff = await gitManager.getDiff({ file, commitHash, status });
 
       // Remove leading whitespace from diff lines
-      rawDiff = rawDiff.replace(/^\s+([+-])/gm, "$1 ");
+      // rawDiff = rawDiff.replace(/^([+-])/gm, "$1 ");
 
       if (rawDiff) {
         const lines = rawDiff.split("\n");

--- a/extensions/git/src/hooks/useGitDiff.ts
+++ b/extensions/git/src/hooks/useGitDiff.ts
@@ -39,9 +39,6 @@ export function useGitDiff({ gitManager, options, execute = true }: UseGitDiffPr
 
       const rawDiff = await gitManager.getDiff({ file, commitHash, status });
 
-      // Remove leading whitespace from diff lines
-      // rawDiff = rawDiff.replace(/^([+-])/gm, "$1 ");
-
       if (rawDiff) {
         const lines = rawDiff.split("\n");
         if (lines.length > MAX_DIFF_LINES) {

--- a/extensions/git/src/hooks/useGitRemotes.ts
+++ b/extensions/git/src/hooks/useGitRemotes.ts
@@ -53,6 +53,7 @@ export function useGitRemotes(gitManager: GitManager): RepositoryContext["remote
           displayName: `${parser.organizationName}/${parser.repositoryName}`,
           repositoryName: parser.repositoryName,
           provider: parser.provider,
+          isOverridedProvider: providerOverrides[primaryUrl] !== undefined,
           avatarUrl: parser.avatarUrl,
           webPages: parser.webPages,
         };

--- a/extensions/git/src/hooks/useGitRemotes.ts
+++ b/extensions/git/src/hooks/useGitRemotes.ts
@@ -1,9 +1,9 @@
-import { useCachedPromise } from "@raycast/utils";
+import { useCachedPromise, useCachedState } from "@raycast/utils";
 import { GitManager } from "../utils/git-manager";
-import { Remote } from "../types";
+import { Remote, RemoteProvider } from "../types";
 import { remoteHostParser } from "../utils/remote-host-parser";
 import { RepositoryContext } from "../open-repository";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 export type RemotesHosts = Record<string, Remote>;
 
@@ -13,6 +13,23 @@ export type RemotesHosts = Record<string, Remote>;
  * Repository path is included in cache dependencies to ensure separate cache per repository.
  */
 export function useGitRemotes(gitManager: GitManager): RepositoryContext["remotes"] {
+  const [providerOverrides, setProviderOverrides] = useCachedState<Record<string, RemoteProvider>>(
+    `git-remote-provider-overrides:${gitManager.repoPath}`,
+    {},
+  );
+
+  const addProviderOverride = useCallback(
+    (provider: RemoteProvider, url: string) => {
+      setProviderOverrides((prev) => {
+        const next = { ...prev };
+        const key = url.trim();
+        if (key) next[key] = provider;
+        return next;
+      });
+    },
+    [setProviderOverrides],
+  );
+
   const {
     data: remotes,
     isLoading,
@@ -25,7 +42,7 @@ export function useGitRemotes(gitManager: GitManager): RepositoryContext["remote
     () =>
       remotes.reduce<RemotesHosts>((dictionary, remote) => {
         const primaryUrl = remote.fetchUrl || remote.pushUrl || "";
-        const parser = remoteHostParser(primaryUrl);
+        const parser = remoteHostParser(primaryUrl, providerOverrides[primaryUrl]);
 
         const info: Remote = {
           name: remote.name,
@@ -43,13 +60,15 @@ export function useGitRemotes(gitManager: GitManager): RepositoryContext["remote
 
         return dictionary;
       }, {} as RemotesHosts),
-    [remotes],
+    [remotes, providerOverrides],
   );
 
   return {
     data: remotesRecords,
     isLoading,
     revalidate,
+    providerOverrides,
+    addProviderOverride,
   };
 }
 

--- a/extensions/git/src/hooks/useIssueTracker.ts
+++ b/extensions/git/src/hooks/useIssueTracker.ts
@@ -1,13 +1,13 @@
-import { useCachedState } from "@raycast/utils";
-import { IssueTrackerConfig } from "../types";
 import { nanoid } from "nanoid";
 import { useCallback } from "react";
+import { IssueTrackerConfig } from "../types";
+import { useStorage } from "./useStorage";
 
 /**
  * Hook to manage URL tracker configurations (global across the extension).
  */
 export function useIssueTracker() {
-  const [configs, setConfigs] = useCachedState<IssueTrackerConfig[]>("issue-tracker-configs", []);
+  const [configs, setConfigs] = useStorage<IssueTrackerConfig[]>("issue-tracker-configs", []);
 
   const addConfig = useCallback(
     (title: string, regex: string, urlPlaceholder: string) => {

--- a/extensions/git/src/hooks/useRepositoriesList.ts
+++ b/extensions/git/src/hooks/useRepositoriesList.ts
@@ -1,5 +1,5 @@
-import { useCachedState } from "@raycast/utils";
 import { useCallback, useEffect } from "react";
+import { useStorage } from "./useStorage";
 import { Repository, RepositoryCloningProcess } from "../types";
 import { detectRepositoryLanguages } from "../utils/language-detector";
 import { resolveTildePath } from "../utils/path-utils";
@@ -12,8 +12,7 @@ import { basename } from "path";
  * Supports tilde (~) paths.
  */
 export function useRepositoriesList() {
-  // Cache the list of repositories between sessions
-  const [repositories, setRepositories] = useCachedState<Repository[]>("managed-repositories-list", []);
+  const [repositories, setRepositories] = useStorage<Repository[]>("managed-repositories-list", []);
 
   // Revalidate all repositories in the list: remove if not valid, update languageStats if missing
   useEffect(() => {
@@ -30,7 +29,7 @@ export function useRepositoriesList() {
     if (invalidRepositories.length === 0) return;
 
     setRepositories((current) => current.filter((r) => !invalidRepositories.includes(r)));
-  }, []);
+  }, [repositories, setRepositories]);
 
   /**
    * Adds a repository to the recent list.

--- a/extensions/git/src/hooks/useStorage.ts
+++ b/extensions/git/src/hooks/useStorage.ts
@@ -1,0 +1,67 @@
+import { Cache, LocalStorage } from "@raycast/api";
+import { showFailureToast, useCachedPromise } from "@raycast/utils";
+import { Dispatch, SetStateAction, useCallback, useRef } from "react";
+
+/** Root Cache instance used by `useCachedState` without a namespace. */
+const rootCache = new Cache();
+
+/**
+ * Persistent storage hook backed by LocalStorage, with a one-time migration from Cache API.
+ *
+ * Mirrors `useCachedState` ergonomics: always returns a defined `T` while loading or migrating
+ * (`initialState`), then the stored value. Persists via LocalStorage.
+ *
+ * `useLocalStorage#setValue` does not reliably re-render; a separate `useCachedState` revision
+ * counter (not the stored payload) is bumped on writes so all hook instances sharing the same
+ * revision key re-render via Cache subscription.
+ *
+ * @param key - Unique storage key (same as former `useCachedState` key for migration).
+ * @param initialState - Value used before storage is ready and when the key does not exist yet.
+ * @returns Tuple of state and setter (same shape as `useCachedState`).
+ */
+export function useStorage<T>(key: string, initialState: T): [T, Dispatch<SetStateAction<T>>] {
+  const { data, mutate } = useCachedPromise(
+    async (cacheKey: string) => {
+      const cachedRaw = rootCache.get(cacheKey);
+      if (cachedRaw !== undefined) {
+        console.warn(`Detected legacy cache for the key ${cacheKey}`);
+        const parsed = JSON.parse(cachedRaw) as T;
+
+        await LocalStorage.setItem(cacheKey, cachedRaw);
+        rootCache.remove(cacheKey);
+        console.warn(`Migrated legacy cache for the key ${cacheKey}.`);
+        return parsed;
+      }
+
+      const rawValue = await LocalStorage.getItem<string>(cacheKey);
+      if (rawValue === undefined) return initialState;
+
+      return JSON.parse(rawValue) as T;
+    },
+    [key],
+    {
+      initialData: initialState,
+    },
+  );
+
+  const dataRef = useRef(data);
+  dataRef.current = data;
+
+  const setValue = useCallback(
+    async (updater: SetStateAction<T>) => {
+      // @ts-expect-error TS struggles to infer the types as T could potentially be a function
+      const nextValue = typeof updater === "function" ? updater(dataRef.current) : updater;
+      try {
+        await mutate(LocalStorage.setItem(key, JSON.stringify(nextValue)), {
+          optimisticUpdate: () => nextValue,
+          shouldRevalidateAfter: false,
+        });
+      } catch (error) {
+        showFailureToast(error, { title: "Failed to update value in local storage" });
+      }
+    },
+    [key, mutate],
+  );
+
+  return [data, setValue];
+}

--- a/extensions/git/src/manage-repositories.tsx
+++ b/extensions/git/src/manage-repositories.tsx
@@ -14,6 +14,7 @@ import {
   LaunchType,
   launchCommand,
   Clipboard,
+  Cache,
 } from "@raycast/api";
 import { useCallback, useMemo, useState } from "react";
 import { useRepositoriesList } from "./hooks/useRepositoriesList";
@@ -206,6 +207,10 @@ function RepositoryListItem({
             />
             <RepositoryAttachedLinksAction remotes={remotes} />
             <RepositoryQuickLinkAction repositoryPath={repo.path} />
+          </ActionPanel.Section>
+
+          <ActionPanel.Section>
+            <RepositoriesClearCacheAction />
             <Action
               title="Remove from List"
               onAction={handleRemove}
@@ -599,4 +604,31 @@ function RepositoryAttachedLinksAction({ remotes }: { remotes: Record<string, Re
       ))}
     </ActionPanel.Submenu>
   );
+}
+
+/**
+ * Action for clearing the extension cache.
+ */
+function RepositoriesClearCacheAction() {
+  const handleClearCache = async () => {
+    const confirmed = await confirmAlert({
+      title: "Clear Extension Cache?",
+      message: "This clears all data stored in Raycast Cache (UI state, filters, drafts, and other cached preferences)",
+      primaryAction: {
+        title: "Clear Cache",
+        style: Alert.ActionStyle.Destructive,
+      },
+    });
+
+    if (confirmed) {
+      new Cache().clear();
+      await showToast({
+        style: Toast.Style.Success,
+        title: "Cache cleared",
+        message: "Extension cache has been cleared",
+      });
+    }
+  };
+
+  return <Action title="Clear Cache" icon={Icon.Eraser} onAction={handleClearCache} style={Action.Style.Destructive} />;
 }

--- a/extensions/git/src/open-repository.tsx
+++ b/extensions/git/src/open-repository.tsx
@@ -24,6 +24,7 @@ import {
   Submodule,
   Branch,
   Remote,
+  RemoteProvider,
   Preferences,
 } from "./types";
 import { useGitRemotes } from "./hooks/useGitRemotes";
@@ -53,6 +54,8 @@ export type RepositoryContext = {
     data: Record<string, Remote>;
     isLoading: boolean;
     revalidate: () => void;
+    providerOverrides: Record<string, RemoteProvider>;
+    addProviderOverride: (provider: RemoteProvider, url: string) => void;
   };
   branches: {
     data: BranchesState;

--- a/extensions/git/src/types/git-types.ts
+++ b/extensions/git/src/types/git-types.ts
@@ -237,6 +237,7 @@ export type Remote = {
   displayName: string;
   repositoryName?: string;
   provider?: RemoteProvider;
+  isOverridedProvider?: boolean;
   avatarUrl?: string;
   webPages: {
     fileRelated: (filePath: string, ref?: string) => RemoteWebPage[];

--- a/extensions/git/src/types/git-types.ts
+++ b/extensions/git/src/types/git-types.ts
@@ -216,7 +216,13 @@ export interface Stash {
 /**
  * Known Git hosting providers.
  */
-export type RemoteProvider = "GitHub" | "GitLab" | "Bitbucket" | "Azure DevOps" | "Gitea" | undefined;
+export enum RemoteProvider {
+  GitHub = "GitHub",
+  GitLab = "GitLab",
+  Bitbucket = "Bitbucket",
+  AzureDevOps = "Azure DevOps",
+  Gitea = "Gitea",
+}
 
 export type RemoteWebPage = Action.OpenInBrowser.Props;
 /**
@@ -230,7 +236,7 @@ export type Remote = {
   organizationName?: string;
   displayName: string;
   repositoryName?: string;
-  provider: RemoteProvider;
+  provider?: RemoteProvider;
   avatarUrl?: string;
   webPages: {
     fileRelated: (filePath: string, ref?: string) => RemoteWebPage[];

--- a/extensions/git/src/utils/git-manager.ts
+++ b/extensions/git/src/utils/git-manager.ts
@@ -1618,7 +1618,7 @@ __REBASE_TODO__
    * Returns a single commit by hash with parsed metadata and changed files.
    */
   async getCommitByHash(commitHash: string): Promise<Commit | null> {
-    const log = await this.git.log(["--max-count=1", "--name-status", "--decorate=full", commitHash]);
+    const log = await this.git.log(["--max-count=1", "--name-status", "--decorate=full", "--first-parent", commitHash]);
 
     if (!log.latest) return null;
 

--- a/extensions/git/src/utils/remote-host-parser.ts
+++ b/extensions/git/src/utils/remote-host-parser.ts
@@ -12,7 +12,7 @@ type RemoteHostParserResult = Pick<
  * @param url - The URL to parse.
  * @returns The parsed remote host info.
  */
-export function remoteHostParser(url: string): RemoteHostParserResult {
+export function remoteHostParser(url: string, providerOverride?: RemoteProvider): RemoteHostParserResult {
   const parsed = parse(url);
 
   if (!parsed) {
@@ -20,19 +20,19 @@ export function remoteHostParser(url: string): RemoteHostParserResult {
   }
 
   const hostname = parsed.hostname.toLowerCase();
-  if (hostname.includes("github")) {
+  if (hostname.includes("github") || providerOverride === RemoteProvider.GitHub) {
     return githubParser(url, parsed);
   }
-  if (hostname.includes("gitlab")) {
+  if (hostname.includes("gitlab") || providerOverride === RemoteProvider.GitLab) {
     return gitlabParser(url, parsed);
   }
-  if (hostname.includes("bitbucket")) {
+  if (hostname.includes("bitbucket") || providerOverride === RemoteProvider.Bitbucket) {
     return bitbucketParser(url, parsed);
   }
-  if (hostname.includes("azure-devops")) {
+  if (hostname.includes("azure-devops") || providerOverride === RemoteProvider.AzureDevOps) {
     return azureDevopsParser(url, parsed);
   }
-  if (hostname.includes("gitea")) {
+  if (hostname.includes("gitea") || providerOverride === RemoteProvider.Gitea) {
     return giteaParser(url, parsed);
   }
   return unknownParser(url, parsed);
@@ -54,7 +54,7 @@ function githubParser(_url: string, parsed: URLComponents): RemoteHostParserResu
   })();
 
   return {
-    provider: "GitHub" as RemoteProvider,
+    provider: RemoteProvider.GitHub,
     organizationName,
     repositoryName,
     get avatarUrl() {
@@ -186,7 +186,7 @@ function gitlabParser(_url: string, parsed: URLComponents): RemoteHostParserResu
   const { protocol: scheme, hostname, path } = parsed;
 
   return {
-    provider: "GitLab" as RemoteProvider,
+    provider: RemoteProvider.GitLab,
     organizationName: (() => {
       const match = path.match(/^([^/]+)/);
       return match ? match[1] : undefined;
@@ -264,7 +264,7 @@ function gitlabParser(_url: string, parsed: URLComponents): RemoteHostParserResu
           },
           {
             title: "Members",
-            url: `${scheme}://${hostname}/${path}/-/members`,
+            url: `${scheme}://${hostname}/${path}/-/project_members`,
             icon: { source: `https://api.iconify.design/tdesign/member.svg`, fallback: Icon.Person },
           },
           {
@@ -304,7 +304,7 @@ function gitlabParser(_url: string, parsed: URLComponents): RemoteHostParserResu
           },
           {
             title: "Settings",
-            url: `${scheme}://${hostname}/${path}/-/settings`,
+            url: `${scheme}://${hostname}/${path}/-/edit`,
             icon: Icon.Gear,
           },
         ];
@@ -317,7 +317,7 @@ function giteaParser(_url: string, parsed: URLComponents): RemoteHostParserResul
   const { protocol: scheme, hostname, path } = parsed;
 
   return {
-    provider: "Gitea" as RemoteProvider,
+    provider: RemoteProvider.Gitea,
     organizationName: (() => {
       const match = path.match(/^([^/]+)/);
       return match ? match[1] : undefined;
@@ -450,7 +450,7 @@ function bitbucketParser(_url: string, parsed: URLComponents): RemoteHostParserR
   })();
 
   return {
-    provider: "Bitbucket" as RemoteProvider,
+    provider: RemoteProvider.Bitbucket,
     organizationName: (() => {
       const match = path.match(/^([^/]+)/);
       return match ? match[1] : undefined;
@@ -586,7 +586,7 @@ function azureDevopsParser(_url: string, parsed: URLComponents): RemoteHostParse
   })();
 
   return {
-    provider: "Azure DevOps" as RemoteProvider,
+    provider: RemoteProvider.AzureDevOps,
     organizationName: (() => {
       if (hostname === "ssh.dev.azure.com" || hostname === "vs-ssh.visualstudio.com") {
         const pathPattern = path.startsWith("v3/")
@@ -676,7 +676,7 @@ function azureDevopsParser(_url: string, parsed: URLComponents): RemoteHostParse
 
 function unknownParser(_url: string, _parsed?: URLComponents): RemoteHostParserResult {
   return {
-    provider: undefined as RemoteProvider,
+    provider: undefined,
     organizationName: undefined,
     repositoryName: undefined,
     avatarUrl: undefined,
@@ -700,7 +700,7 @@ type URLComponents = {
 
 function parse(url: string): URLComponents | undefined {
   // Try SCP-like: user@host:path OR host:path (ssh principal)
-  const scpMatch = url.match(/^[^@\s]+@([^:/]+)[:/](.+)$/);
+  const scpMatch = url.match(/^[^@:/\s]+@([^:/]+)[:/](.+)$/);
   if (scpMatch) {
     const normalizedPath = scpMatch[2]
       .replace(/^\//, "")
@@ -720,7 +720,7 @@ function parse(url: string): URLComponents | undefined {
       .replace(/^scm\//, "")
       .replace(/\.git$/i, "");
     return {
-      protocol: parsed.protocol.replace(":", ""),
+      protocol: parsed.protocol === "ssh:" ? "https" : parsed.protocol.replace(":", ""),
       hostname: parsed.hostname,
       path: normalizedPath,
     };


### PR DESCRIPTION
## Description

### Fixed
- **Diff**: Show raw Git diff output without stripping leading whitespace from added/removed lines, so indented code changes display correctly
- **Commit Details**: Load changed files with `--first-parent` when fetching a commit by hash, matching the commits history view for merge commits

## Screencast

<img width="2000" height="1250" alt="git 2026-05-20 at 22 31 41" src="https://github.com/user-attachments/assets/e6c35e4b-7ceb-4629-b921-a1443546800d" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
