### PR TITLE
[Brand Icons] Add support for Raycast beta versions

### DIFF
--- a/extensions/simple-icons/CHANGELOG.md
+++ b/extensions/simple-icons/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Brand Icons Changelog
 
-## [Enhancement] - {PR_MERGE_DATE}
+## [Enhancement] - 2026-05-27
 
 - Add support for Raycast beta versions
 - Bump all dependencies to the latest

--- a/extensions/simple-icons/CHANGELOG.md
+++ b/extensions/simple-icons/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Brand Icons Changelog
 
+## [Enhancement] - {PR_MERGE_DATE}
+
+- Add support for Raycast beta versions
+- Bump all dependencies to the latest
+
 ## [Bugfix] - 2026-04-08
 
 - Fix `raycast-tint-color` value

--- a/extensions/simple-icons/package-lock.json
+++ b/extensions/simple-icons/package-lock.json
@@ -7,25 +7,25 @@
       "name": "simple-icons",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.11",
-        "@raycast/utils": "^2.2.3",
+        "@raycast/api": "^1.104.18",
+        "@raycast/utils": "^2.2.5",
         "array-shuffle": "^4.1.0",
-        "date-fns": "^4.1.0",
+        "date-fns": "^4.3.0",
         "fast-fuzzy": "^1.12.0",
-        "got": "^15.0.0",
+        "got": "^15.0.5",
         "lodash": "^4.18.1",
         "pacote": "^21.5.0",
         "raycast-cross-extension": "^0.2.3",
-        "semver": "^7.7.4"
+        "semver": "^7.8.1"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
         "@types/lodash": "^4.17.24",
         "@types/pacote": "^11.1.8",
-        "@types/react": "^19.2.14",
+        "@types/react": "^19.2.15",
         "@types/semver": "^7.7.1",
         "eslint": "^9.39.2",
-        "prettier": "^3.8.1",
+        "prettier": "^3.8.3",
         "typescript": "^5.9.3"
       }
     },
@@ -1351,16 +1351,16 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.11",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.11.tgz",
-      "integrity": "sha512-UaLyWDlgtgyruTVclcJ1RAJjRWKc/ISw+WQAzTHui4qpY3olaaXWrE/dox6/7Cd3mFZtkQ6grhdUiYTBsUUfuw==",
+      "version": "1.104.18",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.18.tgz",
+      "integrity": "sha512-Effu0wSTRwtW7VNjyrDtFNxMQ4BbtRFCIY00PbY4qa3yFPOE/CfbcZJbesyo3nYyuenedqeia/+PvLcieBUO4w==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
         "@oclif/plugin-autocomplete": "^3.2.40",
         "@oclif/plugin-help": "^6.2.37",
         "@oclif/plugin-not-found": "^3.2.74",
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "esbuild": "^0.27.3",
         "react": "19.0.0"
@@ -1369,10 +1369,10 @@
         "ray": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.14.0"
+        "node": ">=22.22.2"
       },
       "peerDependencies": {
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "react-devtools": "6.1.1"
       },
@@ -1430,9 +1430,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.3.tgz",
-      "integrity": "sha512-YwqleVl0Wk/FOq+672gtvswuwMqjNqIr+c63FhouTEHc1LJ3zaohLSkW4+UcfBjPU8HySKQm+kJqZW1iOM9fnA==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.5.tgz",
+      "integrity": "sha512-1o6zGRECh1KNe6CBx68iMPOrNYbV56opqs4zUtDr6Wmq4F7Ww3d8uLTXKVzXlGyJmpAys/Eliw6cKIP7dPdFfw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1528,12 +1528,12 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
-      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
+      "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -1589,12 +1589,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -1659,9 +1659,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2334,9 +2334,9 @@
       "license": "MIT"
     },
     "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.3.0.tgz",
+      "integrity": "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3100,12 +3100,12 @@
       }
     },
     "node_modules/got": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-15.0.0.tgz",
