### PR TITLE
Update unsplash extension

### DIFF
--- a/extensions/unsplash/.gitignore
+++ b/extensions/unsplash/.gitignore
@@ -6,3 +6,6 @@ raycast-env.d.ts
 compiled_raycast_swift
 
 node_modules
+.claude
+.remember
+docs

--- a/extensions/unsplash/.gitignore
+++ b/extensions/unsplash/.gitignore
@@ -1,4 +1,5 @@
 
+.DS_Store
 raycast-env.d.ts
 
 .raycast-swift-build

--- a/extensions/unsplash/CHANGELOG.md
+++ b/extensions/unsplash/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unsplash Changelog
 
-## [Modernize & OAuth Setup Guide] - {PR_MERGE_DATE}
+## [Modernize & OAuth Setup Guide] - 2026-05-28
 
 - Added OAuth setup guide shown before login — displays the required redirect URI and a Connect button so users can set up their Unsplash app without confusion
 - Fixed crashes caused by unhandled OAuth errors (`TypeError: Cannot read properties of null (reading 'useState')`)

--- a/extensions/unsplash/CHANGELOG.md
+++ b/extensions/unsplash/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Unsplash Changelog
 
+## [Modernize & OAuth Setup Guide] - {PR_MERGE_DATE}
+
+- Added OAuth setup guide shown before login — displays the required redirect URI and a Connect button so users can set up their Unsplash app without confusion
+- Fixed crashes caused by unhandled OAuth errors (`TypeError: Cannot read properties of null (reading 'useState')`)
+- Migrated deprecated `Grid.itemSize` / `Grid.ItemSize` to `columns` prop
+- Exported all types, merged `LikesResult` into `SearchResult`, extended `User` with optional fields
+- Extracted shared `OrientationDropdown` component used by Search Images and Search Collections
+- Simplified `useSearch` hook — removed intermediate `performSearch` abstraction
+- Moved module-level `getPreferenceValues` calls inside functions to avoid side effects on import
+- Removed `React.FC` annotations and noisy section comments throughout
+- Fixed missing `await` on `LocalStorage.setItem` in likes hook
+
 ## [Keyboard Shortcut Updates] - 2026-05-12
 
 - Added Raycast common keyboard shortcuts

--- a/extensions/unsplash/package-lock.json
+++ b/extensions/unsplash/package-lock.json
@@ -7,16 +7,16 @@
       "name": "unsplash",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.16",
-        "@raycast/utils": "^2.2.4"
+        "@raycast/api": "^1.104.18",
+        "@raycast/utils": "^2.2.5"
       },
       "devDependencies": {
-        "@raycast/eslint-config": "^2.0.4",
-        "@types/node": "^22.13.10",
-        "@types/react": "^19.0.10",
-        "eslint": "^9.22.0",
-        "prettier": "^3.5.3",
-        "typescript": "^5.8.2"
+        "@raycast/eslint-config": "^2.1.1",
+        "@types/node": "^25.9.1",
+        "@types/react": "^19.2.15",
+        "eslint": "^10.4.0",
+        "prettier": "^3.8.3",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -436,9 +436,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.8.0.tgz",
-      "integrity": "sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -455,9 +455,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -465,132 +465,50 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
-      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
-      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -601,49 +519,63 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.2",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1024,48 +956,10 @@
         }
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@oclif/core": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.2.tgz",
-      "integrity": "sha512-LWDalCgy+hYyAkLa9sMIXMXk6ws5RzQhVnkmfXtVIIyEEYigbXQ/9/x+s76p53MiXxNc6SJB7lfwkPF+SdzfMQ==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.4.tgz",
+      "integrity": "sha512-URwiQ5ALx/sJ2iH4vzXEd+H4K6NAI7LRs6Jag3hrgKEpGmaE6alfRC8qjO4GIgb6A3ACaJumqP9twi/M9ywdHQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -1079,10 +973,10 @@
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
         "minimatch": "^10.2.5",
-        "semver": "^7.8.0",
+        "semver": "^7.8.1",
         "string-width": "^4.2.3",
         "supports-color": "^8",
-        "tinyglobby": "^0.2.14",
+        "tinyglobby": "^0.2.16",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -1091,46 +985,10 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@oclif/plugin-autocomplete": {
-      "version": "3.2.48",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.48.tgz",
-      "integrity": "sha512-FQYAEsMvSwK3gKESXdP+29bDeiXfTRhBAH1gWBP5qfApTvrELviW+mD0DQYRDYd69S7hG0fQa6JliUww93cbZA==",
+      "version": "3.2.50",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.50.tgz",
+      "integrity": "sha512-SQRIJSYue/1tIn7X55W/97gTb8UkSoHeFAcBng2r2YMJyWj8uB1DtFl28D8BDXPQXPTiPK89hQGejoT7RdkR2w==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
@@ -1143,9 +1001,9 @@
       }
     },
     "node_modules/@oclif/plugin-help": {
-      "version": "6.2.48",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.48.tgz",
-      "integrity": "sha512-nvGLBtUZUWrHfoAEDRsRZUHKVwptyZ6F+MErdVRLQBo3dja0GCZH8DE33dA7mBux2KOmbxGqop15gyud9HZYhQ==",
+      "version": "6.2.49",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.49.tgz",
+      "integrity": "sha512-fEsO0YU7ThtzHE1RGuoHxFu/OGlqxm7PCfFp+U1PS8sde4E0cDqjVDuv78+VKrr45LpC5lWOApj7pm3FNfHrVA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4"
@@ -1155,13 +1013,13 @@
       }
     },
     "node_modules/@oclif/plugin-not-found": {
-      "version": "3.2.84",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.84.tgz",
-      "integrity": "sha512-oFbkYceJeV0yCoowVnMBZK8GvJPthCVsQ0vRYWbKKIUyFja5ep6+EJrvL5m4hCVtddK5URGcWYspj1eYw9Ibww==",
+      "version": "3.2.86",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.86.tgz",
+      "integrity": "sha512-BJhJSahwsYayZpo18f0fPTg8tKb9dIvydaz03NCK3eMfmcsT1MmXhXqh1KEV8J7mz0sQ6f0qFEb6BXy490/iUg==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",
-        "@oclif/core": "^4.11.0",
+        "@oclif/core": "^4.11.3",
         "ansis": "^3.17.0",
         "fast-levenshtein": "^3.0.0"
       },
@@ -1170,9 +1028,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.16",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.16.tgz",
-      "integrity": "sha512-PFUDslQgRGDhoTVJUDvJylezew6medQ2oZBfOk9HMdB7RfyhyQxZSnqihrRPCMin5FCg30W+M6oTOCwdwbRHRA==",
+      "version": "1.104.18",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.18.tgz",
+      "integrity": "sha512-Effu0wSTRwtW7VNjyrDtFNxMQ4BbtRFCIY00PbY4qa3yFPOE/CfbcZJbesyo3nYyuenedqeia/+PvLcieBUO4w==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
@@ -1207,6 +1065,15 @@
         }
       }
     },
+    "node_modules/@raycast/api/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@raycast/api/node_modules/@types/react": {
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
@@ -1216,18 +1083,24 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@raycast/api/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
     "node_modules/@raycast/eslint-config": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.0.4.tgz",
-      "integrity": "sha512-Sz5Q0HVY8pW21Sv7CDcJw882OGubSM3zx5uiDRQMkgt7Hui3I+IZOqxDInnhLsGG52prSdU7sg3R097hMJkkQw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.1.1.tgz",
+      "integrity": "sha512-W0kxF+FJ+BYQn0EKIV739j2ZrHEtjo/LclsoZgUWg3t364Dq75XKcjqYFYx+59/DBaamY0amdajlfuDAf6veAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint/js": "^9.22.0",
-        "@raycast/eslint-plugin": "^2.0.4",
-        "eslint-config-prettier": "^10.1.1",
-        "globals": "^16.0.0",
-        "typescript-eslint": "^8.26.1"
+        "@eslint/js": "^9.36.0",
+        "@raycast/eslint-plugin": "^2.1.1",
+        "eslint-config-prettier": "^10.1.8",
+        "globals": "^16.4.0",
+        "typescript-eslint": "^8.45.0"
       },
       "peerDependencies": {
         "eslint": ">=8.23.0",
@@ -1236,9 +1109,9 @@
       }
     },
     "node_modules/@raycast/eslint-plugin": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-2.0.7.tgz",
