### PR TITLE
[Things] Add detail view for to-dos

### DIFF
--- a/extensions/things/CHANGELOG.md
+++ b/extensions/things/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Things Changelog
 
+## [Detail View for To-Dos] - {PR_MERGE_DATE}
+
+- Added a Detail view, accessible from any list command by pressing Enter on a row. Renders the to-do's notes as markdown with a metadata sidebar (Status, Created, Start Date, color-coded Deadline, Tags, Project, Area).
+- "Open in Things" remains the secondary action (⌘O) on list rows and becomes the primary action inside the Detail view.
+- Added the to-do's creation date to the data model so it can be shown in the Detail sidebar.
+- Switched date formatting in list-row accessories to US English per the Raycast extension guidelines.
+
 ## [Bug Fixes] - 2026-05-20
 
 - Fix due date accessory not showing for to-dos due in 8–14 days

--- a/extensions/things/CHANGELOG.md
+++ b/extensions/things/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Things Changelog
 
-## [Detail View for To-Dos] - {PR_MERGE_DATE}
+## [Detail View for To-Dos] - 2026-05-25
 
 - Added a Detail view, accessible from any list command by pressing Enter on a row. Renders the to-do's notes as markdown with a metadata sidebar (Status, Created, Start Date, color-coded Deadline, Tags, Project, Area).
 - "Open in Things" remains the secondary action (⌘O) on list rows and becomes the primary action inside the Detail view.

--- a/extensions/things/src/api.ts
+++ b/extensions/things/src/api.ts
@@ -187,6 +187,7 @@ export const getListTodos = (commandListName: CommandListName): Promise<Todo[]> 
       tags: todo.tagNames(),
       dueDate: props.dueDate ? props.dueDate.toISOString() : null,
       activationDate: props.activationDate ? props.activationDate.toISOString() : null,
+      creationDate: props.creationDate ? props.creationDate.toISOString() : null,
       isProject: props.pcls === "project",
       areaTags: areaTags || null,
       project,
@@ -270,6 +271,7 @@ const mapProjectTodoJxa = `todo => {
     tags: todo.tagNames(),
     dueDate: props.dueDate ? props.dueDate.toISOString() : null,
     activationDate: props.activationDate ? props.activationDate.toISOString() : null,
+    creationDate: props.creationDate ? props.creationDate.toISOString() : null,
   };
 }`;
 
@@ -304,6 +306,7 @@ const mapAreaTodoJxa = `todo => {
     tags: todo.tagNames(),
     dueDate: props.dueDate ? props.dueDate.toISOString() : null,
     activationDate: props.activationDate ? props.activationDate.toISOString() : null,
+    creationDate: props.creationDate ? props.creationDate.toISOString() : null,
     isProject: props.pcls === "project",
   };
 }`;

--- a/extensions/things/src/components/OpenInThings.tsx
+++ b/extensions/things/src/components/OpenInThings.tsx
@@ -1,0 +1,17 @@
+import { Action, Keyboard } from '@raycast/api';
+
+type OpenInThingsProps = {
+  id: string;
+  title: string;
+};
+
+export default function OpenInThings({ id, title }: OpenInThingsProps) {
+  return (
+    <Action.Open
+      title={title}
+      icon="things-flat.png"
+      target={`things:///show?id=${id}`}
+      shortcut={Keyboard.Shortcut.Common.Open}
+    />
+  );
+}

--- a/extensions/things/src/components/TodoDetail.tsx
+++ b/extensions/things/src/components/TodoDetail.tsx
@@ -1,17 +1,18 @@
-import { Detail, Color, Icon } from '@raycast/api';
+import { Detail, Icon } from '@raycast/api';
+import { useCachedPromise } from '@raycast/utils';
 import dayjs from 'dayjs';
+import { type ReactNode } from 'react';
 
