### PR TITLE
Trello: open boards/cards in desktop app on Windows + add Default Open Target preference

### DIFF
--- a/extensions/trello/CHANGELOG.md
+++ b/extensions/trello/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Trello Changelog
 
-## [Open in Trello Desktop on Windows + default-target preference] - {PR_MERGE_DATE}
+## [Open in Trello Desktop on Windows + default-target preference] - 2026-06-15
 
 - Open boards and cards directly in the Trello desktop app on Windows via the `trello://` URL scheme (previously only worked on macOS).
 - New `Default Open Target` preference to choose whether pressing Enter opens links on Trello Web or in the Trello desktop app.

--- a/extensions/trello/CHANGELOG.md
+++ b/extensions/trello/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Trello Changelog
 
+## [Open in Trello Desktop on Windows + default-target preference] - {PR_MERGE_DATE}
+
+- Open boards and cards directly in the Trello desktop app on Windows via the `trello://` URL scheme (previously only worked on macOS).
+- New `Default Open Target` preference to choose whether pressing Enter opens links on Trello Web or in the Trello desktop app.
+
 ## [Bug Fix] - 2026-05-18
 
 - Prevent the Create a Card form from crashing when board members cannot be loaded as a list.

--- a/extensions/trello/package.json
+++ b/extensions/trello/package.json
@@ -9,7 +9,8 @@
     "jimmy-b36",
     "brittanyjoiner15",
     "ajaypremshankar",
