### PR TITLE
Update producthunt extension

### DIFF
--- a/extensions/producthunt/CHANGELOG.md
+++ b/extensions/producthunt/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Product Hunt Changelog
 
+## [2.4] - {PR_MERGE_DATE}
+
+- Fix 403 errors by migrating data fetching to the official Product Hunt GraphQL API v2 (#28424)
+- Add optional "API Key" and "API Secret" preferences (your Product Hunt OAuth app credentials from producthunt.com/v2/oauth/applications); the extension exchanges them for a public, read-only client-credentials token
+- Without credentials, the extension falls back to Product Hunt's public Atom feed (limited: no votes, comments, makers, or thumbnails); feed mode hides empty stats, opens launches in the browser, and offers an action to add credentials
+- Product detail view now uses the official API instead of scraping product pages
+- Compute "today" on Product Hunt's Pacific launch day so the list matches the site (UTC could return an empty set near the day boundary)
+- Show a toast with an "Open Extension Preferences" action when API credentials are rejected
+- Add a Refresh action (⌘R) that bypasses the response cache
+- Square-crop list icons and trim taglines for cleaner rendering
+- Add short-lived response caching to stay within the API rate budget
+- No production code fetches Product Hunt HTML anymore, avoiding Cloudflare bot blocks
+
 ## [2.3] - 2025-12-07
 
 - Fix scraper to use `latestScore`/`launchDayScore` fields for vote counts (Product Hunt API changed from `votesCount`)

--- a/extensions/producthunt/CHANGELOG.md
+++ b/extensions/producthunt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Product Hunt Changelog
 
-## [2.4] - {PR_MERGE_DATE}
+## [2.4] - 2026-06-01
 
 - Fix 403 errors by migrating data fetching to the official Product Hunt GraphQL API v2 (#28424)
 - Add optional "API Key" and "API Secret" preferences (your Product Hunt OAuth app credentials from producthunt.com/v2/oauth/applications); the extension exchanges them for a public, read-only client-credentials token

--- a/extensions/producthunt/README.md
+++ b/extensions/producthunt/README.md
@@ -1,42 +1,51 @@
 # Product Hunt for Raycast
 
-Browse and discover the latest products on Product Hunt directly from Raycast.
+Browse and discover the latest products on Product Hunt directly from Raycast, powered by Product Hunt's official API.
 
 ## Features
 
-- View today's featured product launches
-- See detailed product information including descriptions, votes, and comments
-- Browse product galleries with image and video support
-- Navigate through product details, makers, and topics
-- View previous launches of products
-- Copy product links in various formats
-- Open products directly in your browser
+- View today's featured product launches with votes, comments, makers, and topics
+- See detailed product information including descriptions and galleries
+- Open launches directly in your browser
+- Works without setup via a limited public feed, or unlock full data with your own API credentials
+
+## Setup (recommended)
+
+By default the extension shows a **limited public feed** (product names, taglines, and links only — no votes, comments, makers, or thumbnails). To unlock the full experience, connect your own free Product Hunt API application:
+
+1. Go to **[producthunt.com/v2/oauth/applications](https://www.producthunt.com/v2/oauth/applications)** and create an application (any name and redirect URI will do).
+2. Copy the generated **API Key** and **API Secret**.
+3. Open the extension's preferences in Raycast (`⌘` `,` while the command is selected, or via the "Open Extension Preferences" action) and paste them into the **API Key** and **API Secret** fields.
+
+The extension uses these credentials to request a public, read-only token via OAuth client-credentials — no personal login or write access is involved. Maker identity is redacted by Product Hunt for public-scope tokens, so makers are not shown; the launch's submitter ("hunter") is.
 
 ## Commands
 
-- **View Today's Featured Products** - Browse the latest products featured on Product Hunt's homepage
+- **View Today's Featured Products** — Browse the products featured on Product Hunt today
 
 ## Tools
 
-- **Get Today's Featured Products** - AI command to quickly fetch the latest products from Product Hunt
+- **Get Today's Featured Products** — AI command to fetch today's featured products
 
 ## How to Use
 
-1. Launch Raycast and select "View Today's Featured Products"
-2. Browse through the list of today's featured products
-3. Click on a product to view detailed information
-4. Use the action menu to:
-   - Open the product in your browser
-   - Copy the product link
-   - View the product gallery
-   - Explore related topics
-   - Learn about the makers
+1. Launch Raycast and select **View Today's Featured Products**
+2. Browse today's featured launches
+3. Press `Return` to view details (with API credentials) or open the launch in your browser (feed mode)
+4. Use the action menu to open in browser, copy the link, view the gallery, explore topics, or refresh
 
 ## Keyboard Shortcuts
 
-- `↑/↓` - Navigate between products
-- `→` or `Return` - View product details
-- `⌘+[` - Return to featured products list
-- `⌘+G` - View product gallery (when available)
-- `⌘+L` - Copy product link
-- `⌘+⇧+P` - View previous launches (when available)
+- `↑` / `↓` — Navigate between products
+- `Return` — View product details (or open in browser in feed mode)
+- `⌘` `O` — Open the product in your browser
+- `⌘` `⇧` `C` — Copy the product link
+- `⌘` `R` — Refresh
+- `⌘` `G` — View product gallery (when available)
+- `⌘` `⇧` `P` — View previous launches (when available)
+- `⌘` `[` — Return to featured products list
+
+## Notes
+
+- The "today" boundary follows Product Hunt's Pacific launch day, so the list matches the site.
+- Results are briefly cached to stay within Product Hunt's API rate limits; use **Refresh** to force-fetch.

--- a/extensions/producthunt/package-lock.json
+++ b/extensions/producthunt/package-lock.json
@@ -7,9 +7,11 @@
       "name": "producthunt",
       "license": "MIT",
       "dependencies": {
+        "@chrismessina/raycast-logger": "^1.2.2",
         "@raycast/api": "^1.103.10",
         "@raycast/utils": "^2.2.2",
-        "cheerio": "^1.1.2"
+        "cheerio": "^1.1.2",
+        "fast-xml-parser": "^5.8.0"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.0.4",
@@ -21,10 +23,19 @@
         "typescript": "^5.8.2"
       }
     },
+    "node_modules/@chrismessina/raycast-logger": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@chrismessina/raycast-logger/-/raycast-logger-1.2.2.tgz",
+      "integrity": "sha512-Btwrfi9aPYZp/Wu1urYSe2eDzEts0HZ/ydJuwX3jyKPSGkxDWISOJVzZ8Ery6TC6FUygcLqN2zU+CqNS0uU2wQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@raycast/api": "^1.0.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -38,9 +49,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -54,9 +65,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -70,9 +81,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -86,9 +97,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -102,9 +113,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -118,9 +129,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -134,9 +145,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -150,9 +161,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -166,9 +177,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -182,9 +193,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -198,9 +209,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -214,9 +225,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -230,9 +241,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -246,9 +257,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -262,9 +273,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -278,9 +289,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -294,9 +305,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -310,9 +321,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -326,9 +337,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -342,9 +353,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -358,9 +369,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -374,9 +385,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -390,9 +401,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -406,9 +417,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -422,9 +433,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -438,9 +449,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -457,9 +468,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -467,24 +478,31 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -518,7 +536,7 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
+    "node_modules/@eslint/core": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
@@ -531,34 +549,21 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -568,10 +573,17 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -606,9 +618,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
-      "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -642,55 +654,42 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/json-schema": "^7.0.15"
+        "@humanfs/types": "^0.15.0"
       },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
       }
     },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -708,9 +707,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
-      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1069,48 +1068,22 @@
         }
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@oclif/core": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.0.tgz",
-      "integrity": "sha512-jteNUQKgJHLHFbbz806aGZqf+RJJ7t4gwF4MYa8fCwCxQ8/klJNWc0MvaJiBebk7Mc+J39mdlsB4XraaCKznFw==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.4.tgz",
+      "integrity": "sha512-URwiQ5ALx/sJ2iH4vzXEd+H4K6NAI7LRs6Jag3hrgKEpGmaE6alfRC8qjO4GIgb6A3ACaJumqP9twi/M9ywdHQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -1123,11 +1096,11 @@
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
-        "minimatch": "^9.0.5",
-        "semver": "^7.7.3",
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
         "string-width": "^4.2.3",
         "supports-color": "^8",
-        "tinyglobby": "^0.2.14",
+        "tinyglobby": "^0.2.16",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -1137,9 +1110,9 @@
       }
     },
     "node_modules/@oclif/plugin-autocomplete": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.39.tgz",
-      "integrity": "sha512-OwAZNnSpuDjKyhAwoOJkFWxGswPFKBB4hpNIMsj6PUtbKwGBPmD+2wGGPgTsDioVwLmUELSb2bZ+1dxHfvXmvg==",
+      "version": "3.2.50",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.50.tgz",
+      "integrity": "sha512-SQRIJSYue/1tIn7X55W/97gTb8UkSoHeFAcBng2r2YMJyWj8uB1DtFl28D8BDXPQXPTiPK89hQGejoT7RdkR2w==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
@@ -1152,9 +1125,9 @@
       }
     },
     "node_modules/@oclif/plugin-help": {
-      "version": "6.2.36",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.36.tgz",
-      "integrity": "sha512-NBQIg5hEMhvdbi4mSrdqRGl5XJ0bqTAHq6vDCCCDXUcfVtdk3ZJbSxtRVWyVvo9E28vwqu6MZyHOJylevqcHbA==",
+      "version": "6.2.50",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.50.tgz",
+      "integrity": "sha512-rNCG4hUm+kPXFbhJfAVk/fZ3OdWJYwBDASlyX8CqOLP0MssjIGl7iEgfZz7TMuZFa+KucupKU5NRSc0KWfPTQA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4"
@@ -1164,13 +1137,13 @@
       }
     },
     "node_modules/@oclif/plugin-not-found": {
-      "version": "3.2.73",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.73.tgz",
-      "integrity": "sha512-2bQieTGI9XNFe9hKmXQjJmHV5rZw+yn7Rud1+C5uLEo8GaT89KZbiLTJgL35tGILahy/cB6+WAs812wjw7TK6w==",
+      "version": "3.2.86",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.86.tgz",
+      "integrity": "sha512-BJhJSahwsYayZpo18f0fPTg8tKb9dIvydaz03NCK3eMfmcsT1MmXhXqh1KEV8J7mz0sQ6f0qFEb6BXy490/iUg==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",
-        "@oclif/core": "^4.8.0",
+        "@oclif/core": "^4.11.3",
         "ansis": "^3.17.0",
         "fast-levenshtein": "^3.0.0"
       },
