### PR TITLE
[Monocle] Add commands for app v3.5.1

### DIFF
--- a/extensions/monocle/CHANGELOG.md
+++ b/extensions/monocle/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Monocle Changelog
 
+## [Expanded Monocle 3.5.1 commands] - {PR_MERGE_DATE}
+
+- Added blur, grain, monochrome, and tint opacity commands (0–100 argument)
+- Added tint preset dropdown and custom hex color commands
+- Added monochrome on/off/toggle commands
+- Added app-wide focus on/off/toggle commands
+- Added per-screen and global display mode commands
+- Added open settings, check for updates, and quit Monocle commands
+
 ## [Initial Version] - 2026-01-14
 
 - Added overlay toggle commands (on/off/toggle)

--- a/extensions/monocle/CHANGELOG.md
+++ b/extensions/monocle/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Monocle Changelog
 
-## [Expanded Monocle 3.5.1 commands] - {PR_MERGE_DATE}
+## [Expanded Monocle 3.5.1 commands] - 2026-06-15
 
 - Added blur, grain, monochrome, and tint opacity commands (0–100 argument)
 - Added tint preset dropdown and custom hex color commands

--- a/extensions/monocle/README.md
+++ b/extensions/monocle/README.md
@@ -1,6 +1,6 @@
 # Monocle
 