-      "integrity": "sha512-CUqLG9oFZRis7SZq5Bcxh42LpzxXgXwxWVwNljo60oki8Cq3GXVRpDY2K4GwTzYz3htyXf212nfNg2socz4esQ==",
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-15.0.5.tgz",
+      "integrity": "sha512-PMIMaZuYUCK43+Z9JWEXea4kkX2b3301m81D5TS6QpfG4PmNyirzEdO/Oa2OHAN4GsjnPfvWCWsshKN2rq4/gQ==",
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/is": "^7.2.0",
+        "@sindresorhus/is": "^8.0.0",
         "byte-counter": "^0.1.0",
         "cacheable-lookup": "^7.0.0",
         "cacheable-request": "^13.0.18",
@@ -3115,7 +3115,7 @@
         "keyv": "^5.6.0",
         "lowercase-keys": "^4.0.1",
         "responselike": "^4.0.2",
-        "type-fest": "^5.4.4",
+        "type-fest": "^5.6.0",
         "uint8array-extras": "^1.5.0"
       },
       "engines": {
@@ -3147,9 +3147,9 @@
       }
     },
     "node_modules/got/node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -4301,9 +4301,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4559,9 +4559,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4933,9 +4933,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unicode-trie": {

--- a/extensions/simple-icons/package.json
+++ b/extensions/simple-icons/package.json
@@ -145,25 +145,25 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.104.11",
-    "@raycast/utils": "^2.2.3",
+    "@raycast/api": "^1.104.18",
+    "@raycast/utils": "^2.2.5",
     "array-shuffle": "^4.1.0",
-    "date-fns": "^4.1.0",
+    "date-fns": "^4.3.0",
     "fast-fuzzy": "^1.12.0",
-    "got": "^15.0.0",
+    "got": "^15.0.5",
     "lodash": "^4.18.1",
     "pacote": "^21.5.0",
     "raycast-cross-extension": "^0.2.3",
-    "semver": "^7.7.4"
+    "semver": "^7.8.1"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",
     "@types/lodash": "^4.17.24",
     "@types/pacote": "^11.1.8",
-    "@types/react": "^19.2.14",
+    "@types/react": "^19.2.15",
     "@types/semver": "^7.7.1",
     "eslint": "^9.39.2",
-    "prettier": "^3.8.1",
+    "prettier": "^3.8.3",
     "typescript": "^5.9.3"
   }
 }

--- a/extensions/simple-icons/src/utils.ts
+++ b/extensions/simple-icons/src/utils.ts
@@ -39,6 +39,8 @@ export const {
 } = getPreferenceValues<ExtensionPreferences>();
 
 export const hasAccessToAi = environment.canAccess(AI);
+export const isRaycastX = Boolean(process.env.RAYCASTX);
+export const raycastProtocol = isRaycastX ? "raycast-x:" : "raycast:";
 
 export const copyOrPaste = async (content: string | number | Clipboard.Content) => {
   if (usePasteInsteadOfCopy) {
@@ -135,7 +137,9 @@ export const useVersion = ({ launchContext }: { launchContext?: LaunchContext })
               message: "Do you want to reload the command to apply updates?",
             });
             if (confirmed) {
-              open("raycast://extensions/litomore/simple-icons/index" + buildDeeplinkParameters(launchContext));
+              open(
+                `${raycastProtocol}//extensions/litomore/simple-icons/index` + buildDeeplinkParameters(launchContext),
+              );
             }
           } else {
             setVersion(latestVersion);
@@ -273,7 +277,7 @@ export const launchSocialBadge = async (icon: IconData, version: string) => {
         "This feature requires 'Badges - shields.io' extension. Do you want to install the extension from the store?",
     });
     if (yes) {
-      await open("raycast://extensions/litomore/badges");
+      await open(`${raycastProtocol}//extensions/litomore/badges`);
     }
   }
 };


### PR DESCRIPTION
## Description

- Add support for Raycast beta versions
- Bump all dependencies to the latest

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