-    "nahidz3"
+    "nahidz3",
+    "artistro08"
   ],
   "platforms": [
     "macOS",
@@ -105,6 +106,18 @@
       "default": false,
       "description": "Include closed board in list",
       "label": "Include closed boards"
+    },
+    {
+      "name": "defaultOpenTarget",
+      "title": "Default Open Target",
+      "description": "Where to open boards and cards when pressing Enter. Trello desktop uses the trello:// protocol handler (macOS opens in the Trello app; Windows opens in the Trello desktop app if installed).",
+      "type": "dropdown",
+      "required": false,
+      "default": "web",
+      "data": [
+        { "title": "Trello Web (browser)", "value": "web" },
+        { "title": "Trello Desktop App", "value": "app" }
+      ]
     }
   ],
   "dependencies": {

--- a/extensions/trello/src/TrelloListItem.tsx
+++ b/extensions/trello/src/TrelloListItem.tsx
@@ -2,6 +2,7 @@ import { List, Icon, ActionPanel, Action } from "@raycast/api";
 import { JSX } from "react";
 import { TrelloCard } from "./trelloResponse.model";
 import { CardDetail } from "./components/CardDetail";
+import { getDefaultOpenTarget, toTrelloAppUrl } from "./utils/openInTrello";
 
 interface CardListItemProps {
   card: TrelloCard;
@@ -12,6 +13,13 @@ export const CardListItem = ({ card }: CardListItemProps): JSX.Element => {
   const accessories: List.Item.Accessory[] = [];
   if (card.due) accessories.push({ date: new Date(card.due) });
   if (card.labels?.length) accessories.push({ tag: card.labels.map((label) => label.name).join(", ") });
+
+  const webUrl = card.url ?? card.shortUrl ?? "";
+  const openWebAction = <Action.OpenInBrowser url={webUrl} title="Open on Trello Web" icon={Icon.Globe} />;
+  const openAppAction = card.url ? (
+    <Action.Open title="Open in Trello Desktop" icon={Icon.AppWindow} target={toTrelloAppUrl(card.url)} />
+  ) : null;
+  const appFirst = getDefaultOpenTarget() === "app";
 
   return (
     <List.Item
@@ -25,10 +33,8 @@ export const CardListItem = ({ card }: CardListItemProps): JSX.Element => {
         <ActionPanel>
           <Action.Push title="View Details" icon={Icon.Eye} target={<CardDetail cardId={card.id} />} />
           <ActionPanel.Section title="Links">
-            <Action.OpenInBrowser url={card.url ?? card.shortUrl ?? ""} title="Open on Trello Web" icon={Icon.Globe} />
-            {card.url ? (
-              <Action.OpenInBrowser url={card.url.replace("https", "trello")} title="Open in Trello Desktop" />
-            ) : null}
+            {appFirst ? openAppAction : openWebAction}
+            {appFirst ? openWebAction : openAppAction}
             {card.url ? <Action.CopyToClipboard content={card.url} title="Copy URL" /> : null}
           </ActionPanel.Section>
         </ActionPanel>

--- a/extensions/trello/src/components/CardDetail.tsx
+++ b/extensions/trello/src/components/CardDetail.tsx
@@ -2,6 +2,7 @@ import { Action, ActionPanel, Detail, Icon } from "@raycast/api";
 import { useEffect, useState } from "react";
 import { trelloClient } from "../utils/trelloClient";
 import { TrelloCardDetails } from "../trelloResponse.model";
+import { getDefaultOpenTarget, toTrelloAppUrl } from "../utils/openInTrello";
 
 type Props = { cardId: string };
 
@@ -19,6 +20,14 @@ export function CardDetail({ cardId }: Props) {
   }, [cardId]);
 
   const markdown = error ? `**Error:** ${error}` : card ? buildMarkdown(card) : "Loading card details...";
+  const appFirst = getDefaultOpenTarget() === "app";
+  const cardUrl = card?.url;
+  const openWebAction = cardUrl ? (
+    <Action.OpenInBrowser title="Open in Trello Web" url={cardUrl} icon={Icon.Globe} />
+  ) : null;
+  const openAppAction = cardUrl ? (
+    <Action.Open title="Open in Trello Desktop" icon={Icon.AppWindow} target={toTrelloAppUrl(cardUrl)} />
+  ) : null;
 
   return (
     <Detail
@@ -27,8 +36,9 @@ export function CardDetail({ cardId }: Props) {
       actions={
         card ? (
           <ActionPanel>
-            {card.url ? <Action.OpenInBrowser title="Open in Trello" url={card.url} icon={Icon.Globe} /> : null}
-            {card.url ? <Action.CopyToClipboard title="Copy URL" content={card.url} /> : null}
+            {appFirst ? openAppAction : openWebAction}
+            {appFirst ? openWebAction : openAppAction}
+            {cardUrl ? <Action.CopyToClipboard title="Copy URL" content={cardUrl} /> : null}
           </ActionPanel>
         ) : undefined
       }

--- a/extensions/trello/src/listCards.tsx
+++ b/extensions/trello/src/listCards.tsx
@@ -5,6 +5,7 @@ import { Board } from "./Board";
 import { List as TrelloList } from "./List";
 import { TrelloCard } from "./trelloResponse.model";
 import { CardListItem } from "./TrelloListItem";
+import { getDefaultOpenTarget, toTrelloAppUrl } from "./utils/openInTrello";
 
 export default function CardsForList() {
   const [boards, setBoards] = useState<Board[]>([]);
@@ -44,6 +45,15 @@ export default function CardsForList() {
     [boards, selectedBoard],
   );
 
+  const selectedBoardUrl = boards.find((b) => b.id === selectedBoard)?.shortUrl ?? "";
+  const appFirst = getDefaultOpenTarget() === "app";
+  const openWebAction = (
+    <Action.OpenInBrowser title="Open Board on Trello Web" icon={Icon.Globe} url={selectedBoardUrl} />
+  );
+  const openAppAction = (
+    <Action.Open title="Open Board in Trello Desktop" icon={Icon.AppWindow} target={toTrelloAppUrl(selectedBoardUrl)} />
+  );
+
   return (
     <List
       isLoading={loading}
@@ -65,10 +75,8 @@ export default function CardsForList() {
             actions={
               <ActionPanel>
                 <Action.Push title="View Cards" icon={Icon.Eye} target={<CardsList list={list} />} />
-                <Action.OpenInBrowser
-                  title="Open Board"
-                  url={boards.find((b) => b.id === selectedBoard)?.shortUrl ?? ""}
-                />
+                {appFirst ? openAppAction : openWebAction}
+                {appFirst ? openWebAction : openAppAction}
               </ActionPanel>
             }
           />

--- a/extensions/trello/src/searchBoards.tsx
+++ b/extensions/trello/src/searchBoards.tsx
@@ -1,7 +1,8 @@
-import { Action, ActionPanel, List } from "@raycast/api";
+import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useEffect, useState } from "react";
 import { returnBoards } from "./utils/fetchBoards";
 import { Board } from "./Board";
+import { getDefaultOpenTarget, toTrelloAppUrl } from "./utils/openInTrello";
 
 export default function BoardsList() {
   const [allBoards, setAllBoards] = useState<Board[]>([]);
@@ -25,6 +26,8 @@ export default function BoardsList() {
     setBoards(allBoards.filter((x) => x.name.toLowerCase().includes(text.toLowerCase())));
     setLoading(false);
   };
+
+  const appFirst = getDefaultOpenTarget() === "app";
   return (
     <List
       isShowingDetail={false}
@@ -35,6 +38,16 @@ export default function BoardsList() {
     >
       {boards?.length > 0
         ? boards.map((board) => {
+            const openWebAction = (
+              <Action.OpenInBrowser title="Open on Trello Web" icon={Icon.Globe} url={board.shortUrl} />
+            );
+            const openAppAction = (
+              <Action.Open
+                title="Open in Trello Desktop"
+                icon={Icon.AppWindow}
+                target={toTrelloAppUrl(board.shortUrl)}
+              />
+            );
             return (
               <List.Item
                 icon={board.prefs.backgroundImageScaled ? board.prefs.backgroundImageScaled[0].url : ""}
@@ -49,7 +62,9 @@ export default function BoardsList() {
                 }
                 actions={
                   <ActionPanel>
-                    <Action.OpenInBrowser url={board.shortUrl} />
+                    {appFirst ? openAppAction : openWebAction}
+                    {appFirst ? openWebAction : openAppAction}
+                    <Action.CopyToClipboard title="Copy URL" content={board.shortUrl} />
                   </ActionPanel>
                 }
               />

--- a/extensions/trello/src/utils/openInTrello.ts
+++ b/extensions/trello/src/utils/openInTrello.ts
@@ -1,0 +1,12 @@
+import { getPreferenceValues } from "@raycast/api";
+import { preferences } from "./types";
+
+export type OpenTarget = "web" | "app";
+
+export function getDefaultOpenTarget(): OpenTarget {
+  return getPreferenceValues<preferences>().defaultOpenTarget ?? "web";
+}
+
+export function toTrelloAppUrl(url: string): string {
+  return url.replace(/^https?:\/\//i, "trello://");
+}

--- a/extensions/trello/src/utils/openInTrello.ts
+++ b/extensions/trello/src/utils/openInTrello.ts
@@ -1,10 +1,9 @@
 import { getPreferenceValues } from "@raycast/api";
-import { preferences } from "./types";
 
 export type OpenTarget = "web" | "app";
 
 export function getDefaultOpenTarget(): OpenTarget {
-  return getPreferenceValues<preferences>().defaultOpenTarget ?? "web";
+  return getPreferenceValues<Preferences>().defaultOpenTarget ?? "web";
 }
 
 export function toTrelloAppUrl(url: string): string {

--- a/extensions/trello/src/utils/types.ts
+++ b/extensions/trello/src/utils/types.ts
@@ -3,6 +3,7 @@ export type preferences = {
   apitoken: string;
   username?: string;
   closedboards: boolean;
+  defaultOpenTarget: "web" | "app";
 };
 
 export type postValues = {

--- a/extensions/trello/src/utils/types.ts
+++ b/extensions/trello/src/utils/types.ts
@@ -3,7 +3,6 @@ export type preferences = {
   apitoken: string;
   username?: string;
   closedboards: boolean;
-  defaultOpenTarget: "web" | "app";
 };
 
 export type postValues = {

--- a/extensions/trello/tsconfig.json
+++ b/extensions/trello/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node 16",
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "raycast-env.d.ts"],
   "compilerOptions": {
     "lib": ["es2020"],
     "module": "commonjs",


### PR DESCRIPTION
## Description

The Trello Raycast extension lists macOS and Windows as supported platforms, but every "Open" action on Windows opens the link in the default browser. macOS users get the native Trello desktop app via the `trello://` URL scheme — Windows users (who have the same desktop app available with the same protocol handler) do not. This PR fixes that gap.

Changes:

- **Windows desktop-app support.** Switched the "Open in Trello Desktop" action to `Action.Open` with a `trello://` target. `Action.Open` calls `ShellExecute` on Windows, so the OS routes the URL to the Trello desktop app's registered protocol handler. macOS behavior is unchanged.
- **New `Default Open Target` preference** (dropdown: Trello Web / Trello Desktop App, default Web). Whichever target the user picks is rendered first in each `ActionPanel`, making it the primary Enter action. The other target remains available as a secondary action.
- Added a small helper `src/utils/openInTrello.ts` (`toTrelloAppUrl`, `getDefaultOpenTarget`).
- Surfaced the Open-in-Desktop action in `CardDetail`, `searchBoards`, and `listCards` (previously only `TrelloListItem` exposed it).

Verified with `ray lint` and `ray build` (clean — only pre-existing `Fetch all Cards` title-case warning untouched). Tested locally on Windows: Enter on a board with the preference set to "app" opens the board in the Trello desktop app via `trello://`; with the preference set to "web" Enter still goes to the browser.

## Screencast


https://github.com/user-attachments/assets/4eab7094-1c94-41a8-be2e-53add109b8a5


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
