### PR TITLE
[Slack] Fix slack:// deep links on Windows

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Changelog
 
+## [Fix Windows deep links] - {PR_MERGE_DATE}
+
+- "Open in Slack" and "Open Channel"/"Open Chat" Quicklinks now open the requested channel or user on Windows. Previously the `application="Slack"` hint caused Raycast to launch Slack.exe without forwarding the `slack://` URI; the hint is now macOS-only so Windows routes the URI through the registered protocol handler.
+
 ## [Accent-insensitive search] - 2026-05-07
 
 - "Open Channel" and "Send Message" now match channel and user names regardless of diacritics, so typing `Angeles` finds `Ángeles` (and the same for any accented characters).

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Fix Windows deep links] - {PR_MERGE_DATE}
+## [Fix Windows deep links] - 2026-05-27
 
 - "Open in Slack" and "Open Channel"/"Open Chat" Quicklinks now open the requested channel or user on Windows. Previously the `application="Slack"` hint caused Raycast to launch Slack.exe without forwarding the `slack://` URI; the hint is now macOS-only so Windows routes the URI through the registered protocol handler.
 

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -11,7 +11,8 @@
     "dev_y0ngha",
     "erayack",
     "clins1994",
-    "stephlv"
+    "stephlv",
+    "artistro08"
   ],
   "pastContributors": [
     "Elliot67",

--- a/extensions/slack/src/search.tsx
+++ b/extensions/slack/src/search.tsx
@@ -13,6 +13,9 @@ import SendMessage from "./send-message";
 
 const { displayExtraMetadata } = getPreferenceValues<Preferences.Search>();
 
+// See OpenInSlack.tsx — `application` hint is mac-only.
+const isMac = process.platform === "darwin";
+
 function getCoworkerTime(coworkerTimeZone: string): string {
   const localTime = new Date();
   const coworkerTime = toZonedTime(localTime, coworkerTimeZone);
@@ -127,7 +130,10 @@ function Search() {
                     quicklink={{
                       name: `Open Chat with ${name}`,
                       ...(isAppInstalled
-                        ? { link: `slack://user?team=${workspaceId}&id=${userId}`, application: "Slack" }
+                        ? {
+                            link: `slack://user?team=${workspaceId}&id=${userId}`,
+                            ...(isMac ? { application: "Slack" } : {}),
+                          }
                         : { link: `https://app.slack.com/client/${workspaceId}/${conversationId}` }),
                     }}
                     shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
@@ -170,7 +176,10 @@ function Search() {
                     quicklink={{
                       name: `Open #${name} Channel`,
                       ...(isAppInstalled
-                        ? { link: `slack://channel?team=${workspaceId}&id=${channelId}`, application: "Slack" }
+                        ? {
+                            link: `slack://channel?team=${workspaceId}&id=${channelId}`,
+                            ...(isMac ? { application: "Slack" } : {}),
+                          }
                         : { link: `https://app.slack.com/client/${workspaceId}/${channelId}` }),
                     }}
                     shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}

--- a/extensions/slack/src/shared/OpenInSlack.tsx
+++ b/extensions/slack/src/shared/OpenInSlack.tsx
@@ -3,6 +3,12 @@ import { runAppleScript } from "@raycast/utils";
 import { useEffect, useState } from "react";
 import { buildScriptEnsuringSlackIsRunning } from "./utils";
 
+// `application` hint breaks slack:// URI forwarding on Windows; mac-only.
+const isMac = process.platform === "darwin";
+const slackAppOpenProps = isMac
+  ? ({ application: "Slack", icon: { fileIcon: "/Applications/Slack.app" } } as const)
+  : ({ icon: "slack-icon-rounded.png" } as const);
+
 export const useSlackApp = () => {
   const [state, set] = useState<{ isAppInstalled: boolean; isLoading: boolean }>({
     isAppInstalled: false,
@@ -52,8 +58,7 @@ export const OpenChatInSlack = ({
         <Action.Open
           title={"Open in Slack"}
           target={`slack://user?team=${workspaceId}&id=${userId}`}
-          icon={{ fileIcon: "/Applications/Slack.app" }}
-          application="Slack"
+          {...slackAppOpenProps}
           onOpen={async () => {
             await onAction?.();
             await closeMainWindow();
@@ -94,12 +99,11 @@ export const OpenChannelInSlack = ({
         <Action.Open
           title={"Open in Slack"}
           target={`slack://channel?team=${workspaceId}&id=${channelId}`}
+          {...slackAppOpenProps}
           onOpen={async () => {
             await onAction?.();
             await closeMainWindow();
           }}
-          icon={{ fileIcon: "/Applications/Slack.app" }}
-          application="Slack"
         />
       )}
       <Action.OpenInBrowser


### PR DESCRIPTION
## Description

On Windows, the Slack extension's "Open in Slack" action and the Quicklinks created from "Open Channel" / "Open Chat" launch Slack but always land on the default view — the requested channel or user never opens.

### Root cause

`Action.Open` and `Action.CreateQuicklink` are configured with `application="Slack"` plus a `slack://...` URI as the target. On macOS this resolves to `open -a Slack <slack://...>` and the URI reaches Slack.app's registered URL handler, which navigates correctly. On Windows the same `application` hint causes Raycast to launch `Slack.exe` directly, but the URI is not forwarded to it as a command-line argument — Slack just opens to its default view.

### Fix

Gate the `application` hint and the macOS-only `fileIcon: "/Applications/Slack.app"` icon behind `process.platform === "darwin"`. On Windows the hint is omitted, so `Action.Open(target="slack://...")` is routed through the OS's registered protocol handler — which is `Slack.exe` — and the URI is forwarded intact. macOS behavior is unchanged.

Same fix applied to the `Action.CreateQuicklink` calls in `search.tsx` so saved Quicklinks also work on Windows.

## Screencast / proof

_To be added by the author after install — please verify on your Windows + macOS setups before merging._

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension's code
- [x] I checked that assets used by the extension itself are reasonably sized
- [x] The title of this PR follows the [extension title format](https://developers.raycast.com/basics/prepare-an-extension-for-store#title) (`[Slack] Fix slack:// deep links on Windows`)