### PR TITLE
[Tempo] Allow setting start and end time of worklogs

### DIFF
--- a/extensions/tempo/CHANGELOG.md
+++ b/extensions/tempo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tempo Changelog
 
-## [Worklog Time Range Improvements] - {PR_MERGE_DATE}
+## [Worklog Time Range Improvements] - 2026-06-03
 
 - Add optional start and end time entry when logging work and derive the duration automatically
 - Support `8:00`, `08:00`, `8h`, and `8h30` time formats in time-range mode

--- a/extensions/tempo/CHANGELOG.md
+++ b/extensions/tempo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Tempo Changelog
 
+## [Worklog Time Range Improvements] - {PR_MERGE_DATE}
+
+- Add optional start and end time entry when logging work and derive the duration automatically
+- Support `8:00`, `08:00`, `8h`, and `8h30` time formats in time-range mode
+- Remember the preferred time-range input mode between worklogs
+
 ## [Initial Version] - 2025-11-04
 
 - Add Worklog command with issue selection

--- a/extensions/tempo/README.md
+++ b/extensions/tempo/README.md
@@ -5,11 +5,13 @@ Log and manage work hours with Tempo.
 ## Features
 
 - **Add Worklog**: Quickly log work hours to any issue with flexible duration formats (1h, 1h30m, 2h)
-- **List Worklogs**: View recent work logs grouped by day with total hours
+- **Time Range Entry**: Optionally enter start and end times and let the extension derive the duration for you
+- **List Worklogs**: View recent work logs grouped by day with total hours and chronological ordering when start times are available
 - **Edit & Delete**: Modify durations or remove work logs directly
 - **Issue Selection**: Browse favorites, recent activity, assigned issues, and project issues
 - **Smart Search**: Find issues quickly with auto-complete
 - **Favorites**: Star frequently-used issues for quick access
+- **Remembered Input Mode**: Keep the preferred worklog entry mode between runs
 
 ## Setup
 
@@ -43,10 +45,14 @@ You'll also need to provide:
 
 1. Open the "Add Worklog" command
 2. Select an issue from favorites, recent activity, assigned issues, or search
-3. Enter the duration (e.g., 1h, 1h30m, 45m, 2h)
+3. Choose one of the following input modes:
+   - Enter a duration directly (for example `1h`, `1h30m`, `45m`, `2h`)
+   - Enable **Use Start and End Time** to derive the duration from a time range
 4. Optionally add a description
-5. Select the date (or enter a custom date)
+5. Select the date or enter a custom date
 6. Submit to log your work
+
+The extension remembers whether you prefer duration entry or start/end time entry, so you do not need to switch modes every time.
 
 ### Viewing Worklogs
 
@@ -64,6 +70,16 @@ The extension supports flexible duration formats:
 - Combined: `1h30m`, `2h15m`
 - Decimal: `1.5h`, `2.25h`
 - Shorthand: `1h30` (hours and minutes without 'm')
+
+## Time Range Formats
+
+When using start and end time entry, the extension accepts the following 24-hour formats:
+
+- Colon format: `8:00`, `08:00`, `17:30`
+- Hour format: `8h`, `9h`, `17h`
+- Hour and minutes format: `8h30`, `17h45`
+
+The end time must be after the start time on the same day.
 
 ## Future Integrations
 

--- a/extensions/tempo/package-lock.json
+++ b/extensions/tempo/package-lock.json
@@ -19,6 +19,70 @@
         "typescript": "^5.8.2"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.11.tgz",
