### PR TITLE
Update gif-search extension

### DIFF
--- a/extensions/gif-search/CHANGELOG.md
+++ b/extensions/gif-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GIF Search Changelog
 
-## [Add square GIF actions] - {PR_MERGE_DATE}
+## [Add square GIF actions] - 2026-06-02
 
 - Added new actions to copy and paste center-cropped square GIFs on macOS
 

--- a/extensions/gif-search/CHANGELOG.md
+++ b/extensions/gif-search/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GIF Search Changelog
 
+## [Add square GIF actions] - {PR_MERGE_DATE}
+
+- Added new actions to copy and paste center-cropped square GIFs on macOS
+
 ## [Add Paste GIF Link action] - 2026-05-06
 
 - Added a new action to paste a GIF link into the front-most application

--- a/extensions/gif-search/package.json
+++ b/extensions/gif-search/package.json
@@ -136,8 +136,12 @@
           "value": "viewDetails"
         },
         {
-          "title": "Copy GIF as Square",
+          "title": "Copy GIF Square",
           "value": "copySquareGif"
+        },
+        {
+          "title": "Paste GIF Square",
+          "value": "pasteSquareGif"
         },
         {
           "title": "Copy Page Link",

--- a/extensions/gif-search/package.json
+++ b/extensions/gif-search/package.json
@@ -18,7 +18,8 @@
     "seanparkross",
     "YourMCGeek",
     "thomas",
-    "tim_gailey"
+    "tim_gailey",
+    "clins1994"
   ],
   "license": "MIT",
   "categories": [
@@ -133,6 +134,10 @@
         {
           "title": "View GIF Details",
           "value": "viewDetails"
+        },
+        {
+          "title": "Copy GIF as Square",
+          "value": "copySquareGif"
         },
         {
           "title": "Copy Page Link",

--- a/extensions/gif-search/src/components/GifActions.tsx
+++ b/extensions/gif-search/src/components/GifActions.tsx
@@ -111,13 +111,13 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
 
   async function copyGifAsSquare() {
     try {
-      await showToast({ style: Toast.Style.Animated, title: "Copying GIF as Square" });
+      await showToast({ style: Toast.Style.Animated, title: "Copying GIF Square" });
       const file = await copyGifAsSquareToClipboard(item.gif_url, item.download_name);
       await trackUsage();
       await closeMainWindow();
       await showToast({ style: Toast.Style.Success, title: `Copied square GIF "${path.basename(file)}"` });
     } catch (error) {
-      await showFailureToast(error, { title: "Could not copy GIF as square" });
+      await showFailureToast(error, { title: "Could not copy GIF square" });
     }
   }
 
@@ -133,6 +133,20 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
     } catch (error) {
       console.error(error);
       await showFailureToast(error, { title: "Could not paste GIF" });
+    }
+  }
+
+  async function pasteGifSquare() {
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Pasting GIF Square" });
+      const file = await copyGifAsSquareToClipboard(item.gif_url, item.download_name);
+      await trackUsage();
+      await closeMainWindow();
+      await Clipboard.paste({ file });
+      await showToast({ style: Toast.Style.Success, title: `Pasted square GIF "${path.basename(file)}"` });
+    } catch (error) {
+      console.error(error);
+      await showFailureToast(error, { title: "Could not paste GIF square" });
     }
   }
 
@@ -224,6 +238,18 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
       onPaste={trackUsage}
     />
   );
+  const copySquareGif =
+    process.platform === "darwin" ? (
+      <Action icon={Icon.Clipboard} key="copySquareGif" title="Copy GIF Square" onAction={copyGifAsSquare} />
+    ) : (
+      <Action icon={Icon.Clipboard} key="copySquareGif" title="Copy GIF Square (macOS Only)" />
+    );
+  const pasteSquareGif =
+    process.platform === "darwin" ? (
+      <Action icon={Icon.Clipboard} key="pasteSquareGif" title="Paste GIF Square" onAction={pasteGifSquare} />
+    ) : (
+      <Action icon={Icon.Clipboard} key="pasteSquareGif" title="Paste GIF Square (macOS Only)" />
+    );
   const pasteGifUrl = (
     <Action.Paste
       key="pasteGifUrl"
@@ -287,21 +313,6 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
       onPush={trackUsage}
     />
   );
