### PR TITLE
[ccusage] Tolerate sessions with no activity date

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [Tolerate dateless sessions] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Session views no longer crash when `ccusage` reports a session with no activity date (a non-Claude agent row, or one whose entries lack timestamps); the session shows "unknown" instead of failing the entire list
+
+### Changed
+
+- Schema validation failures now report the `ccusage` version and a redacted structural fingerprint of the output (field names and value types, never values), so version-specific schema drift is diagnosable from an error report alone
+
 ## [Monochrome menu bar icon] - 2026-06-02
 
 ### Added

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [Tolerate dateless sessions] - {PR_MERGE_DATE}
+## [Tolerate dateless sessions] - 2026-06-03
 
 ### Fixed
 

--- a/extensions/ccusage/src/components/SessionUsage.tsx
+++ b/extensions/ccusage/src/components/SessionUsage.tsx
@@ -80,7 +80,7 @@ export function SessionUsage() {
           <List.Item.Detail.Metadata.Label
             key={`${session.sessionId || "unknown"}-${index}`}
             title={session.sessionId}
-            text={`${formatTokens(session.totalTokens)} • ${formatCost(session.totalCost)} • ${formatDistanceToNow(new Date(session.lastActivity), { addSuffix: true })}`}
+            text={`${formatTokens(session.totalTokens)} • ${formatCost(session.totalCost)} • ${session.lastActivity ? formatDistanceToNow(new Date(session.lastActivity), { addSuffix: true }) : "unknown"}`}
           />
         ))}
       </List.Item.Detail.Metadata>

