### PR TITLE
Update apfel extension

### DIFF
--- a/extensions/apfel/.gitignore
+++ b/extensions/apfel/.gitignore
@@ -11,3 +11,6 @@ compiled_raycast_swift
 
 # misc
 .DS_Store
+.claude
+.remember
+docs

--- a/extensions/apfel/CHANGELOG.md
+++ b/extensions/apfel/CHANGELOG.md
@@ -1,3 +1,18 @@
 # Apfel Changelog
 
+## [OCR & Streaming Chat] - {PR_MERGE_DATE}
+
+### Added
+- **Read Text from File** — extract text from images and PDFs via auge
+- **Read Text from Clipboard** — OCR an image on the clipboard
+- **Scan QR Code / Barcode** — decode QR/barcodes from clipboard or file; opens URLs directly
+- **Read Text from Screen Area** — interactive region picker, copies result to clipboard
+- Install screen for auge when not present (Homebrew one-click install)
+- Streaming chat responses — text appears as apfel generates it
+
+### Fixed
+- Stale closure bugs in history, conversations, saved chat, and question hooks
+- Removed dead `availableModels` state from model hook
+- Replaced `cpus()[0]` check (crash risk) with `process.arch` for Apple Silicon detection
+
 ## [Initial Version] - 2026-05-11

--- a/extensions/apfel/CHANGELOG.md
+++ b/extensions/apfel/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Apfel Changelog
 
-## [OCR & Streaming Chat] - {PR_MERGE_DATE}
+## [OCR & Streaming Chat] - 2026-05-27
 
 ### Added
 - **Read Text from File** — extract text from images and PDFs via auge

