### PR TITLE
Improve GIF conversion in yafw (fix palette, add quality/fps/speed/loop)

### DIFF
--- a/extensions/yafw/CHANGELOG.md
+++ b/extensions/yafw/CHANGELOG.md
@@ -1,5 +1,13 @@
 # YAFW Changelog
 
+## [Improve GIF conversion] - {PR_MERGE_DATE}
+
+- Fix GIF conversion two-pass palette: the generated palette is now applied with `paletteuse`, producing noticeably better colors and less banding (previously the palette was generated and discarded, so output was effectively single-pass)
+- Add GIF quality preference (1-100) controlling the number of palette colors
+- Make GIF frame rate configurable via a preference (previously hardcoded to 30fps), defaulting to 15fps for smaller files
+- Add GIF speed and loop (forever/once) preferences
+- Use Lanczos scaling when resizing GIFs for sharper output
+
 ## [Add video trim command] - 2026-01-28
 
 - Add new "Trim" command to trim videos by specifying start time and either end time or duration

--- a/extensions/yafw/CHANGELOG.md
+++ b/extensions/yafw/CHANGELOG.md
@@ -1,6 +1,6 @@
 # YAFW Changelog
 
-## [Improve GIF conversion] - {PR_MERGE_DATE}
+## [Improve GIF conversion] - 2026-06-04
 
 - Fix GIF conversion two-pass palette: the generated palette is now applied with `paletteuse`, producing noticeably better colors and less banding (previously the palette was generated and discarded, so output was effectively single-pass)
 - Add GIF quality preference (1-100) controlling the number of palette colors

--- a/extensions/yafw/package.json
+++ b/extensions/yafw/package.json
@@ -54,6 +54,53 @@
           ],
           "required": true
         }
