### PR TITLE
[ccusage] Adopt v20: schema fix and new features

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [ccusage v20] - {PR_MERGE_DATE}
+## [ccusage v20] - 2026-05-25
 
 ### Added
 

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [Fix ccusage v20 schema mismatch] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Compatibility with `ccusage` v20, which renamed per-row `date`/`month`/`sessionId` to `period`, moved `lastActivity` under `metadata`, and renamed the session command's top-level `sessions` array to `session`. Schemas now accept both shapes, restoring daily, monthly, session, and total usage views
+- Replaced the `||` separator in the Usage Limits detail panel's "Resets in" rows with `·` so it no longer reads like a JavaScript operator
+
 ## [v2.3.2] - 2026-04-24
 
 ### Added

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [Fix ccusage v20 schema mismatch] - {PR_MERGE_DATE}
+## [ccusage v20] - {PR_MERGE_DATE}
 
 ### Fixed
 

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -11,8 +11,8 @@
 
 ### Fixed
 
-- Compatibility with `ccusage` v20, which renamed per-row `date`/`month`/`sessionId` to `period`, moved `lastActivity` under `metadata`, and renamed the session command's top-level `sessions` array to `session`. Schemas now accept both shapes, restoring daily, monthly, session, and total usage views
-- Replaced the `||` separator in the Usage Limits detail panel's "Resets in" rows with `·` so it no longer reads like a JavaScript operator
+- Restored daily, monthly, session, and total views, which broke with `ccusage` v20's renamed row fields (`period`, nested `metadata`, `session` array)
+- "Resets in" rows in the Usage Limits detail panel use `·` instead of `||` so the separator no longer reads like a JavaScript operator
 
 ## [v2.3.2] - 2026-04-24
 

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [ccusage v20] - {PR_MERGE_DATE}
 
+### Added
+
+- **Weekly usage view**: a "This Week" item in the main list and a matching menu bar section, with week-over-week cost and token deltas
+- **Active block burn rate and projection**: the menu bar now shows a "Current Block" section with the projected total cost, spend so far, $/hour burn rate, and time left in the 5-hour window
+- **Multi-agent visibility**: when `ccusage` reports usage from more than one coding agent (Claude, Codex, Gemini, etc.), the daily and weekly detail panels show the contributing agents
+- **Menu bar status options**: "Weekly Cost" and "Block Projection" added to the dropdown next to the icon
+
 ### Fixed
 
 - Compatibility with `ccusage` v20, which renamed per-row `date`/`month`/`sessionId` to `period`, moved `lastActivity` under `metadata`, and renamed the session command's top-level `sessions` array to `session`. Schemas now accept both shapes, restoring daily, monthly, session, and total usage views

--- a/extensions/ccusage/package-lock.json
+++ b/extensions/ccusage/package-lock.json
@@ -62,6 +62,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2631,6 +2632,7 @@
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.6.tgz",
       "integrity": "sha512-W3UnZrfh1EH9mteQQOibeUvniDnVsbRgcfSUgVWFTGuI6mzKLFzoM8mD6n5amYQM51JVvbuJbaqtfMqsTmnQCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.5.4",
         "@oclif/plugin-autocomplete": "^3.2.35",
@@ -2854,6 +2856,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -2943,6 +2946,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -3436,6 +3440,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3706,6 +3711,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4232,6 +4238,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5226,6 +5233,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5803,6 +5811,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -6575,6 +6584,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7196,6 +7206,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7357,6 +7368,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/ccusage/package.json
+++ b/extensions/ccusage/package.json
@@ -14,7 +14,8 @@
     "garrick_zhang",
     "pernielsentikaer",
     "raulg",
-    "ridemountainpig"
+    "ridemountainpig",
+    "bendrucker"
   ],
   "license": "MIT",
   "commands": [

--- a/extensions/ccusage/package.json
+++ b/extensions/ccusage/package.json
@@ -50,6 +50,10 @@
               "value": "todayCost"
             },
             {
+              "title": "Weekly Cost",
+              "value": "weeklyCost"
+            },
+            {
               "title": "Monthly Cost",
               "value": "monthlyCost"
             },
@@ -153,6 +157,10 @@
         {
           "title": "Today Usage",
           "value": "today"
+        },
+        {
+          "title": "This Week",
+          "value": "week"
         },
         {
           "title": "Session Usage",

--- a/extensions/ccusage/package.json
+++ b/extensions/ccusage/package.json
@@ -70,6 +70,10 @@
               "value": "utilization"
             },
             {
+              "title": "Block Projection",
+              "value": "blockProjection"
+            },
+            {
               "title": "None",
               "value": "none"
             }

--- a/extensions/ccusage/src/ccusage.tsx
+++ b/extensions/ccusage/src/ccusage.tsx
@@ -1,5 +1,6 @@
 import { List } from "@raycast/api";
 import { DailyUsage } from "./components/DailyUsage";
+import { WeeklyUsage } from "./components/WeeklyUsage";
 import { SessionUsage } from "./components/SessionUsage";
 import { CostAnalysis } from "./components/CostAnalysis";
 import { ModelBreakdown } from "./components/ModelBreakdown";
