### PR TITLE
Add VC Deal Flow Signal MCP server to model-context-protocol-registry

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add VC Deal Flow Signal MCP Server] - 2026-05-27
+## [Add VC Deal Flow Signal MCP Server] - {PR_MERGE_DATE}
 
 Add community VC Deal Flow Signal MCP Server to registry for GitHub-derived engineering acceleration signals across ~400 venture-backed startups in 20 sectors (read-only, no API key).
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Add VC Deal Flow Signal MCP Server] - 2026-05-27
+
+Add community VC Deal Flow Signal MCP Server to registry for GitHub-derived engineering acceleration signals across ~400 venture-backed startups in 20 sectors (read-only, no API key).
+
 ## [Add Alai MCP Server] - 2026-04-30
 
 Add community Alai MCP Server to registry for AI-powered presentation generation (text-to-slides, exports to PDF, PPTX, or shareable link).

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add VC Deal Flow Signal MCP Server] - {PR_MERGE_DATE}
+## [Add VC Deal Flow Signal MCP Server] - 2026-06-03
 
 Add community VC Deal Flow Signal MCP Server to registry for GitHub-derived engineering acceleration signals across ~400 venture-backed startups in 20 sectors (read-only, no API key).
 

--- a/extensions/model-context-protocol-registry/README.md
+++ b/extensions/model-context-protocol-registry/README.md
@@ -93,6 +93,7 @@ To add a new MCP registry to the registry, you need to create a new entry in the
 | [Lightdash](https://github.com/syucream/lightdash-mcp-server) | This server provides MCP-compatible access to Lightdash's API, allowing AI assistants to interact with your Lightdash data through a standardized interface. |
 | [Monday](https://github.com/sakce/mcp-server-monday) | MCP Server for monday.com, enabling MCP clients to interact with Monday.com boards, items, updates, and documents. |
 | [Paperless-NGX](https://github.com/baruchiro/paperless-mcp) | An MCP server for interacting with a Paperless-NGX API server. Manage documents, tags, correspondents, and document types in your Paperless-NGX instance. |
+| [VC Deal Flow Signal](https://github.com/kindrat86/vc-deal-flow-signal) | GitHub-derived engineering acceleration signals for ~400 venture-backed startups across 20 sectors. Five read-only tools for VC sourcing — trending startups, sector lookup, individual signal, dataset summary, methodology. No API key required. |
 
 
 <!-- MCP_SERVERS_END -->

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -906,4 +906,16 @@ export const COMMUNITY_ENTRIES: RegistryEntry[] = [
       },
     },
   },
+  {
+    name: "vc-deal-flow-signal",
+    title: "VC Deal Flow Signal",
+    description:
+      "GitHub-derived engineering acceleration signals for ~400 venture-backed startups across 20 sectors. Five read-only tools for VC sourcing — trending startups, sector lookup, individual signal, dataset summary, methodology. No API key required.",
+    icon: "https://signals.gitdealflow.com/icon.png",
+    homepage: "https://github.com/kindrat86/vc-deal-flow-signal",
+    configuration: {
+      command: "npx",
+      args: ["-y", "@gitdealflow/mcp-signal"],
+    },
+  },
 ];

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -915,7 +915,7 @@ export const COMMUNITY_ENTRIES: RegistryEntry[] = [
     homepage: "https://github.com/kindrat86/vc-deal-flow-signal",
     configuration: {
       command: "npx",
-      args: ["-y", "@gitdealflow/mcp-signal"],
+      args: ["-y", "@gitdealflow/mcp-signal@latest"],
     },
   },
 ];


### PR DESCRIPTION
## Description

Adds **VC Deal Flow Signal** to the model-context-protocol-registry as a community MCP server entry.

GitHub-derived engineering acceleration signals for ~400 venture-backed startups across 20 sectors. Five read-only tools, no API key required.

## What was changed

- `src/registries/builtin/entries.ts` — append to `COMMUNITY_ENTRIES` (+12)
- `CHANGELOG.md` — add `[Add VC Deal Flow Signal MCP Server] - 2026-05-27` (+4)
- `README.md` — add `VC Deal Flow Signal` row to the Community MCP Servers table (+1)

Total: +17, -0. Same shape as recently merged community entries (#27264 Alai, #26106 Sanity, #25960 RouteMesh).

## Tools (5)

| Tool | Returns |
|---|---|
| `get_trending_startups` | Top 20 startups across all sectors by commit-velocity acceleration |
| `search_startups_by_sector` | All tracked startups in one of 20 sectors |
| `get_startup_signal` | Full signal profile for one startup |
| `get_signals_summary` | Dataset snapshot + citation |
| `get_methodology` | How signals are computed |

All read-only, idempotent, no auth. Data sourced live from the public API at signals.gitdealflow.com.

## Verification

- **npm**: [`@gitdealflow/mcp-signal`](https://www.npmjs.com/package/@gitdealflow/mcp-signal) v1.6.0 — 884 downloads last 30 days
- **MCP Registry**: `io.github.kindrat86/vc-deal-flow-signal`
- **Smithery**: [Verified, 98/100](https://smithery.ai/server/kindrat86/vc-deal-flow-signal)
- **Glama**: [A-tier](https://glama.ai/mcp/servers/kindrat86/mcp-deal-flow-signal) (security A, license A)
- **awesome-mcp-servers**: [merged](https://github.com/punkpeye/awesome-mcp-servers/pull/4933) to Finance & Fintech section
- **HuggingFace dataset**: [84-term controlled vocabulary](https://huggingface.co/datasets/the-data-nerd/vc-deal-flow-signal-glossary), CC-BY-4.0 NDJSON
- **License**: MIT

## Context

This supersedes the closed #27618. That PR was converted to draft after CHANGES_REQUESTED ("update README and CHANGELOG before we can merge"), and auto-stale'd before being marked Ready for Review. This new PR addresses both:

- README.md updated (single row in the Community MCP Servers table after Paperless-NGX)
- CHANGELOG.md updated (new section at top, matching the pattern of all recent merged PRs)

Also corrected the description text — the previous version mentioned six tools; the actual server exposes five (no fictional "scout receipts" tool). Marking this PR Ready for Review immediately.

cc @pernielsentikaer @thomaspaulmann @nagauta — happy to address any further feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)