### PR TITLE
[Bitwarden] Update CLI version to 2026.4.2

### DIFF
--- a/extensions/bitwarden/CHANGELOG.md
+++ b/extensions/bitwarden/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Bitwarden Changelog
 
-## [CLI update] - {PR_MERGE_DATE}
+## [CLI update] - 2026-05-27
 
 - Update CLI to v2026.4.2
 

--- a/extensions/bitwarden/CHANGELOG.md
+++ b/extensions/bitwarden/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bitwarden Changelog
 
+## [CLI update] - {PR_MERGE_DATE}
+
+- Update CLI to v2026.4.2
+
 ## [Update Contributors] - 2026-05-19
 
 - Update contributors
@@ -10,6 +14,7 @@
 
 ## [CLI update & Fix] - 2026-04-23
 
+- Update CLI to v2026.3.0
 - Logout whenever there is a "Invalid session token" error
 
 ## [Fix] - 2026-04-20

--- a/extensions/bitwarden/src/api/bitwarden.ts
+++ b/extensions/bitwarden/src/api/bitwarden.ts
@@ -102,11 +102,11 @@ const BinDownloadLogger = (() => {
 })();
 
 export const cliInfo = {
-  version: "2026.3.0",
+  version: "2026.4.2",
   get sha256() {
-    if (platform === "windows") return "3f129e6d15ae950b5840d20ce9bcf99c2248ce5330f4d4c70e859512d5992371";
-    if (process.arch === "arm64") return "d935e9885ed215ecb0de9a7e7251487012b007a74fedbaaec6074d299fef3e02";
-    return "015ed86b1f9e23a366e0c7937a5b5cfcd26348505608e5e446890cd83a00b1d2";
+    if (platform === "windows") return "db30a5b7dfb8ab1c657e14c566a77649b1ef66864c1c09c5e5437b5667f9e014";
+    if (process.arch === "arm64") return "885b4b15074452f175ddf03d1315ec1fa8a83912ee3ac9267750a5a038292599";
+    return "1dc091b65494612a2c371e27a4267a6e29f9ebabc7f854f6323fa8f1ac344cb2";
   },
   downloadPage: "https://github.com/bitwarden/clients/releases",
   path: {


### PR DESCRIPTION
## Description

For me, this fixes the issues described in https://github.com/raycast/extensions/issues/28126 and https://github.com/raycast/extensions/issues/28233.

Recently, operations like `list items` and `folders` started hitting a master password prompt, causing a `Vault is locked` error, even when the `unlock` command was successful and outputted a valid session token. This seems to be an issue on Bitwarden's side, and I'm also experiencing it locally. 

Upgrading the CLI version to 2026.4.2 or downgrading to 2026.2.0 seems to fix the issue for me, let's see for the reporting users.

Related Bitwarden issues: https://github.com/bitwarden/clients/pull/20714

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