@@ -1179,28 +1152,28 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.103.10",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.103.10.tgz",
-      "integrity": "sha512-FOxqq47+YVCo4+Eq8eU8+esoLNwcxHHBVhw/JmZwsViTqMB3DF8WorXL+ZwrXW/8srruuzyyx9+ACyRdZ+zbSg==",
+      "version": "1.104.19",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.19.tgz",
+      "integrity": "sha512-SAVg56BAzxZGy/OPQ0jekUG3pJaoX5pCqleALvFo9JRE7P2tvKoglWnYRcIJArRhLlvV8FtFNMDafd+NNwXXCw==",
       "license": "MIT",
       "dependencies": {
-        "@oclif/core": "^4.5.4",
-        "@oclif/plugin-autocomplete": "^3.2.35",
-        "@oclif/plugin-help": "^6.2.33",
-        "@oclif/plugin-not-found": "^3.2.68",
-        "@types/node": "22.13.10",
+        "@oclif/core": "^4.8.4",
+        "@oclif/plugin-autocomplete": "^3.2.40",
+        "@oclif/plugin-help": "^6.2.37",
+        "@oclif/plugin-not-found": "^3.2.74",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
-        "esbuild": "^0.25.10",
+        "esbuild": "^0.27.3",
         "react": "19.0.0"
       },
       "bin": {
         "ray": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.14.0"
+        "node": ">=22.22.2"
       },
       "peerDependencies": {
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "react-devtools": "6.1.1"
       },
@@ -1217,12 +1190,12 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@raycast/api/node_modules/@types/react": {
@@ -1234,27 +1207,18 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@raycast/api/node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@raycast/eslint-config": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.0.4.tgz",
-      "integrity": "sha512-Sz5Q0HVY8pW21Sv7CDcJw882OGubSM3zx5uiDRQMkgt7Hui3I+IZOqxDInnhLsGG52prSdU7sg3R097hMJkkQw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.1.1.tgz",
+      "integrity": "sha512-W0kxF+FJ+BYQn0EKIV739j2ZrHEtjo/LclsoZgUWg3t364Dq75XKcjqYFYx+59/DBaamY0amdajlfuDAf6veAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint/js": "^9.22.0",
-        "@raycast/eslint-plugin": "^2.0.4",
-        "eslint-config-prettier": "^10.1.1",
-        "globals": "^16.0.0",
-        "typescript-eslint": "^8.26.1"
+        "@eslint/js": "^9.36.0",
+        "@raycast/eslint-plugin": "^2.1.1",
+        "eslint-config-prettier": "^10.1.8",
+        "globals": "^16.4.0",
+        "typescript-eslint": "^8.45.0"
       },
       "peerDependencies": {
         "eslint": ">=8.23.0",
@@ -1263,9 +1227,9 @@
       }
     },
     "node_modules/@raycast/eslint-plugin": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-2.0.4.tgz",
-      "integrity": "sha512-XrKppNp1sW4eoIErVgU/uStIIiwB3cesp+4hc4sK3PJGBGVz+8sO70+6pkqcOwqjeTv2COAeCFVVs6sdINsMHA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-2.1.1.tgz",
+      "integrity": "sha512-r2gs8uIlNp6I2mLOyN/kReGlvigzEeuyQPl4yw7nwLy8Zxjfjhg8txMViaBux8juBWBxbSWq/IfW6ZA50oeOHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1276,9 +1240,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.2.tgz",
-      "integrity": "sha512-tZcyWCHZvz4L/i1CGEnSZkBoK6wwX1pzlTKjcWWugbrQyG0QCMOxjKJfRC/iNkD+hHaqhMWUj4Y0LNo/NknvFw==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.5.tgz",
+      "integrity": "sha512-1o6zGRECh1KNe6CBx68iMPOrNYbV56opqs4zUtDr6Wmq4F7Ww3d8uLTXKVzXlGyJmpAys/Eliw6cKIP7dPdFfw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1304,9 +1268,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1318,41 +1282,40 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.13.tgz",
-      "integrity": "sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.0.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
-      "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.29.0.tgz",
-      "integrity": "sha512-PAIpk/U7NIS6H7TEtN45SPGLQaHNgB7wSjsQV/8+KYokAb2T/gloOA/Bee2yd4/yKVhPKe5LlaUGhAZk5zmSaQ==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
+      "integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.29.0",
-        "@typescript-eslint/type-utils": "8.29.0",
-        "@typescript-eslint/utils": "8.29.0",
-        "@typescript-eslint/visitor-keys": "8.29.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/type-utils": "8.60.0",
+        "@typescript-eslint/utils": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1362,23 +1325,33 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "@typescript-eslint/parser": "^8.60.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.29.0.tgz",
-      "integrity": "sha512-8C0+jlNJOwQso2GapCVWWfW/rzaq7Lbme+vGUFKE31djwNncIpgXD7Cd4weEsDdkoZDjH0lwwr3QDQFuyrMg9g==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
+      "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.29.0",
-        "@typescript-eslint/types": "8.29.0",
-        "@typescript-eslint/typescript-estree": "8.29.0",
-        "@typescript-eslint/visitor-keys": "8.29.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1388,19 +1361,41 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
+      "integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.60.0",
+        "@typescript-eslint/types": "^8.60.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.29.0.tgz",
-      "integrity": "sha512-aO1PVsq7Gm+tcghabUpzEnVSFMCU4/nYIgC2GOatJcllvWfnhrgW0ZEbnTxm36QsikmCN1K/6ZgM7fok2I7xNw==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
+      "integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.29.0",
-        "@typescript-eslint/visitor-keys": "8.29.0"
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1410,17 +1405,35 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
+      "integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.29.0.tgz",
-      "integrity": "sha512-ahaWQ42JAOx+NKEf5++WC/ua17q5l+j1GFrbbpVKzFL/tKVc0aYY8rVSYUpUvt2hUP1YBr7mwXzx+E/DfUWI9Q==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
+      "integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.29.0",
-        "@typescript-eslint/utils": "8.29.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.1"
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0",
+        "@typescript-eslint/utils": "8.60.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1430,14 +1443,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.0.tgz",
-      "integrity": "sha512-wcJL/+cOXV+RE3gjCyl/V2G877+2faqvlgtso/ZRbTCnZazh0gXhe+7gbAnfubzN2bNsBtZjDvlh7ero8uIbzg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
+      "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1449,20 +1462,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.29.0.tgz",
-      "integrity": "sha512-yOfen3jE9ISZR/hHpU/bmNvTtBW1NjRbkSFdZOksL1N+ybPEE7UVGMwqvS6CP022Rp00Sb0tdiIkhSCe6NI8ow==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
+      "integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.29.0",
-        "@typescript-eslint/visitor-keys": "8.29.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.1"
+        "@typescript-eslint/project-service": "8.60.0",
+        "@typescript-eslint/tsconfig-utils": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1472,20 +1486,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.29.0.tgz",
-      "integrity": "sha512-gX/A0Mz9Bskm8avSWFcK0gP7cZpbY4AIo6B0hWYFCaIsz750oaiWR4Jr2CI+PQhfW1CpcQr9OlfPS+kMFegjXA==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
+      "integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.29.0",
-        "@typescript-eslint/types": "8.29.0",
-        "@typescript-eslint/typescript-estree": "8.29.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1495,19 +1509,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.0.tgz",
-      "integrity": "sha512-Sne/pVz8ryR03NFK21VpN88dZ2FdQXOlq3VIklbrTYEt8yXtRFr9tvUhqvCeKjqYk5FSim37sHbooT6vzBTZcg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
+      "integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.29.0",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.60.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1518,22 +1532,22 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1554,9 +1568,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1632,10 +1646,13 @@
       "license": "MIT"
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -1644,25 +1661,15 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/callsites": {
@@ -1712,9 +1719,9 @@
       "license": "MIT"
     },
     "node_modules/cheerio": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
-      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
       "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
@@ -1722,11 +1729,11 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.0.0",
+        "htmlparser2": "^10.1.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.12.0",
+        "undici": "^7.19.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
@@ -1830,9 +1837,9 @@
       }
     },
     "node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
@@ -1846,9 +1853,9 @@
       }
     },
     "node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -1858,9 +1865,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1908,18 +1915,6 @@
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/domelementtype": {
@@ -2010,9 +2005,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2022,9 +2017,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2034,32 +2029,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2075,25 +2070,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
-      "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
-        "@eslint/config-helpers": "^0.4.1",
-        "@eslint/core": "^0.16.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.38.0",
-        "@eslint/plugin-kit": "^0.4.0",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -2112,7 +2107,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2135,13 +2130,16 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.1.tgz",
-      "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
@@ -2177,10 +2175,17 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2199,19 +2204,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
@@ -2259,9 +2251,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2311,23 +2303,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2344,6 +2319,44 @@
         "fastest-levenshtein": "^1.0.7"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -2353,14 +2366,21 @@
         "node": ">= 4.9.1"
       }
     },
