### PR TITLE
[Tiktoken] Add o200k_base tokenizer support

### DIFF
--- a/extensions/tiktoken/CHANGELOG.md
+++ b/extensions/tiktoken/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## [Add o200k_base Support] - {PR_MERGE_DATE}
 
-- Added support for `o200k_base` and lazy tokenizer loading to reduce memory usage.
+- Added support for `o200k_base` using the WASM tokenizer to avoid OOM crashes.
 
 ## [Initial Version] - 2024-01-27

--- a/extensions/tiktoken/CHANGELOG.md
+++ b/extensions/tiktoken/CHANGELOG.md
@@ -1,6 +1,6 @@
 # tiktoken Changelog
 
-## [Add o200k_base Support] - {PR_MERGE_DATE}
+## [Add o200k_base Support] - 2026-05-30
 
 - Added support for `o200k_base` using the WASM tokenizer to avoid OOM crashes.
 

--- a/extensions/tiktoken/CHANGELOG.md
+++ b/extensions/tiktoken/CHANGELOG.md
@@ -1,3 +1,7 @@
 # tiktoken Changelog
 
+## [Add o200k_base Support] - {PR_MERGE_DATE}
+
+- Added support for `o200k_base` and lazy tokenizer loading to reduce memory usage.
+
 ## [Initial Version] - 2024-01-27

--- a/extensions/tiktoken/package-lock.json
+++ b/extensions/tiktoken/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@raycast/api": "^1.66.1",
         "@raycast/utils": "^1.11.1",
-        "js-tiktoken": "^1.0.21"
+        "tiktoken": "^1.0.22"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^1.0.6",
@@ -701,24 +701,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -1302,15 +1284,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/js-tiktoken": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
-      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.5.1"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -1787,6 +1760,12 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiktoken": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/tiktoken/-/tiktoken-1.0.22.tgz",
+      "integrity": "sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA==",
       "license": "MIT"
     },
     "node_modules/title-case": {

--- a/extensions/tiktoken/package-lock.json
+++ b/extensions/tiktoken/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@raycast/api": "^1.66.1",
         "@raycast/utils": "^1.11.1",
-        "js-tiktoken": "^1.0.8"
+        "js-tiktoken": "^1.0.21"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^1.0.6",
@@ -1303,7 +1303,9 @@
       "license": "ISC"
     },
     "node_modules/js-tiktoken": {
-      "version": "1.0.8",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.5.1"

--- a/extensions/tiktoken/package.json
+++ b/extensions/tiktoken/package.json
@@ -84,5 +84,8 @@
         }
       ]
     }
+  ],
+  "platforms": [
+    "macOS"
   ]
 }

--- a/extensions/tiktoken/package.json
+++ b/extensions/tiktoken/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.66.1",
-    "js-tiktoken": "^1.0.8",
+    "js-tiktoken": "^1.0.21",
     "@raycast/utils": "^1.11.1"
   },
   "devDependencies": {

--- a/extensions/tiktoken/package.json
+++ b/extensions/tiktoken/package.json
@@ -53,7 +53,7 @@
       "description": "set the default encoding",
       "required": true,
       "type": "dropdown",
-      "default": "cl100k_base",
+      "default": "o200k_base",
       "data": [
         {
           "title": "gpt2",
@@ -74,6 +74,10 @@
         {
           "title": "cl100k_base",
           "value": "cl100k_base"
+        },
+        {
+          "title": "o200k_base",
+          "value": "o200k_base"
         }
       ]
     }

--- a/extensions/tiktoken/package.json
+++ b/extensions/tiktoken/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.66.1",
-    "js-tiktoken": "^1.0.21",
+    "tiktoken": "^1.0.22",
     "@raycast/utils": "^1.11.1"
   },
   "devDependencies": {

--- a/extensions/tiktoken/package.json
+++ b/extensions/tiktoken/package.json
@@ -10,6 +10,9 @@
     "Productivity"
   ],
   "license": "MIT",
