### PR TITLE
Granola: Auto-refresh expired tokens and improve error logging (v2.1.4)

### DIFF
--- a/extensions/granola/CHANGELOG.md
+++ b/extensions/granola/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Granola Changelog
 
+## [2.1.4] - {PR_MERGE_DATE}
+
+### Bug Fixes
+
+- Automatically refresh expired WorkOS access tokens via Granola's `refresh-access-token` API and persist updated tokens locally, so Search Notes and other commands work again without requiring the Granola app to refresh the session first.
+
+### Enhancements
+
+- Added structured `[Granola]` dev-console logging across auth, fetch, and error UI paths to make troubleshooting easier during `npm run dev`.
+
 ## [2.1.3] - 2026-05-08
 
 ### New Features

--- a/extensions/granola/CHANGELOG.md
+++ b/extensions/granola/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Granola Changelog
 
-## [2.1.4] - {PR_MERGE_DATE}
+## [2.1.4] - 2026-05-26
 
 ### Bug Fixes
 

--- a/extensions/granola/src/export-notes.tsx
+++ b/extensions/granola/src/export-notes.tsx
@@ -46,7 +46,7 @@ const formatDate = (value?: string): string => {
 };
 
 export default function Command() {
-  const { noteData, isLoading, hasError } = useGranolaData();
+  const { noteData, isLoading, hasError, error } = useGranolaData();
 
   // Handle loading and error states
   if (isLoading) {
@@ -54,7 +54,7 @@ export default function Command() {
   }
 
   if (hasError) {
-    return <Unresponsive />;
+    return <Unresponsive context="export-notes" error={error} />;
   }
 
   const untitledNoteTitle = "New note";

--- a/extensions/granola/src/export-transcripts.tsx
+++ b/extensions/granola/src/export-transcripts.tsx
@@ -40,7 +40,7 @@ const formatDate = (value?: string): string => {
 };
 
 export default function Command() {
-  const { noteData, isLoading, hasError } = useGranolaData();
+  const { noteData, isLoading, hasError, error } = useGranolaData();
 
   // Handle loading and error states
   if (isLoading) {
@@ -48,7 +48,7 @@ export default function Command() {
   }
 
   if (hasError) {
-    return <Unresponsive />;
+    return <Unresponsive context="export-transcripts" error={error} />;
   }
 
   if (noteData?.data) {

--- a/extensions/granola/src/search-companies.tsx
+++ b/extensions/granola/src/search-companies.tsx
@@ -10,7 +10,7 @@ import { formatCompanyMeetingDate, sortCompanies, type CompanySortOption } from 
 import { mapColorToHex } from "./utils/iconMapper";
 
 export default function Command() {
-  const { companies, isLoading, hasError } = usePeople();
+  const { companies, isLoading, hasError, error } = usePeople();
   const [sortBy, setSortBy] = useState<CompanySortOption>("meeting-count");
 
   const sortedCompanies = useMemo(() => sortCompanies(companies, sortBy), [companies, sortBy]);
@@ -20,7 +20,7 @@ export default function Command() {
   }
 
   if (hasError) {
-    return <Unresponsive />;
+    return <Unresponsive context="search-companies" error={error} />;
   }
 
   return (

--- a/extensions/granola/src/search-notes.tsx
+++ b/extensions/granola/src/search-notes.tsx
@@ -13,7 +13,7 @@ import { getFolderNoteResults } from "./utils/searchUtils";
 export default function Command() {
   const [selectedFolder, setSelectedFolder] = useState<string>("all");
   const { folders, isLoading: foldersLoading } = useFolders();
-  const { noteData, isLoading, hasError } = useGranolaData();
+  const { noteData, isLoading, hasError, error } = useGranolaData();
   const [foldersWithIds, setFoldersWithIds] = useState<typeof folders>([]);
 
   // Load document_ids lazily after initial render (for counting and filtering)
@@ -68,7 +68,7 @@ export default function Command() {
   }
 
   if (hasError) {
-    return <Unresponsive />;
+    return <Unresponsive context="search-notes" error={error} />;
   }
 
   const untitledNoteTitle = "New note";

--- a/extensions/granola/src/search-people.tsx
+++ b/extensions/granola/src/search-people.tsx
@@ -12,7 +12,7 @@ import { mapColorToHex } from "./utils/iconMapper";
 type SortOption = PeopleSortOption;
 
 export default function Command() {
-  const { people, isLoading, hasError } = usePeople();
+  const { people, isLoading, hasError, error } = usePeople();
   const [sortBy, setSortBy] = useState<SortOption>("last-meeting");
 
   const sortedPeople = useMemo(() => sortPeople(people, sortBy), [people, sortBy]);
@@ -22,7 +22,7 @@ export default function Command() {
   }
 
   if (hasError) {
-    return <Unresponsive />;
+    return <Unresponsive context="search-people" error={error} />;
   }
 
   return (

--- a/extensions/granola/src/templates/unresponsive.tsx
+++ b/extensions/granola/src/templates/unresponsive.tsx
@@ -1,5 +1,17 @@
 import { Detail } from "@raycast/api";
-export default function Unresponsive() {
+import { useEffect } from "react";
+import { logGranolaError } from "../utils/errorUtils";
+
+interface UnresponsiveProps {
+  context?: string;
+  error?: Error;
+}
+
+export default function Unresponsive({ context = "unknown", error }: UnresponsiveProps) {
+  useEffect(() => {
+    logGranolaError("Unresponsive screen shown", error ?? new Error("Granola service unreachable"), { context });
+  }, [context, error]);
+
   return (
     <Detail
       markdown={`# Error from Granola \n\n Could not communicate with the Granola service. Please make sure Granola is open, running, and that you are logged in, then try again.`}

--- a/extensions/granola/src/utils/errorUtils.ts
+++ b/extensions/granola/src/utils/errorUtils.ts
@@ -74,3 +74,39 @@ export const toError = (error: unknown, fallbackMessage = "Unknown error"): Erro
   const message = toErrorMessage(error);
   return new Error(message || fallbackMessage);
 };
+
+const LOG_PREFIX = "[Granola]";
+
+export type GranolaLogContext = Record<string, unknown>;
+
+function getErrorDetails(error: unknown): GranolaLogContext {
+  const details: GranolaLogContext = { message: toErrorMessage(error) };
+
+  if (error instanceof Error) {
+    if (error.name) details.name = error.name;
+    if (error.stack) details.stack = error.stack;
+
+    const err = error as Error & { status?: number; statusText?: string; cause?: unknown };
+    if (typeof err.status === "number") details.status = err.status;
+    if (err.statusText) details.statusText = err.statusText;
+    if (err.cause !== undefined) details.cause = toErrorMessage(err.cause);
+  } else if (error && typeof error === "object") {
+    const err = error as ErrorLike;
+    if (typeof err.status === "number") details.status = err.status;
+    if (err.statusText) details.statusText = err.statusText;
+  }
+
+  return details;
+}
+
+/** Logs structured errors to the Raycast dev console (visible in `npm run dev`). */
+export function logGranolaError(context: string, error: unknown, extra?: GranolaLogContext): void {
+  console.error(`${LOG_PREFIX} ${context}`, {
+    ...getErrorDetails(error),
+    ...extra,
+  });
+}
+
+export function logGranolaWarn(context: string, extra?: GranolaLogContext): void {
+  console.warn(`${LOG_PREFIX} ${context}`, extra ?? {});
+}

--- a/extensions/granola/src/utils/errorUtils.ts
+++ b/extensions/granola/src/utils/errorUtils.ts
@@ -110,3 +110,7 @@ export function logGranolaError(context: string, error: unknown, extra?: Granola
 export function logGranolaWarn(context: string, extra?: GranolaLogContext): void {
   console.warn(`${LOG_PREFIX} ${context}`, extra ?? {});
 }
+
+export function logGranolaInfo(context: string, extra?: GranolaLogContext): void {
+  console.log(`${LOG_PREFIX} ${context}`, extra ?? {});
+}

--- a/extensions/granola/src/utils/fetchData.ts
+++ b/extensions/granola/src/utils/fetchData.ts
@@ -1,7 +1,7 @@
 import { useFetch, showFailureToast } from "@raycast/utils";
 import { useState, useEffect, useMemo } from "react";
 import getAccessToken from "./getAccessToken";
-import { isAbortError, logGranolaError, toError, toErrorMessage } from "./errorUtils";
+import { isAbortError, toError, toErrorMessage } from "./errorUtils";
 import {
   GetDocumentsResponse,
   TranscriptSegment,
@@ -48,9 +48,7 @@ export function fetchGranolaData(route: string) {
       })
       .catch((err) => {
         if (mounted) {
-          const tokenError = new Error(`Failed to get access token: ${toErrorMessage(err)}`, { cause: err });
-          logGranolaError("fetchGranolaData.getAccessToken", tokenError, { route });
-          setError(tokenError);
+          setError(new Error(`Failed to get access token: ${toErrorMessage(err)}`, { cause: err }));
         }
       });
     return () => {
@@ -138,9 +136,7 @@ export function fetchGranolaData(route: string) {
   }
 
   if (fetchError) {
-    const normalizedFetchError = toError(fetchError);
-    logGranolaError("fetchGranolaData.useFetch", normalizedFetchError, { route, url });
-    throw normalizedFetchError;
+    throw toError(fetchError);
   }
 
   // Return transformed data (or original if transformation not needed)

--- a/extensions/granola/src/utils/fetchData.ts
+++ b/extensions/granola/src/utils/fetchData.ts
@@ -1,7 +1,7 @@
 import { useFetch, showFailureToast } from "@raycast/utils";
 import { useState, useEffect, useMemo } from "react";
 import getAccessToken from "./getAccessToken";
-import { isAbortError, toError, toErrorMessage } from "./errorUtils";
+import { isAbortError, logGranolaError, toError, toErrorMessage } from "./errorUtils";
 import {
   GetDocumentsResponse,
   TranscriptSegment,
@@ -48,7 +48,9 @@ export function fetchGranolaData(route: string) {
       })
       .catch((err) => {
         if (mounted) {
-          setError(new Error(`Failed to get access token, ${toErrorMessage(err)}`));
+          const tokenError = new Error(`Failed to get access token: ${toErrorMessage(err)}`, { cause: err });
+          logGranolaError("fetchGranolaData.getAccessToken", tokenError, { route });
+          setError(tokenError);
         }
       });
     return () => {
@@ -60,7 +62,12 @@ export function fetchGranolaData(route: string) {
 
   // Use parseResponse to transform data BEFORE useFetch caches it
   // This ensures only stripped data is cached, reducing memory usage
-  const { isLoading, data, revalidate } = useFetch<GetDocumentsResponse<Document | Doc>>(url, {
+  const {
+    isLoading,
+    data,
+    error: fetchError,
+    revalidate,
+  } = useFetch<GetDocumentsResponse<Document | Doc>>(url, {
     headers: accessToken
       ? {
           Authorization: `Bearer ${accessToken}`,
@@ -128,6 +135,12 @@ export function fetchGranolaData(route: string) {
 
   if (error) {
     throw error;
+  }
+
+  if (fetchError) {
+    const normalizedFetchError = toError(fetchError);
+    logGranolaError("fetchGranolaData.useFetch", normalizedFetchError, { route, url });
+    throw normalizedFetchError;
   }
 
   // Return transformed data (or original if transformation not needed)

--- a/extensions/granola/src/utils/getAccessToken.ts
+++ b/extensions/granola/src/utils/getAccessToken.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "fs";
 import { getStoredAccountsPath, getSupabaseConfigPath } from "./granolaConfig";
-import { logGranolaError, logGranolaWarn } from "./errorUtils";
+import { logGranolaError, logGranolaInfo, logGranolaWarn } from "./errorUtils";
 
 const GRANOLA_API_URL = "https://api.granola.ai/v1";
 const GRANOLA_CLIENT_VERSION = "7.162.1";
@@ -95,7 +95,7 @@ async function refreshWorkOsTokensViaApi(
 
     const newTokens = (await response.json()) as Record<string, unknown>;
     newTokens.obtained_at = Date.now();
-    logGranolaWarn("refreshWorkOsTokensViaApi succeeded", {
+    logGranolaInfo("refreshWorkOsTokensViaApi succeeded", {
       expiresIn: typeof newTokens.expires_in === "number" ? newTokens.expires_in : undefined,
     });
     return newTokens;
@@ -150,7 +150,11 @@ async function tryRefreshAndSelectAccessToken(
   }
 
   if (persist) {
-    await persist(refreshed);
+    try {
+      await persist(refreshed);
+    } catch (persistError) {
+      logGranolaError("tryRefreshAndSelectAccessToken.persist", persistError);
+    }
   }
 
   return selectAccessToken(refreshed);

--- a/extensions/granola/src/utils/getAccessToken.ts
+++ b/extensions/granola/src/utils/getAccessToken.ts
@@ -132,7 +132,7 @@ async function persistWorkOsTokensToStoredAccount(
   }
 
   accounts[accountIndex].tokens = JSON.stringify(newTokens);
-  jsonData.accounts = accounts;
+  jsonData.accounts = typeof accountsValue === "string" ? JSON.stringify(accounts) : accounts;
   await fs.writeFile(getStoredAccountsPath(), JSON.stringify(jsonData));
 }
 

--- a/extensions/granola/src/utils/getAccessToken.ts
+++ b/extensions/granola/src/utils/getAccessToken.ts
@@ -1,5 +1,9 @@
 import { promises as fs } from "fs";
 import { getStoredAccountsPath, getSupabaseConfigPath } from "./granolaConfig";
+import { logGranolaError, logGranolaWarn } from "./errorUtils";
+
+const GRANOLA_API_URL = "https://api.granola.ai/v1";
+const GRANOLA_CLIENT_VERSION = "7.162.1";
 
 const TOKEN_EXPIRY_SKEW_MS = 60_000;
 
@@ -49,6 +53,109 @@ function selectAccessToken(tokens: Record<string, unknown> | undefined): string 
   return tokens.access_token;
 }
 
+function getGranolaApiHeaders(accessToken: string): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${accessToken}`,
+    "User-Agent": `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Granola/${GRANOLA_CLIENT_VERSION} Chrome/146.0.7680.188 Electron/41.2.1 Safari/537.36`,
+    "X-Client-Version": GRANOLA_CLIENT_VERSION,
+  };
+}
+
+async function refreshWorkOsTokensViaApi(
+  tokens: Record<string, unknown>,
+): Promise<Record<string, unknown> | undefined> {
+  const accessToken = tokens.access_token;
+  const refreshToken = tokens.refresh_token;
+  if (typeof accessToken !== "string" || typeof refreshToken !== "string") {
+    return undefined;
+  }
+
+  try {
+    const response = await fetch(`${GRANOLA_API_URL}/refresh-access-token`, {
+      method: "POST",
+      headers: getGranolaApiHeaders(accessToken),
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+
+    if (!response.ok) {
+      let responsePreview = "";
+      try {
+        responsePreview = (await response.text()).slice(0, 200);
+      } catch {
+        // Ignore body read errors
+      }
+      logGranolaWarn("refreshWorkOsTokensViaApi failed", {
+        status: response.status,
+        statusText: response.statusText,
+        responsePreview,
+      });
+      return undefined;
+    }
+
+    const newTokens = (await response.json()) as Record<string, unknown>;
+    newTokens.obtained_at = Date.now();
+    logGranolaWarn("refreshWorkOsTokensViaApi succeeded", {
+      expiresIn: typeof newTokens.expires_in === "number" ? newTokens.expires_in : undefined,
+    });
+    return newTokens;
+  } catch (error) {
+    logGranolaError("refreshWorkOsTokensViaApi", error);
+    return undefined;
+  }
+}
+
+async function persistWorkOsTokensToSupabase(newTokens: Record<string, unknown>): Promise<void> {
+  const configPath = getSupabaseConfigPath();
+  const config = (await readPlaintextSupabaseConfig()) ?? {};
+  config.workos_tokens = JSON.stringify(newTokens);
+  if (typeof newTokens.session_id === "string") {
+    config.session_id = newTokens.session_id;
+  }
+  await fs.writeFile(configPath, JSON.stringify(config));
+}
+
+async function persistWorkOsTokensToStoredAccount(
+  accountIndex: number,
+  newTokens: Record<string, unknown>,
+): Promise<void> {
+  const fileContent = await fs.readFile(getStoredAccountsPath(), "utf8");
+  const jsonData = JSON.parse(fileContent) as Record<string, unknown>;
+  const accountsValue = jsonData.accounts;
+  const accounts = (typeof accountsValue === "string" ? JSON.parse(accountsValue) : accountsValue) as Record<
+    string,
+    unknown
+  >[];
+
+  if (!Array.isArray(accounts) || accountIndex < 0 || accountIndex >= accounts.length) {
+    return;
+  }
+
+  accounts[accountIndex].tokens = JSON.stringify(newTokens);
+  jsonData.accounts = accounts;
+  await fs.writeFile(getStoredAccountsPath(), JSON.stringify(jsonData));
+}
+
+async function tryRefreshAndSelectAccessToken(
+  tokens: Record<string, unknown> | undefined,
+  persist?: (newTokens: Record<string, unknown>) => Promise<void>,
+): Promise<string | undefined> {
+  if (!tokens || typeof tokens.refresh_token !== "string") {
+    return undefined;
+  }
+
+  const refreshed = await refreshWorkOsTokensViaApi(tokens);
+  if (!refreshed) {
+    return undefined;
+  }
+
+  if (persist) {
+    await persist(refreshed);
+  }
+
+  return selectAccessToken(refreshed);
+}
+
 function selectAccessTokenFromSupabaseData(jsonData: Record<string, unknown>): string | undefined {
   if (jsonData.workos_tokens) {
     try {
@@ -95,10 +202,19 @@ async function getAccessTokenFromStoredAccounts(): Promise<string | undefined> {
   const accounts = await readStoredAccounts();
   if (!accounts) return undefined;
 
-  for (const account of sortStoredAccounts(accounts)) {
+  const sortedAccounts = sortStoredAccounts(accounts);
+  for (let index = 0; index < sortedAccounts.length; index++) {
+    const account = sortedAccounts[index];
+    const originalIndex = accounts.indexOf(account);
     try {
-      const token = selectAccessToken(parseMaybeJsonRecord(account.tokens));
+      const parsedTokens = parseMaybeJsonRecord(account.tokens);
+      const token = selectAccessToken(parsedTokens);
       if (token) return token;
+
+      const refreshedToken = await tryRefreshAndSelectAccessToken(parsedTokens, (newTokens) =>
+        persistWorkOsTokensToStoredAccount(originalIndex, newTokens),
+      );
+      if (refreshedToken) return refreshedToken;
     } catch {
       // Try the next saved account.
     }
@@ -118,7 +234,13 @@ export async function readPlaintextSupabaseConfig(): Promise<Record<string, unkn
 
 async function getAccessTokenFromPlaintextSupabase(): Promise<string | undefined> {
   const jsonData = await readPlaintextSupabaseConfig();
-  return jsonData ? selectAccessTokenFromSupabaseData(jsonData) : undefined;
+  if (!jsonData) return undefined;
+
+  const validToken = selectAccessTokenFromSupabaseData(jsonData);
+  if (validToken) return validToken;
+
+  const workosTokens = parseMaybeJsonRecord(jsonData.workos_tokens);
+  return tryRefreshAndSelectAccessToken(workosTokens, persistWorkOsTokensToSupabase);
 }
 
 export async function getLocalGranolaUserInfo(): Promise<LocalGranolaUserInfo> {
@@ -151,13 +273,78 @@ export async function getLocalGranolaUserInfo(): Promise<LocalGranolaUserInfo> {
   throw new Error("A usable user_info object was not found in local Granola data");
 }
 
+function describeTokenRecord(tokens: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!tokens) {
+    return { present: false };
+  }
+
+  const hasAccessToken = typeof tokens.access_token === "string" && tokens.access_token.length > 0;
+  const hasRefreshToken = typeof tokens.refresh_token === "string" && tokens.refresh_token.length > 0;
+  return {
+    present: true,
+    hasAccessToken,
+    hasRefreshToken,
+    expired: isTokenExpired(tokens),
+    obtainedAt: typeof tokens.obtained_at === "number" ? tokens.obtained_at : undefined,
+    expiresIn: typeof tokens.expires_in === "number" ? tokens.expires_in : undefined,
+  };
+}
+
+async function getAccessTokenDiagnostics(): Promise<Record<string, unknown>> {
+  const supabasePath = getSupabaseConfigPath();
+  const storedAccountsPath = getStoredAccountsPath();
+  const diagnostics: Record<string, unknown> = {
+    platform: process.platform,
+    supabaseConfigPath: supabasePath,
+    storedAccountsPath,
+  };
+
+  try {
+    await fs.access(supabasePath);
+    diagnostics.supabaseConfigExists = true;
+    const supabase = await readPlaintextSupabaseConfig();
+    if (supabase) {
+      diagnostics.supabaseHasWorkosTokens = Boolean(supabase.workos_tokens);
+      diagnostics.supabaseHasCognitoTokens = Boolean(supabase.cognito_tokens);
+      diagnostics.supabaseWorkosTokens = describeTokenRecord(parseMaybeJsonRecord(supabase.workos_tokens));
+      diagnostics.supabaseCognitoTokens = describeTokenRecord(parseMaybeJsonRecord(supabase.cognito_tokens));
+    } else {
+      diagnostics.supabaseConfigReadable = false;
+    }
+  } catch {
+    diagnostics.supabaseConfigExists = false;
+  }
+
+  try {
+    await fs.access(storedAccountsPath);
+    diagnostics.storedAccountsExists = true;
+    const accounts = await readStoredAccounts();
+    diagnostics.storedAccountCount = accounts?.length ?? 0;
+    diagnostics.storedAccounts = (accounts ?? []).map((account, index) => ({
+      index,
+      savedAt: typeof account.savedAt === "number" ? account.savedAt : undefined,
+      tokens: describeTokenRecord(parseMaybeJsonRecord(account.tokens)),
+    }));
+  } catch {
+    diagnostics.storedAccountsExists = false;
+  }
+
+  return diagnostics;
+}
+
 async function getAccessToken() {
   const accessToken = (await getAccessTokenFromPlaintextSupabase()) ?? (await getAccessTokenFromStoredAccounts());
 
   if (!accessToken) {
-    throw new Error(
-      "A usable access token was not found in your local Granola data. The plaintext tokens may be expired and stored accounts may be unavailable. Make sure Granola is installed, running, and that you are logged in to the application.",
+    const diagnostics = await getAccessTokenDiagnostics();
+    const workosExpired = diagnostics.supabaseWorkosTokens as { expired?: boolean } | undefined;
+    const error = new Error(
+      workosExpired?.expired
+        ? "Your Granola access token has expired and could not be refreshed automatically. Open the Granola app while logged in to refresh your session, then try again."
+        : "A usable access token was not found in your local Granola data. Make sure Granola is installed, running, and that you are logged in to the application.",
     );
+    logGranolaError("getAccessToken", error, diagnostics);
+    throw error;
   }
 
   return accessToken;

--- a/extensions/granola/src/utils/granolaApi.ts
+++ b/extensions/granola/src/utils/granolaApi.ts
@@ -1,5 +1,5 @@
 import { showFailureToast } from "@raycast/utils";
-import { toError } from "./errorUtils";
+import { logGranolaError, toError } from "./errorUtils";
 import getAccessToken from "./getAccessToken";
 import getUserInfo from "./getUserInfo";
 import { parseEventTime } from "./documentMatching";
@@ -259,6 +259,12 @@ async function handleApiError(response: Response, operationName: string): Promis
       error.retryAfterMs = retryAfterMs;
     }
   }
+
+  logGranolaError(`granolaApi.${operationName}`, error, {
+    status: response.status,
+    statusText: response.statusText,
+    url: response.url,
+  });
 
   throw error;
 }

--- a/extensions/granola/src/utils/useGranolaData.ts
+++ b/extensions/granola/src/utils/useGranolaData.ts
@@ -41,7 +41,7 @@ export function useGranolaData(): GranolaDataState {
     fetchResult = fetchGranolaData("get-documents");
   } catch (error) {
     fetchError = toError(error);
-    logGranolaError("useGranolaData.fetchGranolaData", fetchError);
+    logGranolaError("useGranolaData.fetchGranolaData", fetchError, { route: "get-documents" });
   }
 
   const isValidData = fetchResult && isNoteData(fetchResult);

--- a/extensions/granola/src/utils/useGranolaData.ts
+++ b/extensions/granola/src/utils/useGranolaData.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { fetchGranolaData, getSharedDocuments } from "./fetchData";
 import { NoteData, Doc } from "./types";
-import { toError } from "./errorUtils";
+import { logGranolaError, toError } from "./errorUtils";
 
 function isNoteData(data: unknown): data is NoteData {
   if (typeof data !== "object" || data === null) return false;
@@ -41,6 +41,7 @@ export function useGranolaData(): GranolaDataState {
     fetchResult = fetchGranolaData("get-documents");
   } catch (error) {
     fetchError = toError(error);
+    logGranolaError("useGranolaData.fetchGranolaData", fetchError);
   }
 
   const isValidData = fetchResult && isNoteData(fetchResult);
@@ -66,11 +67,16 @@ export function useGranolaData(): GranolaDataState {
   }
 
   if (!isValidData || !noteData) {
+    const shapeError = new Error("Invalid data shape returned from Granola API. Expected NoteData structure.");
+    logGranolaError("useGranolaData", shapeError, {
+      reason: "invalid data shape",
+      fetchResultType: fetchResult === null ? "null" : typeof fetchResult,
+    });
     return {
       noteData: null,
       isLoading: false,
       hasError: true,
-      error: new Error("Invalid data shape returned from Granola API. Expected NoteData structure."),
+      error: shapeError,
     };
   }
 
@@ -79,7 +85,13 @@ export function useGranolaData(): GranolaDataState {
   }
 
   if (!noteData.data) {
-    return { noteData, isLoading: false, hasError: true, error: new Error("No data available") };
+    const noDataError = new Error("No data available from Granola API (get-documents returned empty response)");
+    logGranolaError("useGranolaData", noDataError, {
+      reason: "empty response",
+      isLoading: noteData.isLoading,
+      hasRevalidate: typeof noteData.revalidate === "function",
+    });
+    return { noteData, isLoading: false, hasError: true, error: noDataError };
   }
 
   // Merge and deduplicate: owned docs take precedence over shared docs

--- a/extensions/granola/src/utils/usePeople.ts
+++ b/extensions/granola/src/utils/usePeople.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { Person, Company, Attendee, Creator } from "./types";
 import { getDocumentsList } from "./fetchData";
+import { logGranolaError, toError } from "./errorUtils";
 
 // Helper function to safely compare dates
 function compareDates(date1: string | undefined, date2: string | undefined): number {
@@ -87,6 +88,7 @@ export function usePeople() {
   const [companies, setCompanies] = useState<Company[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
+  const [error, setError] = useState<Error | undefined>(undefined);
 
   useEffect(() => {
     const fetchPeople = async () => {
@@ -190,8 +192,10 @@ export function usePeople() {
 
         setCompanies(Array.from(companyMap.values()));
         setIsLoading(false);
-      } catch (error) {
-        console.error("Error fetching people data:", error);
+      } catch (caughtError) {
+        const normalizedError = toError(caughtError);
+        logGranolaError("usePeople.getDocumentsList", normalizedError);
+        setError(normalizedError);
         setHasError(true);
         setIsLoading(false);
       }
@@ -200,5 +204,5 @@ export function usePeople() {
     fetchPeople();
   }, []);
 
-  return { people, companies, isLoading, hasError };
+  return { people, companies, isLoading, hasError, error };
 }


### PR DESCRIPTION
## Description

This update fixes Granola commands failing with the generic "Could not communicate with the Granola service" error when the local WorkOS access token has expired but a refresh token is still available.

Fixes #28227

### Token Refresh

- Automatically refresh expired WorkOS tokens via Granola's `refresh-access-token` API (same flow as the desktop app)
- Persist rotated tokens back to `supabase.json` and stored accounts so subsequent requests use valid credentials
- Only refresh when the access token is expired (not on every request)

### Troubleshooting

- Added structured `[Granola]` dev-console logging across auth, fetch, API errors, and the unresponsive error screen
- Improved error messages when refresh fails

## Validation

- `npm run lint`
- `npm run build`

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the **assets** folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)