### PR TITLE
klack: polish stats header and tighten changelog

### DIFF
--- a/extensions/klack/CHANGELOG.md
+++ b/extensions/klack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Klack Changelog
 
+## [Polish] - {PR_MERGE_DATE}
+
+- Revised wording in the Stats view
+
 ## [Fix README Link] - 2026-05-20
 
 - Fixed broken contributor GitHub link in the README

--- a/extensions/klack/CHANGELOG.md
+++ b/extensions/klack/CHANGELOG.md
@@ -6,22 +6,14 @@
 
 ## [Stats and Standalone Support] - 2026-05-20
 
-- Added Klack Stats view with live updates, Markdown export, and tracking-since timestamp
-- Added Set Volume command with a 0–100 scrubber and custom input
+- Added Klack Stats view with live usage counts
+- Added Set Volume command with a 0–100 scrubber
 - Added Turn Klack on, Turn Klack off, and Wake Klack commands
 - Added support for the new Super Red switch set
-- Added per-switch icons in the picker
-- Added AI tools for toggle, turn on, turn off, wake up, set switch, set volume, and get status
-- Added redundancy aware feedback so commands report when Klack is already in the requested state
-- Added support for the standalone Klack build at tryklack.com alongside the App Store build
-- Fixed Set Switch Set search to be case insensitive
-- Fixed Current badge for multi-word switch names
-- Fixed select action triggering before initial current switch fetch resolves
-- Fixed Set Volume to Soft, Balanced, and Loud under Klack v2 by using integer volume
-- Improved error toasts to distinguish not installed, needs update, and permission denied
-- Improved performance via batched state reads, per-process install caching, optimistic updates, persistent cache seeding, lazy form loading, and a fix for the install check leaking a rejected promise
-- Replaced run-applescript dependency with @raycast/utils runAppleScript
-- Updated to @raycast/api 1.104, React 19, and TypeScript 5.9
+- Added support for the standalone Klack build from tryklack.com
+- Added AI tools for the core actions
+- Revised wording, icons, and command feedback
+- Updated dependencies
 
 ## [Milky Yellow Support] - 2025-01-29
 

--- a/extensions/klack/CHANGELOG.md
+++ b/extensions/klack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Klack Changelog
 
-## [Polish] - {PR_MERGE_DATE}
+## [Polish] - 2026-06-01
 
 - Revised wording in the Stats view
 

--- a/extensions/klack/src/stats.tsx
+++ b/extensions/klack/src/stats.tsx
@@ -20,7 +20,7 @@ const TOTAL_ROWS = [
   { title: "Clicks", icon: Icon.Mouse, key: "clicks" as const },
 ];
 
-function formatTrackingSince(d: Date): string {
+function formatSince(d: Date): string {
   return `Since ${d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`;
 }
 
@@ -65,7 +65,7 @@ export default function Command() {
 
   const blocked = data && (!data.enabled || !data.hasPermission);
   const totalsTitle =
-    !blocked && data?.trackingSince ? `Total Usage · ${formatTrackingSince(data.trackingSince)}` : "Total Usage";
+    !blocked && data?.trackingSince ? `Total Usage · ${formatSince(data.trackingSince)}` : "Total Usage";
 
   return (
     <List isLoading={isLoading} navigationTitle="Klack Stats">

--- a/extensions/klack/src/stats.tsx
+++ b/extensions/klack/src/stats.tsx
@@ -21,7 +21,7 @@ const TOTAL_ROWS = [
 ];
 
 function formatTrackingSince(d: Date): string {
-  return `Tracking since ${d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`;
+  return `Since ${d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`;
 }
 
 function StatsActions({ stats, revalidate }: { stats: Stats; revalidate: () => void }) {


### PR DESCRIPTION
## Summary

Two small follow-ups to the recent [Stats and Standalone Support](https://github.com/raycast/extensions/pull/28135) release:

- **Stats header** — drops the leading "Tracking" word so the section now reads `Total Usage · Since May 20, 2026` instead of `… · Tracking since May 20, 2026`. Henrik flagged "tracking" as sounding negative in casual UI copy and asked to simplify.
- **Changelog** — tightens the bullets on the existing `[Stats and Standalone Support] - 2026-05-20` entry so the release notes read more like Klack's earlier entries (short, user-facing) and less like an internal commit log. Dates, section headers, and all other entries are untouched.

## Test plan

- [x] `npx ray build -e dist`
- [x] `npx ray lint`
- [x] Stats view manually verified — header now reads `Total Usage · Since May 20, 2026`