+  "contributors": [
+    "ilian"
+  ],
   "commands": [
     {
       "name": "encode",

--- a/extensions/tiktoken/src/decode.tsx
+++ b/extensions/tiktoken/src/decode.tsx
@@ -16,7 +16,7 @@ export default function Command() {
       popToRoot();
     }
 
-    const { text, encoding } = decode(encodingResult);
+    const { text, encoding } = await decode(encodingResult);
     const shouldTruncate = encodingResult.length > 60;
 
     const md = `### Selected Encoding ${shouldTruncate ? "Preview" : ""}

--- a/extensions/tiktoken/src/encode.tsx
+++ b/extensions/tiktoken/src/encode.tsx
@@ -5,7 +5,7 @@ import { encode } from "./tiktoken";
 export default function Command() {
   const { isLoading, data, error } = usePromise(async () => {
     const selectedText = await getSelectedText();
-    const { tokens, encoding } = encode(selectedText);
+    const { tokens, encoding } = await encode(selectedText);
     const encodedTokens: string = JSON.stringify(tokens) ?? "";
     const shouldTruncate = selectedText.length > 240;
 

--- a/extensions/tiktoken/src/tiktoken.ts
+++ b/extensions/tiktoken/src/tiktoken.ts
@@ -1,63 +1,53 @@
-import { getPreferenceValues } from "@raycast/api";
-import { Tiktoken } from "js-tiktoken/lite";
-import type { TiktokenBPE } from "js-tiktoken/lite";
+import { getPreferenceValues, PreferenceValues } from "@raycast/api";
+import type { TiktokenEncoding } from "tiktoken";
+import { get_encoding, init } from "tiktoken/init";
+import wasm from "tiktoken/tiktoken_bg.wasm";
 
-type EncodingName = "gpt2" | "r50k_base" | "p50k_base" | "p50k_edit" | "cl100k_base" | "o200k_base";
-type Preferences = { encoding: EncodingName };
+const encoders = new Map<TiktokenEncoding, ReturnType<typeof get_encoding>>();
+let tiktokenInitPromise: Promise<void> | undefined;
 
-const encoders = new Map<EncodingName, Tiktoken>();
-
-export function encode(str: string) {
-  const { encoding } = getPreferenceValues<Preferences>();
-  const encoder = getEncoder(encoding);
+export async function encode(str: string) {
+  const { encoding } = getPreferenceValues<PreferenceValues>();
+  const encoder = await getEncoder(encoding);
 
   return {
-    tokens: encoder.encode(str),
+    tokens: Array.from(encoder.encode(str)),
     encoding,
   };
 }
 
-export function decode(list: number[]) {
-  const { encoding } = getPreferenceValues<Preferences>();
-  const encoder = getEncoder(encoding);
+export async function decode(list: number[]) {
+  const { encoding } = getPreferenceValues<PreferenceValues>();
+  const encoder = await getEncoder(encoding);
 
   return {
-    text: encoder.decode(list),
+    text: new TextDecoder().decode(encoder.decode(new Uint32Array(list))),
     encoding,
   };
 }
 
-function getEncoder(encoding: EncodingName) {
+async function getEncoder(encoding: TiktokenEncoding) {
+  await initTiktoken();
+
   const existingEncoder = encoders.get(encoding);
 
   if (existingEncoder) {
     return existingEncoder;
   }
 
-  let ranks: TiktokenBPE;
-  switch (encoding) {
-    case "gpt2":
-      ranks = require("js-tiktoken/ranks/gpt2");
-      break;
-    case "r50k_base":
-      ranks = require("js-tiktoken/ranks/r50k_base");
-      break;
-    case "p50k_base":
-      ranks = require("js-tiktoken/ranks/p50k_base");
-      break;
-    case "p50k_edit":
-      ranks = require("js-tiktoken/ranks/p50k_edit");
-      break;
-    case "cl100k_base":
-      ranks = require("js-tiktoken/ranks/cl100k_base");
-      break;
-    case "o200k_base":
-      ranks = require("js-tiktoken/ranks/o200k_base");
-      break;
-  }
-
-  const encoder = new Tiktoken(ranks);
+  const encoder = get_encoding(encoding);
   encoders.set(encoding, encoder);
 
   return encoder;
+}
+
+function initTiktoken() {
+  // check if tiktoken is already initialized
+  if (tiktokenInitPromise) {
+    return tiktokenInitPromise;
+  }
+
+  tiktokenInitPromise = init((imports) => WebAssembly.instantiate(wasm, imports)).then(() => undefined);
+
+  return tiktokenInitPromise;
 }

--- a/extensions/tiktoken/src/tiktoken.ts
+++ b/extensions/tiktoken/src/tiktoken.ts
@@ -47,7 +47,10 @@ function initTiktoken() {
     return tiktokenInitPromise;
   }
 
-  tiktokenInitPromise = init((imports) => WebAssembly.instantiate(wasm, imports));
+  tiktokenInitPromise = init((imports) => WebAssembly.instantiate(wasm, imports)).catch((error) => {
+    tiktokenInitPromise = undefined;
+    throw error;
+  });
 
   return tiktokenInitPromise;
 }

--- a/extensions/tiktoken/src/tiktoken.ts
+++ b/extensions/tiktoken/src/tiktoken.ts
@@ -1,24 +1,63 @@
-import { getEncoding } from "js-tiktoken";
 import { getPreferenceValues } from "@raycast/api";
+import { Tiktoken } from "js-tiktoken/lite";
+import type { TiktokenBPE } from "js-tiktoken/lite";
+
+type EncodingName = "gpt2" | "r50k_base" | "p50k_base" | "p50k_edit" | "cl100k_base" | "o200k_base";
+type Preferences = { encoding: EncodingName };
+
+const encoders = new Map<EncodingName, Tiktoken>();
 
 export function encode(str: string) {
+  const { encoding } = getPreferenceValues<Preferences>();
+  const encoder = getEncoder(encoding);
+
   return {
-    tokens: getEncoder().encode(str),
-    encoding: getUserEncoding(),
+    tokens: encoder.encode(str),
+    encoding,
   };
 }
 
 export function decode(list: number[]) {
+  const { encoding } = getPreferenceValues<Preferences>();
+  const encoder = getEncoder(encoding);
+
   return {
-    text: getEncoder().decode(list),
-    encoding: getUserEncoding(),
+    text: encoder.decode(list),
+    encoding,
   };
 }
 
-function getEncoder() {
-  return getEncoding(getUserEncoding());
-}
+function getEncoder(encoding: EncodingName) {
+  const existingEncoder = encoders.get(encoding);
 
-function getUserEncoding() {
-  return getPreferenceValues().encoding;
+  if (existingEncoder) {
+    return existingEncoder;
+  }
+
+  let ranks: TiktokenBPE;
+  switch (encoding) {
+    case "gpt2":
+      ranks = require("js-tiktoken/ranks/gpt2");
+      break;
+    case "r50k_base":
+      ranks = require("js-tiktoken/ranks/r50k_base");
+      break;
+    case "p50k_base":
+      ranks = require("js-tiktoken/ranks/p50k_base");
+      break;
+    case "p50k_edit":
+      ranks = require("js-tiktoken/ranks/p50k_edit");
+      break;
+    case "cl100k_base":
+      ranks = require("js-tiktoken/ranks/cl100k_base");
+      break;
+    case "o200k_base":
+      ranks = require("js-tiktoken/ranks/o200k_base");
+      break;
+  }
+
+  const encoder = new Tiktoken(ranks);
+  encoders.set(encoding, encoder);
+
+  return encoder;
 }

--- a/extensions/tiktoken/src/tiktoken.ts
+++ b/extensions/tiktoken/src/tiktoken.ts
@@ -1,9 +1,9 @@
 import { getPreferenceValues, PreferenceValues } from "@raycast/api";
-import type { TiktokenEncoding } from "tiktoken";
+import type { Tiktoken, TiktokenEncoding } from "tiktoken";
 import { get_encoding, init } from "tiktoken/init";
 import wasm from "tiktoken/tiktoken_bg.wasm";
 
-const encoders = new Map<TiktokenEncoding, ReturnType<typeof get_encoding>>();
+const encoders = new Map<TiktokenEncoding, Tiktoken>();
 let tiktokenInitPromise: Promise<void> | undefined;
 
 export async function encode(str: string) {
@@ -47,7 +47,7 @@ function initTiktoken() {
     return tiktokenInitPromise;
   }
 
-  tiktokenInitPromise = init((imports) => WebAssembly.instantiate(wasm, imports)).then(() => undefined);
+  tiktokenInitPromise = init((imports) => WebAssembly.instantiate(wasm, imports));
 
   return tiktokenInitPromise;
 }


### PR DESCRIPTION
## Description

- Adds support for the o200k_base tokenizer (update `js-tiktoken`) and switches tokenizer initialization to lazy rank loading. This avoids loading all tokenizer rank data up front and helps prevent Raycast worker memory limit errors.

Update:
- Switched tokenizer package from js-tiktoken to the WASM-based tiktoken package because o200k_base could hit Raycast’s worker memory limit and crash with OOM.