### PR TITLE
feat(granola): prefix exports with sortable date

### DIFF
--- a/extensions/granola/CHANGELOG.md
+++ b/extensions/granola/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Granola Changelog
 
+## [Sortable date prefixes for exports] - {PR_MERGE_DATE}
+
+- Prefix exported note and transcript filenames with ISO-8601 creation date
+- Sorting files by name now yields chronological order
+
 ## [2.1.4] - 2026-05-26
 
 ### Bug Fixes

--- a/extensions/granola/CHANGELOG.md
+++ b/extensions/granola/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Granola Changelog
 
-## [Sortable date prefixes for exports] - {PR_MERGE_DATE}
+## [Sortable date prefixes for exports] - 2026-05-29
 
 - Prefix exported note and transcript filenames with ISO-8601 creation date
 - Sorting files by name now yields chronological order

--- a/extensions/granola/src/export-notes.tsx
+++ b/extensions/granola/src/export-notes.tsx
@@ -315,7 +315,8 @@ ${enhancedNotes}
             try {
               const markdownContent = formatNoteAsMarkdown(note, batchPanels, batchNotesMarkdown);
               const safeTitle = sanitizeFileName(note.title || untitledNoteTitle);
-              const fileName = `${safeTitle}_${note.id.substring(0, 8)}.md`;
+              const datePrefix = note.created_at ? '_' + new Date(note.created_at).toISOString().split("T")[0] : "";
+              const fileName = `${datePrefix}${safeTitle}_${note.id.substring(0, 8)}.md`;
               const folderName = folderOrg.documentToFolders[note.id];
 
               const relativePath = writeExportFile(tempDir, fileName, markdownContent, folderName);

--- a/extensions/granola/src/export-notes.tsx
+++ b/extensions/granola/src/export-notes.tsx
@@ -315,7 +315,7 @@ ${enhancedNotes}
             try {
               const markdownContent = formatNoteAsMarkdown(note, batchPanels, batchNotesMarkdown);
               const safeTitle = sanitizeFileName(note.title || untitledNoteTitle);
-              const datePrefix = note.created_at ? '_' + new Date(note.created_at).toISOString().split("T")[0] : "";
+              const datePrefix = note.created_at ? new Date(note.created_at).toISOString().split("T")[0] + "_" : "";
               const fileName = `${datePrefix}${safeTitle}_${note.id.substring(0, 8)}.md`;
               const folderName = folderOrg.documentToFolders[note.id];
 

--- a/extensions/granola/src/export-transcripts.tsx
+++ b/extensions/granola/src/export-transcripts.tsx
@@ -409,7 +409,7 @@ ${transcript}
 `;
 
           const safeTitle = sanitizeFileName(note.title || untitledNoteTitle);
-          const datePrefix = note.created_at ? '_' + new Date(note.created_at).toISOString().split("T")[0] : "";
+          const datePrefix = note.created_at ? new Date(note.created_at).toISOString().split("T")[0] + "_" : "";
           const fileName = `${datePrefix}${safeTitle}_${note.id.substring(0, 8)}.md`;
 
           return {

--- a/extensions/granola/src/export-transcripts.tsx
+++ b/extensions/granola/src/export-transcripts.tsx
@@ -409,7 +409,8 @@ ${transcript}
 `;
 
           const safeTitle = sanitizeFileName(note.title || untitledNoteTitle);
-          const fileName = `${safeTitle}_${note.id.substring(0, 8)}.md`;
+          const datePrefix = note.created_at ? '_' + new Date(note.created_at).toISOString().split("T")[0] : "";
+          const fileName = `${datePrefix}${safeTitle}_${note.id.substring(0, 8)}.md`;
 
           return {
             content: transcriptContent,


### PR DESCRIPTION
This patch prefixes the transcript's or note's filename with its creation date using the ISO-8601 format (i.e. 2026-12-31), ensuring that sorting by name results in chronological order -- making it easier to locate exported files.

## Description

Modifies the Granola extension's "Export Notes" and "Export Transcripts" commands to prefix the file name with an ISO-8601 (e.g. '2026-12-31") date, ensuring a lexicographic / alphabetical sort results in a chronological sort.

## Screencast

**Before:**
<img width="473" height="452" alt="SCR-20260528-lhmh" src="https://github.com/user-attachments/assets/30321643-4daf-4394-bf21-401b90b1f81f" />

**After:**
<img width="473" height="452" alt="SCR-20260528-libm-2" src="https://github.com/user-attachments/assets/920a62cd-405b-4f08-b8d1-d998d22c0d3a" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
