### PR TITLE
[FileZilla] Add support for FileZilla Pro (Mac App Store)

### DIFF
--- a/extensions/filezilla/CHANGELOG.md
+++ b/extensions/filezilla/CHANGELOG.md
@@ -1,6 +1,6 @@
 # FileZilla Changelog
 
-## [FileZilla Pro Support] - 2026-05-23
+## [FileZilla Pro Support] - {PR_MERGE_DATE}
 
 - Add support for FileZilla Pro (Mac App Store version) alongside standard FileZilla
 - Detect installed variant by bundle ID and use the corresponding app and config directory

--- a/extensions/filezilla/CHANGELOG.md
+++ b/extensions/filezilla/CHANGELOG.md
@@ -1,5 +1,10 @@
 # FileZilla Changelog
 
+## [FileZilla Pro Support] - 2026-05-23
+
+- Add support for FileZilla Pro (Mac App Store version) alongside standard FileZilla
+- Detect installed variant by bundle ID and use the corresponding app and config directory
+
 ## [Add README + Modernize] - 2026-02-03
 
 - Mention FileZilla needs to be in "Applications"

--- a/extensions/filezilla/CHANGELOG.md
+++ b/extensions/filezilla/CHANGELOG.md
@@ -1,6 +1,6 @@
 # FileZilla Changelog
 
-## [FileZilla Pro Support] - {PR_MERGE_DATE}
+## [FileZilla Pro Support] - 2026-05-25
 
 - Add support for FileZilla Pro (Mac App Store version) alongside standard FileZilla
 - Detect installed variant by bundle ID and use the corresponding app and config directory

--- a/extensions/filezilla/src/open-site-manager.tsx
+++ b/extensions/filezilla/src/open-site-manager.tsx
@@ -17,5 +17,5 @@ export default async () => {
     return;
   }
 
-  openSiteManager();
+  await openSiteManager();
 };

--- a/extensions/filezilla/src/utils.tsx
+++ b/extensions/filezilla/src/utils.tsx
@@ -24,19 +24,24 @@ const VARIANTS: FileZillaVariant[] = [
   },
 ];
 
+let installedVariantPromise: Promise<FileZillaVariant | null> | null = null;
 /**
  * Finds the installed FileZilla variant (standard or Pro from the Mac App Store)
  * @returns The installed variant, or null if neither is installed
  */
 async function getInstalledVariant(): Promise<FileZillaVariant | null> {
-  try {
-    const applications = await getApplications();
-    const installedBundleIds = new Set(applications.map((app) => app.bundleId));
-    return VARIANTS.find((variant) => installedBundleIds.has(variant.bundleId)) ?? null;
-  } catch (error) {
-    handleError(error);
-    return null;
-  }
+  if (installedVariantPromise) return installedVariantPromise;
+  installedVariantPromise = (async () => {
+    try {
+      const applications = await getApplications();
+      const installedBundleIds = new Set(applications.map((app) => app.bundleId));
+      return VARIANTS.find((variant) => installedBundleIds.has(variant.bundleId)) ?? null;
+    } catch (error) {
+      handleError(error);
+      return null;
+    }
+  })();
+  return installedVariantPromise;
 }
 
 /**

--- a/extensions/filezilla/src/utils.tsx
+++ b/extensions/filezilla/src/utils.tsx
@@ -5,6 +5,40 @@ import { homedir } from "os";
 import { readFile } from "fs/promises";
 import { ContentToCheck, Server, Folder, XMLFileContent } from "./types";
 
+interface FileZillaVariant {
+  bundleId: string;
+  appName: string;
+  configDir: string;
+}
+
+const VARIANTS: FileZillaVariant[] = [
+  {
+    bundleId: "org.filezilla-project.filezilla",
+    appName: "FileZilla",
+    configDir: `${homedir()}/.config/filezilla`,
+  },
+  {
+    bundleId: "org.filezilla-project.filezilla.sandbox",
+    appName: "FileZilla Pro",
+    configDir: `${homedir()}/Library/Containers/org.filezilla-project.filezilla.sandbox/Data/.config/filezilla`,
+  },
+];
+
+/**
+ * Finds the installed FileZilla variant (standard or Pro from the Mac App Store)
+ * @returns The installed variant, or null if neither is installed
+ */
+async function getInstalledVariant(): Promise<FileZillaVariant | null> {
+  try {
+    const applications = await getApplications();
+    const installedBundleIds = new Set(applications.map((app) => app.bundleId));
+    return VARIANTS.find((variant) => installedBundleIds.has(variant.bundleId)) ?? null;
+  } catch (error) {
+    handleError(error);
+    return null;
+  }
+}
+
 /**
  * Checks if FileZilla is installed on the device
  * @returns True if FileZilla is installed, false if it isn't;
@@ -13,22 +47,18 @@ export async function isFileZillaInstalled(): Promise<boolean> {
   // I wanted to make custom hook out of it, but for some reason I get
   // TypeError: Cannot read properties of null (reading 'useState') error
   // Hence, I just use this function in every Command component
-  try {
-    const applications = await getApplications();
-    return applications.some(({ bundleId }) => bundleId === "org.filezilla-project.filezilla");
-  } catch (error) {
-    handleError(error);
-    return false;
-  }
+  return (await getInstalledVariant()) !== null;
 }
 
 /**
  * Opens FileZilla's site manager
  */