-      "integrity": "sha512-4dAdua+TFQu7ay3EuDmg5nT7boIAj3Rjf0V1aQ3w5uAx/j98DvI91h/zbbkVb4mIXCom1w7SfRrZQzYIOE+tZw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-2.1.1.tgz",
+      "integrity": "sha512-r2gs8uIlNp6I2mLOyN/kReGlvigzEeuyQPl4yw7nwLy8Zxjfjhg8txMViaBux8juBWBxbSWq/IfW6ZA50oeOHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1249,9 +1122,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.4.tgz",
-      "integrity": "sha512-XkxW5bUZACxl2zP4M6Qtkj9a1nbOKcRBm96BLkJ6O4Q7L/vFSnc+3pPJ/i0ZLVOExx5LJMJY0jnNPo91xqJnFQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.5.tgz",
+      "integrity": "sha512-1o6zGRECh1KNe6CBx68iMPOrNYbV56opqs4zUtDr6Wmq4F7Ww3d8uLTXKVzXlGyJmpAys/Eliw6cKIP7dPdFfw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1266,10 +1139,17 @@
         }
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1281,40 +1161,40 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.1.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
-      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.42.0.tgz",
-      "integrity": "sha512-Aq2dPqsQkxHOLfb2OPv43RnIvfj05nw8v/6n3B2NABIPpHnjQnaLo9QGMTvml+tv4korl/Cjfrb/BYhoL8UUTQ==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
+      "integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.42.0",
-        "@typescript-eslint/type-utils": "8.42.0",
-        "@typescript-eslint/utils": "8.42.0",
-        "@typescript-eslint/visitor-keys": "8.42.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/type-utils": "8.60.0",
+        "@typescript-eslint/utils": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1324,9 +1204,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.42.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.60.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -1340,17 +1220,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.42.0.tgz",
-      "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
+      "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.42.0",
-        "@typescript-eslint/types": "8.42.0",
-        "@typescript-eslint/typescript-estree": "8.42.0",
-        "@typescript-eslint/visitor-keys": "8.42.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1360,20 +1240,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.42.0.tgz",
-      "integrity": "sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
+      "integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.42.0",
-        "@typescript-eslint/types": "^8.42.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.60.0",
+        "@typescript-eslint/types": "^8.60.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1383,18 +1263,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.42.0.tgz",
-      "integrity": "sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
+      "integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.42.0",
-        "@typescript-eslint/visitor-keys": "8.42.0"
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1405,9 +1285,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.42.0.tgz",
-      "integrity": "sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
+      "integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1418,21 +1298,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.42.0.tgz",
-      "integrity": "sha512-9KChw92sbPTYVFw3JLRH1ockhyR3zqqn9lQXol3/YbI6jVxzWoGcT3AsAW0mu1MY0gYtsXnUGV/AKpkAj5tVlQ==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
+      "integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.42.0",
-        "@typescript-eslint/typescript-estree": "8.42.0",
-        "@typescript-eslint/utils": "8.42.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0",
+        "@typescript-eslint/utils": "8.60.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1442,14 +1322,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.42.0.tgz",
-      "integrity": "sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
+      "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1461,22 +1341,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.42.0.tgz",
-      "integrity": "sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
+      "integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.42.0",
-        "@typescript-eslint/tsconfig-utils": "8.42.0",
-        "@typescript-eslint/types": "8.42.0",
-        "@typescript-eslint/visitor-keys": "8.42.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.60.0",
+        "@typescript-eslint/tsconfig-utils": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1486,20 +1365,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.42.0.tgz",
-      "integrity": "sha512-JnIzu7H3RH5BrKC4NoZqRfmjqCIS1u3hGZltDYJgkVdqAezl4L9d1ZLw+36huCujtSBSAirGINF/S4UxOcR+/g==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
+      "integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.42.0",
-        "@typescript-eslint/types": "8.42.0",
-        "@typescript-eslint/typescript-estree": "8.42.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1509,19 +1388,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.42.0.tgz",
-      "integrity": "sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
+      "integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.42.0",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.60.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1532,22 +1411,22 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1568,9 +1447,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1632,13 +1511,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -1646,71 +1518,24 @@
       "license": "MIT"
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/chardet": {
@@ -1773,13 +1598,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1796,9 +1614,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1909,34 +1727,30 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
-      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.3.1",
-        "@eslint/core": "^0.15.2",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.35.0",
-        "@eslint/plugin-kit": "^0.3.5",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
+        "ajv": "^6.14.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -1946,8 +1760,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -1955,7 +1768,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -1986,17 +1799,19 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2015,78 +1830,54 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2136,36 +1927,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2191,14 +1952,21 @@
         "node": ">= 4.9.1"
       }
     },
-    "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -2223,6 +1991,21 @@
         "minimatch": "^5.0.1"
       }
     },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -2233,19 +2016,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -2309,9 +2079,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
-      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2320,13 +2090,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2361,23 +2124,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -2446,16 +2192,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -2490,19 +2226,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-buffer": {
@@ -2578,48 +2301,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2704,19 +2395,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2744,13 +2422,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -2767,9 +2444,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2792,27 +2469,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/react": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
@@ -2822,51 +2478,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2874,9 +2485,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2946,19 +2557,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -2990,52 +2588,10 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3071,9 +2627,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3085,16 +2641,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.42.0.tgz",
-      "integrity": "sha512-ozR/rQn+aQXQxh1YgbCzQWDFrsi9mcg+1PM3l/z5o1+20P7suOIaNg515bpr/OYt6FObz/NHcBstydDLHWeEKg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.0.tgz",
+      "integrity": "sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.42.0",
-        "@typescript-eslint/parser": "8.42.0",
-        "@typescript-eslint/typescript-estree": "8.42.0",
-        "@typescript-eslint/utils": "8.42.0"
+        "@typescript-eslint/eslint-plugin": "8.60.0",
+        "@typescript-eslint/parser": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0",
+        "@typescript-eslint/utils": "8.60.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3104,14 +2660,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {

--- a/extensions/unsplash/package.json
+++ b/extensions/unsplash/package.json
@@ -54,16 +54,14 @@
       "title": "Access Key",
       "description": "Get your API key from https://unsplash.com/oauth/applications",
       "type": "password",
