### PR TITLE
[Port Manager] Fix lsof process leaks

### DIFF
--- a/extensions/port-manager/CHANGELOG.md
+++ b/extensions/port-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Port Manager Changelog
 
-## [Fixed lsof Process Cleanup] - 2026-05-21
+## [Fixed lsof Process Cleanup] - {PR_MERGE_DATE}
 
 - Improved port refreshes to prevent long-running `lsof` processes from piling up when port detection stalls
 

--- a/extensions/port-manager/CHANGELOG.md
+++ b/extensions/port-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Port Manager Changelog
 
-## [Fixed lsof Process Cleanup] - {PR_MERGE_DATE}
+## [Fixed lsof Process Cleanup] - 2026-05-29
 
 - Improved port refreshes to prevent long-running `lsof` processes from piling up when port detection stalls
 

--- a/extensions/port-manager/CHANGELOG.md
+++ b/extensions/port-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Port Manager Changelog
 
+## [Fixed lsof Process Cleanup] - 2026-05-21
+
+- Improved port refreshes to prevent long-running `lsof` processes from piling up when port detection stalls
+
 ## [New Preferences] - 2024-11-25
 
 - Added preferences to customize the primary action of the `Open Port` command

--- a/extensions/port-manager/package.json
+++ b/extensions/port-manager/package.json
@@ -138,5 +138,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/port-manager/src/hooks/useProcesses.ts
+++ b/extensions/port-manager/src/hooks/useProcesses.ts
@@ -2,7 +2,9 @@ import { useCachedPromise } from "@raycast/utils";
 import Process from "../models/Process";
 
 export default function useProcesses() {
-  const { data, revalidate, isLoading, mutate, error } = useCachedPromise(Process.getCurrent);
+  const { data, revalidate, isLoading, mutate, error } = useCachedPromise(Process.getCurrent, [], {
+    keepPreviousData: true,
+  });
 
   return {
     processes: data,

--- a/extensions/port-manager/src/kill-listening-process.tsx
+++ b/extensions/port-manager/src/kill-listening-process.tsx
@@ -1,27 +1,11 @@
 import { LaunchProps, showToast, Toast } from "@raycast/api";
-import { exec } from "child_process";
+import { runCommand } from "./utilities/runCommand";
 
 function isInteger(str: string): boolean {
-  return Number.isInteger(parseInt(str, 10));
+  return /^\d+$/.test(str);
 }
 
-async function run(command: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    exec(command, (error, stdout, stderr) => {
-      if (error) {
-        reject(stderr.trimEnd());
-      } else {
-        resolve(stdout.trimEnd());
-      }
-    });
-  });
-}
-
-export default async function Command(
-  // "Index" here refers to the "name" property of this command
-  // specified in package.json AND matches the name of this source file.
-  props: LaunchProps<{ arguments: Arguments.KillListeningProcess }>
-) {
+export default async function Command(props: LaunchProps<{ arguments: Arguments.KillListeningProcess }>) {
   const { port } = props.arguments;
   if (!isInteger(port)) {
     showToast({
@@ -32,15 +16,19 @@ export default async function Command(
     return;
   }
 
-  const command = `/usr/sbin/lsof -n -iTCP:${port} -sTCP:LISTEN -t`;
-
   try {
-    const pid = await run(command);
-    await run("kill " + pid);
+    const { stdout } = await runCommand("/usr/sbin/lsof", ["-n", `-iTCP:${port}`, "-sTCP:LISTEN", "-t"], {
+      timeout: 5_000,
+      killProcessGroup: true,
+    });
+    const pids = stdout.split(/\s+/).filter(Boolean);
+    if (pids.length === 0) throw new Error(`No process is listening on port ${port}.`);
+
+    await runCommand("/bin/kill", pids, { timeout: 2_000 });
     showToast({
       style: Toast.Style.Success,
       title: "Success",
-      message: `Process ${pid} was killed.`,
+      message: `Process ${pids.join(", ")} was killed.`,
     });
   } catch (error) {
     showToast({

--- a/extensions/port-manager/src/kill-listening-process.tsx
+++ b/extensions/port-manager/src/kill-listening-process.tsx
@@ -1,8 +1,14 @@
 import { LaunchProps, showToast, Toast } from "@raycast/api";
-import { runCommand } from "./utilities/runCommand";
+import { CommandExitError, runCommand } from "./utilities/runCommand";
 
 function isInteger(str: string): boolean {
   return /^\d+$/.test(str);
+}
+
+function isLsofNoMatch(error: unknown) {
+  return (
+    error instanceof CommandExitError && error.exitCode === 1 && error.stdout.length === 0 && error.stderr.length === 0
+  );
 }
 
 export default async function Command(props: LaunchProps<{ arguments: Arguments.KillListeningProcess }>) {
@@ -17,11 +23,19 @@ export default async function Command(props: LaunchProps<{ arguments: Arguments.
   }
 
   try {
-    const { stdout } = await runCommand("/usr/sbin/lsof", ["-n", `-iTCP:${port}`, "-sTCP:LISTEN", "-t"], {
-      timeout: 5_000,
-      killProcessGroup: true,
-    });
-    const pids = stdout.split(/\s+/).filter(Boolean);
+    let pids: string[];
+
+    try {
+      const { stdout } = await runCommand("/usr/sbin/lsof", ["-n", `-iTCP:${port}`, "-sTCP:LISTEN", "-t"], {
+        timeout: 5_000,
+        killProcessGroup: true,
+      });
+      pids = stdout.split(/\s+/).filter(Boolean);
+    } catch (error) {
+      if (!isLsofNoMatch(error)) throw error;
+      pids = [];
+    }
+
     if (pids.length === 0) throw new Error(`No process is listening on port ${port}.`);
 
     await runCommand("/bin/kill", pids, { timeout: 2_000 });
@@ -34,7 +48,7 @@ export default async function Command(props: LaunchProps<{ arguments: Arguments.
     showToast({
       style: Toast.Style.Failure,
       title: "Error",
-      message: `No process is listening on port ${port}.`,
+      message: error instanceof Error ? error.message : "Unknown error",
     });
   }
 }

--- a/extensions/port-manager/src/models/Process.ts
+++ b/extensions/port-manager/src/models/Process.ts
@@ -164,16 +164,27 @@ export default class Process implements ProcessInfo {
     return valuesByProcess.filter((process) => process.pid > 0);
   }
 
+  private static getNetstatPidColumnIndex(lines: string[]) {
+    const header = lines.find((line) => line.trim().startsWith("Proto "));
+    if (header === undefined) return 10;
+
+    const pidHeaderIndex = header.trim().split(/\s+/).indexOf("pid");
+    const pidColumnIndex = pidHeaderIndex - 2;
+    return pidColumnIndex > 0 ? pidColumnIndex : 10;
+  }
+
   private static parseNetstat(stdout: string) {
     const namedPorts = getNamedPorts();
     const valuesByPid = new Map<number, ProcessInfo>();
+    const lines = stdout.split("\n");
+    const pidColumnIndex = Process.getNetstatPidColumnIndex(lines);
 
-    for (const line of stdout.split("\n")) {
+    for (const line of lines) {
       const columns = line.trim().split(/\s+/);
-      if (columns.length < 11) continue;
+      if (columns.length <= pidColumnIndex) continue;
 
       const [protocol, , , localAddress, , state] = columns;
-      const pid = Number(columns[10]);
+      const pid = Number(columns[pidColumnIndex]);
       if (state !== "LISTEN" || Number.isNaN(pid) || pid <= 0) continue;
 
       const portInfo = Process.parseNetstatPortInfo(localAddress, namedPorts);

--- a/extensions/port-manager/src/models/Process.ts
+++ b/extensions/port-manager/src/models/Process.ts
@@ -166,11 +166,11 @@ export default class Process implements ProcessInfo {
 
   private static getNetstatPidColumnIndex(lines: string[]) {
     const header = lines.find((line) => line.trim().startsWith("Proto "));
-    if (header === undefined) return 10;
+    if (header === undefined) return;
 
     const pidHeaderIndex = header.trim().split(/\s+/).indexOf("pid");
     const pidColumnIndex = pidHeaderIndex - 2;
-    return pidColumnIndex > 0 ? pidColumnIndex : 10;
+    return pidColumnIndex > 0 ? pidColumnIndex : undefined;
   }
 
   private static parseNetstat(stdout: string) {
@@ -178,6 +178,7 @@ export default class Process implements ProcessInfo {
     const valuesByPid = new Map<number, ProcessInfo>();
     const lines = stdout.split("\n");
     const pidColumnIndex = Process.getNetstatPidColumnIndex(lines);
+    if (pidColumnIndex === undefined) return [];
 
     for (const line of lines) {
       const columns = line.trim().split(/\s+/);

--- a/extensions/port-manager/src/models/Process.ts
+++ b/extensions/port-manager/src/models/Process.ts
@@ -1,14 +1,20 @@
-import { Cache } from "@raycast/api";
-import { exec as cExec } from "child_process";
-import { promisify } from "util";
+import path from "path";
 import { getNamedPorts } from "../hooks/useNamedPorts";
+import { runCommand } from "../utilities/runCommand";
 import isDigit from "../utilities/isDigit";
 import { LsofPrefix } from "./constants";
 import { PortInfo, ProcessInfo } from "./interfaces";
 
-const cache = new Cache();
+const LSOF_TIMEOUT = 10_000;
+const NETSTAT_TIMEOUT = 3_000;
+const PS_TIMEOUT = 2_000;
+const LSOF_ARGS = ["-n", "+c0", "-iTCP", "-w", "-sTCP:LISTEN", "-P", "-FpcRuLPn"];
+const NETSTAT_ARGS = ["-anv", "-p", "tcp"];
 
-const exec = promisify(cExec);
+let currentProcessesRequest: Promise<Process[]> | undefined;
+
+type ProcessDetails = Pick<ProcessInfo, "name" | "parentPid" | "path" | "parentPath" | "user" | "uid">;
+type NamedPortRecord = ReturnType<typeof getNamedPorts>;
 
 export default class Process implements ProcessInfo {
   public path?: string;
@@ -25,39 +31,95 @@ export default class Process implements ProcessInfo {
     public readonly internetProtocol?: string
   ) {}
 
-  private async getProcessPath(pid: number) {
-    const cmd = `/bin/ps -p ${pid} -o comm=`;
-    const { stdout, stderr } = await exec(cmd);
-    if (stderr) throw new Error(stderr);
-    return stdout.replace("\n", "");
+  private static parsePortInfo(value: string, namedPorts: NamedPortRecord): PortInfo | undefined {
+    const separatorIndex = value.lastIndexOf(":");
+    if (separatorIndex === -1) return;
+
+    const port = Number(value.slice(separatorIndex + 1));
+    if (Number.isNaN(port)) return;
+
+    return {
+      host: value.slice(0, separatorIndex),
+      name: namedPorts[port]?.name,
+      port,
+    };
   }
 
-  public async loadPath() {
-    this.path = await this.getProcessPath(this.pid);
+  private static parseNetstatPortInfo(value: string, namedPorts: NamedPortRecord): PortInfo | undefined {
+    const separatorIndex = value.lastIndexOf(".");
+    if (separatorIndex === -1) return;
+
+    const port = Number(value.slice(separatorIndex + 1));
+    if (Number.isNaN(port)) return;
+
+    return {
+      host: value.slice(0, separatorIndex),
+      name: namedPorts[port]?.name,
+      port,
+    };
   }
 
-  public async loadParentPath() {
-    if (this.parentPid === undefined) return;
-    this.parentPath = await this.getProcessPath(this.parentPid);
+  private static async getProcessDetails(pids: number[]) {
+    const uniquePids = Array.from(new Set(pids.filter((pid) => Number.isFinite(pid) && pid > 0)));
+    const details = new Map<number, ProcessDetails>();
+
+    if (uniquePids.length === 0) {
+      return details;
+    }
+
+    try {
+      const { stdout } = await runCommand(
+        "/bin/ps",
+        ["-p", uniquePids.join(","), "-o", "pid=", "-o", "ppid=", "-o", "uid=", "-o", "user=", "-o", "comm="],
+        {
+          timeout: PS_TIMEOUT,
+        }
+      );
+
+      for (const line of stdout.split("\n")) {
+        const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
+        if (match === null) continue;
+        const processPath = match[5];
+
+        details.set(Number(match[1]), {
+          parentPid: Number(match[2]),
+          uid: Number(match[3]),
+          user: match[4],
+          path: processPath,
+          name: path.basename(processPath),
+        });
+      }
+    } catch {
+      return details;
+    }
+
+    for (const process of details.values()) {
+      if (process.parentPid !== undefined) {
+        process.parentPath = details.get(process.parentPid)?.path;
+      }
+    }
+
+    return details;
   }
 
-  public static async getCurrent() {
+  private static parseLsof(stdout: string) {
     const namedPorts = getNamedPorts();
-    const cmd = `/usr/sbin/lsof +c0 -iTCP -w -sTCP:LISTEN -P -FpcRuLPn`;
-
-    const { stdout, stderr } = await exec(cmd);
-    if (stderr) throw new Error(stderr);
     const processes = stdout.split("\np");
-    const instances: Process[] = [];
+    const valuesByProcess: ProcessInfo[] = [];
+
     for (const process of processes) {
       if (process.length === 0) continue;
+
       const lines = process.split("\n");
       const values: ProcessInfo = { pid: 0 };
+
       for (const line of lines) {
         if (line.length === 0) continue;
+
         const prefix = line[0];
         const value = line.slice(1);
         if (value.length === 0) continue;
+
         switch (prefix) {
           case LsofPrefix.PROCESS_ID:
             values.pid = Number(value);
@@ -77,21 +139,16 @@ export default class Process implements ProcessInfo {
           case LsofPrefix.PROTOCOL:
             values.protocol = value;
             break;
-          case LsofPrefix.PORTS:
-            values.portInfo
-              ? values.portInfo.push({
-                  host: value.split(":")[0],
-                  name: namedPorts[Number(value.split(":")[1])]?.name,
-                  port: Number(value.split(":")[1]),
-                })
-              : (values.portInfo = [
-                  {
-                    host: value.split(":")[0],
-                    name: namedPorts[Number(value.split(":")[1])]?.name,
-                    port: Number(value.split(":")[1]),
-                  },
-                ]);
+          case LsofPrefix.PORTS: {
+            const portInfo = Process.parsePortInfo(value, namedPorts);
+            if (portInfo !== undefined) {
+              if (values.portInfo === undefined) {
+                values.portInfo = [];
+              }
+              values.portInfo.push(portInfo);
+            }
             break;
+          }
           case LsofPrefix.INTERNET_PROTOCOLL:
             values.internetProtocol = value;
             break;
@@ -100,19 +157,100 @@ export default class Process implements ProcessInfo {
             break;
         }
       }
-      const p = new Process(
-        values.pid,
-        values.name,
-        values.parentPid,
-        values.user,
-        values.uid,
-        values.protocol,
-        values.portInfo
-      );
-      await p.loadPath();
-      await p.loadParentPath();
-      instances.push(p);
+
+      valuesByProcess.push(values);
     }
-    return instances;
+
+    return valuesByProcess.filter((process) => process.pid > 0);
+  }
+
+  private static parseNetstat(stdout: string) {
+    const namedPorts = getNamedPorts();
+    const valuesByPid = new Map<number, ProcessInfo>();
+
+    for (const line of stdout.split("\n")) {
+      const columns = line.trim().split(/\s+/);
+      if (columns.length < 11) continue;
+
+      const [protocol, , , localAddress, , state] = columns;
+      const pid = Number(columns[10]);
+      if (state !== "LISTEN" || Number.isNaN(pid) || pid <= 0) continue;
+
+      const portInfo = Process.parseNetstatPortInfo(localAddress, namedPorts);
+      if (portInfo === undefined) continue;
+
+      const values = valuesByPid.get(pid) ?? { pid, protocol: "TCP", internetProtocol: protocol, portInfo: [] };
+      values.portInfo?.push(portInfo);
+      valuesByPid.set(pid, values);
+    }
+
+    return Array.from(valuesByPid.values());
+  }
+
+  private static async loadFromLsof() {
+    const { stdout } = await runCommand("/usr/sbin/lsof", LSOF_ARGS, {
+      timeout: LSOF_TIMEOUT,
+      killProcessGroup: true,
+    });
+
+    return Process.parseLsof(stdout);
+  }
+
+  private static async loadFromNetstat() {
+    const { stdout } = await runCommand("/usr/sbin/netstat", NETSTAT_ARGS, {
+      timeout: NETSTAT_TIMEOUT,
+      killProcessGroup: true,
+    });
+
+    return Process.parseNetstat(stdout);
+  }
+
+  private static async loadCurrent() {
+    let processes = await Process.loadFromNetstat();
+
+    if (processes.length === 0) {
+      processes = await Process.loadFromLsof();
+    }
+
+    const processDetails = await Process.getProcessDetails(processes.map((process) => process.pid));
+    const processAndParentDetails = await Process.getProcessDetails(
+      Array.from(processDetails.values()).flatMap((process) =>
+        process.parentPid === undefined ? [] : [process.parentPid]
+      )
+    );
+
+    for (const [pid, details] of processDetails) {
+      processAndParentDetails.set(pid, details);
+    }
+
+    return processes.map((values) => {
+      const details = processAndParentDetails.get(values.pid);
+      const process = new Process(
+        values.pid,
+        values.name ?? details?.name,
+        values.parentPid ?? details?.parentPid,
+        values.user ?? details?.user,
+        values.uid ?? details?.uid,
+        values.protocol,
+        values.portInfo,
+        values.internetProtocol
+      );
+
+      process.path = values.path ?? details?.path;
+      process.parentPath =
+        values.parentPath ?? details?.parentPath ?? processAndParentDetails.get(process.parentPid ?? 0)?.path;
+
+      return process;
+    });
+  }
+
+  public static async getCurrent() {
+    if (currentProcessesRequest === undefined) {
+      currentProcessesRequest = Process.loadCurrent().finally(() => {
+        currentProcessesRequest = undefined;
+      });
+    }
+
+    return currentProcessesRequest;
   }
 }

--- a/extensions/port-manager/src/models/Process.ts
+++ b/extensions/port-manager/src/models/Process.ts
@@ -218,7 +218,13 @@ export default class Process implements ProcessInfo {
   }
 
   private static async loadCurrent() {
-    let processes = await Process.loadFromNetstat();
+    let processes: ProcessInfo[] = [];
+
+    try {
+      processes = await Process.loadFromNetstat();
+    } catch {
+      processes = [];
+    }
 
     if (processes.length === 0) {
       processes = await Process.loadFromLsof();

--- a/extensions/port-manager/src/open-ports-menu-bar.tsx
+++ b/extensions/port-manager/src/open-ports-menu-bar.tsx
@@ -16,12 +16,9 @@ export default function Command() {
   const { processes, revalidateProcesses, isLoadingProcesses } = useProcesses();
 
   const openPorts = removeDuplicates(
-    processes
-      ?.filter((p) => p.portInfo !== undefined && p.portInfo.length > 0)
-      ?.flatMap((p) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return p.portInfo!.map((info) => ({ port: `${info.port}`, name: info.name, process: p }));
-      }) ?? [],
+    (processes ?? []).flatMap((p) =>
+      (p.portInfo ?? []).map((info) => ({ port: `${info.port}`, name: info.name, process: p }))
+    ),
     "port"
   ).sort((a, b) => parseInt(a.port) - parseInt(b.port));
 

--- a/extensions/port-manager/src/utilities/killProcess.ts
+++ b/extensions/port-manager/src/utilities/killProcess.ts
@@ -1,48 +1,26 @@
-import { exec as cExec } from "child_process";
-import { promisify } from "util";
 import { ProcessInfo } from "../models/interfaces";
-
-const exec = promisify(cExec);
+import { runCommand } from "./runCommand";
 
 export const KillSignal = {
-  /** Hang Up */
   HUP: "1",
-
-  /** Interrupt */
   INT: "2",
-
-  /** Quit */
   QUIT: "3",
-
-  /** Abort */
   ABRT: "6",
-
-  /** Non-catchable, non-ignorable kill */
   KILL: "9",
-
-  /** Alarm clock */
   ALRM: "14",
-
-  /** Software termination signal */
   TERM: "15",
 };
 
 export type KillSignal = typeof KillSignal[keyof typeof KillSignal];
 
 export async function kill(pid: number | number[], signal: KillSignal) {
-  const pidString = pid instanceof Array ? pid.join(" ") : pid;
-  const cmd = `kill -${signal} ${pidString}`;
-
-  const { stderr } = await exec(cmd);
-  if (stderr) throw new Error(stderr);
+  const pids = pid instanceof Array ? pid : [pid];
+  await runCommand("/bin/kill", [`-${signal}`, ...pids.map(String)], { timeout: 2_000 });
 }
 
 export async function killall(processname: string | string[], signal: KillSignal) {
-  const processnameString =
-    processname instanceof Array ? processname.map((n) => `'${n}'`).join(" ") : `'${processname}'`;
-  const cmd = `/usr/bin/killall -${signal} ${processnameString}`;
-  const { stderr } = await exec(cmd);
-  if (stderr) throw new Error(stderr);
+  const processNames = processname instanceof Array ? processname : [processname];
+  await runCommand("/usr/bin/killall", [`-${signal}`, ...processNames], { timeout: 5_000 });
 }
 
 export async function killProcess(

--- a/extensions/port-manager/src/utilities/removeDuplicates.ts
+++ b/extensions/port-manager/src/utilities/removeDuplicates.ts
@@ -1,5 +1,12 @@
 function removeDuplicates<T>(array: T[], key: keyof T) {
-  return array.filter((v, i, a) => a.findIndex((t) => t[key] === v[key]) === i);
+  const seen = new Set<T[keyof T]>();
+
+  return array.filter((value) => {
+    const id = value[key];
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
 }
 
 export default removeDuplicates;

--- a/extensions/port-manager/src/utilities/runCommand.ts
+++ b/extensions/port-manager/src/utilities/runCommand.ts
@@ -73,8 +73,6 @@ export function runCommand(file: string, args: string[], options: RunCommandOpti
         sendSignal(-child.pid, signal);
       }
 
-      sendSignal(child.pid, signal);
-
       try {
         child.kill(signal);
       } catch {
@@ -128,10 +126,6 @@ export function runCommand(file: string, args: string[], options: RunCommandOpti
     child.on("close", (exitCode, signal) => {
       if (settled) return;
       settled = true;
-
-      if (failure !== undefined || timedOut) {
-        killChild("SIGKILL");
-      }
 
       cleanup();
 

--- a/extensions/port-manager/src/utilities/runCommand.ts
+++ b/extensions/port-manager/src/utilities/runCommand.ts
@@ -1,0 +1,163 @@
+import { spawn } from "child_process";
+
+type RunCommandOptions = {
+  timeout?: number;
+  killProcessGroup?: boolean;
+  maxBuffer?: number;
+};
+
+type CommandResult = {
+  stdout: string;
+  stderr: string;
+};
+
+const DEFAULT_MAX_BUFFER = 1024 * 1024;
+const KILL_GRACE_PERIOD = 500;
+const CLOSE_GRACE_PERIOD = 2_000;
+
+export class CommandExitError extends Error {
+  constructor(
+    public readonly file: string,
+    public readonly args: string[],
+    public readonly stdout: string,
+    public readonly stderr: string,
+    public readonly exitCode: number | null,
+    public readonly signal: NodeJS.Signals | null
+  ) {
+    super(stderr || stdout || `${file} exited with code ${exitCode ?? signal}`);
+  }
+}
+
+export class CommandTimeoutError extends Error {
+  constructor(public readonly file: string, public readonly args: string[], public readonly timeout: number) {
+    super(`${file} timed out after ${timeout}ms`);
+  }
+}
+
+export class CommandBufferError extends Error {
+  constructor(public readonly file: string, public readonly args: string[], public readonly maxBuffer: number) {
+    super(`${file} exceeded ${maxBuffer} bytes of output`);
+  }
+}
+
+export function runCommand(file: string, args: string[], options: RunCommandOptions = {}): Promise<CommandResult> {
+  const { timeout, killProcessGroup = false, maxBuffer = DEFAULT_MAX_BUFFER } = options;
+  const detached = killProcessGroup && process.platform !== "win32";
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(file, args, {
+      detached,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let outputSize = 0;
+    let settled = false;
+    let timedOut = false;
+    let failure: Error | undefined;
+    let timeoutId: NodeJS.Timeout | undefined;
+    let killId: NodeJS.Timeout | undefined;
+    let closeId: NodeJS.Timeout | undefined;
+
+    function cleanup() {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      if (killId !== undefined) clearTimeout(killId);
+      if (closeId !== undefined) clearTimeout(closeId);
+    }
+
+    function killChild(signal: NodeJS.Signals) {
+      if (child.pid === undefined) return;
+
+      if (detached) {
+        sendSignal(-child.pid, signal);
+      }
+
+      sendSignal(child.pid, signal);
+
+      try {
+        child.kill(signal);
+      } catch {
+        return;
+      }
+    }
+
+    function sendSignal(pid: number, signal: NodeJS.Signals) {
+      try {
+        process.kill(pid, signal);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    function finish(error: Error) {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    }
+
+    function terminate(error: Error) {
+      failure = error;
+      killChild("SIGTERM");
+      killId = setTimeout(() => killChild("SIGKILL"), KILL_GRACE_PERIOD);
+      closeId = setTimeout(() => finish(error), CLOSE_GRACE_PERIOD);
+    }
+
+    function appendOutput(chunk: Buffer, target: "stdout" | "stderr") {
+      outputSize += chunk.length;
+      if (outputSize > maxBuffer && failure === undefined) {
+        terminate(new CommandBufferError(file, args, maxBuffer));
+      }
+
+      if (target === "stdout") {
+        stdout += chunk.toString();
+      } else {
+        stderr += chunk.toString();
+      }
+    }
+
+    child.stdout?.on("data", (chunk: Buffer) => appendOutput(chunk, "stdout"));
+    child.stderr?.on("data", (chunk: Buffer) => appendOutput(chunk, "stderr"));
+
+    child.on("error", (error) => {
+      finish(error);
+    });
+
+    child.on("close", (exitCode, signal) => {
+      if (settled) return;
+      settled = true;
+
+      if (failure !== undefined || timedOut) {
+        killChild("SIGKILL");
+      }
+
+      cleanup();
+
+      if (failure !== undefined) {
+        reject(failure);
+        return;
+      }
+
+      if (timedOut) {
+        reject(new CommandTimeoutError(file, args, timeout ?? 0));
+        return;
+      }
+
+      if (exitCode !== 0) {
+        reject(new CommandExitError(file, args, stdout.trimEnd(), stderr.trimEnd(), exitCode, signal));
+        return;
+      }
+
+      resolve({ stdout: stdout.trimEnd(), stderr: stderr.trimEnd() });
+    });
+
+    if (timeout !== undefined) {
+      timeoutId = setTimeout(() => {
+        timedOut = true;
+        terminate(new CommandTimeoutError(file, args, timeout));
+      }, timeout);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- replace unbounded shell `exec` calls in Port Manager with a bounded `spawn` helper
- add timeout, output limit, direct child cleanup, and process-group cleanup for `lsof` refreshes
- coalesce concurrent process refreshes and keep previous cached data while revalidating
- batch process path lookup through a single `ps` call and remove O(n^2) duplicate filtering

## Root cause
The menu bar refresh ran `/usr/sbin/lsof` through unbounded child-process execution. When `lsof` stalled under Raycast, refreshes could overlap and leave long-lived high-CPU child processes behind.

## Validation
- `npm run build`
- `npm run lint`
- `npx tsc --noEmit`
- `npx prettier --check src`
- manual dev run while actively using `Open Ports in Menu Bar`; `pgrep -x lsof` stayed at 0 after cleanup and no issue was observed

Fixes #28217