+      ],
+      "preferences": [
+        {
+          "name": "gif_quality",
+          "type": "textfield",
+          "required": false,
+          "title": "GIF Quality",
+          "description": "Quality of the GIF from 1 to 100. Higher values use more colors for better quality at a larger file size. Only applies when converting to GIF.",
+          "default": "90",
+          "placeholder": "90"
+        },
+        {
+          "name": "gif_fps",
+          "type": "textfield",
+          "required": false,
+          "title": "GIF Frame Rate",
+          "description": "Frames per second for the GIF (1-60). Lower values produce smaller files. Only applies when converting to GIF.",
+          "default": "15",
+          "placeholder": "15"
+        },
+        {
+          "name": "gif_speed",
+          "type": "dropdown",
+          "required": false,
+          "title": "GIF Speed",
+          "description": "Playback speed of the GIF. Only applies when converting to GIF.",
+          "default": "1",
+          "data": [
+            { "title": "0.25x", "value": "0.25" },
+            { "title": "0.5x", "value": "0.5" },
+            { "title": "1x (Normal)", "value": "1" },
+            { "title": "1.5x", "value": "1.5" },
+            { "title": "2x", "value": "2" }
+          ]
+        },
+        {
+          "name": "gif_loop",
+          "type": "dropdown",
+          "required": false,
+          "title": "GIF Loop",
+          "description": "Whether the GIF loops forever or plays once. Only applies when converting to GIF.",
+          "default": "forever",
+          "data": [
+            { "title": "Loop Forever", "value": "forever" },
+            { "title": "Play Once", "value": "once" }
+          ]
+        }
       ]
     },
     {

--- a/extensions/yafw/src/abstractions/gif.ts
+++ b/extensions/yafw/src/abstractions/gif.ts
@@ -1,3 +1,14 @@
 export type Gif = {
-  encode: (options?: { width?: number; height?: number }) => Promise<void>;
+  encode: (options?: {
+    width?: number;
+    height?: number;
+    /** Output frame rate. When omitted, the source frame rate is preserved. */
+    fps?: number;
+    /** 1-100. Maps to the number of colors in the generated palette. When omitted, a full palette is used. */
+    quality?: number;
+    /** Playback speed multiplier (e.g. 0.5, 1, 2). When omitted or 1, speed is unchanged. */
+    speed?: number;
+    /** Whether the GIF loops forever or plays once. When omitted, ffmpeg's default (loop forever) is used. */
+    loop?: "forever" | "once";
+  }) => Promise<void>;
 };

--- a/extensions/yafw/src/convert.tsx
+++ b/extensions/yafw/src/convert.tsx
@@ -1,9 +1,10 @@
-import { Toast as RaycastToast } from "@raycast/api";
+import { getPreferenceValues, Toast as RaycastToast } from "@raycast/api";
 import { EncodeOperation } from "./objects/encode.operation";
 import { Ffmpeg } from "./objects/ffmpeg";
 import { FfmpegGif } from "./objects/ffmpeg.gif";
 import { FfmpegVideo } from "./objects/ffmpeg.video";
 import { Ffprobe } from "./objects/ffprobe";
+import { SafeNumber } from "./objects/safe.number";
 import { SafeOperation } from "./objects/safe.operation";
 import { SelectedFinderFiles } from "./objects/selected-finder.files";
 import { Toast } from "./objects/toast";
@@ -18,6 +19,15 @@ export default async function Command(props: { arguments: { format: "mp4" | "web
     },
   });
 
+  const preferences = getPreferenceValues<Preferences.Convert>();
+  const speed = Number(preferences.gif_speed);
+  const gifOptions = {
+    fps: Math.min(60, Math.max(1, new SafeNumber(preferences.gif_fps).toInt() ?? 15)),
+    quality: Math.min(100, Math.max(1, new SafeNumber(preferences.gif_quality).toInt() ?? 90)),
+    speed: Number.isFinite(speed) && speed > 0 ? speed : 1,
+    loop: preferences.gif_loop === "once" ? ("once" as const) : ("forever" as const),
+  };
+
   await new SafeOperation(
     new EncodeOperation(files, async (selectedFiles) => {
       for (const file of selectedFiles) {
@@ -27,7 +37,7 @@ export default async function Command(props: { arguments: { format: "mp4" | "web
         });
 
         if (format === "gif") {
-          await new FfmpegGif(ffmpeg, file).encode();
+          await new FfmpegGif(ffmpeg, file).encode(gifOptions);
           continue;
         }
 

--- a/extensions/yafw/src/objects/ffmpeg.gif.ts
+++ b/extensions/yafw/src/objects/ffmpeg.gif.ts
@@ -1,6 +1,7 @@
 import { environment } from "@raycast/api";
 import path from "path";
 import { File, Gif } from "../abstractions";
+import { sanitizeFileName } from "../utils";
 import { Ffmpeg } from "./ffmpeg";
 import { FsFile } from "./fs.file";
 
@@ -11,32 +12,79 @@ export class FfmpegGif implements Gif {
   ) {}
 
   encode: Gif["encode"] = async (options = {}) => {
-    const { width, height } = options;
+    const { width, height, fps, quality, speed, loop } = options;
 
     const filePath = this.file.path();
     const sourceDirPath = path.dirname(filePath);
     const targetGifPath = path.join(sourceDirPath, this.file.nextName({ extension: ".gif" }));
     const paletteFile = new FsFile(path.join(environment.supportPath, "palette.png"));
-    // @TODO: provide through properties or arguments
-    const frameRate = 30;
+
+    // Filters applied identically in both passes so the generated palette matches the encoded frames.
+    const filterChain = this.buildFilterChain({ width, height, fps, speed });
+    const maxColors = this.paletteColors(quality);
+
+    // Pass 1: generate an optimized palette from the (filtered) frames.
+    const palettegen = `palettegen=stats_mode=diff${maxColors != null ? `:max_colors=${maxColors}` : ""}`;
+    const paletteFilter = filterChain ? `${filterChain},${palettegen}` : palettegen;
+
+    // Pass 2: encode the GIF using that palette. This is the part that was previously missing:
+    // the palette is now passed as a second input and applied with `paletteuse`.
+    const paletteuse = "paletteuse=dither=sierra2_4a";
+    const lavfi = filterChain ? `[0:v] ${filterChain} [x]; [x][1:v] ${paletteuse}` : `[0:v][1:v] ${paletteuse}`;
+    const loopArg = loop == null ? undefined : `-loop ${loop === "once" ? -1 : 0}`;
 
     try {
       await this.ffmpeg.exec({
         input: filePath,
-        params: [`-vf "fps=${frameRate},palettegen=stats_mode=diff"`],
+        params: [`-vf "${paletteFilter}"`],
         output: paletteFile.path(),
       });
       await this.ffmpeg.exec({
         input: filePath,
-        params: [
-          !!width && !height ? `-vf scale=${width}:-2` : undefined,
-          !width && !!height ? `-vf scale=-2:${height}` : undefined,
-          !!width && !!height ? `-vf scale=${width}:${height}` : undefined,
-        ],
+        params: [`-i ${sanitizeFileName(paletteFile.path())}`, `-lavfi "${lavfi}"`, loopArg],
         output: targetGifPath,
       });
     } finally {
       await paletteFile.remove();
     }
   };
+
+  /**
+   * Builds the comma-separated ffmpeg filter chain shared by both passes.
+   * Order matters: speed (setpts) -> frame rate (fps) -> scaling.
+   */
+  private buildFilterChain(options: { width?: number; height?: number; fps?: number; speed?: number }): string {
+    const { width, height, fps, speed } = options;
+    const filters: string[] = [];
+
+    if (speed != null && speed > 0 && speed !== 1) {
+      filters.push(`setpts=${(1 / speed).toFixed(4)}*PTS`);
+    }
+
+    if (fps != null && fps > 0) {
+      filters.push(`fps=${fps}`);
+    }
+
+    if (width != null && height == null) {
+      filters.push(`scale=${width}:-2:flags=lanczos`);
+    } else if (width == null && height != null) {
+      filters.push(`scale=-2:${height}:flags=lanczos`);
+    } else if (width != null && height != null) {
+      filters.push(`scale=${width}:${height}:flags=lanczos`);
+    }
+
+    return filters.join(",");
+  }
+
+  /**
+   * Maps a 1-100 quality value to the number of palette colors (ffmpeg accepts 4-256).
+   * Returns undefined when no quality is provided, leaving the palette at full size.
+   */
+  private paletteColors(quality?: number): number | undefined {
+    if (quality == null) {
+      return undefined;
+    }
+    const clamped = Math.min(100, Math.max(1, quality));
+    return Math.min(256, Math.max(4, Math.round(2 + (clamped / 100) * 254)));
+  }
 }


### PR DESCRIPTION
## Description

This improves GIF support in **yafw** and fixes a bug where the two‑pass palette was generated but never applied.

Context: this comes out of the discussion on #26652, where I proposed a standalone `video2gif` extension. @0xdhrv suggested consolidating GIF functionality into the existing **yafw** extension instead, and [gave the go‑ahead to open this PR](https://github.com/raycast/extensions/pull/26652#issuecomment-4609750963). So this is that PR — bringing the GIF features into yafw, implemented in yafw's own style. cc @pablopunk @0xdhrv

### The bug
`src/objects/ffmpeg.gif.ts` ran `palettegen` in pass 1 to write `palette.png`, but **pass 2 never referenced it** (it only applied `scale`), then deleted the palette in the `finally` block. So the optimized palette was generated and thrown away, making conversion effectively single‑pass — visible color banding / lower quality. The frame rate was also hardcoded to 30fps (with a `@TODO`).

```
# before (pass 2 — palette ignored):
ffmpeg -i input -vf scale=W:-2 output.gif

# after (pass 2 — palette applied):
ffmpeg -i input -i palette.png -lavfi "[0:v] fps=F,scale=W:-2:flags=lanczos [x]; [x][1:v] paletteuse=dither=sierra2_4a" -loop 0 output.gif
```

### What changed
- **Fixed the two‑pass palette** — pass 2 now applies the palette via `paletteuse` (passed as a second input). This is the core fix.
- **Made GIF output configurable via `Convert To` command preferences**, keeping yafw's zero‑config ethos (sensible defaults, no new UI surface):
  - **GIF Quality** (1–100 → number of palette colors)
  - **GIF Frame Rate** (replaces the hardcoded 30fps)
  - **GIF Speed** (0.25×–2×)
  - **GIF Loop** (forever / once)
- Resizing a GIF now uses **Lanczos** scaling for sharper output. The `Resize` command continues to preserve the source frame rate (it doesn't pass an fps), and now also benefits from the palette fix.

**One default to flag:** the frame‑rate default is **15fps** (previously hardcoded to 30). 15 is the common GIF default and produces noticeably smaller files — but happy to set it back to 30 if you'd prefer to keep the prior behavior.

### Testing
- `npm run build` and `npm run lint` both pass.
- I verified the exact ffmpeg commands the code builds (including yafw's `zsh -l -c` wrapper and `sanitizeFileName`) against sample videos, with **spaces and parentheses in the paths**:
  - the palette is applied (`paletteuse` present), and quality/fps/speed/loop are all reflected in the output (confirmed frame counts, dimensions, and loop flag via `ffprobe`);
  - the `Resize → GIF` path preserves the source frame rate;
  - the temporary `palette.png` is cleaned up afterward.

### Proposed follow‑up: live size estimation
In #26652 I also had a live "estimated output size" that updated as you changed settings. That needs a small form (view command), which doesn't fit yafw's zero‑config `Convert To` flow, so I left it out here to keep this PR focused on the bug fix + controls. **If you'd welcome it, I'm happy to add a lightweight GIF form in a follow‑up PR** — I already have a working size heuristic from video2gif to port. Let me know your preference given the "zero config" philosophy.

## Screencast

<!-- A before/after comparison GIF will be added. The visible difference: the "after" output has smooth gradients where the "before" showed banding, because the optimized palette is now actually applied. -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
