### PR TITLE
Fix/table records database views

### DIFF
--- a/extensions/servicenow/CHANGELOG.md
+++ b/extensions/servicenow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ServiceNow Extension Changelog
 
+## [Database View Support & Clearer Errors] - {PR_MERGE_DATE}
+
+- **Explore Records** now works on database views and other tables that don't track an update time, instead of failing to load.
+- **Find Record by Sys ID** and **Find Record References** now tell you why a lookup failed, whether sign-in failed or your account is missing the admin role, and let you edit the profile and retry without leaving the command. If your instance uses single sign-on, they point you to switch the profile to OAuth.
+- In **Explore Records**, hovering the updater avatar now shows both the person's name and their username.
+
 ## [OAuth, Windows Support & New Commands] - 2026-05-19
 
 - Added OAuth 2.0 (PKCE) as an alternative to Basic Auth, selectable per instance profile. Tokens refresh automatically and a **Sign In / Re-authenticate** action recovers expired profiles; auth failures are flagged in **Manage Instance Profiles**.

--- a/extensions/servicenow/CHANGELOG.md
+++ b/extensions/servicenow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ServiceNow Extension Changelog
 
-## [Database View Support & Clearer Errors] - {PR_MERGE_DATE}
+## [Database View Support & Clearer Errors] - 2026-05-21
 
 - **Explore Records** now works on database views and other tables that don't track an update time, instead of failing to load.
 - **Find Record by Sys ID** and **Find Record References** now tell you why a lookup failed, whether sign-in failed or your account is missing the admin role, and let you edit the profile and retry without leaving the command. If your instance uses single sign-on, they point you to switch the profile to OAuth.

--- a/extensions/servicenow/README.md
+++ b/extensions/servicenow/README.md
@@ -31,6 +31,8 @@ Before using the extension, you'll need to configure your ServiceNow instance pr
 
 OAuth uses a public OAuth client (PKCE) registered in your ServiceNow instance. Tokens are stored locally and refreshed automatically.
 
+> If your instance uses **SSO**, configure the profile with OAuth: basic auth may not establish a session, so the admin background-script commands (**Find Record by Sys ID**, **Find Record References**) can fail to authenticate.
+
 #### Recommended: import the default Raycast OAuth client
 
 1. Download the **Raycast Extension – Default OAuth Client** XML from ServiceNow Share (use the `Download Default OAuth Client` action in the instance profile form).

--- a/extensions/servicenow/README.md
+++ b/extensions/servicenow/README.md
@@ -31,7 +31,7 @@ Before using the extension, you'll need to configure your ServiceNow instance pr
 
 OAuth uses a public OAuth client (PKCE) registered in your ServiceNow instance. Tokens are stored locally and refreshed automatically.
 
-> If your instance uses **SSO**, configure the profile with OAuth: basic auth may not establish a session, so the admin background-script commands (**Find Record by Sys ID**, **Find Record References**) can fail to authenticate.
+> If your instance uses **SSO**, configure the profile with OAuth: basic auth can sign in but can't run the background scripts that power the admin commands (**Find Record by Sys ID**, **Find Record References**), so those commands will fail with a basic-auth profile.
 
 #### Recommended: import the default Raycast OAuth client
 

--- a/extensions/servicenow/src/components/TableRecords.tsx
+++ b/extensions/servicenow/src/components/TableRecords.tsx
@@ -34,8 +34,11 @@ type TableRecord = {
   sys_updated_by?: string;
 } & Record<string, string | undefined>;
 