+      "integrity": "sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.11.tgz",
+      "integrity": "sha512-uoa7dU+Dt3HYsethkJ1k6Z9YdcHjTrSb5NUy66ZfZaSV8hEYGD5ZHbEMXnqLFlbBflLsl89Zke7CAdDJ4JI+Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.11.tgz",
+      "integrity": "sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.11.tgz",
+      "integrity": "sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.11",
       "cpu": [
@@ -28,6 +92,342 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.11.tgz",
+      "integrity": "sha512-+hfp3yfBalNEpTGp9loYgbknjR695HkqtY3d3/JjSRUyPg/xd6q+mQqIb5qdywnDxRZykIHs3axEqU6l1+oWEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.11.tgz",
+      "integrity": "sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.11.tgz",
+      "integrity": "sha512-Dyq+5oscTJvMaYPvW3x3FLpi2+gSZTCE/1ffdwuM6G1ARang/mb3jvjxs0mw6n3Lsw84ocfo9CrNMqc5lTfGOw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.11.tgz",
+      "integrity": "sha512-TBMv6B4kCfrGJ8cUPo7vd6NECZH/8hPpBHHlYI3qzoYFvWu2AdTvZNuU/7hsbKWqu/COU7NIK12dHAAqBLLXgw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.11.tgz",
+      "integrity": "sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.11.tgz",
+      "integrity": "sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.11.tgz",
+      "integrity": "sha512-DIGXL2+gvDaXlaq8xruNXUJdT5tF+SBbJQKbWy/0J7OhU8gOHOzKmGIlfTTl6nHaCOoipxQbuJi7O++ldrxgMw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.11.tgz",
+      "integrity": "sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.11.tgz",
+      "integrity": "sha512-nbLFgsQQEsBa8XSgSTSlrnBSrpoWh7ioFDUmwo158gIm5NNP+17IYmNWzaIzWmgCxq56vfr34xGkOcZ7jX6CPw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.11.tgz",
+      "integrity": "sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.11.tgz",
+      "integrity": "sha512-HjLqVgSSYnVXRisyfmzsH6mXqyvj0SA7pG5g+9W7ESgwA70AXYNpfKBqh1KbTxmQVaYxpzA/SvlB9oclGPbApw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.11.tgz",
+      "integrity": "sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.11.tgz",
+      "integrity": "sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.11.tgz",
+      "integrity": "sha512-u7tKA+qbzBydyj0vgpu+5h5AeudxOAGncb8N6C9Kh1N4n7wU1Xw1JDApsRjpShRpXRQlJLb9wY28ELpwdPcZ7A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.11.tgz",
+      "integrity": "sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.11.tgz",
+      "integrity": "sha512-CN+7c++kkbrckTOz5hrehxWN7uIhFFlmS/hqziSFVWpAzpWrQoAG4chH+nN3Be+Kzv/uuo7zhX716x3Sn2Jduw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.11.tgz",
+      "integrity": "sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.11.tgz",
+      "integrity": "sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.11.tgz",
+      "integrity": "sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.11.tgz",
+      "integrity": "sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.11.tgz",
+      "integrity": "sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"

--- a/extensions/tempo/package-lock.json
+++ b/extensions/tempo/package-lock.json
@@ -661,6 +661,7 @@
     "node_modules/@raycast/api": {
       "version": "1.103.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.5.4",
         "@oclif/plugin-autocomplete": "^3.2.35",
@@ -750,6 +751,7 @@
     "node_modules/@types/node": {
       "version": "22.13.10",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -801,6 +803,7 @@
       "version": "8.46.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -986,6 +989,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1299,6 +1303,7 @@
       "version": "9.38.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2054,6 +2059,7 @@
       "version": "3.6.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2271,6 +2277,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2329,6 +2336,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/tempo/src/add-worklog.tsx
+++ b/extensions/tempo/src/add-worklog.tsx
@@ -306,7 +306,6 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
         }
 
         const derivedDurationSeconds = parseTimeRangeToSeconds(values.startTime, values.endTime);
-        const formattedStartTime = formatTimeWithSeconds(values.startTime);
         if (derivedDurationSeconds === null) {
           await showToast({
             style: Toast.Style.Failure,
@@ -316,14 +315,8 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
           return;
         }
 
-        if (!formattedStartTime) {
-          await showToast({
-            style: Toast.Style.Failure,
-            title: "Invalid start time",
-            message: "Use 8:00, 08:00, 8h, or 8h30",
-          });
-          return;
-        }
+        // Safe to assert: parseTimeRangeToSeconds succeeded, so normalizeTimeInput(startTime) is non-null
+        const formattedStartTime = formatTimeWithSeconds(values.startTime) as string;
 
         timeSpentSeconds = derivedDurationSeconds;
         startTime = formattedStartTime;

--- a/extensions/tempo/src/add-worklog.tsx
+++ b/extensions/tempo/src/add-worklog.tsx
@@ -10,7 +10,7 @@ import {
   getPreferenceValues,
   open,
 } from "@raycast/api";
-import { showFailureToast } from "@raycast/utils";
+import { showFailureToast, useCachedState } from "@raycast/utils";
 import { useState, useEffect } from "react";
 import { fetchFromTempoAPI } from "./services/tempo.service";
 import {
@@ -26,6 +26,7 @@ import { getRecentActivityIssues, JiraIssue as RecentJiraIssue } from "./service
 import { parseDuration, formatDuration } from "./utils/duration";
 import { getCurrentUserAccountId, resetCachedAccountId } from "./services/jira-auth.service";
 import { formatDateToString, getDateLabel } from "./utils/date";
+import { formatTimeWithSeconds, parseTimeRangeToSeconds } from "./utils/time";
 import { TempoWorklogsResponse } from "./types/worklog";
 
 interface Preferences {
@@ -38,7 +39,12 @@ type Values = {
   date: string;
   customDate?: string;
   timeSpent: string;
+  useTimeRange?: boolean;
+  startTime?: string;
+  endTime?: string;
 };
+
+const USE_TIME_RANGE_STORAGE_KEY = "add-worklog-use-time-range";
 
 function IssueSelector({ onSelect }: { onSelect: (issueKey: string) => void }) {
   const [favoriteIssues, setFavoriteIssues] = useState<FavoriteIssue[]>([]);
@@ -231,6 +237,7 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
   const [issue, setIssue] = useState<JiraIssue | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [selectedDate, setSelectedDate] = useState<string>(formatDateToString(new Date()));
+  const [useTimeRange, setUseTimeRange] = useCachedState<boolean>(USE_TIME_RANGE_STORAGE_KEY, false);
 
   // Fetch details of the selected issue
   useEffect(() => {
@@ -284,23 +291,59 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
         dateStr = values.customDate;
       }
 
-      // Get current time (HH:MM:SS) for the start time
-      const now = new Date();
-      const hours = String(now.getHours()).padStart(2, "0");
-      const minutes = String(now.getMinutes()).padStart(2, "0");
-      const seconds = String(now.getSeconds()).padStart(2, "0");
-      const startTime = `${hours}:${minutes}:${seconds}`;
+      let submittedDuration = values.timeSpent;
+      let startTime: string;
+      let timeSpentSeconds: number;
 
-      // Parse the duration string (supports "1h30m", "1h30", "2h", "45m", etc.)
-      const timeSpentSeconds = parseDuration(values.timeSpent);
+      if (values.useTimeRange) {
+        if (!values.startTime || !values.endTime) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Time range required",
+            message: "Please provide both start and end time in HH:MM format",
+          });
+          return;
+        }
 
-      if (timeSpentSeconds === 0) {
-        await showToast({
-          style: Toast.Style.Failure,
-          title: "Invalid duration",
-          message: "Please enter a valid duration (e.g., 1h, 1h30m, 30m)",
-        });
-        return;
+        const derivedDurationSeconds = parseTimeRangeToSeconds(values.startTime, values.endTime);
+        const formattedStartTime = formatTimeWithSeconds(values.startTime);
+        if (derivedDurationSeconds === null) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Invalid time range",
+            message: "Use 8:00, 08:00, 8h, or 8h30 and make sure the end time is after the start time",
+          });
+          return;
+        }
+
+        if (!formattedStartTime) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Invalid start time",
+            message: "Use 8:00, 08:00, 8h, or 8h30",
+          });
+          return;
+        }
+
+        timeSpentSeconds = derivedDurationSeconds;
+        startTime = formattedStartTime;
+        submittedDuration = formatDuration(timeSpentSeconds);
+      } else {
+        const now = new Date();
+        const hours = String(now.getHours()).padStart(2, "0");
+        const minutes = String(now.getMinutes()).padStart(2, "0");
+        const seconds = String(now.getSeconds()).padStart(2, "0");
+        startTime = `${hours}:${minutes}:${seconds}`;
+        timeSpentSeconds = parseDuration(values.timeSpent);
+
+        if (timeSpentSeconds === 0) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Invalid duration",
+            message: "Please enter a valid duration (e.g., 1h, 1h30m, 30m)",
+          });
+          return;
+        }
       }
 
       // Check if issue was loaded successfully
