### PR TITLE
things: restore Cmd-Return to Mark as Completed on list rows

### DIFF
--- a/extensions/things/CHANGELOG.md
+++ b/extensions/things/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Things Changelog
 
+## [Bug Fixes] - 2026-06-03
+
+- Restore ⌘↵ to "Mark as Completed" on list rows. The Detail view made "Open in Things" the second action, which Raycast also binds to ⌘↵; "Open in Things" stays reachable via ⌘O.
+
 ## [Detail View for To-Dos] - 2026-05-25
 
 - Added a Detail view, accessible from any list command by pressing Enter on a row. Renders the to-do's notes as markdown with a metadata sidebar (Status, Created, Start Date, color-coded Deadline, Tags, Project, Area).

--- a/extensions/things/CHANGELOG.md
+++ b/extensions/things/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Things Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-06-04
 
 - Restore ⌘↵ to "Mark as Completed" on list rows. The Detail view made "Open in Things" the second action, which Raycast also binds to ⌘↵; "Open in Things" stays reachable via ⌘O.
 

--- a/extensions/things/CHANGELOG.md
+++ b/extensions/things/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Things Changelog
 
-## [Bug Fixes] - 2026-06-03
+## [Bug Fixes] - {PR_MERGE_DATE}
 
 - Restore ⌘↵ to "Mark as Completed" on list rows. The Detail view made "Open in Things" the second action, which Raycast also binds to ⌘↵; "Open in Things" stays reachable via ⌘O.
 

--- a/extensions/things/src/components/TodoListItemActions.tsx
+++ b/extensions/things/src/components/TodoListItemActions.tsx
@@ -199,7 +199,9 @@ New title:
   return (
     <ActionPanel>
       <ActionPanel.Section title={todo.name}>
-        {!fromDetail && (
+        {fromDetail ? (
+          <OpenInThings id={todo.id} title="Open in Things" />
+        ) : (
           <Action.Push
             title="Show Details"
             icon={Icon.Sidebar}
@@ -223,7 +225,6 @@ New title:
             }
           />
         )}
-        <OpenInThings id={todo.id} title="Open in Things" />
         {todo.status !== 'completed' && (
           <Action
             title="Mark as Completed"
@@ -244,6 +245,8 @@ New title:
             }
           />
         )}
+
+        {!fromDetail && <OpenInThings id={todo.id} title="Open in Things" />}
       </ActionPanel.Section>
 
       <ActionPanel.Section>


### PR DESCRIPTION
## Description

Restores ⌘↵ to "Mark as Completed" on to-do list rows. The Detail view (#28298) added "Show Details" as the primary action, which pushed "Open in Things" into the second slot. Raycast auto-binds ⌘↵ to the second action, so ⌘↵ started opening the to-do in Things instead of completing it.

This moves "Open in Things" below the status actions on list rows so "Mark as Completed" reclaims the ⌘↵ slot. "Open in Things" stays reachable via its explicit ⌘O shortcut and remains the primary action inside the Detail view (where "Show Details" is not rendered).

<img width="340" height="272" alt="Screenshot 2026-06-03 at 15 09 09" src="https://github.com/user-attachments/assets/18259c0a-be80-4a17-ad7c-97149967ede8" />


## Screencast

After fix:

<img width="345" height="269" alt="Screenshot 2026-06-03 at 15 18 18" src="https://github.com/user-attachments/assets/58297f48-5b3f-4baf-8138-ecfb3482aa32" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
