### PR TITLE
Apple Developer Docs: filter search history by current query

### DIFF
--- a/extensions/apple-developer-docs/CHANGELOG.md
+++ b/extensions/apple-developer-docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Apple Developer Docs Changelog
 
+## [Fix Search History] - 2026-05-25
+- Search history items are now filtered by the current search text, so they no longer push unrelated entries above live results.
+
 ## [Fix Search API] - 2026-05-18
 - Updated the Apple Developer search request to use the current production endpoint.
 

--- a/extensions/apple-developer-docs/CHANGELOG.md
+++ b/extensions/apple-developer-docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Apple Developer Docs Changelog
 
-## [Fix Search History] - {PR_MERGE_DATE}
+## [Fix Search History] - 2026-05-25
 - Search history items are now filtered by the current search text, so they no longer push unrelated entries above live results.
 
 ## [Fix Search API] - 2026-05-18

--- a/extensions/apple-developer-docs/CHANGELOG.md
+++ b/extensions/apple-developer-docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Apple Developer Docs Changelog
 
-## [Fix Search History] - 2026-05-25
+## [Fix Search History] - {PR_MERGE_DATE}
 - Search history items are now filtered by the current search text, so they no longer push unrelated entries above live results.
 
 ## [Fix Search API] - 2026-05-18

--- a/extensions/apple-developer-docs/package.json
+++ b/extensions/apple-developer-docs/package.json
@@ -5,6 +5,9 @@
   "description": "Search from the Apple Developer documentations",
   "icon": "apple-developer-docs.png",
   "author": "cali",
+  "contributors": [
+    "2369233838"
+  ],
   "categories": [
     "Developer Tools"
   ],

--- a/extensions/apple-developer-docs/src/index.tsx
+++ b/extensions/apple-developer-docs/src/index.tsx
@@ -54,13 +54,12 @@ export default function Command() {
 
   const { results: searchedResults, markAsSearched } = useSearchedResults();
   const filteredSearchedResults = useMemo(() => {
-    if (typeFilter.toLowerCase() === "all") {
-      return searchedResults;
-    }
+    const byType =
+      typeFilter.toLowerCase() === "all"
+        ? searchedResults
+        : searchedResults?.filter((result) => result.type.toLowerCase() === typeFilter.toLowerCase());
 
-    const filteredResults = searchedResults?.filter((result) => result.type.toLowerCase() === typeFilter.toLowerCase());
-
-    return filteredResults?.filter(
+    return byType?.filter(
       (result) => searchText.trim() === "" || result.title.toLowerCase().includes(searchText.toLowerCase())
     );
   }, [searchedResults, searchText, typeFilter]);


### PR DESCRIPTION
## Description

The "Searched" history section was rendered unfiltered whenever the "All" type filter was active (the default). As soon as a user typed a query, up to 20 previously visited entries piled on top of the live results in the list, pushing the actually relevant matches off-screen.

`filteredSearchedResults` in `extensions/apple-developer-docs/src/index.tsx` early-returned `searchedResults` for `typeFilter === "all"`, skipping the title-based text filter that the non-"all" branch already applied.

This change unifies the two branches so the text filter runs in every case:

- `searchText` empty → show full history (unchanged behavior)
- `searchText` non-empty → only history entries whose titles match the query are shown

Non-"all" filters keep their existing combined type + text filtering.

## Screencast

Straightforward logic change — no UI redesign. Verified manually that:
- typing a query no longer pushes unrelated history above results,
- clearing the search restores the full history list,
- switching type filters still works as before.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)