### PR TITLE
Update whois extension

### DIFF
--- a/extensions/whois/CHANGELOG.md
+++ b/extensions/whois/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Whois Changelog
 
+## [URL Sanitization & Subdomain Support] - 2026-06-01
+
+- Added automatic URL sanitization to strip protocol (`http/https`), paths, and `www.` prefixes from pasted inputs.
+- Implemented base domain extraction to query WHOIS for the registered domain (second-level domain) when subdomains are entered, preventing false-positive "Available" results.
+
 ## [WHOIS/RDAP Integration] - 2026-05-15
 
 - Added full WHOIS and RDAP domain lookup via `whoiser`.

--- a/extensions/whois/CHANGELOG.md
+++ b/extensions/whois/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Whois Changelog
 
-## [URL Sanitization & Subdomain Support] - {PR_MERGE_DATE}
+## [URL Sanitization & Subdomain Support] - 2026-06-01
 
 - Added automatic URL sanitization to strip protocol (`http/https`), paths, and `www.` prefixes from pasted inputs.
 - Implemented base domain extraction to query WHOIS for the registered domain (second-level domain) when subdomains are entered, preventing false-positive "Available" results.

--- a/extensions/whois/CHANGELOG.md
+++ b/extensions/whois/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Whois Changelog
 
-## [URL Sanitization & Subdomain Support] - 2026-06-01
+## [URL Sanitization & Subdomain Support] - {PR_MERGE_DATE}
 
 - Added automatic URL sanitization to strip protocol (`http/https`), paths, and `www.` prefixes from pasted inputs.
 - Implemented base domain extraction to query WHOIS for the registered domain (second-level domain) when subdomains are entered, preventing false-positive "Available" results.

--- a/extensions/whois/src/utils/ccslds.ts
+++ b/extensions/whois/src/utils/ccslds.ts
@@ -1,0 +1,53 @@
+/**
+ * A record of country-code top-level domains (ccTLDs) mapped to their
+ * official and commonly used second-level domains (ccSLDs).
+ *
+ * This allows the domain parser to accurately identify base domains (e.g.
+ * `example.co.uk` instead of `co.uk` or `sub.example.co.uk`) and prevents
+ * false positives on ccTLDs that do not use these second-level spaces
+ * (e.g. `sub.blog.io` -> `blog.io`).
+ */
+export const ccSLDs: Record<string, Set<string>> = {
+  uk: new Set(["co", "org", "me", "ltd", "plc", "sch", "ac", "gov", "nhs", "police", "mod"]),
+  us: new Set(["gov", "edu", "mil", "fed", "isa", "nsn", "state"]),
+  ca: new Set(["gc", "ab", "bc", "mb", "nb", "nl", "ns", "nt", "nu", "on", "pe", "qc", "sk", "yk"]),
+  br: new Set(["com", "org", "net", "edu", "gov", "adv", "art", "blog", "eco", "eng", "tv", "nom", "inf", "web"]),
+  mx: new Set(["com", "org", "edu", "gob", "net"]),
+  au: new Set(["com", "org", "net", "edu", "gov", "id", "asn"]),
+  za: new Set(["co", "org", "web", "net", "gov", "ac", "edu", "law", "school", "nom"]),
+  ar: new Set(["com", "org", "net", "gob", "edu", "tur"]),
+  co: new Set(["com", "org", "net", "edu", "gov", "mil", "nom"]),
+  in: new Set(["co", "org", "net", "firm", "gen", "ind", "nic", "edu", "res", "gov", "mil"]),
+  jp: new Set(["co", "ne", "ed", "ac", "go", "or", "ad"]),
+  es: new Set(["com", "org", "nom", "gob", "edu"]),
+  cn: new Set(["com", "org", "net", "gov", "edu"]),
+  nz: new Set(["co", "org", "net", "ac", "school", "geek", "kiwi"]),
+  tr: new Set(["com", "org", "net", "edu", "gov", "info", "tv", "biz"]),
+  id: new Set(["co", "web", "or", "go", "ac", "sch", "net"]),
+  ru: new Set(["com", "net", "org", "pp"]),
+  fr: new Set(["com", "asso", "nom", "prd", "presse", "tm"]),
+  it: new Set(["gov", "edu"]),
+  kr: new Set(["co", "ne", "or", "re", "pe", "go", "mil", "ac", "hs", "ms", "es", "sc"]),
+  tw: new Set(["com", "org", "net", "edu", "gov", "idv"]),
+  hk: new Set(["com", "org", "net", "edu", "gov", "idv"]),
+  sg: new Set(["com", "org", "net", "edu", "gov", "idn"]),
+  my: new Set(["com", "org", "net", "edu", "gov", "mil", "name"]),
+  th: new Set(["co", "or", "net", "in", "ac", "go", "mi"]),
+  vn: new Set(["com", "net", "org", "edu", "gov", "mil", "info", "biz", "name", "pro", "health", "ac"]),
+  ph: new Set(["com", "org", "net", "edu", "gov", "mil", "ngo"]),
+  cr: new Set(["co", "fi", "or", "ac", "go"]),
+  ve: new Set(["com", "co", "org", "edu", "gob"]),
+  pe: new Set(["com", "org", "net", "edu", "gob", "nom"]),
+  uy: new Set(["com", "org", "net", "edu", "gub"]),
+  cl: new Set(["gov", "gob", "edu"]),
+  pl: new Set(["com", "net", "org", "info", "biz", "edu", "gov", "mil", "waw", "wroc", "krakow", "poznan"]),
+  ua: new Set(["com", "edu", "gov", "net", "org", "in", "kiev", "kyiv", "lviv", "dp"]),
+  pk: new Set(["com", "net", "org", "gov", "edu", "web", "fam", "biz"]),
+  sa: new Set(["com", "net", "org", "gov", "med", "edu", "pub", "sch"]),
+  ae: new Set(["co", "net", "org", "gov", "ac", "sch"]),
+  gr: new Set(["com", "edu", "net", "org", "gov"]),
+  pt: new Set(["com", "edu", "gov", "org"]),
+  at: new Set(["co", "or", "gv"]),
+  il: new Set(["co", "org", "net", "ac", "gov", "muni", "idf"]),
+  ec: new Set(["com", "info", "net", "fin", "med", "pro", "org", "edu", "gov", "gob", "mil"]),
+};

