### PR TITLE
Update dev-servers extension

### DIFF
--- a/extensions/dev-servers/CHANGELOG.md
+++ b/extensions/dev-servers/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dev Servers Changelog
 
-## [Start Dev Server] - {PR_MERGE_DATE}
+## [Start Dev Server] - 2026-06-01
 
 Adds a `Start Dev Server` command for spinning up dev servers without leaving Raycast. Works from a Finder selection, from a list of recently-seen projects, or from a native folder picker.
 

--- a/extensions/dev-servers/CHANGELOG.md
+++ b/extensions/dev-servers/CHANGELOG.md
@@ -1,24 +1,61 @@
 # Dev Servers Changelog
 
-## [Custom domain detection] - 2026-05-26
+## [Start Dev Server] - {PR_MERGE_DATE}
+
+Adds a `Start Dev Server` command for spinning up dev servers without leaving Raycast. Works from a Finder selection, from a list of recently-seen projects, or from a native folder picker.
+
+### Start Dev Server
+
+- **From Finder**: select a project folder (or any file inside one) and run **Start Dev Server**. The extension walks up to the nearest `package.json`, detects the package manager (npm / pnpm / yarn / bun), picks the right script, and spawns it with the same PATH-aware login-shell pattern used by Restart. The dashboard opens immediately and shows a "Starting…" toast that transitions to "X is running" the moment the server binds a port.
+- **From recents**: run the command with nothing selected in Finder and you get a picker over the projects the extension has seen running recently. Recents auto-populate from the dashboard's polling loop, with no explicit bookmarking. LRU-bounded at 30 entries. Running projects are hidden from this list (they live in the dashboard); they reappear once stopped.
+- **From anywhere**: the picker also exposes a **Choose Folder…** entry that opens the native macOS folder dialog directly, with no intermediate screen.
+- **From the dashboard**: the empty state offers a primary **Start Dev Server** action (just press `↵` from a fresh dashboard to land in the picker). Each running-server row's action panel also carries `Start Dev Server` (`⌘N`), so spinning up another project never requires bouncing back to root search.
+- Each picker row shows last-seen, git branch when applicable, and a framework tag inferred from `package.json` dependencies. Cached favicons appear inline once the dashboard has seen the project running, so even stopped projects keep their real icon. Per-row actions: Start, Open in Terminal (`⌘T`), Show in Finder (`⌘⇧F`), Copy Path (`⌘C`), Remove from Recents (`⌃X`).
+- Folders that no longer exist on disk are hidden this render but kept in storage so they reappear when (for example) an external drive remounts.
+- **Startup logs**: every spawned server's stdout+stderr is captured to a per-project log. If a server doesn't bind a port within 15s, the toast escalates to a failure with a **View Startup Log** action instead of silently disappearing, so a misconfigured or custom setup (e.g. portless needing sudo, a missing binary, a crashing build) is diagnosable from inside Raycast. Every running-server row also carries a **View Startup Log** action (`⌘L`) for inspecting output on demand.
+
+### Behavior
+
+- Script picker tries `dev` → `start` → `develop` first, then scans script values for known dev-server tools (Vite, Next, Astro, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, Bun watch/hot, nodemon, tsx watch, ts-node-dev, serve, http-server, live-server). Monorepo conventions like `dev:web` and `start:dev` resolve out of the box.
+- Already running on that folder? You get one consolidated alert: `X is already running. Restart?` for a single target, `All 3 already running. Restart them?` when every selected folder is running, or `2 of 3 already running. Restart these, then start the other one?` for the mixed case. No more N-alert cascades for N-folder selections.
+- The Finder selection is only honored when Finder is the frontmost app. Previously a folder selected earlier (to start one server) lingered in Finder's selection, so running the command later from another app, e.g. the browser, would silently treat that stale folder as the target and surface a spurious `already running. Restart?`. Now, unless you're actually in Finder, the command goes straight to the recents picker, where you can start whatever project you meant.
+- After a server is started (from Finder, the picker, or a recent), the dashboard moves the selection onto that new row, so pressing `↵` acts on the server you just launched rather than re-opening whatever was previously selected. Restart (`⌘⇧R`) likewise re-focuses the replacement once it binds.
+- Multi-folder selection prompts for confirmation by default, useful for monorepo siblings or a "frontend + backend" startup, with an opt-out preference for users who do this regularly.
+- New **Open in browser when the port binds** preference auto-opens the URL once the new server starts listening. Off by default; a one-time hint surfaces it in the in-flight toast for the first few starts.
+
+### Under the hood
+
+- The dashboard is the controller for the entire spawn flow. The launching command resolves a target list and hands off via `launchContext`, which lets the user land on the dashboard immediately and watch the spawn happen there, rather than waiting on a blank loading view for a pre-spawn `fetchServers` call.
+- Spawn lifecycle is a clean state machine on the dashboard: `idle → pending → confirming → spawning → done`. The "Starting…" toast lives on the dashboard so it's visible the whole time the user is waiting, and transitions to a green "running" state the moment every expected cwd appears in the polling loop.
+- All filesystem paths flow through `canonicalCwd` (a `realpathSync` wrapper) so symlinked project paths compare equal between Finder selections, the recents store, and `lsof`'s view of running processes.
+- Extracted `startDevServer(cwd)` and `killServer(pid)` so the new command and the existing restart flow share one spawn path. Restart is now `killServer + startDevServer`.
+- The spawn passes the package manager and chosen script as separate arguments rather than building a shell string, so projects with unusual script names (spaces, punctuation) start reliably and the launch surface stays free of shell-interpolation surprises.
+- Shared `tool-display.ts` so the framework tag styling stays consistent across the dashboard and the picker.
+- Favicons cached onto recents for stopped-project icons are size-capped, keeping the recents store small; the live dashboard always renders the real favicon regardless.
+
+### Preferences
+
+- **Terminal App** is now a single shared preference that applies to both **Dev Servers** and **Start Dev Server**: set the terminal `⌘T` opens once, and both commands honor it.
+
+## [Portless & Shortcuts] - 2026-05-26
 
 Surfaces custom local domains from [portless](https://github.com/vercel-labs/portless), and tightens the action panel, shortcuts, and preferences to align with Raycast conventions.
 
-**Custom domain detection**
+### Custom domain detection
 
 - Detect custom local domains via portless and show the named URL (e.g. `myapp.localhost`) as the row title instead of `localhost:PORT`. The `localhost:PORT` pill stays visible alongside it, since the raw loopback target is still useful for env files, OAuth allowlists, CORS rules, and anything that doesn't trust the local CA.
 - "Open in Browser" and "Copy URL" target the custom domain when one is present. New "Open Localhost URL" and "Copy Localhost URL" actions target loopback explicitly.
-- Search the list by custom domain — typing "myapp" surfaces `https://myapp.localhost`.
+- Search the list by custom domain: typing "myapp" surfaces `https://myapp.localhost`.
 - New "Show localhost URL with custom domain" preference, for users who'd rather hide the `localhost:PORT` pill once a named domain is in place.
 - Filter out the portless proxy daemon itself so it never appears as a phantom dev server row.
 
-**Action panel and shortcuts**
+### Action panel and shortcuts
 
 - Kill Server's shortcut moves from `⌘D` to `⌃X`. `⌘D` is officially "Duplicate" in Raycast's keyboard conventions; `⌃X` is "Remove". Kill All for Project and Kill All Servers shift to `⌃⇧X` and `⌃⌥X` to stay in the same family.
 - Copy Localhost URL is bound to `⌘⇧C`, mirroring `⌘C` for Copy URL.
-- Action panel reordered: Restart Server now sits at position 3, above Kill Server. Restarting is the more common mutation (iterate-on-change), and placing it above Kill also means Raycast's reserved `⌘↵` second-action shortcut never auto-fires Kill — it falls through to Open Localhost URL when a custom domain is present, or to Restart otherwise. Both are safe.
+- Action panel reordered: Restart Server now sits at position 3, above Kill Server. Restarting is the more common mutation (iterate-on-change), and placing it above Kill also means Raycast's reserved `⌘↵` second-action shortcut never auto-fires Kill. It falls through to Open Localhost URL when a custom domain is present, or to Restart otherwise. Both are safe.
 
-**Preferences**
+### Preferences
 
 - Refresh Interval (a behavior setting) moves above Project Display (cosmetic), so settings that change what the extension *does* appear before settings that change how it *looks*.
 
@@ -50,7 +87,7 @@ Dashboard for every running dev server, grouped by project.
 - Auto-detects servers from any framework that uses `node_modules/` (Vite, Next.js, Astro, SvelteKit, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, esbuild) plus the Bun runtime.
 - Servers are grouped by project with favicons, uptime, framework, and runtime tags.
   
-Actions:
+### Actions:
 - Open in browser
 - Copy URL
 - Kill

--- a/extensions/dev-servers/README.md
+++ b/extensions/dev-servers/README.md
@@ -1,48 +1,83 @@
 # Dev Servers
 
-A keyboard-first dashboard for every dev server you have running. See them grouped by project, jump into any one in the browser or your terminal, kill stragglers individually or in bulk, and restart with the right package manager, all without leaving Raycast.
+A keyboard-first way to manage and start your local dev servers from Raycast. See everything running grouped by project, jump into any one in the browser or your terminal, kill stragglers individually or in bulk, restart with the right package manager, and spin up a new server from a Finder selection or a recent project, all without leaving Raycast.
 
-## Features
+## Commands
+
+- **Dev Servers**: the dashboard. A live, auto-refreshing list of every dev server currently running, grouped by project.
+- **Start Dev Server**: spin up a server from a Finder selection, a recently-seen project, or any folder you pick. The dashboard opens and shows it coming up.
+
+## Dev Servers (dashboard)
 
 - **Auto-detects** running dev servers including Vite, Next.js, Astro, SvelteKit, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, esbuild, serve, http-server, anything that runs out of `node_modules/`, plus servers running on the Bun runtime
 - **Custom domain aware** so a dev server fronted by [portless](https://github.com/vercel-labs/portless) shows its named URL (e.g. `myapp.localhost`) as the row title, with the `localhost:PORT` pill alongside for when you still need the raw loopback target
 - **Grouped by project** so servers from the same directory appear under one section
-- **Worktree-aware** so multiple git worktrees of the same repo collapse into one section, with a per-row branch tag to tell them apart — also surfaces the current branch on single-worktree projects so you can tell which branch a long-running server is on
-- **Favicons** — PNG, ICO, or SVG — are pulled from each site (with `/favicon.ico` fallback), inlined so they render even when the dev server isn't CORS-friendly, and cached across refreshes
+- **Worktree-aware** so multiple git worktrees of the same repo collapse into one section, with a per-row branch tag to tell them apart. It also surfaces the current branch on single-worktree projects so you can tell which branch a long-running server is on
+- **Favicons** (PNG, ICO, or SVG) are pulled from each site (with `/favicon.ico` fallback), inlined so they render even when the dev server isn't CORS-friendly, and cached across refreshes
 - **Runtime tag** shows a yellow `bun` badge when the listening process is genuinely running on Bun
 - **Uptime tracking** shows how long each server has been running. Hover for the exact start time
 - **Smart restart** picks the right package manager (npm, pnpm, yarn, bun) from the project's lockfile, polls until the new server binds a port, and surfaces failures with a link to the log
+- **Start another server** without leaving the dashboard: `⌘N` from any row, or `↵` from the empty state, opens the Start Dev Server picker
+- **View startup logs** with `⌘L` on any row, so you can inspect a server's captured stdout/stderr on demand
 - **Confirm dialogs on bulk-kill** ensure destructive actions ask first, with a "Don't ask again" option for project-scoped kills
 - **Open in your terminal** uses a configurable terminal app preference (Terminal, iTerm, Warp, Ghostty, etc.)
 - **Search and filter** by typing a project name, branch, or port into the search bar; a framework dropdown appears when you have multiple frameworks running
 - **Stays open** because the window never closes after an action, so you can chain kills and restarts in one session
 - **Auto-refresh** updates the list automatically on a configurable interval, plus manual `⌘R`
 
+## Start Dev Server
+
+Spin up a dev server without opening a terminal. There are three ways in:
+
+- **From Finder**: select a project folder (or any file inside one) and run the command. It walks up to the nearest `package.json`, detects the package manager, picks the right dev script, and starts it. Select several folders to start them together (monorepo siblings, a "frontend + backend" pair). The dashboard opens immediately and a "Starting…" toast tracks each one until it binds a port.
+- **From recents**: run the command with nothing selected and you get a picker over projects the extension has recently seen running. Recents populate automatically from the dashboard, with no bookmarking. Each row shows last-seen time, git branch, a framework tag, and the project's real favicon once it's been seen running. Currently-running projects are hidden here (they live in the dashboard) and reappear once stopped.
+- **From anywhere**: the picker's **Choose Folder…** entry opens the native macOS folder dialog directly, for a one-off project that isn't in your recents.
+
+If a target is already running, you get a single consolidated prompt to restart it (or restart the running ones and start the rest) rather than a cascade of dialogs. If a server doesn't bind a port within 15 seconds, the toast escalates to a failure with a **View Startup Log** action so a misconfigured setup is diagnosable in place.
+
+The script picker tries `dev` → `start` → `develop` first, then scans script values for known dev-server tools, so monorepo conventions like `dev:web` and `start:dev` resolve out of the box.
+
+**Picker row actions:** Start (`↵`), Open in Terminal (`⌘T`), Show in Finder (`⌘⇧F`), Copy Path (`⌘C`), Remove from Recents (`⌃X`).
+
 ## Keyboard Shortcuts
+
+Dashboard (Dev Servers):
 
 | Action | Shortcut |
 |---|---|
 | Open in Browser | `↵` Enter |
 | Open Localhost URL | `⌘` `↵` |
+| Restart Server | `⌘` `⇧` `R` |
 | Kill Server | `⌃` `X` |
 | Copy URL | `⌘` `C` |
 | Copy Localhost URL | `⌘` `⇧` `C` |
-| Restart Server | `⌘` `⇧` `R` |
 | Open in Terminal | `⌘` `T` |
 | Show in Finder | `⌘` `⇧` `F` |
+| Start Dev Server | `⌘` `N` |
+| View Startup Log | `⌘` `L` |
 | Refresh | `⌘` `R` |
 | Kill All for Project | `⌃` `⇧` `X` |
 | Kill All Servers | `⌃` `⌥` `X` |
 
 ## Preferences
 
-- **Terminal App** sets which terminal `⌘T` opens. Defaults to macOS Terminal if unset.
+**Shared**
+
+- **Terminal App** sets which terminal `⌘T` opens, for both commands. Defaults to macOS Terminal if unset.
+
+**Dev Servers**
+
 - **Refresh Interval** sets how often to refresh the server list (2s, 5s, 10s, or 30s).
 - **Project Display** shows the full directory path in section headers instead of just the project folder name.
 - **Row Accessories** independently toggle uptime, the git branch tag, the framework tag, and the `localhost:PORT` pill that appears alongside custom domains.
+
+**Start Dev Server**
+
+- **Open in browser when the port binds** auto-opens each new server's URL once it starts listening. Off by default.
+- **Confirm when starting multiple folders at once** asks before spawning more than one server from a multi-folder Finder selection. On by default.
 
 ## How it differs from Port Manager
 
 Port Manager is built around ports. Dev Servers is built around projects.
 
-Port Manager shows every listening process the same way (Postgres, Docker, SSH tunnels, dev servers). Dev Servers shows only the dev servers, groups them by project, identifies the framework, and restarts with the right package manager. The two are complementary.
+Port Manager shows every listening process the same way (Postgres, Docker, SSH tunnels, dev servers). Dev Servers shows only the dev servers, groups them by project, identifies the framework, restarts with the right package manager, and can start new ones for you. The two are complementary.

--- a/extensions/dev-servers/package.json
+++ b/extensions/dev-servers/package.json
@@ -26,6 +26,15 @@
     "macOS"
   ],
   "license": "MIT",
+  "preferences": [
+    {
+      "name": "terminalApp",
+      "title": "Terminal App",
+      "type": "appPicker",
+      "description": "Which terminal to open when using \"Open in Terminal\". Defaults to macOS Terminal if unset.",
+      "required": false
+    }
+  ],
   "commands": [
     {
       "name": "index",
@@ -33,13 +42,6 @@
       "description": "List and manage running dev servers",
       "mode": "view",
       "preferences": [
-        {
-          "name": "terminalApp",
-          "title": "Terminal App",
-          "type": "appPicker",
-          "description": "Which terminal to open when using \"Open in Terminal\". Defaults to macOS Terminal if unset.",
-          "required": false
-        },
         {
           "name": "refreshInterval",
           "title": "Refresh Interval",
@@ -105,6 +107,39 @@
           "type": "checkbox",
           "label": "Show localhost URL with custom domain",
           "description": "When a custom domain (e.g. via portless) points at a dev server, also show the localhost:PORT pill alongside it",
+          "default": true,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "start",
+      "title": "Start Dev Server",
+      "description": "Start a dev server from a Finder selection, a recent project, or any folder you pick",
+      "mode": "view",
+      "keywords": [
+        "spawn",
+        "boot",
+        "launch",
+        "run",
+        "recent"
+      ],
+      "preferences": [
+        {
+          "name": "autoOpenInBrowser",
+          "title": "After Start",
+          "type": "checkbox",
+          "label": "Open in browser when the port binds",
+          "description": "Once the new dev server starts listening, automatically open its URL in your default browser",
+          "default": false,
+          "required": false
+        },
+        {
+          "name": "confirmMultiStart",
+          "title": "Confirmations",
+          "type": "checkbox",
+          "label": "Confirm when starting multiple folders at once",
+          "description": "Show a confirmation alert before spawning more than one dev server from a multi-folder Finder selection",
           "default": true,
           "required": false
         }

--- a/extensions/dev-servers/src/aliases.ts
+++ b/extensions/dev-servers/src/aliases.ts
@@ -9,7 +9,7 @@ const execFileAsync = promisify(execFile);
 // exists.
 //
 // Resolution path: shell out to `portless list` via a login shell. portless's
-// text output is its public, human-readable interface — far more stable than
+// text output is its public, human-readable interface, far more stable than
 // its internal ~/.portless/ state files. The login shell is required because
 // Raycast's subprocess PATH doesn't include user-installed CLIs (same reason
 // the restart flow in [servers.ts] uses `/bin/zsh -ilc`).
@@ -21,7 +21,7 @@ const execFileAsync = promisify(execFile);
 //
 // Any failure (portless not installed, command-not-found, timeout, unexpected
 // output) returns an empty map. Portless is treated as an optional
-// enhancement, not a runtime dependency — when it's absent the UI silently
+// enhancement, not a runtime dependency. When it's absent the UI silently
 // falls back to plain `localhost:PORT` rows, per Raycast's "gracefully
 // degrade" guidance.
 //

--- a/extensions/dev-servers/src/constants.ts
+++ b/extensions/dev-servers/src/constants.ts
@@ -1,0 +1,9 @@
+import { Application } from "@raycast/api";
+
+// Fallback terminal when the user hasn't set the `terminalApp` preference.
+// Shared by both commands so the default can't drift between them.
+export const DEFAULT_TERMINAL: Application = {
+  name: "Terminal",
+  path: "/System/Applications/Utilities/Terminal.app",
+  bundleId: "com.apple.Terminal",
+};

--- a/extensions/dev-servers/src/index.tsx
+++ b/extensions/dev-servers/src/index.tsx
@@ -718,8 +718,11 @@ export default function Command(
       );
 
       // 5. Spawn every approved target in parallel. The spawn itself
-      //    returns immediately (detached process), so this is fast.
-      await Promise.all(
+      //    returns immediately (detached process), so this is fast. A target
+      //    whose spawn throws (e.g. no recognizable dev script) gets its own
+      //    failure toast here and is dropped from the set we go on to watch —
+      //    see step 6.
+      const spawned = await Promise.all(
         spawn.targets.map(async (t) => {
           try {
             await startDevServer(t.cwd);
@@ -727,20 +730,39 @@ export default function Command(
               cwd: t.cwd,
               projectName: t.name,
             });
+            return t;
           } catch (err) {
             await showFailureToast(err, {
               title: `Failed to start ${t.name}`,
             });
+            return null;
           }
         }),
       );
+      const succeeded = spawned.filter(
+        (t): t is (typeof spawn.targets)[number] => Boolean(t),
+      );
 
-      // 6. Transition to spawning. The watch effect below takes over,
-      //    flipping the toast to Success once every cwd appears in the
-      //    servers state (driven by the normal polling, now at 1s).
+      // 6. Transition to spawning, watching ONLY the targets that actually
+      //    spawned. Failed ones already showed their own failure toast above;
+      //    including them in `expecting` would leave the animated "Starting…"
+      //    toast hanging and let the 15s timeout escalate it into a second,
+      //    duplicate failure for the same non-event. If nothing spawned, the
+      //    per-target toasts have said it all — tear down the "Starting…" toast
+      //    and finish without ever entering the watch/timeout cycle.
+      if (succeeded.length === 0) {
+        await toastRef.current?.hide();
+        toastRef.current = null;
+        setSpawnState({ phase: "done" });
+        return;
+      }
+
+      // The watch effect below takes over, flipping the toast to Success once
+      // every spawned cwd appears in the servers state (driven by the normal
+      // polling, now at 1s).
       setSpawnState({
         phase: "spawning",
-        expecting: new Map(spawn.targets.map((t) => [t.cwd, t.name])),
+        expecting: new Map(succeeded.map((t) => [t.cwd, t.name])),
         autoOpen: spawn.autoOpen,
       });
     })();

--- a/extensions/dev-servers/src/index.tsx
+++ b/extensions/dev-servers/src/index.tsx
@@ -4,27 +4,85 @@ import {
   Alert,
   Application,
   Color,
+  Detail,
   Icon,
   Image,
+  LaunchProps,
+  LaunchType,
   List,
   Toast,
   confirmAlert,
   getPreferenceValues,
+  launchCommand,
+  open,
   openExtensionPreferences,
   showToast,
+  useNavigation,
 } from "@raycast/api";
 import { showFailureToast, useCachedPromise } from "@raycast/utils";
-import * as os from "node:os";
-import * as path from "node:path";
+import * as fs from "node:fs";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { fetchServers, killProcess, restartServer } from "./servers";
+import { DEFAULT_TERMINAL } from "./constants";
+import {
+  recordSeen,
+  recordSeenBatch,
+  toRecent,
+  updateRecentFavicon,
+} from "./recents";
+import {
+  fetchServers,
+  killProcess,
+  killServer,
+  restartServer,
+  spawnLogPath,
+  startDevServer,
+} from "./servers";
+import { toolColor, toolLabel } from "./tool-display";
 import { DevServer } from "./types";
 
-const DEFAULT_TERMINAL: Application = {
-  name: "Terminal",
-  path: "/System/Applications/Utilities/Terminal.app",
-  bundleId: "com.apple.Terminal",
-};
+// Hand off to the Start Dev Server command. Used by the empty-state
+// primary action and by the per-row "Start Dev Server" action, so both
+// surfaces lead to the same picker (recents + Choose Folder) without
+// the user having to bounce back to root search.
+async function openStartCommand(): Promise<void> {
+  try {
+    // forcePicker tells the Start command to skip its Finder-selection
+    // probe and go straight to the recents/Choose-Folder picker. From the
+    // dashboard the user is in "manage running servers" mode and wants to
+    // choose what to start, not have a stale Finder selection hijacked into
+    // a spawn/restart of whatever happens to be selected.
+    await launchCommand({
+      name: "start",
+      type: LaunchType.UserInitiated,
+      context: { forcePicker: true },
+    });
+  } catch (err) {
+    await showFailureToast(err, { title: "Couldn't open Start Dev Server" });
+  }
+}
+
+// Shallow equality on the dashboard's view of the server list: same length,
+// and same pid+port in the same positions. ps returns processes in PID order
+// which is stable for the same processes between polls, so position-wise
+// comparison is enough to catch what we care about (a server starting or
+// dying), and `fetchStableServers` can hand back the previous array reference
+// when nothing changed so React bails out of the re-render.
+//
+// Deliberately compares ONLY pid+port, not derived fields like the portless
+// `url`/`customUrls`. Those come from a `portless list` shell-out with a 3s
+// timeout that can intermittently miss, so including them made the comparison
+// flap (alias present one poll, absent the next), defeating the dedupe and
+// churning re-renders. The tradeoff is that a portless alias attached to an
+// already-running server isn't reflected until its PID changes, which is fine:
+// aliases are set up at server start in practice, and this matches the
+// long-shipped behavior.
+function sameServers(a: DevServer[], b: DevServer[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].pid !== b[i].pid || a[i].port !== b[i].port) return false;
+  }
+  return true;
+}
 
 // Strip scheme and trailing slash so a primary URL renders cleanly as the row
 // title: "https://myapp.localhost/" → "myapp.localhost",
@@ -39,66 +97,6 @@ function formatUptime(startedAt: Date): string {
   if (seconds < 60) return `${seconds}s`;
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
   return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
-}
-
-// Display label for the tool tag. We keep the internal `tool` field lowercase
-// (used for grouping, color lookup, dropdown filter values) and only stylize
-// on the way to the UI. Anything not in this map renders as-is.
-const TOOL_DISPLAY_NAMES: Record<string, string> = {
-  vite: "Vite",
-  sveltekit: "SvelteKit",
-  svelte: "Svelte",
-  astro: "Astro",
-  next: "Next.js",
-  nuxt: "Nuxt",
-  webpack: "Webpack",
-  parcel: "Parcel",
-  gatsby: "Gatsby",
-  remix: "Remix",
-  turbo: "Turbo",
-  esbuild: "esbuild", // intentionally lowercase per upstream brand
-  bun: "Bun",
-  node: "Node",
-  serve: "Serve",
-  "http-server": "http-server", // intentionally lowercase per package name
-  "live-server": "Live Server",
-};
-
-function toolLabel(tool: string): string {
-  return TOOL_DISPLAY_NAMES[tool.toLowerCase()] ?? tool;
-}
-
-// Theme-adaptive overrides for the few frameworks where the named palette
-// renders too muddy or too low-contrast against Raycast's translucent tag
-// background, especially on selected rows in dark mode. The rest fall
-// through to the named palette which works fine.
-const TOOL_COLOR_OVERRIDES: Record<string, { light: string; dark: string }> = {
-  // Purples: deepened in light mode for readable contrast
-  vite: { light: "#5B21B6", dark: "#B49CFF" },
-  astro: { light: "#5B21B6", dark: "#B49CFF" },
-  gatsby: { light: "#5B21B6", dark: "#B49CFF" },
-  // Yellows: Raycast's Color.Yellow is too pale in light mode, so use a deeper
-  // amber there. Keep a warm yellow in dark mode where it reads fine.
-  parcel: { light: "#A16207", dark: "#FDE047" },
-  esbuild: { light: "#A16207", dark: "#FDE047" },
-  bun: { light: "#A16207", dark: "#FDE047" },
-  // Next: Tailwind gray-900 / gray-100 (blue-tinted gray, not neutral)
-  next: { light: "#111827", dark: "#F3F4F6" },
-};
-
-function toolColor(tool: string): Color | { light: string; dark: string } {
-  const key = tool.toLowerCase();
-  if (TOOL_COLOR_OVERRIDES[key]) return TOOL_COLOR_OVERRIDES[key];
-  const colors: Record<string, Color> = {
-    nuxt: Color.Green,
-    webpack: Color.Blue,
-    svelte: Color.Orange,
-    sveltekit: Color.Orange,
-    remix: Color.Magenta,
-    turbo: Color.Blue,
-    node: Color.Green,
-  };
-  return colors[key] ?? Color.Blue;
 }
 
 // Fetch with a hard 3s timeout. Returns null on any failure so callers can
@@ -120,7 +118,7 @@ async function fetchWithTimeout(
 
 // Fetch a favicon and return it as an inline data URI, or undefined if the URL
 // doesn't serve an image. Inlining the bytes (rather than handing Raycast a
-// URL to fetch) sidesteps CORS — some dev servers (notably Astro) don't set
+// URL to fetch) sidesteps CORS, since some dev servers (notably Astro) don't set
 // Access-Control-Allow-Origin on static assets, and Raycast's image loader
 // refuses those.
 //
@@ -170,6 +168,65 @@ async function detectFaviconUrl(port: string): Promise<string | undefined> {
   return fetchFaviconDataUri(`${origin}/favicon.ico`);
 }
 
+// On-demand view of a project's startup log. When a dev server fails to
+// bind a port, the failure detail is in the spawn log (stdout+stderr) that
+// `startDevServer` redirects to `spawnLogPath(cwd)`, not in any terminal
+// the user can see. This surfaces that file so a misconfigured or custom
+// setup (portless needing sudo, a missing binary, a crashing build) is
+// diagnosable from inside Raycast instead of failing opaquely.
+//
+// Reached on demand only: from a per-row action, and from the "View
+// Startup Log" action on the failure toast when a spawn isn't detected.
+function SpawnLogView({ cwd, name }: { cwd: string; name: string }) {
+  const logPath = spawnLogPath(cwd);
+  const { data, isLoading, revalidate } = useCachedPromise(
+    async (p: string): Promise<string> => {
+      try {
+        return await fs.promises.readFile(p, "utf8");
+      } catch {
+        return "";
+      }
+    },
+    [logPath],
+  );
+
+  const log = (data ?? "").trim();
+  const exists = fs.existsSync(logPath);
+  const body = log
+    ? "```\n" + log + "\n```"
+    : exists
+      ? "_The log file exists but is empty. The process wrote no output before exiting._"
+      : "_No startup log found. This server may have been started outside Dev Servers, so we never captured its output._";
+  const markdown = `# Startup log: ${name}\n\n${body}\n\n---\n\n\`${logPath}\``;
+
+  return (
+    <Detail
+      isLoading={isLoading}
+      markdown={markdown}
+      navigationTitle={`Startup log: ${name}`}
+      actions={
+        <ActionPanel>
+          <Action
+            title="Refresh"
+            icon={Icon.ArrowClockwise}
+            onAction={revalidate}
+            shortcut={{ modifiers: ["cmd"], key: "r" }}
+          />
+          {log && <Action.CopyToClipboard title="Copy Log" content={log} />}
+          {exists && (
+            <Action.Open
+              title="Open Log File"
+              target={logPath}
+              icon={Icon.BlankDocument}
+            />
+          )}
+          {exists && <Action.ShowInFinder path={logPath} />}
+        </ActionPanel>
+      }
+    />
+  );
+}
+
 interface RowVisibility {
   branch: boolean;
   uptime: boolean;
@@ -178,6 +235,9 @@ interface RowVisibility {
 }
 
 interface ServerItemProps {
+  // Stable List.Item id (the server pid as a string). Drives controlled
+  // selection from the parent so we can focus a just-spawned server.
+  id: string;
   server: DevServer;
   terminalApp: Application;
   show: RowVisibility;
@@ -189,6 +249,7 @@ interface ServerItemProps {
 }
 
 function ServerItem({
+  id,
   server,
   terminalApp,
   show,
@@ -198,6 +259,7 @@ function ServerItem({
   onRestart,
   onRefresh,
 }: ServerItemProps) {
+  const { push } = useNavigation();
   // Cache the favicon URL by port. Survives revalidations and command
   // relaunches, so the icon doesn't flash back to a placeholder every
   // refresh interval. keepPreviousData keeps the prior URL visible while
@@ -209,6 +271,17 @@ function ServerItem({
       keepPreviousData: true,
     },
   );
+  // Persist resolved favicons onto the project's recents entry so the
+  // picker (in the Start command) can render the real icon even when the
+  // server is stopped. updateRecentFavicon is a no-op when nothing
+  // changed, so this is cheap to call on every render.
+  useEffect(() => {
+    if (!faviconUrl) return;
+    updateRecentFavicon(server.cwd, faviconUrl).catch(() => {
+      // Picker iconography is best-effort; failing to persist must not
+      // disrupt the dashboard.
+    });
+  }, [server.cwd, faviconUrl]);
   const icon: Image.ImageLike = faviconUrl
     ? { source: faviconUrl, fallback: Icon.Globe }
     : { source: Icon.Globe, tintColor: toolColor(server.tool) };
@@ -226,7 +299,7 @@ function ServerItem({
   // When a custom domain (e.g. via portless) points at this port, promote
   // the domain to the title and demote `localhost:PORT` to a pill accessory.
   // The pill lives in accessories (right-aligned) because Raycast subtitles
-  // are plain text — there's no inline-pill primitive. The port stays
+  // are plain text, with no inline-pill primitive. The port stays
   // visible because it's still useful for env files, OAuth allowlists, CORS
   // rules, and tools that don't trust the local CA.
   const hasAlias = !!server.customUrls?.length;
@@ -238,6 +311,7 @@ function ServerItem({
 
   return (
     <List.Item
+      id={id}
       icon={icon}
       title={titleHost}
       subtitle={subtitle}
@@ -258,7 +332,7 @@ function ServerItem({
         ...(localBadgeTag ? [localBadgeTag] : []),
         // Runtime tag is suppressed when it duplicates the tool tag (e.g.
         // tool is already "bun"), and rendered only when the user has the
-        // tool tag visible — otherwise standalone "bun" would look orphaned.
+        // tool tag visible; otherwise standalone "bun" would look orphaned.
         ...(show.tool && server.runtime === "bun" && server.tool !== "bun"
           ? [
               {
@@ -282,18 +356,18 @@ function ServerItem({
         <ActionPanel>
           {/*
            * Action order is deliberate. Raycast auto-binds `↵` and `⌘↵` to
-           * positions 1 and 2 — they can't be overridden — so we keep both
+           * positions 1 and 2 (they can't be overridden), so we keep both
            * slots filled with benign "open" actions.
            *
            * Restart sits above Kill: restarting is the common iterate-on-
            * change action, while Kill is mostly end-of-session cleanup.
            * This also keeps `⌘↵` from auto-firing Kill when there's no
-           * alias — it falls through to Restart (reversible by design).
+           * alias; it falls through to Restart (reversible by design).
            *
            * Kill stays high in the panel rather than at the conventional
            * "destructive at the bottom", because it's frequent and Raycast
            * paints it red as the visual safety signal. The bulk kill
-           * actions further down keep convention — they're genuinely
+           * actions further down keep convention; they're genuinely
            * high-blast-radius.
            */}
           <Action.OpenInBrowser url={server.url} title="Open in Browser" />
@@ -340,6 +414,22 @@ function ServerItem({
               shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
             />
             <Action
+              title="Start Dev Server"
+              icon={Icon.Play}
+              shortcut={{ modifiers: ["cmd"], key: "n" }}
+              onAction={openStartCommand}
+            />
+            <Action
+              title="View Startup Log"
+              icon={Icon.Terminal}
+              shortcut={{ modifiers: ["cmd"], key: "l" }}
+              onAction={() =>
+                push(
+                  <SpawnLogView cwd={server.cwd} name={server.projectName} />,
+                )
+              }
+            />
+            <Action
               title="Refresh"
               icon={Icon.ArrowClockwise}
               shortcut={{ modifiers: ["cmd"], key: "r" }}
@@ -368,28 +458,394 @@ function ServerItem({
   );
 }
 
-export default function Command() {
+// Spawn request handed off by the Start Dev Server command. The dashboard
+// is the controller for the entire spawn flow (confirms, kill+spawn,
+// toast lifecycle, and the eventual transition to a steady-state), so
+// the user sees the dashboard immediately rather than waiting on a blank
+// Start view for the pre-spawn `fetchServers` call.
+interface SpawnRequest {
+  targets: Array<{ cwd: string; name: string }>;
+  // Multi-folder confirm gate, set by the Start command's preference.
+  // Always false for single-target spawns (picker rows, folder picker).
+  confirmMulti: boolean;
+  // Open each new server's URL in the browser when it binds.
+  autoOpen: boolean;
+  // Attach a one-time "Auto-open in Browser?" CTA to the Starting toast.
+  // The Start command pre-decides this based on a usage counter.
+  showAutoOpenHint: boolean;
+}
+
+interface DashboardLaunchContext {
+  spawn?: SpawnRequest;
+}
+
+// Format a list of names with English-style commas and "and":
+//   ["A"]           -> "A"
+//   ["A", "B"]      -> "A and B"
+//   ["A", "B", "C"] -> "A, B, and C"
+function joinNames(names: string[]): string {
+  if (names.length === 0) return "";
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+}
+
+// Single batch confirmation that covers any number of already-running
+// targets in one prompt. Returns true to proceed, false to cancel.
+async function confirmRestartBatch(
+  runningTargets: Array<{
+    target: { name: string };
+    existing: DevServer;
+  }>,
+  totalCount: number,
+): Promise<boolean> {
+  if (runningTargets.length === 0) return true;
+  const names = runningTargets.map((r) => r.target.name);
+  const running = runningTargets.length;
+  const total = totalCount;
+  const remainingCount = total - running;
+
+  if (total === 1) {
+    return await confirmAlert({
+      title: `${names[0]} is already running`,
+      message: `A dev server is listening on ${runningTargets[0].existing.url}. Restart it?`,
+      primaryAction: { title: "Restart" },
+    });
+  }
+  if (running === total) {
+    return await confirmAlert({
+      title: `All ${total} already running`,
+      message: `Restart ${joinNames(names)}?`,
+      primaryAction: { title: "Restart All" },
+    });
+  }
+  const remainingPhrase =
+    remainingCount === 1 ? "the other one" : `the other ${remainingCount}`;
+  return await confirmAlert({
+    title: `${running} of ${total} already running`,
+    message: `Restart ${joinNames(names)}, then start ${remainingPhrase}?`,
+    primaryAction: { title: "Restart & Start All" },
+  });
+}
+
+// Spawn phase state machine. The dashboard transitions:
+//   idle      → no launchContext.spawn, normal dashboard
+//   pending   → spawn request received, waiting for first fetchServers
+//   confirming→ showing confirms (multi-folder and/or batch restart)
+//   spawning  → toast visible, kill+spawn done, watching for servers
+//   done      → terminal state (either success-hidden, timeout-hidden,
+//               or user-cancelled)
+type SpawnPhase =
+  | { phase: "idle" }
+  | { phase: "pending" }
+  | { phase: "confirming" }
+  | {
+      phase: "spawning";
+      expecting: Map<string, string>;
+      autoOpen: boolean;
+    }
+  | { phase: "done" };
+
+export default function Command(
+  props: LaunchProps<{ launchContext?: DashboardLaunchContext }>,
+) {
   const prefs = getPreferenceValues<Preferences.Index>();
+  const { push } = useNavigation();
+  // Capture launchContext once at mount. The destructured props are new
+  // identities every render, so reading via a ref keeps every effect's
+  // closure stable.
+  const launchContextRef = useRef(props.launchContext);
+  const spawnRequest = launchContextRef.current?.spawn;
+
+  // Dedupe `servers` references when content is unchanged. Without this,
+  // every poll (every 1s while expecting servers) hands React a new array
+  // identity, triggering downstream effects/memos to re-evaluate even
+  // when nothing actually changed. Raycast's dev runtime detects this as
+  // "rendering a lot without any changes" and warns, and it's wasted
+  // work regardless of the warning. Returning the previous reference
+  // when pid+port content matches lets React's Object.is bail out of
+  // the re-render entirely.
+  const fetchStableServers = useMemo(() => {
+    let last: DevServer[] = [];
+    return async (): Promise<DevServer[]> => {
+      const next = await fetchServers();
+      if (sameServers(next, last)) return last;
+      last = next;
+      return next;
+    };
+  }, []);
 
   const {
     isLoading,
     data: servers = [],
     mutate,
     revalidate,
-  } = useCachedPromise(fetchServers, [], {
+  } = useCachedPromise(fetchStableServers, [], {
     keepPreviousData: true,
   });
 
-  useEffect(() => {
-    const id = setInterval(revalidate, parseInt(prefs.refreshInterval) * 1000);
-    return () => clearInterval(id);
-  }, [prefs.refreshInterval, revalidate]);
-
-  // Mirror `servers` into a ref so async handlers (like restart's polling
-  // loop) can read the latest value without going stale on closure capture.
+  // Mirror `servers` into a ref so async handlers can read the latest
+  // value without going stale on closure capture.
   const serversRef = useRef(servers);
   useEffect(() => {
     serversRef.current = servers;
+  }, [servers]);
+
+  // `hasLoaded` flips true after the very first fetch completes and
+  // never resets. We gate the List's `isLoading` on this so subsequent
+  // background revalidations don't flicker the EmptyView into Raycast's
+  // default "no results" placeholder (the docs explicitly say EmptyView
+  // is hidden whenever isLoading is true with an empty search bar).
+  const [hasLoaded, setHasLoaded] = useState(false);
+  useEffect(() => {
+    if (!isLoading) setHasLoaded(true);
+  }, [isLoading]);
+  const effectiveLoading = !hasLoaded && isLoading;
+
+  // Spawn phase state machine; see SpawnPhase type for the transitions.
+  const [spawnState, setSpawnState] = useState<SpawnPhase>(() =>
+    spawnRequest ? { phase: "pending" } : { phase: "idle" },
+  );
+  const toastRef = useRef<Toast | null>(null);
+
+  // Controlled list selection. We keep selection in state so we can jump the
+  // cursor to a just-spawned (or just-restarted) server, while onSelectionChange
+  // feeds the user's own navigation back in. This two-way wiring is what keeps
+  // a pinned selectedItemId from yanking the cursor back to the new row on every
+  // background poll — once the user moves, state follows them. The id is the
+  // server pid as a string (see List.Item `id` below); undefined lets Raycast
+  // manage selection itself (initial mount, or when a filter clears the list).
+  const [selectedItemId, setSelectedItemId] = useState<string | undefined>(
+    undefined,
+  );
+
+  // Dashboard polling cadence. Faster only while actively watching for a
+  // just-spawned server to bind a port, so it appears within ~1s. We do NOT
+  // fast-poll during "pending"/"confirming": nothing is spawning yet, and
+  // "confirming" can block indefinitely on a confirm dialog — polling at 1s
+  // there just toggles isLoading every second, producing a burst of identical
+  // re-renders that trips Raycast's "rendering a lot" warning for no benefit.
+  useEffect(() => {
+    const ms =
+      spawnState.phase === "spawning"
+        ? 1000
+        : parseInt(prefs.refreshInterval) * 1000;
+    const id = setInterval(revalidate, ms);
+    return () => clearInterval(id);
+  }, [spawnState.phase, prefs.refreshInterval, revalidate]);
+
+  // Spawn flow: pending → confirming → spawning (or → done on cancel).
+  // Fires once the initial fetch has completed (hasLoaded) so confirms
+  // can be based on the actual current set of running servers.
+  const spawnFlowFired = useRef(false);
+  useEffect(() => {
+    if (spawnFlowFired.current) return;
+    if (spawnState.phase !== "pending") return;
+    if (!hasLoaded) return;
+    spawnFlowFired.current = true;
+
+    void (async () => {
+      const spawn = launchContextRef.current?.spawn;
+      if (!spawn) {
+        setSpawnState({ phase: "done" });
+        return;
+      }
+
+      setSpawnState({ phase: "confirming" });
+
+      // Snapshot current running servers for the confirm logic.
+      const running = new Map(serversRef.current.map((s) => [s.cwd, s]));
+
+      // 1. Multi-folder confirmation (only when N>1 and the pref is on).
+      if (spawn.targets.length > 1 && spawn.confirmMulti) {
+        const ok = await confirmAlert({
+          title: `Start ${spawn.targets.length} dev servers?`,
+          message: spawn.targets.map((t) => t.name).join(", "),
+          primaryAction: { title: "Start All" },
+        });
+        if (!ok) {
+          setSpawnState({ phase: "done" });
+          return;
+        }
+      }
+
+      // 2. Batch restart confirmation: one alert for any number of
+      //    already-running targets.
+      const runningTargets = spawn.targets
+        .map((t) => ({ target: t, existing: running.get(t.cwd) }))
+        .filter(
+          (
+            x,
+          ): x is {
+            target: { cwd: string; name: string };
+            existing: DevServer;
+          } => !!x.existing,
+        );
+      const proceed = await confirmRestartBatch(
+        runningTargets,
+        spawn.targets.length,
+      );
+      if (!proceed) {
+        setSpawnState({ phase: "done" });
+        return;
+      }
+
+      // 3. Show the "Starting…" toast before doing the kill+spawn work
+      //    so the user has feedback the moment they confirm.
+      const label =
+        spawn.targets.length === 1
+          ? spawn.targets[0].name
+          : `${spawn.targets.length} dev servers`;
+      const toast = await showToast({
+        style: Toast.Style.Animated,
+        title: `Starting ${label}…`,
+        primaryAction: spawn.showAutoOpenHint
+          ? {
+              title: "Auto-open in Browser?",
+              onAction: async (t) => {
+                await openExtensionPreferences();
+                await t.hide();
+              },
+            }
+          : undefined,
+      });
+      toastRef.current = toast;
+
+      // 4. Kill running PIDs first so they release their ports before
+      //    we spawn replacements. Parallelized, since they're independent processes.
+      await Promise.all(
+        runningTargets.map((rt) => killServer(rt.existing.pid)),
+      );
+
+      // 5. Spawn every approved target in parallel. The spawn itself
+      //    returns immediately (detached process), so this is fast.
+      await Promise.all(
+        spawn.targets.map(async (t) => {
+          try {
+            await startDevServer(t.cwd);
+            await recordSeen({
+              cwd: t.cwd,
+              projectName: t.name,
+            });
+          } catch (err) {
+            await showFailureToast(err, {
+              title: `Failed to start ${t.name}`,
+            });
+          }
+        }),
+      );
+
+      // 6. Transition to spawning. The watch effect below takes over,
+      //    flipping the toast to Success once every cwd appears in the
+      //    servers state (driven by the normal polling, now at 1s).
+      setSpawnState({
+        phase: "spawning",
+        expecting: new Map(spawn.targets.map((t) => [t.cwd, t.name])),
+        autoOpen: spawn.autoOpen,
+      });
+    })();
+  }, [spawnState.phase, hasLoaded]);
+
+  // Watch for every expected cwd to show up in the servers state.
+  // Drives the toast to Success and auto-hides after a brief beat.
+  useEffect(() => {
+    if (spawnState.phase !== "spawning") return;
+    const expecting = spawnState.expecting;
+    const remaining = new Map(expecting);
+    for (const s of servers) {
+      if (remaining.has(s.cwd)) remaining.delete(s.cwd);
+    }
+    if (remaining.size > 0) return;
+
+    // All expected servers detected. Move the cursor onto the newly started
+    // server so the default ↵ action operates on it instead of whatever row
+    // happened to be selected (the list is ordered by PID, not start time, so
+    // a new server usually lands at the bottom — see the grouping below). When
+    // several were started at once, focus the first; the user can step through
+    // the rest. Resolving by cwd picks whichever server is now listening for
+    // that cwd, which is the freshly spawned one even after a kill+respawn.
+    const firstCwd = [...expecting.keys()][0];
+    const focusTarget = servers.find((x) => x.cwd === firstCwd);
+    if (focusTarget) setSelectedItemId(String(focusTarget.pid));
+
+    if (spawnState.autoOpen) {
+      for (const cwd of expecting.keys()) {
+        const s = servers.find((x) => x.cwd === cwd);
+        if (s) open(s.url).catch(() => {});
+      }
+    }
+    const toast = toastRef.current;
+    if (toast) {
+      toast.style = Toast.Style.Success;
+      toast.title =
+        expecting.size === 1
+          ? `${[...expecting.values()][0]} is running`
+          : `${expecting.size} dev servers running`;
+      setTimeout(() => {
+        toast.hide().catch(() => {});
+      }, 2500);
+    }
+    setSpawnState({ phase: "done" });
+  }, [servers, spawnState]);
+
+  // Hard 15s timeout. If some expected servers still haven't bound a port,
+  // escalate the toast to a Failure that offers the startup log, since that's
+  // where the reason lives (e.g. portless needing sudo, a missing binary,
+  // a crashing build). A server that exits before binding is otherwise
+  // indistinguishable from one still booting, so without this the toast
+  // would just vanish and the user would have no thread to pull on.
+  //
+  // Wording stays soft ("not detected yet") because a genuinely slow build
+  // can exceed 15s; we assert "not seen", not "failed forever". `servers`
+  // is read from the ref so we compare against the latest poll, not the
+  // stale snapshot this effect closed over.
+  useEffect(() => {
+    if (spawnState.phase !== "spawning") return;
+    const expecting = spawnState.expecting;
+    const timer = setTimeout(() => {
+      const present = new Set(serversRef.current.map((s) => s.cwd));
+      const missing = [...expecting.entries()].filter(
+        ([cwd]) => !present.has(cwd),
+      );
+      const toast = toastRef.current;
+      if (toast && missing.length > 0) {
+        const names = joinNames(missing.map(([, name]) => name));
+        toast.style = Toast.Style.Failure;
+        toast.title =
+          missing.length === 1
+            ? `${names} hasn't started yet`
+            : `${names} haven't started yet`;
+        toast.message = "Not detected after 15s. Check the startup log.";
+        const [firstCwd, firstName] = missing[0];
+        toast.primaryAction = {
+          title: "View Startup Log",
+          onAction: (t) => {
+            t.hide().catch(() => {});
+            push(<SpawnLogView cwd={firstCwd} name={firstName} />);
+          },
+        };
+      } else {
+        toast?.hide().catch(() => {});
+      }
+      setSpawnState({ phase: "done" });
+    }, 15000);
+    return () => clearTimeout(timer);
+  }, [spawnState.phase]);
+
+  // Every observed server feeds the recents store, so the Start Recent
+  // Dev Server picker has an up-to-date list of projects without the user
+  // having to bookmark anything explicitly. Dedup by cwd within a single
+  // tick so multi-server projects don't write themselves multiple times.
+  useEffect(() => {
+    if (servers.length === 0) return;
+    const byCwd = new Map<string, ReturnType<typeof toRecent>>();
+    for (const s of servers) {
+      if (!byCwd.has(s.cwd)) byCwd.set(s.cwd, toRecent(s));
+    }
+    recordSeenBatch([...byCwd.values()]).catch(() => {
+      // Recents are a best-effort enhancement; a write failure must not
+      // disrupt the dashboard, so swallow.
+    });
   }, [servers]);
 
   async function kill(pid: number) {
@@ -466,10 +922,15 @@ export default function Command() {
   async function restart(server: DevServer) {
     // Snapshot the project's server count BEFORE killing the old one so we
     // can detect when a new server has bound a port. We use serversRef.current
-    // so we always see the latest state across the polling loop.
-    const baseline = serversRef.current.filter(
-      (s) => s.cwd === server.cwd && s.pid !== server.pid,
-    ).length;
+    // so we always see the latest state across the polling loop. The pid set
+    // (excluding the one we're about to kill) lets us single out the
+    // replacement afterwards so we can move the cursor onto it.
+    const priorPids = new Set(
+      serversRef.current
+        .filter((s) => s.cwd === server.cwd && s.pid !== server.pid)
+        .map((s) => s.pid),
+    );
+    const baseline = priorPids.size;
     try {
       await mutate(restartServer(server), {
         optimisticUpdate: (current) =>
@@ -499,10 +960,17 @@ export default function Command() {
       if (restored) {
         toast.style = Toast.Style.Success;
         toast.title = "Restarted";
+        // Focus the replacement: the cwd's server whose pid wasn't running
+        // before the kill. Falls back to any current server for the cwd in the
+        // unlikely case the new pid matches a prior one (pid reuse).
+        const sameCwd = serversRef.current.filter((s) => s.cwd === server.cwd);
+        const replacement =
+          sameCwd.find((s) => !priorPids.has(s.pid)) ?? sameCwd[0];
+        if (replacement) setSelectedItemId(String(replacement.pid));
       } else {
         toast.style = Toast.Style.Failure;
         toast.title = "Restart timed out";
-        toast.message = `Check ${path.join(os.tmpdir(), "dev-servers-restart-*.log")}`;
+        toast.message = `Check ${spawnLogPath(server.cwd)}`;
       }
     } catch (err) {
       await showFailureToast(err, {
@@ -567,8 +1035,10 @@ export default function Command() {
 
   return (
     <List
-      isLoading={isLoading}
+      isLoading={effectiveLoading}
       searchBarPlaceholder="Filter servers..."
+      selectedItemId={selectedItemId}
+      onSelectionChange={(id) => setSelectedItemId(id ?? undefined)}
       searchBarAccessory={
         availableTools.length > 1 ? (
           <List.Dropdown
@@ -590,12 +1060,17 @@ export default function Command() {
         ) : undefined
       }
     >
-      {servers.length === 0 && !isLoading && (
+      {servers.length === 0 && !effectiveLoading && (
         <List.EmptyView
           title="No Dev Servers Running"
-          description={`Start a dev server and it will appear here.\nRefreshing every ${prefs.refreshInterval}s.`}
+          description={`Refreshing every ${prefs.refreshInterval}s.`}
           actions={
             <ActionPanel>
+              <Action
+                title="Start Dev Server"
+                icon={Icon.Play}
+                onAction={openStartCommand}
+              />
               <Action
                 title="Refresh"
                 icon={Icon.ArrowClockwise}
@@ -627,6 +1102,7 @@ export default function Command() {
           {projectServers.map((server) => (
             <ServerItem
               key={server.pid}
+              id={String(server.pid)}
               server={server}
               terminalApp={terminalApp}
               show={show}

--- a/extensions/dev-servers/src/recents.ts
+++ b/extensions/dev-servers/src/recents.ts
@@ -98,6 +98,20 @@ export async function recordSeen(
   await recordSeenBatch([proj]);
 }
 
+// Remove a single recent by cwd. Reads the current list fresh from storage
+// (rather than filtering a caller-held snapshot) so a concurrent writer —
+// the dashboard's recordSeenBatch poll, or this command's own mount-time
+// migration — isn't clobbered: we only ever drop the one targeted entry and
+// preserve everything else as it stands on disk. Returns the resulting list
+// so a useLocalStorage caller can sync its in-memory state with the same
+// value we just wrote, keeping hook and storage in agreement.
+export async function removeRecent(cwd: string): Promise<RecentProject[]> {
+  const target = canonicalCwd(cwd);
+  const next = (await readAll()).filter((r) => canonicalCwd(r.cwd) !== target);
+  await writeAll(next);
+  return next;
+}
+
 // Attach a favicon to the recent entry matching the given cwd, no-op if
 // no matching entry exists yet (the next recordSeen will add one). Skips
 // the write when the favicon is already up to date so the dashboard's

--- a/extensions/dev-servers/src/recents.ts
+++ b/extensions/dev-servers/src/recents.ts
@@ -1,0 +1,125 @@
+import { LocalStorage } from "@raycast/api";
+import { canonicalCwd } from "./servers";
+import { DevServer } from "./types";
+
+export const STORAGE_KEY = "recent-projects";
+const MAX_RECENTS = 30;
+
+// Cap on the size of a favicon data URI we persist onto a recent entry.
+// The live dashboard always renders the real favicon regardless; this only
+// bounds what we cache for the picker's stopped-project icons, so a handful
+// of fat multi-resolution .ico files can't bloat LocalStorage. Anything over
+// the cap falls back to the framework-tinted folder in the picker.
+const MAX_FAVICON_BYTES = 24 * 1024;
+
+export interface RecentProject {
+  cwd: string; // canonical path (realpath-resolved)
+  projectName: string;
+  branch?: string;
+  // Cached favicon data URI, populated by the dashboard whenever it
+  // successfully resolves one for a running server. Lets the picker
+  // render the project's real icon even when the server is stopped.
+  favicon?: string;
+  lastSeen: number; // unix ms
+}
+
+async function readAll(): Promise<RecentProject[]> {
+  const raw = await LocalStorage.getItem<string>(STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const arr: unknown = JSON.parse(raw);
+    if (!Array.isArray(arr)) return [];
+    return arr.filter(
+      (r): r is RecentProject =>
+        typeof r === "object" &&
+        r !== null &&
+        typeof (r as RecentProject).cwd === "string" &&
+        typeof (r as RecentProject).projectName === "string" &&
+        typeof (r as RecentProject).lastSeen === "number",
+    );
+  } catch {
+    return [];
+  }
+}
+
+async function writeAll(recents: RecentProject[]): Promise<void> {
+  await LocalStorage.setItem(STORAGE_KEY, JSON.stringify(recents));
+}
+
+// Convenience: project payload for recordSeen from a running DevServer.
+export function toRecent(s: DevServer): Omit<RecentProject, "lastSeen"> {
+  return {
+    cwd: s.cwd,
+    projectName: s.projectName,
+    branch: s.branch,
+  };
+}
+
+// Insert-or-refresh a batch of projects in one storage write. The dashboard's
+// refresh loop calls this on every poll, so coalescing avoids 1+N writes per
+// tick. Bounded LRU: oldest entries beyond MAX_RECENTS are dropped.
+//
+// Every write also runs a passive migration: existing entries are
+// re-keyed by their canonical (symlink-resolved) cwd, collapsing
+// duplicates that earlier code paths may have inserted with non-canonical
+// paths. An empty `projects` array is a valid call shape; callers can
+// use it to force a one-shot migration without recording anything new.
+export async function recordSeenBatch(
+  projects: Array<Omit<RecentProject, "lastSeen">>,
+): Promise<void> {
+  const recents = await readAll();
+  const byCwd = new Map<string, RecentProject>();
+  for (const r of recents) {
+    const canon = canonicalCwd(r.cwd);
+    const existing = byCwd.get(canon);
+    if (!existing || r.lastSeen > existing.lastSeen) {
+      byCwd.set(canon, { ...r, cwd: canon });
+    }
+  }
+  const now = Date.now();
+  for (const proj of projects) {
+    const canon = canonicalCwd(proj.cwd);
+    const existing = byCwd.get(canon);
+    byCwd.set(canon, {
+      ...(existing ?? {}),
+      ...proj,
+      cwd: canon,
+      lastSeen: now,
+    });
+  }
+  const next = [...byCwd.values()].sort((a, b) => b.lastSeen - a.lastSeen);
+  if (next.length > MAX_RECENTS) next.length = MAX_RECENTS;
+  await writeAll(next);
+}
+
+export async function recordSeen(
+  proj: Omit<RecentProject, "lastSeen">,
+): Promise<void> {
+  await recordSeenBatch([proj]);
+}
+
+// Attach a favicon to the recent entry matching the given cwd, no-op if
+// no matching entry exists yet (the next recordSeen will add one). Skips
+// the write when the favicon is already up to date so the dashboard's
+// per-render effect doesn't thrash storage.
+export async function updateRecentFavicon(
+  cwd: string,
+  favicon: string,
+): Promise<void> {
+  // Don't persist oversized favicons; they'd accumulate across up to
+  // MAX_RECENTS entries and bloat LocalStorage for a purely cosmetic icon.
+  // The dashboard still shows the real favicon live; the picker just falls
+  // back to the framework-tinted folder for this project when stopped.
+  if (favicon.length > MAX_FAVICON_BYTES) return;
+  const target = canonicalCwd(cwd);
+  const recents = await readAll();
+  let changed = false;
+  for (const r of recents) {
+    if (canonicalCwd(r.cwd) !== target) continue;
+    if (r.favicon === favicon) continue;
+    r.favicon = favicon;
+    r.cwd = target;
+    changed = true;
+  }
+  if (changed) await writeAll(recents);
+}

--- a/extensions/dev-servers/src/servers.ts
+++ b/extensions/dev-servers/src/servers.ts
@@ -459,6 +459,21 @@ export async function startDevServer(cwd: string): Promise<void> {
     detached: true,
     stdio: ["ignore", out, out],
   });
+  // Close our copy of the log fd once the child owns its own dup, so repeated
+  // starts/restarts in a long-lived dashboard session don't leak descriptors.
+  // We wait for the 'spawn' event rather than closing immediately because
+  // libuv dups the fd into the child asynchronously; closing too early could
+  // truncate the child's stdio. The 'error' listener covers the spawn-failed
+  // path and also keeps a spawn error from throwing as an unhandled event.
+  const closeLog = () => {
+    try {
+      fs.closeSync(out);
+    } catch {
+      // Already closed / invalid fd; nothing to do.
+    }
+  };
+  child.once("spawn", closeLog);
+  child.once("error", closeLog);
   child.unref();
 }
 

--- a/extensions/dev-servers/src/servers.ts
+++ b/extensions/dev-servers/src/servers.ts
@@ -192,7 +192,7 @@ function detectTool(command: string, cwd: string): string {
     if (name === "vite" && hasSvelteConfig(cwd)) return "sveltekit";
     return name;
   }
-  // 2. Fall back to the package name from node_modules/<pkg>/ — handles
+  // 2. Fall back to the package name from node_modules/<pkg>/. This handles
   //    `node node_modules/serve/build/main.js` (→ "serve") and scoped
   //    packages like `node_modules/@vitejs/plugin-react/...`.
   const pkg = command.match(/node_modules\/(@[^/]+\/[^/\s]+|[^/\s]+)/);
@@ -205,7 +205,9 @@ function detectTool(command: string, cwd: string): string {
 function hasSvelteConfig(cwd: string): boolean {
   return (
     fs.existsSync(`${cwd}/svelte.config.js`) ||
-    fs.existsSync(`${cwd}/svelte.config.ts`)
+    fs.existsSync(`${cwd}/svelte.config.ts`) ||
+    fs.existsSync(`${cwd}/svelte.config.mjs`) ||
+    fs.existsSync(`${cwd}/svelte.config.cjs`)
   );
 }
 
@@ -235,7 +237,7 @@ export async function fetchServers(): Promise<DevServer[]> {
   ]);
   const candidates = procs.filter(isCandidate);
   const portByPid = lowestPortPerPid(listeners);
-  // Only query cwds for candidates that are actually listening — keeps the
+  // Only query cwds for candidates that are actually listening, which keeps the
   // lsof argument list short and skips dead PIDs.
   const finalPids = candidates
     .map((p) => p.pid)
@@ -243,7 +245,7 @@ export async function fetchServers(): Promise<DevServer[]> {
   const cwdByPid = await listCwds(finalPids);
 
   // Look up git info per unique cwd, in parallel. Worktrees of the same repo
-  // share a git common-dir, so we use that path as the project key — collapses
+  // share a git common-dir, so we use that path as the project key, which collapses
   // sibling worktrees into one group while still letting us show the branch on
   // each row. The project's display name is the basename of the common-dir's
   // parent (the repo root).
@@ -260,7 +262,7 @@ export async function fetchServers(): Promise<DevServer[]> {
     const cwd = cwdByPid.get(proc.pid);
     if (!cwd) continue; // shouldn't happen for live processes, but be safe
     const tool = detectTool(proc.command, cwd);
-    // Drop the portless proxy daemon itself — it's a node process out of
+    // Drop the portless proxy daemon itself. It's a node process out of
     // node_modules/portless/ that binds 80/443/1355, and would otherwise
     // appear as a phantom "dev server" row. Child processes spawned by
     // portless run their own framework binary (next, vite, …) so they
@@ -294,6 +296,11 @@ export async function fetchServers(): Promise<DevServer[]> {
   return servers;
 }
 
+// User-initiated kill: SIGTERM (the default signal), graceful: the
+// dev server gets a chance to flush logs, close connections, etc. Use
+// this from the dashboard's Kill / Kill All flows. Pair with `killServer`
+// below when you need an *immediate* port release (e.g. restart).
+//
 // Async-shaped so callers can pass the returned promise to Raycast's
 // `mutate(fn, { optimisticUpdate })` flow. `process.kill` itself is sync.
 export async function killProcess(pid: number): Promise<void> {
@@ -313,19 +320,110 @@ export function detectPackageManager(cwd: string): PackageManager {
   return "npm";
 }
 
-const PM_COMMAND: Record<PackageManager, [string, string[]]> = {
-  bun: ["bun", ["run", "dev"]],
-  pnpm: ["pnpm", ["dev"]],
-  yarn: ["yarn", ["dev"]],
-  npm: ["npm", ["run", "dev"]],
+// All managers honor `<pm> run <script>`. Explicit `run` works for arbitrary
+// script names (including ones with colons like `dev:web`) and removes the
+// ambiguity of the bare-shorthand form.
+const PM_RUN: Record<PackageManager, [string, string[]]> = {
+  bun: ["bun", ["run"]],
+  pnpm: ["pnpm", ["run"]],
+  yarn: ["yarn", ["run"]],
+  npm: ["npm", ["run"]],
 };
+
+// Heuristic tokens for the script-value fallback in pickDevScript. We match
+// the binary names that frameworks actually invoke in dev mode, with negative
+// lookaheads on the common production subcommands so we don't accidentally
+// pick a `build` or `preview` script. Ordering doesn't matter; first hit
+// wins inside any given script value.
+const DEV_SCRIPT_TOKENS: RegExp[] = [
+  /\bvite\b(?!\s+(?:build|preview|optimize))/,
+  /\bnext\s+dev\b/,
+  /\bastro\s+dev\b/,
+  /\bnuxt\s+dev\b/,
+  /\bwebpack-dev-server\b/,
+  /\bwebpack\s+serve\b/,
+  /\bparcel\b(?!\s+build)/,
+  /\bgatsby\s+develop\b/,
+  /\bremix\s+(?:dev|vite:dev)\b/,
+  /\bturbo\s+(?:run\s+)?dev\b/,
+  /\bbun\s+(?:--watch|--hot|run\s+dev)\b/,
+  /\bnodemon\b/,
+  /\btsx\s+watch\b/,
+  /\bts-node-dev\b/,
+  /\bserve\b/,
+  /\bhttp-server\b/,
+  /\blive-server\b/,
+];
+
+// Pick the most likely dev-server script in a project. First tries the
+// canonical key chain (`dev` → `start` → `develop`), then falls back to a
+// value-side heuristic so monorepo conventions like `dev:web` or
+// `start:dev` still resolve. Returns the script key (not the command), or
+// null when nothing in package.json looks like a dev server.
+export function pickDevScript(cwd: string): string | null {
+  let pkg: { scripts?: Record<string, unknown> };
+  try {
+    pkg = JSON.parse(
+      fs.readFileSync(path.join(cwd, "package.json"), "utf8"),
+    ) as { scripts?: Record<string, unknown> };
+  } catch {
+    return null;
+  }
+  const scripts = pkg.scripts ?? {};
+  for (const name of ["dev", "start", "develop"]) {
+    if (typeof scripts[name] === "string") return name;
+  }
+  // Iterate in declared order (Node preserves JSON insertion order), so the
+  // pick is deterministic for a given package.json.
+  for (const [name, value] of Object.entries(scripts)) {
+    if (typeof value !== "string") continue;
+    if (DEV_SCRIPT_TOKENS.some((re) => re.test(value))) return name;
+  }
+  return null;
+}
+
+// Canonicalize a path so two equivalent forms (alias / symlink / `/tmp` vs
+// `/private/tmp`) compare equal. Critical for the "is this project already
+// running?" check: lsof reports realpath for a process's cwd, so anything
+// we compare against it must also be realpath. Returns the input on
+// failure so callers don't have to handle a missing path twice.
+export function canonicalCwd(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+// Walk up from a filesystem path to the nearest directory containing a
+// package.json. Used to resolve a Finder selection (which may be a file, a
+// subfolder, or the project root itself) to a project root we can spawn in.
+// The returned path is canonicalized so it round-trips through process
+// inspection without symlink-induced mismatches. Returns null when the
+// path isn't inside any Node project.
+export function findProjectRoot(startPath: string): string | null {
+  let cur: string;
+  try {
+    const st = fs.statSync(startPath);
+    cur = st.isDirectory() ? startPath : path.dirname(startPath);
+  } catch {
+    return null;
+  }
+  for (;;) {
+    if (fs.existsSync(path.join(cur, "package.json"))) return canonicalCwd(cur);
+    const parent = path.dirname(cur);
+    if (parent === cur) return null;
+    cur = parent;
+  }
+}
 
 // Slugify cwd for use in a temp-dir log filename.
 function cwdSlug(cwd: string): string {
   return cwd.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "") || "root";
 }
 
-// Restart a dev server using the project's detected package manager.
+// Spawn a dev server for a project. Shared by the Start Dev Server flow
+// in the dashboard and by `restartServer` below.
 //
 // Implementation notes:
 // - We launch via `/bin/zsh -ilc` so the user's PATH is loaded. `-l` reads
@@ -334,38 +432,75 @@ function cwdSlug(cwd: string): string {
 //   GUI-app PATH is otherwise too minimal to find these tools.
 // - `cwd` is passed as a spawn option (NOT shell-concatenated) so the path
 //   never goes through the shell, removing one injection surface.
+// - The package manager, `run`, and the script name are passed as positional
+//   args (`$0`/`$@`) rather than interpolated into the command string. zsh
+//   re-quotes them, so a script key containing spaces or shell metacharacters
+//   can't break or inject; it's just run verbatim.
 // - `detached: true` + `unref()` lets the spawned process outlive the
 //   extension command's lifetime.
 // - The log filename is keyed by a slug of cwd so it stays meaningful after
-//   the PID has been replaced by the new server.
-export async function restartServer(server: DevServer): Promise<void> {
-  // SIGKILL (vs default SIGTERM) so the old listener releases the port
-  // immediately — no graceful-shutdown window where the new spawn races
-  // the old process for the same port. Poll process.kill(pid, 0) until
-  // ESRCH to confirm exit before spawning. Both SIGKILL and signal-0 are
-  // mapped to TerminateProcess / OpenProcess on Windows, so this stays
-  // portable when we add the Windows backend.
-  process.kill(server.pid, "SIGKILL");
-  const deadline = Date.now() + 500;
-  while (Date.now() < deadline) {
-    try {
-      process.kill(server.pid, 0);
-      await new Promise((r) => setTimeout(r, 20));
-    } catch {
-      break;
-    }
+//   the PID has been replaced by the new server. Use `spawnLogPath(cwd)`
+//   to reach it from error toasts.
+//
+// Throws if pickDevScript can't find a runnable script.
+export async function startDevServer(cwd: string): Promise<void> {
+  const script = pickDevScript(cwd);
+  if (!script) {
+    throw new Error(
+      "No dev script found in package.json. Expected one of: dev, start, develop, or a script that invokes a known dev-server tool.",
+    );
   }
-  const pm = detectPackageManager(server.cwd);
-  const [cmd, args] = PM_COMMAND[pm];
-  const logPath = path.join(
-    os.tmpdir(),
-    `dev-servers-restart-${cwdSlug(server.cwd)}.log`,
-  );
-  const out = fs.openSync(logPath, "a");
-  const child = spawn("/bin/zsh", ["-ilc", `exec ${cmd} ${args.join(" ")}`], {
-    cwd: server.cwd,
+  const pm = detectPackageManager(cwd);
+  const [cmd, baseArgs] = PM_RUN[pm];
+  const args = [...baseArgs, script];
+  const out = fs.openSync(spawnLogPath(cwd), "a");
+  const child = spawn("/bin/zsh", ["-ilc", 'exec "$0" "$@"', cmd, ...args], {
+    cwd,
     detached: true,
     stdio: ["ignore", out, out],
   });
   child.unref();
+}
+
+// Path of the spawn log for a given cwd. Useful for error toasts that point
+// the user at the right file when a spawn appears to fail.
+export function spawnLogPath(cwd: string): string {
+  return path.join(os.tmpdir(), `dev-servers-spawn-${cwdSlug(cwd)}.log`);
+}
+
+// Restart pre-spawn kill: SIGKILL + wait-for-exit. Unlike `killProcess`
+// above, this is *not* graceful: the spawn flow needs the listener to
+// release its port immediately so the new server can bind it without
+// racing. Polling `process.kill(pid, 0)` until ESRCH (max 500ms)
+// confirms exit before we return.
+//
+// Best-effort: any error along the way is swallowed. If the kernel
+// refuses to signal the process or it dies between snapshots, the next
+// spawn will either succeed cleanly or fail to bind the port, and both
+// surface their own errors at the right layer.
+//
+// Cross-platform: both SIGKILL and signal-0 map cleanly to Windows'
+// TerminateProcess / OpenProcess, so this stays portable.
+export async function killServer(pid: number): Promise<void> {
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    return;
+  }
+  const deadline = Date.now() + 500;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+      await new Promise((r) => setTimeout(r, 20));
+    } catch {
+      return;
+    }
+  }
+}
+
+// Restart a dev server: force-kill the old listener, then spawn a
+// replacement via startDevServer.
+export async function restartServer(server: DevServer): Promise<void> {
+  await killServer(server.pid);
+  await startDevServer(server.cwd);
 }

--- a/extensions/dev-servers/src/start.tsx
+++ b/extensions/dev-servers/src/start.tsx
@@ -29,8 +29,13 @@ import * as path from "node:path";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { promisify } from "node:util";
 import { DEFAULT_TERMINAL } from "./constants";
-import { RecentProject, STORAGE_KEY, recordSeenBatch } from "./recents";
-import { canonicalCwd, fetchServers, findProjectRoot } from "./servers";
+import {
+  RecentProject,
+  STORAGE_KEY,
+  recordSeenBatch,
+  removeRecent,
+} from "./recents";
+import { fetchServers, findProjectRoot } from "./servers";
 import { toolColor, toolLabel } from "./tool-display";
 import { DevServer } from "./types";
 
@@ -345,6 +350,15 @@ function PickerView({ autoOpen, terminalApp }: PickerProps) {
   // Hide entries that are currently running (the dashboard owns them) or
   // whose folder no longer exists on disk. We keep them in storage so a
   // remounted external drive or stopped server reappears.
+  //
+  // The existence check is intentionally synchronous despite running on the
+  // render path. It's bounded (≤ MAX_RECENTS = 30 stats), runs only when the
+  // recents/running sets change (this view doesn't poll on an interval), and a
+  // local-disk stat is sub-millisecond. Keeping it sync avoids the alternative's
+  // flash: an async check would paint all rows first, then pop out the dead
+  // ones a beat later. Unlike guessFramework (moved off-render because it parses
+  // package.json), this is a single cheap metadata syscall, so the tradeoff
+  // favors no flash over shaving microseconds.
   const visible = useMemo(() => {
     return (recents ?? [])
       .filter((r) => {
@@ -358,14 +372,16 @@ function PickerView({ autoOpen, terminalApp }: PickerProps) {
       .sort((a, b) => b.lastSeen - a.lastSeen);
   }, [recents, runningByCwd]);
 
-  // Drive deletion through useLocalStorage's setValue so the hook is the
-  // only writer. Earlier versions wrote directly to LocalStorage and then
-  // called setValue([...recents]) to force a re-render, but useLocalStorage
-  // doesn't re-read storage on setValue, so that pattern could overwrite
-  // the deletion with the in-memory (pre-delete) value.
+  // Delete via removeRecent, which reads fresh from storage and drops only
+  // the targeted entry. Filtering the hook's in-memory `recents` instead
+  // would clobber any entries written out-of-band since the hook last read:
+  // the dashboard's recordSeenBatch poll and this command's own mount-time
+  // migration both write directly to LocalStorage, and useLocalStorage does
+  // not re-read on those external writes. We then feed the freshly-written
+  // list back through setRecents so the hook's state matches storage (same
+  // value, so no re-clobber).
   async function handleRemove(targetCwd: string) {
-    const target = canonicalCwd(targetCwd);
-    await setRecents((recents ?? []).filter((r) => r.cwd !== target));
+    await setRecents(await removeRecent(targetCwd));
   }
 
   const isLoading = isLoadingRecents || isLoadingRunning;

--- a/extensions/dev-servers/src/start.tsx
+++ b/extensions/dev-servers/src/start.tsx
@@ -1,0 +1,529 @@
+import {
+  Action,
+  ActionPanel,
+  Alert,
+  Application,
+  Color,
+  Icon,
+  LaunchProps,
+  LaunchType,
+  List,
+  LocalStorage,
+  confirmAlert,
+  getFrontmostApplication,
+  getPreferenceValues,
+  getSelectedFinderItems,
+  launchCommand,
+} from "@raycast/api";
+// Note: useNavigation and Form are no longer needed. The Choose
+// Folder flow now opens the native macOS picker directly instead of
+// pushing a Raycast Form view.
+import {
+  showFailureToast,
+  useCachedPromise,
+  useLocalStorage,
+} from "@raycast/utils";
+import { execFile } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { promisify } from "node:util";
+import { DEFAULT_TERMINAL } from "./constants";
+import { RecentProject, STORAGE_KEY, recordSeenBatch } from "./recents";
+import { canonicalCwd, fetchServers, findProjectRoot } from "./servers";
+import { toolColor, toolLabel } from "./tool-display";
+import { DevServer } from "./types";
+
+const execFileAsync = promisify(execFile);
+
+// One-time discoverability nudge for the autoOpenInBrowser pref. The
+// Start command pre-decides whether to surface the CTA (so the counter
+// is consistent regardless of whether the user lands on a confirm or
+// goes straight to spawn), then passes the decision through launchContext
+// for the dashboard to render on its toast.
+const AUTO_OPEN_HINT_MAX = 3;
+const AUTO_OPEN_HINT_KEY = "auto-open-hint-shown";
+
+// Decide whether to surface the one-time "Auto-open in Browser?" CTA and, if
+// so, consume one of its remaining showings, in a single storage read/write
+// rather than a separate should-show check followed by a bump.
+async function maybeConsumeAutoOpenHint(): Promise<boolean> {
+  const raw = await LocalStorage.getItem<string>(AUTO_OPEN_HINT_KEY);
+  const count = raw ? parseInt(raw, 10) : 0;
+  if (!Number.isFinite(count) || count >= AUTO_OPEN_HINT_MAX) return false;
+  await LocalStorage.setItem(AUTO_OPEN_HINT_KEY, String(count + 1));
+  return true;
+}
+
+// Best-guess framework for a project, read from package.json dependencies.
+// UI tag only. Process inspection is still the source of truth for a
+// running server.
+function guessFramework(cwd: string): string | undefined {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(cwd, "package.json"), "utf8"),
+    ) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const deps = {
+      ...(pkg.dependencies ?? {}),
+      ...(pkg.devDependencies ?? {}),
+    };
+    if ("next" in deps) return "next";
+    if ("@sveltejs/kit" in deps) return "sveltekit";
+    if ("svelte" in deps) return "svelte";
+    if ("astro" in deps) return "astro";
+    if ("nuxt" in deps || "nuxt3" in deps) return "nuxt";
+    if ("@remix-run/dev" in deps) return "remix";
+    if ("gatsby" in deps) return "gatsby";
+    if ("vite" in deps) return "vite";
+    if ("webpack" in deps) return "webpack";
+    if ("parcel" in deps) return "parcel";
+    if ("turbo" in deps) return "turbo";
+    if ("esbuild" in deps) return "esbuild";
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function formatLastSeen(ts: number): string {
+  const seconds = Math.floor((Date.now() - ts) / 1000);
+  if (seconds < 60) return "just now";
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  const days = Math.floor(seconds / 86400);
+  return days === 1 ? "yesterday" : `${days}d ago`;
+}
+
+interface Target {
+  cwd: string;
+  projectName: string;
+}
+
+function resolveTarget(rawPath: string): Target | null {
+  const cwd = findProjectRoot(rawPath);
+  if (!cwd) return null;
+  return { cwd, projectName: path.basename(cwd) };
+}
+
+// Hand the spawn request off to the dashboard. The dashboard owns
+// confirms, kill+spawn, and the toast lifecycle; this command only
+// resolves the target list and navigates. Faster perceived flow for
+// the user (dashboard appears immediately instead of waiting on a
+// blank Start view).
+async function launchSpawn(
+  targets: Array<{ cwd: string; name: string }>,
+  options: { autoOpen: boolean; confirmMulti: boolean },
+): Promise<void> {
+  const showAutoOpenHint =
+    !options.autoOpen && (await maybeConsumeAutoOpenHint());
+  try {
+    await launchCommand({
+      name: "index",
+      type: LaunchType.UserInitiated,
+      context: {
+        spawn: {
+          targets,
+          autoOpen: options.autoOpen,
+          confirmMulti: options.confirmMulti,
+          showAutoOpenHint,
+        },
+      },
+    });
+  } catch (err) {
+    await showFailureToast(err, { title: "Couldn't open the dashboard" });
+  }
+}
+
+// Open the native macOS folder picker via osascript. Skips the Form +
+// Form.FilePicker round-trip the API would otherwise require. The user
+// gets the OS dialog immediately instead of a Raycast screen they have
+// to click through first. Returns the picked POSIX path, or null when
+// the user cancels (osascript exits non-zero in that case).
+async function pickFolderNative(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("osascript", [
+      "-e",
+      'POSIX path of (choose folder with prompt "Pick a project folder")',
+    ]);
+    return stdout.trim() || null;
+  } catch {
+    // User canceled or osascript was unavailable; silently no-op.
+    return null;
+  }
+}
+
+// Handler for the picker's "Choose Folder…" action. Opens the native
+// dialog, resolves the pick to a project root, and hands off to the
+// dashboard via launchSpawn.
+async function chooseFolderAndStart(options: {
+  autoOpen: boolean;
+}): Promise<void> {
+  const raw = await pickFolderNative();
+  if (!raw) return;
+  const target = resolveTarget(raw);
+  if (!target) {
+    await showFailureToast(undefined, {
+      title: "No package.json found",
+      message: "That folder isn't inside a Node project.",
+    });
+    return;
+  }
+  await launchSpawn([{ cwd: target.cwd, name: target.projectName }], {
+    autoOpen: options.autoOpen,
+    confirmMulti: false,
+  });
+}
+
+interface RowProps {
+  recent: RecentProject;
+  framework?: string;
+  terminalApp: Application;
+  autoOpen: boolean;
+  onRemove: (cwd: string) => Promise<void>;
+}
+
+function RecentRow({
+  recent,
+  framework,
+  terminalApp,
+  autoOpen,
+  onRemove,
+}: RowProps) {
+  async function start() {
+    await launchSpawn([{ cwd: recent.cwd, name: recent.projectName }], {
+      autoOpen,
+      confirmMulti: false,
+    });
+  }
+
+  async function remove() {
+    const ok = await confirmAlert({
+      title: `Remove ${recent.projectName} from recents?`,
+      message:
+        "The project files stay where they are; only the recents entry is removed.",
+      primaryAction: {
+        title: "Remove",
+        style: Alert.ActionStyle.Destructive,
+      },
+    });
+    if (!ok) return;
+    await onRemove(recent.cwd);
+  }
+
+  const tool = framework;
+  const accessories: List.Item.Accessory[] = [
+    {
+      text: formatLastSeen(recent.lastSeen),
+      tooltip: `Last seen ${new Date(recent.lastSeen).toLocaleString()}`,
+    },
+  ];
+  if (tool) {
+    accessories.push({
+      tag: { value: toolLabel(tool), color: toolColor(tool) },
+    });
+  }
+
+  const branchSubtitle = recent.branch
+    ? { value: recent.branch, tooltip: `Branch: ${recent.branch}` }
+    : undefined;
+
+  // Prefer the cached favicon for projects we've seen running. The
+  // dashboard persists this onto the recents entry, so even stopped
+  // projects display their real icon.
+  const icon = recent.favicon
+    ? { source: recent.favicon, fallback: Icon.Folder }
+    : {
+        source: Icon.Folder,
+        tintColor: tool ? toolColor(tool) : Color.SecondaryText,
+      };
+
+  return (
+    <List.Item
+      icon={icon}
+      title={recent.projectName}
+      subtitle={branchSubtitle}
+      keywords={[recent.cwd, recent.branch].filter((v): v is string =>
+        Boolean(v),
+      )}
+      accessories={accessories}
+      actions={
+        <ActionPanel>
+          <Action title="Start Dev Server" icon={Icon.Play} onAction={start} />
+          <ActionPanel.Section>
+            <Action.Open
+              title={`Open in ${terminalApp.name}`}
+              icon={Icon.Terminal}
+              target={recent.cwd}
+              application={terminalApp}
+              shortcut={{ modifiers: ["cmd"], key: "t" }}
+            />
+            <Action.ShowInFinder
+              path={recent.cwd}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
+            />
+            <Action.CopyToClipboard
+              title="Copy Path"
+              content={recent.cwd}
+              shortcut={{ modifiers: ["cmd"], key: "c" }}
+            />
+          </ActionPanel.Section>
+          <ActionPanel.Section>
+            <Action
+              title="Remove from Recents"
+              icon={Icon.Trash}
+              style={Action.Style.Destructive}
+              shortcut={{ modifiers: ["ctrl"], key: "x" }}
+              onAction={remove}
+            />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+interface PickerProps {
+  autoOpen: boolean;
+  terminalApp: Application;
+}
+
+// Picker view shown when there's no Finder selection. Lists recent
+// projects (excluding currently-running ones, which live in the
+// dashboard) and an always-present "Choose Folder…" entry for one-off
+// picks.
+function PickerView({ autoOpen, terminalApp }: PickerProps) {
+  // Passive migration: every mount triggers an empty recordSeenBatch
+  // which canonicalizes any non-symlink-resolved entries left over from
+  // earlier builds, so the running-server filter below matches reliably.
+  useEffect(() => {
+    void recordSeenBatch([]).catch(() => {});
+  }, []);
+
+  const {
+    value: recents,
+    isLoading: isLoadingRecents,
+    setValue: setRecents,
+  } = useLocalStorage<RecentProject[]>(STORAGE_KEY, []);
+  const { data: running = [], isLoading: isLoadingRunning } = useCachedPromise(
+    fetchServers,
+    [],
+    { keepPreviousData: true },
+  );
+
+  const runningByCwd = useMemo(() => {
+    const m = new Map<string, DevServer>();
+    for (const s of running) m.set(s.cwd, s);
+    return m;
+  }, [running]);
+
+  // Framework detection reads each project's package.json from disk. Run it
+  // off the render path (in a cached promise keyed by the recents' cwds)
+  // rather than synchronously in a useMemo, so opening the picker with a
+  // full recents list doesn't block the first paint on up to MAX_RECENTS
+  // synchronous file reads. keepPreviousData holds the tags steady while a
+  // refreshed list resolves.
+  const recentCwds = useMemo(
+    () => (recents ?? []).map((r) => r.cwd),
+    [recents],
+  );
+  const { data: frameworkByCwd } = useCachedPromise(
+    async (cwds: string[]): Promise<Record<string, string>> => {
+      const out: Record<string, string> = {};
+      for (const cwd of cwds) {
+        const fw = guessFramework(cwd);
+        if (fw) out[cwd] = fw;
+      }
+      return out;
+    },
+    [recentCwds],
+    { keepPreviousData: true, initialData: {} },
+  );
+
+  // Hide entries that are currently running (the dashboard owns them) or
+  // whose folder no longer exists on disk. We keep them in storage so a
+  // remounted external drive or stopped server reappears.
+  const visible = useMemo(() => {
+    return (recents ?? [])
+      .filter((r) => {
+        if (runningByCwd.has(r.cwd)) return false;
+        try {
+          return fs.statSync(r.cwd).isDirectory();
+        } catch {
+          return false;
+        }
+      })
+      .sort((a, b) => b.lastSeen - a.lastSeen);
+  }, [recents, runningByCwd]);
+
+  // Drive deletion through useLocalStorage's setValue so the hook is the
+  // only writer. Earlier versions wrote directly to LocalStorage and then
+  // called setValue([...recents]) to force a re-render, but useLocalStorage
+  // doesn't re-read storage on setValue, so that pattern could overwrite
+  // the deletion with the in-memory (pre-delete) value.
+  async function handleRemove(targetCwd: string) {
+    const target = canonicalCwd(targetCwd);
+    await setRecents((recents ?? []).filter((r) => r.cwd !== target));
+  }
+
+  const isLoading = isLoadingRecents || isLoadingRunning;
+  const hasRecents = visible.length > 0;
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Filter recent projects..."
+    >
+      <List.Section title="Browse">
+        <List.Item
+          icon={Icon.NewFolder}
+          title="Choose Folder…"
+          subtitle="Pick a project that isn't in your recents"
+          actions={
+            <ActionPanel>
+              <Action
+                title="Choose Folder…"
+                icon={Icon.NewFolder}
+                onAction={() => chooseFolderAndStart({ autoOpen })}
+              />
+            </ActionPanel>
+          }
+        />
+      </List.Section>
+      {hasRecents && (
+        <List.Section title="Recent Projects" subtitle={`${visible.length}`}>
+          {visible.map((r) => (
+            <RecentRow
+              key={r.cwd}
+              recent={r}
+              framework={frameworkByCwd[r.cwd]}
+              terminalApp={terminalApp}
+              autoOpen={autoOpen}
+              onRemove={handleRemove}
+            />
+          ))}
+        </List.Section>
+      )}
+    </List>
+  );
+}
+
+// Unified command entry point. This command is now a pure launcher: it
+// resolves the Finder selection (if any) into a target list and hands
+// off to the dashboard, which owns the confirms, kill+spawn, and toast
+// lifecycle. The user lands on the dashboard immediately rather than
+// waiting on a blank Start view for slow pre-spawn work.
+//
+//   ┌─ forcePicker (launched from the dashboard's ⌘N / empty state)?
+//   │      ├─ Yes → render the picker directly, skip the Finder probe.
+//   │      └─ No  → ┌─ Is Finder the frontmost app?
+//   │              │      ├─ No  → render the picker (recents + "Choose Folder…").
+//   │              │      └─ Yes → ┌─ Finder selection resolves to a project?
+//   │              │              │      ├─ Yes → launchCommand to dashboard with
+//   │              │              │      │        spawn details in launchContext.
+//   │              │              │      └─ No  → render the picker.
+//
+// The frontmost-app gate is the key UX safeguard. `getSelectedFinderItems`
+// returns Finder's *persisted* selection regardless of what's actually in
+// focus, so a folder selected an hour ago to start one server would otherwise
+// be silently re-resolved as a target the next time the command runs from,
+// say, the browser — surfacing a baffling "already running, restart?" when the
+// user only meant to open the picker to start a *different* project. Honoring
+// the selection only when Finder is genuinely frontmost matches the user's
+// mental model ("I'm not in Finder, so don't act on its selection") and still
+// preserves the one-keystroke "select in Finder and run" flow. forcePicker is
+// the narrower dashboard-initiated shortcut: there the user is explicitly
+// choosing what to start, so we skip the probe entirely.
+export default function Command(
+  props: LaunchProps<{ launchContext?: { forcePicker?: boolean } }>,
+) {
+  const prefs = getPreferenceValues<Preferences.Start>();
+  const autoOpen = prefs.autoOpenInBrowser ?? false;
+  const confirmMulti = prefs.confirmMultiStart ?? true;
+  const terminalApp = prefs.terminalApp ?? DEFAULT_TERMINAL;
+  const forcePicker = props.launchContext?.forcePicker ?? false;
+
+  const [phase, setPhase] = useState<"checking" | "picker">(
+    forcePicker ? "picker" : "checking",
+  );
+  // Guard against React's StrictMode double-invocation of effects in
+  // development, which would otherwise probe Finder twice.
+  const probedRef = useRef(false);
+
+  useEffect(() => {
+    // Dashboard-initiated launch: go straight to the picker, no Finder probe.
+    if (forcePicker) return;
+    if (probedRef.current) return;
+    probedRef.current = true;
+    void (async () => {
+      // Only honor a Finder selection when Finder is the active app. The
+      // selection persists in Finder indefinitely, so without this gate a
+      // stale pick gets silently turned into a spawn target (see the header
+      // comment for the full rationale). If we can't determine the frontmost
+      // app, fall back to the picker rather than risk acting on a stale
+      // selection.
+      try {
+        const frontmost = await getFrontmostApplication();
+        const isFinder =
+          frontmost.bundleId === "com.apple.finder" ||
+          frontmost.name === "Finder";
+        if (!isFinder) {
+          setPhase("picker");
+          return;
+        }
+      } catch {
+        setPhase("picker");
+        return;
+      }
+
+      let selection: Array<{ path: string }>;
+      try {
+        selection = await getSelectedFinderItems();
+      } catch {
+        setPhase("picker");
+        return;
+      }
+      if (selection.length === 0) {
+        setPhase("picker");
+        return;
+      }
+
+      // Resolve each Finder item to a project root, dedup by cwd.
+      const seen = new Set<string>();
+      const targets: Target[] = [];
+      for (const item of selection) {
+        const t = resolveTarget(item.path);
+        if (!t || seen.has(t.cwd)) continue;
+        seen.add(t.cwd);
+        targets.push(t);
+      }
+      if (targets.length === 0) {
+        await showFailureToast(undefined, {
+          title: "No package.json in selection",
+          message: "Pick a project from your recents instead.",
+        });
+        setPhase("picker");
+        return;
+      }
+
+      // Hand off to the dashboard. No fetchServers, no confirms, no
+      // spawn here; the dashboard handles all of it from its own
+      // lifecycle, so the user sees the dashboard within a few hundred
+      // ms instead of waiting on this view.
+      await launchSpawn(
+        targets.map((t) => ({ cwd: t.cwd, name: t.projectName })),
+        { autoOpen, confirmMulti },
+      );
+    })();
+  }, [autoOpen, confirmMulti, forcePicker]);
+
+  if (phase === "picker") {
+    return <PickerView autoOpen={autoOpen} terminalApp={terminalApp} />;
+  }
+
+  // Minimal placeholder while we resolve the Finder selection. Just the
+  // loading bar; the dashboard is right behind it.
+  return <List isLoading={true} searchBarPlaceholder="Starting dev server…" />;
+}

--- a/extensions/dev-servers/src/tool-display.ts
+++ b/extensions/dev-servers/src/tool-display.ts
@@ -1,0 +1,63 @@
+import { Color } from "@raycast/api";
+
+// Display label for the tool tag. We keep the internal `tool` field lowercase
+// (used for grouping, color lookup, dropdown filter values) and only stylize
+// on the way to the UI. Anything not in this map renders as-is.
+const TOOL_DISPLAY_NAMES: Record<string, string> = {
+  vite: "Vite",
+  sveltekit: "SvelteKit",
+  svelte: "Svelte",
+  astro: "Astro",
+  next: "Next.js",
+  nuxt: "Nuxt",
+  webpack: "Webpack",
+  parcel: "Parcel",
+  gatsby: "Gatsby",
+  remix: "Remix",
+  turbo: "Turbo",
+  esbuild: "esbuild", // intentionally lowercase per upstream brand
+  bun: "Bun",
+  node: "Node",
+  serve: "Serve",
+  "http-server": "http-server", // intentionally lowercase per package name
+  "live-server": "Live Server",
+};
+
+export function toolLabel(tool: string): string {
+  return TOOL_DISPLAY_NAMES[tool.toLowerCase()] ?? tool;
+}
+
+// Theme-adaptive overrides for the few frameworks where the named palette
+// renders too muddy or too low-contrast against Raycast's translucent tag
+// background, especially on selected rows in dark mode. The rest fall
+// through to the named palette which works fine.
+const TOOL_COLOR_OVERRIDES: Record<string, { light: string; dark: string }> = {
+  // Purples: deepened in light mode for readable contrast
+  vite: { light: "#5B21B6", dark: "#B49CFF" },
+  astro: { light: "#5B21B6", dark: "#B49CFF" },
+  gatsby: { light: "#5B21B6", dark: "#B49CFF" },
+  // Yellows: Raycast's Color.Yellow is too pale in light mode, so use a deeper
+  // amber there. Keep a warm yellow in dark mode where it reads fine.
+  parcel: { light: "#A16207", dark: "#FDE047" },
+  esbuild: { light: "#A16207", dark: "#FDE047" },
+  bun: { light: "#A16207", dark: "#FDE047" },
+  // Next: Tailwind gray-900 / gray-100 (blue-tinted gray, not neutral)
+  next: { light: "#111827", dark: "#F3F4F6" },
+};
+
+export function toolColor(
+  tool: string,
+): Color | { light: string; dark: string } {
+  const key = tool.toLowerCase();
+  if (TOOL_COLOR_OVERRIDES[key]) return TOOL_COLOR_OVERRIDES[key];
+  const colors: Record<string, Color> = {
+    nuxt: Color.Green,
+    webpack: Color.Blue,
+    svelte: Color.Orange,
+    sveltekit: Color.Orange,
+    remix: Color.Magenta,
+    turbo: Color.Blue,
+    node: Color.Green,
+  };
+  return colors[key] ?? Color.Blue;
+}

--- a/extensions/dev-servers/src/types.ts
+++ b/extensions/dev-servers/src/types.ts
@@ -2,7 +2,7 @@ export interface DevServer {
   pid: number;
   port: string;
   url: string; // primary URL: first customUrl when present, else http://localhost:PORT
-  localUrl: string; // always http://localhost:PORT — for actions that must target loopback
+  localUrl: string; // always http://localhost:PORT, for actions that must target loopback
   customUrls?: string[]; // custom domains pointing at this port (e.g. https://myapp.localhost)
   tool: string; // vite | next | webpack | etc.
   runtime: "node" | "bun"; // the actual listening process's runtime


### PR DESCRIPTION
Adds a `Start Dev Server` command for spinning up dev servers without leaving Raycast. Works from a Finder selection, from a list of recently-seen projects, or from a native folder picker.

### Start Dev Server

- **From Finder**: select a project folder (or any file inside one) and run **Start Dev Server**. The extension walks up to the nearest `package.json`, detects the package manager (npm / pnpm / yarn / bun), picks the right script, and spawns it with the same PATH-aware login-shell pattern used by Restart. The dashboard opens immediately and shows a "Starting…" toast that transitions to "X is running" the moment the server binds a port.
- **From recents**: run the command with nothing selected in Finder and you get a picker over the projects the extension has seen running recently. Recents auto-populate from the dashboard's polling loop, with no explicit bookmarking. LRU-bounded at 30 entries. Running projects are hidden from this list (they live in the dashboard); they reappear once stopped.
- **From anywhere**: the picker also exposes a **Choose Folder…** entry that opens the native macOS folder dialog directly, with no intermediate screen.
- **From the dashboard**: the empty state offers a primary **Start Dev Server** action (just press `↵` from a fresh dashboard to land in the picker). Each running-server row's action panel also carries `Start Dev Server` (`⌘N`), so spinning up another project never requires bouncing back to root search.
- Each picker row shows last-seen, git branch when applicable, and a framework tag inferred from `package.json` dependencies. Cached favicons appear inline once the dashboard has seen the project running, so even stopped projects keep their real icon. Per-row actions: Start, Open in Terminal (`⌘T`), Show in Finder (`⌘⇧F`), Copy Path (`⌘C`), Remove from Recents (`⌃X`).
- Folders that no longer exist on disk are hidden this render but kept in storage so they reappear when (for example) an external drive remounts.
- **Startup logs**: every spawned server's stdout+stderr is captured to a per-project log. If a server doesn't bind a port within 15s, the toast escalates to a failure with a **View Startup Log** action instead of silently disappearing, so a misconfigured or custom setup (e.g. portless needing sudo, a missing binary, a crashing build) is diagnosable from inside Raycast. Every running-server row also carries a **View Startup Log** action (`⌘L`) for inspecting output on demand.

### Behavior

- Script picker tries `dev` → `start` → `develop` first, then scans script values for known dev-server tools (Vite, Next, Astro, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, Bun watch/hot, nodemon, tsx watch, ts-node-dev, serve, http-server, live-server). Monorepo conventions like `dev:web` and `start:dev` resolve out of the box.
- Already running on that folder? You get one consolidated alert: `X is already running. Restart?` for a single target, `All 3 already running. Restart them?` when every selected folder is running, or `2 of 3 already running. Restart these, then start the other one?` for the mixed case. No more N-alert cascades for N-folder selections.
- The Finder selection is only honored when Finder is the frontmost app. Previously a folder selected earlier (to start one server) lingered in Finder's selection, so running the command later from another app, e.g. the browser, would silently treat that stale folder as the target and surface a spurious `already running. Restart?`. Now, unless you're actually in Finder, the command goes straight to the recents picker, where you can start whatever project you meant.
- After a server is started (from Finder, the picker, or a recent), the dashboard moves the selection onto that new row, so pressing `↵` acts on the server you just launched rather than re-opening whatever was previously selected. Restart (`⌘⇧R`) likewise re-focuses the replacement once it binds.
- Multi-folder selection prompts for confirmation by default, useful for monorepo siblings or a "frontend + backend" startup, with an opt-out preference for users who do this regularly.
- New **Open in browser when the port binds** preference auto-opens the URL once the new server starts listening. Off by default; a one-time hint surfaces it in the in-flight toast for the first few starts.

### Under the hood

- The dashboard is the controller for the entire spawn flow. The launching command resolves a target list and hands off via `launchContext`, which lets the user land on the dashboard immediately and watch the spawn happen there, rather than waiting on a blank loading view for a pre-spawn `fetchServers` call.
- Spawn lifecycle is a clean state machine on the dashboard: `idle → pending → confirming → spawning → done`. The "Starting…" toast lives on the dashboard so it's visible the whole time the user is waiting, and transitions to a green "running" state the moment every expected cwd appears in the polling loop.
- All filesystem paths flow through `canonicalCwd` (a `realpathSync` wrapper) so symlinked project paths compare equal between Finder selections, the recents store, and `lsof`'s view of running processes.
- Extracted `startDevServer(cwd)` and `killServer(pid)` so the new command and the existing restart flow share one spawn path. Restart is now `killServer + startDevServer`.
- The spawn passes the package manager and chosen script as separate arguments rather than building a shell string, so projects with unusual script names (spaces, punctuation) start reliably and the launch surface stays free of shell-interpolation surprises.
- Shared `tool-display.ts` so the framework tag styling stays consistent across the dashboard and the picker.
- Favicons cached onto recents for stopped-project icons are size-capped, keeping the recents store small; the live dashboard always renders the real favicon regardless.

### Preferences

- **Terminal App** is now a single shared preference that applies to both **Dev Servers** and **Start Dev Server**: set the terminal `⌘T` opens once, and both commands honor it.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
