### PR TITLE
Update dev-servers extension

### DIFF
--- a/extensions/dev-servers/CHANGELOG.md
+++ b/extensions/dev-servers/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dev Servers Changelog
 
-## [Worktree grouping and detection rewrite] - {PR_MERGE_DATE}
+## [Worktree grouping and detection rewrite] - 2026-05-26
 
 3x faster, windows port preparation, support for git branches & worktrees, search by project and branch.
 

--- a/extensions/dev-servers/CHANGELOG.md
+++ b/extensions/dev-servers/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Dev Servers Changelog
 
+## [Worktree grouping and detection rewrite] - {PR_MERGE_DATE}
+
+3x faster, windows port preparation, support for git branches & worktrees, search by project and branch.
+
+- Rewrote process detection from an embedded shell pipeline to TypeScript. Output is unchanged; the new path is roughly 3x faster, removes a class of shell-parsing bugs, and lays the groundwork for a future Windows port.
+- Group multiple git worktrees of the same repo into one project section. Each row shows its current branch next to the link, and per-row actions (Open in Terminal, Show in Finder) still target the specific worktree on disk.
+- Show the current git branch on every project's rows, so you can tell at a glance which branch a long-running dev server is on, even for single-worktree projects.
+- Search by project name or branch directly in the Raycast search bar, Raycast's built-in filter previously only matched the port number and subtitle.
+- New preferences to toggle each row accessory (uptime, git branch, framework tag) independently.
+- Stylized framework names (SvelteKit, Astro, Next.js, esbuild, etc.) in the row tag and the filter dropdown.
+- More reliable restarts: the old process is force-killed and confirmed exited before the replacement spawns, closing a rare race where the new server could fail to bind because the old one still held the port.
+
 ## [Detection and favicon improvements] - 2026-05-25
+
+Detects more dev-server tools, renders favicons reliably across frameworks, and handles project paths that contain spaces.
 
 - Detect any Node tool that runs out of `node_modules/`, not just those launched via `node_modules/.bin/`. Surfaces tools like `serve` and `http-server` that were previously missed.
 - Render favicons inline so they display reliably for every framework, including SVG icons and dev servers (such as Astro) that don't expose static assets cross-origin.
@@ -8,6 +22,22 @@
 
 ## [Initial Version] - 2026-05-19
 
-A keyboard-first dashboard for every dev server you have running. Auto-detects servers from any framework that uses `node_modules/.bin/` (Vite, Next.js, Astro, SvelteKit, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, esbuild) plus the Bun runtime. Servers are grouped by project with favicons, uptime, framework, and runtime tags.
+Dashboard for every running dev server, grouped by project.
 
-Actions: open in browser, copy URL, kill, restart, open in terminal, show in Finder, manual refresh, kill all in a project, and kill all globally. Bulk-kill actions ask for confirmation. Restart picks the right package manager from the project's lockfile (npm, pnpm, yarn, bun) and polls until the new server binds a port. Failures surface as toast notifications with a link to the log.
+- A keyboard-first dashboard for every dev server you have running.
+- Auto-detects servers from any framework that uses `node_modules/` (Vite, Next.js, Astro, SvelteKit, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, esbuild) plus the Bun runtime.
+- Servers are grouped by project with favicons, uptime, framework, and runtime tags.
+  
+Actions:
+- Open in browser
+- Copy URL
+- Kill
+- Restart
+- Open in terminal
+- Show in Finder
+- Manual refresh
+- Kill all in a project
+- Kill all globally. 
+- Bulk-kill actions ask for confirmation.
+- Restart picks the right package manager from the project's lockfile (npm, pnpm, yarn, bun) and polls until the new server binds a port.
+- Failures surface as toast notifications with a link to the log.

--- a/extensions/dev-servers/README.md
+++ b/extensions/dev-servers/README.md
@@ -6,13 +6,14 @@ A keyboard-first dashboard for every dev server you have running. See them group
 
 - **Auto-detects** running dev servers including Vite, Next.js, Astro, SvelteKit, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, esbuild, serve, http-server, anything that runs out of `node_modules/`, plus servers running on the Bun runtime
 - **Grouped by project** so servers from the same directory appear under one section
+- **Worktree-aware** so multiple git worktrees of the same repo collapse into one section, with a per-row branch tag to tell them apart — also surfaces the current branch on single-worktree projects so you can tell which branch a long-running server is on
 - **Favicons** — PNG, ICO, or SVG — are pulled from each site (with `/favicon.ico` fallback), inlined so they render even when the dev server isn't CORS-friendly, and cached across refreshes
 - **Runtime tag** shows a yellow `bun` badge when the listening process is genuinely running on Bun
 - **Uptime tracking** shows how long each server has been running. Hover for the exact start time
 - **Smart restart** picks the right package manager (npm, pnpm, yarn, bun) from the project's lockfile, polls until the new server binds a port, and surfaces failures with a link to the log
 - **Confirm dialogs on bulk-kill** ensure destructive actions ask first, with a "Don't ask again" option for project-scoped kills
 - **Open in your terminal** uses a configurable terminal app preference (Terminal, iTerm, Warp, Ghostty, etc.)