-import { statusIcons } from '../helpers';
-
-import TodoListItemActions from './TodoListItemActions';
-import { CommandListName, Todo, List as TList } from '../types';
+import { getListTodos } from '../api';
+import { statusIcons, getDeadlineColor } from '../helpers';
+import { CommandListName, Todo } from '../types';
 
 type TodoDetailProps = {
-  todo: Todo;
-  refreshTodos: () => Promise<void>;
+  todoId: string;
+  initialTodo: Todo;
   commandListName: CommandListName;
-  lists?: TList[];
-  tags?: string[];
+  parentRefresh: () => Promise<unknown>;
+  renderActions: (todo: Todo, refreshTodos: () => Promise<void>) => ReactNode;
 };
 
 const statusLabels: Record<Todo['status'], string> = {
@@ -22,15 +23,21 @@ const statusLabels: Record<Todo['status'], string> = {
 
 const formatDate = (iso: string) => dayjs(iso).format('MMM D, YYYY');
 
-function getDeadlineColor(deadline: string): Color | undefined {
-  const today = dayjs(dayjs().format('YYYY-MM-DD')).toISOString();
-  const diff = dayjs(deadline).diff(today, 'day');
-  if (Math.abs(diff) >= 15) return undefined;
-  if (diff <= 0) return Color.Red;
-  return Color.Orange;
-}
+export default function TodoDetail({
+  todoId,
+  initialTodo,
+  commandListName,
+  parentRefresh,
+  renderActions,
+}: TodoDetailProps) {
+  const { data: todos, mutate } = useCachedPromise((name) => getListTodos(name), [commandListName]);
+  const todo = todos?.find((t) => t.id === todoId) ?? initialTodo;
 
-export default function TodoDetail({ todo, refreshTodos, commandListName, lists, tags }: TodoDetailProps) {
+  async function refreshTodos() {
+    await parentRefresh();
+    await mutate();
+  }
+
   const area = todo.area || todo.project?.area;
   const tagList = todo.tags?.split(', ').filter(Boolean) ?? [];
 
@@ -83,16 +90,7 @@ export default function TodoDetail({ todo, refreshTodos, commandListName, lists,
           )}
         </Detail.Metadata>
       }
-      actions={
-        <TodoListItemActions
-          todo={todo}
-          refreshTodos={refreshTodos}
-          commandListName={commandListName}
-          lists={lists}
-          tags={tags}
-          fromDetail
-        />
-      }
+      actions={renderActions(todo, refreshTodos)}
     />
   );
 }

--- a/extensions/things/src/components/TodoDetail.tsx
+++ b/extensions/things/src/components/TodoDetail.tsx
@@ -1,0 +1,98 @@
+import { Detail, Color, Icon } from '@raycast/api';
+import dayjs from 'dayjs';
+
+import { statusIcons } from '../helpers';
+
+import TodoListItemActions from './TodoListItemActions';
+import { CommandListName, Todo, List as TList } from '../types';
+
+type TodoDetailProps = {
+  todo: Todo;
+  refreshTodos: () => Promise<void>;
+  commandListName: CommandListName;
+  lists?: TList[];
+  tags?: string[];
+};
+
+const statusLabels: Record<Todo['status'], string> = {
+  open: 'Open',
+  completed: 'Completed',
+  canceled: 'Canceled',
+};
+
+const formatDate = (iso: string) => dayjs(iso).format('MMM D, YYYY');
+
+function getDeadlineColor(deadline: string): Color | undefined {
+  const today = dayjs(dayjs().format('YYYY-MM-DD')).toISOString();
+  const diff = dayjs(deadline).diff(today, 'day');
+  if (Math.abs(diff) >= 15) return undefined;
+  if (diff <= 0) return Color.Red;
+  return Color.Orange;
+}
+
+export default function TodoDetail({ todo, refreshTodos, commandListName, lists, tags }: TodoDetailProps) {
+  const area = todo.area || todo.project?.area;
+  const tagList = todo.tags?.split(', ').filter(Boolean) ?? [];
+
+  const markdown = `# ${todo.name}\n\n${todo.notes?.trim() || '_No notes_'}`;
+
+  const deadlineColor = todo.dueDate ? getDeadlineColor(todo.dueDate) : undefined;
+
+  return (
+    <Detail
+      markdown={markdown}
+      metadata={
+        <Detail.Metadata>
+          <Detail.Metadata.Label title="Status" icon={statusIcons[todo.status]} text={statusLabels[todo.status]} />
+          {todo.creationDate && (
+            <Detail.Metadata.Label title="Created" icon={Icon.Plus} text={formatDate(todo.creationDate)} />
+          )}
+          {todo.activationDate && (
+            <Detail.Metadata.Label title="Start Date" icon={Icon.Calendar} text={formatDate(todo.activationDate)} />
+          )}
+          {todo.dueDate && (
+            <Detail.Metadata.Label
+              title="Deadline"
+              icon={deadlineColor ? { source: Icon.Flag, tintColor: deadlineColor } : Icon.Flag}
+              text={
+                deadlineColor ? { value: formatDate(todo.dueDate), color: deadlineColor } : formatDate(todo.dueDate)
+              }
+            />
+          )}
+          {tagList.length > 0 && (
+            <Detail.Metadata.TagList title="Tags">
+              {tagList.map((tag) => (
+                <Detail.Metadata.TagList.Item key={tag} text={tag} icon={Icon.Tag} />
+              ))}
+            </Detail.Metadata.TagList>
+          )}
+          {(todo.project || area) && <Detail.Metadata.Separator />}
+          {todo.project && (
+            <Detail.Metadata.Link
+              title="Project"
+              text={todo.project.name}
+              target={`things:///show?id=${todo.project.id}`}
+            />
+          )}
+          {area && (
+            <Detail.Metadata.Link
+              title="Area"
+              text={area.name}
+              target={`things:///show?id=${area.id.replace('THMAreaParentSource/', '')}`}
+            />
+          )}
+        </Detail.Metadata>
+      }
+      actions={
+        <TodoListItemActions
+          todo={todo}
+          refreshTodos={refreshTodos}
+          commandListName={commandListName}
+          lists={lists}
+          tags={tags}
+          fromDetail
+        />
+      }
+    />
+  );
+}

--- a/extensions/things/src/components/TodoListItem.tsx
+++ b/extensions/things/src/components/TodoListItem.tsx
@@ -13,7 +13,7 @@ const getDueDateAccessory = (dueDate: string): List.Item.Accessory => {
   let text, color;
 
   if (Math.abs(diff) >= 15) {
-    text = dayjs(dueDate).format('D MMM');
+    text = dayjs(dueDate).format('MMM D');
   } else if (diff === 0) {
     text = 'Due today';
     color = Color.Red;
@@ -28,7 +28,7 @@ const getDueDateAccessory = (dueDate: string): List.Item.Accessory => {
   return {
     text: { value: text, color },
     icon: { source: Icon.Flag, tintColor: color },
-    tooltip: `Due date: ${dayjs(dueDate).format('dddd DD MMMM YYYY')}`,
+    tooltip: `Due date: ${dayjs(dueDate).format('dddd, MMMM D, YYYY')}`,
   };
 };
 
@@ -70,7 +70,7 @@ export default function TodoListItem({
     accessories.push({
       icon: Icon.Calendar,
       date,
-      tooltip: `Start date: ${dayjs(todo.activationDate).format('dddd DD MMMM YYYY')}`,
+      tooltip: `Start date: ${dayjs(todo.activationDate).format('dddd, MMMM D, YYYY')}`,
     });
   }
 

--- a/extensions/things/src/components/TodoListItem.tsx
+++ b/extensions/things/src/components/TodoListItem.tsx
@@ -1,7 +1,7 @@
-import { List, Icon, Color } from '@raycast/api';
+import { List, Icon } from '@raycast/api';
 import dayjs from 'dayjs';
 
-import { getTodoIcon } from '../helpers';
+import { getDeadlineColor, getTodoIcon } from '../helpers';
 
 import TodoListItemActions from './TodoListItemActions';
 import { CommandListName, Todo, List as TList } from '../types';
@@ -9,20 +9,17 @@ import { CommandListName, Todo, List as TList } from '../types';
 const getDueDateAccessory = (dueDate: string): List.Item.Accessory => {
   const today = dayjs(dayjs().format('YYYY-MM-DD')).toISOString();
   const diff = dayjs(dueDate).diff(today, 'day');
+  const color = getDeadlineColor(dueDate);
 
-  let text, color;
-
+  let text;
   if (Math.abs(diff) >= 15) {
     text = dayjs(dueDate).format('MMM D');
   } else if (diff === 0) {
     text = 'Due today';
-    color = Color.Red;
-  } else if (diff > 0 && diff <= 14) {
+  } else if (diff > 0) {
     text = `${diff} day${diff === 1 ? '' : 's'} left`;
-    color = Color.Orange;
-  } else if (diff < 0) {
+  } else {
     text = `${-diff} day${diff === -1 ? '' : 's'} ago`;
-    color = Color.Red;
   }
 
   return {

--- a/extensions/things/src/components/TodoListItemActions.tsx
+++ b/extensions/things/src/components/TodoListItemActions.tsx
@@ -74,8 +74,8 @@ export default function TodoListItemActions({
     try {
       await mutation();
       await showToast({ style: Toast.Style.Success, title: successTitle, message: todo.name });
-      await refreshTodos();
       if (fromDetail) pop();
+      await refreshTodos();
     } catch (error) {
       await handleError(error);
     }

--- a/extensions/things/src/components/TodoListItemActions.tsx
+++ b/extensions/things/src/components/TodoListItemActions.tsx
@@ -205,11 +205,20 @@ New title:
             icon={Icon.Sidebar}
             target={
               <TodoDetail
-                todo={todo}
-                refreshTodos={refreshTodos}
+                todoId={todo.id}
+                initialTodo={todo}
                 commandListName={commandListName}
-                lists={lists}
-                tags={tags}
+                parentRefresh={refreshTodos}
+                renderActions={(currentTodo, detailRefresh) => (
+                  <TodoListItemActions
+                    todo={currentTodo}
+                    refreshTodos={detailRefresh}
+                    commandListName={commandListName}
+                    lists={lists}
+                    tags={tags}
+                    fromDetail
+                  />
+                )}
               />
             }
           />

--- a/extensions/things/src/components/TodoListItemActions.tsx
+++ b/extensions/things/src/components/TodoListItemActions.tsx
@@ -9,6 +9,7 @@ import {
   Keyboard,
   AI,
   environment,
+  useNavigation,
 } from '@raycast/api';
 
 import { AddNewTodo } from '../add-new-todo';
@@ -17,6 +18,8 @@ import { getChecklistItemsWithAI, getTypeIcon, listItems, statusIcons } from '..
 import { capitalize } from '../utils';
 
 import EditTodo from './EditTodo';
+import OpenInThings from './OpenInThings';
+import TodoDetail from './TodoDetail';
 import { Todo, List as TList, CommandListName, UpdateTodoParams, UpdateProjectParams } from '../types';
 
 // Match URLs with protocols, with optional //
@@ -28,6 +31,7 @@ type TodoListItemActionsProps = {
   tags?: string[];
   lists?: TList[];
   refreshTodos: () => Promise<void>;
+  fromDetail?: boolean;
 };
 
 export default function TodoListItemActions({
@@ -36,7 +40,9 @@ export default function TodoListItemActions({
   commandListName,
   tags,
   lists,
+  fromDetail = false,
 }: TodoListItemActionsProps) {
+  const { pop } = useNavigation();
   const availableTags =
     tags?.filter((tag) => {
       return !todo.tags?.includes(tag);
@@ -59,6 +65,17 @@ export default function TodoListItemActions({
         message: successToastOptions.message ?? todo.name,
       });
       await refreshTodos();
+    } catch (error) {
+      await handleError(error);
+    }
+  }
+
+  async function terminalMutation(mutation: () => Promise<unknown>, successTitle: string) {
+    try {
+      await mutation();
+      await showToast({ style: Toast.Style.Success, title: successTitle, message: todo.name });
+      await refreshTodos();
+      if (fromDetail) pop();
     } catch (error) {
       await handleError(error);
     }
@@ -148,31 +165,17 @@ New title:
 
   async function deleteToDoOrProject() {
     const isProject = todo.isProject;
+    const confirmed = await confirmAlert({
+      title: isProject ? 'Delete Project' : 'Delete To-Do',
+      message: isProject
+        ? 'Are you sure you want to delete this project?'
+        : 'Are you sure you want to delete this to-do?',
+      icon: { source: Icon.Trash, tintColor: Color.Red },
+    });
+    if (!confirmed) return;
 
-    let title = isProject ? 'Delete Project' : 'Delete To-Do';
-    const message = isProject
-      ? 'Are you sure you want to delete this project?'
-      : 'Are you sure you want to delete this to-do?';
     const deleteFunction = isProject ? deleteProject : deleteTodo;
-
-    if (
-      await confirmAlert({
-        title,
-        message,
-        icon: { source: Icon.Trash, tintColor: Color.Red },
-      })
-    ) {
-      await deleteFunction(todo.id);
-
-      title = isProject ? 'Deleted project' : 'Deleted to-do';
-
-      await showToast({
-        style: Toast.Style.Success,
-        title,
-        message: todo.name,
-      });
-      await refreshTodos();
-    }
+    await terminalMutation(() => deleteFunction(todo.id), isProject ? 'Deleted project' : 'Deleted to-do');
   }
 
   function formatDateTime(date: Date): string {
@@ -196,20 +199,29 @@ New title:
   return (
     <ActionPanel>
       <ActionPanel.Section title={todo.name}>
-        <Action.Open title="Open in Things" icon="things-flat.png" target={`things:///show?id=${todo.id}`} />
+        {!fromDetail && (
+          <Action.Push
+            title="Show Details"
+            icon={Icon.Sidebar}
+            target={
+              <TodoDetail
+                todo={todo}
+                refreshTodos={refreshTodos}
+                commandListName={commandListName}
+                lists={lists}
+                tags={tags}
+              />
+            }
+          />
+        )}
+        <OpenInThings id={todo.id} title="Open in Things" />
         {todo.status !== 'completed' && (
           <Action
             title="Mark as Completed"
             icon={statusIcons.completed}
-            onAction={async () => {
-              await setTodoProperty(todo.id, 'status', 'completed');
-              await showToast({
-                style: Toast.Style.Success,
-                title: 'Marked as Completed',
-                message: todo.name,
-              });
-              await refreshTodos();
-            }}
+            onAction={() =>
+              terminalMutation(() => setTodoProperty(todo.id, 'status', 'completed'), 'Marked as Completed')
+            }
           />
         )}
 
@@ -218,15 +230,9 @@ New title:
             title="Mark as Canceled"
             icon={statusIcons.canceled}
             shortcut={{ modifiers: ['opt', 'cmd'], key: 'k' }}
-            onAction={async () => {
-              await setTodoProperty(todo.id, 'status', 'canceled');
-              await showToast({
-                style: Toast.Style.Success,
-                title: 'Marked as Canceled',
-                message: todo.name,
-              });
-              await refreshTodos();
-            }}
+            onAction={() =>
+              terminalMutation(() => setTodoProperty(todo.id, 'status', 'canceled'), 'Marked as Canceled')
+            }
           />
         )}
       </ActionPanel.Section>
@@ -358,7 +364,6 @@ New title:
           <Action.Open
             title="Open Project in Things"
             icon="things-flat.png"
-            shortcut={{ modifiers: ['cmd'], key: 'o' }}
             target={`things:///show?id=${todo.project.id}`}
           />
           <Action.CopyToClipboard title="Copy Project URL" content={`things:///show?id=${todo.project.id}`} />

--- a/extensions/things/src/helpers.ts
+++ b/extensions/things/src/helpers.ts
@@ -1,4 +1,5 @@
 import { AI, Color, Icon, Image } from '@raycast/api';
+import dayjs from 'dayjs';
 import { List, Todo } from './types';
 
 export const listItems = {
@@ -47,6 +48,14 @@ export function getTypeIcon(type: 'area' | 'project' | 'todo'): Image.ImageLike 
     case 'todo':
       return Icon.Circle;
   }
+}
+
+export function getDeadlineColor(dueDate: string): Color | undefined {
+  const today = dayjs(dayjs().format('YYYY-MM-DD')).toISOString();
+  const diff = dayjs(dueDate).diff(today, 'day');
+  if (Math.abs(diff) >= 15) return undefined;
+  if (diff <= 0) return Color.Red;
+  return Color.Orange;
 }
 
 export function getChecklistItemsWithAI(name: string, notes: string) {

--- a/extensions/things/src/types.ts
+++ b/extensions/things/src/types.ts
@@ -10,6 +10,7 @@ export type Todo = {
   area?: Area;
   dueDate: string;
   activationDate: string;
+  creationDate: string;
   notes: string;
   isProject?: boolean;
 };


### PR DESCRIPTION
## Description

Adds a Detail view for to-dos, accessible from any list command (Today, Inbox, Anytime, Upcoming, Someday). Pressing Enter on a row pushes a Detail with the to-do's notes rendered as markdown and a metadata sidebar. The previous "Open in Things" action becomes the secondary action (still ⌘O).

The pattern mirrors Todoist, Linear, and GitHub: list → Detail → external app.

#### Detail view

New `components/TodoDetail.tsx`. Renders:

- Markdown body: `# ${todo.name}` followed by notes (or `_No notes_` when empty).
- Metadata sidebar: Status, Created, Start Date, Deadline (color-coded by proximity), Tags as a `TagList`, Project link, Area link.

Project and Area entries link to `things:///show?id=...` so they open the right view in Things.

#### Shared "Open in Things" action

New `components/OpenInThings.tsx` extracts the `Action.Open` so the list row, the detail view, and any future caller share one source of truth for icon, target URL, and ⌘O shortcut. Removed the duplicate ⌘O on the project section to avoid a hotkey collision.

#### List action panel

`TodoListItemActions` now accepts a `fromDetail` flag:

- From a list row: prepends a "Show Details" push as the primary action.
- From the detail view: omits the push, and pops back to the list after terminal mutations (complete, cancel, delete) so the user lands on the refreshed list.

Extracted a small `terminalMutation` helper to remove the duplicated mutate, toast, refresh, pop-or-error blocks across the three terminal handlers.

#### Date formatting

Raycast's [store guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store) require US English. `TodoListItem` was using EU formats (`D MMM YYYY`, `dddd DD MMMM YYYY`). Updated those to US format and used the same convention in the new Detail sidebar.

#### Data

Added `creationDate` to the `Todo` type and the three JXA mappers (`getListTodos`, `mapProjectTodoJxa`, `mapAreaTodoJxa`). Same null-safe ISO conversion as the other dates. No extra Apple Events, no perf impact.

## Screencast

<img width="862" height="587" alt="Screenshot 2026-05-24 at 13 02 54" src="https://github.com/user-attachments/assets/38a0c6ff-d44f-4a4d-822f-b728b681e84f" />
<img width="862" height="587" alt="Screenshot 2026-05-24 at 13 03 02" src="https://github.com/user-attachments/assets/f9fb398d-2c79-4613-9350-6e6d3ff1655c" />
<img width="862" height="587" alt="Screenshot 2026-05-24 at 13 03 05" src="https://github.com/user-attachments/assets/6df9ebc8-074f-4332-b9ec-486810a12736" />
<img width="862" height="587" alt="Screenshot 2026-05-24 at 13 03 08" src="https://github.com/user-attachments/assets/703bf171-b45d-4543-96b1-02640c35e8a3" />
<img width="862" height="587" alt="Screenshot 2026-05-24 at 13 04 15" src="https://github.com/user-attachments/assets/cdf0b373-ece2-446b-abeb-835f2a432c45" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)