### PR TITLE
feat(skills): add Default Agents preference

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Default Agents Preference] - {PR_MERGE_DATE}
+## [Default Agents Preference] - 2026-06-01
 
 - Add a "Default Agents" preference to pre-select agents when installing a skill, so frequently-used agents (e.g. Claude Code) are checked automatically without manual selection each time
 

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Skills Changelog
 
+## [Default Agents Preference] - {PR_MERGE_DATE}
+
+- Add a "Default Agents" preference to pre-select agents when installing a skill, so frequently-used agents (e.g. Claude Code) are checked automatically without manual selection each time
+
 ## [Show Installed Skill Audit Details] - 2026-05-20
 
 - Add an "Open on skills.sh" action and `skills.sh` detail link for published installed skills

--- a/extensions/skills/package.json
+++ b/extensions/skills/package.json
@@ -12,7 +12,8 @@
     "elwin_liu",
     "pernielsentikaer",
     "kayo_timoteo",
-    "alexi.build"
+    "alexi.build",
+    "alastair_scheuermann"
   ],
   "platforms": [
     "macOS",
@@ -87,6 +88,14 @@
       "label": "Opt out of Skills CLI telemetry",
       "description": "Opt out of anonymous usage data collected by the underlying Skills CLI for commands run through this extension. The extension itself does not collect telemetry data.",
       "type": "checkbox",
+      "required": false
+    },
+    {
+      "name": "defaultAgents",
+      "title": "Default Agents",
+      "description": "Agents pre-selected when installing a skill. Enter comma-separated display names exactly as shown in the agent picker, e.g. \"Claude Code, Windsurf\". Leave empty to start with no agents pre-selected.",
+      "placeholder": "e.g., Claude Code, Windsurf",
+      "type": "textfield",
       "required": false
     }
   ],

--- a/extensions/skills/src/components/actions/InstallSkillAction.tsx
+++ b/extensions/skills/src/components/actions/InstallSkillAction.tsx
@@ -176,7 +176,7 @@ function AgentPickerInstallForm({
   const selectableAgents = agents.filter((a) => !installedAgents.has(a));
   const defaultAgentNames = getDefaultAgents();
   const [selected, setSelected] = useState<Set<string>>(
-    new Set(selectableAgents.filter((a) => defaultAgentNames.includes(a))),
+    new Set(selectableAgents.filter((a) => defaultAgentNames.some((d) => d.toLowerCase() === a.toLowerCase()))),
   );
   const allSelected = selectableAgents.length > 0 && selected.size === selectableAgents.length;
   const isReplacing = installedMatch.type === "conflict";

--- a/extensions/skills/src/components/actions/InstallSkillAction.tsx
+++ b/extensions/skills/src/components/actions/InstallSkillAction.tsx
@@ -174,10 +174,10 @@ function AgentPickerInstallForm({
   const installedAgents = new Set<string>(installedAgentNames);
   const replacementAgentNames = installedMatch.type === "conflict" ? installedAgentNames : [];
   const selectableAgents = agents.filter((a) => !installedAgents.has(a));
-  const defaultAgentNames = getDefaultAgents();
-  const [selected, setSelected] = useState<Set<string>>(
-    new Set(selectableAgents.filter((a) => defaultAgentNames.some((d) => d.toLowerCase() === a.toLowerCase()))),
-  );
+  const [selected, setSelected] = useState<Set<string>>(() => {
+    const defaultAgentNames = getDefaultAgents().map((d) => d.toLowerCase());
+    return new Set(selectableAgents.filter((a) => defaultAgentNames.includes(a.toLowerCase())));
+  });
   const allSelected = selectableAgents.length > 0 && selected.size === selectableAgents.length;
   const isReplacing = installedMatch.type === "conflict";
   const installedSource = isReplacing ? (installedMatch.source ?? "Unknown source") : "";

--- a/extensions/skills/src/components/actions/InstallSkillAction.tsx
+++ b/extensions/skills/src/components/actions/InstallSkillAction.tsx
@@ -18,6 +18,7 @@ import { type InstalledSkillMatch } from "../../hooks/useInstalledSkillMatches";
 import { type SkillAuditsResult, fetchSkillAudits } from "../../utils/skill-audits";
 import { installSkill } from "../../utils/skills-cli";
 import { withSkillAction } from "../../utils/with-skill-action";
+import { getDefaultAgents } from "../../preferences";
 
 interface InstallSkillActionProps {
   skill: Skill;
@@ -173,7 +174,10 @@ function AgentPickerInstallForm({
   const installedAgents = new Set<string>(installedAgentNames);
   const replacementAgentNames = installedMatch.type === "conflict" ? installedAgentNames : [];
   const selectableAgents = agents.filter((a) => !installedAgents.has(a));
-  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const defaultAgentNames = getDefaultAgents();
+  const [selected, setSelected] = useState<Set<string>>(
+    new Set(selectableAgents.filter((a) => defaultAgentNames.includes(a))),
+  );
   const allSelected = selectableAgents.length > 0 && selected.size === selectableAgents.length;
   const isReplacing = installedMatch.type === "conflict";
   const installedSource = isReplacing ? (installedMatch.source ?? "Unknown source") : "";

--- a/extensions/skills/src/preferences.ts
+++ b/extensions/skills/src/preferences.ts
@@ -25,3 +25,12 @@ export const getGithubToken = (): string | undefined => {
 };
 
 export const shouldDisableSkillsCliTelemetry = (): boolean => preferences.disableSkillsCliTelemetry === true;
+
+export const getDefaultAgents = (): string[] => {
+  const raw = preferences.defaultAgents?.trim();
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+};


### PR DESCRIPTION
## Description

Adds a "Default Agents" preference to the Skills extension where users can enter comma-separated agent display names (e.g. `Claude Code`) that will be automatically pre-checked in the install picker, so users don't have to manually select the same agents each time they install a skill.

Closes #28377

## Screencast

<img width="862" height="587" alt="image" src="https://github.com/user-attachments/assets/bfa508c6-bddd-424c-b0b5-187ad77f43da" />

<img width="912" height="898" alt="image" src="https://github.com/user-attachments/assets/802dfd3e-1874-4ab2-b8e7-374006344e77" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

The extension still successfully installs skills