+// With sysparm_display_value=all every field arrives as { value, display_value }.
+type DisplayValuePair = { value: string; display_value: string };
+
 interface TableRecordsResponse {
-  result: TableRecord[];
+  result: Record<string, DisplayValuePair>[];
 }
 
 interface LiveProfile {
@@ -174,7 +177,7 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
   const { isLoading, data, error, revalidate, pagination } = useFetch(
     (options) => {
       const params = new URLSearchParams({
-        sysparm_display_value: "true",
+        sysparm_display_value: "all",
         sysparm_exclude_reference_link: "true",
         sysparm_limit: "100",
         sysparm_offset: String(options.page * 100),
@@ -199,7 +202,21 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
         showToast(Toast.Style.Failure, "Could not fetch records", err.message);
       },
       mapResult(response: TableRecordsResponse) {
-        return { data: response.result, hasMore: response.result.length > 0 };
+        // Flatten { value, display_value } pairs to the plain string shape the rest
+        // of the component expects. Use display_value everywhere except sys_updated_on,
+        // where we keep the raw value: it's the internal UTC timestamp
+        // (2026-05-20 17:49:24) that `new Date(... + " UTC")` can parse, whereas the
+        // display value is localized to the instance's format/timezone and isn't.
+        const flattened = response.result.map(
+          (rec) =>
+            Object.fromEntries(
+              Object.entries(rec).map(([key, pair]) => [
+                key,
+                key === "sys_updated_on" ? pair?.value : pair?.display_value,
+              ]),
+            ) as TableRecord,
+        );
+        return { data: flattened, hasMore: response.result.length > 0 };
       },
     },
   );

--- a/extensions/servicenow/src/components/TableRecords.tsx
+++ b/extensions/servicenow/src/components/TableRecords.tsx
@@ -182,11 +182,21 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
       headers,
       execute: !!authHeader && !isLoadingDisplay,
       keepPreviousData: true,
+      async parseResponse(response) {
+        if (!response.ok) {
+          // Tag the status so onError can tell a 500 (unknown ORDERBY column) from
+          // a 401/network error that shouldn't trigger the order-by fallback.
+          const err = new Error(response.statusText || `HTTP ${response.status}`);
+          (err as Error & { status?: number }).status = response.status;
+          throw err;
+        }
+        return response.json();
+      },
       onError: (err) => {
-        // First failure while ordering by sys_updated_on: a non-view table that
-        // also lacks the column. Drop the order-by and let the query memo
-        // recompute, which retries the fetch automatically.
-        if (orderByUpdated) {
+        // Only a 500 means the table lacks sys_updated_on (database views aside).
+        // Drop the order-by and let the query memo recompute, which retries the
+        // fetch automatically. Auth/network errors surface immediately instead.
+        if (orderByUpdated && (err as Error & { status?: number }).status === 500) {
           setOrderByDisabled(true);
           return;
         }

--- a/extensions/servicenow/src/components/TableRecords.tsx
+++ b/extensions/servicenow/src/components/TableRecords.tsx
@@ -36,7 +36,8 @@ type TableRecord = {
 } & Record<string, string | undefined>;
 
 // With sysparm_display_value=all every field arrives as { value, display_value }.
-type DisplayValuePair = { value: string; display_value: string };
+// Null is returned by the API when a field has no value.
+type DisplayValuePair = { value: string | null; display_value: string | null } | null;
 
 interface TableRecordsResponse {
   result: Record<string, DisplayValuePair>[];

--- a/extensions/servicenow/src/components/TableRecords.tsx
+++ b/extensions/servicenow/src/components/TableRecords.tsx
@@ -25,7 +25,7 @@ const SPECIAL_AVATARS: Record<string, Image.ImageLike> = {
 };
 
 interface DictionaryResponse {
-  result: { element: string }[];
+  result: { element: string; display: string }[];
 }
 
 type TableRecord = {
@@ -77,17 +77,27 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
     }
   };
 
-  const { data: displayField, isLoading: isLoadingDisplay } = useFetch(
-    `${instanceUrl}/api/now/table/sys_dictionary?sysparm_query=name=${table.name}^display=true&sysparm_fields=element&sysparm_limit=1&sysparm_exclude_reference_link=true`,
+  // Fetch the table's own columns (display flag included) before the records load.
+  // We derive both the display field and — for database views — whether the
+  // sys_updated_on column exists, so we can decide the order-by upfront.
+  const { data: tableMeta, isLoading: isLoadingDisplay } = useFetch(
+    `${instanceUrl}/api/now/table/sys_dictionary?sysparm_query=name=${table.name}^elementISNOTEMPTY&sysparm_fields=element,display&sysparm_limit=2000&sysparm_exclude_reference_link=true`,
     {
       headers,
       execute: !!authHeader,
       keepPreviousData: true,
       mapResult(response: DictionaryResponse) {
-        return { data: response.result[0]?.element ?? null };
+        const rows = response.result ?? [];
+        return {
+          data: {
+            displayField: rows.find((r) => r.display === "true")?.element ?? null,
+            hasUpdatedOn: rows.some((r) => r.element === "sys_updated_on"),
+          },
+        };
       },
     },
   );
+  const displayField = tableMeta?.displayField ?? null;
 
   const fields = useMemo(() => {
     const set = new Set<string>(["sys_id", "sys_updated_on", "sys_updated_by", ...FALLBACK_DISPLAY_FIELDS]);
@@ -120,6 +130,16 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
   // table (querying LIKE on a non-existent field would 400 the whole request).
   const [searchableFields, setSearchableFields] = useState<string[]>([]);
 
+  // Ordering by sys_updated_on 500s the whole request when the table lacks that
+  // column (database views). For views (v_*) the dictionary lists every column —
+  // no inheritance — so its absence there is authoritative and we skip the
+  // order-by upfront. For normal tables sys_updated_on is inherited and won't show
+  // in the table's own dictionary rows, so we keep ordering on and let the onError
+  // fallback below disable it for the rare non-view table that also lacks it.
+  const isDatabaseView = table.name.startsWith("v_");
+  const [orderByDisabled, setOrderByDisabled] = useState(false);
+  const orderByUpdated = !orderByDisabled && (!isDatabaseView || (tableMeta?.hasUpdatedOn ?? true));
+
   // Shared between the records fetch and the "Open <table> List" action so the
   // browser opens the same filtered view the user is looking at.
   const sysparmQuery = useMemo(() => {
@@ -147,9 +167,9 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
       }
       filters.push(orParts.join("^OR"));
     }
-    filters.push("ORDERBYDESCsys_updated_on");
+    if (orderByUpdated) filters.push("ORDERBYDESCsys_updated_on");
     return filters.join("^");
-  }, [searchTerm, extraQuery, searchableFields, users]);
+  }, [searchTerm, extraQuery, searchableFields, users, orderByUpdated]);
 
   const { isLoading, data, error, revalidate, pagination } = useFetch(
     (options) => {
@@ -168,6 +188,13 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
       execute: !!authHeader && !isLoadingDisplay,
       keepPreviousData: true,
       onError: (err) => {
+        // First failure while ordering by sys_updated_on: a non-view table that
+        // also lacks the column. Drop the order-by and let the query memo
+        // recompute, which retries the fetch automatically.
+        if (orderByUpdated) {
+          setOrderByDisabled(true);
+          return;
+        }
         console.error(err);
         showToast(Toast.Style.Failure, "Could not fetch records", err.message);
       },
@@ -297,7 +324,7 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
         </List.Dropdown>
       }
     >
-      {error ? (
+      {error && !isLoading ? (
         <List.EmptyView
           icon={{ source: Icon.ExclamationMark, tintColor: Color.Red }}
           title="Could Not Fetch Records"
@@ -328,8 +355,8 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
                   tooltip: "Favorite",
                 });
               }
-              if (record.sys_updated_on) {
-                const updatedDate = new Date(record.sys_updated_on + " UTC");
+              const updatedDate = record.sys_updated_on ? new Date(record.sys_updated_on + " UTC") : null;
+              if (updatedDate && !isNaN(updatedDate.getTime())) {
                 const daysAgo = differenceInCalendarDays(new Date(), updatedDate);
                 const dateLabel =
                   daysAgo === 0

--- a/extensions/servicenow/src/components/TableRecords.tsx
+++ b/extensions/servicenow/src/components/TableRecords.tsx
@@ -22,6 +22,7 @@ const SPECIAL_AVATARS: Record<string, Image.ImageLike> = {
   system: { source: Icon.ComputerChip, tintColor: Color.Purple },
   admin: { source: Icon.Shield, tintColor: Color.Orange },
   guest: { source: Icon.PersonCircle, tintColor: Color.SecondaryText },
+  maint: { source: Icon.Cog, tintColor: Color.Blue },
 };
 
 interface DictionaryResponse {
@@ -386,9 +387,14 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
                 const displayName = sysUser?.name ?? liveProfile?.["document.name"] ?? userName;
                 const photoPath = liveProfile?.photo || sysUser?.photo;
                 const special = SPECIAL_AVATARS[userName.toLowerCase()];
+                // Drop decorator tokens like "(Admin)" so initials come from the real name words.
+                const trimmed = displayName
+                  .trim()
+                  .split(/\s+/)
+                  .filter((word) => /^\p{L}/u.test(word))
+                  .join(" ");
                 // getAvatarIcon picks the first letter of the first and last words.
                 // Split a single-word name so it still produces two initials (e.g. "system" → "SY").
-                const trimmed = displayName.trim();
                 const nameForAvatar =
                   trimmed.includes(" ") || trimmed.length < 2 ? trimmed : `${trimmed[0]} ${trimmed.slice(1)}`;
                 accessories.push({
@@ -397,7 +403,10 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
                     (photoPath
                       ? { source: `${instanceUrl}/${photoPath}.iix?t=small`, mask: Image.Mask.Circle }
                       : getAvatarIcon(nameForAvatar)),
-                  tooltip: displayName === userName ? `Updated by: ${displayName}` : `Updated by: ${displayName} (${userName})`,
+                  tooltip:
+                    displayName === userName
+                      ? `Updated by: ${displayName}`
+                      : `Updated by: ${displayName} (${userName})`,
                 });
               }
               return (

--- a/extensions/servicenow/src/components/TableRecords.tsx
+++ b/extensions/servicenow/src/components/TableRecords.tsx
@@ -22,6 +22,7 @@ const SPECIAL_AVATARS: Record<string, Image.ImageLike> = {
   system: { source: Icon.ComputerChip, tintColor: Color.Purple },
   admin: { source: Icon.Shield, tintColor: Color.Orange },
   guest: { source: Icon.PersonCircle, tintColor: Color.SecondaryText },
+  maint: { source: Icon.Cog, tintColor: Color.Blue },
 };
 
 interface DictionaryResponse {
@@ -386,9 +387,14 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
                 const displayName = sysUser?.name ?? liveProfile?.["document.name"] ?? userName;
                 const photoPath = liveProfile?.photo || sysUser?.photo;
                 const special = SPECIAL_AVATARS[userName.toLowerCase()];
+                // Drop decorator tokens like "(Admin)" so initials come from the real name words.
+                const trimmed = displayName
+                  .trim()
+                  .split(/\s+/)
+                  .filter((word) => /^\p{L}/u.test(word))
+                  .join(" ");
                 // getAvatarIcon picks the first letter of the first and last words.
                 // Split a single-word name so it still produces two initials (e.g. "system" → "SY").
-                const trimmed = displayName.trim();
                 const nameForAvatar =
                   trimmed.includes(" ") || trimmed.length < 2 ? trimmed : `${trimmed[0]} ${trimmed.slice(1)}`;
                 accessories.push({

--- a/extensions/servicenow/src/components/TableRecords.tsx
+++ b/extensions/servicenow/src/components/TableRecords.tsx
@@ -108,8 +108,7 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
     return Array.from(set);
   }, [displayField]);
 
-  // Loaded before the records fetch so the URL builder can match search text
-  // against the updater's display name (live_profile.document.name).
+  // Maps each updater login to its photo/display name for the row avatar + tooltip.
   const { data: users = [] } = useFetch(
     `${instanceUrl}/api/now/table/live_profile?sysparm_query=type=user&sysparm_fields=sys_id,photo,document.user_name,document.name`,
     {
@@ -149,9 +148,9 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
     const terms = searchTerm.trim().split(/\s+/).filter(Boolean);
     const filters: string[] = [];
     if (extraQuery) filters.push(extraQuery);
-    // Each term gets its own (displayField OR sys_updated_by OR matching-users)
-    // group; groups are ANDed via the `^` join — so "importmate ruben" finds an
-    // "Importmate …" record updated by anyone named Ruben.
+    // Each term gets its own (displayField OR sys_updated_by) group; groups are
+    // ANDed via the `^` join — so "importmate ruben" finds an "Importmate …"
+    // record whose updater login contains "ruben".
     for (const term of terms) {
       const orParts: string[] = [];
       if (searchableFields.length > 0) {
@@ -160,19 +159,11 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
         orParts.push(`123TEXTQUERY321=${term}`);
       }
       orParts.push(`sys_updated_byLIKE${term}`);
-      const lower = term.toLowerCase();
-      const matchingUsernames = users
-        .filter((u) => u["document.name"]?.toLowerCase().includes(lower))
-        .map((u) => u["document.user_name"])
-        .filter(Boolean);
-      if (matchingUsernames.length > 0) {
-        orParts.push(`sys_updated_byIN${matchingUsernames.join(",")}`);
-      }
       filters.push(orParts.join("^OR"));
     }
     if (orderByUpdated) filters.push("ORDERBYDESCsys_updated_on");
     return filters.join("^");
-  }, [searchTerm, extraQuery, searchableFields, users, orderByUpdated]);
+  }, [searchTerm, extraQuery, searchableFields, orderByUpdated]);
 
   const { isLoading, data, error, revalidate, pagination } = useFetch(
     (options) => {
@@ -406,7 +397,7 @@ export default function TableRecords({ table, extraQuery }: { table: DBObject; e
                     (photoPath
                       ? { source: `${instanceUrl}/${photoPath}.iix?t=small`, mask: Image.Mask.Circle }
                       : getAvatarIcon(nameForAvatar)),
-                  tooltip: `Updated by: ${displayName}`,
+                  tooltip: displayName === userName ? `Updated by: ${displayName}` : `Updated by: ${displayName} (${userName})`,
                 });
               }
               return (

--- a/extensions/servicenow/src/find-references.tsx
+++ b/extensions/servicenow/src/find-references.tsx
@@ -16,11 +16,12 @@ import {
 } from "@raycast/api";
 
 import Actions from "./components/Actions";
+import InstanceForm from "./components/InstanceForm";
 import TableRecords from "./components/TableRecords";
 import { Instance } from "./types";
 import useInstances from "./hooks/useInstances";
 import { findReferences } from "./utils/snSnippets";
-import { ServiceNowClient } from "./utils/serviceNowClient";
+import { backgroundScriptAuthErrorMessage, ServiceNowClient } from "./utils/serviceNowClient";
 import { buildServiceNowUrl } from "./utils/buildServiceNowUrl";
 import { getURL } from "./utils/browserScripts";
 import { getInstanceBaseUrl, isServiceNowUrl } from "./utils/instanceUrl";
@@ -62,7 +63,15 @@ function decodeHtmlEntities(str: string): string {
 
 export default function FindReferences(props: LaunchProps) {
   const { table: argTable, sysId: argSysId, instanceName } = props.arguments;
-  const { instances, selectedInstance, setSelectedInstance, isLoading: isLoadingInstances } = useInstances();
+  const {
+    instances,
+    selectedInstance,
+    setSelectedInstance,
+    editInstance,
+    deleteInstance,
+    mutate,
+    isLoading: isLoadingInstances,
+  } = useInstances();
   const hasAnyArg = !!(argTable || argSysId || instanceName);
   const argTableTrimmed = argTable?.trim() || null;
   const argSysIdTrimmed = argSysId?.trim() || null;
@@ -77,6 +86,7 @@ export default function FindReferences(props: LaunchProps) {
   const [references, setReferences] = useState<Reference[] | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [errorFetching, setErrorFetching] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const detectionStarted = useRef(false);
 
   useEffect(() => {
@@ -170,6 +180,7 @@ export default function FindReferences(props: LaunchProps) {
     let cancelled = false;
     setIsLoading(true);
     setErrorFetching(false);
+    setErrorMessage(null);
     setReferences(null);
 
     (async () => {
@@ -179,6 +190,7 @@ export default function FindReferences(props: LaunchProps) {
       const authed = await client.init();
       if (cancelled) return;
       if (!authed) {
+        setErrorMessage(backgroundScriptAuthErrorMessage(selectedInstance));
         setErrorFetching(true);
         setIsLoading(false);
         return;
@@ -319,7 +331,23 @@ export default function FindReferences(props: LaunchProps) {
         <List.EmptyView
           icon={{ source: Icon.ExclamationMark, tintColor: Color.Red }}
           title="Could Not Fetch References"
-          description="Check that you are an admin on this instance and that the table name is correct."
+          description={
+            errorMessage ?? "Check that you are an admin on this instance and that the table name is correct."
+          }
+          actions={
+            errorMessage && selectedInstance ? (
+              <ActionPanel>
+                <Action.Push
+                  title="Edit Profile"
+                  icon={Icon.Pencil}
+                  target={
+                    <InstanceForm onSubmit={editInstance} onDelete={deleteInstance} instance={selectedInstance} />
+                  }
+                  onPop={mutate}
+                />
+              </ActionPanel>
+            ) : undefined
+          }
         />
       ) : references && references.length === 0 ? (
         <List.EmptyView

--- a/extensions/servicenow/src/find-references.tsx
+++ b/extensions/servicenow/src/find-references.tsx
@@ -198,12 +198,12 @@ export default function FindReferences(props: LaunchProps) {
       await client.startBackgroundScript(findReferences(target.table, target.sysId), (response) => {
         if (cancelled) return;
         const match = response.match(/###([\s\S]*?)###/);
-        if (!match || !match[1]) {
-          showToast({
-            style: Toast.Style.Failure,
-            title: "Could Not Search References",
-            message: "Check that you are an admin and the table name is correct.",
-          });
+        if (!match) {
+          // No marker means the background script never ran (missing admin access or SSO + basic auth).
+          showToast({ style: Toast.Style.Failure, title: "Could Not Search References" });
+          setErrorMessage(
+            `${backgroundScriptAuthErrorMessage(selectedInstance)} Also confirm the table name is correct.`,
+          );
           setErrorFetching(true);
           setIsLoading(false);
           return;

--- a/extensions/servicenow/src/find-references.tsx
+++ b/extensions/servicenow/src/find-references.tsx
@@ -21,7 +21,11 @@ import TableRecords from "./components/TableRecords";
 import { Instance } from "./types";
 import useInstances from "./hooks/useInstances";
 import { findReferences } from "./utils/snSnippets";
-import { backgroundScriptAuthErrorMessage, ServiceNowClient } from "./utils/serviceNowClient";
+import {
+  authenticationFailedMessage,
+  backgroundScriptBlockedMessage,
+  ServiceNowClient,
+} from "./utils/serviceNowClient";
 import { buildServiceNowUrl } from "./utils/buildServiceNowUrl";
 import { getURL } from "./utils/browserScripts";
 import { getInstanceBaseUrl, isServiceNowUrl } from "./utils/instanceUrl";
@@ -87,6 +91,7 @@ export default function FindReferences(props: LaunchProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [errorFetching, setErrorFetching] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
   const detectionStarted = useRef(false);
 
   useEffect(() => {
@@ -190,7 +195,7 @@ export default function FindReferences(props: LaunchProps) {
       const authed = await client.init();
       if (cancelled) return;
       if (!authed) {
-        setErrorMessage(backgroundScriptAuthErrorMessage(selectedInstance));
+        setErrorMessage(authenticationFailedMessage(selectedInstance));
         setErrorFetching(true);
         setIsLoading(false);
         return;
@@ -202,7 +207,7 @@ export default function FindReferences(props: LaunchProps) {
           // No marker means the background script never ran (missing admin access or SSO + basic auth).
           showToast({ style: Toast.Style.Failure, title: "Could Not Search References" });
           setErrorMessage(
-            `${backgroundScriptAuthErrorMessage(selectedInstance)} Also confirm the table name is correct.`,
+            `${backgroundScriptBlockedMessage(selectedInstance)} Also confirm the table name is correct.`,
           );
           setErrorFetching(true);
           setIsLoading(false);
@@ -223,7 +228,7 @@ export default function FindReferences(props: LaunchProps) {
     return () => {
       cancelled = true;
     };
-  }, [selectedInstance?.id, target?.table, target?.sysId]);
+  }, [selectedInstance?.id, target?.table, target?.sysId, retryCount]);
 
   const onInstanceChange = (newValue: string) => {
     const found = instances.find((i) => i.id === newValue);
@@ -343,7 +348,10 @@ export default function FindReferences(props: LaunchProps) {
                   target={
                     <InstanceForm onSubmit={editInstance} onDelete={deleteInstance} instance={selectedInstance} />
                   }
-                  onPop={mutate}
+                  onPop={() => {
+                    mutate();
+                    setRetryCount((c) => c + 1);
+                  }}
                 />
               </ActionPanel>
             ) : undefined

--- a/extensions/servicenow/src/search-sysid.tsx
+++ b/extensions/servicenow/src/search-sysid.tsx
@@ -20,7 +20,11 @@ import InstanceForm from "./components/InstanceForm";
 import { Instance } from "./types";
 import useInstances from "./hooks/useInstances";
 import { findSysID } from "./utils/snSnippets";
-import { backgroundScriptAuthErrorMessage, ServiceNowClient } from "./utils/serviceNowClient";
+import {
+  authenticationFailedMessage,
+  backgroundScriptBlockedMessage,
+  ServiceNowClient,
+} from "./utils/serviceNowClient";
 import { buildServiceNowUrl } from "./utils/buildServiceNowUrl";
 import { instanceLabel } from "./utils/instanceLabel";
 import { matchInstance, notFoundToast, NO_PROFILES_TOAST } from "./utils/instanceResolver";
@@ -63,6 +67,7 @@ export default function SearchSysId(props: LaunchProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [canReconfigure, setCanReconfigure] = useState(false);
+  const [retryCount, setRetryCount] = useState(0);
   const detectionStarted = useRef(false);
 
   useEffect(() => {
@@ -114,7 +119,7 @@ export default function SearchSysId(props: LaunchProps) {
       const authed = await client.init();
       if (cancelled) return;
       if (!authed) {
-        setErrorMessage(backgroundScriptAuthErrorMessage(selectedInstance));
+        setErrorMessage(authenticationFailedMessage(selectedInstance));
         setCanReconfigure(true);
         setIsLoading(false);
         return;
@@ -125,7 +130,7 @@ export default function SearchSysId(props: LaunchProps) {
         if (answer == null) {
           // No marker means the background script never ran (missing admin access or SSO + basic auth).
           showToast({ style: Toast.Style.Failure, title: "Could Not Run Lookup" });
-          setErrorMessage(backgroundScriptAuthErrorMessage(selectedInstance));
+          setErrorMessage(backgroundScriptBlockedMessage(selectedInstance));
           setCanReconfigure(true);
           setIsLoading(false);
         } else if (answer[1] && answer[1] !== "NOT_FOUND") {
@@ -144,7 +149,7 @@ export default function SearchSysId(props: LaunchProps) {
     return () => {
       cancelled = true;
     };
-  }, [selectedInstance?.id, sysId]);
+  }, [selectedInstance?.id, sysId, retryCount]);
 
   const onInstanceChange = (newValue: string) => {
     const found = instances.find((i) => i.id === newValue);
@@ -261,7 +266,10 @@ export default function SearchSysId(props: LaunchProps) {
                   target={
                     <InstanceForm onSubmit={editInstance} onDelete={deleteInstance} instance={selectedInstance} />
                   }
-                  onPop={mutate}
+                  onPop={() => {
+                    mutate();
+                    setRetryCount((c) => c + 1);
+                  }}
                 />
               )}
               <Action title="Try Another Sys ID" icon={Icon.MagnifyingGlass} onAction={resetToForm} />

--- a/extensions/servicenow/src/search-sysid.tsx
+++ b/extensions/servicenow/src/search-sysid.tsx
@@ -62,6 +62,7 @@ export default function SearchSysId(props: LaunchProps) {
   }, []);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [canReconfigure, setCanReconfigure] = useState(false);
   const detectionStarted = useRef(false);
 
   useEffect(() => {
@@ -104,6 +105,7 @@ export default function SearchSysId(props: LaunchProps) {
     let cancelled = false;
     setIsLoading(true);
     setErrorMessage(null);
+    setCanReconfigure(false);
 
     (async () => {
       const client = new ServiceNowClient(selectedInstance, (updated) => {
@@ -113,21 +115,20 @@ export default function SearchSysId(props: LaunchProps) {
       if (cancelled) return;
       if (!authed) {
         setErrorMessage(backgroundScriptAuthErrorMessage(selectedInstance));
+        setCanReconfigure(true);
         setIsLoading(false);
         return;
       }
       await client.startBackgroundScript(findSysID(sysId), (response) => {
         if (cancelled) return;
         const answer = response.match(/###(.*)###/);
-        if (response.length === 0) {
-          showToast({
-            style: Toast.Style.Failure,
-            title: "Could Not Search for Sys ID",
-            message: "Admin access is required.",
-          });
-          setErrorMessage("Admin access is required to run this lookup.");
+        if (answer == null) {
+          // No marker means the background script never ran (missing admin access or SSO + basic auth).
+          showToast({ style: Toast.Style.Failure, title: "Could Not Run Lookup" });
+          setErrorMessage(backgroundScriptAuthErrorMessage(selectedInstance));
+          setCanReconfigure(true);
           setIsLoading(false);
-        } else if (answer != null && answer[1]) {
+        } else if (answer[1] && answer[1] !== "NOT_FOUND") {
           const table = answer[1].split("^")[0];
           open(buildServiceNowUrl(selectedInstance.name, `${table}.do?sys_id=${sysId}`));
           popToRoot();
@@ -253,8 +254,7 @@ export default function SearchSysId(props: LaunchProps) {
           description={errorMessage}
           actions={
             <ActionPanel>
-              <Action title="Try Another Sys ID" icon={Icon.MagnifyingGlass} onAction={resetToForm} />
-              {selectedInstance && (
+              {canReconfigure && selectedInstance && (
                 <Action.Push
                   title="Edit Profile"
                   icon={Icon.Pencil}
@@ -264,6 +264,7 @@ export default function SearchSysId(props: LaunchProps) {
                   onPop={mutate}
                 />
               )}
+              <Action title="Try Another Sys ID" icon={Icon.MagnifyingGlass} onAction={resetToForm} />
             </ActionPanel>
           }
         />

--- a/extensions/servicenow/src/search-sysid.tsx
+++ b/extensions/servicenow/src/search-sysid.tsx
@@ -16,10 +16,11 @@ import {
 } from "@raycast/api";
 
 import Actions from "./components/Actions";
+import InstanceForm from "./components/InstanceForm";
 import { Instance } from "./types";
 import useInstances from "./hooks/useInstances";
 import { findSysID } from "./utils/snSnippets";
-import { ServiceNowClient } from "./utils/serviceNowClient";
+import { backgroundScriptAuthErrorMessage, ServiceNowClient } from "./utils/serviceNowClient";
 import { buildServiceNowUrl } from "./utils/buildServiceNowUrl";
 import { instanceLabel } from "./utils/instanceLabel";
 import { matchInstance, notFoundToast, NO_PROFILES_TOAST } from "./utils/instanceResolver";
@@ -40,7 +41,15 @@ function sourceSuffix(source: SysIdSource | null): string {
 
 export default function SearchSysId(props: LaunchProps) {
   const { sys_id: argSysId, instanceName } = props.arguments;
-  const { instances, selectedInstance, setSelectedInstance, isLoading: isLoadingInstances } = useInstances();
+  const {
+    instances,
+    selectedInstance,
+    setSelectedInstance,
+    editInstance,
+    deleteInstance,
+    mutate,
+    isLoading: isLoadingInstances,
+  } = useInstances();
   const argTrimmed = argSysId?.trim() || null;
   const argInitial = argTrimmed && SYS_ID_RE.test(argTrimmed) ? argTrimmed : null;
   const argInvalid = argTrimmed !== null && argInitial === null;
@@ -103,7 +112,7 @@ export default function SearchSysId(props: LaunchProps) {
       const authed = await client.init();
       if (cancelled) return;
       if (!authed) {
-        setErrorMessage("Authentication failed");
+        setErrorMessage(backgroundScriptAuthErrorMessage(selectedInstance));
         setIsLoading(false);
         return;
       }
@@ -245,6 +254,16 @@ export default function SearchSysId(props: LaunchProps) {
           actions={
             <ActionPanel>
               <Action title="Try Another Sys ID" icon={Icon.MagnifyingGlass} onAction={resetToForm} />
+              {selectedInstance && (
+                <Action.Push
+                  title="Edit Profile"
+                  icon={Icon.Pencil}
+                  target={
+                    <InstanceForm onSubmit={editInstance} onDelete={deleteInstance} instance={selectedInstance} />
+                  }
+                  onPop={mutate}
+                />
+              )}
             </ActionPanel>
           }
         />

--- a/extensions/servicenow/src/types.ts
+++ b/extensions/servicenow/src/types.ts
@@ -178,21 +178,6 @@ export interface FavoriteRecord {
   group?: string;
 }
 
-export interface CodeSearchResponse {
-  result: CodeSearchTableResult[];
-}
-
-export interface CodeSearchGroupsResponse {
-  result: CodeSearchGroupRecord[];
-}
-
-export interface CodeSearchGroupRecord {
-  sys_id: string;
-  name: string;
-  // Dot-walked from sys_scope reference; returned as a flat key by the Table API.
-  "sys_scope.scope": string;
-}
-
 export interface CodeSearchTableResult {
   tableLabel: string;
   recordType: string;

--- a/extensions/servicenow/src/utils/getSectionTitle.ts
+++ b/extensions/servicenow/src/utils/getSectionTitle.ts
@@ -7,6 +7,13 @@ const timeAgo = new TimeAgo("en-US");
 
 export const getSectionTitle = (dateTime: string) => {
   const utcDate = new Date(dateTime + " UTC");
+  // Tables without a sys_updated_on field (or with an unparseable value) yield an
+  // Invalid Date; guard so timeAgo.format() below isn't handed a NaN timestamp,
+  // which throws RangeError: Invalid "number" argument: NaN.
+  if (isNaN(utcDate.getTime())) {
+    return "Unknown date";
+  }
+
   const diffInMinutes = differenceInMinutes(new Date(), utcDate);
 
   if (diffInMinutes < 1) {

--- a/extensions/servicenow/src/utils/serviceNowClient.ts
+++ b/extensions/servicenow/src/utils/serviceNowClient.ts
@@ -4,11 +4,10 @@ import { OnTokenRefresh } from "./auth";
 import { serviceNowFetchRaw } from "./serviceNowFetch";
 
 export function backgroundScriptAuthErrorMessage(instance: Instance): string {
-  const base = "Could not authenticate against /sys.scripts.do, which requires admin access.";
   if (instance.authMode === "oauth") {
-    return `${base} Verify your OAuth user has the admin role on this instance.`;
+    return "The background script could not run. Verify your OAuth user has the admin role on this instance.";
   }
-  return `${base} If this instance uses SSO, basic auth can't establish a session — edit this profile and switch Authentication to OAuth. Otherwise verify your username, password, and admin role.`;
+  return "The background script could not run. If this instance uses SSO, basic auth can sign in but can't run background scripts — edit this profile and switch Authentication to OAuth. Otherwise verify your credentials and admin role.";
 }
 
 export class ServiceNowClient {

--- a/extensions/servicenow/src/utils/serviceNowClient.ts
+++ b/extensions/servicenow/src/utils/serviceNowClient.ts
@@ -3,11 +3,20 @@ import { Instance } from "../types";
 import { OnTokenRefresh } from "./auth";
 import { serviceNowFetchRaw } from "./serviceNowFetch";
 
-export function backgroundScriptAuthErrorMessage(instance: Instance): string {
+// Shown when /sn_devstudio_/v1/get_publish_info rejects the request — sign-in failed.
+export function authenticationFailedMessage(instance: Instance): string {
+  if (instance.authMode === "oauth") {
+    return "Could not authenticate. Re-sign in and verify your OAuth user has the admin role on this instance.";
+  }
+  return "Could not authenticate. Check your username and password, and that the account has the admin role. If this instance uses SSO, switch this profile to OAuth.";
+}
+
+// Shown when sign-in succeeded but the background script never ran (admin-only /sys.scripts.do).
+export function backgroundScriptBlockedMessage(instance: Instance): string {
   if (instance.authMode === "oauth") {
     return "The background script could not run. Verify your OAuth user has the admin role on this instance.";
   }
-  return "The background script could not run. If this instance uses SSO, basic auth can sign in but can't run background scripts — edit this profile and switch Authentication to OAuth. Otherwise verify your credentials and admin role.";
+  return "The background script could not run. Check that you have the admin role. If this instance uses SSO, switch this profile to OAuth.";
 }
 
 export class ServiceNowClient {

--- a/extensions/servicenow/src/utils/serviceNowClient.ts
+++ b/extensions/servicenow/src/utils/serviceNowClient.ts
@@ -3,6 +3,14 @@ import { Instance } from "../types";
 import { OnTokenRefresh } from "./auth";
 import { serviceNowFetchRaw } from "./serviceNowFetch";
 
+export function backgroundScriptAuthErrorMessage(instance: Instance): string {
+  const base = "Could not authenticate against /sys.scripts.do, which requires admin access.";
+  if (instance.authMode === "oauth") {
+    return `${base} Verify your OAuth user has the admin role on this instance.`;
+  }
+  return `${base} If this instance uses SSO, basic auth can't establish a session — edit this profile and switch Authentication to OAuth. Otherwise verify your username, password, and admin role.`;
+}
+
 export class ServiceNowClient {
   private instance: Instance;
   private onRefresh?: OnTokenRefresh;

--- a/extensions/servicenow/src/utils/serviceNowFetch.ts
+++ b/extensions/servicenow/src/utils/serviceNowFetch.ts
@@ -2,17 +2,6 @@ import { Instance } from "../types";
 import { getAuthHeader, OnTokenRefresh } from "./auth";
 import { getInstanceBaseUrl } from "./instanceUrl";
 
-export class ServiceNowApiError extends Error {
-  status: number;
-  body: string;
-  constructor(status: number, body: string, message: string) {
-    super(message);
-    this.name = "ServiceNowApiError";
-    this.status = status;
-    this.body = body;
-  }
-}
-
 export type ServiceNowFetchOptions = Omit<RequestInit, "headers"> & {
   headers?: Record<string, string>;
   noAuth?: boolean;
@@ -39,24 +28,4 @@ export async function serviceNowFetchRaw(
 ): Promise<Response> {
   const init = await buildRequestInit(instance, options);
   return fetch(buildUrl(instance, path), init);
-}
-
-export async function serviceNowFetch<T = unknown>(
-  instance: Instance,
-  path: string,
-  options?: ServiceNowFetchOptions,
-): Promise<T> {
-  const response = await serviceNowFetchRaw(instance, path, {
-    ...options,
-    headers: { Accept: "application/json", ...(options?.headers ?? {}) },
-  });
-  if (!response.ok) {
-    const body = await response.text();
-    throw new ServiceNowApiError(
-      response.status,
-      body,
-      `Request failed (${response.status}): ${body || response.statusText}`,
-    );
-  }
-  return (await response.json()) as T;
 }

--- a/extensions/servicenow/src/utils/snSnippets.js
+++ b/extensions/servicenow/src/utils/snSnippets.js
@@ -113,6 +113,7 @@ export function findSysID(sys_id) {
         return;
       }
     }
+    gs.print("###NOT_FOUND###");
     function findClass(table, sys_id) {
       try {
         var grTable = new GlideRecord(table);


### PR DESCRIPTION
## Description

Follow-up fixes for the ServiceNow extension after the OAuth/Windows release.

### Fixes
- **Explore Records** now works on database views (`v_*`) and other tables without a `sys_updated_on` column. Before, the `ORDERBY sys_updated_on` failed the whole request (HTTP 500), and an unparseable update date could crash the list. The order-by is now skipped upfront for views and falls back on error for the rare non-view table that also lacks the column.
- **Find Record by Sys ID** and **Find Record References** now distinguish a sign-in failure from a missing admin role, and offer an **Edit Profile** action to fix the profile and retry in place. When an instance uses SSO, the message points you to switch the profile to OAuth, since Basic Auth can't run the background scripts these commands rely on.

### Internals
- Switched **Explore Records** to `sysparm_display_value=all` (shows display values, keeps the raw UTC `sys_updated_on` for the relative-date labels).
- Updater avatars show display name + login in the tooltip and derive initials from real name words, ignoring decorators like "(Admin)".
- Removed unused response types and the unused `serviceNowFetch` / `ServiceNowApiError` helpers.

## Screencast

<!-- TODO: add a short screencast/screenshot of Explore Records on a database view and the Edit Profile recovery action -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our metadata tool
