### PR TITLE
Update vercast extension

### DIFF
--- a/extensions/vercast/CHANGELOG.md
+++ b/extensions/vercast/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Vercast Changelog
 
+## [2.18] - {PR_MERGE_DATE}
+
+- Use orange status dot for in-progress deployments (building/initializing) for better contrast with ready (green)
+- Added `Copy URL` action to deployment detail view
+
 ## [2.17] - 2026-02-20
 
 - Added `Cancel Deployment` action to deployments

--- a/extensions/vercast/CHANGELOG.md
+++ b/extensions/vercast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Vercast Changelog
 
-## [2.18] - {PR_MERGE_DATE}
+## [2.18] - 2026-05-27
 
 - Use orange status dot for in-progress deployments (building/initializing) for better contrast with ready (green)
 - Added `Copy URL` action to deployment detail view

--- a/extensions/vercast/src/pages/inspect-deployment.tsx
+++ b/extensions/vercast/src/pages/inspect-deployment.tsx
@@ -108,6 +108,15 @@ const InspectDeployment = ({ deployment, selectedTeam, username }: Props) => {
               }
             />
           )}
+          <Action.CopyToClipboard
+            title="Copy URL"
+            content={`https://${deployment.url}`}
+            icon={Icon.CopyClipboard}
+            shortcut={{
+              macOS: { modifiers: ["cmd", "opt"], key: "c" },
+              Windows: { modifiers: ["ctrl", "opt"], key: "c" },
+            }}
+          />
         </ActionPanel>
       }
       metadata={

--- a/extensions/vercast/src/pages/lists/deployments-list.tsx
+++ b/extensions/vercast/src/pages/lists/deployments-list.tsx
@@ -137,7 +137,7 @@ export const StateIcon = (state?: DeploymentState) => {
       return { source: Icon.Dot, tintColor: Color.Green };
     case "BUILDING":
     case "INITIALIZING":
-      return { source: Icon.Dot, tintColor: Color.Blue };
+      return { source: Icon.Dot, tintColor: Color.Orange };
     case "FAILED":
       return { source: Icon.Dot, tintColor: Color.Red };
     case "CANCELED":


### PR DESCRIPTION
## Description

Small UX improvements to the Vercel (vercast) extension:

- **In-progress status color:** Building and initializing deployments now use an orange status dot instead of blue, matching Vercel’s UI and improving contrast with the green “ready” state.
- **Copy URL on detail view:** Added the same `Copy URL` action (⌘⌥C) to the deployment detail view that already exists in the deployments list.

## Screencast

<img width="1872" height="1320" alt="CleanShot 2026-05-27 at 16 24 56@2x" src="https://github.com/user-attachments/assets/28668842-5f0a-4432-80e7-8a817138078c" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder