### PR TITLE
[proton-pass] Prefer installed pass-cli

### DIFF
--- a/extensions/proton-pass/CHANGELOG.md
+++ b/extensions/proton-pass/CHANGELOG.md
@@ -1,5 +1,9 @@
 # proton-pass Changelog
 
+## [Improvements] - 2026-06-01
+
+- Prefer a user-installed `pass-cli` from PATH before falling back to the bundled CLI
+
 ## [Improvements] - 2026-05-01
 
 - Fix: Search Items command could show results from only one vault when "All Vaults" was selected (vault share_id now used as fallback during item normalization)

--- a/extensions/proton-pass/src/lib/pass-cli.ts
+++ b/extensions/proton-pass/src/lib/pass-cli.ts
@@ -78,11 +78,28 @@ function getConfiguredCliPath(): string | undefined {
   return stripSurroundingQuotes(configured);
 }
 
+async function getCliPathFromPath(): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync("/usr/bin/which", [DEFAULT_CLI_COMMAND], {
+      env: createExecEnv(),
+      timeout: 5_000,
+    });
+    return trimOrUndefined(stdout);
+  } catch {
+    return undefined;
+  }
+}
+
 async function getCliPathAsync(): Promise<string> {
   // Check if user configured a custom path
   const configured = getConfiguredCliPath();
   if (configured) {
     return configured;
+  }
+
+  const cliPath = await getCliPathFromPath();
+  if (cliPath) {
+    return cliPath;
   }
 
   // This extension is macOS-only, but keeping a non-throwing fallback here


### PR DESCRIPTION
## What changed

- Prefer a user-installed `pass-cli` resolved from PATH before falling back to the extension-managed bundled CLI.
- Keep the existing explicit CLI Path preference as the highest-priority override.
- Update the Proton Pass changelog.

## Why

The extension currently falls back to its bundled CLI whenever the CLI Path preference is left as the default `pass-cli`. That can leave users on an older extension-managed binary even when a newer authenticated `pass-cli` is already installed in a standard location such as `~/.local/bin`, `/opt/homebrew/bin`, or `/usr/local/bin`.

This change lets users benefit from their installed CLI without having to manually enter an absolute path, while preserving the auto-download fallback for users without `pass-cli` installed.

## Validation

- `npm run lint`
- `npm test`
- `npm run build`
- `git diff --check`
