### PR TITLE
Fix Pivot preset editor heap spike

### DIFF
--- a/extensions/pivot/CHANGELOG.md
+++ b/extensions/pivot/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Pivot Changelog
 
+## [Fix Preset Editor Memory Usage] - {PR_MERGE_DATE}
+
+- Fixed a memory spike that could crash Raycast when editing presets with many discovered extensions.
+
 ## [Initial Version] - 2026-06-01
 
 - Pivot Apps — bulk-rebind the default macOS app for any set of file extensions in one confirmation.

--- a/extensions/pivot/CHANGELOG.md
+++ b/extensions/pivot/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Pivot Changelog
 
-## [Fix Preset Editor Memory Usage] - {PR_MERGE_DATE}
+## [Fix Preset Editor Memory Usage] - 2026-06-02
 
 - Fixed a memory spike that could crash Raycast when editing presets with many discovered extensions.
 

--- a/extensions/pivot/src/manage-presets.tsx
+++ b/extensions/pivot/src/manage-presets.tsx
@@ -251,6 +251,7 @@ function EditPresetView({
     () => [...new Set([...discoveredExts, ...customs, ...selected])].sort(),
     [discoveredExts, customs, selected],
   );
+  const allExtsSet = useMemo(() => new Set(allExts), [allExts]);
   const customSet = useMemo(() => new Set(customs), [customs]);
 
   const candidateExt = normalizeExt(searchText);
@@ -340,7 +341,7 @@ function EditPresetView({
             title="Add Custom Extension…"
             icon={Icon.Plus}
             shortcut={{ modifiers: ["cmd"], key: "n" }}
-            target={<InlineAddCustom existing={new Set(allExts)} onAdded={addCustom} />}
+            target={<InlineAddCustom existing={allExtsSet} onAdded={addCustom} />}
           />
         </ActionPanel>
       }
@@ -396,7 +397,7 @@ function EditPresetView({
                     title="Add Custom Extension…"
                     icon={Icon.Plus}
                     shortcut={{ modifiers: ["cmd"], key: "n" }}
-                    target={<InlineAddCustom existing={new Set(allExts)} onAdded={addCustom} />}
+                    target={<InlineAddCustom existing={allExtsSet} onAdded={addCustom} />}
                   />
                 </ActionPanel>
               }
@@ -462,6 +463,7 @@ function NewPresetExtensionsView({
     () => [...new Set([...discoveredExts, ...customs, ...selected])].sort(),
     [discoveredExts, customs, selected],
   );
+  const allExtsSet = useMemo(() => new Set(allExts), [allExts]);
   const customSet = useMemo(() => new Set(customs), [customs]);
 
   const candidateExt = normalizeExt(searchText);
@@ -573,7 +575,7 @@ function NewPresetExtensionsView({
                     title="Add Custom Extension…"
                     icon={Icon.Plus}
                     shortcut={{ modifiers: ["cmd"], key: "n" }}
-                    target={<InlineAddCustom existing={new Set(allExts)} onAdded={addCustom} />}
+                    target={<InlineAddCustom existing={allExtsSet} onAdded={addCustom} />}
                   />
                 </ActionPanel>
               }


### PR DESCRIPTION
## Description

Fixes #28473.

Entering Pivot's preset editor rendered an `Add Custom Extension` action for every extension row. Each action target built `new Set(allExts)`, so opening a preset with a large discovered extension list could allocate a full duplicate lookup set per row and exhaust the Raycast worker heap.

This memoizes the extension lookup set once per preset editor view and reuses it for duplicate checks in both edit and new-preset flows.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