-    "node_modules/fastq": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
-      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -2377,12 +2397,27 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -2395,19 +2430,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -2458,22 +2480,22 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "is-glob": "^4.0.1"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/globals": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
-      "integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2482,13 +2504,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2500,9 +2515,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -2514,14 +2529,26 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2625,16 +2652,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-wsl": {
@@ -2766,40 +2783,16 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2946,6 +2939,18 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2954,6 +2959,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -2973,13 +2993,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -2996,9 +3015,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3021,26 +3040,14 @@
         "node": ">=6"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
+    "node_modules/react": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3052,41 +3059,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3094,9 +3066,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3179,6 +3151,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -3195,13 +3179,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3210,52 +3194,10 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3291,9 +3233,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3305,15 +3247,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.29.0.tgz",
-      "integrity": "sha512-ep9rVd9B4kQsZ7ZnWCVxUE/xDLUUUsRzE0poAeNu+4CkFErLfuvPt/qtm2EpnSyfvsR0S6QzDFSrPCFBwf64fg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.0.tgz",
+      "integrity": "sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.29.0",
-        "@typescript-eslint/parser": "8.29.0",
-        "@typescript-eslint/utils": "8.29.0"
+        "@typescript-eslint/eslint-plugin": "8.60.0",
+        "@typescript-eslint/parser": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0",
+        "@typescript-eslint/utils": "8.60.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3323,23 +3266,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
-      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -3356,6 +3299,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -3444,6 +3388,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/extensions/producthunt/package.json
+++ b/extensions/producthunt/package.json
@@ -23,6 +23,20 @@
   ],
   "preferences": [
     {
+      "name": "apiKey",
+      "title": "API Key",
+      "description": "From your app at producthunt.com/v2/oauth/applications. Optional — blank uses the basic feed.",
+      "type": "password",
+      "required": false
+    },
+    {
+      "name": "apiSecret",
+      "title": "API Secret",
+      "description": "From the same Product Hunt app page.",
+      "type": "password",
+      "required": false
+    },
+    {
       "name": "username",
       "title": "Username",
       "description": "Your Product Hunt username.",
@@ -168,9 +182,11 @@
     ]
   },
   "dependencies": {
+    "@chrismessina/raycast-logger": "^1.2.2",
     "@raycast/api": "^1.103.10",
     "@raycast/utils": "^2.2.2",
-    "cheerio": "^1.1.2"
+    "cheerio": "^1.1.2",
+    "fast-xml-parser": "^5.8.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.0.4",

--- a/extensions/producthunt/src/api/client.ts
+++ b/extensions/producthunt/src/api/client.ts
@@ -1,0 +1,182 @@
+import { getPreferenceValues, LocalStorage } from "@raycast/api";
+import { logger } from "@chrismessina/raycast-logger";
+import { operationNameOf } from "./queries-util";
+
+const TOKEN_ENDPOINT = "https://api.producthunt.com/v2/oauth/token";
+const GRAPHQL_ENDPOINT = "https://api.producthunt.com/v2/api/graphql";
+const TOKEN_CACHE_KEY = "ph_access_token_v1";
+// PH's documented token response omits expires_in; cache conservatively and retry-clear on 401/403.
+const TOKEN_TTL_MS = 30 * 60 * 1000;
+
+const authLog = logger.child("[ProductHuntAuth]");
+const apiLog = logger.child("[ProductHuntAPI]");
+
+export type ApiErrorCategory =
+  | "missingCredentials"
+  | "invalidCredentials"
+  | "rateLimited"
+  | "graphql"
+  | "network"
+  | "unknown";
+
+export class ApiError extends Error {
+  category: ApiErrorCategory;
+  constructor(category: ApiErrorCategory, message: string) {
+    super(message);
+    this.name = "ApiError";
+    this.category = category;
+  }
+}
+
+export interface Credentials {
+  apiKey: string;
+  apiSecret: string;
+}
+
+export function hasCredentials(c: Credentials): boolean {
+  return Boolean(c.apiKey && c.apiSecret);
+}
+
+export function getCredentials(): Credentials {
+  const prefs = getPreferenceValues<{ apiKey?: string; apiSecret?: string }>();
+  const apiKey = (prefs.apiKey ?? "").trim();
+  const apiSecret = (prefs.apiSecret ?? "").trim();
+  // One present, one missing is a config error, not silent fallback.
+  if ((apiKey && !apiSecret) || (!apiKey && apiSecret)) {
+    throw new ApiError("missingCredentials", "Both Product Hunt API Key and API Secret are required.");
+  }
+  return { apiKey, apiSecret };
+}
+
+interface CachedToken {
+  token: string;
+  expiresAt: number;
+}
+
+async function requestClientToken(creds: Credentials): Promise<string> {
+  const done = authLog.time("client_credentials token request");
+  try {
+    const res = await fetch(TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: { Accept: "application/json", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_id: creds.apiKey,
+        client_secret: creds.apiSecret,
+        grant_type: "client_credentials",
+      }),
+    });
+    done({ status: res.status });
+    if (res.status === 401 || res.status === 403) {
+      throw new ApiError("invalidCredentials", "Product Hunt rejected the API Key/Secret.");
+    }
+    if (!res.ok) {
+      throw new ApiError("network", `Token request failed with status ${res.status}.`);
+    }
+    let json: { access_token?: string };
+    try {
+      json = (await res.json()) as { access_token?: string };
+    } catch {
+      throw new ApiError("network", `Token response body was not valid JSON (status ${res.status}).`);
+    }
+    if (!json.access_token) {
+      throw new ApiError("unknown", "Token response did not include access_token.");
+    }
+    return json.access_token;
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
+    authLog.error("token request failed", error);
+    throw new ApiError("network", error instanceof Error ? error.message : "Token request failed.");
+  }
+}
+
+async function getAccessToken(forceRefresh = false): Promise<string> {
+  const creds = getCredentials();
+  if (!hasCredentials(creds)) {
+    throw new ApiError("missingCredentials", "No Product Hunt API credentials configured.");
+  }
+  if (!forceRefresh) {
+    const raw = await LocalStorage.getItem<string>(TOKEN_CACHE_KEY);
+    if (raw) {
+      try {
+        const cached = JSON.parse(raw) as CachedToken;
+        if (cached.token && cached.expiresAt > Date.now()) {
+          authLog.debug("using cached access token", { expiresInMs: cached.expiresAt - Date.now() });
+          return cached.token;
+        }
+      } catch {
+        // fall through to refresh
+      }
+    }
+  }
+  authLog.debug("no valid cached token; requesting new one");
+  const token = await requestClientToken(creds);
+  const entry: CachedToken = { token, expiresAt: Date.now() + TOKEN_TTL_MS };
+  await LocalStorage.setItem(TOKEN_CACHE_KEY, JSON.stringify(entry));
+  return token;
+}
+
+async function postGraphql(query: string, variables: Record<string, unknown>, token: string): Promise<Response> {
+  return fetch(GRAPHQL_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+}
+
+export async function graphql<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  const done = apiLog.time("GraphQL request");
+  apiLog.debug("request", { operation: operationNameOf(query), variables });
+
+  let token = await getAccessToken();
+  let res: Response;
+  try {
+    res = await postGraphql(query, variables, token);
+  } catch (error) {
+    apiLog.error("GraphQL network error", error);
+    throw new ApiError("network", error instanceof Error ? error.message : "Network error.");
+  }
+
+  // Token may be stale despite TTL; refresh once on auth rejection.
+  if (res.status === 401 || res.status === 403) {
+    await LocalStorage.removeItem(TOKEN_CACHE_KEY);
+    apiLog.debug("auth rejected (cleared token cache); retrying once");
+    token = await getAccessToken(true);
+    res = await postGraphql(query, variables, token);
+  }
+
+  done({
+    status: res.status,
+    rateLimitRemaining: res.headers.get("X-Rate-Limit-Remaining"),
+    rateLimitReset: res.headers.get("X-Rate-Limit-Reset"),
+  });
+
+  if (res.status === 429) {
+    const reset = res.headers.get("X-Rate-Limit-Reset");
+    throw new ApiError("rateLimited", `Rate limited.${reset ? ` Resets in ${reset}s.` : ""}`);
+  }
+  if (res.status === 401 || res.status === 403) {
+    throw new ApiError("invalidCredentials", "Product Hunt rejected the API credentials.");
+  }
+  if (!res.ok) {
+    throw new ApiError("network", `GraphQL request failed with status ${res.status}.`);
+  }
+
+  let json: { data?: T; errors?: Array<{ message: string }> };
+  try {
+    json = (await res.json()) as { data?: T; errors?: Array<{ message: string }> };
+  } catch {
+    throw new ApiError("network", `GraphQL response body was not valid JSON (status ${res.status}).`);
+  }
+  if (json.errors && json.errors.length > 0) {
+    throw new ApiError("graphql", json.errors.map((e) => e.message).join("; "));
+  }
+  if (!json.data) {
+    throw new ApiError("graphql", "GraphQL response contained no data.");
+  }
+  apiLog.debug("GraphQL response ok", { operation: operationNameOf(query) });
+  return json.data;
+}