-export function openSiteManager(): void {
+export async function openSiteManager(): Promise<void> {
+  const variant = await getInstalledVariant();
+  if (!variant) return;
   // Unfortunatelly FileZilla does not provide a way to change current state of the working app via it's API.
   // Hence we need to reopen the app every time we want to perform some action in FileZilla via Raycast
-  exec("(pkill -x filezilla; open /Applications/FileZilla.app --args -s)");
+  exec(`(pkill -x filezilla; open -a "${variant.appName}" --args -s)`);
 }
 
 /**
@@ -136,10 +166,13 @@ function getAvailableServers(content: ContentToCheck, folderPath?: string): Cont
  */
 export async function getServers(location: "sitemanager" | "recentservers"): Promise<Server[]> {
   try {
+    const variant = await getInstalledVariant();
+    if (!variant) return [];
+
     const serversFolder = location === "sitemanager" ? "Servers" : "RecentServers";
     const parser = new XMLParser();
     const xmlFileContent = parser.parse(
-      await readFile(homedir() + `/.config/filezilla/${location}.xml`, {
+      await readFile(`${variant.configDir}/${location}.xml`, {
         flag: "r",
       }),
     );
@@ -164,8 +197,10 @@ export async function getServers(location: "sitemanager" | "recentservers"): Pro
  * Connects to the specified server
  * @param server Server to which we want to connect
  */
-export function connectToTheServer(server: Server): void {
+export async function connectToTheServer(server: Server): Promise<void> {
+  const variant = await getInstalledVariant();
+  if (!variant) return;
   // Unfortunatelly FileZilla does not provide a way to change connections inside a currently working app via it's API.
   // Hence we need to reopen the app every time we want to perform some action in FileZilla via Raycast
-  exec(`(pkill -x filezilla; open /Applications/FileZilla.app --args --site=${server.Path})`);
+  exec(`(pkill -x filezilla; open -a "${variant.appName}" --args --site=${server.Path})`);
 }


### PR DESCRIPTION
## Description

This adds support for the Mac App Store version of FileZilla, sold as "FileZilla Pro." It is a sandboxed app with a different bundle identifier and a different config location, so the extension previously reported it as not installed and could not read its saved sites.

### Changes

- Introduce a `getInstalledVariant()` helper that detects which version of FileZilla is installed (standard or Pro) by bundle ID, and returns its app name and config directory.
- `isFileZillaInstalled`, `openSiteManager`, `getServers`, and `connectToTheServer` now use the detected variant. Free FileZilla users see no change in behavior.
- Replace hardcoded `/Applications/FileZilla.app` paths with `open -a "<app name>"`, so the extension does not depend on the app's install location.

### Bundle IDs and config paths

| Variant | Bundle ID | Config directory |
| --- | --- | --- |
| FileZilla (free) | `org.filezilla-project.filezilla` | `~/.config/filezilla/` |
| FileZilla Pro (Mac App Store) | `org.filezilla-project.filezilla.sandbox` | `~/Library/Containers/org.filezilla-project.filezilla.sandbox/Data/.config/filezilla/` |

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder do not contain copyrighted material
- [x] I tested the extension locally with FileZilla Pro installed
- [x] I added an entry to `CHANGELOG.md`

## Screencast

Tested locally — "List Saved Servers", "Open Site Manager", and "Show Latest Connections" all work correctly with FileZilla Pro installed and read sites from the sandboxed config directory.