### PR TITLE
Update agent-usage extension

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Agent Usage Changelog
 
+## [Add Kimi CLI Support] - 2026-05-26
+
+### New Features
+
+- **Kimi CLI Auto-Detection** — Automatically detect and use credentials from the official `kimi` CLI (`~/.kimi/credentials/kimi-code.json`)
+- **Automatic Token Refresh** — When a Kimi CLI token expires, the extension automatically refreshes it using Moonshot's OAuth refresh endpoint and persists the new token back to the credentials file
+- Kimi CLI credentials appear as "Auto-detected (Kimi CLI)" in multi-account view alongside OpenCode and manual accounts
+
 ## [Add OpenCode Go Provider] - 2026-05-15
 
 - Add OpenCode Go plan usage display

--- a/extensions/agent-usage/src/kimi/auth.ts
+++ b/extensions/agent-usage/src/kimi/auth.ts
@@ -1,0 +1,126 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const KIMI_CREDENTIALS_PATH = path.join(os.homedir(), ".kimi", "credentials", "kimi-code.json");
+const KIMI_OAUTH_REFRESH_API = "https://auth.kimi.com/api/oauth/token";
+const KIMI_OAUTH_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098";
+
+export interface KimiCredentials {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt?: number;
+  scope: string;
+  tokenType: string;
+}
+
+interface KimiCredentialsFile {
+  access_token?: string;
+  refresh_token?: string;
+  expires_at?: number;
+  scope?: string;
+  token_type?: string;
+  expires_in?: number;
+}
+
+interface KimiRefreshResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  token_type: string;
+  scope?: string;
+}
+
+function readCredentialsFile(): KimiCredentialsFile | null {
+  try {
+    if (!fs.existsSync(KIMI_CREDENTIALS_PATH)) return null;
+    const raw = fs.readFileSync(KIMI_CREDENTIALS_PATH, "utf-8");
+    return JSON.parse(raw) as KimiCredentialsFile;
+  } catch {
+    return null;
+  }
+}
+
+export function readKimiCliCredentials(): { credentials: KimiCredentials | null; error: string | null } {
+  const parsed = readCredentialsFile();
+  if (!parsed) {
+    return { credentials: null, error: null };
+  }
+
+  const accessToken = parsed.access_token?.trim() || "";
+  const refreshToken = parsed.refresh_token?.trim() || "";
+
+  if (!accessToken || !refreshToken) {
+    return { credentials: null, error: "Kimi CLI credentials missing access_token or refresh_token." };
+  }
+
+  return {
+    credentials: {
+      accessToken,
+      refreshToken,
+      expiresAt: typeof parsed.expires_at === "number" ? parsed.expires_at : undefined,
+      scope: parsed.scope || "kimi-code",
+      tokenType: parsed.token_type || "Bearer",
+    },
+    error: null,
+  };
+}
+
+function buildCredentialsFile(credentials: KimiCredentials): KimiCredentialsFile {
+  return {
+    access_token: credentials.accessToken,
+    refresh_token: credentials.refreshToken,
+    expires_at: credentials.expiresAt,
+    scope: credentials.scope,
+    token_type: credentials.tokenType,
+  };
+}
+
+export function persistKimiCredentials(credentials: KimiCredentials): void {
+  try {
+    const dir = path.dirname(KIMI_CREDENTIALS_PATH);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(KIMI_CREDENTIALS_PATH, `${JSON.stringify(buildCredentialsFile(credentials), null, 2)}\n`, "utf-8");
+    // Restrict permissions to owner-read/write only
+    try {
+      fs.chmodSync(KIMI_CREDENTIALS_PATH, 0o600);
+    } catch {
+      // Best effort
+    }
+  } catch {
+    // Best effort; continue with refreshed token in memory
+  }
+}
+
+export async function refreshKimiToken(refreshToken: string): Promise<KimiRefreshResponse | null> {
+  const body = new URLSearchParams({
+    client_id: KIMI_OAUTH_CLIENT_ID,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  });
+
+  try {
+    const response = await fetch(KIMI_OAUTH_REFRESH_API, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: body.toString(),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as KimiRefreshResponse;
+    if (!data.access_token || typeof data.expires_in !== "number") {
+      return null;
+    }
+    return data;
+  } catch {
+    return null;
+  }
+}

--- a/extensions/agent-usage/src/kimi/fetcher.ts
+++ b/extensions/agent-usage/src/kimi/fetcher.ts
@@ -7,6 +7,7 @@ import { readOpencodeAuthToken } from "../agents/opencode-auth";
 import { isOpenCodeActiveToken } from "../agents/opencode-active";
 import { loadAccounts } from "../accounts/storage";
 import type { AccountUsageState } from "../accounts/types";
+import { readKimiCliCredentials, refreshKimiToken, persistKimiCredentials } from "./auth";
 
 const KIMI_OPENCODE_KEY = "kimi-for-coding";
 
@@ -90,21 +91,67 @@ function parseKimiApiResponse(data: unknown): { usage: KimiUsage | null; error: 
 
 // --- Core fetcher ---
 
-async function fetchKimiUsage(token: string): Promise<{ usage: KimiUsage | null; error: KimiError | null }> {
-  const { data, error } = await httpFetch({
+async function fetchKimiUsage(
+  token: string,
+  refreshToken?: string,
+): Promise<{ usage: KimiUsage | null; error: KimiError | null }> {
+  const result = await httpFetch({
     url: KIMI_USAGE_API,
     method: "GET",
     token,
     headers: { Accept: "application/json" },
   });
-  if (error) return { usage: null, error };
-  return parseKimiApiResponse(data);
+
+  // If unauthorized and we have a refresh token, try to refresh and retry
+  if (result.error?.type === "unauthorized" && refreshToken) {
+    const refreshed = await refreshKimiToken(refreshToken);
+    if (refreshed) {
+      persistKimiCredentials({
+        accessToken: refreshed.access_token,
+        refreshToken: refreshed.refresh_token || refreshToken,
+        expiresAt: Date.now() + refreshed.expires_in * 1000,
+        scope: refreshed.scope || "kimi-code",
+        tokenType: refreshed.token_type || "Bearer",
+      });
+
+      const retry = await httpFetch({
+        url: KIMI_USAGE_API,
+        method: "GET",
+        token: refreshed.access_token,
+        headers: { Accept: "application/json" },
+      });
+
+      if (retry.error) return { usage: null, error: retry.error };
+      return parseKimiApiResponse(retry.data);
+    }
+  }
+
+  if (result.error) return { usage: null, error: result.error };
+  return parseKimiApiResponse(result.data);
 }
 
-function resolveKimiTokens(prefs: AgentUsagePrefs): string {
-  // Slot 1: manual preference → OpenCode auto-detect
+interface ResolvedToken {
+  token: string;
+  refreshToken?: string;
+  source: "preference" | "opencode" | "kimi-cli";
+}
+
+function resolveKimiTokens(prefs: AgentUsagePrefs): ResolvedToken | null {
+  // Slot 1: manual preference
   const pref1 = (prefs.kimiAuthToken as string | undefined)?.trim() || "";
-  return pref1 || readOpencodeAuthToken("kimi-for-coding") || "";
+  if (pref1) return { token: pref1, source: "preference" };
+
+  // Slot 2: OpenCode auto-detect
+  const opencode = readOpencodeAuthToken("kimi-for-coding");
+  if (opencode) return { token: opencode, source: "opencode" };
+
+  // Slot 3: Kimi CLI auto-detect
+  const { credentials } = readKimiCliCredentials();
+  if (credentials) {
+    return { token: credentials.accessToken, refreshToken: credentials.refreshToken, source: "kimi-cli" };
+  }
+
+  return null;
 }
 
 // --- Dual-source auth hook ---
@@ -120,13 +167,14 @@ export function useKimiUsage(enabled = true): UsageState<KimiUsage, KimiError> {
     const requestId = ++requestIdRef.current;
 
     const prefs = getPreferenceValues<AgentUsagePrefs>();
-    const token = resolveKimiTokens(prefs);
+    const resolved = resolveKimiTokens(prefs);
 
-    if (!token) {
+    if (!resolved) {
       setUsage(null);
       setError({
         type: "not_configured",
-        message: "Kimi token not found. Login via OpenCode (kimi-for-coding) or add it in extension settings (Cmd+,).",
+        message:
+          "Kimi token not found. Login via OpenCode (kimi-for-coding), run 'kimi' CLI, or add it in extension settings (Cmd+,).",
       });
       setIsLoading(false);
       setHasInitialFetch(true);
@@ -136,7 +184,7 @@ export function useKimiUsage(enabled = true): UsageState<KimiUsage, KimiError> {
     setIsLoading(true);
     setError(null);
 
-    const result = await fetchKimiUsage(token);
+    const result = await fetchKimiUsage(resolved.token, resolved.refreshToken);
     if (requestId !== requestIdRef.current) return;
 
     setUsage(result.usage);
@@ -172,7 +220,7 @@ export function useKimiUsage(enabled = true): UsageState<KimiUsage, KimiError> {
 
 /**
  * Returns one UsageState per named Kimi account stored in LocalStorage.
- * Falls back to the preference/OpenCode token if no accounts are stored.
+ * Falls back to the preference/OpenCode/Kimi CLI token if no accounts are stored.
  *
  * Each entry in the returned array corresponds to one account.
  * The array is stable in order (matches LocalStorage order).
@@ -195,8 +243,11 @@ export function useKimiAccounts(enabled = true): AccountUsageState<KimiUsage, Ki
     const autoToken = readOpencodeAuthToken("kimi-for-coding");
     const prefToken = (prefs.kimiAuthToken as string | undefined)?.trim() || "";
 
+    // Get auto-detected token from Kimi CLI
+    const { credentials: kimiCliCreds } = readKimiCliCredentials();
+
     // Build list of all accounts: manual + auto-detected (if not duplicate)
-    const accounts = [...manualAccounts];
+    const accounts: Array<{ id: string; label: string; token: string; refreshToken?: string }> = [...manualAccounts];
 
     // Add preference token as "Manual" if different from manual accounts
     if (prefToken && !accounts.some((a) => a.token === prefToken)) {
@@ -207,12 +258,22 @@ export function useKimiAccounts(enabled = true): AccountUsageState<KimiUsage, Ki
       });
     }
 
-    // Add auto-detected token as "Auto-detected" if different from existing
+    // Add OpenCode auto-detected token as "Auto-detected" if different from existing
     if (autoToken && !accounts.some((a) => a.token === autoToken)) {
       accounts.push({
         id: "kimi-opencode",
         label: "Auto-detected",
         token: autoToken,
+      });
+    }
+
+    // Add Kimi CLI auto-detected token as "Auto-detected (Kimi CLI)" if different from existing
+    if (kimiCliCreds && !accounts.some((a) => a.token === kimiCliCreds.accessToken)) {
+      accounts.push({
+        id: "kimi-cli",
+        label: "Auto-detected (Kimi CLI)",
+        token: kimiCliCreds.accessToken,
+        refreshToken: kimiCliCreds.refreshToken,
       });
     }
 
@@ -228,7 +289,7 @@ export function useKimiAccounts(enabled = true): AccountUsageState<KimiUsage, Ki
           error: {
             type: "not_configured",
             message:
-              "Kimi token not found. Login via OpenCode (kimi-for-coding) or add an account via Manage Accounts.",
+              "Kimi token not found. Login via OpenCode (kimi-for-coding), run 'kimi' CLI, or add an account via Manage Accounts.",
           },
           revalidate: async () => {
             await fetchAll();
@@ -241,7 +302,7 @@ export function useKimiAccounts(enabled = true): AccountUsageState<KimiUsage, Ki
     // Kick off all fetches in parallel
     const results = await Promise.all(
       accounts.map(async (account) => {
-        const result = await fetchKimiUsage(account.token);
+        const result = await fetchKimiUsage(account.token, account.refreshToken);
         return { account, result };
       }),
     );


### PR DESCRIPTION
## Description

Add native support for the official Moonshot Kimi CLI, including automatic token refresh.

### New Features

- Kimi CLI Auto-Detection: Detect credentials from ~/.kimi/credentials/kimi-code.json (the official Kimi CLI credential file)
- Automatic Token Refresh: Kimi CLI access tokens expire after 15 minutes. When the API returns 401, the extension automatically calls Moonshot's OAuth refresh endpoint and persists the new token back to the credentials file
- Multi-Account Support: Kimi CLI appears as "Auto-detected (Kimi CLI)" alongside OpenCode and manual accounts

### Why

Currently, the extension only supports manual token entry and OpenCode auto-detection. Users who use the official kimi CLI have no way to auto-detect their credentials, and even if they paste the access token manually it expires in 15 minutes. This PR closes that gap.

### How to Test

1. Install the official Kimi CLI and run kimi login
2. Open the Agent Usage extension - Kimi should appear as "Auto-detected (Kimi CLI)"
3. Wait 15+ minutes and refresh - the extension should silently refresh the token

### Checklist

- [x] I read the extension guidelines
- [x] I ran npm run build and tested this submission
- [x] I ran npm run lint and fixed all issues