-  const copySquareGif =
-    process.platform === "darwin" ? (
-      <Action
-        icon={Icon.Crop}
-        key="copySquareGif"
-        title="Copy GIF as Square"
-        onAction={copyGifAsSquare}
-        shortcut={{
-          macOS: { modifiers: ["cmd", "shift"], key: "s" },
-          Windows: { modifiers: ["ctrl", "shift"], key: "s" },
-        }}
-      />
-    ) : (
-      <Action icon={Icon.Crop} key="copySquareGif" title="Copy GIF as Square (macOS Only)" />
-    );
 
   const copyPageUrl = url ? (
     <Action.CopyToClipboard
@@ -337,8 +348,8 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
   );
 
   const actions: Array<(React.JSX.Element | undefined)[]> = [
-    [copyFile, pasteFile, copyGifUrl, pasteGifUrl, copyGifMarkdown, pasteGifMarkdown],
-    [toggleFav, removeRecent, showViewDetails ? viewDetails : undefined, copySquareGif],
+    [copyFile, pasteFile, copyGifUrl, pasteGifUrl, copyGifMarkdown, pasteGifMarkdown, copySquareGif, pasteSquareGif],
+    [toggleFav, removeRecent, showViewDetails ? viewDetails : undefined],
     [copyPageUrl, openUrlInBrowser, downloadFileAction],
   ];
 

--- a/extensions/gif-search/src/components/GifActions.tsx
+++ b/extensions/gif-search/src/components/GifActions.tsx
@@ -18,6 +18,7 @@ import { GifDetails } from "./GifDetails";
 import { IGif } from "../models/gif";
 
 import copyFileToClipboard from "../lib/copyFileToClipboard";
+import copyGifAsSquareToClipboard from "../lib/copyGifAsSquareToClipboard";
 import stripQParams from "../lib/stripQParams";
 import downloadFile from "../lib/downloadFile";
 import { removeGifFromCache } from "../lib/cachedGifs";
@@ -105,6 +106,18 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
       await showToast({ style: Toast.Style.Success, title: `Copied GIF "${path.basename(file)}" to clipboard` });
     } catch (error) {
       await showFailureToast(error, { title: "Could not copy GIF" });
+    }
+  }
+
+  async function copyGifAsSquare() {
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Copying GIF as Square" });
+      const file = await copyGifAsSquareToClipboard(item.gif_url, item.download_name);
+      await trackUsage();
+      await closeMainWindow();
+      await showToast({ style: Toast.Style.Success, title: `Copied square GIF "${path.basename(file)}"` });
+    } catch (error) {
+      await showFailureToast(error, { title: "Could not copy GIF as square" });
     }
   }
 
@@ -274,6 +287,21 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
       onPush={trackUsage}
     />
   );
