### PR TITLE
Update dev-servers extension

### DIFF
--- a/extensions/dev-servers/CHANGELOG.md
+++ b/extensions/dev-servers/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Dev Servers Changelog
 
+## [Custom domain detection] - {PR_MERGE_DATE}
+
+Surfaces custom local domains from [portless](https://github.com/vercel-labs/portless), and tightens the action panel, shortcuts, and preferences to align with Raycast conventions.
+
+**Custom domain detection**
+
+- Detect custom local domains via portless and show the named URL (e.g. `myapp.localhost`) as the row title instead of `localhost:PORT`. The `localhost:PORT` pill stays visible alongside it, since the raw loopback target is still useful for env files, OAuth allowlists, CORS rules, and anything that doesn't trust the local CA.
+- "Open in Browser" and "Copy URL" target the custom domain when one is present. New "Open Localhost URL" and "Copy Localhost URL" actions target loopback explicitly.
+- Search the list by custom domain — typing "myapp" surfaces `https://myapp.localhost`.
+- New "Show localhost URL with custom domain" preference, for users who'd rather hide the `localhost:PORT` pill once a named domain is in place.
+- Filter out the portless proxy daemon itself so it never appears as a phantom dev server row.
+
+**Action panel and shortcuts**
+
+- Kill Server's shortcut moves from `⌘D` to `⌃X`. `⌘D` is officially "Duplicate" in Raycast's keyboard conventions; `⌃X` is "Remove". Kill All for Project and Kill All Servers shift to `⌃⇧X` and `⌃⌥X` to stay in the same family.
+- Copy Localhost URL is bound to `⌘⇧C`, mirroring `⌘C` for Copy URL.
+- Action panel reordered: Restart Server now sits at position 3, above Kill Server. Restarting is the more common mutation (iterate-on-change), and placing it above Kill also means Raycast's reserved `⌘↵` second-action shortcut never auto-fires Kill — it falls through to Open Localhost URL when a custom domain is present, or to Restart otherwise. Both are safe.
+
+**Preferences**
+
+- Refresh Interval (a behavior setting) moves above Project Display (cosmetic), so settings that change what the extension *does* appear before settings that change how it *looks*.
+
 ## [Worktree grouping and detection rewrite] - 2026-05-26
 
 3x faster, windows port preparation, support for git branches & worktrees, search by project and branch.

--- a/extensions/dev-servers/CHANGELOG.md
+++ b/extensions/dev-servers/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dev Servers Changelog
 
-## [Custom domain detection] - {PR_MERGE_DATE}
+## [Custom domain detection] - 2026-05-26
 
 Surfaces custom local domains from [portless](https://github.com/vercel-labs/portless), and tightens the action panel, shortcuts, and preferences to align with Raycast conventions.
 

--- a/extensions/dev-servers/README.md
+++ b/extensions/dev-servers/README.md
@@ -5,6 +5,7 @@ A keyboard-first dashboard for every dev server you have running. See them group
 ## Features
 
 - **Auto-detects** running dev servers including Vite, Next.js, Astro, SvelteKit, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, esbuild, serve, http-server, anything that runs out of `node_modules/`, plus servers running on the Bun runtime
+- **Custom domain aware** so a dev server fronted by [portless](https://github.com/vercel-labs/portless) shows its named URL (e.g. `myapp.localhost`) as the row title, with the `localhost:PORT` pill alongside for when you still need the raw loopback target
 - **Grouped by project** so servers from the same directory appear under one section
 - **Worktree-aware** so multiple git worktrees of the same repo collapse into one section, with a per-row branch tag to tell them apart — also surfaces the current branch on single-worktree projects so you can tell which branch a long-running server is on
 - **Favicons** — PNG, ICO, or SVG — are pulled from each site (with `/favicon.ico` fallback), inlined so they render even when the dev server isn't CORS-friendly, and cached across refreshes
@@ -22,20 +23,23 @@ A keyboard-first dashboard for every dev server you have running. See them group
 | Action | Shortcut |
 |---|---|
 | Open in Browser | `↵` Enter |
-| Kill Server | `⌘` `D` |
+| Open Localhost URL | `⌘` `↵` |
+| Kill Server | `⌃` `X` |
 | Copy URL | `⌘` `C` |
+| Copy Localhost URL | `⌘` `⇧` `C` |
 | Restart Server | `⌘` `⇧` `R` |
 | Open in Terminal | `⌘` `T` |
 | Show in Finder | `⌘` `⇧` `F` |
 | Refresh | `⌘` `R` |
-| Kill All for Project | `⌘` `⇧` `D` |
-| Kill All Servers | `⌘` `⌥` `D` |
+| Kill All for Project | `⌃` `⇧` `X` |
+| Kill All Servers | `⌃` `⌥` `X` |
 
 ## Preferences
 
 - **Terminal App** sets which terminal `⌘T` opens. Defaults to macOS Terminal if unset.
-- **Project Display** shows the full directory path in section headers instead of just the project folder name.
 - **Refresh Interval** sets how often to refresh the server list (2s, 5s, 10s, or 30s).
+- **Project Display** shows the full directory path in section headers instead of just the project folder name.
+- **Row Accessories** independently toggle uptime, the git branch tag, the framework tag, and the `localhost:PORT` pill that appears alongside custom domains.
 
 ## How it differs from Port Manager
 

--- a/extensions/dev-servers/package.json
+++ b/extensions/dev-servers/package.json
@@ -14,6 +14,7 @@
     "localhost",
     "port",
     "ports",
+    "portless",
     "kill",
     "restart",
     "process",
@@ -37,15 +38,6 @@
           "title": "Terminal App",
           "type": "appPicker",
           "description": "Which terminal to open when using \"Open in Terminal\". Defaults to macOS Terminal if unset.",
-          "required": false
-        },
-        {
-          "name": "showFullPath",
-          "title": "Project Display",
-          "type": "checkbox",
-          "label": "Show full directory path",
-          "description": "Show the full path instead of the project name",
-          "default": false,
           "required": false
         },
         {
@@ -75,6 +67,15 @@
           ]
         },
         {
+          "name": "showFullPath",
+          "title": "Project Display",
+          "type": "checkbox",
+          "label": "Show full directory path",
+          "description": "Show the full path instead of the project name",
+          "default": false,
+          "required": false
+        },
+        {
           "name": "showUptime",
           "title": "Row Accessories",
           "type": "checkbox",
@@ -96,6 +97,14 @@
           "type": "checkbox",
           "label": "Show framework tag",
           "description": "Show the framework / tool tag (Vite, SvelteKit, Astro, etc.) on each row",
+          "default": true,
+          "required": false
+        },
+        {
+          "name": "showLocalUrl",
+          "type": "checkbox",
+          "label": "Show localhost URL with custom domain",
+          "description": "When a custom domain (e.g. via portless) points at a dev server, also show the localhost:PORT pill alongside it",
           "default": true,
           "required": false
         }

--- a/extensions/dev-servers/src/aliases.ts
+++ b/extensions/dev-servers/src/aliases.ts
@@ -14,10 +14,16 @@ const execFileAsync = promisify(execFile);
 // Raycast's subprocess PATH doesn't include user-installed CLIs (same reason
 // the restart flow in [servers.ts] uses `/bin/zsh -ilc`).
 //
-// Any failure (portless not installed, command-not-found, unexpected output)
-// returns an empty map. Portless is treated as an optional enhancement, not a
-// runtime dependency — when it's absent the UI silently falls back to plain
-// `localhost:PORT` rows, per Raycast's "gracefully degrade" guidance.
+// Hard 3s timeout: this call sits in fetchServers' Promise.all, so a hung
+// portless daemon would otherwise block the entire refresh cycle. On timeout
+// the call rejects and we fall through to the same empty-map fallback as
+// any other failure.
+//
+// Any failure (portless not installed, command-not-found, timeout, unexpected
+// output) returns an empty map. Portless is treated as an optional
+// enhancement, not a runtime dependency — when it's absent the UI silently
+// falls back to plain `localhost:PORT` rows, per Raycast's "gracefully
+// degrade" guidance.
 //
 // Cross-platform note: the zsh login-shell pattern is macOS/Linux. Windows
 // will need its own variant (powershell -c "portless list"), wired up
@@ -26,7 +32,9 @@ export async function fetchAliases(): Promise<Map<number, string[]>> {
   const out = new Map<number, string[]>();
   let stdout: string;
   try {
-    ({ stdout } = await execFileAsync("/bin/zsh", ["-ilc", "portless list"]));
+    ({ stdout } = await execFileAsync("/bin/zsh", ["-ilc", "portless list"], {
+      timeout: 3000,
+    }));
   } catch {
     return out;
   }

--- a/extensions/dev-servers/src/aliases.ts
+++ b/extensions/dev-servers/src/aliases.ts
@@ -1,0 +1,46 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// Returns a map from listening port → list of custom URLs registered to that
+// port (e.g. https://myapp.localhost → 3000). Used by the UI to swap the
+// primary row label from `localhost:PORT` to the named domain when one
+// exists.
+//
+// Resolution path: shell out to `portless list` via a login shell. portless's
+// text output is its public, human-readable interface — far more stable than
+// its internal ~/.portless/ state files. The login shell is required because
+// Raycast's subprocess PATH doesn't include user-installed CLIs (same reason
+// the restart flow in [servers.ts] uses `/bin/zsh -ilc`).
+//
+// Any failure (portless not installed, command-not-found, unexpected output)
+// returns an empty map. Portless is treated as an optional enhancement, not a
+// runtime dependency — when it's absent the UI silently falls back to plain
+// `localhost:PORT` rows, per Raycast's "gracefully degrade" guidance.
+//
+// Cross-platform note: the zsh login-shell pattern is macOS/Linux. Windows
+// will need its own variant (powershell -c "portless list"), wired up
+// alongside the other platform primitives in [servers.ts].
+export async function fetchAliases(): Promise<Map<number, string[]>> {
+  const out = new Map<number, string[]>();
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileAsync("/bin/zsh", ["-ilc", "portless list"]));
+  } catch {
+    return out;
+  }
+  // portless list output is one route per line:
+  //   "  https://myapp.localhost  ->  localhost:3000  (pid 12345)"
+  //   "  https://api.myapp.localhost  ->  localhost:3001  (alias)"
+  for (const line of stdout.split("\n")) {
+    const match = line.match(/^\s*(https?:\/\/\S+)\s+->\s+localhost:(\d+)\b/);
+    if (!match) continue;
+    const port = parseInt(match[2], 10);
+    if (!(port > 0)) continue;
+    const arr = out.get(port) ?? [];
+    arr.push(match[1]);
+    out.set(port, arr);
+  }
+  return out;
+}

