### PR TITLE
[Extend Display] Fix Sidecar connection on macOS 26

### DIFF
--- a/extensions/extend-display/CHANGELOG.md
+++ b/extensions/extend-display/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Extend Display Changelog
 
+## [Fix Sidecar Connection] - {PR_MERGE_DATE}
+
+- Connect to iPads through SidecarCore, since the System Settings menu no longer starts Sidecar on macOS 26
+- Keep the System Settings backend for non-Sidecar targets, with SidecarCore treated as optional
+- Fix the stale Displays settings URL and make the display menu lookup more reliable
+
 ## [Bugfix] - 2026-03-09
 
 Fixed display menu click failing on macOS Tahoe (26+).

--- a/extensions/extend-display/src/utils/connect.ts
+++ b/extensions/extend-display/src/utils/connect.ts
@@ -5,6 +5,11 @@ import {
   watchAndRevertAudio,
   forceAudioLock,
 } from "./audio";
+import {
+  listSidecarDevices,
+  setSidecarConnection,
+  normalizeName,
+} from "./sidecar";
 
 const execFileAsync = promisify(execFile);
 const execAsync = promisify(exec);
@@ -12,7 +17,7 @@ const execAsync = promisify(exec);
 const MIRROR_SECTION_NAME = "Mirror or extend to";
 
 const connectScript = `
-do shell script "open -b com.apple.systempreferences /System/Library/PreferencePanes/Displays.prefPane"
+do shell script "open 'x-apple.systempreferences:com.apple.Displays-Settings.extension'"
 
 set device to (system attribute "Device_Name")
 set mirrorSectionName to (system attribute "Mirror_Section_Name")
@@ -24,6 +29,16 @@ on cleanup()
   do shell script "open raycast://"
   delay 0.3
 end cleanup
+
+on normalizeDisplayName(displayName)
+  set originalDelimiters to AppleScript's text item delimiters
+  set AppleScript's text item delimiters to character id 8217
+  set displayNameParts to text items of (displayName as string)
+  set AppleScript's text item delimiters to "'"
+  set normalizedDisplayName to displayNameParts as string
+  set AppleScript's text item delimiters to originalDelimiters
+  return normalizedDisplayName
+end normalizeDisplayName
 
 tell application "System Events"
   set windowWait to 0
@@ -39,19 +54,21 @@ tell application "System Events"
   tell process "System Settings"
     set frontmost to true
     delay 0.5
-    
+
     set popUpButton to missing value
     set loopCount to 0
     set maxAttempts to 30
-    
+
     repeat until popUpButton is not missing value or loopCount >= maxAttempts
       try
-        -- Tahoe (macOS 26+)
+        -- Tahoe (macOS 26+); "get role" forces evaluation so a missing element errors
         set popUpButton to menu button 1 of group 1 of group 3 of splitter group 1 of group 1 of window 1
+        get role of popUpButton
       on error
         try
           -- Pre-Tahoe
           set popUpButton to pop up button 1 of group 1 of group 2 of splitter group 1 of group 1 of window 1
+          get role of popUpButton
         on error
           set popUpButton to missing value
         end try
@@ -59,7 +76,7 @@ tell application "System Events"
       delay 0.1
       set loopCount to loopCount + 1
     end repeat
-    
+
     if popUpButton is missing value then
       my cleanup()
       error "Could not find display menu button after " & maxAttempts & " attempts"
@@ -67,7 +84,7 @@ tell application "System Events"
 
     click popUpButton
     delay 0.3
-    
+
     -- Use try-based check instead of "exists" which throws -1700 on AXMenuButton
     set menuWait to 0
     set menuReady to false
@@ -90,16 +107,17 @@ tell application "System Events"
     tell menu 1 of popUpButton
       set targetItem to missing value
       set mirrorFound to false
+      set normalizedDevice to my normalizeDisplayName(device)
       repeat with i from 1 to count of menu items
         set currentItem to menu item i
         set itemName to name of currentItem
         if mirrorFound then
-          if itemName contains device then
+          if itemName is not missing value and my normalizeDisplayName(itemName) contains normalizedDevice then
             set targetItem to currentItem
             exit repeat
           end if
         else
-          if itemName contains mirrorSectionName then
+          if itemName is not missing value and itemName contains mirrorSectionName then
             set mirrorFound to true
           end if
         end if
@@ -110,10 +128,10 @@ tell application "System Events"
         my cleanup()
         error "Display '" & device & "' not found in menu"
       end if
-      
+
       perform action "AXPress" of targetItem
     end tell
-    
+
     delay 2
   end tell
 end tell
@@ -125,7 +143,11 @@ return "success"
 `;
 
 /**
- * Check if a display is currently connected by examining system profiler output
+ * Best-effort connection check for the System Settings backend.
+ *
+ * Heuristic only: a Sidecar display reports as "Sidecar Display" in
+ * system_profiler rather than by the iPad's name, so the SidecarCore
+ * backend does not rely on this and uses connectedDevices instead.
  */
 export async function getDisplayState(displayName: string): Promise<boolean> {
   try {
@@ -147,6 +169,42 @@ export interface ConnectionProgress {
   audioReverted?: boolean;
 }
 
+/**
+ * Return the matching SidecarCore device name, or null when the target is not
+ * a Sidecar device (or SidecarCore is unavailable). Used to pick a backend.
+ */
+async function matchSidecarDevice(displayName: string): Promise<string | null> {
+  const { devices } = await listSidecarDevices();
+  const target = normalizeName(displayName);
+  return (
+    devices.find((d) => normalizeName(d) === target) ??
+    devices.find((d) => normalizeName(d).includes(target)) ??
+    null
+  );
+}
+
+/**
+ * Legacy backend: toggle a display through the System Settings
+ * "Mirror or extend to" menu. Covers non-Sidecar targets (e.g. AirPlay Macs).
+ */
+async function connectViaSystemSettings(
+  displayName: string,
+): Promise<{ connected: boolean }> {
+  const initialState = await getDisplayState(displayName);
+
+  await execFileAsync("osascript", ["-e", connectScript], {
+    timeout: 15000,
+    env: {
+      ...process.env,
+      Device_Name: displayName,
+      Mirror_Section_Name: MIRROR_SECTION_NAME,
+    },
+  });
+
+  const newState = await getDisplayState(displayName);
+  return { connected: newState !== initialState ? newState : !initialState };
+}
+
 export async function connectToDisplay(
   displayName: string,
   onProgress?: (progress: ConnectionProgress) => void,
@@ -158,28 +216,27 @@ export async function connectToDisplay(
     console.error("Failed to get audio source", e);
   }
 
-  const initialState = await getDisplayState(displayName);
+  // prefer the SidecarCore backend when the target is a Sidecar device,
+  // otherwise fall back to the System Settings menu flow
+  const sidecarName = await matchSidecarDevice(displayName);
 
   try {
-    const connectPromise = execFileAsync("osascript", ["-e", connectScript], {
-      timeout: 15000,
-      env: {
-        ...process.env,
-        Device_Name: displayName,
-        Mirror_Section_Name: MIRROR_SECTION_NAME,
-      },
-    });
+    const connectPromise: Promise<{ connected: boolean }> = sidecarName
+      ? setSidecarConnection(sidecarName, "toggle")
+      : connectViaSystemSettings(displayName);
 
     let audioReverted = false;
+    let result: { connected: boolean };
+
     if (currentAudio) {
       const audioLockPromise = forceAudioLock(currentAudio, 2000);
 
-      await connectPromise;
+      result = await connectPromise;
 
       onProgress?.({
         phase: "clicked",
         success: true,
-        connected: !initialState,
+        connected: result.connected,
       });
 
       audioReverted = await watchAndRevertAudio(currentAudio);
@@ -190,21 +247,18 @@ export async function connectToDisplay(
 
       await audioLockPromise;
     } else {
-      await connectPromise;
+      result = await connectPromise;
 
       onProgress?.({
         phase: "clicked",
         success: true,
-        connected: !initialState,
+        connected: result.connected,
       });
     }
 
-    const newState = await getDisplayState(displayName);
-    const connected = newState !== initialState ? newState : !initialState;
-
     return {
       success: true,
-      connected,
+      connected: result.connected,
       audioReverted,
       phase: "verified" as const,
     };

--- a/extensions/extend-display/src/utils/displays.ts
+++ b/extensions/extend-display/src/utils/displays.ts
@@ -1,6 +1,7 @@
 import { LocalStorage, environment } from "@raycast/api";
 import { execFile } from "child_process";
 import { promisify } from "util";
+import { listSidecarDevices, normalizeName } from "./sidecar";
 
 const execFileAsync = promisify(execFile);
 
@@ -18,7 +19,7 @@ const MIRROR_SECTION_NAME = "Mirror or extend to";
 const scanScript = `
 set mirrorSectionName to (system attribute "Mirror_Section_Name")
 
-do shell script "open -b com.apple.systempreferences /System/Library/PreferencePanes/Displays.prefPane"
+do shell script "open 'x-apple.systempreferences:com.apple.Displays-Settings.extension'"
 
 set deviceNames to {}
 
@@ -43,19 +44,21 @@ tell application "System Events"
   tell process "System Settings"
     set frontmost to true
     delay 0.5
-    
+
     set popUpButton to missing value
     set loopCount to 0
     set maxAttempts to 30
-    
+
     repeat until popUpButton is not missing value or loopCount >= maxAttempts
       try
-        -- Tahoe (macOS 26+)
+        -- Tahoe (macOS 26+); "get role" forces evaluation so a missing element errors
         set popUpButton to menu button 1 of group 1 of group 3 of splitter group 1 of group 1 of window 1
+        get role of popUpButton
       on error
         try
           -- Pre-Tahoe
           set popUpButton to pop up button 1 of group 1 of group 2 of splitter group 1 of group 1 of window 1
+          get role of popUpButton
         on error
           set popUpButton to missing value
         end try
@@ -63,7 +66,7 @@ tell application "System Events"
       delay 0.1
       set loopCount to loopCount + 1
     end repeat
-    
+
     if popUpButton is missing value then
       my cleanup()
       return ""
@@ -72,7 +75,7 @@ tell application "System Events"
     -- Click to open the menu
     click popUpButton
     delay 0.3
-    
+
     -- Use try-based check instead of "exists" which throws -1700 on AXMenuButton
     set menuWait to 0
     set menuReady to false
@@ -102,7 +105,7 @@ tell application "System Events"
             set end of deviceNames to itemName
           end if
         else
-          if itemName contains mirrorSectionName then
+          if itemName is not missing value and itemName contains mirrorSectionName then
             set mirrorFound to true
           end if
         end if
@@ -121,40 +124,65 @@ set AppleScript's text item delimiters to "|||"
 return deviceNames as string
 `;
 
-// Scan displays from System Settings dropdown
+// legacy scan: read every "Mirror or extend to" entry from the System
+// Settings dropdown; covers non-Sidecar targets (e.g. AirPlay Macs)
+async function scanViaSystemSettings(): Promise<string[]> {
+  const deeplink = `raycast://extensions/${environment.ownerOrAuthorName}/${environment.extensionName}/connect-to-display`;
+  const { stdout } = await execFileAsync("osascript", ["-e", scanScript], {
+    timeout: 15000,
+    env: {
+      ...process.env,
+      Mirror_Section_Name: MIRROR_SECTION_NAME,
+      Raycast_Deeplink: deeplink,
+    },
+  });
+
+  if (!stdout || stdout.trim() === "") return [];
+
+  return stdout
+    .split("|||")
+    .map((name) => name.trim())
+    .filter((name) => name !== "");
+}
+
+// scan displays from both SidecarCore (iPads) and the System Settings
+// "Mirror or extend to" menu (other targets), de-duplicated by name
 export async function scanDisplaysFromSystem(): Promise<Display[]> {
-  try {
-    const deeplink = `raycast://extensions/${environment.ownerOrAuthorName}/${environment.extensionName}/connect-to-display`;
-    const { stdout } = await execFileAsync("osascript", ["-e", scanScript], {
-      timeout: 15000,
-      env: {
-        ...process.env,
-        Mirror_Section_Name: MIRROR_SECTION_NAME,
-        Raycast_Deeplink: deeplink,
-      },
-    });
+  const [sidecarResult, menuResult] = await Promise.allSettled([
+    listSidecarDevices(),
+    scanViaSystemSettings(),
+  ]);
 
-    if (!stdout || stdout.trim() === "") return [];
+  // de-dupe by normalized name; SidecarCore entries take precedence
+  const byKey = new Map<string, Display>();
 
-    const displays = stdout
-      .split("|||")
-      .filter((name) => name.trim() !== "")
-      .map((name) => ({
-        name: name.trim(),
-        type: "display" as const,
-        lastConnected: undefined,
-      }));
-
-    // Merge with stored displays to preserve lastConnected times
-    const stored = await getStoredDisplays();
-    return displays.map((d) => {
-      const existing = stored.find((s) => s.name === d.name);
-      return existing ? { ...d, lastConnected: existing.lastConnected } : d;
-    });
-  } catch (e) {
-    console.error("Failed to scan displays:", e);
-    return [];
+  if (sidecarResult.status === "fulfilled") {
+    for (const name of sidecarResult.value.devices) {
+      byKey.set(normalizeName(name), { name, type: "ipad" });
+    }
+  } else {
+    console.error("SidecarCore scan failed:", sidecarResult.reason);
   }
+
+  if (menuResult.status === "fulfilled") {
+    for (const name of menuResult.value) {
+      const key = normalizeName(name);
+      if (!byKey.has(key)) byKey.set(key, { name, type: "display" });
+    }
+  } else {
+    console.error("System Settings scan failed:", menuResult.reason);
+  }
+
+  const scanned = [...byKey.values()];
+
+  // merge with stored displays to preserve lastConnected times
+  const stored = await getStoredDisplays();
+  return scanned.map((d) => {
+    const existing = stored.find(
+      (s) => normalizeName(s.name) === normalizeName(d.name),
+    );
+    return existing ? { ...d, lastConnected: existing.lastConnected } : d;
+  });
 }
 
 // Get stored displays from local storage

--- a/extensions/extend-display/src/utils/sidecar.ts
+++ b/extensions/extend-display/src/utils/sidecar.ts
@@ -1,0 +1,233 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * JXA bridge to the SidecarCore framework, used as a targeted fast path for
+ * iPad/Sidecar targets.
+ *
+ * On macOS 26, selecting a Sidecar device through the System Settings
+ * "Mirror or extend to" menu via Accessibility (AXPress) reports success but
+ * does not start a session. SidecarDisplayManager uses the same Sidecar
+ * subsystem exposed by System Settings, so it is used here for iPads while the
+ * UI-scripting backend is kept for other targets.
+ *
+ * Note: SidecarCore is a private framework, so its API may change across macOS
+ * releases; callers treat it as optional and fall back when it is unavailable.
+ *
+ * Reads SIDECAR_ACTION ("list" | "connect" | "disconnect" | "toggle") and
+ * SIDECAR_DEVICE from the environment, prints a single JSON line to stdout.
+ */
+const SIDECAR_BRIDGE = `
+function run() {
+  ObjC.import('Foundation');
+
+  function reply(o) { return JSON.stringify(o); }
+
+  var env = $.NSProcessInfo.processInfo.environment;
+  function envStr(key) {
+    var v = env.objectForKey(key);
+    return (v && !v.isNil()) ? ObjC.unwrap(v) : '';
+  }
+
+  var bundle = $.NSBundle.bundleWithPath('/System/Library/PrivateFrameworks/SidecarCore.framework');
+  if (!bundle || bundle.isNil() || !bundle.load) {
+    return reply({ ok: false, error: 'load-failed' });
+  }
+
+  var mgrClass = $.NSClassFromString('SidecarDisplayManager');
+  if (!mgrClass || mgrClass.isNil()) {
+    return reply({ ok: false, error: 'no-manager' });
+  }
+  var mgr = mgrClass.sharedManager;
+
+  // normalize curly/straight apostrophes and case for name matching
+  function norm(s) {
+    return String(s).replace(/[\\u2018\\u2019\\u02BC\\u0060\\u00B4]/g, "'").trim().toLowerCase();
+  }
+
+  function deviceList(selector) {
+    var arr = mgr[selector];
+    var res = [];
+    if (arr && !arr.isNil()) {
+      for (var i = 0; i < arr.count; i++) {
+        var d = arr.objectAtIndex(i);
+        var n = d.name;
+        res.push({ name: (n && !n.isNil()) ? ObjC.unwrap(n) : '', dev: d });
+      }
+    }
+    return res;
+  }
+
+  function connectedNames() {
+    return deviceList('connectedDevices').map(function (x) { return x.name; });
+  }
+
+  var action = envStr('SIDECAR_ACTION') || 'list';
+  var devices = deviceList('devices');
+
+  if (action === 'list') {
+    return reply({
+      ok: true,
+      devices: devices.map(function (x) { return x.name; }),
+      connected: connectedNames(),
+    });
+  }
+
+  var wanted = norm(envStr('SIDECAR_DEVICE'));
+  if (!wanted) return reply({ ok: false, error: 'no-device-name' });
+
+  var target = null;
+  for (var i = 0; i < devices.length; i++) {
+    if (norm(devices[i].name) === wanted) { target = devices[i]; break; }
+  }
+  if (!target) {
+    for (var j = 0; j < devices.length; j++) {
+      if (norm(devices[j].name).indexOf(wanted) !== -1) { target = devices[j]; break; }
+    }
+  }
+  if (!target) {
+    return reply({
+      ok: false,
+      error: 'device-not-found',
+      devices: devices.map(function (x) { return x.name; }),
+    });
+  }
+
+  function targetConnected() {
+    var t = norm(target.name);
+    return connectedNames().some(function (n) { return norm(n) === t; });
+  }
+
+  var shouldConnect = action === 'connect' ? true
+    : action === 'disconnect' ? false
+    : !targetConnected();
+
+  // SidecarCore completion blocks are not delivered back to JXA, so we pass an
+  // empty block and poll connectedDevices to learn the real outcome.
+  if (shouldConnect) {
+    mgr.connectToDeviceCompletion(target.dev, function () {});
+  } else {
+    mgr.disconnectFromDeviceCompletion(target.dev, function () {});
+  }
+
+  var deadline = $.NSDate.dateWithTimeIntervalSinceNow(13);
+  while ($.NSDate.date.compare(deadline) < 0) {
+    $.NSRunLoop.currentRunLoop.runModeBeforeDate(
+      $.NSDefaultRunLoopMode,
+      $.NSDate.dateWithTimeIntervalSinceNow(0.25),
+    );
+    if (targetConnected() === shouldConnect) break;
+  }
+
+  var finalConnected = targetConnected();
+  return reply({
+    ok: finalConnected === shouldConnect,
+    connected: finalConnected,
+    requested: shouldConnect ? 'connect' : 'disconnect',
+    target: target.name,
+  });
+}
+`;
+
+/**
+ * Normalize a device name for matching: unify curly/straight apostrophes,
+ * trim, and lowercase. Mirrors the `norm()` used inside the JXA bridge.
+ */
+export function normalizeName(name: string): string {
+  return name
+    .replace(/[‘’ʼ`´]/g, "'")
+    .trim()
+    .toLowerCase();
+}
+
+export type SidecarAction = "list" | "connect" | "disconnect" | "toggle";
+
+interface SidecarReply {
+  ok: boolean;
+  error?: string;
+  devices?: string[];
+  connected?: boolean | string[];
+  requested?: string;
+  target?: string;
+}
+
+async function runBridge(
+  action: SidecarAction,
+  deviceName?: string,
+): Promise<SidecarReply> {
+  const { stdout } = await execFileAsync(
+    "osascript",
+    ["-l", "JavaScript", "-e", SIDECAR_BRIDGE],
+    {
+      timeout: 20000,
+      env: {
+        ...process.env,
+        SIDECAR_ACTION: action,
+        SIDECAR_DEVICE: deviceName ?? "",
+      },
+    },
+  );
+
+  const text = stdout.trim();
+  if (!text) {
+    throw new Error("Sidecar bridge returned no output");
+  }
+  return JSON.parse(text) as SidecarReply;
+}
+
+/**
+ * List Sidecar-capable devices (iPads) known to SidecarCore, plus the names of
+ * those currently connected.
+ *
+ * Never throws: if SidecarCore is unavailable (framework missing, future macOS
+ * change, osascript failure) it returns empty lists so callers can fall back
+ * to the System Settings backend.
+ */
+export async function listSidecarDevices(): Promise<{
+  devices: string[];
+  connected: string[];
+}> {
+  try {
+    const reply = await runBridge("list");
+    if (!reply.ok) {
+      console.error(
+        `SidecarCore unavailable: ${reply.error ?? "unknown error"}`,
+      );
+      return { devices: [], connected: [] };
+    }
+    return {
+      devices: reply.devices ?? [],
+      connected: Array.isArray(reply.connected) ? reply.connected : [],
+    };
+  } catch (e) {
+    console.error("SidecarCore list failed:", e);
+    return { devices: [], connected: [] };
+  }
+}
+
+/**
+ * Connect, disconnect, or toggle a Sidecar device by name. Curly and straight
+ * apostrophes are treated as equal.
+ */
+export async function setSidecarConnection(
+  deviceName: string,
+  action: "connect" | "disconnect" | "toggle",
+): Promise<{ connected: boolean; target: string }> {
+  const reply = await runBridge(action, deviceName);
+  if (!reply.ok) {
+    if (reply.error === "device-not-found") {
+      throw new Error(
+        `"${deviceName}" not found. Make sure the iPad is nearby, unlocked, and signed in to the same Apple Account.`,
+      );
+    }
+    throw new Error(
+      `Sidecar ${action} failed: ${reply.error ?? "unknown error"}`,
+    );
+  }
+  return {
+    connected: reply.connected === true,
+    target: reply.target ?? deviceName,
+  };
+}


### PR DESCRIPTION
On macOS 26, picking a Sidecar device from the System Settings "Mirror or extend to" menu via Accessibility (AXPress) reports success but never actually starts a session, so connecting to an iPad is broken.

This adds SidecarCore as an optional fast path for iPad/Sidecar targets. Non-Sidecar targets (e.g. AirPlay Macs) keep using the existing System Settings backend untouched. SidecarCore is a private framework, so it is treated as optional: if it cannot load, the extension falls back to the System Settings path.

While in there I also fixed a few existing AppleScript bugs: the stale `Displays.prefPane` URL (the cause of the original failure toast), an Accessibility lookup that never actually validated the element, missing-value guards on menu item names, and curly/straight apostrophe matching.

Tested on macOS 26.5: scan finds the iPad, connect starts a real Sidecar session (confirmed via `system_profiler`). `npm run build` and `npm run lint` pass.