### PR TITLE
[Display Placer] Fix auto-close after preset loading

### DIFF
--- a/extensions/displayplacer/.gitignore
+++ b/extensions/displayplacer/.gitignore
@@ -1,0 +1,14 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# Raycast specific files
+raycast-env.d.ts
+.raycast-swift-build
+.swiftpm
+compiled_raycast_swift
+compiled_raycast_rust
+
+# misc
+.DS_Store

--- a/extensions/displayplacer/CHANGELOG.md
+++ b/extensions/displayplacer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # DisplayPlacer Changelog
 
-## [Fix auto-closing] - {PR_MERGE_DATE}
+## [Fix auto-closing] - 2026-06-03
 
 - Fixed raycast not closing correctly after preset was loaded
 

--- a/extensions/displayplacer/CHANGELOG.md
+++ b/extensions/displayplacer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DisplayPlacer Changelog
 
+## [Fix auto-closing] - {PR_MERGE_DATE}
+
+- Fixed raycast not closing correctly after preset was loaded
+
 ## [Improve Onboarding Experience] — 2022-04-26
 
 - Added "Help / Configure Extension" command to onboard new users with this extension

--- a/extensions/displayplacer/package.json
+++ b/extensions/displayplacer/package.json
@@ -5,6 +5,9 @@
   "description": "Manage favorite display configurations",
   "icon": "displayplacer.png",
   "author": "eluce2",
+  "contributors": [
+    "LBBO"
+  ],
   "license": "MIT",
   "preferences": [
     {

--- a/extensions/displayplacer/package.json
+++ b/extensions/displayplacer/package.json
@@ -87,5 +87,8 @@
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/displayplacer/src/preset1.ts
+++ b/extensions/displayplacer/src/preset1.ts
@@ -3,6 +3,6 @@ import loadPresetByIndex from "./utils/loadPresetByIndex";
 
 export default async function main() {
   const index = parseInt(path.basename(__filename).replace("preset", "").replace(".js", "")) - 1;
-  loadPresetByIndex(index);
+  await loadPresetByIndex(index);
   return null;
 }

--- a/extensions/displayplacer/src/preset2.ts
+++ b/extensions/displayplacer/src/preset2.ts
@@ -3,6 +3,6 @@ import loadPresetByIndex from "./utils/loadPresetByIndex";
 
 export default async function main() {
   const index = parseInt(path.basename(__filename).replace("preset", "").replace(".js", "")) - 1;
-  loadPresetByIndex(index);
+  await loadPresetByIndex(index);
   return null;
 }

--- a/extensions/displayplacer/src/preset3.ts
+++ b/extensions/displayplacer/src/preset3.ts
@@ -3,6 +3,6 @@ import loadPresetByIndex from "./utils/loadPresetByIndex";
 
 export default async function main() {
   const index = parseInt(path.basename(__filename).replace("preset", "").replace(".js", "")) - 1;
-  loadPresetByIndex(index);
+  await loadPresetByIndex(index);
   return null;
 }

--- a/extensions/displayplacer/src/preset4.ts
+++ b/extensions/displayplacer/src/preset4.ts
@@ -3,6 +3,6 @@ import loadPresetByIndex from "./utils/loadPresetByIndex";
 
 export default async function main() {
   const index = parseInt(path.basename(__filename).replace("preset", "").replace(".js", "")) - 1;
-  loadPresetByIndex(index);
+  await loadPresetByIndex(index);
   return null;
 }

--- a/extensions/displayplacer/src/preset5.ts
+++ b/extensions/displayplacer/src/preset5.ts
@@ -3,6 +3,6 @@ import loadPresetByIndex from "./utils/loadPresetByIndex";
 
 export default async function main() {
   const index = parseInt(path.basename(__filename).replace("preset", "").replace(".js", "")) - 1;
-  loadPresetByIndex(index);
+  await loadPresetByIndex(index);
   return null;
 }


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Currently, when running a `Load Display Preset #n` command, Raycast stays open after the command finishes. I believe this is a bug, since the code explicitly calls `await closeMainWindow()`. The issue is that `loadPresetByIndex` wasn't `await`ed. I fixed that and the commands now correctly close the main window.

This is particularly important to me as I want to trigger the commands via a shortcut and don't want to have Raycast open just because I needed to change my display settings.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder

(I didn't change the assets or the README)