@@ -12,6 +13,7 @@ export default function CCUsage() {
   return (
     <List selectedItemId={selectedItemId} isShowingDetail>
       <DailyUsage />
+      <WeeklyUsage />
       <SessionUsage />
       <CostAnalysis />
       <ModelBreakdown />

--- a/extensions/ccusage/src/components/DailyUsage.tsx
+++ b/extensions/ccusage/src/components/DailyUsage.tsx
@@ -36,9 +36,7 @@ export function DailyUsage() {
     ? STANDARD_ACCESSORIES.ERROR
     : dailyUsage === undefined
       ? STANDARD_ACCESSORIES.LOADING
-      : !dailyUsage
-        ? STANDARD_ACCESSORIES.NO_DATA
-        : [{ text: formatCost(dailyUsage.totalCost), icon: Icon.Coins }];
+      : [{ text: formatCost(dailyUsage.totalCost), icon: Icon.Coins }];
 
   const renderDetailMetadata = (): ReactNode => {
     if (error || !dailyUsage) {

--- a/extensions/ccusage/src/components/DailyUsage.tsx
+++ b/extensions/ccusage/src/components/DailyUsage.tsx
@@ -54,6 +54,13 @@ export function DailyUsage() {
     return (
       <List.Item.Detail.Metadata>
         <List.Item.Detail.Metadata.Label title="Date" text={dailyUsage.date} icon={Icon.Calendar} />
+        {dailyUsage.metadata?.agents && dailyUsage.metadata.agents.length > 1 && (
+          <List.Item.Detail.Metadata.Label
+            title="Agents"
+            text={dailyUsage.metadata.agents.join(", ")}
+            icon={Icon.PersonCircle}
+          />
+        )}
         <List.Item.Detail.Metadata.Separator />
 
         <List.Item.Detail.Metadata.Label title="Token Usage" />

--- a/extensions/ccusage/src/components/DailyUsage.tsx
+++ b/extensions/ccusage/src/components/DailyUsage.tsx
@@ -82,10 +82,14 @@ export function DailyUsage() {
             <List.Item.Detail.Metadata.Label
               title="Cost Delta"
               text={formatCostDelta(dailyUsage.totalCost, previousDayData.totalCost)}
-              icon={{
-                source: dailyUsage.totalCost >= previousDayData.totalCost ? Icon.ArrowUp : Icon.ArrowDown,
-                tintColor: dailyUsage.totalCost >= previousDayData.totalCost ? Color.Red : Color.Green,
-              }}
+              icon={
+                dailyUsage.totalCost === previousDayData.totalCost
+                  ? undefined
+                  : {
+                      source: dailyUsage.totalCost > previousDayData.totalCost ? Icon.ArrowUp : Icon.ArrowDown,
+                      tintColor: dailyUsage.totalCost > previousDayData.totalCost ? Color.Red : Color.Green,
+                    }
+              }
             />
             <List.Item.Detail.Metadata.Label
               title="Token Delta"

--- a/extensions/ccusage/src/components/UsageLimits.tsx
+++ b/extensions/ccusage/src/components/UsageLimits.tsx
@@ -115,7 +115,7 @@ export function UsageLimits() {
           title="Resets in"
           text={
             data.five_hour.resets_at
-              ? `${formatTimeRemaining(data.five_hour.resets_at)} || ${new Date(data.five_hour.resets_at).toLocaleString("en-US", { hour12: false })}`
+              ? `${formatTimeRemaining(data.five_hour.resets_at)} · ${new Date(data.five_hour.resets_at).toLocaleString("en-US", { hour12: false })}`
               : "N/A"
           }
           icon={Icon.ArrowClockwise}
@@ -147,7 +147,7 @@ export function UsageLimits() {
           title="Resets in"
           text={
             data.seven_day.resets_at
-              ? `${formatTimeRemaining(data.seven_day.resets_at)} || ${new Date(data.seven_day.resets_at).toLocaleString("en-US", { hour12: false })}`
+              ? `${formatTimeRemaining(data.seven_day.resets_at)} · ${new Date(data.seven_day.resets_at).toLocaleString("en-US", { hour12: false })}`
               : "N/A"
           }
           icon={Icon.ArrowClockwise}

--- a/extensions/ccusage/src/components/WeeklyUsage.tsx
+++ b/extensions/ccusage/src/components/WeeklyUsage.tsx
@@ -1,0 +1,107 @@
+import { List, Icon, Color } from "@raycast/api";
+import { ReactNode, useMemo } from "react";
+import {
+  formatTokens,
+  formatCost,
+  formatCostDelta,
+  formatTokenDelta,
+  getTokenEfficiency,
+  getCostPerMTok,
+} from "../utils/data-formatter";
+import { useWeeklyUsage } from "../hooks/useWeeklyUsage";
+import { ErrorMetadata } from "./ErrorMetadata";
+import { StandardActions, type ExternalLink } from "./common/StandardActions";
+import { STANDARD_ACCESSORIES } from "./common/accessories";
+
+const externalLinks: ExternalLink[] = [
+  { title: "View ccusage Repository", url: "https://github.com/ryoppippi/ccusage", icon: Icon.Code },
+];
+
+export function WeeklyUsage() {
+  const { data: weeklyUsage, previousWeekData, isLoading, error } = useWeeklyUsage();
+
+  const efficiency = useMemo(
+    () => (weeklyUsage ? getTokenEfficiency(weeklyUsage.inputTokens, weeklyUsage.outputTokens) : "0.00"),
+    [weeklyUsage?.inputTokens, weeklyUsage?.outputTokens],
+  );
+  const costPerMTok = useMemo(
+    () => (weeklyUsage ? getCostPerMTok(weeklyUsage.totalCost, weeklyUsage.totalTokens) : "$0.00"),
+    [weeklyUsage?.totalCost, weeklyUsage?.totalTokens],
+  );
+
+  const accessories: List.Item.Accessory[] = error
+    ? STANDARD_ACCESSORIES.ERROR
+    : weeklyUsage === undefined
+      ? STANDARD_ACCESSORIES.LOADING
+      : !weeklyUsage
+        ? STANDARD_ACCESSORIES.NO_DATA
+        : [{ text: formatCost(weeklyUsage.totalCost), icon: Icon.Coins }];
+
+  const renderDetailMetadata = (): ReactNode => {
+    if (error || !weeklyUsage) {
+      return <ErrorMetadata error={error} noDataMessage={!weeklyUsage ? "No usage recorded this week" : undefined} />;
+    }
+
+    return (
+      <List.Item.Detail.Metadata>
+        <List.Item.Detail.Metadata.Label title="Week of" text={weeklyUsage.week} icon={Icon.Calendar} />
+        {weeklyUsage.metadata?.agents && weeklyUsage.metadata.agents.length > 1 && (
+          <List.Item.Detail.Metadata.Label
+            title="Agents"
+            text={weeklyUsage.metadata.agents.join(", ")}
+            icon={Icon.PersonCircle}
+          />
+        )}
+        <List.Item.Detail.Metadata.Separator />
+
+        <List.Item.Detail.Metadata.Label title="Token Usage" />
+        <List.Item.Detail.Metadata.Label title="Input Tokens" text={formatTokens(weeklyUsage.inputTokens)} />
+        <List.Item.Detail.Metadata.Label title="Output Tokens" text={formatTokens(weeklyUsage.outputTokens)} />
+        <List.Item.Detail.Metadata.Label title="Total Tokens" text={formatTokens(weeklyUsage.totalTokens)} />
+        <List.Item.Detail.Metadata.Separator />
+
+        <List.Item.Detail.Metadata.Label title="Cost Analysis" />
+        <List.Item.Detail.Metadata.Label
+          title="Total Cost"
+          text={formatCost(weeklyUsage.totalCost)}
+          icon={Icon.Coins}
+        />
+        <List.Item.Detail.Metadata.Label title="Cost per MTok" text={costPerMTok} />
+        <List.Item.Detail.Metadata.Separator />
+
+        <List.Item.Detail.Metadata.Label title="Efficiency Metrics" />
+        <List.Item.Detail.Metadata.Label title="Output/Input Ratio" text={efficiency} />
+
+        {previousWeekData && (
+          <>
+            <List.Item.Detail.Metadata.Separator />
+            <List.Item.Detail.Metadata.Label title="Week-over-Week" text={previousWeekData.week} />
+            <List.Item.Detail.Metadata.Label
+              title="Cost Delta"
+              text={formatCostDelta(weeklyUsage.totalCost, previousWeekData.totalCost)}
+              icon={{
+                source: weeklyUsage.totalCost >= previousWeekData.totalCost ? Icon.ArrowUp : Icon.ArrowDown,
+                tintColor: weeklyUsage.totalCost >= previousWeekData.totalCost ? Color.Red : Color.Green,
+              }}
+            />
+            <List.Item.Detail.Metadata.Label
+              title="Token Delta"
+              text={formatTokenDelta(weeklyUsage.totalTokens, previousWeekData.totalTokens)}
+            />
+          </>
+        )}
+      </List.Item.Detail.Metadata>
+    );
+  };
+
+  return (
+    <List.Item
+      id="week"
+      title="This Week"
+      icon={Icon.Calendar}
+      accessories={accessories}
+      detail={<List.Item.Detail isLoading={isLoading} metadata={renderDetailMetadata()} />}
+      actions={<StandardActions externalLinks={externalLinks} />}
+    />
+  );
+}

--- a/extensions/ccusage/src/components/WeeklyUsage.tsx
+++ b/extensions/ccusage/src/components/WeeklyUsage.tsx
@@ -79,10 +79,14 @@ export function WeeklyUsage() {
             <List.Item.Detail.Metadata.Label
               title="Cost Delta"
               text={formatCostDelta(weeklyUsage.totalCost, previousWeekData.totalCost)}
-              icon={{
-                source: weeklyUsage.totalCost >= previousWeekData.totalCost ? Icon.ArrowUp : Icon.ArrowDown,
-                tintColor: weeklyUsage.totalCost >= previousWeekData.totalCost ? Color.Red : Color.Green,
-              }}
+              icon={
+                weeklyUsage.totalCost === previousWeekData.totalCost
+                  ? undefined
+                  : {
+                      source: weeklyUsage.totalCost > previousWeekData.totalCost ? Icon.ArrowUp : Icon.ArrowDown,
+                      tintColor: weeklyUsage.totalCost > previousWeekData.totalCost ? Color.Red : Color.Green,
+                    }
+              }
             />
             <List.Item.Detail.Metadata.Label
               title="Token Delta"

--- a/extensions/ccusage/src/components/WeeklyUsage.tsx
+++ b/extensions/ccusage/src/components/WeeklyUsage.tsx
@@ -33,9 +33,7 @@ export function WeeklyUsage() {
     ? STANDARD_ACCESSORIES.ERROR
     : weeklyUsage === undefined
       ? STANDARD_ACCESSORIES.LOADING
-      : !weeklyUsage
-        ? STANDARD_ACCESSORIES.NO_DATA
-        : [{ text: formatCost(weeklyUsage.totalCost), icon: Icon.Coins }];
+      : [{ text: formatCost(weeklyUsage.totalCost), icon: Icon.Coins }];
 
   const renderDetailMetadata = (): ReactNode => {
     if (error || !weeklyUsage) {

--- a/extensions/ccusage/src/hooks/useCCUsageWeeklyCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageWeeklyCli.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect } from "react";
+import { Cache } from "@raycast/api";
+import { useExec } from "@raycast/utils";
+import { WeeklyUsageCommandResponse, WeeklyUsageCommandResponseSchema } from "../types/usage-types";
+import { getExecOptions } from "../utils/exec-options";
+import { stringToJSON } from "../utils/string-to-json-schema";
+import { preferences } from "../preferences";
+
+const cache = new Cache();
+const CACHE_KEY = "ccusage-weekly";
+
+export const useCCUsageWeeklyCli = () => {
+  const useDirectCommand = preferences.useDirectCcusageCommand;
+
+  const [initialData] = useState<WeeklyUsageCommandResponse | undefined>(() => {
+    const cached = cache.get(CACHE_KEY);
+    return cached ? (JSON.parse(cached) as WeeklyUsageCommandResponse) : undefined;
+  });
+
+  const command = useDirectCommand ? "ccusage" : "npx";
+  const args = useDirectCommand ? ["weekly", "--json"] : ["ccusage@latest", "weekly", "--json"];
+
+  const result = useExec(command, args, {
+    ...getExecOptions(),
+    initialData,
+    parseOutput: ({ stdout }) => {
+      if (!stdout) {
+        throw new Error("No output received from ccusage weekly command");
+      }
+
+      const parseResult = stringToJSON.pipe(WeeklyUsageCommandResponseSchema).safeParse(stdout.toString());
+
+      if (!parseResult.success) {
+        throw new Error(`Invalid weekly usage data: ${parseResult.error.message}`);
+      }
+
+      cache.set(CACHE_KEY, JSON.stringify(parseResult.data));
+      return parseResult.data;
+    },
+    keepPreviousData: true,
+    failureToastOptions: {
+      title: "Failed to fetch weekly usage data",
+      primaryAction: {
+        title: "Retry",
+        onAction: (toast) => {
+          toast.hide();
+          result.revalidate();
+        },
+      },
+    },
+  });
+
+  const intervalMs = parseInt(preferences.usageLimitsRefreshInterval || "60", 10) * 1000;
+  useEffect(() => {
+    const id = setInterval(() => result.revalidate(), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs, result.revalidate]);
+
+  return result;
+};

--- a/extensions/ccusage/src/hooks/useWeeklyUsage.ts
+++ b/extensions/ccusage/src/hooks/useWeeklyUsage.ts
@@ -1,6 +1,6 @@
 import { useCCUsageWeeklyCli } from "./useCCUsageWeeklyCli";
 import { WeeklyUsageData } from "../types/usage-types";
-import { getCurrentWeekStart, getPreviousWeekStart } from "../utils/date-formatter";
+import { getCurrentWeekStart } from "../utils/date-formatter";
 
 export const useWeeklyUsage = (): {
   data: WeeklyUsageData | undefined;
@@ -12,12 +12,8 @@ export const useWeeklyUsage = (): {
   const { data: rawData, isLoading, error, revalidate } = useCCUsageWeeklyCli();
 
   const weeks = rawData?.weekly ?? [];
-  const currentWeek = getCurrentWeekStart();
-  const previousWeek = getPreviousWeekStart();
-
-  const data = weeks.find((entry) => entry.week === currentWeek) ?? weeks.at(-1);
-  const previousWeekData =
-    weeks.find((entry) => entry.week === previousWeek) ?? weeks.filter((e) => e.week < currentWeek).at(-1);
+  const data = weeks.find((entry) => entry.week === getCurrentWeekStart()) ?? weeks.at(-1);
+  const previousWeekData = data ? weeks.filter((entry) => entry.week < data.week).at(-1) : undefined;
 
   return { data, previousWeekData, isLoading, error, revalidate };
 };

--- a/extensions/ccusage/src/hooks/useWeeklyUsage.ts
+++ b/extensions/ccusage/src/hooks/useWeeklyUsage.ts
@@ -1,0 +1,23 @@
+import { useCCUsageWeeklyCli } from "./useCCUsageWeeklyCli";
+import { WeeklyUsageData } from "../types/usage-types";
+import { getCurrentWeekStart, getPreviousWeekStart } from "../utils/date-formatter";
+
+export const useWeeklyUsage = (): {
+  data: WeeklyUsageData | undefined;
+  previousWeekData: WeeklyUsageData | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+  revalidate: () => void;
+} => {
+  const { data: rawData, isLoading, error, revalidate } = useCCUsageWeeklyCli();
+
+  const weeks = rawData?.weekly ?? [];
+  const currentWeek = getCurrentWeekStart();
+  const previousWeek = getPreviousWeekStart();
+
+  const data = weeks.find((entry) => entry.week === currentWeek) ?? weeks.at(-1);
+  const previousWeekData =
+    weeks.find((entry) => entry.week === previousWeek) ?? weeks.filter((e) => e.week < currentWeek).at(-1);
+
+  return { data, previousWeekData, isLoading, error, revalidate };
+};

--- a/extensions/ccusage/src/hooks/useWorkingTime.ts
+++ b/extensions/ccusage/src/hooks/useWorkingTime.ts
@@ -5,6 +5,7 @@ import { Block } from "../types/usage-types";
 type WorkingTimeResult = {
   todayMs: number;
   yesterdayMs: number;
+  activeBlock: Block | null;
   isLoading: boolean;
   error: Error | undefined;
   revalidate: () => void;
@@ -36,6 +37,7 @@ export const useWorkingTime = (): WorkingTimeResult => {
   const blocks = data?.blocks ?? [];
   const todayMs = workingMsForDate(blocks, todayStr, now);
   const yesterdayMs = workingMsForDate(blocks, yesterdayStr, now);
+  const activeBlock = blocks.find((b) => b.isActive && !b.isGap) ?? null;
 
-  return { todayMs, yesterdayMs, isLoading, error, revalidate };
+  return { todayMs, yesterdayMs, activeBlock, isLoading, error, revalidate };
 };

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -124,6 +124,8 @@ export default function MenuBarccusage() {
       return highestUtilization !== null
         ? `${(preferRemaining ? 100 - highestUtilization : highestUtilization).toFixed(0)}%`
         : undefined;
+    if (menuBarTitlePref === "blockProjection")
+      return workingTime.activeBlock?.projection ? formatCost(workingTime.activeBlock.projection.totalCost) : undefined;
     return todayUsage
       ? `${formatCost(todayUsage.totalCost)} · ${formatTokensAsMTok(todayUsage.totalTokens)}`
       : undefined;
@@ -261,6 +263,31 @@ export default function MenuBarccusage() {
               onAction={() => open("raycast://extensions/nyatinte/ccusage/ccusage")}
             />
           </MenuBarExtra.Section>
+
+          {workingTime.activeBlock && (
+            <MenuBarExtra.Section title="Current Block">
+              <MenuBarExtra.Item
+                title={
+                  workingTime.activeBlock.projection
+                    ? `${formatCost(workingTime.activeBlock.projection.totalCost)} projected`
+                    : formatCost(workingTime.activeBlock.costUSD)
+                }
+                subtitle={[
+                  workingTime.activeBlock.burnRate
+                    ? `${formatCost(workingTime.activeBlock.burnRate.costPerHour)}/hr`
+                    : null,
+                  `${formatCost(workingTime.activeBlock.costUSD)} so far`,
+                  workingTime.activeBlock.projection
+                    ? `${formatDuration(workingTime.activeBlock.projection.remainingMinutes * 60 * 1000)} left`
+                    : null,
+                ]
+                  .filter(Boolean)
+                  .join(" · ")}
+                icon={Icon.Gauge}
+                onAction={() => open("raycast://extensions/nyatinte/ccusage/ccusage")}
+              />
+            </MenuBarExtra.Section>
+          )}
 
           <MenuBarExtra.Section title="Working Time">
             <MenuBarExtra.Item

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -1,6 +1,7 @@
 import { MenuBarExtra, Icon, open, openCommandPreferences } from "@raycast/api";
 import { useState, useEffect, useRef } from "react";
 import { useDailyUsage } from "./hooks/useDailyUsage";
+import { useWeeklyUsage } from "./hooks/useWeeklyUsage";
 import { useMonthlyUsage } from "./hooks/useMonthlyUsage";
 import { useTotalUsage } from "./hooks/useTotalUsage";
 import { useClaudeUsageLimits } from "./hooks/useClaudeUsageLimits";
@@ -24,6 +25,7 @@ const MOCK_LIMITS_DATA = {
 export default function MenuBarccusage() {
   const [, forceRender] = useState(0);
   const { data: todayUsage, previousDayData, isLoading: dailyLoading, error: dailyError } = useDailyUsage();
+  const { data: weeklyUsage, isLoading: weeklyLoading, error: weeklyError } = useWeeklyUsage();
   const { data: monthlyUsage, isLoading: monthlyLoading, error: monthlyError } = useMonthlyUsage();
   const { data: totalUsage, isLoading: totalLoading, error: totalError } = useTotalUsage();
   const {
@@ -46,9 +48,9 @@ export default function MenuBarccusage() {
 
   const effectiveLimitsData = MOCK_LIMITS_ENABLED ? MOCK_LIMITS_DATA : limitsData;
 
-  const hasData = todayUsage || monthlyUsage || totalUsage;
-  const hasError = !hasData && (dailyError || monthlyError || totalError);
-  const isLoading = dailyLoading || monthlyLoading || totalLoading;
+  const hasData = todayUsage || weeklyUsage || monthlyUsage || totalUsage;
+  const hasError = !hasData && (dailyError || weeklyError || monthlyError || totalError);
+  const isLoading = dailyLoading || weeklyLoading || monthlyLoading || totalLoading;
 
   if (isLoading) {
     return <MenuBarExtra icon={{ source: Icon.Clock }} tooltip="Loading Claude usage..." isLoading={true} />;
@@ -110,6 +112,7 @@ export default function MenuBarccusage() {
         ? `${formatCost(todayUsage.totalCost)} · ${formatTokensAsMTok(todayUsage.totalTokens)}`
         : undefined;
     if (menuBarTitlePref === "todayCost") return todayUsage ? formatCost(todayUsage.totalCost) : undefined;
+    if (menuBarTitlePref === "weeklyCost") return weeklyUsage ? formatCost(weeklyUsage.totalCost) : undefined;
     if (menuBarTitlePref === "monthlyCost") return monthlyUsage ? formatCost(monthlyUsage.totalCost) : undefined;
     if (menuBarTitlePref === "todayTokens") return todayUsage ? formatTokensAsMTok(todayUsage.totalTokens) : undefined;
     if (menuBarTitlePref === "fiveHour")
@@ -243,6 +246,14 @@ export default function MenuBarccusage() {
                   ? `vs yesterday: ${formatCostDelta(todayUsage.totalCost, previousDayData.totalCost)}`
                   : undefined
               }
+              icon={Icon.Calendar}
+              onAction={() => open("raycast://extensions/nyatinte/ccusage/ccusage")}
+            />
+          </MenuBarExtra.Section>
+
+          <MenuBarExtra.Section title="This Week">
+            <MenuBarExtra.Item
+              title={formatUsageTitle(weeklyLoading, weeklyUsage, "No usage data available")}
               icon={Icon.Calendar}
               onAction={() => open("raycast://extensions/nyatinte/ccusage/ccusage")}
             />

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -127,8 +127,10 @@ export default function MenuBarccusage() {
       return highestUtilization !== null
         ? `${(preferRemaining ? 100 - highestUtilization : highestUtilization).toFixed(0)}%`
         : undefined;
-    if (menuBarTitlePref === "blockProjection")
-      return workingTime.activeBlock?.projection ? formatCost(workingTime.activeBlock.projection.totalCost) : undefined;
+    if (menuBarTitlePref === "blockProjection") {
+      const block = workingTime.activeBlock;
+      return block ? formatCost(block.projection?.totalCost ?? block.costUSD) : undefined;
+    }
     return todayUsage
       ? `${formatCost(todayUsage.totalCost)} · ${formatTokensAsMTok(todayUsage.totalTokens)}`
       : undefined;

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -25,7 +25,7 @@ const MOCK_LIMITS_DATA = {
 export default function MenuBarccusage() {
   const [, forceRender] = useState(0);
   const { data: todayUsage, previousDayData, isLoading: dailyLoading, error: dailyError } = useDailyUsage();
-  const { data: weeklyUsage, isLoading: weeklyLoading, error: weeklyError } = useWeeklyUsage();
+  const { data: weeklyUsage, previousWeekData, isLoading: weeklyLoading, error: weeklyError } = useWeeklyUsage();
   const { data: monthlyUsage, isLoading: monthlyLoading, error: monthlyError } = useMonthlyUsage();
   const { data: totalUsage, isLoading: totalLoading, error: totalError } = useTotalUsage();
   const {
@@ -50,7 +50,7 @@ export default function MenuBarccusage() {
 
   const hasData = todayUsage || weeklyUsage || monthlyUsage || totalUsage;
   const hasError = !hasData && (dailyError || weeklyError || monthlyError || totalError);
-  const isLoading = dailyLoading || weeklyLoading || monthlyLoading || totalLoading;
+  const isLoading = dailyLoading || monthlyLoading || totalLoading;
 
   if (isLoading) {
     return <MenuBarExtra icon={{ source: Icon.Clock }} tooltip="Loading Claude usage..." isLoading={true} />;
@@ -256,6 +256,11 @@ export default function MenuBarccusage() {
           <MenuBarExtra.Section title="This Week">
             <MenuBarExtra.Item
               title={formatUsageTitle(weeklyLoading, weeklyUsage, "No usage data available")}
+              subtitle={
+                weeklyUsage && previousWeekData
+                  ? `vs last week: ${formatCostDelta(weeklyUsage.totalCost, previousWeekData.totalCost)}`
+                  : undefined
+              }
               icon={Icon.Calendar}
               onAction={() => open("raycast://extensions/nyatinte/ccusage/ccusage")}
             />

--- a/extensions/ccusage/src/preferences.ts
+++ b/extensions/ccusage/src/preferences.ts
@@ -8,7 +8,7 @@ const menuBarPreferences = getPreferenceValues<Preferences.MenubarCcusage>();
 
 export const showRemainingUsage = (): boolean => (menuBarPreferences.showRemainingUsage as string) !== "consumed";
 
-export const getMenuBarTitle = ():
+export type MenuBarTitleMode =
   | "todayUsage"
   | "todayCost"
   | "monthlyCost"
@@ -16,16 +16,11 @@ export const getMenuBarTitle = ():
   | "fiveHour"
   | "sevenDay"
   | "utilization"
-  | "none" =>
-  (menuBarPreferences.menuBarTitle as
-    | "todayUsage"
-    | "todayCost"
-    | "monthlyCost"
-    | "todayTokens"
-    | "fiveHour"
-    | "sevenDay"
-    | "utilization"
-    | "none") ?? "todayUsage";
+  | "blockProjection"
+  | "none";
+
+export const getMenuBarTitle = (): MenuBarTitleMode =>
+  (menuBarPreferences.menuBarTitle as MenuBarTitleMode) ?? "todayUsage";
 
 export const getProgressBarStyle = (): ProgressBarStyle =>
   (menuBarPreferences.progressBarStyle as ProgressBarStyle) ?? "solid";

--- a/extensions/ccusage/src/preferences.ts
+++ b/extensions/ccusage/src/preferences.ts
@@ -11,6 +11,7 @@ export const showRemainingUsage = (): boolean => (menuBarPreferences.showRemaini
 export type MenuBarTitleMode =
   | "todayUsage"
   | "todayCost"
+  | "weeklyCost"
   | "monthlyCost"
   | "todayTokens"
   | "fiveHour"

--- a/extensions/ccusage/src/preferences.ts
+++ b/extensions/ccusage/src/preferences.ts
@@ -8,7 +8,7 @@ const menuBarPreferences = getPreferenceValues<Preferences.MenubarCcusage>();
 
 export const showRemainingUsage = (): boolean => (menuBarPreferences.showRemainingUsage as string) !== "consumed";
 
-export type MenuBarTitleMode =
+type MenuBarTitleMode =
   | "todayUsage"
   | "todayCost"
   | "weeklyCost"

--- a/extensions/ccusage/src/types/usage-types.test.ts
+++ b/extensions/ccusage/src/types/usage-types.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  BlocksCommandResponseSchema,
+  DailyUsageCommandResponseSchema,
+  MonthlyUsageCommandResponseSchema,
+  SessionUsageCommandResponseSchema,
+  WeeklyUsageCommandResponseSchema,
+} from "./usage-types";
+
+const tokenCounts = {
+  inputTokens: 1,
+  outputTokens: 1,
+  cacheCreationTokens: 0,
+  cacheReadTokens: 0,
+  totalTokens: 2,
+  totalCost: 0.01,
+};
+
+const modelBreakdown = {
+  modelName: "claude-opus-4-7",
+  inputTokens: 1,
+  outputTokens: 1,
+  cacheCreationTokens: 0,
+  cacheReadTokens: 0,
+  cost: 0.01,
+};
+
+const rowBase = {
+  ...tokenCounts,
+  modelsUsed: ["claude-opus-4-7"],
+  modelBreakdowns: [modelBreakdown],
+};
+
+const totals = { ...tokenCounts };
+
+describe("DailyUsageCommandResponseSchema", () => {
+  it("parses ccusage v20 rows keyed by `period` and `metadata.agents`", () => {
+    const result = DailyUsageCommandResponseSchema.parse({
+      daily: [{ ...rowBase, period: "2026-05-24", agent: "all", metadata: { agents: ["claude", "codex"] } }],
+    });
+
+    expect(result.daily[0].date).toBe("2026-05-24");
+    expect(result.daily[0].metadata?.agents).toEqual(["claude", "codex"]);
+  });
+
+  it("parses legacy rows that already carry `date`", () => {
+    const result = DailyUsageCommandResponseSchema.parse({
+      daily: [{ ...rowBase, date: "2026-05-24" }],
+    });
+
+    expect(result.daily[0].date).toBe("2026-05-24");
+  });
+
+  it("accepts `metadata` without an `agents` field", () => {
+    const result = DailyUsageCommandResponseSchema.parse({
+      daily: [{ ...rowBase, period: "2026-05-24", metadata: {} }],
+    });
+
+    expect(result.daily[0].metadata?.agents).toBeUndefined();
+  });
+});
+
+describe("WeeklyUsageCommandResponseSchema", () => {
+  it("parses ccusage v20 weekly rows keyed by `period`", () => {
+    const result = WeeklyUsageCommandResponseSchema.parse({
+      weekly: [{ ...rowBase, period: "2026-05-18", agent: "all", metadata: { agents: ["claude"] } }],
+    });
+
+    expect(result.weekly[0].week).toBe("2026-05-18");
+  });
+});
+
+describe("MonthlyUsageCommandResponseSchema", () => {
+  it("parses ccusage v20 monthly rows keyed by `period`", () => {
+    const result = MonthlyUsageCommandResponseSchema.parse({
+      monthly: [{ ...rowBase, period: "2026-05", agent: "all", metadata: { agents: ["claude"] } }],
+    });
+
+    expect(result.monthly[0].month).toBe("2026-05");
+  });
+
+  it("parses legacy rows that already carry `month`", () => {
+    const result = MonthlyUsageCommandResponseSchema.parse({
+      monthly: [{ ...rowBase, month: "2026-05" }],
+    });
+
+    expect(result.monthly[0].month).toBe("2026-05");
+  });
+});
+
+describe("SessionUsageCommandResponseSchema", () => {
+  it("parses ccusage v20 sessions with `session` top key, `period`, and `metadata.lastActivity`", () => {
+    const result = SessionUsageCommandResponseSchema.parse({
+      session: [
+        {
+          ...rowBase,
+          period: "abc-123",
+          agent: "claude",
+          metadata: { lastActivity: "2026-05-24" },
+        },
+      ],
+      totals,
+    });
+
+    expect(result.sessions[0].sessionId).toBe("abc-123");
+    expect(result.sessions[0].lastActivity).toBe("2026-05-24");
+  });
+
+  it("parses legacy sessions with `sessions` top key and top-level `sessionId`/`lastActivity`", () => {
+    const result = SessionUsageCommandResponseSchema.parse({
+      sessions: [{ ...rowBase, sessionId: "abc-123", lastActivity: "2026-05-24" }],
+      totals,
+    });
+
+    expect(result.sessions[0].sessionId).toBe("abc-123");
+    expect(result.sessions[0].lastActivity).toBe("2026-05-24");
+  });
+
+  it("rejects sessions whose `metadata.lastActivity` is null with a clear field path", () => {
+    const result = SessionUsageCommandResponseSchema.safeParse({
+      session: [{ ...rowBase, period: "abc-123", metadata: { lastActivity: null } }],
+      totals,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(["sessions", 0, "lastActivity"]);
+    }
+  });
+});
+
+describe("BlocksCommandResponseSchema", () => {
+  const baseBlock = {
+    id: "2026-05-24T17:00:00.000Z",
+    startTime: "2026-05-24T17:00:00.000Z",
+    endTime: "2026-05-24T22:00:00.000Z",
+    actualEndTime: null,
+    isActive: true,
+    isGap: false,
+    totalTokens: 100,
+    costUSD: 1.5,
+    models: ["claude-opus-4-7"],
+  };
+
+  it("parses an active block with `burnRate` and `projection`", () => {
+    const result = BlocksCommandResponseSchema.parse({
+      blocks: [
+        {
+          ...baseBlock,
+          burnRate: { costPerHour: 65, tokensPerMinute: 1000 },
+          projection: { remainingMinutes: 156, totalCost: 306, totalTokens: 50000 },
+        },
+      ],
+    });
+
+    expect(result.blocks[0].burnRate?.costPerHour).toBe(65);
+    expect(result.blocks[0].projection?.totalCost).toBe(306);
+  });
+
+  it("parses an inactive block where `burnRate` and `projection` are null", () => {
+    const result = BlocksCommandResponseSchema.parse({
+      blocks: [{ ...baseBlock, isActive: false, burnRate: null, projection: null }],
+    });
+
+    expect(result.blocks[0].burnRate).toBeNull();
+    expect(result.blocks[0].projection).toBeNull();
+  });
+
+  it("parses a legacy block with neither `burnRate` nor `projection` present", () => {
+    const result = BlocksCommandResponseSchema.parse({
+      blocks: [baseBlock],
+    });
+
+    expect(result.blocks[0].burnRate).toBeUndefined();
+  });
+});

--- a/extensions/ccusage/src/types/usage-types.ts
+++ b/extensions/ccusage/src/types/usage-types.ts
@@ -1,68 +1,87 @@
 import { z } from "zod";
 
-export const DailyUsageResponseSchema = z.object({
-  date: z.string(),
+// ccusage v20 renamed per-row `date`/`month`/`sessionId` to a single `period`
+// field and moved session `lastActivity` under a nested `metadata` object. The
+// session command's top-level array was also renamed `sessions` → `session`.
+// We preprocess each shape back into the original field names so that the rest
+// of the extension can keep using the stable property names.
+
+const aliasPeriodTo =
+  (key: "date" | "month" | "sessionId") =>
+  (raw: unknown): unknown => {
+    if (typeof raw !== "object" || raw === null) return raw;
+    const row = raw as Record<string, unknown>;
+    if (key in row || !("period" in row)) return row;
+    return { ...row, [key]: row.period };
+  };
+
+const liftSessionMetadata = (raw: unknown): unknown => {
+  if (typeof raw !== "object" || raw === null) return raw;
+  const row = raw as Record<string, unknown>;
+  if ("lastActivity" in row) return row;
+  const metadata = row.metadata;
+  if (typeof metadata !== "object" || metadata === null) return row;
+  const lastActivity = (metadata as Record<string, unknown>).lastActivity;
+  if (lastActivity === undefined) return row;
+  return { ...row, lastActivity };
+};
+
+const normalizeSessionRow = (raw: unknown): unknown => liftSessionMetadata(aliasPeriodTo("sessionId")(raw));
+
+const modelBreakdownSchema = z.object({
+  modelName: z.string(),
   inputTokens: z.number(),
   outputTokens: z.number(),
   cacheCreationTokens: z.number(),
   cacheReadTokens: z.number(),
-  totalTokens: z.number(),
-  totalCost: z.number(),
-  modelsUsed: z.array(z.string()),
-  modelBreakdowns: z.array(
-    z.object({
-      modelName: z.string(),
-      inputTokens: z.number(),
-      outputTokens: z.number(),
-      cacheCreationTokens: z.number(),
-      cacheReadTokens: z.number(),
-      cost: z.number(),
-    }),
-  ),
+  cost: z.number(),
 });
 
-export const MonthlyUsageResponseSchema = z.object({
-  month: z.string(),
-  inputTokens: z.number(),
-  outputTokens: z.number(),
-  cacheCreationTokens: z.number(),
-  cacheReadTokens: z.number(),
-  totalTokens: z.number(),
-  totalCost: z.number(),
-  modelsUsed: z.array(z.string()),
-  modelBreakdowns: z.array(
-    z.object({
-      modelName: z.string(),
-      inputTokens: z.number(),
-      outputTokens: z.number(),
-      cacheCreationTokens: z.number(),
-      cacheReadTokens: z.number(),
-      cost: z.number(),
-    }),
-  ),
-});
+export const DailyUsageResponseSchema = z.preprocess(
+  aliasPeriodTo("date"),
+  z.object({
+    date: z.string(),
+    inputTokens: z.number(),
+    outputTokens: z.number(),
+    cacheCreationTokens: z.number(),
+    cacheReadTokens: z.number(),
+    totalTokens: z.number(),
+    totalCost: z.number(),
+    modelsUsed: z.array(z.string()),
+    modelBreakdowns: z.array(modelBreakdownSchema),
+  }),
+);
 
-export const SessionResponseSchema = z.object({
-  sessionId: z.string(),
-  inputTokens: z.number(),
-  outputTokens: z.number(),
-  cacheCreationTokens: z.number(),
-  cacheReadTokens: z.number(),
-  totalTokens: z.number(),
-  totalCost: z.number(),
-  lastActivity: z.string(),
-  modelsUsed: z.array(z.string()),
-  modelBreakdowns: z.array(
-    z.object({
-      modelName: z.string(),
-      inputTokens: z.number(),
-      outputTokens: z.number(),
-      cacheCreationTokens: z.number(),
-      cacheReadTokens: z.number(),
-      cost: z.number(),
-    }),
-  ),
-});
+export const MonthlyUsageResponseSchema = z.preprocess(
+  aliasPeriodTo("month"),
+  z.object({
+    month: z.string(),
+    inputTokens: z.number(),
+    outputTokens: z.number(),
+    cacheCreationTokens: z.number(),
+    cacheReadTokens: z.number(),
+    totalTokens: z.number(),
+    totalCost: z.number(),
+    modelsUsed: z.array(z.string()),
+    modelBreakdowns: z.array(modelBreakdownSchema),
+  }),
+);
+
+export const SessionResponseSchema = z.preprocess(
+  normalizeSessionRow,
+  z.object({
+    sessionId: z.string(),
+    inputTokens: z.number(),
+    outputTokens: z.number(),
+    cacheCreationTokens: z.number(),
+    cacheReadTokens: z.number(),
+    totalTokens: z.number(),
+    totalCost: z.number(),
+    lastActivity: z.string(),
+    modelsUsed: z.array(z.string()),
+    modelBreakdowns: z.array(modelBreakdownSchema),
+  }),
+);
 
 export const ModelUsageSchema = z.object({
   model: z.string(),
@@ -106,17 +125,25 @@ export const MonthlyUsageCommandResponseSchema = z.object({
   monthly: z.array(MonthlyUsageResponseSchema),
 });
 
-export const SessionUsageCommandResponseSchema = z.object({
-  sessions: z.array(SessionResponseSchema),
-  totals: z.object({
-    inputTokens: z.number(),
-    outputTokens: z.number(),
-    cacheCreationTokens: z.number(),
-    cacheReadTokens: z.number(),
-    totalCost: z.number(),
-    totalTokens: z.number(),
+export const SessionUsageCommandResponseSchema = z.preprocess(
+  (raw) => {
+    if (typeof raw !== "object" || raw === null) return raw;
+    const root = raw as Record<string, unknown>;
+    if ("sessions" in root || !("session" in root)) return root;
+    return { ...root, sessions: root.session };
+  },
+  z.object({
+    sessions: z.array(SessionResponseSchema),
+    totals: z.object({
+      inputTokens: z.number(),
+      outputTokens: z.number(),
+      cacheCreationTokens: z.number(),
+      cacheReadTokens: z.number(),
+      totalCost: z.number(),
+      totalTokens: z.number(),
+    }),
   }),
-});
+);
 
 export const LimitWindowSchema = z.object({
   utilization: z.number(),

--- a/extensions/ccusage/src/types/usage-types.ts
+++ b/extensions/ccusage/src/types/usage-types.ts
@@ -1,33 +1,26 @@
 import { z } from "zod";
 
-// ccusage emits a single `period` field per row that means different things
-// per command (date for daily, month for monthly, session id for sessions),
-// nests session `lastActivity` under `metadata`, and keys the session
-// command's top-level array as `session`. Preprocess maps these into
-// `date` / `month` / `sessionId` / `lastActivity` / `sessions` so consumers
-// see a consistent shape.
+// `ccusage` exposes row dates as a generic `period` field, nests session
+// `lastActivity` under `metadata`, and keys the session command's rows under
+// `session`. Preprocess normalizes these to the explicit names declared below.
 
-const aliasPeriodTo =
-  (key: "date" | "month" | "sessionId") =>
+const asObject = (raw: unknown): Record<string, unknown> | null =>
+  raw && typeof raw === "object" ? (raw as Record<string, unknown>) : null;
+
+const alias =
+  (from: string, to: string) =>
   (raw: unknown): unknown => {
-    if (typeof raw !== "object" || raw === null) return raw;
-    const row = raw as Record<string, unknown>;
-    if (key in row || !("period" in row)) return row;
-    return { ...row, [key]: row.period };
+    const obj = asObject(raw);
+    if (!obj || to in obj || !(from in obj)) return raw;
+    return { ...obj, [to]: obj[from] };
   };
 
-const liftSessionMetadata = (raw: unknown): unknown => {
-  if (typeof raw !== "object" || raw === null) return raw;
-  const row = raw as Record<string, unknown>;
-  if ("lastActivity" in row) return row;
-  const metadata = row.metadata;
-  if (typeof metadata !== "object" || metadata === null) return row;
-  const lastActivity = (metadata as Record<string, unknown>).lastActivity;
-  if (lastActivity === undefined) return row;
-  return { ...row, lastActivity };
+const liftLastActivity = (raw: unknown): unknown => {
+  const obj = asObject(raw);
+  if (!obj || "lastActivity" in obj) return raw;
+  const meta = asObject(obj.metadata);
+  return meta && "lastActivity" in meta ? { ...obj, lastActivity: meta.lastActivity } : raw;
 };
-
-const normalizeSessionRow = (raw: unknown): unknown => liftSessionMetadata(aliasPeriodTo("sessionId")(raw));
 
 const modelBreakdownSchema = z.object({
   modelName: z.string(),
@@ -38,50 +31,34 @@ const modelBreakdownSchema = z.object({
   cost: z.number(),
 });
 
+const tokenTotals = {
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  cacheCreationTokens: z.number(),
+  cacheReadTokens: z.number(),
+  totalTokens: z.number(),
+  totalCost: z.number(),
+};
+
+const usageRowBase = {
+  ...tokenTotals,
+  modelsUsed: z.array(z.string()),
+  modelBreakdowns: z.array(modelBreakdownSchema),
+};
+
 export const DailyUsageResponseSchema = z.preprocess(
-  aliasPeriodTo("date"),
-  z.object({
-    date: z.string(),
-    inputTokens: z.number(),
-    outputTokens: z.number(),
-    cacheCreationTokens: z.number(),
-    cacheReadTokens: z.number(),
-    totalTokens: z.number(),
-    totalCost: z.number(),
-    modelsUsed: z.array(z.string()),
-    modelBreakdowns: z.array(modelBreakdownSchema),
-  }),
+  alias("period", "date"),
+  z.object({ date: z.string(), ...usageRowBase }),
 );
 
 export const MonthlyUsageResponseSchema = z.preprocess(
-  aliasPeriodTo("month"),
-  z.object({
-    month: z.string(),
-    inputTokens: z.number(),
-    outputTokens: z.number(),
-    cacheCreationTokens: z.number(),
-    cacheReadTokens: z.number(),
-    totalTokens: z.number(),
-    totalCost: z.number(),
-    modelsUsed: z.array(z.string()),
-    modelBreakdowns: z.array(modelBreakdownSchema),
-  }),
+  alias("period", "month"),
+  z.object({ month: z.string(), ...usageRowBase }),
 );
 
 export const SessionResponseSchema = z.preprocess(
-  normalizeSessionRow,
-  z.object({
-    sessionId: z.string(),
-    inputTokens: z.number(),
-    outputTokens: z.number(),
-    cacheCreationTokens: z.number(),
-    cacheReadTokens: z.number(),
-    totalTokens: z.number(),
-    totalCost: z.number(),
-    lastActivity: z.string(),
-    modelsUsed: z.array(z.string()),
-    modelBreakdowns: z.array(modelBreakdownSchema),
-  }),
+  (raw) => liftLastActivity(alias("period", "sessionId")(raw)),
+  z.object({ sessionId: z.string(), lastActivity: z.string(), ...usageRowBase }),
 );
 
 export const ModelUsageSchema = z.object({
@@ -97,25 +74,11 @@ export const DailyUsageDataSchema = DailyUsageResponseSchema;
 export const MonthlyUsageDataSchema = MonthlyUsageResponseSchema;
 export const SessionDataSchema = SessionResponseSchema;
 
-export const TotalUsageDataSchema = z.object({
-  inputTokens: z.number(),
-  outputTokens: z.number(),
-  cacheCreationTokens: z.number(),
-  cacheReadTokens: z.number(),
-  totalTokens: z.number(),
-  totalCost: z.number(),
-});
+export const TotalUsageDataSchema = z.object(tokenTotals);
 
 export const TotalUsageResponseSchema = z.object({
   daily: z.array(DailyUsageResponseSchema),
-  totals: z.object({
-    inputTokens: z.number(),
-    outputTokens: z.number(),
-    cacheCreationTokens: z.number(),
-    cacheReadTokens: z.number(),
-    totalTokens: z.number(),
-    totalCost: z.number(),
-  }),
+  totals: z.object(tokenTotals),
 });
 
 export const DailyUsageCommandResponseSchema = z.object({
@@ -127,22 +90,10 @@ export const MonthlyUsageCommandResponseSchema = z.object({
 });
 
 export const SessionUsageCommandResponseSchema = z.preprocess(
-  (raw) => {
-    if (typeof raw !== "object" || raw === null) return raw;
-    const root = raw as Record<string, unknown>;
-    if ("sessions" in root || !("session" in root)) return root;
-    return { ...root, sessions: root.session };
-  },
+  alias("session", "sessions"),
   z.object({
     sessions: z.array(SessionResponseSchema),
-    totals: z.object({
-      inputTokens: z.number(),
-      outputTokens: z.number(),
-      cacheCreationTokens: z.number(),
-      cacheReadTokens: z.number(),
-      totalCost: z.number(),
-      totalTokens: z.number(),
-    }),
+    totals: z.object(tokenTotals),
   }),
 );
 

--- a/extensions/ccusage/src/types/usage-types.ts
+++ b/extensions/ccusage/src/types/usage-types.ts
@@ -126,6 +126,19 @@ export const BlockSchema = z.object({
   totalTokens: z.number(),
   costUSD: z.number(),
   models: z.array(z.string()),
+  burnRate: z
+    .object({
+      costPerHour: z.number(),
+      tokensPerMinute: z.number(),
+    })
+    .nullish(),
+  projection: z
+    .object({
+      remainingMinutes: z.number(),
+      totalCost: z.number(),
+      totalTokens: z.number(),
+    })
+    .nullish(),
 });
 
 export const BlocksCommandResponseSchema = z.object({

--- a/extensions/ccusage/src/types/usage-types.ts
+++ b/extensions/ccusage/src/types/usage-types.ts
@@ -46,14 +46,16 @@ const usageRowBase = {
   modelBreakdowns: z.array(modelBreakdownSchema),
 };
 
+const aggregateMetadata = z.object({ agents: z.array(z.string()) }).nullish();
+
 export const DailyUsageResponseSchema = z.preprocess(
   alias("period", "date"),
-  z.object({ date: z.string(), ...usageRowBase }),
+  z.object({ date: z.string(), ...usageRowBase, metadata: aggregateMetadata }),
 );
 
 export const MonthlyUsageResponseSchema = z.preprocess(
   alias("period", "month"),
-  z.object({ month: z.string(), ...usageRowBase }),
+  z.object({ month: z.string(), ...usageRowBase, metadata: aggregateMetadata }),
 );
 
 export const SessionResponseSchema = z.preprocess(

--- a/extensions/ccusage/src/types/usage-types.ts
+++ b/extensions/ccusage/src/types/usage-types.ts
@@ -18,8 +18,8 @@ const alias =
 const liftLastActivity = (raw: unknown): unknown => {
   const obj = asObject(raw);
   if (!obj || "lastActivity" in obj) return raw;
-  const meta = asObject(obj.metadata);
-  return meta && "lastActivity" in meta ? { ...obj, lastActivity: meta.lastActivity } : raw;
+  const lastActivity = asObject(obj.metadata)?.lastActivity;
+  return typeof lastActivity === "string" ? { ...obj, lastActivity } : raw;
 };
 
 const modelBreakdownSchema = z.object({
@@ -46,7 +46,7 @@ const usageRowBase = {
   modelBreakdowns: z.array(modelBreakdownSchema),
 };
 
-const aggregateMetadata = z.object({ agents: z.array(z.string()) }).nullish();
+const aggregateMetadata = z.object({ agents: z.array(z.string()).optional() }).nullish();
 
 export const DailyUsageResponseSchema = z.preprocess(
   alias("period", "date"),

--- a/extensions/ccusage/src/types/usage-types.ts
+++ b/extensions/ccusage/src/types/usage-types.ts
@@ -53,6 +53,11 @@ export const DailyUsageResponseSchema = z.preprocess(
   z.object({ date: z.string(), ...usageRowBase, metadata: aggregateMetadata }),
 );
 
+export const WeeklyUsageResponseSchema = z.preprocess(
+  alias("period", "week"),
+  z.object({ week: z.string(), ...usageRowBase, metadata: aggregateMetadata }),
+);
+
 export const MonthlyUsageResponseSchema = z.preprocess(
   alias("period", "month"),
   z.object({ month: z.string(), ...usageRowBase, metadata: aggregateMetadata }),
@@ -73,6 +78,7 @@ export const ModelUsageSchema = z.object({
 });
 
 export const DailyUsageDataSchema = DailyUsageResponseSchema;
+export const WeeklyUsageDataSchema = WeeklyUsageResponseSchema;
 export const MonthlyUsageDataSchema = MonthlyUsageResponseSchema;
 export const SessionDataSchema = SessionResponseSchema;
 
@@ -85,6 +91,10 @@ export const TotalUsageResponseSchema = z.object({
 
 export const DailyUsageCommandResponseSchema = z.object({
   daily: z.array(DailyUsageResponseSchema),
+});
+
+export const WeeklyUsageCommandResponseSchema = z.object({
+  weekly: z.array(WeeklyUsageResponseSchema),
 });
 
 export const MonthlyUsageCommandResponseSchema = z.object({
@@ -151,15 +161,18 @@ export type Block = z.infer<typeof BlockSchema>;
 export type BlocksCommandResponse = z.infer<typeof BlocksCommandResponseSchema>;
 
 export type DailyUsageData = z.infer<typeof DailyUsageDataSchema>;
+export type WeeklyUsageData = z.infer<typeof WeeklyUsageDataSchema>;
 export type MonthlyUsageData = z.infer<typeof MonthlyUsageDataSchema>;
 export type SessionData = z.infer<typeof SessionDataSchema>;
 export type ModelUsage = z.infer<typeof ModelUsageSchema>;
 export type TotalUsageData = z.infer<typeof TotalUsageDataSchema>;
 export type TotalUsageResponse = z.infer<typeof TotalUsageResponseSchema>;
 export type DailyUsageResponse = z.infer<typeof DailyUsageResponseSchema>;
+export type WeeklyUsageResponse = z.infer<typeof WeeklyUsageResponseSchema>;
 export type MonthlyUsageResponse = z.infer<typeof MonthlyUsageResponseSchema>;
 export type SessionResponse = z.infer<typeof SessionResponseSchema>;
 export type DailyUsageCommandResponse = z.infer<typeof DailyUsageCommandResponseSchema>;
+export type WeeklyUsageCommandResponse = z.infer<typeof WeeklyUsageCommandResponseSchema>;
 export type MonthlyUsageCommandResponse = z.infer<typeof MonthlyUsageCommandResponseSchema>;
 export type SessionUsageCommandResponse = z.infer<typeof SessionUsageCommandResponseSchema>;
 export type LimitWindow = z.infer<typeof LimitWindowSchema>;

--- a/extensions/ccusage/src/types/usage-types.ts
+++ b/extensions/ccusage/src/types/usage-types.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
 
-// ccusage v20 renamed per-row `date`/`month`/`sessionId` to a single `period`
-// field and moved session `lastActivity` under a nested `metadata` object. The
-// session command's top-level array was also renamed `sessions` → `session`.
-// We preprocess each shape back into the original field names so that the rest
-// of the extension can keep using the stable property names.
+// ccusage emits a single `period` field per row that means different things
+// per command (date for daily, month for monthly, session id for sessions),
+// nests session `lastActivity` under `metadata`, and keys the session
+// command's top-level array as `session`. Preprocess maps these into
+// `date` / `month` / `sessionId` / `lastActivity` / `sessions` so consumers
+// see a consistent shape.
 
 const aliasPeriodTo =
   (key: "date" | "month" | "sessionId") =>

--- a/extensions/ccusage/src/utils/date-formatter.ts
+++ b/extensions/ccusage/src/utils/date-formatter.ts
@@ -1,9 +1,10 @@
-import { format } from "date-fns";
+import { format, startOfISOWeek, subWeeks } from "date-fns";
 
-export const getCurrentLocalDate = (): string => {
-  return format(new Date(), "yyyy-MM-dd");
-};
+export const getCurrentLocalDate = (): string => format(new Date(), "yyyy-MM-dd");
 
-export const getCurrentLocalMonth = (): string => {
-  return format(new Date(), "yyyy-MM");
-};
+export const getCurrentLocalMonth = (): string => format(new Date(), "yyyy-MM");
+
+// `ccusage weekly` keys each row by the ISO-week Monday in `YYYY-MM-DD`.
+export const getCurrentWeekStart = (): string => format(startOfISOWeek(new Date()), "yyyy-MM-dd");
+
+export const getPreviousWeekStart = (): string => format(startOfISOWeek(subWeeks(new Date(), 1)), "yyyy-MM-dd");

--- a/extensions/ccusage/src/utils/date-formatter.ts
+++ b/extensions/ccusage/src/utils/date-formatter.ts
@@ -1,4 +1,4 @@
-import { format, startOfISOWeek, subWeeks } from "date-fns";
+import { format, startOfISOWeek } from "date-fns";
 
 export const getCurrentLocalDate = (): string => format(new Date(), "yyyy-MM-dd");
 
@@ -6,5 +6,3 @@ export const getCurrentLocalMonth = (): string => format(new Date(), "yyyy-MM");
 
 // `ccusage weekly` keys each row by the ISO-week Monday in `YYYY-MM-DD`.
 export const getCurrentWeekStart = (): string => format(startOfISOWeek(new Date()), "yyyy-MM-dd");
-
-export const getPreviousWeekStart = (): string => format(startOfISOWeek(subWeeks(new Date(), 1)), "yyyy-MM-dd");


### PR DESCRIPTION
## Description

`ccusage@20` contains breaking changes for fields this extension relies on (row fields renamed to `period`, `lastActivity` moved under `metadata`, session top-level `sessions` array renamed `session`), so every view that depends on daily, monthly, session, or total data crashes with `Invalid <command> usage data`. This PR restores those views and uses the v20 upgrade to surface data the extension was already fetching but discarding.

### Schema fix

Wrap the row schemas in `z.preprocess` so they accept both the legacy v18 shape (`date` / `month` / `sessionId` / `lastActivity` direct) and the v20 shape. Inferred TS types are unchanged, so hooks, components, and tools keep working without modification. Also extracts `tokenTotals` and `usageRowBase` to remove the six-field token block previously repeated across four schemas, and folds the per-field rename helpers into a single generic `alias(from, to)`.

### New features

- **Weekly usage view**: a "This Week" item in the main list and a matching menu bar section, with week-over-week cost and token deltas.
- **Active block burn rate and projection**: the menu bar shows a "Current Block" section with the projected total cost, spend so far, $/hour burn rate, and time left in the 5-hour window. The data was already being fetched for the existing Working Time card, but the `burnRate` and `projection` fields were ignored.
- **Multi-agent visibility**: when `ccusage` reports usage from more than one coding agent (Claude, Codex, Gemini, etc.), the daily and weekly detail panels show the contributing agents from `metadata.agents`.
- **Menu bar status options**: "Weekly Cost" and "Block Projection" added to the dropdown next to the icon.

### UI cleanup

- The Usage Limits detail panel's "Resets in" rows used `||` between the relative and absolute timestamps, which read like a JavaScript logical OR. Replaced with `·`.

### Tests

New `usage-types.test.ts` covers both row shapes (legacy and v20) for daily, weekly, monthly, and session schemas, plus the `metadata`-without-`agents` defensive case, the `metadata.lastActivity: null` rejection path, and `BlockSchema` with and without `burnRate` / `projection`.

Closes #28037.

## Related

#28044 is an independent fix for the same v20 breakage. It only renames the top-level `session` array to `sessions` and does not handle the row-level `period`, `metadata.lastActivity`, daily `date`, monthly `month`, or total command shape, so per-row validation still rejects in practice. This PR supersedes #28044 by fixing all four shapes, extends the test style that PR introduced to cover the v20 row shapes it omitted, and rolls in the rest of v20 (weekly, block projection, multi-agent).

## Screencast

<img width="862" height="586" alt="Screenshot 2026-05-24 at 12 50 55" src="https://github.com/user-attachments/assets/41026398-5b33-46ea-9d0f-febe2fd056ac" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
