### PR TITLE
Add copy flight number action

### DIFF
--- a/extensions/flighty/CHANGELOG.md
+++ b/extensions/flighty/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Flighty Changelog
 
-## [Copy Flight Number Action] - {PR_MERGE_DATE}
+## [Copy Flight Number Action] - 2026-05-22
 
 - Add action to copy flight number
 

--- a/extensions/flighty/CHANGELOG.md
+++ b/extensions/flighty/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Flighty Changelog
 
+## {PR_MERGE_DATE}
+
+- Add action to copy flight number
+
 ## [UI Improvements] - 2025-06-05
 
 - Flight details are now easier to read with a more compact layout

--- a/extensions/flighty/CHANGELOG.md
+++ b/extensions/flighty/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Flighty Changelog
 
-## {PR_MERGE_DATE}
+## [Copy Flight Number Action] - {PR_MERGE_DATE}
 
 - Add action to copy flight number
 

--- a/extensions/flighty/package.json
+++ b/extensions/flighty/package.json
@@ -39,5 +39,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/flighty/package.json
+++ b/extensions/flighty/package.json
@@ -6,7 +6,8 @@
   "icon": "flighty.png",
   "author": "hrishabhn",
   "contributors": [
-    "damian_duchnowski"
+    "damian_duchnowski",
+    "effektsvk"
   ],
   "license": "MIT",
   "commands": [

--- a/extensions/flighty/src/view-flights.tsx
+++ b/extensions/flighty/src/view-flights.tsx
@@ -108,6 +108,11 @@ export default function () {
                                 <ActionPanel title="Flight">
                                     <Action.OpenInBrowser title="Open in Flighty" url={link} />
                                     <Action.CopyToClipboard title="Copy Link" content={link} />
+                                    <Action.CopyToClipboard
+                                        title="Copy Flight Number"
+                                        content={`${flight.airlineIata} ${flight.number}`}
+                                        shortcut={{modifiers: ['cmd'], key: '.'}}
+                                    />
                                     {flight.pnr && <Action.CopyToClipboard title="Copy Booking Code" content={flight.pnr} />}
                                 </ActionPanel>
                             }


### PR DESCRIPTION
## Description

Adds a Copy Flight Number action to the Flighty extension action panel, with a Command + . shortcut.

## Screencast

Not applicable; action-only change.