-- **Tool filter** appears in the search bar dropdown when you have multiple frameworks running
+- **Search and filter** by typing a project name, branch, or port into the search bar; a framework dropdown appears when you have multiple frameworks running
 - **Stays open** because the window never closes after an action, so you can chain kills and restarts in one session
 - **Auto-refresh** updates the list automatically on a configurable interval, plus manual `⌘R`
 

--- a/extensions/dev-servers/package.json
+++ b/extensions/dev-servers/package.json
@@ -8,6 +8,19 @@
   "categories": [
     "Developer Tools"
   ],
+  "keywords": [
+    "dev server",
+    "dev servers",
+    "localhost",
+    "port",
+    "ports",
+    "kill",
+    "restart",
+    "process",
+    "dashboard",
+    "manage",
+    "monitor"
+  ],
   "platforms": [
     "macOS"
   ],
@@ -60,6 +73,31 @@
               "value": "30"
             }
           ]
+        },
+        {
+          "name": "showUptime",
+          "title": "Row Accessories",
+          "type": "checkbox",
+          "label": "Show uptime",
+          "description": "Show how long each server has been running",
+          "default": true,
+          "required": false
+        },
+        {
+          "name": "showBranch",
+          "type": "checkbox",
+          "label": "Show git branch",
+          "description": "Show the current git branch next to each server when the project is a git repo",
+          "default": true,
+          "required": false
+        },
+        {
+          "name": "showTool",
+          "type": "checkbox",
+          "label": "Show framework tag",
+          "description": "Show the framework / tool tag (Vite, SvelteKit, Astro, etc.) on each row",
+          "default": true,
+          "required": false
         }
       ]
     }

--- a/extensions/dev-servers/src/index.tsx
+++ b/extensions/dev-servers/src/index.tsx
@@ -13,14 +13,11 @@ import {
   openExtensionPreferences,
   showToast,
 } from "@raycast/api";