--- a/extensions/apfel/README.md
+++ b/extensions/apfel/README.md
@@ -56,7 +56,7 @@ Explain local files & folders.
 - Apple Intelligence enabled
 - Apfel CLI from Homebrew or [source](https://github.com/Arthur-Ficial/apfel)
   - ```bash
-      brew install Arthur-Ficial/tap/apfel
+      brew install apfel
     ```
 
 # Thanks To

--- a/extensions/apfel/package.json
+++ b/extensions/apfel/package.json
@@ -76,6 +76,30 @@
       "title": "Explain Directory",
       "description": "Explain the directory using Apfel",
       "mode": "view"
+    },
+    {
+      "name": "ocr-file",
+      "title": "Read Text from File",
+      "description": "Extract text from a file using auge",
+      "mode": "view"
+    },
+    {
+      "name": "ocr-clipboard",
+      "title": "Read Text from Clipboard",
+      "description": "Extract text from the image in your clipboard using auge",
+      "mode": "view"
+    },
+    {
+      "name": "ocr-qr",
+      "title": "Scan QR Code / Barcode",
+      "description": "Decode a QR code or barcode from clipboard or a file using auge",
+      "mode": "view"
+    },
+    {
+      "name": "ocr-screen",
+      "title": "Read Text from Screen Area",
+      "description": "Select a screen region and extract text to clipboard using auge",
+      "mode": "no-view"
     }
   ],
   "dependencies": {

--- a/extensions/apfel/src/api/apfel/ask.ts
+++ b/extensions/apfel/src/api/apfel/ask.ts
@@ -1,19 +1,41 @@
+import { spawn } from "child_process";
 import { Model } from "../../type";
 import { getApfelPath } from ".";
-import { escapeForShell } from "../../utils";
-import { runAppleScript } from "@raycast/utils";
 
-export async function askApfel(prompt: string, model?: Model): Promise<string> {
-  const args = [
-    model?.prompt ? `-s '${escapeForShell(model.prompt)}'` : "",
-    model?.temperature ? `--temperature '${escapeForShell(model.temperature)}'` : "",
-    model?.max_tokens ? `--max-tokens '${escapeForShell(model.max_tokens)}'` : "",
-    `'${escapeForShell(prompt)}'`,
-  ].filter(Boolean);
+export function askApfelStreaming(
+  prompt: string,
+  model: Model | undefined,
+  onChunk: (partialAnswer: string) => void,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const args: string[] = ["--stream", "--quiet", "--no-color"];
+    if (model?.prompt) args.push("-s", model.prompt);
+    if (model?.temperature) args.push("--temperature", model.temperature);
+    if (model?.max_tokens) args.push("--max-tokens", model.max_tokens);
+    args.push(prompt);
 
-  const result = await runAppleScript(`do shell script "${getApfelPath()} ${args.join(" ")}"`, {
-    timeout: 60000,
+    const proc = spawn(getApfelPath(), args, {
+      env: { ...process.env, PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let accumulated = "";
+    let stderrOutput = "";
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      accumulated += chunk.toString();
+      onChunk(accumulated);
+    });
+
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderrOutput += chunk.toString();
+    });
+
+    proc.on("close", (code) => {
+      if (code === 0) resolve(accumulated.trim());
+      else reject(new Error(stderrOutput.trim() || `apfel exited with code ${code}`));
+    });
+
+    proc.on("error", reject);
   });
-
-  return result;
 }

--- a/extensions/apfel/src/api/apfel/index.ts
+++ b/extensions/apfel/src/api/apfel/index.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "fs";
 import { escapeForShell } from "../../utils";
 import { runAppleScript } from "@raycast/utils";
-import { getSelectedFinderItems } from "@raycast/api";
+import { hasFinderPermission } from "../../utils/finder";
 
 export const getApfelPath = () => {
   const candidates = [
@@ -14,7 +14,7 @@ export const getApfelPath = () => {
     if (existsSync(p)) return p;
   }
 
-  throw new Error("apfel binary not found. Install it with:\n  brew install Arthur-Ficial/tap/apfel");
+  throw new Error("apfel binary not found. Install it with:\n  brew install apfel");
 };
 
 function isApfelInstalled() {
@@ -32,23 +32,6 @@ async function isAppleIntelligenceAvailable() {
     return result.includes("available:  yes");
   } catch {
     return false;
-  }
-}
-
-async function hasFinderPermission() {
-  try {
-    await getSelectedFinderItems();
-    return true;
-  } catch {
-    // ignore
-  }
-
-  try {
-    await runAppleScript(`tell application "Finder" to get selection`);
-    return true;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return !message.includes("-1743") && !message.includes("not allowed");
   }
 }
 

--- a/extensions/apfel/src/api/auge/index.ts
+++ b/extensions/apfel/src/api/auge/index.ts
@@ -5,7 +5,7 @@ import { hasFinderPermission } from "../../utils/finder";
 
 const execFileAsync = promisify(execFile);
 
-const ENV = { PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" };
+const ENV = { ...process.env, PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" };
 
 export const getAugePath = () => {
   const candidates = ["/opt/homebrew/bin/auge", "/usr/local/bin/auge", "/usr/bin/auge"];

--- a/extensions/apfel/src/api/auge/index.ts
+++ b/extensions/apfel/src/api/auge/index.ts
@@ -1,0 +1,62 @@
+import { existsSync } from "fs";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { hasFinderPermission } from "../../utils/finder";
+
+const execFileAsync = promisify(execFile);
+
+const ENV = { PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" };
+
+export const getAugePath = () => {
+  const candidates = ["/opt/homebrew/bin/auge", "/usr/local/bin/auge", "/usr/bin/auge"];
+  for (const p of candidates) {
+    if (existsSync(p)) return p;
+  }
+  throw new Error("auge binary not found.");
+};
+
+function isAugeInstalled() {
+  try {
+    getAugePath();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function checkAuge(
+  checkForFileSystemPermission = false,
+): Promise<"not_installed" | "finder_permission_denied" | "ready"> {
+  if (!isAugeInstalled()) return "not_installed";
+  if (checkForFileSystemPermission && !(await hasFinderPermission())) return "finder_permission_denied";
+  return "ready";
+}
+
+type Source = { type: "file"; path: string } | { type: "clipboard" };
+
+async function runAuge(mode: "--ocr" | "--barcode", source: Source): Promise<string> {
+  const augePath = getAugePath();
+  const args = source.type === "file" ? [mode, "--quiet", source.path] : [mode, "--quiet", "--clipboard"];
+  try {
+    const { stdout } = await execFileAsync(augePath, args, { env: ENV });
+    return stdout.trim();
+  } catch (err) {
+    const raw = err instanceof Error ? err.message : String(err);
+    if (raw.includes("[clipboard empty]")) {
+      throw new Error("Clipboard does not contain an image. Copy a PNG, JPEG, HEIC, or TIFF first.");
+    }
+    throw err;
+  }
+}
+
+export const runAugeOcr = (source: Source) => runAuge("--ocr", source);
+
+export const runAugeBarcode = async (source: Source) => {
+  const raw = await runAuge("--barcode", source);
+  // auge prefixes each barcode result with its type, e.g. "[QR] https://…" — strip it
+  return raw
+    .split("\n")
+    .map((line) => line.replace(/^\[.*?\]\s*/, ""))
+    .join("\n")
+    .trim();
+};

--- a/extensions/apfel/src/chat.tsx
+++ b/extensions/apfel/src/chat.tsx
@@ -96,7 +96,7 @@ function Chat(props: { conversation?: Conversation }) {
       isLoading={chats.isLoading}
       onSearchTextChange={question.update}
       throttle={false}
-      navigationTitle={"Ask"}
+      navigationTitle={"Chat"}
       actions={
         !question.data ? (
           <ActionPanel>

--- a/extensions/apfel/src/components/ApfelGuard.tsx
+++ b/extensions/apfel/src/components/ApfelGuard.tsx
@@ -1,7 +1,7 @@
 import { Detail } from "@raycast/api";
 import { useApfelCheck } from "../hooks/useApfelCheck";
 
-import NotFoundView from "../views/not-found";
+import NotFoundView from "../views/apfel-not-found";
 import IntelligenceNotReadyView from "../views/intelligence-not-ready";
 import FinderPermissionDeniedView from "../views/finder-permission-denied";
 

--- a/extensions/apfel/src/components/AugeGuard.tsx
+++ b/extensions/apfel/src/components/AugeGuard.tsx
@@ -1,0 +1,14 @@
+import { Detail } from "@raycast/api";
+import { useAugeCheck } from "../hooks/useAugeCheck";
+import AugeNotFoundView from "../views/auge-not-found";
+import FinderPermissionDeniedView from "../views/finder-permission-denied";
+
+export function AugeGuard(props: { children: React.ReactNode; checkForFileSystemPermission?: boolean }) {
+  const { data, isLoading } = useAugeCheck(props.checkForFileSystemPermission);
+
+  if (isLoading) return <Detail isLoading />;
+  else if (data === "not_installed") return <AugeNotFoundView />;
+  else if (data === "finder_permission_denied") return <FinderPermissionDeniedView />;
+
+  return <>{props.children}</>;
+}

--- a/extensions/apfel/src/hooks/useAugeCheck.ts
+++ b/extensions/apfel/src/hooks/useAugeCheck.ts
@@ -1,0 +1,6 @@
+import { usePromise } from "@raycast/utils";
+import { checkAuge } from "../api/auge";
+
+export function useAugeCheck(checkForFileSystemPermission?: boolean) {
+  return usePromise(checkAuge, [checkForFileSystemPermission]);
+}

--- a/extensions/apfel/src/hooks/useChat.tsx
+++ b/extensions/apfel/src/hooks/useChat.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { Chat, ChatHook, Model } from "../type";
 import { useHistory } from "./useHistory";
-import { askApfel } from "../api/apfel/ask";
+import { askApfelStreaming } from "../api/apfel/ask";
 
 export function useChat<T extends Chat>(props: T[]): ChatHook {
   const [data, setData] = useState<Chat[]>(props);
@@ -28,15 +28,13 @@ export function useChat<T extends Chat>(props: T[]): ChatHook {
       created_at: new Date().toISOString(),
     };
 
-    setData((prev) => {
-      return [...prev, chat];
-    });
+    setData((prev) => [...prev, chat]);
+    setSelectedChatId(chat.id);
 
     try {
-      const answer = await askApfel(question, model);
-
-      setData((prev) => prev.map((c) => (c.id === chat.id ? { ...c, answer } : c)));
-      setSelectedChatId(chat.id);
+      const answer = await askApfelStreaming(question, model, (partial) => {
+        setData((prev) => prev.map((c) => (c.id === chat.id ? { ...c, answer: partial } : c)));
+      });
 
       history.add({ ...chat, answer });
 
@@ -44,6 +42,7 @@ export function useChat<T extends Chat>(props: T[]): ChatHook {
       toast.style = Toast.Style.Success;
     } catch (err) {
       setData((prev) => prev.filter((c) => c.id !== chat.id));
+      setSelectedChatId(null);
 
       toast.title = "Failed to get answer";
       toast.message = err instanceof Error ? err.message : String(err);

--- a/extensions/apfel/src/hooks/useConversations.tsx
+++ b/extensions/apfel/src/hooks/useConversations.tsx
@@ -28,23 +28,16 @@ export function useConversations(): ConversationsHook {
 
   const add = useCallback(
     async (conversation: Conversation) => {
-      setData([...data, conversation]);
+      setData((prev) => [...prev, conversation]);
     },
-    [setData, data],
+    [setData],
   );
 
   const update = useCallback(
     async (conversation: Conversation) => {
-      setData((prev) => {
-        return prev.map((x) => {
-          if (x.id === conversation.id) {
-            return conversation;
-          }
-          return x;
-        });
-      });
+      setData((prev) => prev.map((x) => (x.id === conversation.id ? conversation : x)));
     },
-    [setData, data],
+    [setData],
   );
 
   const remove = useCallback(
@@ -53,12 +46,11 @@ export function useConversations(): ConversationsHook {
         title: "Removing conversation...",
         style: Toast.Style.Animated,
       });
-      const newConversations: Conversation[] = data.filter((item) => item.id !== conversation.id);
-      setData(newConversations);
+      setData((prev) => prev.filter((item) => item.id !== conversation.id));
       toast.title = "Conversation removed!";
       toast.style = Toast.Style.Success;
     },
-    [setData, data],
+    [setData],
   );
 
   const clear = useCallback(async () => {

--- a/extensions/apfel/src/hooks/useHistory.tsx
+++ b/extensions/apfel/src/hooks/useHistory.tsx
@@ -28,9 +28,9 @@ export function useHistory(): HistoryHook {
 
   const add = useCallback(
     async (chat: Chat) => {
-      setData([...data, chat]);
+      setData((prev) => [...prev, chat]);
     },
-    [setData, data],
+    [setData],
   );
 
   const remove = useCallback(
@@ -39,12 +39,11 @@ export function useHistory(): HistoryHook {
         title: "Removing answer...",
         style: Toast.Style.Animated,
       });
-      const newHistory: Chat[] = data.filter((item) => item.id !== answer.id);
-      setData(newHistory);
+      setData((prev) => prev.filter((item) => item.id !== answer.id));
       toast.title = "Answer removed!";
       toast.style = Toast.Style.Success;
     },
-    [setData, data],
+    [setData],
   );
 
   const clear = useCallback(async () => {

--- a/extensions/apfel/src/hooks/useModel.tsx
+++ b/extensions/apfel/src/hooks/useModel.tsx
@@ -25,7 +25,6 @@ async function getStoredModels(): Promise<Model[]> {
 export function useModel(): ModelHook {
   const [data, setData] = useState<Model[]>([]);
   const [isLoading, setLoading] = useState(false);
-  const [availableModels] = useState<Array<{ id: string; display_name: string }>>([]);
 
   useEffect(() => {
     setLoading(true);
@@ -106,7 +105,7 @@ export function useModel(): ModelHook {
   }, [setData]);
 
   return useMemo(
-    () => ({ data, isLoading, availableModels, add, update, remove, clear }),
-    [data, isLoading, availableModels, add, update, remove, clear],
+    () => ({ data, isLoading, add, update, remove, clear }),
+    [data, isLoading, add, update, remove, clear],
   );
 }

--- a/extensions/apfel/src/hooks/useQuestion.tsx
+++ b/extensions/apfel/src/hooks/useQuestion.tsx
@@ -10,7 +10,7 @@ export function useQuestion(props: { initialQuestion: string }): Omit<QuestionHo
     async (question: string) => {
       setData(question);
     },
-    [setData, data],
+    [setData],
   );
 
   return useMemo(() => ({ data, update }), [data, update]);

--- a/extensions/apfel/src/hooks/useSavedChat.tsx
+++ b/extensions/apfel/src/hooks/useSavedChat.tsx
@@ -32,12 +32,11 @@ export function useSavedChat(): SavedChatHook {
         title: "Saving your answer...",
         style: Toast.Style.Animated,
       });
-      const newSavedChat: SavedChat = { ...chat, saved_at: new Date().toISOString() };
-      setData([...data, newSavedChat]);
+      setData((prev) => [...prev, { ...chat, saved_at: new Date().toISOString() }]);
       toast.title = "Answer saved!";
       toast.style = Toast.Style.Success;
     },
-    [setData, data],
+    [setData],
   );
 
   const remove = useCallback(
@@ -46,12 +45,11 @@ export function useSavedChat(): SavedChatHook {
         title: "Unsaving your answer...",
         style: Toast.Style.Animated,
       });
-      const newSavedChats = data.filter((savedAnswer) => savedAnswer.id !== chat.id);
-      setData(newSavedChats);
+      setData((prev) => prev.filter((savedAnswer) => savedAnswer.id !== chat.id));
       toast.title = "Answer unsaved!";
       toast.style = Toast.Style.Success;
     },
-    [setData, data],
+    [setData],
   );
 
   const clear = useCallback(async () => {

--- a/extensions/apfel/src/ocr-clipboard.tsx
+++ b/extensions/apfel/src/ocr-clipboard.tsx
@@ -1,0 +1,51 @@
+import { Action, ActionPanel, Clipboard, Detail, showToast, Toast } from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import { runAugeOcr } from "./api/auge";
+import { AugeGuard } from "./components/AugeGuard";
+
+export default function Command() {
+  return (
+    <AugeGuard>
+      <OcrClipboard />
+    </AugeGuard>
+  );
+}
+
+function OcrClipboard() {
+  const { isLoading, data } = usePromise(async () => {
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Extracting text from clipboard…" });
+
+    try {
+      const text = await runAugeOcr({ type: "clipboard" });
+
+      if (!text) {
+        toast.title = "No text found in clipboard image";
+        toast.style = Toast.Style.Failure;
+        return;
+      }
+
+      await Clipboard.copy(text);
+      toast.title = "Text copied to clipboard!";
+      toast.style = Toast.Style.Success;
+
+      return text;
+    } catch (err) {
+      toast.title = err instanceof Error ? err.message : String(err);
+      toast.style = Toast.Style.Failure;
+    }
+  });
+
+  return (
+    <Detail
+      isLoading={isLoading}
+      markdown={data ?? ""}
+      actions={
+        data ? (
+          <ActionPanel>
+            <Action.CopyToClipboard title="Copy Text" content={data} />
+          </ActionPanel>
+        ) : null
+      }
+    />
+  );
+}

--- a/extensions/apfel/src/ocr-file.tsx
+++ b/extensions/apfel/src/ocr-file.tsx
@@ -1,0 +1,83 @@
+import { Action, ActionPanel, Clipboard, Detail, popToRoot, showHUD, showToast, Toast } from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import { basename, extname } from "path";
+import { runAugeOcr } from "./api/auge";
+import { AugeGuard } from "./components/AugeGuard";
+import { getFinderSelection, isDirectory } from "./utils/finder";
+
+const SUPPORTED_EXTENSIONS = new Set(["png", "jpg", "jpeg", "tiff", "tif", "bmp", "gif", "heic", "pdf"]);
+
+export default function Command() {
+  return (
+    <AugeGuard checkForFileSystemPermission>
+      <OcrFile />
+    </AugeGuard>
+  );
+}
+
+function OcrFile() {
+  const { isLoading, data, error } = usePromise(async () => {
+    const selection = await getFinderSelection();
+
+    if (!selection) {
+      await showHUD("No file selected in Finder");
+      await popToRoot();
+      return;
+    }
+
+    const filePath = selection as string;
+
+    if (isDirectory(filePath)) {
+      await showHUD("Selected item is a directory, not a file");
+      await popToRoot();
+      return;
+    }
+
+    const ext = extname(filePath).slice(1).toLowerCase();
+    if (!SUPPORTED_EXTENSIONS.has(ext)) {
+      await showHUD(`Unsupported file type: .${ext || "unknown"}. Use PNG, JPEG, TIFF, BMP, GIF, HEIC, or PDF.`);
+      await popToRoot();
+      return;
+    }
+
+    await showToast({ style: Toast.Style.Animated, title: "Extracting text…" });
+
+    const text = await runAugeOcr({ type: "file", path: filePath });
+
+    if (!text) {
+      await showToast({ style: Toast.Style.Failure, title: "No text found in file" });
+      return;
+    }
+
+    await Clipboard.copy(text);
+    await showToast({ style: Toast.Style.Success, title: "Text copied to clipboard!" });
+
+    return { text, name: basename(filePath), path: filePath };
+  });
+
+  if (error) {
+    return <Detail markdown={`# Error\n\n${error.message}`} />;
+  }
+
+  return (
+    <Detail
+      isLoading={isLoading}
+      markdown={data?.text ?? ""}
+      metadata={
+        data && (
+          <Detail.Metadata>
+            <Detail.Metadata.Label title="File" text={data.name} />
+            <Detail.Metadata.Label title="Path" text={data.path} />
+          </Detail.Metadata>
+        )
+      }
+      actions={
+        data ? (
+          <ActionPanel>
+            <Action.CopyToClipboard title="Copy Text" content={data.text} />
+          </ActionPanel>
+        ) : null
+      }
+    />
+  );
+}

--- a/extensions/apfel/src/ocr-qr.tsx
+++ b/extensions/apfel/src/ocr-qr.tsx
@@ -6,7 +6,7 @@ import { getFinderSelection } from "./utils/finder";
 
 export default function Command() {
   return (
-    <AugeGuard>
+    <AugeGuard checkForFileSystemPermission>
       <OcrQr />
     </AugeGuard>
   );

--- a/extensions/apfel/src/ocr-qr.tsx
+++ b/extensions/apfel/src/ocr-qr.tsx
@@ -1,0 +1,92 @@
+import { Action, ActionPanel, Clipboard, Detail, Icon, List, showToast, Toast } from "@raycast/api";
+import { useState } from "react";
+import { runAugeBarcode } from "./api/auge";
+import { AugeGuard } from "./components/AugeGuard";
+import { getFinderSelection } from "./utils/finder";
+
+export default function Command() {
+  return (
+    <AugeGuard>
+      <OcrQr />
+    </AugeGuard>
+  );
+}
+
+function OcrQr() {
+  const [result, setResult] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function readFromSource(source: "clipboard" | "file") {
+    setIsLoading(true);
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Reading QR / barcode…" });
+
+      let text: string;
+
+      if (source === "clipboard") {
+        text = await runAugeBarcode({ type: "clipboard" });
+      } else {
+        const path = await getFinderSelection();
+        if (!path) {
+          await showToast({ style: Toast.Style.Failure, title: "No file selected in Finder" });
+          return;
+        }
+        text = await runAugeBarcode({ type: "file", path: path });
+      }
+
+      if (!text) {
+        await showToast({ style: Toast.Style.Failure, title: "No QR code or barcode found" });
+        return;
+      }
+
+      await Clipboard.copy(text);
+      await showToast({ style: Toast.Style.Success, title: "Result copied to clipboard!" });
+      setResult(text);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await showToast({ style: Toast.Style.Failure, title: "Error", message });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  if (result) {
+    const isUrl = result.startsWith("http://") || result.startsWith("https://");
+    return (
+      <Detail
+        markdown={`# QR / Barcode Result\n\n\`\`\`\n${result}\n\`\`\``}
+        actions={
+          <ActionPanel>
+            <Action.CopyToClipboard title="Copy Again" content={result} />
+            {isUrl && <Action.OpenInBrowser title="Open URL" url={result} />}
+          </ActionPanel>
+        }
+      />
+    );
+  }
+
+  return (
+    <List isLoading={isLoading}>
+      <List.Item
+        title="Read from Clipboard"
+        subtitle="Use image currently in clipboard"
+        icon={Icon.Clipboard}
+        actions={
+          <ActionPanel>
+            <Action title="Read from Clipboard" onAction={() => readFromSource("clipboard")} />
+          </ActionPanel>
+        }
+      />
+      <List.Item
+        title="Read from File"
+        subtitle="Use file selected in Finder"
+        icon={Icon.Document}
+        actions={
+          <ActionPanel>
+            <Action title="Read from File" onAction={() => readFromSource("file")} />
+          </ActionPanel>
+        }
+      />
+    </List>
+  );
+}

--- a/extensions/apfel/src/ocr-screen.tsx
+++ b/extensions/apfel/src/ocr-screen.tsx
@@ -1,0 +1,54 @@
+import { Clipboard, closeMainWindow, showHUD } from "@raycast/api";
+import { execFile } from "child_process";
+import { existsSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { promisify } from "util";
+import { checkAuge, runAugeOcr } from "./api/auge";
+
+const execFileAsync = promisify(execFile);
+
+export default async function Command() {
+  if ((await checkAuge()) === "not_installed") {
+    await showHUD("auge not installed — brew tap Arthur-Ficial/tap && brew install Arthur-Ficial/tap/auge");
+    return;
+  }
+
+  await closeMainWindow();
+
+  const tmpFile = join(tmpdir(), `auge-ocr-${Date.now()}.png`);
+
+  // Brief pause after window close for macOS to transfer focus
+  await new Promise<void>((resolve) => setTimeout(resolve, 200));
+
+  try {
+    // screencapture exits non-zero when Escape is pressed — treat as silent cancel
+    await execFileAsync("/usr/sbin/screencapture", ["-i", tmpFile]);
+  } catch {
+    return;
+  }
+
+  // On some macOS versions screencapture exits 0 on Escape without writing a file
+  if (!existsSync(tmpFile)) return;
+
+  try {
+    const text = await runAugeOcr({ type: "file", path: tmpFile });
+
+    if (!text) {
+      await showHUD("No text found in selected area");
+      return;
+    }
+
+    await Clipboard.copy(text);
+    await showHUD(`Copied ${text.length} characters to clipboard`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await showHUD(`OCR failed: ${message}`);
+  } finally {
+    try {
+      unlinkSync(tmpFile);
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/extensions/apfel/src/type.ts
+++ b/extensions/apfel/src/type.ts
@@ -70,7 +70,6 @@ export type QuestionHook = BaseHook<string> & { update: PromiseFunctionWithOneAr
 
 export type ModelHook = Hook<Model> & {
   update: PromiseFunctionWithOneArg<Model>;
-  availableModels: Array<{ id: string; display_name: string }>;
 };
 
 export interface ChatHook {

--- a/extensions/apfel/src/utils/finder.ts
+++ b/extensions/apfel/src/utils/finder.ts
@@ -30,3 +30,19 @@ export async function getFinderSelection() {
 export function isDirectory(path: string): boolean {
   return statSync(path).isDirectory();
 }
+
+export async function hasFinderPermission(): Promise<boolean> {
+  try {
+    await getSelectedFinderItems();
+    return true;
+  } catch {
+    // ignore
+  }
+  try {
+    await runAppleScript(`tell application "Finder" to get selection`);
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return !message.includes("-1743") && !message.includes("not allowed");
+  }
+}

--- a/extensions/apfel/src/views/apfel-not-found.tsx
+++ b/extensions/apfel/src/views/apfel-not-found.tsx
@@ -1,16 +1,16 @@
 import { Action, ActionPanel, Detail, Icon, popToRoot, showToast, Toast } from "@raycast/api";
 import { execFile } from "child_process";
-import { cpus, homedir } from "os";
+import { homedir } from "os";
 import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
-const brewPath = cpus()[0].model.includes("Apple") ? "/opt/homebrew/bin/brew" : "/usr/local/bin/brew";
+const brewPath = process.arch === "arm64" ? "/opt/homebrew/bin/brew" : "/usr/local/bin/brew";
 
 async function handleInstall() {
   await showToast({ style: Toast.Style.Animated, title: "Installing Apfel…", message: "This may take a minute" });
 
   try {
-    await execFileAsync(brewPath, ["install", "Arthur-Ficial/tap/apfel"], {
+    await execFileAsync(brewPath, ["install", "apfel"], {
       env: {
         HOME: homedir(),
         PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
@@ -41,7 +41,7 @@ export default function NotFoundView() {
 The \`apfel\` binary could not be found on your system. You can try installing it within Raycast or install it yourself:
 
 \`\`\`bash
-brew install Arthur-Ficial/tap/apfel
+brew install apfel
 \`\`\`
 
 ## Requirements
@@ -62,7 +62,7 @@ After installing, reopen this command.
           {/* eslint-disable-next-line @raycast/prefer-title-case */}
           <Action title="Install via Homebrew" icon={Icon.Download} onAction={handleInstall} />
           <Action.OpenInBrowser title="Open Apfel Website" url="https://apfel.franzai.com" />
-          <Action.CopyToClipboard title="Copy Install Command" content="brew install Arthur-Ficial/tap/apfel" />
+          <Action.CopyToClipboard title="Copy Install Command" content="brew install apfel" />
         </ActionPanel>
       }
     />

--- a/extensions/apfel/src/views/auge-not-found.tsx
+++ b/extensions/apfel/src/views/auge-not-found.tsx
@@ -1,0 +1,68 @@
+import { Action, ActionPanel, Detail, Icon, popToRoot, showToast, Toast } from "@raycast/api";
+import { execFile } from "child_process";
+import { homedir } from "os";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+const brewPath = process.arch === "arm64" ? "/opt/homebrew/bin/brew" : "/usr/local/bin/brew";
+const ENV = {
+  HOME: homedir(),
+  PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
+  HOMEBREW_NO_AUTO_UPDATE: "1",
+};
+
+async function handleInstall() {
+  await showToast({ style: Toast.Style.Animated, title: "Installing auge…", message: "This may take a minute" });
+
+  try {
+    await execFileAsync(brewPath, ["tap", "Arthur-Ficial/tap"], { env: ENV });
+    await execFileAsync(brewPath, ["install", "Arthur-Ficial/tap/auge"], { env: ENV });
+
+    await showToast({
+      style: Toast.Style.Success,
+      title: "auge installed!",
+      message: "Reopen the command to get started",
+    });
+
+    await popToRoot();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await showToast({ style: Toast.Style.Failure, title: "Installation failed", message });
+  }
+}
+
+export default function AugeNotFoundView() {
+  const markdown = `# auge Not Found
+
+The \`auge\` binary could not be found on your system. You can install it within Raycast or run these commands yourself:
+
+\`\`\`bash
+brew tap Arthur-Ficial/tap
+brew install Arthur-Ficial/tap/auge
+\`\`\`
+
+## Requirements
+
+- macOS 10.15 or later
+- No API keys or cloud services — runs entirely on-device
+
+After installing, reopen this command.
+`;
+
+  return (
+    <Detail
+      markdown={markdown}
+      navigationTitle="auge Not Installed"
+      actions={
+        <ActionPanel>
+          {/* eslint-disable-next-line @raycast/prefer-title-case */}
+          <Action title="Install via Homebrew" icon={Icon.Download} onAction={handleInstall} />
+          <Action.CopyToClipboard
+            title="Copy Install Commands"
+            content="brew tap Arthur-Ficial/tap && brew install Arthur-Ficial/tap/auge"
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}

--- a/extensions/apfel/src/views/chat.tsx
+++ b/extensions/apfel/src/views/chat.tsx
@@ -84,7 +84,7 @@ export const ChatView = ({
             key={sortedChat.id}
             accessories={[{ text: `#${use.chats.data.length - i}` }]}
             title={sortedChat.question}
-            detail={sortedChat.answer && <AnswerDetailView item={sortedChat} />}
+            detail={<AnswerDetailView item={sortedChat} />}
             actions={use.chats.isLoading ? undefined : getActionPanel(sortedChat)}
           />
         );


### PR DESCRIPTION
## Description

### New: OCR Commands via `auge`

Four new commands powered by the [`auge`](https://github.com/Arthur-Ficial/auge) Vision CLI. Results are automatically copied to clipboard.

- **Read Text from File** — pick an image or PDF from Finder and extract text
- **Read Text from Clipboard** — OCR an image already on the clipboard
- **Scan QR Code / Barcode** — decode QR/barcodes from clipboard or a file; opens URLs directly
- **Read Text from Screen Area** — interactive region picker via `screencapture`, no window shown

This is all done with on-device capabilities using Apple's built-in tools. No internet, subscription or API required.

If `auge` is not installed, users see an install screen with a one-click Homebrew button (same pattern as the existing `apfel` guard).

This was a suggestion by @apfelbaum021, and closes #28226.

### New: Streaming Chat

Chat responses now stream word-by-word as `apfel` generates them instead of waiting for the full answer. Uses `spawn` with `--stream --quiet --no-color` flags.

### Fixes & Cleanup

- Stale closure bug in `useHistory`, `useConversations`, `useSavedChat`, `useQuestion` hooks — switched to functional `setState` form
- Removed dead `availableModels` state from `useModel`
- Extracted `hasFinderPermission` to shared util to remove duplication between `api/apfel` and `api/auge`
- Renamed `not-found.tsx` → `apfel-not-found.tsx`
- Replaced `cpus()[0].model` check (crash risk in sandboxed env) with `process.arch === "arm64"`

## Screencast

https://github.com/user-attachments/assets/484ffca2-44f7-4a99-bbed-f6ff7629c6c7

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
