### PR TITLE
Update visual-studio-code extension

### DIFF
--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Visual Studio Code Changelog
 
-## [Fix: Search Recent Projects empty on macOS] - {PR_MERGE_DATE}
+## [Fix: Search Recent Projects empty on macOS] - 2026-06-02
 
 - Fixed `Search Recent Projects` showing no results on macOS with VS Code 1.118+. The shared storage database (`.vscode-shared/sharedStorage/state.vscdb`) is placed in the home directory on all platforms, not inside `~/Library/Application Support`. Also removed a spurious `User/` path segment from the Windows shared storage path. Fixes [#28311](https://github.com/raycast/extensions/issues/28311).
 

--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Visual Studio Code Changelog
 
+## [Fix: Search Recent Projects empty on macOS] - {PR_MERGE_DATE}
+
+- Fixed `Search Recent Projects` showing no results on macOS with VS Code 1.118+. The shared storage database (`.vscode-shared/sharedStorage/state.vscdb`) is placed in the home directory on all platforms, not inside `~/Library/Application Support`. Also removed a spurious `User/` path segment from the Windows shared storage path. Fixes [#28311](https://github.com/raycast/extensions/issues/28311).
+
 ## [Fix: Recent Projects on Windows] - 2026-05-25
 
 - Fixed `Search Recent Projects` on Windows by reading the current VS Code state key `recently.opened` while keeping compatibility with the older `history.recentlyOpenedPathsList` key used by older VS Code internals.

--- a/extensions/visual-studio-code-recent-projects/src/lib/db.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/db.ts
@@ -6,7 +6,7 @@ import path from "path";
 import { useEffect, useMemo, useState } from "react";
 import { build } from "./preferences";
 import { EntryLike, RecentEntries } from "./types";
-import { isMac, isSameEntry, isWin } from "./utils";
+import { isSameEntry, isWin } from "./utils";
 import { execFilePromise } from "../utils/exec";
 import { getBuildNamePreference, getProductJSONPath } from "./vscode";
 
@@ -307,23 +307,9 @@ function getSharedStateDatabasePath() {
 
   if (!sharedDataFolderName) return undefined;
 
-  if (isWin) {
-    return path.join(homedir(), "AppData", "Roaming", sharedDataFolderName, "User", "sharedStorage", "state.vscdb");
-  }
-
-  if (isMac) {
-    return path.join(
-      homedir(),
-      "Library",
-      "Application Support",
-      sharedDataFolderName,
-      "User",
-      "sharedStorage",
-      "state.vscdb",
-    );
-  }
-
-  return undefined;
+  // sharedDataFolderName (e.g. ".vscode-shared") lives directly in the home
+  // directory on all platforms — not in AppData/Roaming or Library/Application Support.
+  return path.join(homedir(), sharedDataFolderName, "sharedStorage", "state.vscdb");
 }
 
 function getSharedDataFolderName() {


### PR DESCRIPTION
## Description

Fixes `Search Recent Projects` returning an empty list on macOS with VS Code 1.118+.

VS Code 1.118 moved the recently-opened workspaces list out of `globalStorage/state.vscdb` and into a new shared storage database at `~/.vscode-shared/sharedStorage/state.vscdb`. The `sharedDataFolderName` (e.g. `.vscode-shared`) is a home-directory dotfolder on all platforms — it is not inside `~/Library/Application Support` on macOS or `%APPDATA%\\Roaming` on Windows.

The previous path construction had two mistakes on Mac (`Library/Application Support` prefix + a spurious `User/` segment) and one on Windows (the extra `User/` segment), so `fs.existsSync` always returned false and the extension silently fell through to the old `globalStorage` DB, which is now empty for this key on 1.118+.

Fix collapses both platform branches into a single line using `homedir()` directly, which is what VS Code itself does ([source](https://github.com/microsoft/vscode/blob/main/src/vs/platform/environment/common/environmentService.ts)). Backward compatible — on older VS Code where `~/.vscode-shared` doesn't exist, `existsSync` still falls through to the globalStorage path as before.

Fixes #28311