--- a/extensions/whois/src/utils/index.test.ts
+++ b/extensions/whois/src/utils/index.test.ts
@@ -105,6 +105,18 @@ describe("parseDomain", () => {
     expect(parseDomain("sub.person.id.au").input).toBe("person.id.au");
     // Direct au domain (should keep 2 parts)
     expect(parseDomain("sub.company.au").input).toBe("company.au");
+
+    // US cases
+    expect(parseDomain("sub.agency.gov.us").input).toBe("agency.gov.us");
+    expect(parseDomain("sub.school.edu.us").input).toBe("school.edu.us");
+
+    // CA cases
+    expect(parseDomain("sub.government.gc.ca").input).toBe("government.gc.ca");
+    expect(parseDomain("sub.site.on.ca").input).toBe("site.on.ca");
+
+    // PL cases
+    expect(parseDomain("sub.company.com.pl").input).toBe("company.com.pl");
+    expect(parseDomain("sub.city.waw.pl").input).toBe("city.waw.pl");
   });
 
   it("leaves IP addresses intact", () => {
@@ -121,5 +133,11 @@ describe("parseDomain", () => {
     expect(parseDomain("sub.google.com").input).toBe("google.com");
     // nic is not in commonSecondLevels, so sub.nic.google becomes nic.google
     expect(parseDomain("sub.nic.google").input).toBe("nic.google");
+
+    // Test cases for false triggers on two-letter TLDs that are not registered for those second levels
+    expect(parseDomain("sub.blog.io").input).toBe("blog.io");
+    expect(parseDomain("sub.id.me").input).toBe("id.me");
+    expect(parseDomain("sub.art.is").input).toBe("art.is");
+    expect(parseDomain("sub.tv.li").input).toBe("tv.li");
   });
 });

--- a/extensions/whois/src/utils/index.test.ts
+++ b/extensions/whois/src/utils/index.test.ts
@@ -16,11 +16,21 @@ describe("parseDomain", () => {
     expect(result.input).toBe("raycast.com");
   });
 
