### PR TITLE
Update prompt stash extension

### DIFF
--- a/extensions/prompt-stash/CHANGELOG.md
+++ b/extensions/prompt-stash/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PromptStash Changelog
 
+## [Add Export and Import commands] - {PR_MERGE_DATE}
+
+- Added `Export Prompts` command that saves your full prompt collection as a JSON file in your Downloads folder
+- Added `Import Prompts` command with a file picker and three conflict strategies (skip, replace, import as new)
+
 ## [Refactor validation system and increase content limit] - 2025-05-27
 
 - Centralized form validations in a dedicated utils file for better maintainability

--- a/extensions/prompt-stash/CHANGELOG.md
+++ b/extensions/prompt-stash/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PromptStash Changelog
 
-## [Add Export and Import commands] - {PR_MERGE_DATE}
+## [Add Export and Import commands] - 2026-05-28
 
 - Added `Export Prompts` command that saves your full prompt collection as a JSON file in your Downloads folder
 - Added `Import Prompts` command with a file picker and three conflict strategies (skip, replace, import as new)

--- a/extensions/prompt-stash/package.json
+++ b/extensions/prompt-stash/package.json
@@ -21,6 +21,20 @@
       "subtitle": "Your AI prompt collection manager",
       "description": "Manage your AI prompts with ease",
       "mode": "view"