+  const copySquareGif =
+    process.platform === "darwin" ? (
+      <Action
+        icon={Icon.Crop}
+        key="copySquareGif"
+        title="Copy GIF as Square"
+        onAction={copyGifAsSquare}
+        shortcut={{
+          macOS: { modifiers: ["cmd", "shift"], key: "s" },
+          Windows: { modifiers: ["ctrl", "shift"], key: "s" },
+        }}
+      />
+    ) : (
+      <Action icon={Icon.Crop} key="copySquareGif" title="Copy GIF as Square (macOS Only)" />
+    );
 
   const copyPageUrl = url ? (
     <Action.CopyToClipboard
@@ -310,7 +338,7 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
 
   const actions: Array<(React.JSX.Element | undefined)[]> = [
     [copyFile, pasteFile, copyGifUrl, pasteGifUrl, copyGifMarkdown, pasteGifMarkdown],
-    [toggleFav, removeRecent, showViewDetails ? viewDetails : undefined],
+    [toggleFav, removeRecent, showViewDetails ? viewDetails : undefined, copySquareGif],
     [copyPageUrl, openUrlInBrowser, downloadFileAction],
   ];
 

--- a/extensions/gif-search/src/components/GifActions.tsx
+++ b/extensions/gif-search/src/components/GifActions.tsx
@@ -112,7 +112,7 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
   async function copyGifAsSquare() {
     try {
       await showToast({ style: Toast.Style.Animated, title: "Copying GIF Square" });
-      const file = await copyGifAsSquareToClipboard(item.gif_url, item.download_name);
+      const file = await copyGifAsSquareToClipboard(item.download_url, item.download_name);
       await trackUsage();
       await closeMainWindow();
       await showToast({ style: Toast.Style.Success, title: `Copied square GIF "${path.basename(file)}"` });
@@ -139,7 +139,7 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
   async function pasteGifSquare() {
     try {
       await showToast({ style: Toast.Style.Animated, title: "Pasting GIF Square" });
-      const file = await copyGifAsSquareToClipboard(item.gif_url, item.download_name);
+      const file = await copyGifAsSquareToClipboard(item.download_url, item.download_name);
       await trackUsage();
       await closeMainWindow();
       await Clipboard.paste({ file });
@@ -241,15 +241,11 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
   const copySquareGif =
     process.platform === "darwin" ? (
       <Action icon={Icon.Clipboard} key="copySquareGif" title="Copy GIF Square" onAction={copyGifAsSquare} />
-    ) : (
-      <Action icon={Icon.Clipboard} key="copySquareGif" title="Copy GIF Square (macOS Only)" />
-    );
+    ) : undefined;
   const pasteSquareGif =
     process.platform === "darwin" ? (
       <Action icon={Icon.Clipboard} key="pasteSquareGif" title="Paste GIF Square" onAction={pasteGifSquare} />
-    ) : (
-      <Action icon={Icon.Clipboard} key="pasteSquareGif" title="Paste GIF Square (macOS Only)" />
-    );
+    ) : undefined;
   const pasteGifUrl = (
     <Action.Paste
       key="pasteGifUrl"

--- a/extensions/gif-search/src/lib/copyGifAsSquareToClipboard.ts
+++ b/extensions/gif-search/src/lib/copyGifAsSquareToClipboard.ts
@@ -1,10 +1,13 @@
 import path from "path";
 import { execFile } from "child_process";
+import { existsSync, mkdirSync } from "fs";
+import { writeFile, unlink } from "fs/promises";
 import { promisify } from "util";
-import { Clipboard } from "@raycast/api";
+import { Clipboard, environment } from "@raycast/api";
 import tempy from "tempy";
 
 const execFileAsync = promisify(execFile);
+const scriptFile = path.join(environment.supportPath, "copy-gif-as-square.swift");
 
 const MACOS_SQUARE_GIF_SCRIPT = `
 import CoreGraphics
@@ -120,17 +123,31 @@ export default async function copyGifAsSquareToClipboard(url: string, name: stri
 
   const response = await fetch(url);
 
-  if (response.status !== 200) {
+  if (!response.ok) {
     throw new Error(`GIF file download failed. Server responded with ${response.status}`);
   }
 
   const squareGifName = name || path.basename(url);
   const inputFile = await tempy.write(Buffer.from(await response.arrayBuffer()), { extension: "gif" });
   const file = tempy.file({ name: squareGifName });
-  const scriptFile = await tempy.write(MACOS_SQUARE_GIF_SCRIPT, { extension: "swift" });
 
-  await execFileAsync("/usr/bin/swift", [scriptFile, inputFile, file]);
-  await Clipboard.copy({ file });
+  try {
+    await ensureScriptFile();
+    await execFileAsync("/usr/bin/swift", [scriptFile, inputFile, file]);
+    await Clipboard.copy({ file });
+  } finally {
+    await unlink(inputFile).catch(() => undefined);
+  }
 
   return file;
+}
+
+async function ensureScriptFile() {
+  if (!existsSync(environment.supportPath)) {
+    mkdirSync(environment.supportPath, { recursive: true });
+  }
+
+  if (!existsSync(scriptFile)) {
+    await writeFile(scriptFile, MACOS_SQUARE_GIF_SCRIPT);
+  }
 }

--- a/extensions/gif-search/src/lib/copyGifAsSquareToClipboard.ts
+++ b/extensions/gif-search/src/lib/copyGifAsSquareToClipboard.ts
@@ -1,0 +1,136 @@
+import path from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { Clipboard } from "@raycast/api";
+import tempy from "tempy";
+
+const execFileAsync = promisify(execFile);
+
+const MACOS_SQUARE_GIF_SCRIPT = `
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+func fail(_ message: String) -> Never {
+  FileHandle.standardError.write(Data((message + "\\n").utf8))
+  exit(1)
+}
+
+guard CommandLine.arguments.count == 3 else {
+  fail("Expected input and output paths")
+}
+
+let inputURL = URL(fileURLWithPath: CommandLine.arguments[1])
+let outputURL = URL(fileURLWithPath: CommandLine.arguments[2])
+
+guard let source = CGImageSourceCreateWithURL(inputURL as CFURL, nil) else {
+  fail("Could not read GIF")
+}
+
+let frameCount = CGImageSourceGetCount(source)
+guard frameCount > 0 else {
+  fail("GIF has no frames")
+}
+
+guard
+  let firstFrameProperties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+  let width = firstFrameProperties[kCGImagePropertyPixelWidth] as? Int,
+  let height = firstFrameProperties[kCGImagePropertyPixelHeight] as? Int
+else {
+  fail("Could not read GIF dimensions")
+}
+
+let edgeLength = min(width, height)
+let cropX = (width - edgeLength) / 2
+let cropY = (height - edgeLength) / 2
+let colorSpace = CGColorSpaceCreateDeviceRGB()
+let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+let gifType = UTType.gif.identifier as CFString
+
+guard let destination = CGImageDestinationCreateWithURL(outputURL as CFURL, gifType, frameCount, nil) else {
+  fail("Could not create square GIF")
+}
+
+if
+  let sourceProperties = CGImageSourceCopyProperties(source, nil) as? [CFString: Any],
+  let sourceGifProperties = sourceProperties[kCGImagePropertyGIFDictionary] as? [CFString: Any],
+  let loopCount = sourceGifProperties[kCGImagePropertyGIFLoopCount]
+{
+  CGImageDestinationSetProperties(destination, [
+    kCGImagePropertyGIFDictionary: [
+      kCGImagePropertyGIFLoopCount: loopCount
+    ]
+  ] as CFDictionary)
+}
+
+for frameIndex in 0..<frameCount {
+  guard let frame = CGImageSourceCreateImageAtIndex(source, frameIndex, nil) else {
+    fail("Could not read GIF frame \\(frameIndex)")
+  }
+
+  guard
+    let context = CGContext(
+      data: nil,
+      width: edgeLength,
+      height: edgeLength,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: colorSpace,
+      bitmapInfo: bitmapInfo
+    )
+  else {
+    fail("Could not create square GIF frame \\(frameIndex)")
+  }
+
+  context.clear(CGRect(x: 0, y: 0, width: edgeLength, height: edgeLength))
+  context.draw(frame, in: CGRect(x: -cropX, y: -cropY, width: width, height: height))
+
+  guard let squareFrame = context.makeImage() else {
+    fail("Could not render square GIF frame \\(frameIndex)")
+  }
+
+  var frameGifProperties: [CFString: Any] = [:]
+  if
+    let frameProperties = CGImageSourceCopyPropertiesAtIndex(source, frameIndex, nil) as? [CFString: Any],
+    let sourceGifProperties = frameProperties[kCGImagePropertyGIFDictionary] as? [CFString: Any]
+  {
+    if let unclampedDelay = sourceGifProperties[kCGImagePropertyGIFUnclampedDelayTime] {
+      frameGifProperties[kCGImagePropertyGIFUnclampedDelayTime] = unclampedDelay
+    }
+    if let delay = sourceGifProperties[kCGImagePropertyGIFDelayTime] {
+      frameGifProperties[kCGImagePropertyGIFDelayTime] = delay
+    }
+  }
+
+  CGImageDestinationAddImage(destination, squareFrame, [
+    kCGImagePropertyGIFDictionary: frameGifProperties
+  ] as CFDictionary)
+}
+
+guard CGImageDestinationFinalize(destination) else {
+  fail("Could not write square GIF")
+}
+`;
+
+export default async function copyGifAsSquareToClipboard(url: string, name: string) {
+  if (process.platform !== "darwin") {
+    throw new Error("Copy GIF as Square is only supported on macOS");
+  }
+
+  const response = await fetch(url);
+
+  if (response.status !== 200) {
+    throw new Error(`GIF file download failed. Server responded with ${response.status}`);
+  }
+
+  const squareGifName = name || path.basename(url);
+  const inputFile = await tempy.write(Buffer.from(await response.arrayBuffer()), { extension: "gif" });
+  const file = tempy.file({ name: squareGifName });
+  const scriptFile = await tempy.write(MACOS_SQUARE_GIF_SCRIPT, { extension: "swift" });
+
+  await execFileAsync("/usr/bin/swift", [scriptFile, inputFile, file]);
+  await Clipboard.copy({ file });
+
+  return file;
+}

--- a/extensions/gif-search/src/lib/copyGifAsSquareToClipboard.ts
+++ b/extensions/gif-search/src/lib/copyGifAsSquareToClipboard.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { execFile } from "child_process";
 import { existsSync, mkdirSync } from "fs";
-import { writeFile, unlink } from "fs/promises";
+import { readFile, writeFile, unlink } from "fs/promises";
 import { promisify } from "util";
 import { Clipboard, environment } from "@raycast/api";
 import tempy from "tempy";
@@ -147,7 +147,7 @@ async function ensureScriptFile() {
     mkdirSync(environment.supportPath, { recursive: true });
   }
 
-  if (!existsSync(scriptFile)) {
+  if (!existsSync(scriptFile) || (await readFile(scriptFile, "utf8")) !== MACOS_SQUARE_GIF_SCRIPT) {
     await writeFile(scriptFile, MACOS_SQUARE_GIF_SCRIPT);
   }
 }


### PR DESCRIPTION
## Description

Pretty straightforward

### New actions

- Copy GIF Square: copies the GIF as a square (aspect ratio: 1:1)
- Paste GIF Square: pastes the GIF as a square (aspect ratio 1:1)

### Screenshots

<img width="812" height="512" alt="Screenshot 2026-05-22 at 19 21 12" src="https://github.com/user-attachments/assets/bf4c24de-410e-466a-8094-26afdb7d9e40" />

<img width="300" height="300" alt="Kapture 2026-05-22 at 19 22 21" src="https://github.com/user-attachments/assets/1c3befea-45c4-4fd6-939d-ffe1b218bb54" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