--- a/extensions/dev-servers/src/index.tsx
+++ b/extensions/dev-servers/src/index.tsx
@@ -26,6 +26,13 @@ const DEFAULT_TERMINAL: Application = {
   bundleId: "com.apple.Terminal",
 };
 
+// Strip scheme and trailing slash so a primary URL renders cleanly as the row
+// title: "https://myapp.localhost/" → "myapp.localhost",
+// "http://localhost:4321" → "localhost:4321".
+function displayHost(url: string): string {
+  return url.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+}
+
 function formatUptime(startedAt: Date): string {
   const seconds = Math.floor((Date.now() - startedAt.getTime()) / 1000);
   if (isNaN(seconds) || seconds < 0) return "?";
@@ -167,6 +174,7 @@ interface RowVisibility {
   branch: boolean;
   uptime: boolean;
   tool: boolean;
+  localUrl: boolean;
 }
 
 interface ServerItemProps {
@@ -205,8 +213,8 @@ function ServerItem({
     ? { source: faviconUrl, fallback: Icon.Globe }
     : { source: Icon.Globe, tintColor: toolColor(server.tool) };
 
-  // Branch goes in the left-rail subtitle (right next to the title), not in
-  // the accessories on the right. Raycast dims subtitles automatically.
+  // Branch goes in the left-rail subtitle (right next to the title). Raycast
+  // dims subtitles automatically.
   const subtitle =
     show.branch && server.branch
       ? {
@@ -215,14 +223,29 @@ function ServerItem({
         }
       : undefined;
 
+  // When a custom domain (e.g. via portless) points at this port, promote
+  // the domain to the title and demote `localhost:PORT` to a pill accessory.
+  // The pill lives in accessories (right-aligned) because Raycast subtitles
+  // are plain text — there's no inline-pill primitive. The port stays
+  // visible because it's still useful for env files, OAuth allowlists, CORS
+  // rules, and tools that don't trust the local CA.
+  const hasAlias = !!server.customUrls?.length;
+  const titleHost = displayHost(server.url);
+  const localBadgeTag =
+    hasAlias && show.localUrl
+      ? { tag: { value: `localhost:${server.port}` } }
+      : undefined;
+
   return (
     <List.Item
       icon={icon}
-      title={`localhost:${server.port}`}
+      title={titleHost}
       subtitle={subtitle}
-      keywords={[server.projectName, server.branch].filter((v): v is string =>
-        Boolean(v),
-      )}
+      keywords={[
+        server.projectName,
+        server.branch,
+        ...(server.customUrls ?? []).map(displayHost),
+      ].filter((v): v is string => Boolean(v))}
       accessories={[
         ...(show.uptime
           ? [
@@ -232,6 +255,7 @@ function ServerItem({
               },
             ]
           : []),
+        ...(localBadgeTag ? [localBadgeTag] : []),
         // Runtime tag is suppressed when it duplicates the tool tag (e.g.
         // tool is already "bun"), and rendered only when the user has the
         // tool tag visible — otherwise standalone "bun" would look orphaned.
@@ -256,22 +280,53 @@ function ServerItem({
       ]}
       actions={
         <ActionPanel>
+          {/*
+           * Action order is deliberate. Raycast auto-binds `↵` and `⌘↵` to
+           * positions 1 and 2 — they can't be overridden — so we keep both
+           * slots filled with benign "open" actions.
+           *
+           * Restart sits above Kill: restarting is the common iterate-on-
+           * change action, while Kill is mostly end-of-session cleanup.
+           * This also keeps `⌘↵` from auto-firing Kill when there's no
+           * alias — it falls through to Restart (reversible by design).
+           *
+           * Kill stays high in the panel rather than at the conventional
+           * "destructive at the bottom", because it's frequent and Raycast
+           * paints it red as the visual safety signal. The bulk kill
+           * actions further down keep convention — they're genuinely
+           * high-blast-radius.
+           */}
           <Action.OpenInBrowser url={server.url} title="Open in Browser" />
-          <Action
-            title="Kill Server"
-            icon={Icon.Stop}
-            style={Action.Style.Destructive}
-            shortcut={{ modifiers: ["cmd"], key: "d" }}
-            onAction={onKill}
-          />
-          {/* CopyToClipboard already uses Cmd+C by default */}
-          <Action.CopyToClipboard title="Copy URL" content={server.url} />
+          {hasAlias && (
+            <Action.OpenInBrowser
+              url={server.localUrl}
+              title="Open Localhost URL"
+            />
+          )}
           <Action
             title="Restart Server"
             icon={Icon.ArrowClockwise}
             shortcut={{ modifiers: ["cmd", "shift"], key: "r" }}
             onAction={onRestart}
           />
+          <Action
+            title="Kill Server"
+            icon={Icon.Stop}
+            style={Action.Style.Destructive}
+            shortcut={{ modifiers: ["ctrl"], key: "x" }}
+            onAction={onKill}
+          />
+          <ActionPanel.Section>
+            {/* CopyToClipboard already uses Cmd+C by default */}
+            <Action.CopyToClipboard title="Copy URL" content={server.url} />
+            {hasAlias && (
+              <Action.CopyToClipboard
+                title="Copy Localhost URL"
+                content={server.localUrl}
+                shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+              />
+            )}
+          </ActionPanel.Section>
           <ActionPanel.Section>
             <Action.Open
               title={`Open in ${terminalApp.name}`}
@@ -296,14 +351,14 @@ function ServerItem({
               title="Kill All for Project"
               icon={Icon.Trash}
               style={Action.Style.Destructive}
-              shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
+              shortcut={{ modifiers: ["ctrl", "shift"], key: "x" }}
               onAction={onKillProject}
             />
             <Action
               title="Kill All Servers"
               icon={Icon.XMarkCircle}
               style={Action.Style.Destructive}
-              shortcut={{ modifiers: ["cmd", "opt"], key: "d" }}
+              shortcut={{ modifiers: ["ctrl", "opt"], key: "x" }}
               onAction={onKillAll}
             />
           </ActionPanel.Section>
@@ -465,11 +520,12 @@ export default function Command() {
     branch: prefs.showBranch ?? true,
     uptime: prefs.showUptime ?? true,
     tool: prefs.showTool ?? true,
+    localUrl: prefs.showLocalUrl ?? true,
   };
 
-  // Manual refresh: useExec's revalidate is silent because keepPreviousData
-  // keeps the list rendered. Show a brief animated toast so the user knows
-  // their ⌘R actually did something.
+  // Manual refresh: useCachedPromise's revalidate is silent because
+  // keepPreviousData keeps the list rendered. Show a brief animated toast so
+  // the user knows their ⌘R actually did something.
   async function refresh() {
     const toast = await showToast({
       style: Toast.Style.Animated,

--- a/extensions/dev-servers/src/servers.ts
+++ b/extensions/dev-servers/src/servers.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { promisify } from "node:util";
+import { fetchAliases } from "./aliases";
 import { DevServer } from "./types";
 
 const execFileAsync = promisify(execFile);
@@ -13,11 +14,13 @@ const execFileAsync = promisify(execFile);
 //
 // Everything below the next section divider is pure TypeScript and runs
 // unchanged on any OS. To port the extension to a new platform (e.g.
-// Windows), swap the three helpers in this section for equivalents that
-// return the same shapes. Suggested mapping:
+// Windows), swap the helpers in this section, plus fetchAliases in
+// [aliases.ts], for equivalents that return the same shapes. Suggested
+// mapping:
 //   listProcesses  → Get-CimInstance Win32_Process     (or PowerShell)
 //   listListeners  → Get-NetTCPConnection -State Listen
 //   listCwds       → Win32_Process.ExecutablePath / CWD via WMI
+//   fetchAliases   → powershell -c "portless list"     (see aliases.ts)
 
 interface RawProcess {
   pid: number;
@@ -225,9 +228,10 @@ function lowestPortPerPid(listeners: RawListener[]): Map<number, number> {
 // ---------------------------------------------------------------------------
 
 export async function fetchServers(): Promise<DevServer[]> {
-  const [procs, listeners] = await Promise.all([
+  const [procs, listeners, aliasesByPort] = await Promise.all([
     listProcesses(),
     listListeners(),
+    fetchAliases(),
   ]);
   const candidates = procs.filter(isCandidate);
   const portByPid = lowestPortPerPid(listeners);
@@ -255,6 +259,13 @@ export async function fetchServers(): Promise<DevServer[]> {
     if (port === undefined) continue;
     const cwd = cwdByPid.get(proc.pid);
     if (!cwd) continue; // shouldn't happen for live processes, but be safe
+    const tool = detectTool(proc.command, cwd);
+    // Drop the portless proxy daemon itself — it's a node process out of
+    // node_modules/portless/ that binds 80/443/1355, and would otherwise
+    // appear as a phantom "dev server" row. Child processes spawned by
+    // portless run their own framework binary (next, vite, …) so they
+    // resolve to that tool, not "portless".
+    if (tool === "portless") continue;
     const git = gitByCwd.get(cwd);
     // For git projects: key is the shared .git dir path (stable across all
     // worktrees of the repo), name is the basename of its parent (the repo
@@ -263,11 +274,15 @@ export async function fetchServers(): Promise<DevServer[]> {
       ? path.basename(path.dirname(git.commonDir))
       : path.basename(cwd) || cwd;
     const projectKey = git ? git.commonDir : cwd;
+    const customUrls = aliasesByPort.get(port);
+    const localUrl = `http://localhost:${port}`;
     servers.push({
       pid: proc.pid,
       port: String(port),
-      url: `http://localhost:${port}`,
-      tool: detectTool(proc.command, cwd),
+      url: customUrls?.[0] ?? localUrl,
+      localUrl,
+      customUrls,
+      tool,
       runtime: detectRuntime(proc.command),
       cwd,
       projectKey,

--- a/extensions/dev-servers/src/types.ts
+++ b/extensions/dev-servers/src/types.ts
@@ -1,7 +1,9 @@
 export interface DevServer {
   pid: number;
   port: string;
-  url: string; // http://localhost:PORT
+  url: string; // primary URL: first customUrl when present, else http://localhost:PORT
+  localUrl: string; // always http://localhost:PORT — for actions that must target loopback
+  customUrls?: string[]; // custom domains pointing at this port (e.g. https://myapp.localhost)
   tool: string; // vite | next | webpack | etc.
   runtime: "node" | "bun"; // the actual listening process's runtime
   cwd: string; // /Users/tav/Dev/MyProject (the worktree directory)


### PR DESCRIPTION
## Description

Surfaces custom local domains from [portless](https://github.com/vercel-labs/portless), and tightens the action panel, shortcuts, and preferences to align with Raycast conventions.

**Custom domain detection**

- Detect custom local domains via portless and show the named URL (e.g. `myapp.localhost`) as the row title instead of `localhost:PORT`. The `localhost:PORT` pill stays visible alongside it, since the raw loopback target is still useful for env files, OAuth allowlists, CORS rules, and anything that doesn't trust the local CA.
- "Open in Browser" and "Copy URL" target the custom domain when one is present. New "Open Localhost URL" and "Copy Localhost URL" actions target loopback explicitly.
- Search the list by custom domain — typing "myapp" surfaces `https://myapp.localhost`.
- New "Show localhost URL with custom domain" preference, for users who'd rather hide the `localhost:PORT` pill once a named domain is in place.
- Filter out the portless proxy daemon itself so it never appears as a phantom dev server row.

**Action panel and shortcuts**

- Kill Server's shortcut moves from `⌘D` to `⌃X`. `⌘D` is officially "Duplicate" in Raycast's keyboard conventions; `⌃X` is "Remove". Kill All for Project and Kill All Servers shift to `⌃⇧X` and `⌃⌥X` to stay in the same family.
- Copy Localhost URL is bound to `⌘⇧C`, mirroring `⌘C` for Copy URL.
- Action panel reordered: Restart Server now sits at position 3, above Kill Server. Restarting is the more common mutation (iterate-on-change), and placing it above Kill also means Raycast's reserved `⌘↵` second-action shortcut never auto-fires Kill — it falls through to Open Localhost URL when a custom domain is present, or to Restart otherwise. Both are safe.

**Preferences**

- Refresh Interval (a behavior setting) moves above Project Display (cosmetic), so settings that change what the extension *does* appear before settings that change how it *looks*.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