-  it("correctly identifies a subdomain", () => {
+  it("correctly extracts base domain from standard subdomains", () => {
     const result = parseDomain("docs.raycast.com");
     expect(result.isIp).toBe(false);
     expect(result.isDomain).toBe(true);
-    expect(result.input).toBe("docs.raycast.com");
+    expect(result.input).toBe("raycast.com");
+
+    const result2 = parseDomain("dash.cloudflare.com");
+    expect(result2.isIp).toBe(false);
+    expect(result2.isDomain).toBe(true);
+    expect(result2.input).toBe("cloudflare.com");
+
+    const result3 = parseDomain("deep.nested.subdomain.example.org");
+    expect(result3.isIp).toBe(false);
+    expect(result3.isDomain).toBe(true);
+    expect(result3.input).toBe("example.org");
   });
 
   it("handles empty strings", () => {
@@ -35,5 +45,81 @@ describe("parseDomain", () => {
     expect(result.isIp).toBe(false);
     expect(result.isDomain).toBe(false);
     expect(result.input).toBe("not-a-domain-or-ip");
+  });
+
+  it("sanitizes URLs with protocols, paths, and extracts base domain", () => {
+    const result = parseDomain("https://ardehtulum.com/");
+    expect(result.isIp).toBe(false);
+    expect(result.isDomain).toBe(true);
+    expect(result.input).toBe("ardehtulum.com");
+
+    const result2 = parseDomain("http://www.dash.cloudflare.com/path/to/page?query=string#hash");
+    expect(result2.isIp).toBe(false);
+    expect(result2.isDomain).toBe(true);
+    expect(result2.input).toBe("cloudflare.com");
+
+    const result3 = parseDomain("https://1.1.1.1/some/path");
+    expect(result3.isIp).toBe(true);
+    expect(result3.isDomain).toBe(false);
+    expect(result3.input).toBe("1.1.1.1");
+  });
+
+  it("correctly handles complex ccTLD subdomains", () => {
+    const result1 = parseDomain("subdomain.example.co.uk");
+    expect(result1.input).toBe("example.co.uk");
+
+    const result2 = parseDomain("sub.example.com.mx");
+    expect(result2.input).toBe("example.com.mx");
+
+    const result3 = parseDomain("gov.uk");
+    expect(result3.input).toBe("gov.uk");
+
+    const result4 = parseDomain("another.sub.example.edu.co");
+    expect(result4.input).toBe("example.edu.co");
+
+    // UK cases
+    expect(parseDomain("sub.example.ltd.uk").input).toBe("example.ltd.uk");
+    expect(parseDomain("nested.sub.example.plc.uk").input).toBe("example.plc.uk");
+    expect(parseDomain("sub.example.sch.uk").input).toBe("example.sch.uk");
+    expect(parseDomain("my.personal.blog.me.uk").input).toBe("blog.me.uk");
+
+    // Brazil cases
+    expect(parseDomain("sub.empresa.com.br").input).toBe("empresa.com.br");
+    expect(parseDomain("sub.advogado.adv.br").input).toBe("advogado.adv.br");
+    expect(parseDomain("canal.canal.tv.br").input).toBe("canal.tv.br");
+    expect(parseDomain("sub.projeto.org.br").input).toBe("projeto.org.br");
+
+    // Japan cases
+    expect(parseDomain("sub.company.co.jp").input).toBe("company.co.jp");
+    expect(parseDomain("sub.network.ne.jp").input).toBe("network.ne.jp");
+    expect(parseDomain("sub.school.ed.jp").input).toBe("school.ed.jp");
+
+    // South Africa cases
+    expect(parseDomain("sub.company.co.za").input).toBe("company.co.za");
+    expect(parseDomain("sub.firm.law.za").input).toBe("firm.law.za");
+    expect(parseDomain("sub.school.school.za").input).toBe("school.school.za");
+
+    // Australia cases
+    expect(parseDomain("sub.company.com.au").input).toBe("company.com.au");
+    expect(parseDomain("sub.association.asn.au").input).toBe("association.asn.au");
+    expect(parseDomain("sub.person.id.au").input).toBe("person.id.au");
+    // Direct au domain (should keep 2 parts)
+    expect(parseDomain("sub.company.au").input).toBe("company.au");
+  });
+
+  it("leaves IP addresses intact", () => {
+    const result1 = parseDomain("192.168.1.1");
+    expect(result1.isIp).toBe(true);
+    expect(result1.input).toBe("192.168.1.1");
+
+    const result2 = parseDomain("2606:4700:4700::1111");
+    expect(result2.input).toBe("2606:4700:4700::1111");
+  });
+
+  it("does not truncate standard non-ccTLD domains with matching words", () => {
+    // google is not 2 letters, so google.com is resolved as example.com (google.com)
+    expect(parseDomain("sub.google.com").input).toBe("google.com");
+    // nic is not in commonSecondLevels, so sub.nic.google becomes nic.google
+    expect(parseDomain("sub.nic.google").input).toBe("nic.google");
   });
 });

--- a/extensions/whois/src/utils/index.ts
+++ b/extensions/whois/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { runAppleScript } from "@raycast/utils";
+import { ccSLDs } from "./ccslds";
 
 const getFrontmostApp = () => {
   return runAppleScript(`
@@ -57,40 +58,6 @@ export interface ParsedInput {
   input?: string;
 }
 
-const commonSecondLevels = new Set([
-  "com",
-  "co",
-  "org",
-  "net",
-  "edu",
-  "gob",
-  "gov",
-  "mil",
-  "nom",
-  "ac",
-  "sch",
-  "or",
-  "gv",
-  "asn",
-  "id",
-  "biz",
-  "info",
-  "web",
-  "me",
-  "tv",
-  "ltd",
-  "plc",
-  "adv",
-  "eng",
-  "art",
-  "blog",
-  "eco",
-  "law",
-  "school",
-  "ne",
-  "ed",
-]);
-
 export const getBaseDomain = (hostname: string): string => {
   if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(hostname) || hostname.includes(":")) {
     return hostname;
@@ -104,7 +71,7 @@ export const getBaseDomain = (hostname: string): string => {
   const last = parts[parts.length - 1].toLowerCase();
   const penultimate = parts[parts.length - 2].toLowerCase();
 
-  if (last.length === 2 && commonSecondLevels.has(penultimate)) {
+  if (last.length === 2 && ccSLDs[last]?.has(penultimate)) {
     return parts.slice(-3).join(".");
   }
 

--- a/extensions/whois/src/utils/index.ts
+++ b/extensions/whois/src/utils/index.ts
@@ -57,8 +57,88 @@ export interface ParsedInput {
   input?: string;
 }
 
+const commonSecondLevels = new Set([
+  "com",
+  "co",
+  "org",
+  "net",
+  "edu",
+  "gob",
+  "gov",
+  "mil",
+  "nom",
+  "ac",
+  "sch",
+  "or",
+  "gv",
+  "asn",
+  "id",
+  "biz",
+  "info",
+  "web",
+  "me",
+  "tv",
+  "ltd",
+  "plc",
+  "adv",
+  "eng",
+  "art",
+  "blog",
+  "eco",
+  "law",
+  "school",
+  "ne",
+  "ed",
+]);
+
+export const getBaseDomain = (hostname: string): string => {
+  if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(hostname) || hostname.includes(":")) {
+    return hostname;
+  }
+
+  const parts = hostname.split(".");
+  if (parts.length <= 2) {
+    return hostname;
+  }
+
+  const last = parts[parts.length - 1].toLowerCase();
+  const penultimate = parts[parts.length - 2].toLowerCase();
+
+  if (last.length === 2 && commonSecondLevels.has(penultimate)) {
+    return parts.slice(-3).join(".");
+  }
+
+  return parts.slice(-2).join(".");
+};
+
+export const cleanInput = (domainOrIp: string): string => {
+  let cleaned = domainOrIp.trim();
+  if (!cleaned) return "";
+
+  if (cleaned.startsWith("//")) {
+    cleaned = "http:" + cleaned;
+  } else if (!/^[a-zA-Z]+:\/\//.test(cleaned)) {
+    cleaned = "http://" + cleaned;
+  }
+
+  try {
+    const url = new URL(cleaned);
+    let hostname = url.hostname;
+    hostname = hostname.replace(/^www\./i, "");
+    return getBaseDomain(hostname);
+  } catch {
+    let fallback = domainOrIp
+      .trim()
+      .replace(/^[a-zA-Z]+:\/\//i, "")
+      .replace(/^www\./i, "");
+    fallback = fallback.split(/[/?#]/)[0];
+    return getBaseDomain(fallback);
+  }
+};
+
 export const parseDomain = (domainOrIp: string): ParsedInput => {
-  const isIp = domainOrIp ? /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(domainOrIp) : false;
-  const isDomain = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/.test(domainOrIp);
-  return { isIp, isDomain, input: domainOrIp };
+  const cleaned = cleanInput(domainOrIp);
+  const isIp = cleaned ? /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(cleaned) : false;
+  const isDomain = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/.test(cleaned);
+  return { isIp, isDomain, input: cleaned };
 };


### PR DESCRIPTION
## Description

This update improves the robustness and reliability of domain inputs in the WHOIS extension by introducing automatic URL sanitization and registered base domain extraction.

### Key Changes:
* **URL Sanitization**: Paste raw URLs (e.g. `https://ardehtulum.com/about` or `http://www.google.com/?query=1`) straight from the browser address bar. The extension automatically strips the protocols (`http://`, `https://`, `//`), paths, query parameters, hashes, and the `www.` prefix.
* **Registered Base Domain Extraction**: Resolves an issue where querying a subdomain (like `dash.cloudflare.com`) caused the WHOIS query to fail (registry returned no records for the subdomain host), which was previously incorrectly parsed as the domain being **Available** for registration. Now, the extension intelligently extracts the registered base domain (e.g. `dash.cloudflare.com` -> `cloudflare.com`, `sub.example.co.uk` -> `example.co.uk`) to query WHOIS.
* **Intact IP Resolution**: Ensures valid IPv4 and IPv6 addresses are left untouched so they continue to resolve IP geolocation info accurately.

### Why:
* **UX Improvement**: Users can copy-paste full URLs without having to manually edit or clean the text string.
* **Reliability**: Eliminates false-positive "Available" registration statuses when entering subdomains.

## Screencast

*(No visual changes to the UI itself, this is a logic improvement for parsing and sanitizing inputs to resolve domain whois data properly).*

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder