### PR TITLE
Update Sublime extension to use new v3 endpoints

### DIFF
--- a/extensions/sublime/CHANGELOG.md
+++ b/extensions/sublime/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Sublime Changelog
 
-## [Migrate to v3 API] - {PR_MERGE_DATE}
+## [Migrate to v3 API] - 2026-06-11
 
 Migrated the extension to Sublime's new v3 endpoints. No changes to functionality.
 

--- a/extensions/sublime/CHANGELOG.md
+++ b/extensions/sublime/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sublime Changelog
 
+## [Migrate to v3 API] - {PR_MERGE_DATE}
+
+Migrated the extension to Sublime's new v3 endpoints. No changes to functionality.
+
 ## [Fix Tweet Texts] - 2024-10-09
 
 The text of Tweet cards now turns up correctly when searching!

--- a/extensions/sublime/package-lock.json
+++ b/extensions/sublime/package-lock.json
@@ -1,10 +1,10 @@
 {
-    "name": "sublime",
+    "name": "sublime-staging",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "sublime",
+            "name": "sublime-staging",
             "license": "MIT",
             "dependencies": {
                 "@raycast/api": "^1.81.2",
@@ -76,22 +76,20 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -124,22 +122,20 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -298,6 +294,58 @@
                 }
             }
         },
+        "node_modules/@raycast/eslint-config/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+            "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "6.21.0",
+                "@typescript-eslint/utils": "6.21.0",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@raycast/eslint-config/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+            "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@types/json-schema": "^7.0.12",
+                "@types/semver": "^7.5.0",
+                "@typescript-eslint/scope-manager": "6.21.0",
+                "@typescript-eslint/types": "6.21.0",
+                "@typescript-eslint/typescript-estree": "6.21.0",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0"
+            }
+        },
         "node_modules/@raycast/eslint-config/node_modules/@typescript-eslint/parser": {
             "version": "6.21.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
@@ -324,60 +372,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@raycast/eslint-config/node_modules/@typescript-eslint/type-utils": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-            "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "@typescript-eslint/utils": "6.21.0",
-                "debug": "^4.3.4",
-                "ts-api-utils": "^1.0.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@raycast/eslint-config/node_modules/@typescript-eslint/utils": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-            "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "@types/json-schema": "^7.0.12",
-                "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/@raycast/eslint-plugin": {
@@ -686,11 +680,10 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -748,11 +741,10 @@
             "dev": true
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -846,11 +838,10 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -1041,22 +1032,20 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -1255,11 +1244,10 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-            "dev": true,
-            "license": "ISC"
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+            "dev": true
         },
         "node_modules/formdata-node": {
             "version": "6.0.3",
@@ -1320,22 +1308,20 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -1495,11 +1481,10 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -1563,10 +1548,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-            "license": "MIT"
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -1796,11 +1780,10 @@
             }
         },
         "node_modules/picomatch": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },

