### PR TITLE
Slack: Update message history to fallback to attachment text

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Changelog
 
+## [Fix AI Tool for Channel History Failing] - 2026-06-03
+
+- Add fallback to attachment text for the Channel History AI tool.
+
 ## [Fix Windows deep links] - 2026-05-27
 
 - "Open in Slack" and "Open Channel"/"Open Chat" Quicklinks now open the requested channel or user on Windows. Previously the `application="Slack"` hint caused Raycast to launch Slack.exe without forwarding the `slack://` URI; the hint is now macOS-only so Windows routes the URI through the registered protocol handler.
@@ -12,7 +16,7 @@
 
 - Merged slack-status Extension into the main Slack extension, enabling users to view, set, update, AI-generate, and clear their status in one place.
 - Added full support for custom workspace emojis (beyond default emojis).
- 
+
 ## [Add proxy support for corporate networks] - 2026-02-13
 
 - Add optional "Proxy URL" preference for routing Slack API requests through a corporate proxy

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Fix AI Tool for Channel History Failing] - {PR_MERGE_DATE}
+## [Fix AI Tool for Channel History Failing] - 2026-06-03
 
 - Add fallback to attachment text for the Channel History AI tool.
 

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Fix AI Tool for Channel History Failing] - 2026-06-03
+## [Fix AI Tool for Channel History Failing] - {PR_MERGE_DATE}
 
 - Add fallback to attachment text for the Channel History AI tool.
 

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -12,7 +12,8 @@
     "erayack",
     "clins1994",
     "stephlv",
-    "artistro08"
+    "artistro08",
+    "andreaselia"
   ],
   "pastContributors": [
     "Elliot67",

--- a/extensions/slack/src/tools/get-channel-history.ts
+++ b/extensions/slack/src/tools/get-channel-history.ts
@@ -64,6 +64,36 @@ async function getChannelIdByChannelName(channelName?: string) {
   return undefined;
 }
 
+type HistoryMessage = NonNullable<
+  Awaited<ReturnType<ReturnType<typeof getSlackWebClient>["conversations"]["history"]>>["messages"]
+>[number];
+
+/**
+ * Extracts the text content of a message. Bot/webhook messages (e.g. IFTTT tweet streams)
+ * often have an empty top-level `text` with the actual content living in `attachments` or `blocks`.
+ */
+function getMessageText(message: HistoryMessage) {
+  if (message.text) {
+    return message.text;
+  }
+
+  const attachmentText = message.attachments
+    ?.map(
+      (attachment) =>
+        attachment.fallback ?? [attachment.pretext, attachment.title, attachment.text].filter(Boolean).join("\n"),
+    )
+    .filter(Boolean)
+    .join("\n");
+  if (attachmentText) {
+    return attachmentText;
+  }
+
+  return message.blocks
+    ?.map((block) => block.text?.text)
+    .filter(Boolean)
+    .join("\n");
+}
+
 async function getChannelHistory(input: Input) {
   const slackWebClient = getSlackWebClient();
   const { after, text }: Input = input;
@@ -92,8 +122,8 @@ async function getChannelHistory(input: Input) {
   }
 
   return messages.messages?.map((message) => ({
-    text: message.text,
-    user: message.user,
+    text: getMessageText(message),
+    user: message.user ?? message.bot_profile?.name ?? message.username,
     ts: message.ts,
     date: message.ts ? new Date(parseInt(message.ts, 10) * 1000).toISOString() : undefined,
   }));

--- a/extensions/slack/src/tools/get-channel-history.ts
+++ b/extensions/slack/src/tools/get-channel-history.ts
@@ -80,10 +80,10 @@ function getMessageText(message: HistoryMessage) {
   const attachmentText = message.attachments
     ?.map(
       (attachment) =>
-        attachment.fallback ?? [attachment.pretext, attachment.title, attachment.text].filter(Boolean).join("\n"),
+        [attachment.pretext, attachment.title, attachment.text].filter(Boolean).join("\n") || attachment.fallback,
     )
     .filter(Boolean)
-    .join("\n");
+    .join("\n\n");
   if (attachmentText) {
     return attachmentText;
   }


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
