### PR TITLE
Update dev-servers extension

### DIFF
--- a/extensions/dev-servers/CHANGELOG.md
+++ b/extensions/dev-servers/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dev Servers Changelog
 
-## [Detection and favicon improvements] - {PR_MERGE_DATE}
+## [Detection and favicon improvements] - 2026-05-25
 
 - Detect any Node tool that runs out of `node_modules/`, not just those launched via `node_modules/.bin/`. Surfaces tools like `serve` and `http-server` that were previously missed.
 - Render favicons inline so they display reliably for every framework, including SVG icons and dev servers (such as Astro) that don't expose static assets cross-origin.

--- a/extensions/dev-servers/CHANGELOG.md
+++ b/extensions/dev-servers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dev Servers Changelog
 
+## [Detection and favicon improvements] - {PR_MERGE_DATE}
+
+- Detect any Node tool that runs out of `node_modules/`, not just those launched via `node_modules/.bin/`. Surfaces tools like `serve` and `http-server` that were previously missed.
+- Render favicons inline so they display reliably for every framework, including SVG icons and dev servers (such as Astro) that don't expose static assets cross-origin.
+- Preserve spaces in detected project paths. Restart, Open in Terminal, and Show in Finder no longer break on projects whose absolute path contains a space.
+
 ## [Initial Version] - 2026-05-19
 
 A keyboard-first dashboard for every dev server you have running. Auto-detects servers from any framework that uses `node_modules/.bin/` (Vite, Next.js, Astro, SvelteKit, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, esbuild) plus the Bun runtime. Servers are grouped by project with favicons, uptime, framework, and runtime tags.

--- a/extensions/dev-servers/README.md
+++ b/extensions/dev-servers/README.md
@@ -4,9 +4,9 @@ A keyboard-first dashboard for every dev server you have running. See them group
 
 ## Features
 
-- **Auto-detects** running dev servers including Vite, Next.js, Astro, SvelteKit, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, esbuild, anything launched via `node_modules/.bin/`, plus servers running on the Bun runtime
+- **Auto-detects** running dev servers including Vite, Next.js, Astro, SvelteKit, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, esbuild, serve, http-server, anything that runs out of `node_modules/`, plus servers running on the Bun runtime
 - **Grouped by project** so servers from the same directory appear under one section
-- **Favicons** are pulled from each site (with `/favicon.ico` fallback) and cached across refreshes
+- **Favicons** — PNG, ICO, or SVG — are pulled from each site (with `/favicon.ico` fallback), inlined so they render even when the dev server isn't CORS-friendly, and cached across refreshes
 - **Runtime tag** shows a yellow `bun` badge when the listening process is genuinely running on Bun
 - **Uptime tracking** shows how long each server has been running. Hover for the exact start time
 - **Smart restart** picks the right package manager (npm, pnpm, yarn, bun) from the project's lockfile, polls until the new server binds a port, and surfaces failures with a link to the log

--- a/extensions/dev-servers/package-lock.json
+++ b/extensions/dev-servers/package-lock.json
@@ -7,8 +7,8 @@
       "name": "dev-servers",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.12",
-        "@raycast/utils": "^2.2.3"
+        "@raycast/api": "^1.104.18",
+        "@raycast/utils": "^2.2.5"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^1.0.11",
@@ -1054,16 +1054,16 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.12",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.12.tgz",
-      "integrity": "sha512-DdrtoksnzLw4q60BgFr/H+PIvIObOfJrW15duTFH7QXVx/0Vxzw9fY7wo+H2gQ2JDDAh9sEMCpc5akP3UxKjTw==",
+      "version": "1.104.18",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.18.tgz",
+      "integrity": "sha512-Effu0wSTRwtW7VNjyrDtFNxMQ4BbtRFCIY00PbY4qa3yFPOE/CfbcZJbesyo3nYyuenedqeia/+PvLcieBUO4w==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
         "@oclif/plugin-autocomplete": "^3.2.40",
         "@oclif/plugin-help": "^6.2.37",
         "@oclif/plugin-not-found": "^3.2.74",
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "esbuild": "^0.27.3",
         "react": "19.0.0"
@@ -1072,10 +1072,10 @@
         "ray": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.14.0"
+        "node": ">=22.22.2"
       },
       "peerDependencies": {
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "react-devtools": "6.1.1"
       },
