### PR TITLE
[minimax-ai] Use MiniMax Token Plan endpoint

### DIFF
--- a/extensions/minimax-ai/CHANGELOG.md
+++ b/extensions/minimax-ai/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.1] - 2026-05-31
+
+- Default the China endpoint to the MiniMax Token Plan Anthropic-compatible API.
+- Add Anthropic Messages request handling while preserving the legacy International endpoint.
+- Make MiniMax M2.7-highspeed the recommended default model.
+
 ## [1.2.0] - 2026-05-10
 
 Thanks to [@tolshao](https://github.com/tolshao) for contributing this release.

--- a/extensions/minimax-ai/README.md
+++ b/extensions/minimax-ai/README.md
@@ -1,10 +1,10 @@
 # MiniMax - Raycast Extension
 
-A "Bring Your Own Key" Raycast extension for AI chat. Supports **MiniMax M2.7**, **M2.5**, **M2.1**, and **M2** models with streaming responses, for both **China** and **International** regions.
+A "Bring Your Own Key" Raycast extension for AI chat. Supports **MiniMax M2.7**, **M2.5**, **M2.1**, and **M2** models with streaming responses. The default China route uses the Token Plan Anthropic-compatible endpoint.
 
 ## Features
 
-- **Dual-region support** — China (`api.minimaxi.com`) and International (`api.minimax.io`) endpoints
+- **Token Plan default** — China uses `https://api.minimaxi.com/anthropic`, with the legacy International endpoint still available as a fallback
 - **Conversational chat** with persistent history
 - **Streaming responses** in real-time
 - **Quick question** (Ask AI) for simple queries
@@ -30,20 +30,21 @@ npm run dev
 
 Open Raycast → Search for "AI Chat" → `Cmd + ,` to open preferences:
 
-| Preference           | Type     | Description                                                                  |
-| -------------------- | -------- | ---------------------------------------------------------------------------- |
-| **MiniMax API Key**  | password | Your MiniMax API key (required)                                              |
-| **API Endpoint**     | dropdown | China (`api.minimaxi.com`) or International (`api.minimax.io`) (default: International) |
-| **Model**            | dropdown | MiniMax-M2.7 (recommended), M2.7-highspeed, M2.5, M2.5-highspeed, M2-her, M2.1, M2 |
-| **System Prompt**    | text     | Custom system prompt (optional)                                              |
-| **Temperature**      | dropdown | 0.3 / 0.7 / 1.0 / 1.5                                                       |
-| **Max Tokens**       | dropdown | 1024 / 2048 / 4096 / 8192                                                    |
-| **Stream Responses** | checkbox | Enable streaming (default: true)                                             |
-| **Concise Mode**     | checkbox | Brief 2-3 sentence answers unless more detail requested (default: true)      |
+| Preference           | Type     | Description                                                                                                            |
+| -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **MiniMax API Key**  | password | Your MiniMax API key (required)                                                                                        |
+| **API Endpoint**     | dropdown | China Token Plan (`api.minimaxi.com/anthropic`) or International legacy (`api.minimax.io`) (default: China Token Plan) |
+| **Model**            | dropdown | MiniMax-M2.7-highspeed (recommended), M2.7, M2.5, M2.5-highspeed, M2-her, M2.1, M2                                     |
+| **System Prompt**    | text     | Custom system prompt (optional)                                                                                        |
+| **Temperature**      | dropdown | 0.3 / 0.7 / 1.0 / 1.5                                                                                                  |
+| **Max Tokens**       | dropdown | 1024 / 2048 / 4096 / 8192                                                                                              |
+| **Stream Responses** | checkbox | Enable streaming (default: true)                                                                                       |
+| **Concise Mode**     | checkbox | Brief 2-3 sentence answers unless more detail requested (default: true)                                                |
 
 ### Getting a MiniMax API Key
 
 **International users:**
+
 1. Visit [MiniMax Platform](https://platform.minimax.chat/)
 2. Create an account or sign in
 3. Navigate to API Keys section
@@ -51,6 +52,7 @@ Open Raycast → Search for "AI Chat" → `Cmd + ,` to open preferences:
 5. Copy and paste it into the extension preferences
 
 **China users:**
+
 1. Visit [MiniMax Platform (China)](https://platform.minimaxi.com/)
 2. Create an account or sign in
 3. Navigate to API Keys section
@@ -106,15 +108,15 @@ raycast-minimax/
 
 ## MiniMax API
 
-| Region      | Endpoint                                        |
-| ----------- | ----------------------------------------------- |
-| International | `https://api.minimax.io/v1/chat/completions`   |
-| China       | `https://api.minimaxi.com/v1/chat/completions` |
+| Route                | Endpoint                                         | Protocol                |
+| -------------------- | ------------------------------------------------ | ----------------------- |
+| China Token Plan     | `https://api.minimaxi.com/anthropic/v1/messages` | Anthropic Messages      |
+| International Legacy | `https://api.minimax.io/v1/chat/completions`     | OpenAI Chat Completions |
 
 **Models:**
 
-- `MiniMax-M2.7`: Latest generation, recommended
-- `MiniMax-M2.7-highspeed`: Fast variant of M2.7
+- `MiniMax-M2.7-highspeed`: Fast variant of M2.7, recommended
+- `MiniMax-M2.7`: Latest generation
 - `MiniMax-M2.5`: Previous generation
 - `MiniMax-M2.5-highspeed`: Fast variant of M2.5
 - `M2-her`: Roleplay-optimized model

--- a/extensions/minimax-ai/package.json
+++ b/extensions/minimax-ai/package.json
@@ -51,15 +51,15 @@
       "type": "dropdown",
       "required": false,
       "title": "API Endpoint",
-      "description": "Select the API endpoint based on your account region",
-      "default": "international",
+      "description": "Select the MiniMax endpoint. China uses the Token Plan Anthropic-compatible endpoint.",
+      "default": "china",
       "data": [
         {
-          "title": "China (api.minimaxi.com)",
+          "title": "China Token Plan (api.minimaxi.com/anthropic)",
           "value": "china"
         },
         {
-          "title": "International (api.minimax.io)",
+          "title": "International Legacy (api.minimax.io)",
           "value": "international"
         }
       ]
@@ -70,14 +70,14 @@
       "required": false,
       "title": "Model",
       "description": "MiniMax model to use for AI responses",
-      "default": "MiniMax-M2.7",
+      "default": "MiniMax-M2.7-highspeed",
       "data": [
         {
-          "title": "MiniMax M2.7 (Recommended)",
+          "title": "MiniMax M2.7",
           "value": "MiniMax-M2.7"
         },
         {
-          "title": "MiniMax M2.7-highspeed",
+          "title": "MiniMax M2.7-highspeed (Recommended)",
           "value": "MiniMax-M2.7-highspeed"
         },
         {

--- a/extensions/minimax-ai/src/hooks/useChat.ts
+++ b/extensions/minimax-ai/src/hooks/useChat.ts
@@ -22,11 +22,12 @@ export function useChat(): UseChatReturn {
   // Validate API key on mount and re-validate when key changes
   useEffect(() => {
     const prefs = getPreferenceValues<Preferences>();
-    if (prefs.minimaxApiKey === validatedKeyRef.current) return;
+    const apiEndpoint = prefs.apiEndpoint === "international" ? API_ENDPOINTS.international : API_ENDPOINTS.china;
+    const validationTarget = `${prefs.minimaxApiKey}:${apiEndpoint}`;
+    if (validationTarget === validatedKeyRef.current) return;
 
     const validateApiKey = async () => {
-      validatedKeyRef.current = prefs.minimaxApiKey;
-      const apiEndpoint = prefs.apiEndpoint === "international" ? API_ENDPOINTS.international : API_ENDPOINTS.china;
+      validatedKeyRef.current = validationTarget;
 
       const result = await MiniMaxProvider.validateApiKey(prefs.minimaxApiKey, apiEndpoint);
       setIsApiKeyValid(result.valid);

--- a/extensions/minimax-ai/src/providers/minimax.ts
+++ b/extensions/minimax-ai/src/providers/minimax.ts
@@ -2,10 +2,11 @@ import { AIProvider, ChatRequest, ChatResponse, StreamCallbacks, ProviderConfig,
 
 export const API_ENDPOINTS = {
   international: "https://api.minimax.io/v1/chat/completions",
-  china: "https://api.minimaxi.com/v1/chat/completions",
+  china: "https://api.minimaxi.com/anthropic",
 };
 
 const REQUEST_TIMEOUT_MS = 60000; // 60 seconds timeout
+const ANTHROPIC_VERSION = "2023-06-01";
 
 interface MiniMaxChatResponse {
   choices?: Array<{
@@ -14,9 +15,18 @@ interface MiniMaxChatResponse {
   }>;
 }
 
+interface MiniMaxAnthropicResponse {
+  content?: Array<{ type?: string; text?: string }>;
+  stop_reason?: string;
+}
+
 interface MiniMaxErrorResponse {
   error?: { message?: string };
   message?: string;
+}
+
+function isChatCompletionResponse(data: MiniMaxChatResponse | MiniMaxAnthropicResponse): data is MiniMaxChatResponse {
+  return Array.isArray((data as MiniMaxChatResponse).choices);
 }
 
 export class MiniMaxProvider implements AIProvider {
@@ -30,26 +40,39 @@ export class MiniMaxProvider implements AIProvider {
 
   constructor(config: ProviderConfig & { apiEndpoint?: string }) {
     this.apiKey = config.apiKey;
-    this.model = config.model || "MiniMax-M2.7";
+    this.model = config.model || "MiniMax-M2.7-highspeed";
     this.defaultTemperature = config.temperature ?? 0.7;
     this.defaultMaxTokens = config.maxTokens ?? 4096;
     this.systemPrompt = config.systemPrompt;
-    this.apiEndpoint = config.apiEndpoint || API_ENDPOINTS.international;
+    this.apiEndpoint = config.apiEndpoint || API_ENDPOINTS.china;
   }
 
   static async validateApiKey(apiKey: string, apiEndpoint: string): Promise<{ valid: boolean | null; error?: string }> {
     try {
-      const response = await fetch(apiEndpoint, {
+      const anthropic = MiniMaxProvider.isAnthropicEndpoint(apiEndpoint);
+      const response = await fetch(MiniMaxProvider.requestUrlForEndpoint(apiEndpoint), {
         method: "POST",
         headers: {
           Authorization: `Bearer ${apiKey}`,
+          ...(anthropic
+            ? {
+                "x-api-key": apiKey,
+                "api-key": apiKey,
+                "anthropic-version": ANTHROPIC_VERSION,
+              }
+            : {}),
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          model: "MiniMax-M2.5",
-          messages: [{ role: "user", content: "Hi" }],
-          max_tokens: 10,
-        }),
+        body: JSON.stringify(
+          MiniMaxProvider.buildRequestBody(
+            "MiniMax-M2.7-highspeed",
+            [{ role: "user", content: "Hi" }],
+            0.7,
+            10,
+            false,
+            anthropic,
+          ),
+        ),
       });
 
       if (response.ok) {
@@ -75,9 +98,99 @@ export class MiniMaxProvider implements AIProvider {
     return messages;
   }
 
+  private static isAnthropicEndpoint(apiEndpoint: string): boolean {
+    return apiEndpoint.replace(/\/+$/, "").toLowerCase().includes("/anthropic");
+  }
+
+  private get isAnthropicEndpoint(): boolean {
+    return MiniMaxProvider.isAnthropicEndpoint(this.apiEndpoint);
+  }
+
+  private static requestUrlForEndpoint(apiEndpoint: string): string {
+    const trimmed = apiEndpoint.replace(/\/+$/, "");
+    if (MiniMaxProvider.isAnthropicEndpoint(apiEndpoint)) {
+      if (trimmed.endsWith("/v1/messages")) return trimmed;
+      if (trimmed.endsWith("/v1")) return `${trimmed}/messages`;
+      return `${trimmed}/v1/messages`;
+    }
+    return trimmed.endsWith("/chat/completions") ? trimmed : `${trimmed}/chat/completions`;
+  }
+
+  private endpointUrl(): string {
+    return MiniMaxProvider.requestUrlForEndpoint(this.apiEndpoint);
+  }
+
+  private static buildRequestBody(
+    model: string,
+    messages: Message[],
+    temperature: number,
+    maxTokens: number,
+    stream: boolean,
+    anthropic: boolean,
+  ): Record<string, unknown> {
+    if (!anthropic) {
+      return {
+        model,
+        messages,
+        temperature,
+        max_tokens: maxTokens,
+        stream,
+      };
+    }
+
+    const system = messages
+      .filter((message) => message.role === "system")
+      .map((message) => message.content)
+      .join("\n\n");
+    const chatMessages = messages.filter((message) => message.role !== "system");
+
+    return {
+      model,
+      ...(system ? { system } : {}),
+      messages: chatMessages.length ? chatMessages : [{ role: "user", content: "Hi" }],
+      temperature,
+      max_tokens: maxTokens,
+      stream,
+      thinking: { type: "disabled" },
+    };
+  }
+
+  private requestHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json",
+    };
+    if (this.isAnthropicEndpoint) {
+      headers["x-api-key"] = this.apiKey;
+      headers["api-key"] = this.apiKey;
+      headers["anthropic-version"] = ANTHROPIC_VERSION;
+    }
+    return headers;
+  }
+
   private removeThinking(content: string): string {
     // Remove <think>...</think> blocks (including multiline)
     return content.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
+  }
+
+  private contentFromResponse(data: MiniMaxChatResponse | MiniMaxAnthropicResponse): ChatResponse {
+    if (isChatCompletionResponse(data)) {
+      const rawContent = data.choices?.[0]?.message?.content ?? "";
+      return {
+        content: this.removeThinking(rawContent),
+        finishReason: data.choices?.[0]?.finish_reason,
+      };
+    }
+
+    const rawContent =
+      data.content
+        ?.filter((part) => part.type === "text" || typeof part.text === "string")
+        .map((part) => part.text ?? "")
+        .join("") ?? "";
+    return {
+      content: this.removeThinking(rawContent),
+      finishReason: data.stop_reason,
+    };
   }
 
   async chat(request: ChatRequest): Promise<ChatResponse> {
@@ -85,19 +198,19 @@ export class MiniMaxProvider implements AIProvider {
     const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
     try {
-      const response = await fetch(this.apiEndpoint, {
+      const response = await fetch(this.endpointUrl(), {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: this.model,
-          messages: this.buildMessages(request.messages),
-          temperature: request.temperature ?? this.defaultTemperature,
-          max_tokens: request.maxTokens ?? this.defaultMaxTokens,
-          stream: false,
-        }),
+        headers: this.requestHeaders(),
+        body: JSON.stringify(
+          MiniMaxProvider.buildRequestBody(
+            this.model,
+            this.buildMessages(request.messages),
+            request.temperature ?? this.defaultTemperature,
+            request.maxTokens ?? this.defaultMaxTokens,
+            false,
+            this.isAnthropicEndpoint,
+          ),
+        ),
         signal: controller.signal,
       });
 
@@ -108,12 +221,8 @@ export class MiniMaxProvider implements AIProvider {
         throw error;
       }
 
-      const data = (await response.json()) as MiniMaxChatResponse;
-      const rawContent = data.choices?.[0]?.message?.content ?? "";
-      return {
-        content: this.removeThinking(rawContent),
-        finishReason: data.choices?.[0]?.finish_reason,
-      };
+      const data = (await response.json()) as MiniMaxChatResponse | MiniMaxAnthropicResponse;
+      return this.contentFromResponse(data);
     } catch (error) {
       clearTimeout(timeoutId);
       if (error instanceof Error && error.name === "AbortError") {
@@ -129,19 +238,19 @@ export class MiniMaxProvider implements AIProvider {
 
     let response: Response;
     try {
-      response = await fetch(this.apiEndpoint, {
+      response = await fetch(this.endpointUrl(), {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: this.model,
-          messages: this.buildMessages(request.messages),
-          temperature: request.temperature ?? this.defaultTemperature,
-          max_tokens: request.maxTokens ?? this.defaultMaxTokens,
-          stream: true,
-        }),
+        headers: this.requestHeaders(),
+        body: JSON.stringify(
+          MiniMaxProvider.buildRequestBody(
+            this.model,
+            this.buildMessages(request.messages),
+            request.temperature ?? this.defaultTemperature,
+            request.maxTokens ?? this.defaultMaxTokens,
+            true,
+            this.isAnthropicEndpoint,
+          ),
+        ),
         signal: controller.signal,
       });
       clearTimeout(timeoutId);
@@ -192,7 +301,7 @@ export class MiniMaxProvider implements AIProvider {
 
           try {
             const json = JSON.parse(trimmed.slice(6));
-            const content = json.choices?.[0]?.delta?.content;
+            const content = json.choices?.[0]?.delta?.content ?? json.delta?.text;
             if (content) {
               // Filter out <think>...</think> content during streaming
               let processedContent = "";


### PR DESCRIPTION
## Summary

- Default the MiniMax China route to the Token Plan Anthropic-compatible endpoint.
- Add automatic request/response handling for Anthropic Messages while preserving the legacy International OpenAI-compatible route.
- Update preferences and README copy to make `MiniMax-M2.7-highspeed` and `https://api.minimaxi.com/anthropic` the recommended path.

## Validation

- `npm ci`
- `npm run lint`
- `npm run build`
- `npx tsc --noEmit --pretty false`
- MiniMax provider mock smoke for `https://api.minimaxi.com/anthropic/v1/messages`
- `git diff --check`

## Notes

`npm audit --audit-level=high --omit=dev` still reports existing transitive vulnerabilities in `minimatch` and `picomatch`; this PR does not change the dependency tree.
