### PR TITLE
[Open With App] Fix default selection on Raycast 2

### DIFF
--- a/extensions/open-with-app/CHANGELOG.md
+++ b/extensions/open-with-app/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Open With App Changelog
 
-## [Fix default selection on Raycast 2] - {PR_MERGE_DATE}
+## [Fix default selection on Raycast 2] - 2026-05-25
 
 - Fix: default the highlighted row to the first Recommended Application instead of the first Other Application
 - Fix: prevent a one-row scroll the first time the user presses the down arrow

--- a/extensions/open-with-app/CHANGELOG.md
+++ b/extensions/open-with-app/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Open With App Changelog
 
+## [Fix default selection on Raycast 2] - {PR_MERGE_DATE}
+
+- Fix: default the highlighted row to the first Recommended Application instead of the first Other Application
+- Fix: prevent a one-row scroll the first time the user presses the down arrow
+
 ## [Add Bloom support] - 2026-05-05
 
 - Read the selection from Bloom in addition to Finder

--- a/extensions/open-with-app/src/index.tsx
+++ b/extensions/open-with-app/src/index.tsx
@@ -12,7 +12,7 @@ import {
 } from "@raycast/api";
 import { useCachedPromise, useFrecencySorting, usePromise, showFailureToast } from "@raycast/utils";
 import { homedir } from "node:os";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { PROVIDERS, resolveActiveProvider } from "./file-managers";
 
 /**
@@ -73,10 +73,12 @@ function makeTitle(items: FileSystemItem[]) {
 }
 
 function ApplicationListItem({
+  id,
   app,
   items,
   onAction,
 }: {
+  id: string;
   app: Application;
   items: FileSystemItem[];
   onAction?: (app: Application) => void;
@@ -89,6 +91,7 @@ function ApplicationListItem({
   }
   return (
     <List.Item
+      id={id}
       title={app.name}
       icon={{ fileIcon: app.path }}
       actions={
@@ -162,19 +165,41 @@ export default function Command() {
     filterOtherList(sortedOtherApps.filter((item) => item.name.toLowerCase().includes(searchText.toLowerCase())));
   }, [searchText, isLoading]);
 
+  // Seed the selection to the first Recommended app on initial load and on
+  // search changes. Without this, Raycast 2 auto-selects the first item of
+  // "Other Applications". We don't sync selectedItemId from onSelectionChange
+  // so Raycast handles arrow-key navigation internally without re-applying the
+  // prop on every selection change (which caused a one-row scroll on the first
+  // arrow press).
+  const [selectedItemId, setSelectedItemId] = useState<string | undefined>();
+  const lastDefaultFirstIdRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const firstId = filteredRecommendedList?.[0]?.path ?? filteredOtherList?.[0]?.path;
+    if (firstId !== lastDefaultFirstIdRef.current) {
+      lastDefaultFirstIdRef.current = firstId;
+      setSelectedItemId(firstId);
+    }
+  }, [filteredRecommendedList, filteredOtherList]);
+
   return (
-    <List filtering={false} onSearchTextChange={setSearchText} isLoading={isLoading} searchBarPlaceholder={placeholder}>
+    <List
+      filtering={false}
+      onSearchTextChange={setSearchText}
+      isLoading={isLoading}
+      searchBarPlaceholder={placeholder}
+      selectedItemId={selectedItemId}
+    >
       {items.length > 0 && !isLoading && filteredRecommendedList.length > 0 && (
         <List.Section title="Recommended Applications">
           {filteredRecommendedList.map((app) => (
-            <ApplicationListItem key={app.path} app={app} items={items} onAction={visitScope} />
+            <ApplicationListItem id={app.path} key={app.path} app={app} items={items} onAction={visitScope} />
           ))}
         </List.Section>
       )}
       {items.length > 0 && !isLoading && filteredOtherList.length > 0 && (
         <List.Section title="Other Applications">
           {filteredOtherList.map((app) => (
-            <ApplicationListItem key={app.path} app={app} items={items} onAction={visitAll} />
+            <ApplicationListItem id={app.path} key={app.path} app={app} items={items} onAction={visitAll} />
           ))}
         </List.Section>
       )}


### PR DESCRIPTION
## Description

Fixes two related selection bugs in the Open With App extension on Raycast 2 (the bug doesn't manifest in Raycast 1):

1. The command auto-selected the first item of "Other Applications" instead of the first item of "Recommended Applications" — so pressing Enter would open the file with an unrelated app (e.g., 1Password) instead of the user's expected default (e.g., Preview).
2. After fixing #1 with a controlled `selectedItemId`, the first arrow-down press caused a one-row scroll that hid the "Recommended Applications" section header.

### Implementation notes

- Give each `List.Item` an explicit `id` (`app.path`) so Raycast no longer auto-generates UUIDs.
- Seed `selectedItemId` to the first Recommended app on initial load and on search changes via a `useRef` that tracks the "default first id", so it only overrides when the default actually changes.
- Deliberately do **not** wire `onSelectionChange`. Re-applying `selectedItemId` on every selection change made Raycast 2 nudge the viewport by one row on the first arrow press. Leaving the prop seeded only on initial load / search lets Raycast handle arrow-key navigation internally, and the section header stays visible until the selection naturally moves past it.

## Type of change

- [x] Bug fix

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I checked the linter (`npm run lint`) and code is formatted correctly
- [x] Verified in Raycast 2 (beta) — first Recommended app is selected, no scroll glitch on first arrow-down
- [x] Verified in Raycast 1 (stable) — existing behavior unchanged