-      "required": true,
-      "placeholder": "XXX...XX"
+      "required": true
     },
     {
       "name": "secretKey",
       "title": "Secret Key",
       "description": "Get your secret key from https://unsplash.com/oauth/applications",
       "type": "password",
-      "required": true,
-      "placeholder": "XXX...XX"
+      "required": true
     },
     {
       "name": "gridItemSize",
@@ -169,23 +167,23 @@
           "value": "none"
         },
         {
-          "title": "10 minute",
+          "title": "10 minutes",
           "value": "10 minute"
         },
         {
-          "title": "20 minute",
+          "title": "20 minutes",
           "value": "20 minute"
         },
         {
-          "title": "30 minute",
+          "title": "30 minutes",
           "value": "30 minute"
         },
         {
-          "title": "40 minute",
+          "title": "40 minutes",
           "value": "40 minute"
         },
         {
-          "title": "50 minute",
+          "title": "50 minutes",
           "value": "50 minute"
         },
         {
@@ -193,91 +191,91 @@
           "value": "1 hour"
         },
         {
-          "title": "2 hour",
+          "title": "2 hours",
           "value": "2 hour"
         },
         {
-          "title": "3 hour",
+          "title": "3 hours",
           "value": "3 hour"
         },
         {
-          "title": "4 hour",
+          "title": "4 hours",
           "value": "4 hour"
         },
         {
-          "title": "5 hour",
+          "title": "5 hours",
           "value": "5 hour"
         },
         {
-          "title": "6 hour",
+          "title": "6 hours",
           "value": "6 hour"
         },
         {
-          "title": "7 hour",
+          "title": "7 hours",
           "value": "7 hour"
         },
         {
-          "title": "8 hour",
+          "title": "8 hours",
           "value": "8 hour"
         },
         {
-          "title": "9 hour",
+          "title": "9 hours",
           "value": "9 hour"
         },
         {
-          "title": "10 hour",
+          "title": "10 hours",
           "value": "10 hour"
         },
         {
-          "title": "11 hour",
+          "title": "11 hours",
           "value": "11 hour"
         },
         {
-          "title": "12 hour",
+          "title": "12 hours",
           "value": "12 hour"
         },
         {
-          "title": "13 hour",
+          "title": "13 hours",
           "value": "13 hour"
         },
         {
-          "title": "14 hour",
+          "title": "14 hours",
           "value": "14 hour"
         },
         {
-          "title": "15 hour",
+          "title": "15 hours",
           "value": "15 hour"
         },
         {
-          "title": "16 hour",
+          "title": "16 hours",
           "value": "16 hour"
         },
         {
-          "title": "17 hour",
+          "title": "17 hours",
           "value": "17 hour"
         },
         {
-          "title": "18 hour",
+          "title": "18 hours",
           "value": "18 hour"
         },
         {
-          "title": "19 hour",
+          "title": "19 hours",
           "value": "19 hour"
         },
         {
-          "title": "20 hour",
+          "title": "20 hours",
           "value": "20 hour"
         },
         {
-          "title": "21 hour",
+          "title": "21 hours",
           "value": "21 hour"
         },
         {
-          "title": "22 hour",
+          "title": "22 hours",
           "value": "22 hour"
         },
         {
-          "title": "23 hour",
+          "title": "23 hours",
           "value": "23 hour"
         },
         {
@@ -285,54 +283,53 @@
           "value": "1 day"
         },
         {
-          "title": "2 day",
+          "title": "2 days",
           "value": "2 day"
         },
         {
-          "title": "3 day",
+          "title": "3 days",
           "value": "3 day"
         },
         {
-          "title": "4 day",
+          "title": "4 days",
           "value": "4 day"
         },
         {
-          "title": "5 day",
+          "title": "5 days",
           "value": "5 day"
         },
         {
-          "title": "6 day",
+          "title": "6 days",
           "value": "6 day"
         },
         {
-          "title": "7 day",
+          "title": "7 days",
           "value": "7 day"
         },
         {
-          "title": "14 day",
+          "title": "14 days",
           "value": "14 day"
         }
       ]
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.104.16",
-    "@raycast/utils": "^2.2.4"
+    "@raycast/api": "^1.104.18",
+    "@raycast/utils": "^2.2.5"
   },
   "devDependencies": {
-    "@raycast/eslint-config": "^2.0.4",
-    "@types/node": "^22.13.10",
-    "@types/react": "^19.0.10",
-    "eslint": "^9.22.0",
-    "prettier": "^3.5.3",
-    "typescript": "^5.8.2"
+    "@raycast/eslint-config": "^2.1.1",
+    "@types/node": "^25.9.1",
+    "@types/react": "^19.2.15",
+    "eslint": "^10.4.0",
+    "prettier": "^3.8.3",
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "build": "ray build",
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
   },
   "platforms": [

--- a/extensions/unsplash/src/collections.tsx
+++ b/extensions/unsplash/src/collections.tsx
@@ -1,73 +1,55 @@
 import { useState } from "react";
 import { Grid } from "@raycast/api";
-import { getGridItemSize, showImageTitle, toTitleCase } from "@/functions/utils";
-
-// Hooks
+import { getGridColumns, showImageTitle, toTitleCase } from "@/functions/utils";
 import { useSearch } from "@/hooks/useSearch";
-
-// Components
+import { useSetupAuth } from "@/hooks/useSetupAuth";
 import Actions from "@/components/ActionsCollection";
-
-// Types
+import OrientationDropdown from "@/components/OrientationDropdown";
+import OAuthSetupGuide from "@/components/OAuthSetupGuide";
 import { CollectionResult, Orientation } from "@/types";
-interface CollectionListItemProps {
-  searchResult: CollectionResult;
+
+export default function UnsplashCollections() {
+  const auth = useSetupAuth();
+
+  if (auth.status === "loading") return <Grid isLoading />;
+  if (auth.status === "needs-setup")
+    return <OAuthSetupGuide onConnect={auth.connect} connectError={auth.connectError} />;
+
+  return <CollectionGrid />;
 }
 
-const UnsplashCollections: React.FC = () => {
+function CollectionGrid() {
   const [orientation, setOrientation] = useState<Orientation>("landscape");
   const [search, setSearch] = useState("");
   const { state } = useSearch(search, "collections", orientation);
-  const itemSize = getGridItemSize();
-
-  const handleOrientationChange = (value: string) => {
-    setOrientation(value as Orientation);
-  };
 
   return (
     <Grid
       isLoading={state.isLoading}
-      itemSize={itemSize}
+      columns={getGridColumns()}
       onSearchTextChange={setSearch}
       searchBarPlaceholder="Search collections..."
-      searchBarAccessory={
-        <Grid.Dropdown
-          tooltip="Orientation"
-          storeValue={true}
-          defaultValue={orientation}
-          onChange={handleOrientationChange}
-        >
-          <Grid.Dropdown.Section title="Orientation">
-            <Grid.Dropdown.Item title="All" value="all" />
-            <Grid.Dropdown.Item title="Landscape" value="landscape" />
-            <Grid.Dropdown.Item title="Portrait" value="portrait" />
-            <Grid.Dropdown.Item title="Squarish" value="squarish" />
-          </Grid.Dropdown.Section>
-        </Grid.Dropdown>
-      }
+      searchBarAccessory={<OrientationDropdown onChange={setOrientation} />}
       throttle
       pagination={state.pagination}
     >
-      <Grid.Section title="Results" subtitle={String(state?.results?.length)}>
+      <Grid.Section title="Results" subtitle={String(state.results.length)}>
         {state.results.map((result) => (
-          <SearchListItem key={result.id} searchResult={result as unknown as CollectionResult} />
+          <CollectionGridItem key={result.id} result={result} />
         ))}
       </Grid.Section>
     </Grid>
   );
-};
+}
 
-const SearchListItem: React.FC<CollectionListItemProps> = ({ searchResult }) => {
-  const [title, image] = [
-    searchResult.title || searchResult.description,
-    searchResult.cover_photo?.urls?.thumb ||
-      searchResult.cover_photo?.urls?.small ||
-      searchResult.cover_photo?.urls?.regular,
-  ];
-
-  const gridItemTitle = showImageTitle() ? toTitleCase(title) : "";
-
-  return <Grid.Item content={image} title={gridItemTitle} actions={<Actions item={searchResult} details />} />;
-};
-
-export default UnsplashCollections;
+function CollectionGridItem({ result }: { result: CollectionResult }) {
+  const title = result.title || result.description;
+  const image = result.cover_photo?.urls?.thumb || result.cover_photo?.urls?.small || result.cover_photo?.urls?.regular;
+  return (
+    <Grid.Item
+      content={image}
+      title={showImageTitle() ? toTitleCase(title) : ""}
+      actions={<Actions item={result} details />}
+    />
+  );
+}

--- a/extensions/unsplash/src/collections.tsx
+++ b/extensions/unsplash/src/collections.tsx
@@ -43,7 +43,7 @@ function CollectionGrid() {
 }
 
 function CollectionGridItem({ result }: { result: CollectionResult }) {
-  const title = result.title || result.description;
+  const title = result.title || result.description || "No Name";
   const image = result.cover_photo?.urls?.thumb || result.cover_photo?.urls?.small || result.cover_photo?.urls?.regular;
   return (
     <Grid.Item

--- a/extensions/unsplash/src/components/Actions.tsx
+++ b/extensions/unsplash/src/components/Actions.tsx
@@ -1,52 +1,55 @@
-import { ActionPanel, Icon, Keyboard, getPreferenceValues, Action } from "@raycast/api";
-import { likeOrDislike } from "@/functions/utils";
+import { ActionPanel, Icon, Keyboard, getPreferenceValues, Action, showToast, Toast } from "@raycast/api";
+import { apiRequest } from "@/functions/apiRequest";
 import { useState } from "react";
-
-// Functions
+import Details from "@/views/Details";
+import { copyFileToClipboard } from "@/functions/copyFileToClipboard";
 import { saveImage } from "@/functions/saveImage";
 import { setWallpaper } from "@/functions/setWallpaper";
-import { copyFileToClipboard } from "@/functions/copyFileToClipboard";
-
-// Components
-import Details from "@/views/Details";
 import { SearchResult } from "@/types";
 
-// Types
-interface BaseProps {
+interface Props {
   item: SearchResult;
   details?: boolean;
   unlike?: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-export const Actions = ({ details, item, unlike }: BaseProps) => (
-  <ActionPanel>
-    <Sections details={details} item={item} unlike={unlike} />
-  </ActionPanel>
-);
+async function likeOrDislike(id: number, liked: boolean) {
+  const toast = await showToast(Toast.Style.Animated, `${liked ? "Unliking" : "Liking"} photo...`);
+  try {
+    await apiRequest(`/photos/${id}/like`, { method: liked ? "DELETE" : "POST" });
+    toast.style = Toast.Style.Success;
+    toast.title = `Photo ${liked ? "unliked" : "liked"}!`;
+  } catch {
+    toast.style = Toast.Style.Failure;
+    toast.title = "An error occurred";
+  }
+}
 
-export const Sections = ({ details = false, item, unlike }: BaseProps) => {
+export function Actions({ details, item, unlike }: Props) {
+  return (
+    <ActionPanel>
+      <ActionsContent details={details} item={item} unlike={unlike} />
+    </ActionPanel>
+  );
+}
+
+function ActionsContent({ details = false, item, unlike }: Props) {
   const { downloadSize } = getPreferenceValues<Preferences>();
   const [liked, setLiked] = useState(item.liked_by_user);
 
-  const imageUrl = item.urls?.raw || item.urls?.full || item.urls?.regular || item.urls?.small;
+  const imageUrl = item.urls.raw || item.urls.full || item.urls.regular || item.urls.small;
+  const clipboardUrl = item.urls[downloadSize] || imageUrl;
 
   const handleLike = async () => {
     await likeOrDislike(item.id, liked);
-
-    if (liked && unlike) unlike((p) => [...p, String(item.id)]);
+    if (liked && unlike) unlike((prev) => [...prev, String(item.id)]);
     setLiked(!liked);
-  };
-
-  const clipboardCopyUrl = {
-    url: item.urls?.[downloadSize] || imageUrl,
-    id: `${item.id}-${downloadSize}`,
   };
 
   return (
     <>
       <ActionPanel.Section>
         {details && <Action.Push title="Show Details" icon={Icon.List} target={<Details result={item} />} />}
-
         <Action
           title={`${liked ? "Unlike" : "Like"} Photo`}
           icon={Icon.Heart}
@@ -54,11 +57,9 @@ export const Sections = ({ details = false, item, unlike }: BaseProps) => {
           shortcut={{ modifiers: ["cmd"], key: "l" }}
           onAction={handleLike}
         />
-
         {item.links?.html && (
           <Action.OpenInBrowser url={item.links.html} title="Open Original" shortcut={Keyboard.Shortcut.Common.Open} />
         )}
-
         {item.user?.links?.html && (
           <Action.OpenInBrowser
             url={item.user.links.html}
@@ -76,9 +77,8 @@ export const Sections = ({ details = false, item, unlike }: BaseProps) => {
               title="Copy to Clipboard"
               icon={Icon.Clipboard}
               shortcut={Keyboard.Shortcut.Common.Copy}
-              onAction={() => copyFileToClipboard(clipboardCopyUrl)}
+              onAction={() => copyFileToClipboard({ url: clipboardUrl, id: `${item.id}-${downloadSize}` })}
             />
-
             <Action
               title="Download Image"
               icon={Icon.Desktop}
@@ -94,7 +94,6 @@ export const Sections = ({ details = false, item, unlike }: BaseProps) => {
               shortcut={{ modifiers: ["cmd", "shift"], key: "w" }}
               onAction={() => setWallpaper({ url: imageUrl, id: String(item.id) })}
             />
-
             <Action
               title="Every Monitor"
               icon={Icon.Desktop}
@@ -114,7 +113,6 @@ export const Sections = ({ details = false, item, unlike }: BaseProps) => {
             shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
           />
         )}
-
         {imageUrl && (
           <Action.CopyToClipboard
             content={imageUrl}
@@ -123,7 +121,6 @@ export const Sections = ({ details = false, item, unlike }: BaseProps) => {
             shortcut={Keyboard.Shortcut.Common.CopyPath}
           />
         )}
-
         {item.user?.links?.html && (
           <Action.CopyToClipboard
             content={item.user.links.html}
@@ -135,6 +132,6 @@ export const Sections = ({ details = false, item, unlike }: BaseProps) => {
       </ActionPanel.Section>
     </>
   );
-};
+}
 
 export default Actions;

--- a/extensions/unsplash/src/components/ActionsCollection.tsx
+++ b/extensions/unsplash/src/components/ActionsCollection.tsx
@@ -1,23 +1,22 @@
 import { ActionPanel, Icon, Keyboard, Action } from "@raycast/api";
-
-// Components
 import Details from "@/views/DetailsCollections";
 import { CollectionResult } from "@/types";
 
-// Types
-interface BaseProps {
+interface Props {
   item: CollectionResult;
   details?: boolean;
 }
 
-export const Actions: React.FC<BaseProps> = ({ details = false, item }) => (
-  <ActionPanel>
-    <Sections details={details} item={item} />
-  </ActionPanel>
-);
+export function Actions({ details = false, item }: Props) {
+  return (
+    <ActionPanel>
+      <ActionsContent details={details} item={item} />
+    </ActionPanel>
+  );
+}
 
-export const Sections: React.FC<BaseProps> = ({ details = false, item }) => {
-  const imageUrl =
+function ActionsContent({ details = false, item }: Props) {
+  const coverUrl =
     item.cover_photo?.urls?.raw ||
     item.cover_photo?.urls?.full ||
     item.cover_photo?.urls?.regular ||
@@ -27,7 +26,6 @@ export const Sections: React.FC<BaseProps> = ({ details = false, item }) => {
     <>
       <ActionPanel.Section>
         {details && <Action.Push title="Show Details" icon={Icon.List} target={<Details result={item} />} />}
-
         {item.links?.html && (
           <Action.OpenInBrowser
             url={item.links.html}
@@ -35,7 +33,6 @@ export const Sections: React.FC<BaseProps> = ({ details = false, item }) => {
             shortcut={Keyboard.Shortcut.Common.Open}
           />
         )}
-
         {item.user?.links?.html && (
           <Action.OpenInBrowser
             url={item.user.links.html}
@@ -44,8 +41,7 @@ export const Sections: React.FC<BaseProps> = ({ details = false, item }) => {
             title="Open Author"
           />
         )}
-
-        {Boolean(item.id) && (
+        {item.id && (
           <Action.CopyToClipboard
             content={item.id}
             title="Copy Collection ID"
@@ -64,16 +60,14 @@ export const Sections: React.FC<BaseProps> = ({ details = false, item }) => {
             shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
           />
         )}
-
-        {imageUrl && (
+        {coverUrl && (
           <Action.CopyToClipboard
-            content={imageUrl}
+            content={coverUrl}
             title="Copy Cover URL"
             icon={Icon.Clipboard}
             shortcut={Keyboard.Shortcut.Common.CopyPath}
           />
         )}
-
         {item.user?.links?.html && (
           <Action.CopyToClipboard
             content={item.user.links.html}
@@ -85,6 +79,6 @@ export const Sections: React.FC<BaseProps> = ({ details = false, item }) => {
       </ActionPanel.Section>
     </>
   );
-};
+}
 
 export default Actions;

--- a/extensions/unsplash/src/components/OAuthSetupGuide.tsx
+++ b/extensions/unsplash/src/components/OAuthSetupGuide.tsx
@@ -1,0 +1,55 @@
+import { Action, ActionPanel, Detail, Icon } from "@raycast/api";
+
+interface Props {
+  onConnect: () => Promise<void>;
+  connectError?: string;
+}
+
+export function OAuthSetupGuide({ onConnect, connectError }: Props) {
+  const markdown = `
+# Connect to Unsplash
+
+${connectError ? `> ⚠️ ${connectError}\n` : ""}Before connecting, add the redirect URI to your Unsplash app — otherwise the login page will show an error.
+
+## Steps
+
+1. Open [Unsplash Developer Applications](https://unsplash.com/oauth/applications)
+2. Click your application → **Redirect URI & Permissions**
+3. Add this URI exactly:
+
+\`\`\`
+https://raycast.com/redirect
+\`\`\`
+
+4. Save, then press **Connect to Unsplash** below
+
+---
+
+**Also check**
+- Access Key and Secret Key in Raycast preferences match the app above
+`;
+
+  return (
+    <Detail
+      markdown={markdown}
+      navigationTitle="Connect to Unsplash"
+      actions={
+        <ActionPanel>
+          <Action title="Connect to Unsplash" icon={Icon.PersonCircle} onAction={onConnect} />
+          <Action.OpenInBrowser
+            title="Open Unsplash Applications"
+            url="https://unsplash.com/oauth/applications"
+            icon={Icon.Globe}
+          />
+          <Action.CopyToClipboard
+            title="Copy Redirect URI"
+            content="https://raycast.com/redirect"
+            icon={Icon.Clipboard}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+export default OAuthSetupGuide;

--- a/extensions/unsplash/src/components/OrientationDropdown.tsx
+++ b/extensions/unsplash/src/components/OrientationDropdown.tsx
@@ -1,0 +1,26 @@
+import { Grid } from "@raycast/api";
+import { Orientation } from "@/types";
+
+interface Props {
+  onChange: (value: Orientation) => void;
+}
+
+export function OrientationDropdown({ onChange }: Props) {
+  return (
+    <Grid.Dropdown
+      tooltip="Orientation"
+      storeValue
+      defaultValue="landscape"
+      onChange={(v) => onChange(v as Orientation)}
+    >
+      <Grid.Dropdown.Section title="Orientation">
+        <Grid.Dropdown.Item title="All" value="all" />
+        <Grid.Dropdown.Item title="Landscape" value="landscape" />
+        <Grid.Dropdown.Item title="Portrait" value="portrait" />
+        <Grid.Dropdown.Item title="Squarish" value="squarish" />
+      </Grid.Dropdown.Section>
+    </Grid.Dropdown>
+  );
+}
+
+export default OrientationDropdown;

--- a/extensions/unsplash/src/functions/apiRequest.ts
+++ b/extensions/unsplash/src/functions/apiRequest.ts
@@ -2,9 +2,7 @@ import { LocalStorage, OAuth, getPreferenceValues } from "@raycast/api";
 import { client, doAuth } from "@/oauth";
 import { Errors } from "@/types";
 
-const { accessKey } = getPreferenceValues<Preferences>();
-
-export const apiRequest = async <T>(path: string, options?: RequestInit) => {
+export const apiRequest = async <T>(path: string, options?: RequestInit): Promise<T> => {
   const tokens = await client.getTokens();
   let accessToken = tokens?.accessToken;
 
@@ -26,6 +24,7 @@ export const apiRequest = async <T>(path: string, options?: RequestInit) => {
       ...options?.headers,
     },
   });
+
   if (!response.headers.get("Content-Type")?.includes("json")) throw new Error(await response.text());
   const result = await response.json();
   if (!response.ok) throw new Error((result as Errors).errors[0]);
@@ -33,8 +32,8 @@ export const apiRequest = async <T>(path: string, options?: RequestInit) => {
 };
 
 async function refreshTokens(refreshToken: string) {
+  const { accessKey } = getPreferenceValues<Preferences>();
   const params = new URLSearchParams();
-
   params.append("client_id", accessKey.trim());
   params.append("refresh_token", refreshToken.trim());
   params.append("grant_type", "refresh_token");
@@ -47,6 +46,5 @@ async function refreshTokens(refreshToken: string) {
 
   const tokenResponse = (await response.json()) as OAuth.TokenResponse;
   tokenResponse.refresh_token = tokenResponse.refresh_token ?? refreshToken;
-
   return tokenResponse;
 }

--- a/extensions/unsplash/src/functions/utils.ts
+++ b/extensions/unsplash/src/functions/utils.ts
@@ -1,43 +1,27 @@
-import { Grid, getPreferenceValues, showToast, Toast } from "@raycast/api";
+import { getPreferenceValues, showToast, Toast } from "@raycast/api";
 import { join } from "path";
 import { homedir } from "os";
 import { apiRequest } from "@/functions/apiRequest";
 
-const preferences = getPreferenceValues<Preferences>();
-
-export const getGridItemSize = (): Grid.ItemSize => {
-  const { gridItemSize } = preferences;
-
-  if (gridItemSize == "small") return Grid.ItemSize.Small;
-  else if (gridItemSize == "large") return Grid.ItemSize.Large;
-  else return Grid.ItemSize.Medium;
+export const getGridColumns = (): number => {
+  const { gridItemSize } = getPreferenceValues<Preferences>();
+  if (gridItemSize === "small") return 8;
+  if (gridItemSize === "large") return 3;
+  return 5;
 };
 
-export const showImageTitle = (): boolean => {
-  return preferences.showImageTitle;
-};
+export const showImageTitle = (): boolean => getPreferenceValues<Preferences>().showImageTitle;
 
-export const toTitleCase = (str: string): string => {
-  return str.replace(/\w\S*/g, (text: string) => {
-    return text.charAt(0).toUpperCase() + text.substring(1).toLowerCase();
-  });
-};
+export const toTitleCase = (str: string): string =>
+  str.replace(/\w\S*/g, (text) => text.charAt(0).toUpperCase() + text.slice(1).toLowerCase());
 
-export const resolveHome = (filepath: string) => {
-  if (filepath[0] === "~") {
-    return join(homedir(), filepath.slice(1));
-  }
-  return filepath;
-};
+export const resolveHome = (filepath: string): string =>
+  filepath.startsWith("~") ? join(homedir(), filepath.slice(1)) : filepath;
 
 export const likeOrDislike = async (id: number, liked?: boolean) => {
   const toast = await showToast(Toast.Style.Animated, `${liked ? "Unliking" : "Liking"} photo...`);
-
   try {
-    await apiRequest(`/photos/${id}/like`, {
-      method: liked ? "DELETE" : "POST",
-    });
-
+    await apiRequest(`/photos/${id}/like`, { method: liked ? "DELETE" : "POST" });
     toast.style = Toast.Style.Success;
     toast.title = `Photo ${liked ? "unliked" : "liked"}!`;
   } catch {

--- a/extensions/unsplash/src/functions/utils.ts
+++ b/extensions/unsplash/src/functions/utils.ts
@@ -1,7 +1,6 @@
-import { getPreferenceValues, showToast, Toast } from "@raycast/api";
+import { getPreferenceValues } from "@raycast/api";
 import { join } from "path";
 import { homedir } from "os";
-import { apiRequest } from "@/functions/apiRequest";
 
 export const getGridColumns = (): number => {
   const { gridItemSize } = getPreferenceValues<Preferences>();
@@ -17,15 +16,3 @@ export const toTitleCase = (str: string): string =>
 
 export const resolveHome = (filepath: string): string =>
   filepath.startsWith("~") ? join(homedir(), filepath.slice(1)) : filepath;
-
-export const likeOrDislike = async (id: number, liked?: boolean) => {
-  const toast = await showToast(Toast.Style.Animated, `${liked ? "Unliking" : "Liking"} photo...`);
-  try {
-    await apiRequest(`/photos/${id}/like`, { method: liked ? "DELETE" : "POST" });
-    toast.style = Toast.Style.Success;
-    toast.title = `Photo ${liked ? "unliked" : "liked"}!`;
-  } catch {
-    toast.style = Toast.Style.Failure;
-    toast.title = "An error occured";
-  }
-};

--- a/extensions/unsplash/src/hooks/useLikes.ts
+++ b/extensions/unsplash/src/hooks/useLikes.ts
@@ -1,32 +1,27 @@
 import { LocalStorage } from "@raycast/api";
 import { apiRequest } from "@/functions/apiRequest";
 import { useCachedPromise } from "@raycast/utils";
-import { LikesResult, User } from "@/types";
+import { SearchResult, User } from "@/types";
 
-export const useLikes = () => {
-  const { isLoading: loading, data: likes } = useCachedPromise(getUserLikes, [], {
-    failureToastOptions: {
-      title: "Failed to fetch likes.",
-    },
+export function useLikes() {
+  const {
+    isLoading: loading,
+    data: likes,
+    error,
+  } = useCachedPromise(getUserLikes, [], {
+    failureToastOptions: { title: "Failed to fetch likes." },
   });
+  return { loading, likes, error };
+}
 
-  return {
-    loading,
-    likes,
-  };
-};
-
-export const getUserLikes = async () => {
-  let username = await LocalStorage.getItem("username");
-
+async function getUserLikes(): Promise<SearchResult[]> {
+  let username = await LocalStorage.getItem<string>("username");
   if (!username) {
     const user = await apiRequest<User>("/me");
-    LocalStorage.setItem("username", user.username);
+    await LocalStorage.setItem("username", user.username);
     username = user.username;
   }
-
-  const likes = await apiRequest<LikesResult[]>(`/users/${username}/likes`);
-  return likes;
-};
+  return apiRequest<SearchResult[]>(`/users/${username}/likes`);
+}
 
 export default useLikes;

--- a/extensions/unsplash/src/hooks/useSearch.ts
+++ b/extensions/unsplash/src/hooks/useSearch.ts
@@ -2,79 +2,32 @@ import { apiRequest } from "@/functions/apiRequest";
 import { CollectionResult, Orientation, SearchResult } from "@/types";
 import { useCachedPromise } from "@raycast/utils";
 
-export const useSearch = <T extends "collections" | "photos">(query: string, type: T, orientation: Orientation) => {
-  const { isLoading, data, pagination } = useCachedPromise(
-    (searchText: string, orientation: Orientation) => async (options: { page: number }) => {
-      if (!searchText.trim())
-        return {
-          data: [],
-          hasMore: false,
-        };
+type SearchType = "photos" | "collections";
+type ResultFor<T extends SearchType> = T extends "collections" ? CollectionResult : SearchResult;
+
+export function useSearch<T extends SearchType>(query: string, type: T, orientation: Orientation) {
+  const { isLoading, data, pagination, error } = useCachedPromise(
+    (text: string, orient: Orientation) => async (options: { page: number }) => {
+      if (!text.trim()) return { data: [] as ResultFor<T>[], hasMore: false };
 
       const page = options.page + 1;
-      const { results, total_pages } = await performSearch({
-        searchText,
-        options: {
-          page,
-          orientation,
-          type: type || "photos",
-        },
-      });
+      const params = new URLSearchParams({ page: String(page), query: text, per_page: "30" });
+      if (orient !== "all") params.append("orientation", orient);
 
-      return {
-        data: results,
-        hasMore: page < total_pages,
-      };
+      const { results, total_pages } = await apiRequest<{ results: ResultFor<T>[]; total_pages: number }>(
+        `/search/${type}?${params}`,
+      );
+
+      return { data: results, hasMore: page < total_pages };
     },
     [query, orientation],
     {
-      initialData: [],
-      failureToastOptions: {
-        title: `Failed to fetch ${type}.`,
-      },
+      initialData: [] as ResultFor<T>[],
+      failureToastOptions: { title: `Failed to fetch ${type}.` },
     },
   );
 
-  return {
-    state: { results: data, isLoading, pagination },
-  };
-};
-
-// Perform Search
-interface PerformSearchProps {
-  searchText: string;
-  options: {
-    page: number;
-    orientation: Orientation;
-    type: "photos" | "collections";
-  };
+  return { state: { results: data, isLoading, pagination }, error };
 }
-
-type SearchOrCollectionResult<T extends PerformSearchProps> = T extends { options: { type: "collections" } }
-  ? CollectionResult[]
-  : SearchResult[];
-
-export const performSearch = async <T extends PerformSearchProps>({
-  searchText,
-  options,
-}: PerformSearchProps): Promise<{ results: SearchOrCollectionResult<T>; total_pages: number }> => {
-  const searchParams = new URLSearchParams({
-    page: options.page.toString(),
-    query: searchText,
-    per_page: "30",
-  });
-
-  if (options.orientation !== "all") searchParams.append("orientation", options.orientation);
-
-  const { results, total_pages } = await apiRequest<{
-    results: SearchOrCollectionResult<T>;
-    total_pages: number;
-  }>(`/search/${options.type}?${searchParams.toString()}`);
-
-  return {
-    results,
-    total_pages,
-  };
-};
 
 export default useSearch;

--- a/extensions/unsplash/src/hooks/useSetupAuth.ts
+++ b/extensions/unsplash/src/hooks/useSetupAuth.ts
@@ -8,9 +8,12 @@ export function useSetupAuth() {
   const [connectError, setConnectError] = useState("");
 
   useEffect(() => {
-    client.getTokens().then((tokens) => {
-      setStatus(tokens?.accessToken ? "ready" : "needs-setup");
-    });
+    client
+      .getTokens()
+      .then((tokens) => {
+        setStatus(tokens?.accessToken ? "ready" : "needs-setup");
+      })
+      .catch(() => setStatus("needs-setup"));
   }, []);
 
   const connect = useCallback(async () => {

--- a/extensions/unsplash/src/hooks/useSetupAuth.ts
+++ b/extensions/unsplash/src/hooks/useSetupAuth.ts
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useState } from "react";
+import { client, doAuth } from "@/oauth";
+
+type AuthStatus = "loading" | "needs-setup" | "ready";
+
+export function useSetupAuth() {
+  const [status, setStatus] = useState<AuthStatus>("loading");
+  const [connectError, setConnectError] = useState("");
+
+  useEffect(() => {
+    client.getTokens().then((tokens) => {
+      setStatus(tokens?.accessToken ? "ready" : "needs-setup");
+    });
+  }, []);
+
+  const connect = useCallback(async () => {
+    setConnectError("");
+    try {
+      await doAuth();
+      setStatus("ready");
+    } catch (error) {
+      const msg = error instanceof Error ? error.message.toLowerCase() : "";
+      if (!msg.includes("cancel") && !msg.includes("abort")) {
+        setConnectError("Authentication failed. Please verify your setup and try again.");
+      }
+    }
+  }, []);
+
+  return { status, connectError, connect };
+}

--- a/extensions/unsplash/src/images.tsx
+++ b/extensions/unsplash/src/images.tsx
@@ -1,71 +1,55 @@
 import { useState } from "react";
 import { Grid } from "@raycast/api";
-import { getGridItemSize, showImageTitle, toTitleCase } from "@/functions/utils";
-
-// Hooks
+import { getGridColumns, showImageTitle, toTitleCase } from "@/functions/utils";
 import { useSearch } from "@/hooks/useSearch";
-
-// Components
+import { useSetupAuth } from "@/hooks/useSetupAuth";
 import Actions from "@/components/Actions";
-
-// Types
+import OrientationDropdown from "@/components/OrientationDropdown";
+import OAuthSetupGuide from "@/components/OAuthSetupGuide";
 import { Orientation, SearchResult } from "@/types";
-interface SearchListItemProps {
-  searchResult: SearchResult;
+
+export default function UnsplashImages() {
+  const auth = useSetupAuth();
+
+  if (auth.status === "loading") return <Grid isLoading />;
+  if (auth.status === "needs-setup")
+    return <OAuthSetupGuide onConnect={auth.connect} connectError={auth.connectError} />;
+
+  return <ImageGrid />;
 }
 
-const UnsplashImages: React.FC = () => {
+function ImageGrid() {
   const [orientation, setOrientation] = useState<Orientation>("landscape");
   const [search, setSearch] = useState("");
   const { state } = useSearch(search, "photos", orientation);
-  const itemSize = getGridItemSize();
-
-  const handleOrientationChange = (value: string) => {
-    setOrientation(value as Orientation);
-  };
 
   return (
     <Grid
       isLoading={state.isLoading}
-      itemSize={itemSize}
+      columns={getGridColumns()}
       onSearchTextChange={setSearch}
       searchBarPlaceholder="Search wallpapers..."
-      searchBarAccessory={
-        <Grid.Dropdown
-          tooltip="Orientation"
-          storeValue={true}
-          defaultValue={orientation}
-          onChange={handleOrientationChange}
-        >
-          <Grid.Dropdown.Section title="Orientation">
-            <Grid.Dropdown.Item title="All" value="all" />
-            <Grid.Dropdown.Item title="Landscape" value="landscape" />
-            <Grid.Dropdown.Item title="Portrait" value="portrait" />
-            <Grid.Dropdown.Item title="Squarish" value="squarish" />
-          </Grid.Dropdown.Section>
-        </Grid.Dropdown>
-      }
+      searchBarAccessory={<OrientationDropdown onChange={setOrientation} />}
       throttle
       pagination={state.pagination}
     >
-      <Grid.Section title="Results" subtitle={String(state?.results?.length)}>
+      <Grid.Section title="Results" subtitle={String(state.results.length)}>
         {state.results.map((result) => (
-          <SearchListItem key={result.id} searchResult={result} />
+          <ImageGridItem key={result.id} result={result} />
         ))}
       </Grid.Section>
     </Grid>
   );
-};
+}
 
-const SearchListItem: React.FC<SearchListItemProps> = ({ searchResult }) => {
-  const [title, image] = [
-    searchResult.description || searchResult.alt_description || searchResult.user.name || "No Name",
-    searchResult.urls?.thumb || searchResult.urls?.small || searchResult.urls?.regular,
-  ];
-
-  const gridItemTitle = showImageTitle() ? toTitleCase(title) : "";
-
-  return <Grid.Item content={image} title={gridItemTitle} actions={<Actions item={searchResult} details />} />;
-};
-
-export default UnsplashImages;
+function ImageGridItem({ result }: { result: SearchResult }) {
+  const title = result.description || result.alt_description || result.user.name || "No Name";
+  const image = result.urls.thumb || result.urls.small || result.urls.regular;
+  return (
+    <Grid.Item
+      content={image}
+      title={showImageTitle() ? toTitleCase(title) : ""}
+      actions={<Actions item={result} details />}
+    />
+  );
+}

--- a/extensions/unsplash/src/likes.tsx
+++ b/extensions/unsplash/src/likes.tsx
@@ -1,58 +1,57 @@
-import { getGridItemSize, showImageTitle, toTitleCase } from "@/functions/utils";
 import { useMemo, useState } from "react";
 import { Grid } from "@raycast/api";
-
-// Hooks
+import { getGridColumns, showImageTitle, toTitleCase } from "@/functions/utils";
 import { useLikes } from "@/hooks/useLikes";
-
-// Components
+import { useSetupAuth } from "@/hooks/useSetupAuth";
 import Actions from "@/components/Actions";
-import { LikesResult, SearchResult } from "@/types";
+import OAuthSetupGuide from "@/components/OAuthSetupGuide";
+import { SearchResult } from "@/types";
 
-// Types
-interface SearchListItemProps {
-  item: LikesResult;
-  unlike: React.Dispatch<React.SetStateAction<string[]>>;
+export default function UnsplashLikes() {
+  const auth = useSetupAuth();
+
+  if (auth.status === "loading") return <Grid isLoading />;
+  if (auth.status === "needs-setup")
+    return <OAuthSetupGuide onConnect={auth.connect} connectError={auth.connectError} />;
+
+  return <LikesGrid />;
 }
 
-const UnsplashLikes = () => {
+function LikesGrid() {
   const { loading, likes } = useLikes();
-  const itemSize = getGridItemSize();
   const [unliked, setUnliked] = useState<string[]>([]);
 
-  const filteredLikes = useMemo(() => {
-    return likes?.filter((like) => !unliked.includes(String(like.id))) || [];
-  }, [unliked, likes]);
+  const filteredLikes = useMemo(
+    () => likes?.filter((like) => !unliked.includes(String(like.id))) ?? [],
+    [unliked, likes],
+  );
 
   return (
-    <Grid isLoading={loading} itemSize={itemSize} searchBarPlaceholder="Search your likes...">
+    <Grid isLoading={loading} columns={getGridColumns()} searchBarPlaceholder="Search your likes...">
       <Grid.EmptyView icon="empty-states-photos.png" />
-      <Grid.Section title="Results" subtitle={String(filteredLikes?.length)}>
-        {filteredLikes?.map((like) => (
-          <SearchListItem key={like.id} item={like} unlike={setUnliked} />
+      <Grid.Section title="Results" subtitle={String(filteredLikes.length)}>
+        {filteredLikes.map((like) => (
+          <LikeGridItem key={like.id} item={like} unlike={setUnliked} />
         ))}
       </Grid.Section>
     </Grid>
   );
-};
+}
 
-const SearchListItem = ({ item, unlike }: SearchListItemProps) => {
-  const [title, image] = [
-    item.title || item.description || item.user.name || "No Name",
-    item.urls?.thumb || item.urls?.small || item.urls?.regular,
-  ];
-
-  const mimicItem: SearchResult = {
-    ...item,
-    title,
-    alt_description: "",
-  };
-
-  const gridItemTitle = showImageTitle() ? toTitleCase(title) : "";
-
+function LikeGridItem({
+  item,
+  unlike,
+}: {
+  item: SearchResult;
+  unlike: React.Dispatch<React.SetStateAction<string[]>>;
+}) {
+  const title = item.description || item.alt_description || item.user.name || "No Name";
+  const image = item.urls.thumb || item.urls.small || item.urls.regular;
   return (
-    <Grid.Item content={image} title={gridItemTitle} actions={<Actions item={mimicItem} unlike={unlike} details />} />
+    <Grid.Item
+      content={image}
+      title={showImageTitle() ? toTitleCase(title) : ""}
+      actions={<Actions item={item} unlike={unlike} details />}
+    />
   );
-};
-
-export default UnsplashLikes;
+}

--- a/extensions/unsplash/src/oauth.ts
+++ b/extensions/unsplash/src/oauth.ts
@@ -1,7 +1,5 @@
 import { OAuth, getPreferenceValues } from "@raycast/api";
 
-const { accessKey, secretKey } = getPreferenceValues<Preferences>();
-
 export const client = new OAuth.PKCEClient({
   redirectMethod: OAuth.RedirectMethod.Web,
   providerName: "Unsplash",
@@ -9,7 +7,8 @@ export const client = new OAuth.PKCEClient({
   description: "Login to your Unsplash account.",
 });
 
-export const doAuth = async () => {
+export async function doAuth() {
+  const { accessKey, secretKey } = getPreferenceValues<Preferences>();
   const authRequest = await client.authorizationRequest({
     endpoint: "https://unsplash.com/oauth/authorize",
     clientId: accessKey,
@@ -36,4 +35,4 @@ export const doAuth = async () => {
   }
 
   await client.setTokens((await tokenResponse.json()) as OAuth.TokenResponse);
-};
+}

--- a/extensions/unsplash/src/types/index.d.ts
+++ b/extensions/unsplash/src/types/index.d.ts
@@ -1,15 +1,23 @@
-interface SearchState<T> {
-  results: T extends "collections" ? CollectionResult[] : SearchResult[];
-  isLoading: boolean;
+export interface Urls {
+  raw: string;
+  full: string;
+  regular: string;
+  small: string;
+  thumb: string;
 }
 
-// Common Types
-export type Errors = { errors: string[] };
-
-interface User {
+export interface User {
   id: string;
   username: string;
   name: string;
+  portfolio_url?: string;
+  bio?: string;
+  location?: string;
+  total_likes?: number;
+  total_photos?: number;
+  total_collections?: number;
+  instagram_username?: string;
+  twitter_username?: string;
   profile_image: {
     small: string;
     medium: string;
@@ -20,21 +28,15 @@ interface User {
   };
 }
 
-interface Urls {
-  raw: string;
-  full: string;
-  regular: string;
-  small: string;
-  thumb: string;
-}
-
-// Image Search
-interface SearchResult {
+export interface SearchResult {
   id: number;
   created_at: string;
+  updated_at?: string;
   title: string;
   width: number;
   height: number;
+  color?: string;
+  blur_hash?: string;
   likes: number;
   description: string;
   alt_description: string;
@@ -47,8 +49,7 @@ interface SearchResult {
   };
 }
 
-// Collection Search
-interface CollectionResult {
+export interface CollectionResult {
   id: number;
   title: string;
   description: string;
@@ -76,50 +77,6 @@ interface CollectionResult {
   };
 }
 
-// Likes Result
-interface LikesResult {
-  id: number;
-  title: string;
-  created_at: string;
-  updated_at: string;
-  width: number;
-  height: number;
-  color: string;
-  blur_hash: string;
-  likes: number;
-  liked_by_user: false;
-  description: string;
-  user: {
-    id: string;
-    username: string;
-    name: string;
-    portfolio_url: string;
-    bio: string;
-    location: string;
-    total_likes: number;
-    total_photos: number;
-    total_collections: number;
-    instagram_username: string;
-    twitter_username: string;
-    profile_image: {
-      small: string;
-      medium: string;
-      large: string;
-    };
-    links: {
-      html: string;
-    };
-  };
-  urls: {
-    raw: string;
-    full: string;
-    regular: string;
-    small: string;
-    thumb: string;
-  };
-  links: {
-    html: string;
-  };
-}
-
+export type LikesResult = SearchResult;
+export type Errors = { errors: string[] };
 export type Orientation = "all" | "landscape" | "portrait" | "squarish";

--- a/extensions/unsplash/src/views/Details.tsx
+++ b/extensions/unsplash/src/views/Details.tsx
@@ -1,16 +1,15 @@
 import { Detail, Icon } from "@raycast/api";
-
-// Components
 import Actions from "@/components/Actions";
 import { SearchResult } from "@/types";
 
-export const Details: React.FC<{ result: SearchResult }> = ({ result }) => {
-  const image = result.urls?.regular || result.urls?.small || result.urls?.thumb;
+export function Details({ result }: { result: SearchResult }) {
+  const image = result.urls.regular || result.urls.small || result.urls.thumb;
   const date = result.created_at ? new Date(result.created_at).toLocaleString() : "Unknown";
 
   return (
     <Detail
       markdown={`![${result.alt_description}](${image})`}
+      navigationTitle={result.user?.name}
       metadata={
         <Detail.Metadata>
           {result.description && <Detail.Metadata.Label title="Description" text={result.description} />}
@@ -20,10 +19,9 @@ export const Details: React.FC<{ result: SearchResult }> = ({ result }) => {
           <Detail.Metadata.Label title="Dimensions" text={`${result.width}x${result.height}`} icon={Icon.AppWindow} />
         </Detail.Metadata>
       }
-      navigationTitle={result.user?.name}
       actions={<Actions item={result} />}
     />
   );
-};
+}
 
 export default Details;

--- a/extensions/unsplash/src/views/DetailsCollections.tsx
+++ b/extensions/unsplash/src/views/DetailsCollections.tsx
@@ -1,10 +1,8 @@
 import { Detail, Icon } from "@raycast/api";
-
-// Components
 import Actions from "@/components/ActionsCollection";
 import { CollectionResult } from "@/types";
 
-export const Details: React.FC<{ result: CollectionResult }> = ({ result }) => {
+export function Details({ result }: { result: CollectionResult }) {
   const coverImage =
     result.cover_photo?.urls?.regular || result.cover_photo?.urls?.small || result.cover_photo?.urls?.thumb;
   const date = result.published_at ? new Date(result.published_at).toLocaleString() : "Unknown";
@@ -25,6 +23,6 @@ export const Details: React.FC<{ result: CollectionResult }> = ({ result }) => {
       actions={<Actions item={result} />}
     />
   );
-};
+}
 
 export default Details;

--- a/extensions/unsplash/tsconfig.json
+++ b/extensions/unsplash/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src/**/*", "raycast-env.d.ts"],
   "compilerOptions": {
     "lib": ["ES2023"],
+    "types": ["node"],
     "module": "commonjs",
     "target": "ES2023",
     "strict": true,


### PR DESCRIPTION
## Description

Modernizes the Unsplash extension with several quality-of-life fixes and a smoother OAuth onboarding experience.

**OAuth setup guide:** Users who hadn't configured their Unsplash app's redirect URI were landing on a confusing Unsplash error page with no explanation. Now, before any OAuth flow begins, a setup guide is shown with the required redirect URI (`https://raycast.com/redirect`) and a "Connect to Unsplash" button — so users know exactly what to do before hitting any errors.

**Bug fixes:**
- Fixed `TypeError: Cannot read properties of null (reading 'useState')` crashes caused by unhandled OAuth errors propagating outside React's render cycle
- Fixed `Grid.itemSize` / `Grid.ItemSize` deprecation warnings — migrated to the `columns` prop

**Code improvements:**
- Extracted a shared `OrientationDropdown` component used by both Search Images and Search Collections
- Simplified `useSearch` hook by removing an unnecessary `performSearch` abstraction
- Moved `getPreferenceValues` calls inside functions (calling it at module level caused side effects on import)

## Screencast

<img width="1000" height="625" alt="image" src="https://github.com/user-attachments/assets/16c431ee-fa95-438b-aeb0-ad6d1381d12d" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