--- a/extensions/ccusage/src/hooks/useCCUsageBlocksCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageBlocksCli.ts
@@ -4,6 +4,8 @@ import { useExec } from "@raycast/utils";
 import { BlocksCommandResponse, BlocksCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
+import { describeParseFailure } from "../utils/parse-diagnostics";
+import { getCcusageVersionSync } from "../utils/ccusage-version";
 import { preferences } from "../preferences";
 
 const cache = new Cache();
@@ -31,7 +33,9 @@ export const useCCUsageBlocksCli = () => {
       const parseResult = stringToJSON.pipe(BlocksCommandResponseSchema).safeParse(stdout.toString());
 
       if (!parseResult.success) {
-        throw new Error(`Invalid blocks data: ${parseResult.error.message}`);
+        throw new Error(
+          describeParseFailure("Invalid blocks data", stdout.toString(), parseResult.error, getCcusageVersionSync()),
+        );
       }
 
       cache.set(CACHE_KEY, JSON.stringify(parseResult.data));

--- a/extensions/ccusage/src/hooks/useCCUsageDailyCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageDailyCli.ts
@@ -4,6 +4,8 @@ import { useExec } from "@raycast/utils";
 import { DailyUsageCommandResponse, DailyUsageCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
+import { describeParseFailure } from "../utils/parse-diagnostics";
+import { getCcusageVersionSync } from "../utils/ccusage-version";
 import { preferences } from "../preferences";
 
 const cache = new Cache();
@@ -30,7 +32,14 @@ export const useCCUsageDailyCli = () => {
       const parseResult = stringToJSON.pipe(DailyUsageCommandResponseSchema).safeParse(stdout.toString());
 
       if (!parseResult.success) {
-        throw new Error(`Invalid daily usage data: ${parseResult.error.message}`);
+        throw new Error(
+          describeParseFailure(
+            "Invalid daily usage data",
+            stdout.toString(),
+            parseResult.error,
+            getCcusageVersionSync(),
+          ),
+        );
       }
 
       cache.set(CACHE_KEY, JSON.stringify(parseResult.data));

--- a/extensions/ccusage/src/hooks/useCCUsageMonthlyCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageMonthlyCli.ts
@@ -4,6 +4,8 @@ import { useExec } from "@raycast/utils";
 import { MonthlyUsageCommandResponse, MonthlyUsageCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
+import { describeParseFailure } from "../utils/parse-diagnostics";
+import { getCcusageVersionSync } from "../utils/ccusage-version";
 import { preferences } from "../preferences";
 
 const cache = new Cache();
@@ -31,7 +33,14 @@ export const useCCUsageMonthlyCli = () => {
       const parseResult = stringToJSON.pipe(MonthlyUsageCommandResponseSchema).safeParse(stdout.toString());
 
       if (!parseResult.success) {
-        throw new Error(`Invalid monthly usage data: ${parseResult.error.message}`);
+        throw new Error(
+          describeParseFailure(
+            "Invalid monthly usage data",
+            stdout.toString(),
+            parseResult.error,
+            getCcusageVersionSync(),
+          ),
+        );
       }
 
       cache.set(CACHE_KEY, JSON.stringify(parseResult.data));

--- a/extensions/ccusage/src/hooks/useCCUsageSessionCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageSessionCli.ts
@@ -4,6 +4,8 @@ import { useExec } from "@raycast/utils";
 import { SessionUsageCommandResponse, SessionUsageCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
+import { describeParseFailure } from "../utils/parse-diagnostics";
+import { getCcusageVersionSync } from "../utils/ccusage-version";
 import { preferences } from "../preferences";
 
 const cache = new Cache();
@@ -31,7 +33,14 @@ export const useCCUsageSessionCli = () => {
       const parseResult = stringToJSON.pipe(SessionUsageCommandResponseSchema).safeParse(stdout.toString());
 
       if (!parseResult.success) {
-        throw new Error(`Invalid session usage data: ${parseResult.error.message}`);
+        throw new Error(
+          describeParseFailure(
+            "Invalid session usage data",
+            stdout.toString(),
+            parseResult.error,
+            getCcusageVersionSync(),
+          ),
+        );
       }
 
       cache.set(CACHE_KEY, JSON.stringify(parseResult.data));

--- a/extensions/ccusage/src/hooks/useCCUsageTotalCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageTotalCli.ts
@@ -4,6 +4,8 @@ import { useExec } from "@raycast/utils";
 import { TotalUsageResponse, TotalUsageResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
+import { describeParseFailure } from "../utils/parse-diagnostics";
+import { getCcusageVersionSync } from "../utils/ccusage-version";
 import { preferences } from "../preferences";
 
 const cache = new Cache();
@@ -31,7 +33,14 @@ export const useCCUsageTotalCli = () => {
       const parseResult = stringToJSON.pipe(TotalUsageResponseSchema).safeParse(stdout.toString());
 
       if (!parseResult.success) {
-        throw new Error(`Invalid total usage data: ${parseResult.error.message}`);
+        throw new Error(
+          describeParseFailure(
+            "Invalid total usage data",
+            stdout.toString(),
+            parseResult.error,
+            getCcusageVersionSync(),
+          ),
+        );
       }
 
       cache.set(CACHE_KEY, JSON.stringify(parseResult.data));

--- a/extensions/ccusage/src/hooks/useCCUsageWeeklyCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageWeeklyCli.ts
@@ -4,6 +4,8 @@ import { useExec } from "@raycast/utils";
 import { WeeklyUsageCommandResponse, WeeklyUsageCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
+import { describeParseFailure } from "../utils/parse-diagnostics";
+import { getCcusageVersionSync } from "../utils/ccusage-version";
 import { preferences } from "../preferences";
 
 const cache = new Cache();
@@ -31,7 +33,14 @@ export const useCCUsageWeeklyCli = () => {
       const parseResult = stringToJSON.pipe(WeeklyUsageCommandResponseSchema).safeParse(stdout.toString());
 
       if (!parseResult.success) {
-        throw new Error(`Invalid weekly usage data: ${parseResult.error.message}`);
+        throw new Error(
+          describeParseFailure(
+            "Invalid weekly usage data",
+            stdout.toString(),
+            parseResult.error,
+            getCcusageVersionSync(),
+          ),
+        );
       }
 
       cache.set(CACHE_KEY, JSON.stringify(parseResult.data));

--- a/extensions/ccusage/src/tools/get-daily-usage.ts
+++ b/extensions/ccusage/src/tools/get-daily-usage.ts
@@ -3,6 +3,8 @@ import { getCustomNpxPath } from "../preferences";
 import { execAsync } from "../utils/exec-async";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
+import { describeParseFailure } from "../utils/parse-diagnostics";
+import { captureCcusageVersion } from "../utils/ccusage-version";
 import { validateDateFormat } from "../utils/date-validator";
 import { getCurrentLocalDate } from "../utils/date-formatter";
 
@@ -63,7 +65,8 @@ export default async function getDailyUsage(input?: Input): Promise<{
   const parseResult = stringToJSON.pipe(DailyUsageCommandResponseSchema).safeParse(stdout.toString());
 
   if (!parseResult.success) {
-    throw new Error(`Invalid daily usage data: ${parseResult.error.message}`);
+    const version = await captureCcusageVersion();
+    throw new Error(describeParseFailure("Invalid daily usage data", stdout.toString(), parseResult.error, version));
   }
 
   const today = getCurrentLocalDate();

--- a/extensions/ccusage/src/tools/get-monthly-usage.ts
+++ b/extensions/ccusage/src/tools/get-monthly-usage.ts
@@ -3,6 +3,8 @@ import { getCustomNpxPath } from "../preferences";
 import { execAsync } from "../utils/exec-async";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
+import { describeParseFailure } from "../utils/parse-diagnostics";
+import { captureCcusageVersion } from "../utils/ccusage-version";
 import { validateDateFormat } from "../utils/date-validator";
 import { getCurrentLocalMonth } from "../utils/date-formatter";
 
@@ -78,7 +80,8 @@ export default async function getMonthlyUsage(input?: Input): Promise<{
   const parseResult = stringToJSON.pipe(MonthlyUsageCommandResponseSchema).safeParse(stdout.toString());
 
   if (!parseResult.success) {
-    throw new Error(`Invalid monthly usage data: ${parseResult.error.message}`);
+    const version = await captureCcusageVersion();
+    throw new Error(describeParseFailure("Invalid monthly usage data", stdout.toString(), parseResult.error, version));
   }
 
   const currentMonth = getCurrentLocalMonth();

--- a/extensions/ccusage/src/tools/get-session-usage.ts
+++ b/extensions/ccusage/src/tools/get-session-usage.ts
@@ -3,6 +3,8 @@ import { getCustomNpxPath } from "../preferences";
 import { execAsync } from "../utils/exec-async";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
+import { describeParseFailure } from "../utils/parse-diagnostics";
+import { captureCcusageVersion } from "../utils/ccusage-version";
 import { validateDateFormat } from "../utils/date-validator";
 
 type Input = {
@@ -32,7 +34,7 @@ export default async function getSessionUsage(input?: Input): Promise<{
     cacheCreationTokens: number;
     cacheReadTokens: number;
     modelName: string;
-    date: string;
+    date?: string;
   }>;
   sessionCount: number;
 }> {
@@ -69,7 +71,8 @@ export default async function getSessionUsage(input?: Input): Promise<{
   const parseResult = stringToJSON.pipe(SessionUsageCommandResponseSchema).safeParse(stdout.toString());
 
   if (!parseResult.success) {
-    throw new Error(`Invalid session usage data: ${parseResult.error.message}`);
+    const version = await captureCcusageVersion();
+    throw new Error(describeParseFailure("Invalid session usage data", stdout.toString(), parseResult.error, version));
   }
 
   return {

--- a/extensions/ccusage/src/tools/get-total-usage.ts
+++ b/extensions/ccusage/src/tools/get-total-usage.ts
@@ -3,6 +3,8 @@ import { getCustomNpxPath } from "../preferences";
 import { execAsync } from "../utils/exec-async";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
+import { describeParseFailure } from "../utils/parse-diagnostics";
+import { captureCcusageVersion } from "../utils/ccusage-version";
 
 /**
  * Get comprehensive Claude Code usage statistics including totals, sessions, and model breakdowns
@@ -37,7 +39,8 @@ export default async function getTotalUsage(): Promise<{
   const parseResult = stringToJSON.pipe(TotalUsageResponseSchema).safeParse(stdout.toString());
 
   if (!parseResult.success) {
-    throw new Error(`Invalid total usage data: ${parseResult.error.message}`);
+    const version = await captureCcusageVersion();
+    throw new Error(describeParseFailure("Invalid total usage data", stdout.toString(), parseResult.error, version));
   }
 
   const data = parseResult.data;

--- a/extensions/ccusage/src/types/usage-types.test.ts
+++ b/extensions/ccusage/src/types/usage-types.test.ts
@@ -116,16 +116,38 @@ describe("SessionUsageCommandResponseSchema", () => {
     expect(result.sessions[0].lastActivity).toBe("2026-05-24");
   });
 
-  it("rejects sessions whose `metadata.lastActivity` is null with a clear field path", () => {
-    const result = SessionUsageCommandResponseSchema.safeParse({
+  it("accepts a session with no `metadata` at all, leaving `lastActivity` undefined", () => {
+    // ccusage emits some rows (e.g. a non-Claude agent) without a metadata
+    // object, so neither a top-level nor a nested lastActivity exists. One such
+    // row must not fail the whole list. See raycast/extensions#28423.
+    const result = SessionUsageCommandResponseSchema.parse({
+      session: [{ ...rowBase, period: "abc-123", agent: "claude" }],
+      totals,
+    });
+
+    expect(result.sessions[0].sessionId).toBe("abc-123");
+    expect(result.sessions[0].lastActivity).toBeUndefined();
+  });
+
+  it("accepts a session whose `metadata.lastActivity` is null, leaving `lastActivity` undefined", () => {
+    const result = SessionUsageCommandResponseSchema.parse({
       session: [{ ...rowBase, period: "abc-123", metadata: { lastActivity: null } }],
       totals,
     });
 
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues[0].path).toEqual(["sessions", 0, "lastActivity"]);
-    }
+    expect(result.sessions[0].lastActivity).toBeUndefined();
+  });
+
+  it("keeps dated sessions intact when one in the list is dateless", () => {
+    const result = SessionUsageCommandResponseSchema.parse({
+      session: [
+        { ...rowBase, period: "dated", metadata: { lastActivity: "2026-05-24" } },
+        { ...rowBase, period: "dateless", agent: "claude" },
+      ],
+      totals,
+    });
+
+    expect(result.sessions.map((s) => s.lastActivity)).toEqual(["2026-05-24", undefined]);
   });
 });
 

--- a/extensions/ccusage/src/types/usage-types.ts
+++ b/extensions/ccusage/src/types/usage-types.ts
@@ -22,6 +22,12 @@ const liftLastActivity = (raw: unknown): unknown => {
   return typeof lastActivity === "string" ? { ...obj, lastActivity } : raw;
 };
 
+// Some ccusage sessions carry no usable activity date: a non-Claude agent row,
+// or a session whose entries lack timestamps, arrives with neither a top-level
+// `lastActivity` nor a `metadata.lastActivity` string. Keep `lastActivity`
+// optional so one dateless session degrades to "unknown" instead of failing the
+// entire session list. See raycast/extensions#28423.
+
 const modelBreakdownSchema = z.object({
   modelName: z.string(),
   inputTokens: z.number(),
@@ -65,7 +71,7 @@ export const MonthlyUsageResponseSchema = z.preprocess(
 
 export const SessionResponseSchema = z.preprocess(
   (raw) => liftLastActivity(alias("period", "sessionId")(raw)),
-  z.object({ sessionId: z.string(), lastActivity: z.string(), ...usageRowBase }),
+  z.object({ sessionId: z.string(), lastActivity: z.string().optional(), ...usageRowBase }),
 );
 
 export const ModelUsageSchema = z.object({

--- a/extensions/ccusage/src/utils/ccusage-version.ts
+++ b/extensions/ccusage/src/utils/ccusage-version.ts
@@ -1,0 +1,42 @@
+import { execAsync } from "./exec-async";
+import { getExecOptions } from "./exec-options";
+import { getCustomNpxPath, preferences } from "../preferences";
+
+// The extension runs `ccusage@latest`, so the CLI version varies per machine and
+// is the single most useful fact for diagnosing schema-mismatch reports. ccusage
+// does not include its version in `--json` output, so capture it separately,
+// best-effort, and memoize it for the lifetime of the process.
+
+let cachedVersion: string | undefined;
+let captureStarted = false;
+
+const versionCommand = (): string => {
+  if (preferences.useDirectCcusageCommand) return "ccusage --version";
+  const npxCommand = getCustomNpxPath() ?? "npx";
+  return `${npxCommand} ccusage@latest --version`;
+};
+
+export const captureCcusageVersion = async (): Promise<string | undefined> => {
+  captureStarted = true;
+  try {
+    const { stdout } = await execAsync(versionCommand(), getExecOptions());
+    const version = stdout.toString().trim();
+    if (version) cachedVersion = version;
+  } catch {
+    // Version is a diagnostic nicety; never let its absence mask the real error.
+  }
+  return cachedVersion;
+};
+
+/**
+ * Returns the memoized ccusage version, or `undefined` if it has not been
+ * captured yet. The first call from a synchronous context (e.g. a hook's
+ * `parseOutput`) kicks off a background capture so later calls (parse errors
+ * recur on the refresh interval) can include it.
+ */
+export const getCcusageVersionSync = (): string | undefined => {
+  if (cachedVersion === undefined && !captureStarted) {
+    void captureCcusageVersion();
+  }
+  return cachedVersion;
+};

--- a/extensions/ccusage/src/utils/parse-diagnostics.test.ts
+++ b/extensions/ccusage/src/utils/parse-diagnostics.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "@jest/globals";
+import { describeShape, describeParseFailure } from "./parse-diagnostics";
+import { SessionUsageCommandResponseSchema } from "../types/usage-types";
+import { stringToJSON } from "./string-to-json-schema";
+
+describe("describeShape", () => {
+  it("reports object keys and value types without the values", () => {
+    expect(describeShape({ sessionId: "abc", totalCost: 1.23, modelsUsed: ["opus"] })).toEqual({
+      modelsUsed: { array: 1, of: "string" },
+      sessionId: "string",
+      totalCost: "number",
+    });
+  });
+
+  it("collapses arrays to a length plus the first element shape", () => {
+    expect(describeShape([{ a: 1 }, { a: 2 }, { a: 3 }])).toEqual({ array: 3, of: { a: "number" } });
+  });
+
+  it("distinguishes null from objects", () => {
+    expect(describeShape(null)).toBe("null");
+    expect(describeShape({ resets_at: null })).toEqual({ resets_at: "null" });
+  });
+});
+
+describe("describeParseFailure", () => {
+  it("includes the version and the actual record shape for a renamed top-level key", () => {
+    // ccusage v19+ keys the array under `session` and nests lastActivity under
+    // metadata, so the legacy `sessions` schema rejects at the top level.
+    const raw = JSON.stringify({ session: [{ period: "p0", agent: "claude" }], totals: {} });
+    const result = stringToJSON.pipe(SessionUsageCommandResponseSchema).safeParse(raw);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const message = describeParseFailure("Invalid session usage data", raw, result.error, "ccusage 20.0.6");
+
+    expect(message).toContain("ccusage version: ccusage 20.0.6");
+    // The `session` vs `sessions` rename is visible in the output shape.
+    expect(message).toContain('"session":');
+  });
+
+  it("falls back to 'unknown' when no version was captured", () => {
+    const raw = JSON.stringify({ totals: {} });
+    const result = stringToJSON.pipe(SessionUsageCommandResponseSchema).safeParse(raw);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const message = describeParseFailure("Invalid session usage data", raw, result.error);
+
+    expect(message).toContain("ccusage version: unknown");
+  });
+
+  it("reports a non-JSON payload without throwing", () => {
+    const raw = "command not found: ccusage";
+    const result = stringToJSON.pipe(SessionUsageCommandResponseSchema).safeParse(raw);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const message = describeParseFailure("Invalid session usage data", raw, result.error);
+
+    expect(message).toContain("was not valid JSON");
+  });
+});

--- a/extensions/ccusage/src/utils/parse-diagnostics.ts
+++ b/extensions/ccusage/src/utils/parse-diagnostics.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+import { extractJSON } from "./string-to-json-schema";
+
+// `ccusage` is run as `ccusage@latest`, so its JSON shape shifts between
+// releases (fields renamed, moved into nested objects, or dropped). A bare Zod
+// message ("expected string, received undefined") names the path that failed
+// but not what the payload actually looked like, leaving a maintainer unable to
+// tell which release a reporter is on or how the schema diverged. This builds a
+// redacted structural fingerprint: object keys and value types only, never the
+// values, so it is safe to paste into a bug report.
+
+const MAX_ISSUES = 8;
+const SHAPE_DEPTH = 5;
+const RECORD_DEPTH = 2;
+
+type Shape = string | { array: number; of?: Shape } | { [key: string]: Shape };
+
+/**
+ * Describes a value by type. Arrays collapse to their length plus the shape of
+ * their first element so a large payload stays compact while still revealing the
+ * element schema.
+ */
+export function describeShape(value: unknown, depth: number = SHAPE_DEPTH): Shape {
+  if (value === null) return "null";
+
+  if (Array.isArray(value)) {
+    if (value.length === 0 || depth <= 0) return { array: value.length };
+    return { array: value.length, of: describeShape(value[0], depth - 1) };
+  }
+
+  if (typeof value === "object") {
+    if (depth <= 0) return "object";
+    const record = value as Record<string, unknown>;
+    const shape: Record<string, Shape> = {};
+    for (const key of Object.keys(record).sort()) {
+      shape[key] = describeShape(record[key], depth - 1);
+    }
+    return shape;
+  }
+
+  return typeof value;
+}
+
+function valueAtPath(root: unknown, path: ReadonlyArray<string | number>): unknown {
+  let current = root;
+  for (const key of path) {
+    if (current === null || typeof current !== "object") return undefined;
+    current = (current as Record<string | number, unknown>)[key];
+  }
+  return current;
+}
+
+/**
+ * Builds a privacy-preserving, traceable error message for a ccusage schema
+ * mismatch: the ccusage version, the overall output shape, and the actual key
+ * set of each record that failed validation.
+ */
+export function describeParseFailure(label: string, rawStdout: string, error: z.ZodError, version?: string): string {
+  let root: unknown;
+  let jsonParsed = true;
+  try {
+    root = JSON.parse(extractJSON(rawStdout));
+  } catch {
+    jsonParsed = false;
+  }
+
+  const lines = [
+    `${label}: ccusage output did not match the expected schema.`,
+    `ccusage version: ${version ?? "unknown"}`,
+  ];
+
+  if (jsonParsed) {
+    lines.push(`Output shape: ${JSON.stringify(describeShape(root))}`);
+  } else {
+    lines.push(`Output was not valid JSON (${rawStdout.length} chars).`);
+  }
+
+  const shown = error.issues.slice(0, MAX_ISSUES);
+  const suffix = error.issues.length > MAX_ISSUES ? ` (first ${MAX_ISSUES})` : "";
+  lines.push(`${error.issues.length} schema issue(s)${suffix}:`);
+
+  for (const issue of shown) {
+    const pathStr = issue.path.length ? issue.path.join(".") : "(root)";
+    lines.push(`  • ${pathStr}: ${issue.message}`);
+
+    if (jsonParsed && issue.path.length) {
+      const parentPath = issue.path.slice(0, -1);
+      const parent = valueAtPath(root, parentPath);
+      if (parent !== null && typeof parent === "object" && !Array.isArray(parent)) {
+        const parentLabel = parentPath.length ? parentPath.join(".") : "root";
+        lines.push(`    actual ${parentLabel} shape: ${JSON.stringify(describeShape(parent, RECORD_DEPTH))}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/extensions/ccusage/src/utils/string-to-json-schema.ts
+++ b/extensions/ccusage/src/utils/string-to-json-schema.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
  * this helper locates the first `{` or `[` character and slices from there so
  * that the parser only sees valid JSON.
  */
-function extractJSON(raw: string): string {
+export function extractJSON(raw: string): string {
   const objStart = raw.indexOf("{");
   const arrStart = raw.indexOf("[");
 

--- a/extensions/ccusage/src/utils/usage-calculator.ts
+++ b/extensions/ccusage/src/utils/usage-calculator.ts
@@ -6,7 +6,11 @@ export const getTopModels = (models: ModelUsage[], limit: number = 5): ModelUsag
 };
 
 export const getRecentSessions = (sessions: SessionData[], limit: number = 10): SessionData[] => {
-  return orderBy(sessions, [(session) => new Date(session.lastActivity).getTime()], ["desc"]).slice(0, limit);
+  return orderBy(
+    sessions,
+    [(session) => (session.lastActivity ? new Date(session.lastActivity).getTime() : 0)],
+    ["desc"],
+  ).slice(0, limit);
 };
 
 export const calculateAverageSessionCost = (sessions: SessionData[]): number => {


### PR DESCRIPTION
## Description

Makes a session's `lastActivity` optional so one dateless session no longer crashes the whole session view. `ccusage` emits some sessions with no `metadata` object at all (a non-Claude agent row, or a session whose entries lack timestamps), so neither a top-level `lastActivity` nor a nested `metadata.lastActivity` exists. The v20 schema still required `lastActivity: z.string()`, so a single such row failed Zod validation and took down the daily and session views with `Invalid session usage data`. Closes #28423.

### Issue

The error names `lastActivity` as missing on specific session indices (e.g. `sessions.158.lastActivity: Required`). I reproduced it against `ccusage` 20.0.6: of 363 sessions, one carried `metadata: undefined` and no `lastActivity`. The v20 adoption (#28299) lifted `metadata.lastActivity` to the top level but kept the field required, so it handled the rename, not the genuinely-absent case. The failure is data-dependent: only machines whose history contains such a session hit it, which is why it was hard to reproduce.

### Changes

- `SessionResponseSchema` marks `lastActivity` optional. The three consumers guard the now-optional field: the recent-session sort treats a missing date as oldest, the session detail shows `unknown`, and the `get-session-usage` tool's `date` field is optional.
- Schema parse failures across every CLI hook and tool now go through `describeParseFailure`, which reports the `ccusage` version and a redacted structural fingerprint of the output (field names and value types, never the values). `ccusage` omits its version from `--json`, so a best-effort `ccusage --version` capture supplies it. This replaces the raw Zod dump, which named the failing path but never showed what the payload actually contained, leaving schema drift across `ccusage` releases impossible to diagnose from a report.

### Testing

- `usage-types.test.ts`: a session with no `metadata`, a session with `metadata.lastActivity: null`, and a mixed list all parse, leaving `lastActivity` undefined on the dateless rows.
- `parse-diagnostics.test.ts`: the failure message carries the version and the divergent record's shape, falls back to `unknown` with no version, and handles non-JSON output.

## Screencast

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