-Control [Monocle](https://www.heyiam.dk/monocle) 3.0 for macOS directly from Raycast.
+Control [Monocle](https://www.heyiam.dk/monocle) for macOS directly from Raycast.
 
 Monocle is a noise-cancelling app for your screen with cursor shake detection.
 
@@ -11,20 +11,32 @@ Monocle is a noise-cancelling app for your screen with cursor shake detection.
 | Command | Description |
 |---------|-------------|
 | Toggle Overlay | Turn the Monocle overlay on or off |
-| Toggle Focus Mode | Switch between Ambient and Deep mode |
-| Toggle App Exclusion | Include or exclude current app from overlay |
+| Toggle Focus Mode | Switch between Ambient and Deep |
+| Toggle App Exclusion | Include or exclude the current app |
+| Set Blur | Set the blur intensity (0–100) |
+| Toggle Monochrome | Turn the monochrome effect on or off |
+| Set Tint Preset | Pick a tint color from a dropdown |
+| Toggle App-Wide Focus | Show all windows from the focused app |
 
 ### Additional Commands (enable in settings)
 
 | Command | Description |
 |---------|-------------|
-| Turn Overlay On | Enable the overlay |
-| Turn Overlay Off | Disable the overlay |
-| Ambient Mode | Set focus mode to gradient |
-| Deep Focus Mode | Set focus mode to fullscreen |
-| Exclude Current App | Add app to ignore list |
-| Include Current App | Remove app from ignore list |
+| Turn Overlay on / off | Explicit overlay on/off |
+| Ambient Mode / Deep Focus Mode | Set focus mode directly |
+| Exclude / Include Current App | Direct app ignore-list control |
+| Set Grain | Set the grain intensity (0–100) |
+| Turn Monochrome on / off | Explicit monochrome on/off |
+| Set Monochrome | Set the monochrome intensity (0–100) |
+| Set Tint Opacity | Set the tint opacity (0–100) |
+| Set Tint Color (Hex) | Set a custom tint from a RRGGBB hex value |
+| Per-Screen Display Mode | Render the overlay on each screen independently |
+| Global Display Mode | Anchor the overlay to one screen |
+| Turn App-Wide Focus on / off | Explicit app-wide focus on/off |
+| Open Settings | Open the Monocle settings window |
+| Check for Updates | Run Monocle's update check |
+| Quit Monocle | Quit the Monocle app |
 
 ## Requirements
 
-- [Monocle](https://www.heyiam.dk/monocle) must be installed and running
+- [Monocle](https://www.heyiam.dk/monocle) 3.5.1 or later must be installed and running

--- a/extensions/monocle/README.md
+++ b/extensions/monocle/README.md
@@ -8,34 +8,34 @@ Monocle is a noise-cancelling app for your screen with cursor shake detection.
 
 ### Default Commands (enabled on install)
 
-| Command | Description |
-|---------|-------------|
-| Toggle Overlay | Turn the Monocle overlay on or off |
-| Toggle Focus Mode | Switch between Ambient and Deep |
-| Toggle App Exclusion | Include or exclude the current app |
-| Set Blur | Set the blur intensity (0–100) |
-| Toggle Monochrome | Turn the monochrome effect on or off |
-| Set Tint Preset | Pick a tint color from a dropdown |
+| Command               | Description                           |
+| --------------------- | ------------------------------------- |
+| Toggle Overlay        | Turn the Monocle overlay on or off    |
+| Toggle Focus Mode     | Switch between Ambient and Deep       |
+| Toggle App Exclusion  | Include or exclude the current app    |
+| Set Blur              | Set the blur intensity (0–100)        |
+| Toggle Monochrome     | Turn the monochrome effect on or off  |
+| Set Tint Preset       | Pick a tint color from a dropdown     |
 | Toggle App-Wide Focus | Show all windows from the focused app |
 
 ### Additional Commands (enable in settings)
 
-| Command | Description |
-|---------|-------------|
-| Turn Overlay on / off | Explicit overlay on/off |
-| Ambient Mode / Deep Focus Mode | Set focus mode directly |
-| Exclude / Include Current App | Direct app ignore-list control |
-| Set Grain | Set the grain intensity (0–100) |
-| Turn Monochrome on / off | Explicit monochrome on/off |
-| Set Monochrome | Set the monochrome intensity (0–100) |
-| Set Tint Opacity | Set the tint opacity (0–100) |
-| Set Tint Color (Hex) | Set a custom tint from a RRGGBB hex value |
-| Per-Screen Display Mode | Render the overlay on each screen independently |
-| Global Display Mode | Anchor the overlay to one screen |
-| Turn App-Wide Focus on / off | Explicit app-wide focus on/off |
-| Open Settings | Open the Monocle settings window |
-| Check for Updates | Run Monocle's update check |
-| Quit Monocle | Quit the Monocle app |
+| Command                        | Description                                     |
+| ------------------------------ | ----------------------------------------------- |
+| Turn Overlay on / off          | Explicit overlay on/off                         |
+| Ambient Mode / Deep Focus Mode | Set focus mode directly                         |
+| Exclude / Include Current App  | Direct app ignore-list control                  |
+| Set Grain                      | Set the grain intensity (0–100)                 |
+| Turn Monochrome on / off       | Explicit monochrome on/off                      |
+| Set Monochrome                 | Set the monochrome intensity (0–100)            |
+| Set Tint Opacity               | Set the tint opacity (0–100)                    |
+| Set Tint Color (Hex)           | Set a custom tint from a RRGGBB hex value       |
+| Per-Screen Display Mode        | Render the overlay on each screen independently |
+| Global Display Mode            | Anchor the overlay to one screen                |
+| Turn App-Wide Focus on / off   | Explicit app-wide focus on/off                  |
+| Open Settings                  | Open the Monocle settings window                |
+| Check for Updates              | Run Monocle's update check                      |
+| Quit Monocle                   | Quit the Monocle app                            |
 
 ## Requirements
 

--- a/extensions/monocle/package-lock.json
+++ b/extensions/monocle/package-lock.json
@@ -19,6 +19,70 @@
         "typescript": "^5.8.2"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
@@ -30,6 +94,342 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -703,6 +1103,7 @@
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.1.tgz",
       "integrity": "sha512-5v52JDzAAoCA6/JOoBfsgCXK4fzIY02lvMH0IA3ghuxZuk8i2ID2rtPkTuIAbebpkILADB7gP4yaBphkMLiCJA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.5.4",
         "@oclif/plugin-autocomplete": "^3.2.35",
@@ -804,6 +1205,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -862,6 +1264,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -1066,6 +1469,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1426,6 +1830,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2210,6 +2615,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2233,6 +2639,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2460,6 +2867,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/monocle/package.json
+++ b/extensions/monocle/package.json
@@ -25,7 +25,7 @@
     },
     {
       "name": "on",
-      "title": "Turn Overlay on",
+      "title": "Turn Overlay On",
       "subtitle": "Enable the overlay",
       "description": "Turn the Monocle overlay on",
       "mode": "no-view",
@@ -33,7 +33,7 @@
     },
     {
       "name": "off",
-      "title": "Turn Overlay off",
+      "title": "Turn Overlay Off",
       "subtitle": "Disable the overlay",
       "description": "Turn the Monocle overlay off",
       "mode": "no-view",
@@ -125,7 +125,7 @@
     },
     {
       "name": "monochrome-on",
-      "title": "Turn Monochrome on",
+      "title": "Turn Monochrome On",
       "subtitle": "Enable monochrome",
       "description": "Turn the Monocle monochrome effect on",
       "mode": "no-view",
@@ -133,7 +133,7 @@
     },
     {
       "name": "monochrome-off",
-      "title": "Turn Monochrome off",
+      "title": "Turn Monochrome Off",
       "subtitle": "Disable monochrome",
       "description": "Turn the Monocle monochrome effect off",
       "mode": "no-view",
@@ -168,16 +168,46 @@
           "type": "dropdown",
           "required": true,
           "data": [
-            { "title": "System", "value": "system" },
-            { "title": "Blue", "value": "blue" },
-            { "title": "Purple", "value": "purple" },
-            { "title": "Pink", "value": "pink" },
-            { "title": "Red", "value": "red" },
-            { "title": "Orange", "value": "orange" },
-            { "title": "Yellow", "value": "yellow" },
-            { "title": "Green", "value": "green" },
-            { "title": "Graphite", "value": "graphite" },
-            { "title": "Black", "value": "black" }
+            {
+              "title": "System",
+              "value": "system"
+            },
+            {
+              "title": "Blue",
+              "value": "blue"
+            },
+            {
+              "title": "Purple",
+              "value": "purple"
+            },
+            {
+              "title": "Pink",
+              "value": "pink"
+            },
+            {
+              "title": "Red",
+              "value": "red"
+            },
+            {
+              "title": "Orange",
+              "value": "orange"
+            },
+            {
+              "title": "Yellow",
+              "value": "yellow"
+            },
+            {
+              "title": "Green",
+              "value": "green"
+            },
+            {
+              "title": "Graphite",
+              "value": "graphite"
+            },
+            {
+              "title": "Black",
+              "value": "black"
+            }
           ]
         }
       ]
@@ -239,7 +269,7 @@
     },
     {
       "name": "app-wide-focus-on",
-      "title": "Turn App-Wide Focus on",
+      "title": "Turn App-Wide Focus On",
       "subtitle": "Enable showing all windows",
       "description": "Turn app-wide focus on (show all windows from the focused app)",
       "mode": "no-view",
@@ -247,7 +277,7 @@
     },
     {
       "name": "app-wide-focus-off",
-      "title": "Turn App-Wide Focus off",
+      "title": "Turn App-Wide Focus Off",
       "subtitle": "Disable showing all windows",
       "description": "Turn app-wide focus off",
       "mode": "no-view",

--- a/extensions/monocle/package.json
+++ b/extensions/monocle/package.json
@@ -2,9 +2,12 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "monocle",
   "title": "Monocle",
-  "description": "Extension to control Monocle 3.0 for macOS\n\nNoise-cancelling for your  screen now with cursor shake",
+  "description": "Extension to control Monocle for macOS\n\nNoise-cancelling for your screen with cursor shake",
   "icon": "extension-icon.png",
   "author": "emlez",
+  "contributors": [
+    "heyiamdk"
+  ],
   "platforms": [
     "macOS"
   ],
@@ -39,14 +42,14 @@
     {
       "name": "toggle-mode",
       "title": "Toggle Focus Mode",
-      "subtitle": "Switch between Ambient and Deep mode",
+      "subtitle": "Switch between Ambient and Deep",
       "description": "Toggle the focus mode between Ambient and Deep",
       "mode": "no-view"
     },
     {
       "name": "ambient",
       "title": "Ambient Mode",
-      "subtitle": "Set focus mode to gradient",
+      "subtitle": "Gradient overlay",
       "description": "Set focus mode to Ambient (gradient overlay)",
       "mode": "no-view",
       "disabledByDefault": true
@@ -54,7 +57,7 @@
     {
       "name": "deep",
       "title": "Deep Focus Mode",
-      "subtitle": "Set focus mode to fullscreen",
+      "subtitle": "Fullscreen overlay",
       "description": "Set focus mode to Deep (fullscreen overlay)",
       "mode": "no-view",
       "disabledByDefault": true
@@ -70,7 +73,7 @@
       "name": "ignore",
       "title": "Exclude Current App",
       "subtitle": "Add app to ignore list",
-      "description": "Exclude the currently focused app from Monocle overlay",
+      "description": "Exclude the currently focused app from the Monocle overlay",
       "mode": "no-view",
       "disabledByDefault": true
     },
@@ -78,7 +81,199 @@
       "name": "unignore",
       "title": "Include Current App",
       "subtitle": "Remove app from ignore list",
-      "description": "Include the currently focused app in Monocle overlay",
+      "description": "Include the currently focused app in the Monocle overlay",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
+      "name": "set-blur",
+      "title": "Set Blur",
+      "subtitle": "Blur intensity",
+      "description": "Set the Monocle blur intensity (0–100)",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "level",
+          "placeholder": "0–100",
+          "type": "text",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "set-grain",
+      "title": "Set Grain",
+      "subtitle": "Grain intensity",
+      "description": "Set the Monocle grain intensity (0–100)",
+      "mode": "no-view",
+      "disabledByDefault": true,
+      "arguments": [
+        {
+          "name": "level",
+          "placeholder": "0–100",
+          "type": "text",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "toggle-monochrome",
+      "title": "Toggle Monochrome",
+      "subtitle": "Turn monochrome on or off",
+      "description": "Toggle the Monocle monochrome effect on or off",
+      "mode": "no-view"
+    },
+    {
+      "name": "monochrome-on",
+      "title": "Turn Monochrome on",
+      "subtitle": "Enable monochrome",
+      "description": "Turn the Monocle monochrome effect on",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
+      "name": "monochrome-off",
+      "title": "Turn Monochrome off",
+      "subtitle": "Disable monochrome",
+      "description": "Turn the Monocle monochrome effect off",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
+      "name": "set-monochrome",
+      "title": "Set Monochrome",
+      "subtitle": "Monochrome intensity",
+      "description": "Set the Monocle monochrome intensity (0–100)",
+      "mode": "no-view",
+      "disabledByDefault": true,
+      "arguments": [
+        {
+          "name": "level",
+          "placeholder": "0–100",
+          "type": "text",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "set-tint-preset",
+      "title": "Set Tint Preset",
+      "subtitle": "Pick a tint color",
+      "description": "Set the Monocle tint to a preset color",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "preset",
+          "placeholder": "Preset",
+          "type": "dropdown",
+          "required": true,
+          "data": [
+            { "title": "System", "value": "system" },
+            { "title": "Blue", "value": "blue" },
+            { "title": "Purple", "value": "purple" },
+            { "title": "Pink", "value": "pink" },
+            { "title": "Red", "value": "red" },
+            { "title": "Orange", "value": "orange" },
+            { "title": "Yellow", "value": "yellow" },
+            { "title": "Green", "value": "green" },
+            { "title": "Graphite", "value": "graphite" },
+            { "title": "Black", "value": "black" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "set-tint-opacity",
+      "title": "Set Tint Opacity",
+      "subtitle": "Tint opacity",
+      "description": "Set the Monocle tint opacity (0–100)",
+      "mode": "no-view",
+      "disabledByDefault": true,
+      "arguments": [
+        {
+          "name": "level",
+          "placeholder": "0–100",
+          "type": "text",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "set-tint-hex",
+      "title": "Set Tint Color (Hex)",
+      "subtitle": "Custom tint color",
+      "description": "Set the Monocle tint to a custom RRGGBB hex color",
+      "mode": "no-view",
+      "disabledByDefault": true,
+      "arguments": [
+        {
+          "name": "hex",
+          "placeholder": "RRGGBB",
+          "type": "text",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "display-per-screen",
+      "title": "Per-Screen Display Mode",
+      "subtitle": "Render per screen",
+      "description": "Render the Monocle overlay on each screen independently",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
+      "name": "display-global",
+      "title": "Global Display Mode",
+      "subtitle": "Render globally",
+      "description": "Render the Monocle overlay anchored to one screen",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
+      "name": "toggle-app-wide-focus",
+      "title": "Toggle App-Wide Focus",
+      "subtitle": "Show all windows from active app",
+      "description": "Toggle showing all windows from the focused app",
+      "mode": "no-view"
+    },
+    {
+      "name": "app-wide-focus-on",
+      "title": "Turn App-Wide Focus on",
+      "subtitle": "Enable showing all windows",
+      "description": "Turn app-wide focus on (show all windows from the focused app)",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
+      "name": "app-wide-focus-off",
+      "title": "Turn App-Wide Focus off",
+      "subtitle": "Disable showing all windows",
+      "description": "Turn app-wide focus off",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
+      "name": "open-settings",
+      "title": "Open Settings",
+      "subtitle": "Open the settings window",
+      "description": "Open the Monocle settings window",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
+      "name": "check-updates",
+      "title": "Check for Updates",
+      "subtitle": "Run Monocle's update check",
+      "description": "Check for Monocle updates",
+      "mode": "no-view",
+      "disabledByDefault": true
+    },
+    {
+      "name": "quit-monocle",
+      "title": "Quit Monocle",
+      "subtitle": "Quit the app",
+      "description": "Quit the Monocle app",
       "mode": "no-view",
       "disabledByDefault": true
     }

--- a/extensions/monocle/src/app-wide-focus-off.ts
+++ b/extensions/monocle/src/app-wide-focus-off.ts
@@ -1,0 +1,5 @@
+import { monocle } from "./monocle";
+
+export default async function main() {
+  await monocle("reveal-all/off", "App-wide focus off");
+}

--- a/extensions/monocle/src/app-wide-focus-on.ts
+++ b/extensions/monocle/src/app-wide-focus-on.ts
@@ -1,0 +1,5 @@
+import { monocle } from "./monocle";
+
+export default async function main() {
+  await monocle("reveal-all/on", "App-wide focus on");
+}

--- a/extensions/monocle/src/check-updates.ts
+++ b/extensions/monocle/src/check-updates.ts
@@ -1,0 +1,5 @@
+import { monocle } from "./monocle";
+
+export default async function main() {
+  await monocle("check-updates", "Checking for updates");
+}

--- a/extensions/monocle/src/display-global.ts
+++ b/extensions/monocle/src/display-global.ts
@@ -1,0 +1,5 @@
+import { monocle } from "./monocle";
+
+export default async function main() {
+  await monocle("display/global", "Display: global");
+}

--- a/extensions/monocle/src/display-per-screen.ts
+++ b/extensions/monocle/src/display-per-screen.ts
@@ -1,0 +1,5 @@
+import { monocle } from "./monocle";
+
+export default async function main() {
+  await monocle("display/perScreen", "Display: per-screen");
+}

--- a/extensions/monocle/src/monochrome-off.ts
+++ b/extensions/monocle/src/monochrome-off.ts
@@ -1,0 +1,5 @@
+import { monocle } from "./monocle";
+
+export default async function main() {
+  await monocle("grayscale/off", "Monochrome off");
+}

--- a/extensions/monocle/src/monochrome-on.ts
+++ b/extensions/monocle/src/monochrome-on.ts
@@ -1,0 +1,5 @@
+import { monocle } from "./monocle";
+
+export default async function main() {
+  await monocle("grayscale/on", "Monochrome on");
+}

--- a/extensions/monocle/src/monocle.ts
+++ b/extensions/monocle/src/monocle.ts
@@ -4,3 +4,10 @@ export async function monocle(path: string, message: string) {
   await open(`monocle://${path}`);
   await showHUD(message);
 }
+
+export function parsePercent(input: string): number | null {
+  const v = Number(input.trim());
+  if (!Number.isFinite(v)) return null;
+  if (v < 0 || v > 100) return null;
+  return Math.round(v);
+}

--- a/extensions/monocle/src/open-settings.ts
+++ b/extensions/monocle/src/open-settings.ts
@@ -1,0 +1,5 @@
+import { monocle } from "./monocle";
+
+export default async function main() {
+  await monocle("settings", "Opened Monocle settings");
+}

--- a/extensions/monocle/src/quit-monocle.ts
+++ b/extensions/monocle/src/quit-monocle.ts
@@ -1,0 +1,5 @@
+import { monocle } from "./monocle";
+
+export default async function main() {
+  await monocle("quit", "Quitting Monocle");
+}

--- a/extensions/monocle/src/set-blur.ts
+++ b/extensions/monocle/src/set-blur.ts
@@ -1,7 +1,7 @@
 import { LaunchProps, showHUD } from "@raycast/api";
 import { monocle, parsePercent } from "./monocle";
 
-export default async function main(props: LaunchProps<{ arguments: { level: string } }>) {
+export default async function main(props: LaunchProps<{ arguments: Arguments.SetBlur }>) {
   const pct = parsePercent(props.arguments.level);
   if (pct === null) {
     await showHUD("Enter a number 0–100");

--- a/extensions/monocle/src/set-blur.ts
+++ b/extensions/monocle/src/set-blur.ts
@@ -1,0 +1,11 @@
+import { LaunchProps, showHUD } from "@raycast/api";
+import { monocle, parsePercent } from "./monocle";
+
+export default async function main(props: LaunchProps<{ arguments: { level: string } }>) {
+  const pct = parsePercent(props.arguments.level);
+  if (pct === null) {
+    await showHUD("Enter a number 0–100");
+    return;
+  }
+  await monocle(`blur/${pct}`, `Blur ${pct}%`);
+}

--- a/extensions/monocle/src/set-grain.ts
+++ b/extensions/monocle/src/set-grain.ts
@@ -1,0 +1,11 @@
+import { LaunchProps, showHUD } from "@raycast/api";
+import { monocle, parsePercent } from "./monocle";
+
+export default async function main(props: LaunchProps<{ arguments: { level: string } }>) {
+  const pct = parsePercent(props.arguments.level);
+  if (pct === null) {
+    await showHUD("Enter a number 0–100");
+    return;
+  }
+  await monocle(`grain/${pct}`, `Grain ${pct}%`);
+}

--- a/extensions/monocle/src/set-grain.ts
+++ b/extensions/monocle/src/set-grain.ts
@@ -1,7 +1,7 @@
 import { LaunchProps, showHUD } from "@raycast/api";
 import { monocle, parsePercent } from "./monocle";
 
-export default async function main(props: LaunchProps<{ arguments: { level: string } }>) {
+export default async function main(props: LaunchProps<{ arguments: Arguments.SetGrain }>) {
   const pct = parsePercent(props.arguments.level);
   if (pct === null) {
     await showHUD("Enter a number 0–100");

--- a/extensions/monocle/src/set-monochrome.ts
+++ b/extensions/monocle/src/set-monochrome.ts
@@ -1,7 +1,7 @@
 import { LaunchProps, showHUD } from "@raycast/api";
 import { monocle, parsePercent } from "./monocle";
 
-export default async function main(props: LaunchProps<{ arguments: { level: string } }>) {
+export default async function main(props: LaunchProps<{ arguments: Arguments.SetMonochrome }>) {
   const pct = parsePercent(props.arguments.level);
   if (pct === null) {
     await showHUD("Enter a number 0–100");

--- a/extensions/monocle/src/set-monochrome.ts
+++ b/extensions/monocle/src/set-monochrome.ts
@@ -1,0 +1,11 @@
+import { LaunchProps, showHUD } from "@raycast/api";
+import { monocle, parsePercent } from "./monocle";
+
+export default async function main(props: LaunchProps<{ arguments: { level: string } }>) {
+  const pct = parsePercent(props.arguments.level);
+  if (pct === null) {
+    await showHUD("Enter a number 0–100");
+    return;
+  }
+  await monocle(`grayscale/${pct}`, `Monochrome ${pct}%`);
+}

--- a/extensions/monocle/src/set-tint-hex.ts
+++ b/extensions/monocle/src/set-tint-hex.ts
@@ -1,0 +1,11 @@
+import { LaunchProps, showHUD } from "@raycast/api";
+import { monocle } from "./monocle";
+
+export default async function main(props: LaunchProps<{ arguments: { hex: string } }>) {
+  const raw = props.arguments.hex.trim().replace(/^#/, "");
+  if (!/^[0-9a-fA-F]{6}$/.test(raw)) {
+    await showHUD("Enter a 6-digit hex color (e.g. FF6B6B)");
+    return;
+  }
+  await monocle(`tint/color/${raw}`, `Tint #${raw.toUpperCase()}`);
+}

--- a/extensions/monocle/src/set-tint-hex.ts
+++ b/extensions/monocle/src/set-tint-hex.ts
@@ -1,7 +1,7 @@
 import { LaunchProps, showHUD } from "@raycast/api";
 import { monocle } from "./monocle";
 
-export default async function main(props: LaunchProps<{ arguments: { hex: string } }>) {
+export default async function main(props: LaunchProps<{ arguments: Arguments.SetTintHex }>) {
   const raw = props.arguments.hex.trim().replace(/^#/, "");
   if (!/^[0-9a-fA-F]{6}$/.test(raw)) {
     await showHUD("Enter a 6-digit hex color (e.g. FF6B6B)");

--- a/extensions/monocle/src/set-tint-opacity.ts
+++ b/extensions/monocle/src/set-tint-opacity.ts
@@ -1,7 +1,7 @@
 import { LaunchProps, showHUD } from "@raycast/api";
 import { monocle, parsePercent } from "./monocle";
 
-export default async function main(props: LaunchProps<{ arguments: { level: string } }>) {
+export default async function main(props: LaunchProps<{ arguments: Arguments.SetTintOpacity }>) {
   const pct = parsePercent(props.arguments.level);
   if (pct === null) {
     await showHUD("Enter a number 0–100");

--- a/extensions/monocle/src/set-tint-opacity.ts
+++ b/extensions/monocle/src/set-tint-opacity.ts
@@ -1,0 +1,11 @@
+import { LaunchProps, showHUD } from "@raycast/api";
+import { monocle, parsePercent } from "./monocle";
+
+export default async function main(props: LaunchProps<{ arguments: { level: string } }>) {
+  const pct = parsePercent(props.arguments.level);
+  if (pct === null) {
+    await showHUD("Enter a number 0–100");
+    return;
+  }
+  await monocle(`tint/opacity/${pct}`, `Tint opacity ${pct}%`);
+}

--- a/extensions/monocle/src/set-tint-preset.ts
+++ b/extensions/monocle/src/set-tint-preset.ts
@@ -1,0 +1,8 @@
+import { LaunchProps } from "@raycast/api";
+import { monocle } from "./monocle";
+
+export default async function main(props: LaunchProps<{ arguments: { preset: string } }>) {
+  const preset = props.arguments.preset;
+  const label = preset.charAt(0).toUpperCase() + preset.slice(1);
+  await monocle(`tint/color/${preset}`, `Tint: ${label}`);
+}

--- a/extensions/monocle/src/set-tint-preset.ts
+++ b/extensions/monocle/src/set-tint-preset.ts
@@ -1,7 +1,7 @@
 import { LaunchProps } from "@raycast/api";
 import { monocle } from "./monocle";
 
-export default async function main(props: LaunchProps<{ arguments: { preset: string } }>) {
+export default async function main(props: LaunchProps<{ arguments: Arguments.SetTintPreset }>) {
   const preset = props.arguments.preset;
   const label = preset.charAt(0).toUpperCase() + preset.slice(1);
   await monocle(`tint/color/${preset}`, `Tint: ${label}`);

--- a/extensions/monocle/src/toggle-app-wide-focus.ts
+++ b/extensions/monocle/src/toggle-app-wide-focus.ts
@@ -1,0 +1,5 @@
+import { monocle } from "./monocle";
+
+export default async function main() {
+  await monocle("reveal-all/toggle", "Toggled app-wide focus");
+}

--- a/extensions/monocle/src/toggle-monochrome.ts
+++ b/extensions/monocle/src/toggle-monochrome.ts
@@ -1,0 +1,5 @@
+import { monocle } from "./monocle";
+
+export default async function main() {
+  await monocle("grayscale/toggle", "Toggled monochrome");
+}


### PR DESCRIPTION
## Description

Expands the Monocle extension with commands for the new `monocle://` URL endpoints introduced in [Monocle 3.5.1](https://www.heyiam.dk/monocle) (released 2026-05-19).

I'm the developer of Monocle (`heyiamdk`) and `emlez` remains attributed as the extension's original author.

### New commands

**Visual style scalars (0–100 argument):**
- Set Blur, Set Grain, Set Monochrome, Set Tint Opacity

**Tint color:**
- Set Tint Preset — dropdown: System / Blue / Purple / Pink / Red / Orange / Yellow / Green / Graphite / Black
- Set Tint Color (Hex) — RRGGBB input

**Toggles + explicit state:**
- Toggle Monochrome + Turn Monochrome on / off
- Toggle App-Wide Focus + Turn App-Wide Focus on / off

**Display mode:**
- Per-Screen Display Mode, Global Display Mode

**Utility:**
- Open Settings, Check for Updates, Quit Monocle

### Naming alignment with the app

Raycast-side labels were renamed to match the app's in-product terminology:

- "Grayscale" → "Monochrome" (URL path stays `grayscale` for compatibility)
- "Reveal All Windows" → "App-Wide Focus" (URL path stays `reveal-all` for compatibility)

### Defaults

7 commands enabled by default (the main toggles + Set Blur + Set Tint Preset); the rest are `disabledByDefault: true` to keep root search tidy.

cc @emlez (original author) — happy to adjust naming, defaults, or split this PR if anything looks off.

## Screencast

_Recording in progress — will attach shortly._

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
