### PR TITLE
fix(clip): handle history errors gracefully in URL shortener

### DIFF
--- a/extensions/clip/CHANGELOG.md
+++ b/extensions/clip/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Clip - URL Shortener Changelog
 
+## [Fix] - 2026-05-31
+
+### 🐛 Bug Fix
+
+- Fixed an issue where a history save failure (e.g. "Could not create extension support directory") would incorrectly report the URL shortening as failed, even though the URL was already shortened and copied to the clipboard
+
 ## [Initial Version] - 2026-04-13
 
 ### ✨ URL Shortening Functionality

--- a/extensions/clip/src/shorten-url.tsx
+++ b/extensions/clip/src/shorten-url.tsx
@@ -72,7 +72,11 @@ export default function ShortenUrl() {
       const result = await shortenUrl(service.id, activeUrl, apiKey);
 
       await Clipboard.copy(result.shortUrl);
-      addToHistory(result).catch(() => undefined);
+      try {
+        await addToHistory(result);
+      } catch {
+        // history errors are non-fatal; shortening already succeeded
+      }
 
       toast.style = Toast.Style.Success;
       toast.title = "URL shortened";

--- a/extensions/clip/src/shorten-url.tsx
+++ b/extensions/clip/src/shorten-url.tsx
@@ -72,7 +72,7 @@ export default function ShortenUrl() {
       const result = await shortenUrl(service.id, activeUrl, apiKey);
 
       await Clipboard.copy(result.shortUrl);
-      await addToHistory(result);
+      addToHistory(result).catch(() => undefined);
 
       toast.style = Toast.Style.Success;
       toast.title = "URL shortened";


### PR DESCRIPTION
## Description

This pull request updates the URL shortening functionality to prevent unhandled promise rejections when adding entries to history fails.

**Error handling improvement:**
* Modified `shorten-url.tsx` to catch and suppress errors from `addToHistory()` calls, ensuring that history save failures don't interrupt the URL shortening flow or prevent success notifications from being displayed to the user.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