--- a/extensions/sublime/package.json
+++ b/extensions/sublime/package.json
@@ -1,91 +1,94 @@
 {
-    "$schema": "https://www.raycast.com/schemas/extension.json",
-    "name": "sublime",
-    "title": "Sublime",
-    "description": "Search, discover, and add cards to your library.",
-    "icon": "icon.png",
-    "author": "sublime.app",
-    "access": "public",
-    "owner": "sublime",
-    "categories": [
-        "Web",
-        "Media",
-        "Productivity"
-    ],
-    "license": "MIT",
-    "type": "module",
-    "commands": [
-        {
-            "name": "save-link",
-            "title": "Save Link",
-            "description": "Save a link to Sublime",
-            "mode": "view"
-        },
-        {
-            "name": "save-file",
-            "title": "Save Image or File",
-            "description": "Save an image or file to Sublime",
-            "mode": "view"
-        },
-        {
-            "name": "search-library",
-            "title": "Search",
-            "description": "Search your Sublime Library",
-            "mode": "view"
-        },
-        {
-            "name": "search-collections",
-            "title": "Search My Collections",
-            "description": "Search your Sublime Collections",
-            "mode": "view"
-        },
-        {
-            "name": "see-related",
-            "title": "Related Cards",
-            "description": "Find Sublime Cards related to a link or text",
-            "mode": "view"
-        },
-        {
-            "name": "open-library",
-            "title": "Open Library",
-            "description": "Open your Sublime Library",
-            "mode": "no-view"
-        },
-        {
-            "name": "save-text",
-            "title": "Save Text",
-            "description": "Save a text to Sublime",
-            "mode": "view"
-        }
-    ],
-    "dependencies": {
-        "@raycast/api": "^1.81.2",
-        "@raycast/utils": "^1.16.5",
-        "dayjs": "^1.11.13",
-        "formdata-node": "^6.0.3",
-        "lodash": "^4.17.21",
-        "mime": "^4.0.4",
-        "node-fetch": "^3.3.2",
-        "react": "^18.3.1",
-        "turndown": "^7.2.0"
+  "$schema": "https://www.raycast.com/schemas/extension.json",
+  "name": "sublime",
+  "title": "Sublime",
+  "description": "Search, discover, and add cards to your library.",
+  "icon": "icon.png",
+  "author": "sublime.app",
+  "access": "public",
+  "owner": "sublime",
+  "categories": [
+    "Web",
+    "Media",
+    "Productivity"
+  ],
+  "license": "MIT",
+  "type": "module",
+  "commands": [
+    {
+      "name": "save-link",
+      "title": "Save Link",
+      "description": "Save a link to Sublime",
+      "mode": "view"
     },
-    "devDependencies": {
-        "@raycast/eslint-config": "^1.0.11",
-        "@types/lodash": "^4.17.7",
-        "@types/node": "22.4.2",
-        "@types/react": "18.3.4",
-        "@types/turndown": "^5.0.5",
-        "eslint": "^8.57.0",
-        "prettier": "^3.3.3",
-        "typescript": "^5.5.4"
+    {
+      "name": "save-file",
+      "title": "Save Image or File",
+      "description": "Save an image or file to Sublime",
+      "mode": "view"
     },
-    "scripts": {
-        "build": "ray build -e dist",
-        "dev": "ray develop",
-        "fix-lint": "ray lint --fix",
-        "lint": "ray lint",
-        "patch-prod": "node scripts/patch-prod.js",
-        "publish-staging": "ray publish",
-        "publish-prod": "./scripts/publish-prod.sh"
+    {
+      "name": "search-library",
+      "title": "Search",
+      "description": "Search your Sublime Library",
+      "mode": "view"
+    },
+    {
+      "name": "search-collections",
+      "title": "Search My Collections",
+      "description": "Search your Sublime Collections",
+      "mode": "view"
+    },
+    {
+      "name": "see-related",
+      "title": "Related Cards",
+      "description": "Find Sublime Cards related to a link or text",
+      "mode": "view"
+    },
+    {
+      "name": "open-library",
+      "title": "Open Library",
+      "description": "Open your Sublime Library",
+      "mode": "no-view"
+    },
+    {
+      "name": "save-text",
+      "title": "Save Text",
+      "description": "Save a text to Sublime",
+      "mode": "view"
     }
+  ],
+  "dependencies": {
+    "@raycast/api": "^1.81.2",
+    "@raycast/utils": "^1.16.5",
+    "dayjs": "^1.11.13",
+    "formdata-node": "^6.0.3",
+    "lodash": "^4.17.21",
+    "mime": "^4.0.4",
+    "node-fetch": "^3.3.2",
+    "react": "^18.3.1",
+    "turndown": "^7.2.0"
+  },
+  "devDependencies": {
+    "@raycast/eslint-config": "^1.0.11",
+    "@types/lodash": "^4.17.7",
+    "@types/node": "22.4.2",
+    "@types/react": "18.3.4",
+    "@types/turndown": "^5.0.5",
+    "eslint": "^8.57.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.5.4"
+  },
+  "scripts": {
+    "build": "ray build -e dist",
+    "dev": "ray develop",
+    "fix-lint": "ray lint --fix",
+    "lint": "ray lint",
+    "patch-prod": "node scripts/patch-prod.js",
+    "publish-staging": "ray publish",
+    "publish-prod": "./scripts/publish-prod.sh"
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/sublime/src/hooks/search.ts
+++ b/extensions/sublime/src/hooks/search.ts
@@ -50,7 +50,11 @@ export function useCardsSearch(
         }
         isLoadingMore.current = true;
 
-        const { results: newCards, nextCursor: newNextCursor } = await search(searchQuery, restrictToLibrary, nextCursor);
+        const { results: newCards, nextCursor: newNextCursor } = await search(
+            searchQuery,
+            restrictToLibrary,
+            nextCursor,
+        );
         setCards([...cards!, ...newCards.map(populateCardMarkdown)]);
         setNextCursor(newNextCursor);
         isLoadingMore.current = false;

--- a/extensions/sublime/src/hooks/search.ts
+++ b/extensions/sublime/src/hooks/search.ts
@@ -9,29 +9,29 @@ export function useCardsSearch(
     search: (
         query: string,
         restrictToLibrary: boolean,
-        page?: number,
-    ) => Promise<{ results: SublimeCard[]; nextPage?: number }>,
+        cursor?: string,
+    ) => Promise<{ results: SublimeCard[]; nextCursor?: string }>,
     fetchInitial = false,
 ) {
     // Search cards via API
     const [isLoading, setIsLoading] = useState(true);
     const [cards, setCards] = useState<SublimeCardWithMarkdown[]>();
-    const [nextPage, setNextPage] = useState<number>();
+    const [nextCursor, setNextCursor] = useState<string>();
     function runSearch(query: string, restrictToLibrary: boolean) {
         if (!query && !fetchInitial) {
             // Reset
             setIsLoading(false);
             setCards(undefined);
-            setNextPage(undefined);
+            setNextCursor(undefined);
             return;
         }
 
         setIsLoading(true);
         search(query, restrictToLibrary)
-            .then(({ results, nextPage }) => {
+            .then(({ results, nextCursor }) => {
                 setIsLoading(false);
                 setCards(results.map(populateCardMarkdown));
-                setNextPage(nextPage);
+                setNextCursor(nextCursor);
             })
             .catch((error) => {
                 setIsLoading(false);
@@ -45,14 +45,14 @@ export function useCardsSearch(
     // Fetch more results when scrolled down
     const isLoadingMore = useRef(false);
     async function onLoadMore() {
-        if ((!searchQuery && !fetchInitial) || !nextPage || isLoadingMore.current) {
+        if ((!searchQuery && !fetchInitial) || !nextCursor || isLoadingMore.current) {
             return;
         }
         isLoadingMore.current = true;
 
-        const { results: newCards, nextPage: newNextPage } = await search(searchQuery, restrictToLibrary, nextPage);
+        const { results: newCards, nextCursor: newNextCursor } = await search(searchQuery, restrictToLibrary, nextCursor);
         setCards([...cards!, ...newCards.map(populateCardMarkdown)]);
-        setNextPage(newNextPage);
+        setNextCursor(newNextCursor);
         isLoadingMore.current = false;
     }
 
@@ -61,7 +61,7 @@ export function useCardsSearch(
         cards,
         pagination: {
             pageSize: 15,
-            hasMore: nextPage !== undefined,
+            hasMore: nextCursor !== undefined,
             onLoadMore,
         },
     };

--- a/extensions/sublime/src/search-collections.tsx
+++ b/extensions/sublime/src/search-collections.tsx
@@ -35,7 +35,7 @@ function SearchCollections() {
                 <List.Item
                     key={item.uuid}
                     title={item.name!}
-                    subtitle={`${item.number_of_cards || item.number_of_connections || ""}`}
+                    subtitle={`${item.number_of_cards ?? item.number_of_connections ?? ""}`}
                     icon={getEntityIcon(item)}
                     actions={
                         <ActionPanel title={item.name}>

--- a/extensions/sublime/src/search-collections.tsx
+++ b/extensions/sublime/src/search-collections.tsx
@@ -1,6 +1,6 @@
 import { authService } from "./utils/auth";
 import { withAccessToken } from "@raycast/utils";
-import { searchCardsInCollection, searchSublimeCards } from "./utils/api";
+import { browseMyCollections, searchCardsInCollection, searchCollectionsByName } from "./utils/api";
 import { useCardsSearch } from "./hooks/search";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { getEntityIcon, getIconPath } from "./utils/icons";
@@ -14,8 +14,8 @@ function SearchCollections() {
     const { cards, isLoading, pagination } = useCardsSearch(
         searchQuery,
         true,
-        (query, restrictToLibrary, page) =>
-            searchSublimeCards(query, true, "collection.collection", !query ? "most_recent" : undefined, page),
+        (query, restrictToLibrary, cursor) =>
+            query ? searchCollectionsByName(query, cursor) : browseMyCollections(cursor),
         true,
     );
 
@@ -35,7 +35,7 @@ function SearchCollections() {
                 <List.Item
                     key={item.uuid}
                     title={item.name!}
-                    subtitle={`${item.number_of_cards}`}
+                    subtitle={`${item.number_of_cards || item.number_of_connections || ""}`}
                     icon={getEntityIcon(item)}
                     actions={
                         <ActionPanel title={item.name}>
@@ -59,7 +59,7 @@ function CollectionCardsList({ collectionUuid, collectionTitle }: { collectionUu
     const { cards, isLoading, pagination } = useCardsSearch(
         searchQuery,
         true,
-        (query, restrictToLibrary, page) => searchCardsInCollection(collectionUuid, query, page),
+        (query, restrictToLibrary, cursor) => searchCardsInCollection(collectionUuid, query, cursor),
         true,
     );
 

--- a/extensions/sublime/src/search-library.tsx
+++ b/extensions/sublime/src/search-library.tsx
@@ -13,7 +13,7 @@ function SearchLibrary() {
     const { cards, isLoading, pagination } = useCardsSearch(
         searchQuery,
         restrictToLibrary,
-        (query, restrictToLibrary, page) => searchSublimeCards(query, restrictToLibrary, undefined, undefined, page),
+        (query, restrictToLibrary, cursor) => searchSublimeCards(query, restrictToLibrary, undefined, undefined, cursor),
     );
 
     return (

--- a/extensions/sublime/src/search-library.tsx
+++ b/extensions/sublime/src/search-library.tsx
@@ -13,7 +13,8 @@ function SearchLibrary() {
     const { cards, isLoading, pagination } = useCardsSearch(
         searchQuery,
         restrictToLibrary,
-        (query, restrictToLibrary, cursor) => searchSublimeCards(query, restrictToLibrary, undefined, undefined, cursor),
+        (query, restrictToLibrary, cursor) =>
+            searchSublimeCards(query, restrictToLibrary, undefined, undefined, cursor),
     );
 
     return (

--- a/extensions/sublime/src/see-related.tsx
+++ b/extensions/sublime/src/see-related.tsx
@@ -67,18 +67,18 @@ function RelatedCardsList({ link, text }: { link?: string; text?: string }) {
     const { cards, isLoading, pagination } = useCardsSearch(
         "",
         true,
-        async (query, restrictToLibrary, page) => {
+        async (query, restrictToLibrary, cursor) => {
             if (link) {
                 const pageInfo = await previewLink(link);
                 if (pageInfo.uuid) {
-                    return await fetchRelatedCards(pageInfo.uuid, undefined, page);
+                    return await fetchRelatedCards(pageInfo.uuid, undefined, cursor);
                 }
 
                 // If link not saved yet, search by its title
                 const pageDescription = `${pageInfo.name}\n${pageInfo.description}`.trim();
-                return await fetchRelatedCards(undefined, pageDescription, page);
+                return await fetchRelatedCards(undefined, pageDescription, cursor);
             } else {
-                return await fetchRelatedCards(undefined, text, page);
+                return await fetchRelatedCards(undefined, text, cursor);
             }
         },
         true,

--- a/extensions/sublime/src/utils/api.ts
+++ b/extensions/sublime/src/utils/api.ts
@@ -383,9 +383,7 @@ export async function searchCollections(query: string): Promise<Collection[]> {
 // Browse the current user's collections. v3 feed/library scopes to collections
 // only via `collections=true`; its default queryset excludes collection types,
 // so an entity_type filter alone returns nothing.
-export async function browseMyCollections(
-    cursor?: string,
-): Promise<{ results: SublimeCard[]; nextCursor?: string }> {
+export async function browseMyCollections(cursor?: string): Promise<{ results: SublimeCard[]; nextCursor?: string }> {
     const data = await fetchApi("GET", `v3/feed/library/`, {
         searchParams: cursor
             ? Object.fromEntries(new URLSearchParams(cursor))

--- a/extensions/sublime/src/utils/api.ts
+++ b/extensions/sublime/src/utils/api.ts
@@ -65,7 +65,7 @@ class HTTPError extends Error {
 export class FreemiumLimitReachedError extends Error {}
 
 export async function getActiveUserInfo(): Promise<UserInfo> {
-    return await fetchApi("GET", `settings/profile/`);
+    return await fetchApi("GET", `v2/settings/profile/`);
 }
 
 export async function searchSublimeCards(
@@ -73,64 +73,68 @@ export async function searchSublimeCards(
     restrictToLibrary: boolean,
     entityType?: string,
     orderBy?: string,
-    page = 1,
+    cursor?: string,
 ): Promise<{
     results: SublimeCard[];
-    nextPage?: number;
+    nextCursor?: string;
 }> {
-    const data = await fetchApi("GET", restrictToLibrary ? `feed/library/` : `feed/search/`, {
-        searchParams: {
-            knn: query, // Always use smart search
-            page,
-            page_size: 15, // Raycast pagination requires at least 10 items per page to work
-            entity_type: entityType,
-            order_by: orderBy,
-        },
+    const data = await fetchApi("GET", restrictToLibrary ? `v3/feed/library/` : `v3/feed/search/`, {
+        searchParams: cursor
+            ? Object.fromEntries(new URLSearchParams(cursor))
+            : {
+                  search: query, // v3 renamed the smart-search param knn -> search
+                  page_size: 15, // Raycast pagination requires at least 10 items per page to work
+                  entity_type: entityType,
+                  // v3 ordering whitelist has no "most_recent"; map it to newest
+                  order_by: orderBy === "most_recent" ? "-first_connection_at" : orderBy,
+              },
     });
 
     return {
-        results: data.results,
-        nextPage: data.next ? page + 1 : undefined,
+        results: data.results.map(flattenV3Card),
+        nextCursor: nextCursorOf(data),
     };
 }
 
 export async function searchCardsInCollection(
     collectionUuid: string,
     query: string,
-    page = 1,
+    cursor?: string,
 ): Promise<{
     results: SublimeCard[];
-    nextPage?: number;
+    nextCursor?: string;
 }> {
-    const data = await fetchApi("GET", `feed/connections/`, {
-        searchParams: {
-            entity: collectionUuid,
-            knn: query, // Always use smart search
-            page, // Raycast pagination requires at least 10 items per page to work
-            page_size: 15,
-        },
+    const data = await fetchApi("GET", `v2/feed/connections/`, {
+        searchParams: cursor
+            ? Object.fromEntries(new URLSearchParams(cursor))
+            : {
+                  entity: collectionUuid,
+                  knn: query, // Always use smart search
+                  page_size: 15,
+              },
     });
 
     return {
         results: data.results,
-        nextPage: data.next ? page + 1 : undefined,
+        nextCursor: nextCursorOf(data),
     };
 }
 
 export async function fetchRelatedCards(
     entityId?: string,
     queryText?: string,
-    page = 1,
+    cursor?: string,
 ): Promise<{
     results: SublimeCard[];
-    nextPage?: number;
+    nextCursor?: string;
 }> {
-    const data = await fetchApi(entityId ? "GET" : "POST", `feed/related/`, {
-        searchParams: {
-            entity: entityId,
-            page_size: 15,
-            page,
-        },
+    const data = await fetchApi(entityId ? "GET" : "POST", `v3/feed/related/`, {
+        searchParams: cursor
+            ? Object.fromEntries(new URLSearchParams(cursor))
+            : {
+                  uuid: entityId,
+                  page_size: 15,
+              },
         json: queryText
             ? {
                   text: queryText,
@@ -144,14 +148,46 @@ export async function fetchRelatedCards(
     }
 
     return {
-        results: data.results,
-        nextPage: data.next ? page + 1 : undefined,
+        results: data.results.map(flattenV3Card),
+        nextCursor: nextCursorOf(data),
     };
+}
+
+// v3 newfeed uses DRF cursor pagination, v2 feed uses page pagination; both
+// return a `next` URL that already encodes the params for the following page.
+// Forward that query string verbatim instead of computing page numbers.
+function nextCursorOf(data: any): string | undefined {
+    return data?.next ? new URL(data.next).search.slice(1) : undefined;
+}
+
+// Reshape a v3 newfeed entity (feed/related, feed/search, feed/library) back
+// into the v2 SublimeCard shape the list view expects: metadata.* is lifted to
+// the root, the singular `url` becomes a `urls` array, and the always-present
+// empty `source` object is dropped.
+function flattenV3Card(entity: any): SublimeCard {
+    const metadata = entity.metadata ?? {};
+    return {
+        ...metadata,
+        ...entity,
+        // v3 NameField sometimes joins OG title + H1 with "\n"; collapse dupes.
+        name: typeof metadata.name === "string" ? collapseDuplicateLines(metadata.name) : metadata.name,
+        urls: entity.url ? [entity.url] : [],
+        source: entity.source?.name || entity.source?.domain ? entity.source : undefined,
+    };
+}
+
+function collapseDuplicateLines(s: string): string {
+    const out: string[] = [];
+    for (const line of s.split("\n")) {
+        if (out.length && out[out.length - 1].trim() === line.trim()) continue;
+        out.push(line);
+    }
+    return out.join("\n");
 }
 
 // fetch page info and existing user notes if present
 export async function previewLink(url: string): Promise<PageInfo> {
-    const response: PageInfo = await fetchApi("GET", "cx/preview/", {
+    const response: PageInfo = await fetchApi("GET", "v2/cx/preview/", {
         searchParams: {
             url: cleanWebsiteUrl(url),
         },
@@ -193,7 +229,7 @@ export async function saveLink(
         let response: any;
         if (pageInfo.uuid) {
             // update existing entity
-            response = await fetchApi("POST", `entities/${pageInfo.uuid}/recurate/`, {
+            response = await fetchApi("POST", `v2/entities/${pageInfo.uuid}/recurate/`, {
                 json: {
                     entity_type: "curation.article",
                     ...curatorFields,
@@ -202,11 +238,11 @@ export async function saveLink(
 
             // delete note separately
             if (!note && noteId) {
-                await fetchApi("DELETE", `entities/${noteId}/`);
+                await fetchApi("DELETE", `v2/entities/${noteId}/`);
             }
         } else {
             // create new entity
-            response = await fetchApi("POST", "entities/add/", {
+            response = await fetchApi("POST", "v2/entities/add/", {
                 json: {
                     ...pageInfo,
                     entity_type: pageInfo.entity_type || "curation.article",
@@ -248,7 +284,7 @@ export async function saveTextEntity(
 ): Promise<PageEntity> {
     try {
         // highlights are always new in app
-        const entity = await fetchApi("POST", `entities/add/`, {
+        const entity = await fetchApi("POST", `v2/entities/add/`, {
             json: {
                 entity_type: "curation.text",
                 html,
@@ -290,7 +326,7 @@ export async function saveFileEntity(
         body.append("file", new File([buffer], fileName, { type: mimeType }));
 
         console.info(`Uploading file: ${fileName} ${mimeType} from ${tempFile}`);
-        const response = await fetch(`${apiUrl}/cx/upload-file/`, {
+        const response = await fetch(`${apiUrl}/v2/cx/upload-file/`, {
             method: "POST",
             body,
             headers: {
@@ -306,7 +342,7 @@ export async function saveFileEntity(
 
         // Now save new file highlight
         const isImage = mimeType.startsWith("image/");
-        const entity = await fetchApi("POST", `entities/add/`, {
+        const entity = await fetchApi("POST", `v2/entities/add/`, {
             json: {
                 entity_type: isImage ? "curation.image" : "curation.file",
                 url: remoteUrl,
@@ -335,7 +371,7 @@ export async function saveFileEntity(
 }
 
 export async function searchCollections(query: string): Promise<Collection[]> {
-    const response: any = await fetchApi("GET", `cx/search/collections/`, {
+    const response: any = await fetchApi("GET", `v3/cx/search/collections/`, {
         searchParams: {
             search: query,
             page_size: 20,
@@ -344,11 +380,55 @@ export async function searchCollections(query: string): Promise<Collection[]> {
     return response.results;
 }
 
+// Browse the current user's collections. v3 feed/library scopes to collections
+// only via `collections=true`; its default queryset excludes collection types,
+// so an entity_type filter alone returns nothing.
+export async function browseMyCollections(
+    cursor?: string,
+): Promise<{ results: SublimeCard[]; nextCursor?: string }> {
+    const data = await fetchApi("GET", `v3/feed/library/`, {
+        searchParams: cursor
+            ? Object.fromEntries(new URLSearchParams(cursor))
+            : {
+                  collections: "true",
+                  page_size: 15,
+                  order_by: "-first_connection_at", // newest first
+              },
+    });
+
+    return {
+        results: data.results.map(flattenV3Card),
+        nextCursor: nextCursorOf(data),
+    };
+}
+
+// Name-based collection search (cx/search/collections), wrapped in the paginated
+// envelope so the "Search My Collections" command can share the cards hook.
+// feed/library does semantic search, which doesn't match collections by name.
+export async function searchCollectionsByName(
+    query: string,
+    cursor?: string,
+): Promise<{ results: SublimeCard[]; nextCursor?: string }> {
+    const data = await fetchApi("GET", `v3/cx/search/collections/`, {
+        searchParams: cursor
+            ? Object.fromEntries(new URLSearchParams(cursor))
+            : {
+                  search: query,
+                  page_size: 15,
+              },
+    });
+
+    return {
+        results: data.results,
+        nextCursor: nextCursorOf(data),
+    };
+}
+
 export async function getSuggestedCollections(entityId?: string): Promise<Collection[]> {
     if (entityId) {
-        return await fetchApi("GET", `cx/${entityId}/suggested-connections/`);
+        return await fetchApi("GET", `v2/cx/${entityId}/suggested-connections/`);
     } else {
-        return await fetchApi("GET", `cx/recent-connections/`);
+        return await fetchApi("GET", `v2/cx/recent-connections/`);
     }
 }
 

--- a/extensions/sublime/src/utils/constants.ts
+++ b/extensions/sublime/src/utils/constants.ts
@@ -8,4 +8,4 @@ export const getCardUrl = ({ entity_type, slug }: { entity_type: string; slug: s
           ? `${webUrl}/${slug}`
           : `${webUrl}/card/${slug}`;
 
-export const apiUrl = isStaging ? `https://staging.api.sublime.app/api/v2` : `https://api.sublime.app/api/v2`;
+export const apiUrl = isStaging ? `https://staging.api.sublime.app/api` : `https://api.sublime.app/api`;

--- a/extensions/sublime/src/utils/types.ts
+++ b/extensions/sublime/src/utils/types.ts
@@ -70,14 +70,14 @@ export interface SublimeCard {
         images: string[];
     };
 
-    urls: string[];
+    urls?: string[];
     source?: {
         name: string;
         domain: string;
         url: string; // does not include https://
     };
     domain?: string;
-    authors: string[];
+    authors?: string[];
 
     privacy?: string;
     curated_by?: {

--- a/extensions/sublime/src/views/list.tsx
+++ b/extensions/sublime/src/views/list.tsx
@@ -86,20 +86,22 @@ export default function CardsList({
                                         />
                                     )}
 
-                                    {(item.source || item.domain) && (
+                                    {(item.source?.name || item.source?.domain || item.domain) && (
                                         <List.Item.Detail.Metadata.Label
                                             title="Source"
                                             text={
-                                                item.source
-                                                    ? `${item.source.name} (${item.source.domain})`
-                                                    : item.domain
+                                                item.source?.name
+                                                    ? item.source?.domain
+                                                        ? `${item.source.name} (${item.source.domain})`
+                                                        : item.source.name
+                                                    : item.source?.domain || item.domain || ""
                                             }
                                         />
                                     )}
-                                    {item.authors[0] && (
+                                    {item.authors?.[0] && (
                                         <List.Item.Detail.Metadata.Label title="Author" text={item.authors[0]} />
                                     )}
-                                    {item.curated_by?.first && (
+                                    {item.curated_by?.first?.name && (
                                         <List.Item.Detail.Metadata.Label
                                             title={item.number_of_cards ? "By" : "Added by"}
                                             text={
@@ -142,8 +144,8 @@ export default function CardsList({
                     actions={
                         <ActionPanel>
                             <Action.OpenInBrowser title="Open Card" url={getCardUrl(item)} />
-                            {(item.urls[0] || item.source?.url) && (
-                                <Action.OpenInBrowser title="Open Source" url={item.urls[0] || item.source!.url} />
+                            {(item.urls?.[0] || item.source?.url) && (
+                                <Action.OpenInBrowser title="Open Source" url={item.urls?.[0] || item.source!.url} />
                             )}
                         </ActionPanel>
                     }


### PR DESCRIPTION
## Description

This update doesn't change or add any new functionality, it only migrates from old v2 endpoints to new v3 endpoints.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