+    },
+    {
+      "name": "export-prompts",
+      "title": "Export Prompts",
+      "subtitle": "Prompt Stash",
+      "description": "Export all prompts to a JSON file in your Downloads folder",
+      "mode": "no-view"
+    },
+    {
+      "name": "import-prompts",
+      "title": "Import Prompts",
+      "subtitle": "Prompt Stash",
+      "description": "Import prompts from a Prompt Stash JSON export file",
+      "mode": "view"
     }
   ],
   "preferences": [

--- a/extensions/prompt-stash/src/export-prompts.tsx
+++ b/extensions/prompt-stash/src/export-prompts.tsx
@@ -1,0 +1,42 @@
+import { LocalStorage, Toast, showInFinder, showToast } from "@raycast/api";
+import { writeFile } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+import { Prompt } from "./types";
+import { PROMPTS_KEY, buildExport } from "./utils/transfer";
+
+export default async function Command() {
+  await showToast({ style: Toast.Style.Animated, title: "Exporting prompts…" });
+
+  try {
+    const stored = await LocalStorage.getItem<string>(PROMPTS_KEY);
+    const prompts: Prompt[] = stored ? JSON.parse(stored) : [];
+
+    if (prompts.length === 0) {
+      await showToast({ style: Toast.Style.Failure, title: "No prompts to export" });
+      return;
+    }
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+    const filename = `prompt-stash-${timestamp}.json`;
+    const filepath = join(homedir(), "Downloads", filename);
+
+    await writeFile(filepath, JSON.stringify(buildExport(prompts), null, 2), "utf-8");
+
+    await showToast({
+      style: Toast.Style.Success,
+      title: `Exported ${prompts.length} prompt${prompts.length === 1 ? "" : "s"}`,
+      message: filename,
+      primaryAction: {
+        title: "Show in Finder",
+        onAction: () => showInFinder(filepath),
+      },
+    });
+  } catch (error) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Export failed",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+}

--- a/extensions/prompt-stash/src/hooks/index.tsx
+++ b/extensions/prompt-stash/src/hooks/index.tsx
@@ -1,8 +1,7 @@
 import { Alert, confirmAlert, Icon, LocalStorage, showToast } from "@raycast/api";
 import { useEffect, useState } from "react";
 import { Prompt, SuccessCallback, UseLocalPromptsReturn, UsePromptReturn } from "../types";
-
-const PROMPTS_KEY = "prompts";
+import { PROMPTS_KEY } from "../utils/transfer";
 
 const sortPrompts = (prompts: Prompt[]) => {
   return prompts.sort((a: Prompt, b: Prompt) => {

--- a/extensions/prompt-stash/src/import-prompts.tsx
+++ b/extensions/prompt-stash/src/import-prompts.tsx
@@ -1,0 +1,99 @@
+import { Action, ActionPanel, Form, Icon, LocalStorage, Toast, showToast, useNavigation } from "@raycast/api";
+import { FormValidation, useForm } from "@raycast/utils";
+import { readFile } from "fs/promises";
+import { Prompt } from "./types";
+import { PROMPTS_KEY, parseExportFile } from "./utils/transfer";
+
+type Strategy = "skip" | "replace" | "duplicate";
+
+interface ImportFormValues {
+  files: string[];
+  strategy: Strategy;
+}
+
+export default function Command() {
+  const { pop } = useNavigation();
+
+  const { handleSubmit, itemProps } = useForm<ImportFormValues>({
+    initialValues: { files: [], strategy: "skip" },
+    validation: {
+      files: FormValidation.Required,
+    },
+    async onSubmit({ files, strategy }) {
+      try {
+        const fileContent = await readFile(files[0], "utf-8");
+        const imported = parseExportFile(fileContent);
+
+        const stored = await LocalStorage.getItem<string>(PROMPTS_KEY);
+        const existing: Prompt[] = stored ? JSON.parse(stored) : [];
+        const existingById = new Map(existing.map((p) => [p.id, p]));
+
+        let added = 0;
+        let replaced = 0;
+        let skipped = 0;
+        const merged: Prompt[] = [...existing];
+
+        for (let i = 0; i < imported.length; i++) {
+          const prompt = imported[i];
+          if (existingById.has(prompt.id)) {
+            if (strategy === "replace") {
+              const idx = merged.findIndex((p) => p.id === prompt.id);
+              merged[idx] = prompt;
+              replaced++;
+            } else if (strategy === "duplicate") {
+              merged.push({ ...prompt, id: `${Date.now()}-${i}` });
+              added++;
+            } else {
+              skipped++;
+            }
+          } else {
+            merged.push(prompt);
+            added++;
+          }
+        }
+
+        await LocalStorage.setItem(PROMPTS_KEY, JSON.stringify(merged));
+
+        await showToast({
+          style: Toast.Style.Success,
+          title: "Import complete",
+          message: `${added} added · ${replaced} replaced · ${skipped} skipped`,
+        });
+        pop();
+      } catch (error) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Import failed",
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    },
+  });
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Import Prompts" icon={Icon.Upload} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.FilePicker
+        {...itemProps.files}
+        title="Export File"
+        allowMultipleSelection={false}
+        canChooseDirectories={false}
+        canChooseFiles
+      />
+      <Form.Dropdown {...itemProps.strategy} title="If Prompt Already Exists">
+        <Form.Dropdown.Item value="skip" title="Skip Duplicates" icon={Icon.Forward} />
+        <Form.Dropdown.Item value="replace" title="Replace Existing" icon={Icon.Repeat} />
+        <Form.Dropdown.Item value="duplicate" title="Import as New" icon={Icon.PlusCircle} />
+      </Form.Dropdown>
+      <Form.Description
+        title="About"
+        text="Import prompts from a JSON file previously exported by Prompt Stash. Existing prompts are matched by their unique ID."
+      />
+    </Form>
+  );
+}

--- a/extensions/prompt-stash/src/import-prompts.tsx
+++ b/extensions/prompt-stash/src/import-prompts.tsx
@@ -8,7 +8,7 @@ type Strategy = "skip" | "replace" | "duplicate";
 
 interface ImportFormValues {
   files: string[];
-  strategy: Strategy;
+  strategy: string;
 }
 
 export default function Command() {
@@ -19,7 +19,8 @@ export default function Command() {
     validation: {
       files: FormValidation.Required,
     },
-    async onSubmit({ files, strategy }) {
+    async onSubmit({ files, strategy: strategyValue }) {
+      const strategy = strategyValue as Strategy;
       try {
         const fileContent = await readFile(files[0], "utf-8");
         const imported = parseExportFile(fileContent);

--- a/extensions/prompt-stash/src/utils/transfer.ts
+++ b/extensions/prompt-stash/src/utils/transfer.ts
@@ -60,8 +60,10 @@ export function parseExportFile(content: string): Prompt[] {
 
 function collectValidPrompts(value: unknown[]): Prompt[] {
   const result: Prompt[] = [];
+  const seenIds = new Set<string>();
   for (const item of value) {
-    if (isValidPrompt(item)) {
+    if (isValidPrompt(item) && !seenIds.has(item.id)) {
+      seenIds.add(item.id);
       result.push({ ...item, createdAt: item.createdAt ?? new Date() });
     }
   }
@@ -79,6 +81,7 @@ function isValidPrompt(value: unknown): value is Omit<Prompt, "createdAt"> & { c
     typeof p.title === "string" &&
     typeof p.content === "string" &&
     Array.isArray(p.tags) &&
+    p.tags.every((tag) => typeof tag === "string") &&
     typeof p.isFavorite === "boolean"
   );
 }

--- a/extensions/prompt-stash/src/utils/transfer.ts
+++ b/extensions/prompt-stash/src/utils/transfer.ts
@@ -1,0 +1,84 @@
+import { Prompt } from "../types";
+
+export const PROMPTS_KEY = "prompts";
+
+export const EXPORT_SCHEMA = "prompt-stash-export";
+export const EXPORT_VERSION = 1;
+
+export interface PromptStashExport {
+  $schema: typeof EXPORT_SCHEMA;
+  version: number;
+  exportedAt: string;
+  count: number;
+  prompts: Prompt[];
+}
+
+export function buildExport(prompts: Prompt[]): PromptStashExport {
+  return {
+    $schema: EXPORT_SCHEMA,
+    version: EXPORT_VERSION,
+    exportedAt: new Date().toISOString(),
+    count: prompts.length,
+    prompts,
+  };
+}
+
+/**
+ * Parse and validate a Prompt Stash export file. Also accepts the legacy
+ * "raw array" shape (the format directly written to LocalStorage), so that
+ * users who manually rescue the previous storage value can still import it.
+ */
+export function parseExportFile(content: string): Prompt[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error("File is not valid JSON");
+  }
+
+  if (Array.isArray(parsed)) {
+    return collectValidPrompts(parsed);
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Invalid export file structure");
+  }
+
+  const obj = parsed as Partial<PromptStashExport>;
+  if (obj.$schema !== EXPORT_SCHEMA) {
+    throw new Error("Not a Prompt Stash export file");
+  }
+  if (typeof obj.version !== "number" || obj.version > EXPORT_VERSION) {
+    throw new Error(`Unsupported export version: ${String(obj.version)}`);
+  }
+  if (!Array.isArray(obj.prompts)) {
+    throw new Error("Export file is missing the prompts array");
+  }
+
+  return collectValidPrompts(obj.prompts);
+}
+
+function collectValidPrompts(value: unknown[]): Prompt[] {
+  const result: Prompt[] = [];
+  for (const item of value) {
+    if (isValidPrompt(item)) {
+      result.push({ ...item, createdAt: item.createdAt ?? new Date() });
+    }
+  }
+  if (result.length === 0) {
+    throw new Error("Export file does not contain any valid prompts");
+  }
+  return result;
+}
+
+function isValidPrompt(value: unknown): value is Omit<Prompt, "createdAt"> & { createdAt?: Prompt["createdAt"] } {
+  if (!value || typeof value !== "object") return false;
+  const p = value as Partial<Prompt>;
+  return (
+    typeof p.id === "string" &&
+    typeof p.title === "string" &&
+    typeof p.content === "string" &&
+    Array.isArray(p.tags) &&
+    typeof p.isFavorite === "boolean"
+  );
+}


### PR DESCRIPTION
## Description
- Added `Export Prompts` command that saves your full prompt collection as a JSON file in your Downloads folder
- Added `Import Prompts` command with a file picker and three conflict strategies (skip, replace, import as new)
- Close #28359
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1000" height="625" alt="Raycast 2026-05-28 at 10 44 06" src="https://github.com/user-attachments/assets/138483ca-414e-4b75-a662-6961f00b8cde" />
<img width="1000" height="625" alt="Raycast 2026-05-28 at 10 44 13" src="https://github.com/user-attachments/assets/91801f5e-7f00-4178-9236-44ae88d3d8cb" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