-import { showFailureToast, useCachedPromise, useExec } from "@raycast/utils";
+import { showFailureToast, useCachedPromise } from "@raycast/utils";
+import * as os from "node:os";
+import * as path from "node:path";
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  FETCH_SCRIPT,
-  killProcess,
-  parseServers,
-  restartServer,
-} from "./servers";
+import { fetchServers, killProcess, restartServer } from "./servers";
 import { DevServer } from "./types";
 
 const DEFAULT_TERMINAL: Application = {
@@ -35,6 +32,33 @@ function formatUptime(startedAt: Date): string {
   if (seconds < 60) return `${seconds}s`;
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
   return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+}
+
+// Display label for the tool tag. We keep the internal `tool` field lowercase
+// (used for grouping, color lookup, dropdown filter values) and only stylize
+// on the way to the UI. Anything not in this map renders as-is.
+const TOOL_DISPLAY_NAMES: Record<string, string> = {
+  vite: "Vite",
+  sveltekit: "SvelteKit",
+  svelte: "Svelte",
+  astro: "Astro",
+  next: "Next.js",
+  nuxt: "Nuxt",
+  webpack: "Webpack",
+  parcel: "Parcel",
+  gatsby: "Gatsby",
+  remix: "Remix",
+  turbo: "Turbo",
+  esbuild: "esbuild", // intentionally lowercase per upstream brand
+  bun: "Bun",
+  node: "Node",
+  serve: "Serve",
+  "http-server": "http-server", // intentionally lowercase per package name
+  "live-server": "Live Server",
+};
+
+function toolLabel(tool: string): string {
+  return TOOL_DISPLAY_NAMES[tool.toLowerCase()] ?? tool;
 }
 
 // Theme-adaptive overrides for the few frameworks where the named palette
@@ -139,9 +163,16 @@ async function detectFaviconUrl(port: string): Promise<string | undefined> {
   return fetchFaviconDataUri(`${origin}/favicon.ico`);
 }
 
+interface RowVisibility {
+  branch: boolean;
+  uptime: boolean;
+  tool: boolean;
+}
+
 interface ServerItemProps {
   server: DevServer;
   terminalApp: Application;
+  show: RowVisibility;
   onKill: () => void;
   onKillProject: () => void;
   onKillAll: () => void;
@@ -152,6 +183,7 @@ interface ServerItemProps {
 function ServerItem({
   server,
   terminalApp,
+  show,
   onKill,
   onKillProject,
   onKillAll,
@@ -173,26 +205,54 @@ function ServerItem({
     ? { source: faviconUrl, fallback: Icon.Globe }
     : { source: Icon.Globe, tintColor: toolColor(server.tool) };
 
+  // Branch goes in the left-rail subtitle (right next to the title), not in
+  // the accessories on the right. Raycast dims subtitles automatically.
+  const subtitle =
+    show.branch && server.branch
+      ? {
+          value: server.branch,
+          tooltip: `Branch: ${server.branch}\nWorktree: ${server.cwd}`,
+        }
+      : undefined;
+
   return (
     <List.Item
       icon={icon}
       title={`localhost:${server.port}`}
+      subtitle={subtitle}
+      keywords={[server.projectName, server.branch].filter((v): v is string =>
+        Boolean(v),
+      )}
       accessories={[
-        {
-          text: formatUptime(server.startedAt),
-          tooltip: `Started ${server.startedAt.toLocaleString()}`,
-        },
-        // Show the runtime tag only when it adds new information.
-        // If the framework tag is already "bun", a second "bun" tag is just noise.
-        ...(server.runtime === "bun" && server.tool !== "bun"
+        ...(show.uptime
           ? [
               {
-                tag: { value: "bun", color: Color.Yellow },
+                text: formatUptime(server.startedAt),
+                tooltip: `Started ${server.startedAt.toLocaleString()}`,
+              },
+            ]
+          : []),
+        // Runtime tag is suppressed when it duplicates the tool tag (e.g.
+        // tool is already "bun"), and rendered only when the user has the
+        // tool tag visible — otherwise standalone "bun" would look orphaned.
+        ...(show.tool && server.runtime === "bun" && server.tool !== "bun"
+          ? [
+              {
+                tag: { value: "Bun", color: Color.Yellow },
                 tooltip: "Listening process is running on the Bun runtime",
               },
             ]
           : []),
-        { tag: { value: server.tool, color: toolColor(server.tool) } },
+        ...(show.tool
+          ? [
+              {
+                tag: {
+                  value: toolLabel(server.tool),
+                  color: toolColor(server.tool),
+                },
+              },
+            ]
+          : []),
       ]}
       actions={
         <ActionPanel>
@@ -261,8 +321,7 @@ export default function Command() {
     data: servers = [],
     mutate,
     revalidate,
-  } = useExec("/bin/zsh", ["-c", FETCH_SCRIPT], {
-    parseOutput: ({ stdout }) => parseServers(stdout),
+  } = useCachedPromise(fetchServers, [], {
     keepPreviousData: true,
   });
 
@@ -290,8 +349,8 @@ export default function Command() {
     }
   }
 
-  async function killProject(cwd: string) {
-    const targets = servers.filter((s) => s.cwd === cwd);
+  async function killProject(projectKey: string) {
+    const targets = servers.filter((s) => s.projectKey === projectKey);
     if (targets.length === 0) return;
     const projectName = targets[0].projectName;
     const confirmed = await confirmAlert({
@@ -311,7 +370,7 @@ export default function Command() {
         })(),
         {
           optimisticUpdate: (current) =>
-            (current ?? []).filter((s) => s.cwd !== cwd),
+            (current ?? []).filter((s) => s.projectKey !== projectKey),
           rollbackOnError: true,
         },
       );
@@ -388,7 +447,7 @@ export default function Command() {
       } else {
         toast.style = Toast.Style.Failure;
         toast.title = "Restart timed out";
-        toast.message = "Check /tmp/dev-servers-restart-*.log";
+        toast.message = `Check ${path.join(os.tmpdir(), "dev-servers-restart-*.log")}`;
       }
     } catch (err) {
       await showFailureToast(err, {
@@ -399,6 +458,14 @@ export default function Command() {
 
   const terminalApp = prefs.terminalApp ?? DEFAULT_TERMINAL;
   const [toolFilter, setToolFilter] = useState<string>("all");
+
+  // Visibility prefs default to true so first-time users see everything.
+  // Raycast returns `undefined` for an unset checkbox on first launch.
+  const show: RowVisibility = {
+    branch: prefs.showBranch ?? true,
+    uptime: prefs.showUptime ?? true,
+    tool: prefs.showTool ?? true,
+  };
 
   // Manual refresh: useExec's revalidate is silent because keepPreviousData
   // keeps the list rendered. Show a brief animated toast so the user knows
@@ -429,10 +496,13 @@ export default function Command() {
       ? servers
       : servers.filter((s) => s.tool === toolFilter);
 
+  // Group by projectKey (git common-dir for git projects, cwd otherwise) so
+  // sibling worktrees of the same repo collapse into one section. Each row
+  // still carries its own cwd/branch so per-row actions stay correct.
   const grouped = Object.entries(
     visible.reduce(
       (acc, s) => {
-        (acc[s.cwd] ??= []).push(s);
+        (acc[s.projectKey] ??= []).push(s);
         return acc;
       },
       {} as Record<string, DevServer[]>,
@@ -453,7 +523,11 @@ export default function Command() {
             <List.Dropdown.Item title="All Tools" value="all" />
             <List.Dropdown.Section>
               {availableTools.map((tool) => (
-                <List.Dropdown.Item key={tool} title={tool} value={tool} />
+                <List.Dropdown.Item
+                  key={tool}
+                  title={toolLabel(tool)}
+                  value={tool}
+                />
               ))}
             </List.Dropdown.Section>
           </List.Dropdown>
@@ -481,10 +555,17 @@ export default function Command() {
           }
         />
       )}
-      {grouped.map(([cwd, projectServers]) => (
+      {grouped.map(([projectKey, projectServers]) => (
         <List.Section
-          key={cwd}
-          title={prefs.showFullPath ? cwd : projectServers[0].projectName}
+          key={projectKey}
+          title={
+            // When showFullPath is on, use the first row's cwd as a concrete
+            // path hint. (For multi-worktree sections the per-row branch tag
+            // and its tooltip distinguish which worktree each row belongs to.)
+            prefs.showFullPath
+              ? projectServers[0].cwd
+              : projectServers[0].projectName
+          }
           subtitle={`${projectServers.length} server${projectServers.length > 1 ? "s" : ""}`}
         >
           {projectServers.map((server) => (
@@ -492,8 +573,9 @@ export default function Command() {
               key={server.pid}
               server={server}
               terminalApp={terminalApp}
+              show={show}
               onKill={() => kill(server.pid)}
-              onKillProject={() => killProject(cwd)}
+              onKillProject={() => killProject(projectKey)}
               onKillAll={killAll}
               onRestart={() => restart(server)}
               onRefresh={refresh}

--- a/extensions/dev-servers/src/servers.ts
+++ b/extensions/dev-servers/src/servers.ts
@@ -239,9 +239,10 @@ export async function fetchServers(): Promise<DevServer[]> {
   const cwdByPid = await listCwds(finalPids);
 
   // Look up git info per unique cwd, in parallel. Worktrees of the same repo
-  // share a git common-dir, so we use that (well, its parent's basename) as
-  // the project key — collapses sibling worktrees into one group while still
-  // letting us show the branch on each row.
+  // share a git common-dir, so we use that path as the project key — collapses
+  // sibling worktrees into one group while still letting us show the branch on
+  // each row. The project's display name is the basename of the common-dir's
+  // parent (the repo root).
   const uniqueCwds = [...new Set([...cwdByPid.values()])];
   const gitByCwd = new Map<string, GitInfo | undefined>();
   await Promise.all(
@@ -255,8 +256,9 @@ export async function fetchServers(): Promise<DevServer[]> {
     const cwd = cwdByPid.get(proc.pid);
     if (!cwd) continue; // shouldn't happen for live processes, but be safe
     const git = gitByCwd.get(cwd);
-    // For git projects: project name & key come from the directory holding
-    // the shared .git dir. For non-git: fall back to the worktree basename.
+    // For git projects: key is the shared .git dir path (stable across all
+    // worktrees of the repo), name is the basename of its parent (the repo
+    // root). For non-git: both fall back to the worktree itself.
     const projectName = git
       ? path.basename(path.dirname(git.commonDir))
       : path.basename(cwd) || cwd;

--- a/extensions/dev-servers/src/servers.ts
+++ b/extensions/dev-servers/src/servers.ts
@@ -1,102 +1,293 @@
-import { exec, spawn } from "child_process";
+import { execFile, spawn } from "node:child_process";
 import * as fs from "node:fs";
-import { promisify } from "util";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
 import { DevServer } from "./types";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
-// Grabs all listening ports once up front to avoid repeated lsof calls,
-// then iterates over candidate dev-server PIDs (anything running a script
-// from node_modules/, plus bun processes) and emits one pipe-delimited
-// line per server: PID|PORT|CWD|STARTED|TOOL
+// ---------------------------------------------------------------------------
+// Platform primitives
+// ---------------------------------------------------------------------------
 //
-// Uses `while read -r PID` (not `for PID in $PIDS`) to correctly iterate in zsh,
-// where unquoted variable expansion does not word-split on newlines.
-//
-// lstart format: "Wed Apr 16 10:23:45 2026". V8 parses this correctly via new Date().
-//
-// The awk filter matches node_modules/ anywhere in the command line OR a
-// bare `bun` in the executable column ($11). The broader node_modules/
-// match (vs. the narrower .bin/) catches tools invoked as
-// `node node_modules/<pkg>/...` — e.g. `serve`, `http-server`. Over-
-// collection is harmless: the `[ -z "$PORT" ] && continue` below drops
-// any PID not actually listening on TCP.
-export const FETCH_SCRIPT = `
-PORTS=$(lsof -iTCP -sTCP:LISTEN -nP 2>/dev/null | awk 'NR>1 {n=split($9,a,":"); print $2, a[n]}')
-ps aux | grep -v grep | awk '
-  /node_modules\\// { print $2; next }
-  $11 ~ /(\\/|^)bun$/ { print $2 }
-' | sort -u | while read -r PID; do
-  CMD=$(ps -p $PID -o command= 2>/dev/null) || continue
-  # A single dev-server PID often has multiple LISTEN sockets: the main HTTP
-  # server plus ephemeral OS-assigned ports for HMR/IPC/prebundling. We pick
-  # the LOWEST port because configured dev ports (3000, 4321, 5173, 8080)
-  # are always below ephemeral ports (32768-65535). lsof's order is otherwise
-  # non-deterministic and would flicker the displayed port across refreshes.
-  PORT=$(echo "$PORTS" | awk -v p=$PID '$1==p {print $2}' | sort -n | head -1)
-  [ -z "$PORT" ] && continue
-  # -F n emits machine-readable output (one field per line, prefixed by a
-  # type letter); 'n<path>' lines contain the full cwd including spaces.
-  # The column-formatted form would split on whitespace and truncate.
-  CWD=$(lsof -p $PID -a -d cwd -F n 2>/dev/null | awk '/^n/ {print substr($0,2)}')
-  STARTED=$(ps -p $PID -o lstart= 2>/dev/null)
-  # Prefer the .bin/ name when present, otherwise fall back to the package
-  # name from node_modules/<pkg>/ — handles \`node node_modules/serve/build/main.js\`.
-  TOOL=$(echo "$CMD" | grep -oE 'node_modules/\\.bin/[^ ]+' | xargs basename 2>/dev/null)
-  if [[ -z "$TOOL" ]]; then
-    TOOL=$(echo "$CMD" | grep -oE 'node_modules/(@[^/]+/)?[^/ ]+' | head -1 | sed 's|node_modules/||')
-  fi
-  # Runtime detection: check the actual executable, not the full command line.
-  # ps -o comm= returns the process basename (sometimes a full path on macOS).
-  # This identifies "true bun" only. Bun delegating to node via vite's shebang
-  # shows as node here, which is correct since the listening process IS node.
-  COMM=$(ps -p $PID -o comm= 2>/dev/null)
-  if [[ "$COMM" == "bun" || "$COMM" == */bun ]]; then
-    RUNTIME="bun"
-  else
-    RUNTIME="node"
-  fi
-  # If no node_modules/.bin/ tool was found but the command is bun, label it bun
-  if [[ -z "$TOOL" ]] && echo "$CMD" | grep -qE '(/|^)bun( |$)'; then
-    TOOL="bun"
-  fi
-  # SvelteKit runs under vite, so detect it by the presence of svelte.config in the project root
-  if [[ "$TOOL" == "vite" && (-f "$CWD/svelte.config.js" || -f "$CWD/svelte.config.ts") ]]; then
-    TOOL="sveltekit"
-  fi
-  echo "$PID|$PORT|$CWD|$STARTED|$TOOL|$RUNTIME"
-done
-`;
+// Everything below the next section divider is pure TypeScript and runs
+// unchanged on any OS. To port the extension to a new platform (e.g.
+// Windows), swap the three helpers in this section for equivalents that
+// return the same shapes. Suggested mapping:
+//   listProcesses  → Get-CimInstance Win32_Process     (or PowerShell)
+//   listListeners  → Get-NetTCPConnection -State Listen
+//   listCwds       → Win32_Process.ExecutablePath / CWD via WMI
 
-export function parseServers(stdout: string): DevServer[] {
-  return stdout
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => {
-      const [pid, port, cwd, started, tool, runtime] = line.split("|");
-      return {
-        pid: parseInt(pid),
-        port,
-        url: `http://localhost:${port}`,
-        tool: tool?.trim() || "node",
-        runtime: runtime?.trim() === "bun" ? "bun" : "node",
-        cwd,
-        projectName: cwd?.split("/").pop() || cwd,
-        startedAt: new Date(started?.trim() ?? ""),
-      } as DevServer;
-    })
-    .filter((s) => s.port && !isNaN(s.pid));
+interface RawProcess {
+  pid: number;
+  lstart: string; // raw `ps` lstart text, e.g. "Tue May 19 20:02:57 2026"
+  command: string; // full command line (including the executable path)
 }
 
+interface RawListener {
+  pid: number;
+  port: number;
+}
+
+// Capture stdout even when the child exits non-zero (lsof exits 1 if any of
+// the queried PIDs has died between our two queries, but the rest of the
+// output is still useful).
+function stdoutOrThrow(err: unknown): string {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "stdout" in err &&
+    typeof (err as { stdout: unknown }).stdout === "string"
+  ) {
+    return (err as { stdout: string }).stdout;
+  }
+  throw err;
+}
+
+async function listProcesses(): Promise<RawProcess[]> {
+  // ps -A: all processes. -ww: don't truncate long command lines.
+  // pid= / lstart= / command= : suppress headers; output each field
+  // as-is. lstart is fixed-width 24 chars (`Tue May 19 20:02:57 2026`).
+  const { stdout } = await execFileAsync("ps", [
+    "-A",
+    "-ww",
+    "-o",
+    "pid=,lstart=,command=",
+  ]);
+  const procs: RawProcess[] = [];
+  for (const line of stdout.split("\n")) {
+    const match = line.match(/^\s*(\d+)\s+(.+)$/);
+    if (!match) continue;
+    const rest = match[2];
+    if (rest.length < 25) continue; // need at least lstart + one char
+    procs.push({
+      pid: parseInt(match[1], 10),
+      lstart: rest.slice(0, 24),
+      command: rest.slice(24).trimStart(),
+    });
+  }
+  return procs;
+}
+
+async function listListeners(): Promise<RawListener[]> {
+  // -F pn outputs one field per line, prefixed by a type letter:
+  //   p<pid> starts a process group
+  //   f<fd>  marks a file within that group (we ignore these)
+  //   n<addr> is the network address, e.g. "*:3000" or "[::1]:5173"
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileAsync("lsof", [
+      "-iTCP",
+      "-sTCP:LISTEN",
+      "-nP",
+      "-F",
+      "pn",
+    ]));
+  } catch (err) {
+    stdout = stdoutOrThrow(err);
+  }
+  const out: RawListener[] = [];
+  let currentPid = 0;
+  for (const line of stdout.split("\n")) {
+    if (line[0] === "p") {
+      currentPid = parseInt(line.slice(1), 10);
+    } else if (line[0] === "n" && currentPid > 0) {
+      const addr = line.slice(1);
+      const port = parseInt(addr.slice(addr.lastIndexOf(":") + 1), 10);
+      if (port > 0) out.push({ pid: currentPid, port });
+    }
+  }
+  return out;
+}
+
+async function listCwds(pids: number[]): Promise<Map<number, string>> {
+  const out = new Map<number, string>();
+  if (pids.length === 0) return out;
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileAsync("lsof", [
+      "-p",
+      pids.join(","),
+      "-a",
+      "-d",
+      "cwd",
+      "-F",
+      "n",
+    ]));
+  } catch (err) {
+    stdout = stdoutOrThrow(err);
+  }
+  let currentPid = 0;
+  for (const line of stdout.split("\n")) {
+    if (line[0] === "p") {
+      currentPid = parseInt(line.slice(1), 10);
+    } else if (line[0] === "n" && currentPid > 0) {
+      out.set(currentPid, line.slice(1));
+    }
+  }
+  return out;
+}
+
+interface GitInfo {
+  // Absolute path to the shared .git directory. Same value for every
+  // worktree of the same repo, so it's a stable grouping key.
+  commonDir: string;
+  // Branch name, or empty for detached HEAD / non-git.
+  branch: string;
+}
+
+// Resolve git common-dir and branch for a cwd. Returns undefined when cwd
+// isn't inside a git working tree. One process spawn per call.
+async function getGitInfo(cwd: string): Promise<GitInfo | undefined> {
+  try {
+    const { stdout } = await execFileAsync("git", [
+      "-C",
+      cwd,
+      "rev-parse",
+      "--git-common-dir",
+      "--abbrev-ref",
+      "HEAD",
+    ]);
+    const [commonDirRaw, branchRaw] = stdout.trim().split("\n");
+    if (!commonDirRaw) return undefined;
+    const commonDir = path.isAbsolute(commonDirRaw)
+      ? commonDirRaw
+      : path.resolve(cwd, commonDirRaw);
+    const branch = branchRaw === "HEAD" ? "" : (branchRaw ?? "");
+    return { commonDir, branch };
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure aggregation (cross-platform)
+// ---------------------------------------------------------------------------
+
+// A candidate is anything launched from node_modules (broader than .bin/ so
+// we catch `node node_modules/serve/build/main.js` etc.) OR a bare bun
+// process. Over-collection is harmless: only PIDs with a LISTEN socket
+// survive the join below.
+function isCandidate(proc: RawProcess): boolean {
+  if (/node_modules\//.test(proc.command)) return true;
+  const exec = proc.command.split(/\s+/, 1)[0];
+  return /(\/|^)bun$/.test(exec);
+}
+
+function detectRuntime(command: string): "node" | "bun" {
+  const exec = command.split(/\s+/, 1)[0];
+  return /(\/|^)bun$/.test(exec) ? "bun" : "node";
+}
+
+function detectTool(command: string, cwd: string): string {
+  // 1. Prefer the .bin/ name (e.g. node_modules/.bin/vite)
+  const bin = command.match(/node_modules\/\.bin\/(\S+)/);
+  if (bin) {
+    const name = bin[1];
+    // SvelteKit runs under vite; promote when svelte.config is present.
+    if (name === "vite" && hasSvelteConfig(cwd)) return "sveltekit";
+    return name;
+  }
+  // 2. Fall back to the package name from node_modules/<pkg>/ — handles
+  //    `node node_modules/serve/build/main.js` (→ "serve") and scoped
+  //    packages like `node_modules/@vitejs/plugin-react/...`.
+  const pkg = command.match(/node_modules\/(@[^/]+\/[^/\s]+|[^/\s]+)/);
+  if (pkg) return pkg[1];
+  // 3. Bare bun script (no node_modules anywhere in the command).
+  if (detectRuntime(command) === "bun") return "bun";
+  return "node";
+}
+
+function hasSvelteConfig(cwd: string): boolean {
+  return (
+    fs.existsSync(`${cwd}/svelte.config.js`) ||
+    fs.existsSync(`${cwd}/svelte.config.ts`)
+  );
+}
+
+// A single dev-server PID often has multiple LISTEN sockets: the main HTTP
+// server plus ephemeral HMR/IPC/prebundling ports. Pick the LOWEST per PID
+// because configured dev ports (3000, 4321, 5173, 8080) are always below
+// ephemeral ports (32768+); without this the displayed port flickers across
+// refreshes.
+function lowestPortPerPid(listeners: RawListener[]): Map<number, number> {
+  const out = new Map<number, number>();
+  for (const { pid, port } of listeners) {
+    const cur = out.get(pid);
+    if (cur === undefined || port < cur) out.set(pid, port);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function fetchServers(): Promise<DevServer[]> {
+  const [procs, listeners] = await Promise.all([
+    listProcesses(),
+    listListeners(),
+  ]);
+  const candidates = procs.filter(isCandidate);
+  const portByPid = lowestPortPerPid(listeners);
+  // Only query cwds for candidates that are actually listening — keeps the
+  // lsof argument list short and skips dead PIDs.
+  const finalPids = candidates
+    .map((p) => p.pid)
+    .filter((pid) => portByPid.has(pid));
+  const cwdByPid = await listCwds(finalPids);
+
+  // Look up git info per unique cwd, in parallel. Worktrees of the same repo
+  // share a git common-dir, so we use that (well, its parent's basename) as
+  // the project key — collapses sibling worktrees into one group while still
+  // letting us show the branch on each row.
+  const uniqueCwds = [...new Set([...cwdByPid.values()])];
+  const gitByCwd = new Map<string, GitInfo | undefined>();
+  await Promise.all(
+    uniqueCwds.map(async (cwd) => gitByCwd.set(cwd, await getGitInfo(cwd))),
+  );
+
+  const servers: DevServer[] = [];
+  for (const proc of candidates) {
+    const port = portByPid.get(proc.pid);
+    if (port === undefined) continue;
+    const cwd = cwdByPid.get(proc.pid);
+    if (!cwd) continue; // shouldn't happen for live processes, but be safe
+    const git = gitByCwd.get(cwd);
+    // For git projects: project name & key come from the directory holding
+    // the shared .git dir. For non-git: fall back to the worktree basename.
+    const projectName = git
+      ? path.basename(path.dirname(git.commonDir))
+      : path.basename(cwd) || cwd;
+    const projectKey = git ? git.commonDir : cwd;
+    servers.push({
+      pid: proc.pid,
+      port: String(port),
+      url: `http://localhost:${port}`,
+      tool: detectTool(proc.command, cwd),
+      runtime: detectRuntime(proc.command),
+      cwd,
+      projectKey,
+      projectName,
+      branch: git?.branch || undefined,
+      startedAt: new Date(proc.lstart),
+    });
+  }
+  return servers;
+}
+
+// Async-shaped so callers can pass the returned promise to Raycast's
+// `mutate(fn, { optimisticUpdate })` flow. `process.kill` itself is sync.
 export async function killProcess(pid: number): Promise<void> {
-  await execAsync(`kill ${pid}`);
+  process.kill(pid);
 }
 
 export type PackageManager = "bun" | "pnpm" | "yarn" | "npm";
 
-// Detect package manager from lockfile presence. First match wins.
-// Order is bun → pnpm → yarn → npm because bun/pnpm/yarn projects often
-// also retain a stale package-lock.json.
+// Detect package manager from lockfile presence. First match wins; order is
+// bun → pnpm → yarn → npm because bun/pnpm/yarn projects often retain a
+// stale package-lock.json from before a migration.
 export function detectPackageManager(cwd: string): PackageManager {
   if (fs.existsSync(`${cwd}/bun.lockb`) || fs.existsSync(`${cwd}/bun.lock`))
     return "bun";
@@ -112,7 +303,7 @@ const PM_COMMAND: Record<PackageManager, [string, string[]]> = {
   npm: ["npm", ["run", "dev"]],
 };
 
-// Slugify cwd for use in a /tmp log filename.
+// Slugify cwd for use in a temp-dir log filename.
 function cwdSlug(cwd: string): string {
   return cwd.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "") || "root";
 }
@@ -124,17 +315,35 @@ function cwdSlug(cwd: string): string {
 //   `~/.zprofile`; `-i` reads `~/.zshrc`. Most users put their PATH additions
 //   for nvm/bun/pnpm in `~/.zshrc`, so both flags are required. Raycast's
 //   GUI-app PATH is otherwise too minimal to find these tools.
-// - `cwd` is passed as a spawn option (NOT shell-concatenated) which removes
-//   the prior shell-injection surface in the path.
-// - `detached: true` + `unref()` lets the spawned process outlive the extension
-//   command's lifetime.
-// - The log filename is now keyed by a slug of cwd, so it stays meaningful
-//   after the PID has been replaced by the new server.
+// - `cwd` is passed as a spawn option (NOT shell-concatenated) so the path
+//   never goes through the shell, removing one injection surface.
+// - `detached: true` + `unref()` lets the spawned process outlive the
+//   extension command's lifetime.
+// - The log filename is keyed by a slug of cwd so it stays meaningful after
+//   the PID has been replaced by the new server.
 export async function restartServer(server: DevServer): Promise<void> {
-  await execAsync(`kill ${server.pid}`);
+  // SIGKILL (vs default SIGTERM) so the old listener releases the port
+  // immediately — no graceful-shutdown window where the new spawn races
+  // the old process for the same port. Poll process.kill(pid, 0) until
+  // ESRCH to confirm exit before spawning. Both SIGKILL and signal-0 are
+  // mapped to TerminateProcess / OpenProcess on Windows, so this stays
+  // portable when we add the Windows backend.
+  process.kill(server.pid, "SIGKILL");
+  const deadline = Date.now() + 500;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(server.pid, 0);
+      await new Promise((r) => setTimeout(r, 20));
+    } catch {
+      break;
+    }
+  }
   const pm = detectPackageManager(server.cwd);
   const [cmd, args] = PM_COMMAND[pm];
-  const logPath = `/tmp/dev-servers-restart-${cwdSlug(server.cwd)}.log`;
+  const logPath = path.join(
+    os.tmpdir(),
+    `dev-servers-restart-${cwdSlug(server.cwd)}.log`,
+  );
   const out = fs.openSync(logPath, "a");
   const child = spawn("/bin/zsh", ["-ilc", `exec ${cmd} ${args.join(" ")}`], {
     cwd: server.cwd,

--- a/extensions/dev-servers/src/types.ts
+++ b/extensions/dev-servers/src/types.ts
@@ -4,7 +4,9 @@ export interface DevServer {
   url: string; // http://localhost:PORT
   tool: string; // vite | next | webpack | etc.
   runtime: "node" | "bun"; // the actual listening process's runtime
-  cwd: string; // /Users/tav/Dev/MyProject
-  projectName: string; // MyProject
+  cwd: string; // /Users/tav/Dev/MyProject (the worktree directory)
+  projectKey: string; // stable id for grouping; cwd or git common-dir parent
+  projectName: string; // MyProject (display label for the project section)
+  branch?: string; // current git branch when cwd is inside a worktree
   startedAt: Date;
 }

--- a/extensions/dev-servers/src/types.ts
+++ b/extensions/dev-servers/src/types.ts
@@ -5,8 +5,8 @@ export interface DevServer {
   tool: string; // vite | next | webpack | etc.
   runtime: "node" | "bun"; // the actual listening process's runtime
   cwd: string; // /Users/tav/Dev/MyProject (the worktree directory)
-  projectKey: string; // stable id for grouping; cwd or git common-dir parent
+  projectKey: string; // stable id for grouping; cwd, or git common-dir (the .git path) for repos
   projectName: string; // MyProject (display label for the project section)
-  branch?: string; // current git branch when cwd is inside a worktree
+  branch?: string; // current git branch when cwd is inside any git repo
   startedAt: Date;
 }


### PR DESCRIPTION
## Description

**3x faster, windows port preparation, support for git branches & worktrees, search by project and branch.**

- Rewrote process detection from an embedded shell pipeline to TypeScript. Output is unchanged; the new path is roughly 3x faster, removes a class of shell-parsing bugs, and lays the groundwork for a future Windows port.
- Group multiple git worktrees of the same repo into one project section. Each row shows its current branch next to the link, and per-row actions (Open in Terminal, Show in Finder) still target the specific worktree on disk.
- Show the current git branch on every project's rows, so you can tell at a glance which branch a long-running dev server is on, even for single-worktree projects.
- Search by project name or branch directly in the Raycast search bar, Raycast's built-in filter previously only matched the port number and subtitle.
- New preferences to toggle each row accessory (uptime, git branch, framework tag) independently.
- Stylized framework names (SvelteKit, Astro, Next.js, esbuild, etc.) in the row tag and the filter dropdown.
- More reliable restarts: the old process is force-killed and confirmed exited before the replacement spawns, closing a rare race where the new server could fail to bind because the old one still held the port.


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