@@ -1124,9 +1124,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.3.tgz",
-      "integrity": "sha512-YwqleVl0Wk/FOq+672gtvswuwMqjNqIr+c63FhouTEHc1LJ3zaohLSkW4+UcfBjPU8HySKQm+kJqZW1iOM9fnA==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.5.tgz",
+      "integrity": "sha512-1o6zGRECh1KNe6CBx68iMPOrNYbV56opqs4zUtDr6Wmq4F7Ww3d8uLTXKVzXlGyJmpAys/Eliw6cKIP7dPdFfw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1156,12 +1156,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/react": {
@@ -3378,9 +3378,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/uri-js": {

--- a/extensions/dev-servers/package.json
+++ b/extensions/dev-servers/package.json
@@ -65,8 +65,8 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.104.12",
-    "@raycast/utils": "^2.2.3"
+    "@raycast/api": "^1.104.18",
+    "@raycast/utils": "^2.2.5"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^1.0.11",

--- a/extensions/dev-servers/src/index.tsx
+++ b/extensions/dev-servers/src/index.tsx
@@ -87,46 +87,56 @@ async function fetchWithTimeout(
   }
 }
 
-// Verify a URL actually serves an image (HEAD 200). Skipping this check
-// would let us cache a 404'd favicon path, causing Raycast to render its
-// untinted grey-globe fallback instead of our nicer tinted placeholder.
-async function urlExists(url: string): Promise<boolean> {
-  const res = await fetchWithTimeout(url, { method: "HEAD" });
-  return !!res && res.ok;
+// Fetch a favicon and return it as an inline data URI, or undefined if the URL
+// doesn't serve an image. Inlining the bytes (rather than handing Raycast a
+// URL to fetch) sidesteps CORS — some dev servers (notably Astro) don't set
+// Access-Control-Allow-Origin on static assets, and Raycast's image loader
+// refuses those.
+//
+// SVG uses URL-encoded payload, raster uses base64. That split mirrors what
+// @raycast/utils does internally for its own SVG icons.
+async function fetchFaviconDataUri(url: string): Promise<string | undefined> {
+  const res = await fetchWithTimeout(url);
+  if (!res || !res.ok) return undefined;
+  const ct = (res.headers.get("content-type") ?? "")
+    .split(";")[0]
+    .trim()
+    .toLowerCase();
+  if (!ct.startsWith("image/")) return undefined;
+  if (ct.includes("svg")) {
+    const svg = await res.text();
+    return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  return `data:${ct};base64,${buf.toString("base64")}`;
 }
 
-// Resolve the best favicon URL for a localhost dev server. Tries in order:
-//  1. <link rel="icon"> in the page HTML (HEAD-validated)
+// Resolve the best favicon for a localhost dev server. Tries in order:
+//  1. <link rel="icon"> in the page HTML
 //  2. /favicon.ico (the convention every framework starter ships with)
 //  3. undefined → caller renders a framework-tinted globe instead.
 async function detectFaviconUrl(port: string): Promise<string | undefined> {
   const origin = `http://localhost:${port}`;
 
-  // 1. Page <link rel="icon">
   const html = await fetchWithTimeout(`${origin}/`).then((r) =>
     r ? r.text() : null,
   );
   if (html) {
     const linkTags = html.match(/<link[^>]+>/gi) ?? [];
     for (const tag of linkTags) {
-      if (/rel=["'][^"']*icon[^"']*["']/i.test(tag)) {
-        const hrefMatch = tag.match(/href=["']([^"']+)["']/i);
-        if (hrefMatch) {
-          const href = hrefMatch[1];
-          const url = href.startsWith("http")
-            ? href
-            : `${origin}${href.startsWith("/") ? href : `/${href}`}`;
-          if (await urlExists(url)) return url;
-        }
-      }
+      if (!/rel=["'][^"']*icon[^"']*["']/i.test(tag)) continue;
+      const hrefMatch = tag.match(/href=["']([^"']+)["']/i);
+      if (!hrefMatch) continue;
+      const href = hrefMatch[1];
+      const url = href.startsWith("http")
+        ? href
+        : `${origin}${href.startsWith("/") ? href : `/${href}`}`;
+      const dataUri = await fetchFaviconDataUri(url);
+      if (dataUri) return dataUri;
     }
   }
 
-  // 2. /favicon.ico fallback
-  const icoUrl = `${origin}/favicon.ico`;
-  if (await urlExists(icoUrl)) return icoUrl;
-
-  return undefined;
+  return fetchFaviconDataUri(`${origin}/favicon.ico`);
 }
 
 interface ServerItemProps {

--- a/extensions/dev-servers/src/servers.ts
+++ b/extensions/dev-servers/src/servers.ts
@@ -6,8 +6,8 @@ import { DevServer } from "./types";
 const execAsync = promisify(exec);
 
 // Grabs all listening ports once up front to avoid repeated lsof calls,
-// then iterates over candidate dev-server PIDs (anything launched via
-// node_modules/.bin/, plus bun processes) and emits one pipe-delimited
+// then iterates over candidate dev-server PIDs (anything running a script
+// from node_modules/, plus bun processes) and emits one pipe-delimited
 // line per server: PID|PORT|CWD|STARTED|TOOL
 //
 // Uses `while read -r PID` (not `for PID in $PIDS`) to correctly iterate in zsh,
@@ -15,14 +15,16 @@ const execAsync = promisify(exec);
 //
 // lstart format: "Wed Apr 16 10:23:45 2026". V8 parses this correctly via new Date().
 //
-// Bun support: the awk filter matches either node_modules/.bin/ in the full
-// command line OR a bare `bun` (or path-suffixed `/bun`) in the executable
-// column ($11). The `[ -z "$PORT" ] && continue` then drops any bun process
-// not actually listening, so we never surface random `bun some-script.ts` runs.
+// The awk filter matches node_modules/ anywhere in the command line OR a
+// bare `bun` in the executable column ($11). The broader node_modules/
+// match (vs. the narrower .bin/) catches tools invoked as
+// `node node_modules/<pkg>/...` — e.g. `serve`, `http-server`. Over-
+// collection is harmless: the `[ -z "$PORT" ] && continue` below drops
+// any PID not actually listening on TCP.
 export const FETCH_SCRIPT = `
 PORTS=$(lsof -iTCP -sTCP:LISTEN -nP 2>/dev/null | awk 'NR>1 {n=split($9,a,":"); print $2, a[n]}')
 ps aux | grep -v grep | awk '
-  /node_modules\\/\\.bin\\// { print $2; next }
+  /node_modules\\// { print $2; next }
   $11 ~ /(\\/|^)bun$/ { print $2 }
 ' | sort -u | while read -r PID; do
   CMD=$(ps -p $PID -o command= 2>/dev/null) || continue
@@ -33,9 +35,17 @@ ps aux | grep -v grep | awk '
   # non-deterministic and would flicker the displayed port across refreshes.
   PORT=$(echo "$PORTS" | awk -v p=$PID '$1==p {print $2}' | sort -n | head -1)
   [ -z "$PORT" ] && continue
-  CWD=$(lsof -p $PID -a -d cwd 2>/dev/null | awk 'NR>1 {print $NF}')
+  # -F n emits machine-readable output (one field per line, prefixed by a
+  # type letter); 'n<path>' lines contain the full cwd including spaces.
+  # The column-formatted form would split on whitespace and truncate.
+  CWD=$(lsof -p $PID -a -d cwd -F n 2>/dev/null | awk '/^n/ {print substr($0,2)}')
   STARTED=$(ps -p $PID -o lstart= 2>/dev/null)
-  TOOL=$(echo "$CMD" | grep -oE 'node_modules/.bin/[^ ]+' | xargs basename 2>/dev/null)
+  # Prefer the .bin/ name when present, otherwise fall back to the package
+  # name from node_modules/<pkg>/ — handles \`node node_modules/serve/build/main.js\`.
+  TOOL=$(echo "$CMD" | grep -oE 'node_modules/\\.bin/[^ ]+' | xargs basename 2>/dev/null)
+  if [[ -z "$TOOL" ]]; then
+    TOOL=$(echo "$CMD" | grep -oE 'node_modules/(@[^/]+/)?[^/ ]+' | head -1 | sed 's|node_modules/||')
+  fi
   # Runtime detection: check the actual executable, not the full command line.
   # ps -o comm= returns the process basename (sometimes a full path on macOS).
   # This identifies "true bun" only. Bun delegating to node via vite's shebang


### PR DESCRIPTION
## Description

- Detect any Node tool that runs out of `node_modules/`, not just those launched via `node_modules/.bin/`. Surfaces tools like `serve` and `http-server` that were previously missed.
- Render favicons inline so they display reliably for every framework, including SVG icons and dev servers (such as Astro) that don't expose static assets cross-origin.
- Preserve spaces in detected project paths. Restart, Open in Terminal, and Show in Finder no longer break on projects whose absolute path contains a space.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