@@ -340,7 +383,7 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
       await showToast({
         style: Toast.Style.Success,
         title: "Worklog added",
-        message: `${values.timeSpent} logged. ${dayLabel}: ${totalDuration}`,
+        message: `${submittedDuration} logged. ${dayLabel}: ${totalDuration}`,
         primaryAction: {
           title: "View Worklogs",
           onAction: async () => {
@@ -366,13 +409,37 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
       }
     >
       <Form.Description text={`Add worklog to ${issueKey}${issue ? `: ${issue.fields.summary}` : ""}`} />
-      <Form.TextField
-        id="timeSpent"
-        title="Time Spent"
-        placeholder="1h, 1h30m, 30m"
-        defaultValue="1h"
-        info="Enter duration in human format: 1h, 1h30m, 2h, 45m, etc."
+      <Form.Checkbox
+        id="useTimeRange"
+        title="Use Start and End Time"
+        label="Derive duration from a time range"
+        value={useTimeRange}
+        onChange={setUseTimeRange}
       />
+      {useTimeRange ? (
+        <>
+          <Form.TextField
+            id="startTime"
+            title="Start Time"
+            placeholder="8:00 or 8h"
+            info="Use 24-hour 8:00, 08:00, 8h, or 8h30 format"
+          />
+          <Form.TextField
+            id="endTime"
+            title="End Time"
+            placeholder="9:00 or 9h"
+            info="Use 24-hour 9:00, 09:00, 9h, or 9h30 format"
+          />
+        </>
+      ) : (
+        <Form.TextField
+          id="timeSpent"
+          title="Time Spent"
+          placeholder="1h, 1h30m, 30m"
+          defaultValue="1h"
+          info="Enter duration in human format: 1h, 1h30m, 2h, 45m, etc."
+        />
+      )}
       <Form.Dropdown id="date" title="Date" value={selectedDate} onChange={setSelectedDate}>
         {Array.from({ length: 7 }, (_, i) => {
           const date = new Date();

--- a/extensions/tempo/src/utils/time.ts
+++ b/extensions/tempo/src/utils/time.ts
@@ -1,0 +1,63 @@
+/**
+ * Normalize supported time input to HH:MM.
+ * Supports H:MM, HH:MM, Hh, and HhMM.
+ */
+export function normalizeTimeInput(time: string): string | null {
+  const normalized = time.trim().toLowerCase();
+  const colonMatch = normalized.match(/^(\d{1,2}):(\d{2})$/);
+  const hourMatch = normalized.match(/^(\d{1,2})h$/);
+  const hourMinuteMatch = normalized.match(/^(\d{1,2})h(\d{2})$/);
+
+  let hours: number;
+  let minutes: number;
+
+  if (colonMatch) {
+    hours = parseInt(colonMatch[1], 10);
+    minutes = parseInt(colonMatch[2], 10);
+  } else if (hourMatch) {
+    hours = parseInt(hourMatch[1], 10);
+    minutes = 0;
+  } else if (hourMinuteMatch) {
+    hours = parseInt(hourMinuteMatch[1], 10);
+    minutes = parseInt(hourMinuteMatch[2], 10);
+  } else {
+    return null;
+  }
+
+  if (hours > 23 || minutes > 59) {
+    return null;
+  }
+
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+}
+
+export function formatTimeWithSeconds(time: string): string | null {
+  const normalizedTime = normalizeTimeInput(time);
+
+  if (!normalizedTime) {
+    return null;
+  }
+
+  return `${normalizedTime}:00`;
+}
+
+export function parseTimeRangeToSeconds(startTime: string, endTime: string): number | null {
+  const normalizedStartTime = normalizeTimeInput(startTime);
+  const normalizedEndTime = normalizeTimeInput(endTime);
+
+  if (!normalizedStartTime || !normalizedEndTime) {
+    return null;
+  }
+
+  const [startHours, startMinutes] = normalizedStartTime.split(":").map((value) => parseInt(value, 10));
+  const [endHours, endMinutes] = normalizedEndTime.split(":").map((value) => parseInt(value, 10));
+
+  const startTotalMinutes = startHours * 60 + startMinutes;
+  const endTotalMinutes = endHours * 60 + endMinutes;
+
+  if (endTotalMinutes <= startTotalMinutes) {
+    return null;
+  }
+
+  return (endTotalMinutes - startTotalMinutes) * 60;
+}


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Closes https://github.com/raycast/extensions/issues/27923 

In this pull-request, I add an option to set the start and end time of a Tempo worklog to automatically deduce its duration. 
It also persists the actual start and end time in Tempo, which some team seem to use.

The option choice is persisted in the application cache, so that the user does not need to select it every time he needs to persist a new worklog.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->


https://github.com/user-attachments/assets/c9b81e5b-b91b-4d51-a63b-d5ef04ff1136

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
