### PR TITLE
[Team Time] Use Hong Kong and Macau ISO codes for their own flags

### DIFF
--- a/extensions/team-time/CHANGELOG.md
+++ b/extensions/team-time/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Team Time Changelog
 
-## [Fix Hong Kong and Macau Flags] - {PR_MERGE_DATE}
+## [Fix Hong Kong and Macau Flags] - 2026-06-01
 
 - Split Hong Kong SAR and Macau SAR out of the China entry into their own country entries with ISO codes `HK` and `MO`, so they show their own flags instead of the China flag.
 - Switched Hong Kong SAR to the `Asia/Hong_Kong` time zone and Macau SAR to `Asia/Macau`.

--- a/extensions/team-time/CHANGELOG.md
+++ b/extensions/team-time/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Team Time Changelog
 
+## [Fix Hong Kong and Macau Flags] - {PR_MERGE_DATE}
+
+- Split Hong Kong SAR and Macau SAR out of the China entry into their own country entries with ISO codes `HK` and `MO`, so they show their own flags instead of the China flag.
+- Switched Hong Kong SAR to the `Asia/Hong_Kong` time zone and Macau SAR to `Asia/Macau`.
+
 ## [Fix Edit Label input] - 2026-05-19
 
 - Fixed the Edit Label command so custom flag fields accept typed input reliably.

--- a/extensions/team-time/src/world_cities_timezones.json
+++ b/extensions/team-time/src/world_cities_timezones.json
@@ -387,9 +387,7 @@
           "Nanjing",
           "Wuhan",
           "Xi'an",
-          "Hangzhou",
-          "Hong Kong SAR",
-          "Macau SAR"
+          "Hangzhou"
         ]
       },
       { "zone": "Asia/Urumqi", "cities": ["Ürümqi", "Kashgar"] }
@@ -605,6 +603,11 @@
     "timeZones": [{ "zone": "America/Tegucigalpa", "cities": ["Tegucigalpa", "San Pedro Sula"] }]
   },
   {
+    "country": "Hong Kong SAR",
+    "isoCode": "HK",
+    "timeZones": [{ "zone": "Asia/Hong_Kong", "cities": ["Hong Kong SAR"] }]
+  },
+  {
     "country": "Hungary",
     "isoCode": "HU",
     "timeZones": [{ "zone": "Europe/Budapest", "cities": ["Budapest", "Debrecen", "Szeged", "Miskolc", "Pécs"] }]
@@ -797,6 +800,11 @@
     "country": "Luxembourg",
     "isoCode": "LU",
     "timeZones": [{ "zone": "Europe/Luxembourg", "cities": ["Luxembourg", "Esch-sur-Alzette"] }]
+  },
+  {
+    "country": "Macau SAR",
+    "isoCode": "MO",
+    "timeZones": [{ "zone": "Asia/Macau", "cities": ["Macau SAR"] }]
   },
   {
     "country": "Madagascar",


### PR DESCRIPTION
## Description

Closes #28417. Hong Kong SAR and Macau SAR were added under the China country entry in `src/world_cities_timezones.json` in #19811, so `getFlagEmoji()` rendered the China flag for both cities. This PR splits them out into their own country entries with ISO codes `HK` and `MO` and their own IANA zones (`Asia/Hong_Kong`, `Asia/Macau`), so they show their own flags.

Repro before this change:

```js
function getFlagEmoji(isoCode){return isoCode.toUpperCase().replace(/./g,c=>String.fromCodePoint(c.charCodeAt(0)+127397));}
getFlagEmoji('CN'); // 🇨🇳 (rendered for Hong Kong SAR and Macau SAR)
```

After:

```js
getFlagEmoji('HK'); // 🇭🇰
getFlagEmoji('MO'); // 🇲🇴
```

Note for existing users: saved entries for Hong Kong SAR or Macau SAR added before this change keep the old `isoCode: "CN"` in local storage, so removing and re-adding those cities is needed to pick up the corrected flag.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our metadata tool