### PR TITLE
fix(ccusage): use middle dot in "Resets in" separator

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [Fix Reset Time Separator] - {PR_MERGE_DATE}
+
+### Fixed
+
+- "Resets in" rows in the Usage Limits detail panel now use a middle dot (`·`) between the relative and absolute time instead of `||`, which read like a JavaScript logical OR operator
+
 ## [v2.3.2] - 2026-04-24
 
 ### Added

--- a/extensions/ccusage/src/components/UsageLimits.tsx
+++ b/extensions/ccusage/src/components/UsageLimits.tsx
@@ -115,7 +115,7 @@ export function UsageLimits() {
           title="Resets in"
           text={
             data.five_hour.resets_at
-              ? `${formatTimeRemaining(data.five_hour.resets_at)} || ${new Date(data.five_hour.resets_at).toLocaleString("en-US", { hour12: false })}`
+              ? `${formatTimeRemaining(data.five_hour.resets_at)} · ${new Date(data.five_hour.resets_at).toLocaleString("en-US", { hour12: false })}`
               : "N/A"
           }
           icon={Icon.ArrowClockwise}
@@ -147,7 +147,7 @@ export function UsageLimits() {
           title="Resets in"
           text={
             data.seven_day.resets_at
-              ? `${formatTimeRemaining(data.seven_day.resets_at)} || ${new Date(data.seven_day.resets_at).toLocaleString("en-US", { hour12: false })}`
+              ? `${formatTimeRemaining(data.seven_day.resets_at)} · ${new Date(data.seven_day.resets_at).toLocaleString("en-US", { hour12: false })}`
               : "N/A"
           }
           icon={Icon.ArrowClockwise}


### PR DESCRIPTION
## Description

The "Resets in" rows in the Usage Limits detail panel separated the relative time from the absolute timestamp with `||`, which renders as the JavaScript logical OR operator and looks like a syntax glitch in the UI. I replaced it with `·` (middle dot) to match the separator already used elsewhere in this extension (menu bar title, rate limits section header).

Affected: `extensions/ccusage/src/components/UsageLimits.tsx` (the 5-Hour and 7-Day "Resets in" labels).

## Screencast

Before: `10m || 5/24/26, 14:00`
After: `10m · 5/24/26, 14:00`

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