--- a/extensions/producthunt/src/api/client.ts
+++ b/extensions/producthunt/src/api/client.ts
@@ -38,7 +38,7 @@ export function hasCredentials(c: Credentials): boolean {
 }
 
 export function getCredentials(): Credentials {
-  const prefs = getPreferenceValues<{ apiKey?: string; apiSecret?: string }>();
+  const prefs = getPreferenceValues<Preferences>();
   const apiKey = (prefs.apiKey ?? "").trim();
   const apiSecret = (prefs.apiSecret ?? "").trim();
   // One present, one missing is a config error, not silent fallback.
@@ -145,7 +145,12 @@ export async function graphql<T>(query: string, variables: Record<string, unknow
     await LocalStorage.removeItem(TOKEN_CACHE_KEY);
     apiLog.debug("auth rejected (cleared token cache); retrying once");
     token = await getAccessToken(true);
-    res = await postGraphql(query, variables, token);
+    try {
+      res = await postGraphql(query, variables, token);
+    } catch (error) {
+      apiLog.error("GraphQL network error (retry)", error);
+      throw new ApiError("network", error instanceof Error ? error.message : "Network error.");
+    }
   }
 
   done({

--- a/extensions/producthunt/src/api/feed.ts
+++ b/extensions/producthunt/src/api/feed.ts
@@ -1,0 +1,106 @@
+import { XMLParser } from "fast-xml-parser";
+import { Product } from "../types";
+import { cleanText } from "../util/textUtils";
+import { logger } from "@chrismessina/raycast-logger";
+
+const FEED_URL = "https://www.producthunt.com/feed";
+const feedLog = logger.child("[ProductHuntFeed]");
+
+interface RawEntry {
+  id?: string;
+  title?: string | number | boolean | { "#text"?: string };
+  link?: { "@_rel"?: string; "@_href"?: string } | Array<{ "@_rel"?: string; "@_href"?: string }>;
+  published?: string;
+  updated?: string;
+  author?: { name?: string };
+  content?: string | number | boolean | { "#text"?: string };
+}
+
+function textOf(v: string | number | boolean | { "#text"?: string } | undefined): string {
+  if (v === undefined || v === null) return "";
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return v["#text"] ?? "";
+}
+
+function alternateHref(entry: RawEntry): string {
+  const links = Array.isArray(entry.link) ? entry.link : entry.link ? [entry.link] : [];
+  const alt = links.find((l) => l["@_rel"] === "alternate") ?? links[0];
+  return alt?.["@_href"] ?? "";
+}
+
+function numericPostId(rawId: string | undefined): string | null {
+  if (!rawId) return null;
+  const m = rawId.match(/Post\/(\d+)/);
+  return m ? m[1] : null;
+}
+
+function firstParagraphText(contentHtml: string): string {
+  const m = contentHtml.match(/<p>([\s\S]*?)<\/p>/i);
+  const inner = m ? m[1] : contentHtml;
+  return cleanText(inner.replace(/<[^>]+>/g, "").trim());
+}
+
+export function parseAtomFeed(xml: string): Product[] {
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "@_", parseTagValue: false });
+  let doc: { feed?: { entry?: RawEntry | RawEntry[] } };
+  try {
+    doc = parser.parse(xml);
+  } catch (error) {
+    throw new Error(`Failed to parse Atom feed XML: ${error instanceof Error ? error.message : "unknown"}`);
+  }
+  if (!doc.feed) {
+    throw new Error("Atom feed missing <feed> root element");
+  }
+  const rawEntries = doc.feed.entry ? (Array.isArray(doc.feed.entry) ? doc.feed.entry : [doc.feed.entry]) : [];
+
+  const seen = new Set<string>();
+  const products: Product[] = [];
+  for (const entry of rawEntries) {
+    const id = numericPostId(entry.id);
+    const url = alternateHref(entry);
+    const name = cleanText(textOf(entry.title));
+    if (!id || !url || !name) {
+      feedLog.debug("skipping malformed feed entry", { id: entry.id });
+      continue;
+    }
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    const tagline = firstParagraphText(textOf(entry.content));
+    if (!tagline) {
+      feedLog.debug("feed entry produced empty tagline", { id });
+    }
+    products.push({
+      id,
+      name,
+      tagline,
+      description: "",
+      url,
+      thumbnail: "",
+      votesCount: 0,
+      commentsCount: 0,
+      // The feed's `published` is the post's ORIGINAL creation date (can be months before a
+      // re-feature); `updated` tracks recent feature activity and is closer to "launched today".
+      // Prefer `updated`, falling back to `published`.
+      createdAt: entry.updated ?? entry.published ?? "1970-01-01T00:00:00.000Z",
+      topics: [],
+      maker: entry.author?.name
+        ? { id: `feed-${id}`, name: cleanText(entry.author.name), username: "", avatarUrl: "" }
+        : undefined,
+      isFeedFallback: true,
+    });
+  }
+  return products;
+}
+
+export async function getFeedProducts(): Promise<Product[]> {
+  const res = await fetch(FEED_URL, { headers: { Accept: "application/atom+xml" } });
+  if (!res.ok) {
+    throw new Error(`Atom feed request failed with status ${res.status}`);
+  }
+  const xml = await res.text();
+  const products = parseAtomFeed(xml);
+  feedLog.debug("parsed feed", { count: products.length });
+  return products;
+}

--- a/extensions/producthunt/src/api/feed.ts
+++ b/extensions/producthunt/src/api/feed.ts
@@ -85,7 +85,9 @@ export function parseAtomFeed(xml: string): Product[] {
       // Prefer `updated`, falling back to `published`.
       createdAt: entry.updated ?? entry.published ?? "1970-01-01T00:00:00.000Z",
       topics: [],
-      maker: entry.author?.name
+      // The feed's <author> is the post submitter (same role as the API's Post.user), not a
+      // verified maker — model it as submittedBy.
+      submittedBy: entry.author?.name
         ? { id: `feed-${id}`, name: cleanText(entry.author.name), username: "", avatarUrl: "" }
         : undefined,
       isFeedFallback: true,

--- a/extensions/producthunt/src/api/index.ts
+++ b/extensions/producthunt/src/api/index.ts
@@ -164,7 +164,15 @@ export async function getFrontpageProducts(options?: { forceRefresh?: boolean })
 }
 
 // API-detail-backed replacement for the old scraper enrichment. Never fetches PH HTML.
-// If no credentials or the detail query fails, returns the product unchanged (feed/list data stands).
+//
+// Two distinct outcomes, deliberately handled differently (per review: detail views must not
+// silently fall back to thin data the way list views may):
+//   - Enrichment NOT APPLICABLE (no credentials, no slug, or the post genuinely isn't found):
+//     return the product unchanged. The detail view renders the list-level data it already has;
+//     this is expected, not a failure.
+//   - Enrichment ERRORED (GraphQL/network failure while we were able and trying to enrich):
+//     THROW, so the detail view shows a visible error with retry / open-in-browser actions rather
+//     than a broken-looking page presented as if it were complete.
 export async function enhanceProductWithMetadata(product: Product): Promise<Product> {
   let credsComplete = false;
   try {
@@ -199,14 +207,20 @@ export async function enhanceProductWithMetadata(product: Product): Promise<Prod
   try {
     log.debug("enriching product detail via API", { slug });
     const data = await graphql<PostDetailResponse>(POST_DETAIL_QUERY, { slug });
-    if (!data.post) return product;
+    // Post genuinely not found: not an error — return what we have.
+    if (!data.post) {
+      log.debug("detail enrichment: post not found", { slug });
+      return product;
+    }
     const detailed = postDetailToProduct(data.post);
     await writeCache(detailCacheKey, detailed);
     log.debug("detail enrichment ok", { slug });
     // Preserve any list-level fields not present on detail.
     return { ...product, ...detailed };
   } catch (error) {
-    log.warn("detail enrichment failed; using list-level product", error);
-    return product;
+    // A real failure (GraphQL/network) while enriching: surface it so the detail view can show an
+    // error + retry/open-in-browser, instead of rendering thin list data as if it were complete.
+    log.error("detail enrichment failed", error);
+    throw error instanceof Error ? error : new Error("Failed to load product details.");
   }
 }

--- a/extensions/producthunt/src/api/index.ts
+++ b/extensions/producthunt/src/api/index.ts
@@ -1,0 +1,212 @@
+// Public API facade. All components/tools import from here, never from ./scraper.
+// Credentialed: official GraphQL. No-key: Atom feed. No production HTML scraping.
+import { LocalStorage } from "@raycast/api";
+import { Product } from "../types";
+import { graphql, getCredentials, hasCredentials, ApiError } from "./client";
+import { FEATURED_POSTS_QUERY, POST_DETAIL_QUERY, FeaturedPostsResponse, PostDetailResponse } from "./queries";
+import { postNodeToProduct, postDetailToProduct } from "./product";
+import { getFeedProducts } from "./feed";
+import { logger } from "@chrismessina/raycast-logger";
+
+const log = logger.child("[ProductHuntAPI]");
+
+// Product Hunt's "launch day" runs on Pacific time (posts feature at ~00:01 PT). Using UTC midnight
+// returns an empty set during the ~7-8h window between UTC midnight and Pacific midnight (PH's
+// "today" hasn't started yet). Compute midnight in America/Los_Angeles so "today's featured" matches
+// PH's day. Uses Intl (full ICU is available in the Raycast runtime); falls back to UTC if anything
+// unexpected happens.
+function pacificMidnightIso(): string {
+  try {
+    const now = new Date();
+    // Y-M-D of "now" as seen in Los Angeles (en-CA gives ISO-ish "2026-05-30").
+    const ymd = new Intl.DateTimeFormat("en-CA", {
+      timeZone: "America/Los_Angeles",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(now);
+    // Current PT offset (PDT in summer = -07:00, PST in winter = -08:00).
+    const tzName = new Intl.DateTimeFormat("en-US", {
+      timeZone: "America/Los_Angeles",
+      timeZoneName: "short",
+    })
+      .formatToParts(now)
+      .find((p) => p.type === "timeZoneName")?.value;
+    const offset = tzName === "PST" ? "-08:00" : "-07:00";
+    return new Date(`${ymd}T00:00:00${offset}`).toISOString();
+  } catch {
+    const now = new Date();
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())).toISOString();
+  }
+}
+
+// Short-TTL LocalStorage response caching (rate-budget safety). The official frontpage GraphQL query
+// consumes ~3300 of the API's 6250 complexity-points-per-15min budget, so two reopens within 15 min
+// could 429. These caches let repeated command opens reuse a recent result. This is RESPONSE caching,
+// separate from the token cache in client.ts.
+const FRONTPAGE_API_CACHE_KEY = "frontpage_api_cache_v1";
+const FRONTPAGE_FEED_CACHE_KEY = "frontpage_feed_cache_v1";
+const PRODUCT_DETAIL_CACHE_PREFIX = "product_detail_api_cache_v1:";
+const FRONTPAGE_CACHE_TTL_MS = 60_000; // 60s
+const PRODUCT_DETAIL_CACHE_TTL_MS = 300_000; // 5 min
+
+async function readCache<T>(key: string, ttlMs: number, validate?: (v: unknown) => boolean): Promise<T | null> {
+  try {
+    const raw = await LocalStorage.getItem<string>(key);
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as { ts: number; value: unknown };
+    if (typeof entry.ts === "number" && Date.now() - entry.ts < ttlMs) {
+      if (!validate || validate(entry.value)) {
+        return entry.value as T;
+      }
+    }
+  } catch {
+    // ignore cache read errors; fall through to live fetch
+  }
+  return null;
+}
+
+async function writeCache<T>(key: string, value: T): Promise<void> {
+  try {
+    await LocalStorage.setItem(key, JSON.stringify({ ts: Date.now(), value }));
+  } catch {
+    // ignore cache write errors
+  }
+}
+
+// Why a feed fallback happened, so the UI can surface the right message/action.
+export type FeedReason = "no-credentials" | "invalid-credentials" | "api-error";
+
+export async function getFrontpageProducts(options?: { forceRefresh?: boolean }): Promise<{
+  products: Product[];
+  error?: string;
+  usingFeed?: boolean;
+  feedReason?: FeedReason;
+}> {
+  // forceRefresh (e.g. a "Refresh" action) bypasses the response cache so the user gets fresh data;
+  // results are still written back to the cache afterward.
+  const forceRefresh = options?.forceRefresh ?? false;
+  let credsComplete = false;
+  try {
+    credsComplete = hasCredentials(getCredentials());
+  } catch (error) {
+    // One-of-two credentials missing: surface config error, do not silently fall back.
+    if (error instanceof ApiError && error.category === "missingCredentials") {
+      return { products: [], error: error.message };
+    }
+    // Any other (currently unreachable) credential-read failure: log, then degrade to feed.
+    log.warn("unexpected error reading credentials; falling back to feed", error);
+  }
+
+  if (credsComplete) {
+    const cached = forceRefresh
+      ? null
+      : await readCache<Product[]>(FRONTPAGE_API_CACHE_KEY, FRONTPAGE_CACHE_TTL_MS, Array.isArray);
+    if (cached) {
+      log.debug("frontpage served from API cache", { count: cached.length });
+      return { products: cached };
+    }
+    try {
+      const postedAfter = pacificMidnightIso();
+      log.debug("fetching frontpage via official API", { postedAfter });
+      const data = await graphql<FeaturedPostsResponse>(FEATURED_POSTS_QUERY, {
+        first: 30,
+        postedAfter,
+      });
+      const products = data.posts.edges.map((e) => postNodeToProduct(e.node));
+      log.debug("frontpage API returned", { count: products.length });
+      if (products.length > 0) await writeCache(FRONTPAGE_API_CACHE_KEY, products);
+      return { products };
+    } catch (error) {
+      log.warn("frontpage API failed, falling back to feed", error);
+      // Distinguish bad credentials (actionable: fix them in prefs) from a transient API error.
+      const reason: FeedReason =
+        error instanceof ApiError && error.category === "invalidCredentials" ? "invalid-credentials" : "api-error";
+      // List view may fall back to feed (spec); detail view may not.
+      const cachedFeed = forceRefresh
+        ? null
+        : await readCache<Product[]>(FRONTPAGE_FEED_CACHE_KEY, FRONTPAGE_CACHE_TTL_MS, Array.isArray);
+      if (cachedFeed) {
+        log.debug("frontpage served from feed cache", { count: cachedFeed.length });
+        return { products: cachedFeed, usingFeed: true, feedReason: reason };
+      }
+      try {
+        const products = await getFeedProducts();
+        log.debug("frontpage feed returned", { count: products.length });
+        if (products.length > 0) await writeCache(FRONTPAGE_FEED_CACHE_KEY, products);
+        return { products, usingFeed: true, feedReason: reason };
+      } catch (feedError) {
+        return {
+          products: [],
+          error: feedError instanceof Error ? feedError.message : "Failed to load products.",
+        };
+      }
+    }
+  }
+
+  // No credentials: feed-only mode.
+  const cachedFeed = forceRefresh
+    ? null
+    : await readCache<Product[]>(FRONTPAGE_FEED_CACHE_KEY, FRONTPAGE_CACHE_TTL_MS, Array.isArray);
+  if (cachedFeed) {
+    log.debug("frontpage served from feed cache", { count: cachedFeed.length });
+    return { products: cachedFeed, usingFeed: true, feedReason: "no-credentials" };
+  }
+  try {
+    log.debug("no credentials; fetching frontpage via Atom feed");
+    const products = await getFeedProducts();
+    log.debug("frontpage feed returned", { count: products.length });
+    if (products.length > 0) await writeCache(FRONTPAGE_FEED_CACHE_KEY, products);
+    return { products, usingFeed: true, feedReason: "no-credentials" };
+  } catch (error) {
+    return { products: [], error: error instanceof Error ? error.message : "Failed to load products." };
+  }
+}
+
+// API-detail-backed replacement for the old scraper enrichment. Never fetches PH HTML.
+// If no credentials or the detail query fails, returns the product unchanged (feed/list data stands).
+export async function enhanceProductWithMetadata(product: Product): Promise<Product> {
+  let credsComplete = false;
+  try {
+    credsComplete = hasCredentials(getCredentials());
+  } catch {
+    credsComplete = false;
+  }
+  if (!credsComplete) {
+    log.debug("detail enrichment skipped (no credentials)");
+    return product;
+  }
+
+  const slugMatch = product.url.match(/posts\/([^/?#]+)/);
+  const slug = slugMatch ? slugMatch[1] : null;
+  if (!slug) {
+    log.debug("detail enrichment skipped (no slug in url)", { url: product.url });
+    return product;
+  }
+
+  const detailCacheKey = `${PRODUCT_DETAIL_CACHE_PREFIX}${slug}`;
+  const cached = await readCache<Product>(
+    detailCacheKey,
+    PRODUCT_DETAIL_CACHE_TTL_MS,
+    (v) => typeof v === "object" && v !== null,
+  );
+  // Preserve any list-level fields the caller passed (same merge as the live path).
+  if (cached) {
+    log.debug("detail served from cache", { slug });
+    return { ...product, ...cached };
+  }
+
+  try {
+    log.debug("enriching product detail via API", { slug });
+    const data = await graphql<PostDetailResponse>(POST_DETAIL_QUERY, { slug });
+    if (!data.post) return product;
+    const detailed = postDetailToProduct(data.post);
+    await writeCache(detailCacheKey, detailed);
+    log.debug("detail enrichment ok", { slug });
+    // Preserve any list-level fields not present on detail.
+    return { ...product, ...detailed };
+  } catch (error) {
+    log.warn("detail enrichment failed; using list-level product", error);
+    return product;
+  }
+}

--- a/extensions/producthunt/src/api/product.ts
+++ b/extensions/producthunt/src/api/product.ts
@@ -1,0 +1,71 @@
+import { Product, User, Topic } from "../types";
+import { ApiPostNode, ApiUser } from "./queries";
+import { cleanText } from "../util/textUtils";
+
+// The PH public (client-credentials) API redacts makers to "[REDACTED]" with id "0".
+// Maker identity requires a user-context OAuth token, which is out of scope. Drop redacted entries.
+function isRedactedUser(u: ApiUser): boolean {
+  return u.id === "0" || u.name === "[REDACTED]" || u.username === "[REDACTED]";
+}
+
+function apiUserToUser(u: ApiUser): User {
+  return {
+    id: u.id,
+    name: cleanText(u.name),
+    username: u.username,
+    avatarUrl: u.profileImage ?? "",
+    profileImage: u.profileImage,
+    profileUrl: u.url,
+    headline: u.headline ? cleanText(u.headline) : undefined,
+    twitterUsername: u.twitterUsername,
+    websiteUrl: u.websiteUrl,
+  };
+}
+
+function apiTopicsToTopics(node: ApiPostNode): Topic[] {
+  return (
+    node.topics?.edges?.map((e) => ({
+      id: e.node.id,
+      name: cleanText(e.node.name),
+      slug: e.node.slug,
+      description: e.node.description,
+    })) ?? []
+  );
+}
+
+// Shared mapping used by both list and detail. Detail adds media-derived gallery.
+function baseMap(node: ApiPostNode): Product {
+  const visibleApiMakers = node.makers?.filter((m) => !isRedactedUser(m));
+  const rawMakers = visibleApiMakers?.map(apiUserToUser);
+  const makers = rawMakers && rawMakers.length > 0 ? rawMakers : undefined;
+  return {
+    id: node.id,
+    name: cleanText(node.name),
+    tagline: cleanText(node.tagline),
+    description: cleanText(node.description ?? ""),
+    url: node.url,
+    thumbnail: node.thumbnail?.url ?? "",
+    featuredImage: node.thumbnail?.url,
+    votesCount: node.votesCount ?? 0,
+    commentsCount: node.commentsCount ?? 0,
+    createdAt: node.featuredAt ?? node.createdAt,
+    maker: makers ? makers[0] : node.user && !isRedactedUser(node.user) ? apiUserToUser(node.user) : undefined,
+    makers,
+    // Do NOT infer hunter from `user`; the public API has no verified hunter field (spec Locked Decision).
+    hunter: undefined,
+    topics: apiTopicsToTopics(node),
+  };
+}
+
+export function postNodeToProduct(node: ApiPostNode): Product {
+  return baseMap(node);
+}
+
+export function postDetailToProduct(node: ApiPostNode): Product {
+  const product = baseMap(node);
+  const galleryImages = (node.media ?? []).map((m) => m.url).filter((u) => u.length > 0);
+  return {
+    ...product,
+    galleryImages: galleryImages.length > 0 ? galleryImages : undefined,
+  };
+}

--- a/extensions/producthunt/src/api/product.ts
+++ b/extensions/producthunt/src/api/product.ts
@@ -49,10 +49,16 @@ function baseMap(node: ApiPostNode): Product {
     votesCount: node.votesCount ?? 0,
     commentsCount: node.commentsCount ?? 0,
     createdAt: node.featuredAt ?? node.createdAt,
-    maker: makers ? makers[0] : node.user && !isRedactedUser(node.user) ? apiUserToUser(node.user) : undefined,
+    // maker/makers come ONLY from the API's `makers` (the documented maker role). On a public token
+    // these are redacted and filtered out, leaving these undefined — that's correct: we cannot see
+    // real makers, so we do not invent them from `user`.
+    maker: makers ? makers[0] : undefined,
     makers,
     // Do NOT infer hunter from `user`; the public API has no verified hunter field (spec Locked Decision).
     hunter: undefined,
+    // `Post.user` is "User who created the Post" — the submitter, a distinct documented role.
+    // Modeled separately and labeled "Posted by"; never relabeled as maker or hunter.
+    submittedBy: node.user && !isRedactedUser(node.user) ? apiUserToUser(node.user) : undefined,
     topics: apiTopicsToTopics(node),
   };
 }

--- a/extensions/producthunt/src/api/queries-util.ts
+++ b/extensions/producthunt/src/api/queries-util.ts
@@ -1,0 +1,5 @@
+// Extracts the GraphQL operation name for logging (e.g. "FeaturedPosts").
+export function operationNameOf(query: string): string {
+  const m = query.match(/\b(query|mutation)\s+(\w+)/);
+  return m ? m[2] : "anonymous";
+}

--- a/extensions/producthunt/src/api/queries.ts
+++ b/extensions/producthunt/src/api/queries.ts
@@ -1,0 +1,161 @@
+// Product Hunt GraphQL API v2 query strings and typed response shapes.
+// Public schema only: posts/post, thumbnail{url}, votesCount, user/makers, media, topics.
+// Do NOT reuse scraper-only field names (homefeed, latestScore, thumbnailImageUuid, hunter).
+
+export const FEATURED_POSTS_QUERY = /* GraphQL */ `
+  query FeaturedPosts($first: Int!, $postedAfter: DateTime) {
+    posts(first: $first, featured: true, postedAfter: $postedAfter, order: VOTES) {
+      edges {
+        node {
+          id
+          name
+          tagline
+          description
+          slug
+          url
+          votesCount
+          commentsCount
+          createdAt
+          featuredAt
+          thumbnail {
+            url(width: 1024, height: 512)
+          }
+          user {
+            id
+            name
+            username
+            url
+            profileImage
+          }
+          makers {
+            id
+            name
+            username
+            url
+            profileImage
+          }
+          topics(first: 8) {
+            edges {
+              node {
+                id
+                name
+                slug
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const POST_DETAIL_QUERY = /* GraphQL */ `
+  query PostDetail($slug: String!) {
+    post(slug: $slug) {
+      id
+      name
+      tagline
+      description
+      slug
+      url
+      website
+      votesCount
+      commentsCount
+      createdAt
+      featuredAt
+      thumbnail {
+        url(width: 1200, height: 800)
+        videoUrl
+        type
+      }
+      media {
+        url(width: 1200, height: 800)
+        videoUrl
+        type
+      }
+      productLinks {
+        type
+        url
+      }
+      user {
+        id
+        name
+        username
+        url
+        profileImage
+        headline
+        twitterUsername
+        websiteUrl
+      }
+      makers {
+        id
+        name
+        username
+        url
+        profileImage
+        headline
+        twitterUsername
+        websiteUrl
+      }
+      topics(first: 20) {
+        edges {
+          node {
+            id
+            name
+            slug
+            description
+          }
+        }
+      }
+    }
+  }
+`;
+
+export interface ApiUser {
+  id: string;
+  name: string;
+  username: string;
+  url: string;
+  profileImage?: string;
+  headline?: string;
+  twitterUsername?: string;
+  websiteUrl?: string;
+}
+
+export interface ApiTopicEdge {
+  node: { id: string; name: string; slug: string; description?: string };
+}
+
+export interface ApiMedia {
+  url: string;
+  videoUrl?: string;
+  type: string;
+}
+
+export interface ApiPostNode {
+  id: string;
+  name: string;
+  tagline: string;
+  description?: string;
+  slug: string;
+  url: string;
+  website?: string; // String! in schema, but absent from FEATURED_POSTS_QUERY which shares this type
+  votesCount: number;
+  commentsCount: number;
+  createdAt: string;
+  featuredAt?: string;
+  thumbnail?: { url: string };
+  media?: ApiMedia[];
+  productLinks?: Array<{ type: string; url: string }>;
+  user?: ApiUser;
+  makers?: ApiUser[];
+  topics?: { edges: ApiTopicEdge[] };
+}
+
+export interface FeaturedPostsResponse {
+  posts: { edges: Array<{ node: ApiPostNode }> };
+}
+
+export interface PostDetailResponse {
+  post: ApiPostNode | null;
+}

--- a/extensions/producthunt/src/components/FrontpageContent.tsx
+++ b/extensions/producthunt/src/components/FrontpageContent.tsx
@@ -1,8 +1,8 @@
-import { List, showToast, Toast } from "@raycast/api";
-import { useState, useEffect } from "react";
+import { List, showToast, Toast, Action, ActionPanel, Icon, Keyboard, openExtensionPreferences } from "@raycast/api";
+import { useState, useEffect, useCallback } from "react";
 import { Product } from "../types";
 import { ProductListItem } from "./ProductListItem";
-import { getFrontpageProducts } from "../api/scraper";
+import { getFrontpageProducts } from "../api";
 
 /**
  * Shared component for displaying the frontpage content
@@ -12,58 +12,114 @@ export function FrontpageContent() {
   const [isLoading, setIsLoading] = useState(true);
   const [products, setProducts] = useState<Product[]>([]);
   const [error, setError] = useState<string | undefined>();
+  const [usingFeed, setUsingFeed] = useState(false);
 
-  useEffect(() => {
-    async function fetchProducts() {
-      try {
-        setIsLoading(true);
-        const { products, error } = await getFrontpageProducts();
+  const fetchProducts = useCallback(async (forceRefresh = false) => {
+    try {
+      setIsLoading(true);
+      setError(undefined);
+      const { products, error, usingFeed, feedReason } = await getFrontpageProducts({ forceRefresh });
 
-        if (error) {
-          await showToast({
-            style: Toast.Style.Failure,
-            title: "Failed to load products",
-            message: error,
-          });
-          setError(error);
-        } else {
-          setProducts(products);
-        }
-      } catch (e) {
-        const errorMessage = e instanceof Error ? e.message : "Unknown error occurred";
+      if (error) {
         await showToast({
           style: Toast.Style.Failure,
           title: "Failed to load products",
-          message: errorMessage,
+          message: error,
         });
-        setError(errorMessage);
-      } finally {
-        setIsLoading(false);
+        setError(error);
+      } else {
+        setProducts(products);
+        setUsingFeed(Boolean(usingFeed));
+        if (feedReason === "invalid-credentials") {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Invalid Product Hunt API credentials",
+            message: "Showing the limited public feed. Update your API Key/Secret in Preferences.",
+            primaryAction: {
+              title: "Open Extension Preferences",
+              onAction: () => {
+                openExtensionPreferences();
+              },
+            },
+          });
+        }
       }
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : "Unknown error occurred";
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Failed to load products",
+        message: errorMessage,
+      });
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
     }
-
-    fetchProducts();
   }, []);
+
+  useEffect(() => {
+    fetchProducts();
+  }, [fetchProducts]);
 
   return (
     <List isLoading={isLoading} searchBarPlaceholder="Search products...">
       {error ? (
-        <List.EmptyView icon="no-view.png" title="Something went wrong" description={error} />
-      ) : (
-        <>
-          <List.Section title="Today's Featured Launches">
-            {products.map((product, index) => (
-              <ProductListItem
-                key={product.id}
-                product={product}
-                featured={true}
-                index={index}
-                totalProducts={products.length}
-                allProducts={products}
+        <List.EmptyView
+          icon="no-view.png"
+          title="Something went wrong"
+          description={error}
+          actions={
+            <ActionPanel>
+              <Action
+                title="Refresh"
+                icon={Icon.ArrowClockwise}
+                shortcut={Keyboard.Shortcut.Common.Refresh}
+                onAction={() => fetchProducts(true)}
               />
-            ))}
-          </List.Section>
-        </>
+              <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={openExtensionPreferences} />
+              <Action.OpenInBrowser
+                title="Create a Product Hunt API App"
+                url="https://www.producthunt.com/v2/oauth/applications"
+              />
+            </ActionPanel>
+          }
+        />
+      ) : products.length === 0 && !isLoading ? (
+        <List.EmptyView
+          icon="no-view.png"
+          title="No featured products found"
+          description={usingFeed ? "The feed returned no entries. Try again later." : "Check back later."}
+          actions={
+            <ActionPanel>
+              <Action
+                title="Refresh"
+                icon={Icon.ArrowClockwise}
+                shortcut={Keyboard.Shortcut.Common.Refresh}
+                onAction={() => fetchProducts(true)}
+              />
+              <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={openExtensionPreferences} />
+            </ActionPanel>
+          }
+        />
+      ) : (
+        <List.Section
+          title="Today's Featured Launches"
+          subtitle={
+            usingFeed ? "Basic feed — add API credentials for votes, comments & makers in Preferences" : undefined
+          }
+        >
+          {products.map((product, index) => (
+            <ProductListItem
+              key={product.id}
+              product={product}
+              featured={true}
+              index={index}
+              totalProducts={products.length}
+              allProducts={products}
+              onRefresh={() => fetchProducts(true)}
+            />
+          ))}
+        </List.Section>
       )}
     </List>
   );

--- a/extensions/producthunt/src/components/ProductActions.tsx
+++ b/extensions/producthunt/src/components/ProductActions.tsx
@@ -1,5 +1,15 @@
 import React from "react";
-import { ActionPanel, Action, Icon, Color, open, showToast, Toast } from "@raycast/api";
+import {
+  ActionPanel,
+  Action,
+  Icon,
+  Color,
+  open,
+  showToast,
+  Toast,
+  Keyboard,
+  openExtensionPreferences,
+} from "@raycast/api";
 import { Product, User } from "../types";
 import { ProductDetailView } from "./ProductDetailView";
 import { ProductGalleryView } from "./ProductGalleryView";
@@ -28,6 +38,7 @@ interface ProductActionsProps {
   onNavigateToProduct?: (product: Product, newIndex: number) => void;
   viewContext: ViewContext;
   showTopics?: boolean;
+  onRefresh?: () => void;
 }
 
 export function ProductActions({
@@ -39,6 +50,7 @@ export function ProductActions({
   onNavigateToProduct,
   viewContext,
   showTopics = true,
+  onRefresh,
 }: ProductActionsProps) {
   const handleUserAction = (user: User, role: string) => {
     if (user.profileUrl) {
@@ -54,34 +66,41 @@ export function ProductActions({
     <ActionPanel>
       {/* Primary Actions Section */}
       <ActionPanel.Section>
-        {/* In List view, first action is View Details */}
-        {viewContext === ViewContext.List && (
-          <Action.Push
-            title="View Details"
-            icon={Icon.Eye}
-            target={
-              <ProductDetailView
-                product={product}
-                index={index}
-                totalProducts={totalProducts || allProducts.length}
-                onNavigateToProduct={onNavigateToProduct}
+        {/* For feed items the in-app detail view has no real data, so Open in Browser is primary */}
+        {product.isFeedFallback ? (
+          <Action.OpenInBrowser url={product.url} title="Open in Browser" />
+        ) : (
+          <>
+            {/* In List view, first action is View Details */}
+            {viewContext === ViewContext.List && (
+              <Action.Push
+                title="View Details"
+                icon={Icon.Eye}
+                target={
+                  <ProductDetailView
+                    product={product}
+                    index={index}
+                    totalProducts={totalProducts || allProducts.length}
+                    onNavigateToProduct={onNavigateToProduct}
+                  />
+                }
               />
-            }
-          />
-        )}
+            )}
 
-        {/* In Detail view, first action is Open in Browser */}
-        <Action.OpenInBrowser
-          url={product.url}
-          title="Open in Browser"
-          shortcut={viewContext === ViewContext.Detail ? undefined : { modifiers: ["cmd"], key: "o" }}
-        />
+            {/* In Detail view, first action is Open in Browser */}
+            <Action.OpenInBrowser
+              url={product.url}
+              title="Open in Browser"
+              shortcut={viewContext === ViewContext.Detail ? undefined : Keyboard.Shortcut.Common.Open}
+            />
+          </>
+        )}
 
         {/* Copy URL action */}
         <Action.CopyToClipboard
           title="Copy URL"
           content={product.url}
-          shortcut={{ modifiers: ["cmd"], key: viewContext === ViewContext.List ? "c" : "o" }}
+          shortcut={viewContext === ViewContext.List ? Keyboard.Shortcut.Common.Copy : undefined}
         />
 
         {/* Gallery action - available in both views if gallery images exist */}
@@ -101,6 +120,16 @@ export function ProductActions({
             title={product.previousLaunches === 1 ? "View Previous Launch" : "View Previous Launches"}
             url={product.productHubUrl}
             shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
+          />
+        )}
+
+        {/* Refresh action - re-fetches the frontpage with fresh data when provided */}
+        {onRefresh && (
+          <Action
+            title="Refresh"
+            icon={Icon.ArrowClockwise}
+            shortcut={Keyboard.Shortcut.Common.Refresh}
+            onAction={onRefresh}
           />
         )}
       </ActionPanel.Section>
@@ -178,6 +207,11 @@ export function ProductActions({
           />
         </ActionPanel.Section>
       )}
+
+      {/* Settings Section - always available so users can add/update API credentials */}
+      <ActionPanel.Section title="Settings">
+        <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={openExtensionPreferences} />
+      </ActionPanel.Section>
     </ActionPanel>
   );
 }

--- a/extensions/producthunt/src/components/ProductDetailView.tsx
+++ b/extensions/producthunt/src/components/ProductDetailView.tsx
@@ -2,7 +2,7 @@ import { Detail, Color, showToast, Toast, open } from "@raycast/api";
 import { Product } from "../types";
 import { generateTopicUrl } from "../util/topicUtils";
 import { useState, useEffect } from "react";
-import { enhanceProductWithMetadata } from "../api/scraper";
+import { enhanceProductWithMetadata } from "../api";
 import { HOST_URL } from "../constants";
 import { ProductActions, ViewContext } from "./ProductActions";
 import { cleanText } from "../util/textUtils";
@@ -87,8 +87,10 @@ export function ProductDetailView({
       metadata={
         <Detail.Metadata>
           {/* Product Stats */}
-          <Detail.Metadata.Label title="Votes" text={product.votesCount.toString()} />
-          <Detail.Metadata.Label title="Comments" text={product.commentsCount.toString()} />
+          {!product.isFeedFallback && <Detail.Metadata.Label title="Votes" text={product.votesCount.toString()} />}
+          {!product.isFeedFallback && (
+            <Detail.Metadata.Label title="Comments" text={product.commentsCount.toString()} />
+          )}
           <Detail.Metadata.Label title="Launch Date" text={formattedDate} />
 
           {/* Ranking Information */}

--- a/extensions/producthunt/src/components/ProductDetailView.tsx
+++ b/extensions/producthunt/src/components/ProductDetailView.tsx
@@ -1,11 +1,14 @@
-import { Detail, Color, showToast, Toast, open } from "@raycast/api";
+import { Detail, Color, showToast, Toast, open, ActionPanel, Action, Icon } from "@raycast/api";
 import { Product } from "../types";
 import { generateTopicUrl } from "../util/topicUtils";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { enhanceProductWithMetadata } from "../api";
 import { HOST_URL } from "../constants";
 import { ProductActions, ViewContext } from "./ProductActions";
 import { cleanText } from "../util/textUtils";
+import { logger } from "@chrismessina/raycast-logger";
+
+const log = logger.child("[ProductHuntDetail]");
 
 interface ProductDetailViewProps {
   product: Product;
@@ -22,24 +25,27 @@ export function ProductDetailView({
 }: ProductDetailViewProps) {
   const [product, setProduct] = useState<Product>(initialProduct);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>();
+
+  const loadDetail = useCallback(async () => {
+    setIsLoading(true);
+    setError(undefined);
+    try {
+      const enhancedProduct = await enhanceProductWithMetadata(initialProduct);
+      setProduct(enhancedProduct);
+    } catch (e) {
+      // enhanceProductWithMetadata throws only on a real enrichment failure (not on
+      // no-creds/no-slug/not-found). Surface it visibly rather than showing thin data as complete.
+      log.error("detail enrichment failed", e);
+      setError(e instanceof Error ? e.message : "Failed to load product details.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [initialProduct]);
 
   useEffect(() => {
-    const fetchEnhancedProduct = async () => {
-      setIsLoading(true);
-      try {
-        const enhancedProduct = await enhanceProductWithMetadata(initialProduct);
-        setProduct(enhancedProduct);
-      } catch (error) {
-        console.error("Error enhancing product:", error);
-        // If enhancement fails, use the initial product
-        setProduct(initialProduct);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchEnhancedProduct();
-  }, [initialProduct.id]);
+    loadDetail();
+  }, [loadDetail]);
 
   const formattedDate = new Date(product.createdAt).toLocaleDateString();
 
@@ -52,10 +58,27 @@ export function ProductDetailView({
         // Check if it's a valid URL or base64 data URL
         return img && (img.startsWith("http") || img.startsWith("data:"));
       } catch (e) {
-        console.error("Invalid gallery image URL:", img, e);
+        log.error("invalid gallery image URL", { img, error: e });
         return false;
       }
     }) || [];
+
+  // Detail enrichment errored — show a visible error with retry / open-in-browser, NOT a
+  // thin page masquerading as complete (per review: detail must not silently degrade).
+  if (error) {
+    return (
+      <Detail
+        navigationTitle={cleanText(initialProduct.name)}
+        markdown={`# Couldn't load details\n\n${cleanText(initialProduct.name)} couldn't be loaded from the Product Hunt API.\n\n\`\`\`\n${error}\n\`\`\``}
+        actions={
+          <ActionPanel>
+            <Action title="Retry" icon={Icon.ArrowClockwise} onAction={loadDetail} />
+            <Action.OpenInBrowser title="Open in Browser" url={initialProduct.url} />
+          </ActionPanel>
+        }
+      />
+    );
+  }
 
   // Create markdown content for the product details
   const markdown = `
@@ -164,6 +187,30 @@ export function ProductDetailView({
           ) : product.maker && product.hunter && product.maker.name !== product.hunter.name ? (
             // Only show maker if it's not the same person as the hunter
             <Detail.Metadata.Label title="Maker" text={product.maker.name} />
+          ) : null}
+
+          {/* Posted By Section - the submitter (Post.user); the one identity available on a public
+              token. Labeled honestly as "Posted by", not maker/hunter. */}
+          {product.submittedBy ? (
+            <Detail.Metadata.TagList title="Posted by">
+              <Detail.Metadata.TagList.Item
+                key={product.submittedBy.id || "submitter"}
+                text={product.submittedBy.name}
+                color={Color.Blue}
+                onAction={() => {
+                  const url =
+                    product.submittedBy?.profileUrl ??
+                    (product.submittedBy?.username ? `${HOST_URL}@${product.submittedBy.username}` : undefined);
+                  if (url) {
+                    showToast({
+                      style: Toast.Style.Success,
+                      title: `Opening profile: ${product.submittedBy?.name}`,
+                    });
+                    open(url);
+                  }
+                }}
+              />
+            </Detail.Metadata.TagList>
           ) : null}
 
           {/* Topics Section */}

--- a/extensions/producthunt/src/components/ProductListItem.tsx
+++ b/extensions/producthunt/src/components/ProductListItem.tsx
@@ -4,6 +4,14 @@ import { Product } from "../types";
 import { ProductDetailView } from "./ProductDetailView";
 import { ProductActions, ViewContext } from "./ProductActions";
 import { cleanText } from "../util/textUtils";
+import { processImageUrl, ImgixFit } from "../api/imgix";
+
+// PH product images are wide (e.g. 1024x512), which renders as a non-square, cropped-looking
+// list icon. Square-crop imgix URLs to a centered 64x64 so list icons read as logos.
+function squareListIcon(url: string): string {
+  if (!url.includes("imgix.net")) return url;
+  return processImageUrl(url, { width: 64, height: 64, fit: ImgixFit.CROP, auto: ["format", "compress"] });
+}
 
 interface ProductListItemProps {
   product: Product;
@@ -13,6 +21,7 @@ interface ProductListItemProps {
   index?: number;
   totalProducts?: number;
   allProducts?: Product[];
+  onRefresh?: () => void;
 }
 
 export function ProductListItem({
@@ -23,22 +32,27 @@ export function ProductListItem({
   index,
   totalProducts,
   allProducts = [],
+  onRefresh,
 }: ProductListItemProps) {
   const { push } = useNavigation();
 
   const formattedDate = new Date(product.createdAt).toLocaleDateString();
 
-  // Use featuredImage if available, otherwise fall back to thumbnail
-  const thumbnailSource = product.featuredImage || product.thumbnail || Icon.Document;
+  // Use featuredImage if available, otherwise fall back to thumbnail; square-crop URLs for the
+  // list icon (the Icon.Document fallback is not a URL and passes through untouched).
+  const rawThumbnail = product.featuredImage || product.thumbnail;
+  const thumbnailSource = rawThumbnail ? squareListIcon(rawThumbnail) : Icon.Document;
 
   let baseAccessories: List.Item.Accessory[] = [];
 
   if (featured) {
-    baseAccessories = [
-      { text: product.commentsCount ? `${product.commentsCount}` : undefined, icon: { source: Icon.Bubble } },
-      { text: `${product.votesCount}`, icon: { source: Icon.ArrowUp } },
-      ...(product.maker ? [{ text: `by ${product.maker.name}` }] : []),
-    ];
+    baseAccessories = product.isFeedFallback
+      ? [...(product.maker ? [{ text: product.maker.name }] : [])]
+      : [
+          { text: product.commentsCount ? `${product.commentsCount}` : undefined, icon: { source: Icon.Bubble } },
+          { text: `${product.votesCount}`, icon: { source: Icon.ArrowUp } },
+          ...(product.maker ? [{ text: `by ${product.maker.name}` }] : []),
+        ];
   } else {
     baseAccessories = [
       { text: `${product.votesCount} votes` },
@@ -90,6 +104,7 @@ export function ProductListItem({
             onNavigateToProduct={handleNavigateToProduct}
             viewContext={ViewContext.List}
             showTopics={showTopics}
+            onRefresh={onRefresh}
           />
         ) as JSX.Element
       }

--- a/extensions/producthunt/src/components/ProductListItem.tsx
+++ b/extensions/producthunt/src/components/ProductListItem.tsx
@@ -45,13 +45,16 @@ export function ProductListItem({
 
   let baseAccessories: List.Item.Accessory[] = [];
 
+  // The submitter (Post.user / feed author) — a documented role, shown as a bare name (not "by",
+  // which would imply making/authorship we can't verify on a public token).
+  const submitter = product.submittedBy ?? product.maker;
   if (featured) {
     baseAccessories = product.isFeedFallback
-      ? [...(product.maker ? [{ text: product.maker.name }] : [])]
+      ? [...(submitter ? [{ text: submitter.name }] : [])]
       : [
           { text: product.commentsCount ? `${product.commentsCount}` : undefined, icon: { source: Icon.Bubble } },
           { text: `${product.votesCount}`, icon: { source: Icon.ArrowUp } },
-          ...(product.maker ? [{ text: `by ${product.maker.name}` }] : []),
+          ...(submitter ? [{ text: submitter.name }] : []),
         ];
   } else {
     baseAccessories = [

--- a/extensions/producthunt/src/tools/get-latest-products.ts
+++ b/extensions/producthunt/src/tools/get-latest-products.ts
@@ -1,5 +1,8 @@
 import { getFrontpageProducts } from "../api";
 import { Product } from "../types";
+import { logger } from "@chrismessina/raycast-logger";
+
+const log = logger.child("[ProductHuntTool]");
 
 /**
  * Returns the latest products from Product Hunt.
@@ -10,6 +13,7 @@ export default async function (): Promise<
     title: string;
     description: string;
     author: string;
+    submittedBy: string | null;
     link: string;
     votesCount: number;
     commentsCount: number;
@@ -29,14 +33,17 @@ export default async function (): Promise<
     const { products, error } = await getFrontpageProducts();
 
     if (error) {
-      console.error("Error fetching Product Hunt data:", error);
+      log.error("error fetching Product Hunt data", error);
       throw new Error(error);
     }
 
     return products.map((product: Product) => ({
       title: product.name,
       description: product.tagline,
-      author: product.maker?.name || "Unknown",
+      // The submitter (Post.user) is the only verified identity on a public token; makers are
+      // redacted. Report it honestly rather than labeling it a maker.
+      author: product.submittedBy?.name || product.maker?.name || "Unknown",
+      submittedBy: product.submittedBy?.name || null,
       link: product.url,
       votesCount: product.votesCount,
       commentsCount: product.commentsCount,
@@ -54,7 +61,7 @@ export default async function (): Promise<
       createdAt: product.createdAt,
     }));
   } catch (error) {
-    console.error("Error fetching Product Hunt data:", error);
+    log.error("error fetching Product Hunt data", error);
     throw error;
   }
 }

--- a/extensions/producthunt/src/tools/get-latest-products.ts
+++ b/extensions/producthunt/src/tools/get-latest-products.ts
@@ -1,4 +1,4 @@
-import { getFrontpageProducts } from "../api/scraper";
+import { getFrontpageProducts } from "../api";
 import { Product } from "../types";
 
 /**

--- a/extensions/producthunt/src/types/index.ts
+++ b/extensions/producthunt/src/types/index.ts
@@ -14,6 +14,10 @@ export interface Product {
   // Additional detailed information
   makers?: User[];
   hunter?: User;
+  // The user who created/submitted the post (Post.user in the API: "User who created the Post").
+  // This is a documented, distinct role — NOT a maker and not a guaranteed "hunter" — so it is
+  // modeled and labeled separately ("Posted by") rather than conflated with maker/hunter.
+  submittedBy?: User;
   galleryImages?: string[];
   shoutouts?: Shoutout[];
   weeklyRank?: number;

--- a/extensions/producthunt/src/types/index.ts
+++ b/extensions/producthunt/src/types/index.ts
@@ -20,6 +20,10 @@ export interface Product {
   dailyRank?: number;
   productHubUrl?: string;
   previousLaunches?: number;
+  // True when this product came from the token-free Atom feed (limited data: no real votes,
+  // comments, makers, or thumbnails). UI uses this to suppress empty stats and prefer opening
+  // the launch in the browser over the (thin) in-app detail view.
+  isFeedFallback?: boolean;
 }
 
 export interface Topic {

--- a/extensions/producthunt/src/util/textUtils.ts
+++ b/extensions/producthunt/src/util/textUtils.ts
@@ -20,6 +20,10 @@ export function cleanText(text: string | undefined | null): string {
         (_, entity: "amp" | "lt" | "gt" | "quot" | "#39") =>
           ({ amp: "&", lt: "<", gt: ">", quot: '"', "#39": "'" })[entity] || _,
       )
+      // Collapse internal whitespace runs (feed content is pretty-printed with newlines/indent)
+      // and trim ends, so taglines/names don't leak markdown markers (e.g. `_tagline _`).
+      .replace(/\s+/g, " ")
+      .trim()
   );
 }
 


### PR DESCRIPTION
## Description

Fixes [#28424](https://github.com/raycast/extensions/issues/28424): the extension was returning **HTTP 403** on every command because Product Hunt's Cloudflare bot protection now blocks the HTML-scraping approach the extension relied on.

This migrates data fetching to **Product Hunt's official GraphQL API v2** and removes all HTML scraping from production paths.

**What changed (v2.4):**
- Fetch data via the official GraphQL API (`api.producthunt.com/v2/api/graphql`) instead of scraping `producthunt.com` HTML.
- New optional **API Key** / **API Secret** preferences. The extension exchanges them for a public, read-only `client_credentials` token (no personal login, no write scope). Users create a free app at [producthunt.com/v2/oauth/applications](https://www.producthunt.com/v2/oauth/applications).
- **No credentials?** The extension falls back to Product Hunt's public Atom feed (`/feed`) — a basic list (names, taglines, links) with empty stats hidden and launches opening in the browser. An action surfaces to add credentials.
- Product detail view now uses the official API instead of scraping product pages.
- "Today" is computed on Product Hunt's **Pacific launch day** so the list matches the site (UTC could return an empty set near the day boundary).
- Toast + action when API credentials are rejected; a **Refresh** action (⌘R) that bypasses the short response cache; square-cropped list icons; trimmed taglines.
- Maker names are not shown because Product Hunt redacts them for public-scope tokens; the launch submitter ("hunter") is shown.

Note: a small amount of legacy scraper code is retained but is **off all production paths** (nothing in the running extension fetches Product Hunt HTML). A follow-up **v3.0** is in progress that strips out the scraper entirely, drops the `cheerio` dependency, and migrates the remaining surfaces (search/topics) to the official API.

## Screencast

_Tested locally against the live API: today's featured products load with votes, comments, topics, and thumbnails; no-credentials mode falls back to the Atom feed._

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build for issues](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that this change adheres to the [linting rules](https://developers.raycast.com/basics/prepare-an-extension-for-store#linting) (`npm run lint`)
- [x] I updated the CHANGELOG with a `{PR_MERGE_DATE}` entry