### PR TITLE
[Coffee] Fix menu bar icon refresh after caffeination changes

### DIFF
--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coffee Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-06-02
 
 - Fixed the menu bar icon not updating immediately after caffeinating or decaffeinating.
 

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Coffee Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed the menu bar icon not updating immediately after caffeinating or decaffeinating.
+
 ## [Add Keyboard Shortcuts] - 2026-05-16
 
 - Added a Toggle shortcut for pausing and resuming caffeination schedules.

--- a/extensions/coffee/package.json
+++ b/extensions/coffee/package.json
@@ -15,7 +15,8 @@
     "zakj",
     "Visual-Studio-Coder",
     "Katsuba",
-    "alexi.build"
+    "alexi.build",
+    "mbuvarp"
   ],
   "platforms": [
     "macOS"

--- a/extensions/coffee/src/index.tsx
+++ b/extensions/coffee/src/index.tsx
@@ -73,14 +73,15 @@ export default function Command(props: LaunchProps) {
 
   const extraInfoStr = data.timeRemaining;
 
-  const [localCaffeinateStatus, setLocalCaffeinateStatus] = useState(caffeinateStatus);
+  const [localCaffeinateStatus, setLocalCaffeinateStatus] = useState<boolean | null>(null);
+  const displayCaffeinateStatus = localCaffeinateStatus ?? caffeinateStatus;
 
   useEffect(() => {
-    setLocalCaffeinateStatus(caffeinateStatus);
+    setLocalCaffeinateStatus(null);
   }, [caffeinateStatus]);
 
   const handleCaffeinateStatus = async () => {
-    if (localCaffeinateStatus) {
+    if (displayCaffeinateStatus) {
       setLocalCaffeinateStatus(false);
       await mutate(stopCaffeinate({ menubar: true, status: true }), {
         optimisticUpdate: () => ({ isRunning: false, timeRemaining: null }),
@@ -96,7 +97,7 @@ export default function Command(props: LaunchProps) {
     }
   };
 
-  if (preferences.hidenWhenDecaffeinated && !localCaffeinateStatus && !isLoading) {
+  if (preferences.hidenWhenDecaffeinated && !displayCaffeinateStatus && !isLoading) {
     return null;
   }
 
@@ -104,17 +105,17 @@ export default function Command(props: LaunchProps) {
     <MenuBarExtra
       isLoading={caffeinateLoader}
       icon={
-        localCaffeinateStatus
+        displayCaffeinateStatus
           ? { source: `${preferences.icon}-filled.svg`, tintColor: Color.PrimaryText }
           : { source: `${preferences.icon}-empty.svg`, tintColor: Color.PrimaryText }
       }
     >
       {isLoading ? null : (
         <>
-          <MenuBarExtra.Section title={`Your mac is ${localCaffeinateStatus ? "caffeinated" : "decaffeinated"}`} />
-          {localCaffeinateStatus && extraInfoStr && <MenuBarExtra.Section title={extraInfoStr} />}
+          <MenuBarExtra.Section title={`Your mac is ${displayCaffeinateStatus ? "caffeinated" : "decaffeinated"}`} />
+          {displayCaffeinateStatus && extraInfoStr && <MenuBarExtra.Section title={extraInfoStr} />}
           <MenuBarExtra.Item
-            title={localCaffeinateStatus ? "Decaffeinate" : "Caffeinate"}
+            title={displayCaffeinateStatus ? "Decaffeinate" : "Caffeinate"}
             onAction={handleCaffeinateStatus}
           />
         </>


### PR DESCRIPTION
## Description

Fixes the Coffee menu bar icon sometimes not updating immediately after running the Caffeinate or Decaffeinate actions.

The menu bar command now renders from the current launch context immediately on background refresh, while keeping local state only as an optimistic override for actions triggered from the menu bar item itself. This prevents the first background render from showing stale caffeination state.

Also adds the required changelog entry and contributor metadata.

## Screencast

N/A - this is a state refresh fix for the existing menu bar icon behavior.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)