### PR TITLE
Update video-downloader extension

### DIFF
--- a/extensions/video-downloader/CHANGELOG.md
+++ b/extensions/video-downloader/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Video Downloader Changelog
 
+## [Improvement] - {PR_MERGE_DATE}
+
+- Added a "Use Cookies from Browser" preference to fix X/Twitter "Bad guest token" failures by using your logged-in session (also helps with age-restricted and private posts)
+- Failures are now recoverable: added a "Try Again" action (⌘R) so a transient error no longer leaves the command stuck
+- Clearer error messages — failures like an unsupported site now show a plain-language reason instead of the raw command output, and only offer "Try Again" when retrying could actually help
+- Added a "Copy Logs" action to failure toasts for easier debugging
+- Added an "Update Libraries" shortcut to the download-failed toast to quickly update yt-dlp and FFmpeg
+- Space out requests and retry known extractor errors to reduce rate-limit failures
+- Download success/failure is now determined by yt-dlp's exit code, and a file that downloaded despite a non-fatal error can still be opened
+- Download progress in the toast is no longer overwritten by background log output
+- The Update Libraries view now shows a timestamp, and surfaces an error instead of spinning forever when a check fails
+- Added a "Download entire playlist" option that appears for playlist URLs (defaults to downloading just the linked video)
+- Fixed video titles being truncated at the first period, exclamation, or question mark (e.g. "Dr. Mehmet Oz…" no longer becomes "Dr")
+- Transcript extraction now returns the requested language instead of falling back to another
+- Fixed file path detection for downloads on Windows
+- Friendlier placeholder for the video title before a URL is queried
+- Updated dependencies
+
 ## [Improvement] - 2026-01-28
 
 - Added MP3 format option for audio downloads

--- a/extensions/video-downloader/CHANGELOG.md
+++ b/extensions/video-downloader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Video Downloader Changelog
 
-## [Improvement] - {PR_MERGE_DATE}
+## [Improvement] - 2026-06-04
 
 - Added a "Use Cookies from Browser" preference to fix X/Twitter "Bad guest token" failures by using your logged-in session (also helps with age-restricted and private posts)
 - Failures are now recoverable: added a "Try Again" action (⌘R) so a transient error no longer leaves the command stuck

--- a/extensions/video-downloader/README.md
+++ b/extensions/video-downloader/README.md
@@ -4,6 +4,16 @@
 
 ![video-downloader-1.png](metadata%2Fvideo-downloader-1.png)
 
+## Features
+
+- **Download from anywhere yt-dlp supports** — paste a URL, pick a format, and download. Audio-only (MP3) is included.
+- **Auto-fill the URL** — optionally load the link from your clipboard, selected text, or the active browser tab (see preferences).
+- **Use your browser's cookies** — work around auth-protected media, age restrictions, and "Bad guest token" rate-limit errors on X/Twitter by passing your logged-in browser's cookies (see the _Use Cookies from Browser_ preference).
+- **Playlists, opt-in** — for a playlist URL, a _Download entire playlist_ checkbox appears; leave it unchecked to grab just the linked video.
+- **Recover from hiccups** — transient failures show a _Try Again_ action (⌘R) and a _Copy Logs_ action, plus a one-key jump to update yt-dlp and ffmpeg.
+- **Extract transcripts** — pull a video's subtitles as Markdown, with language selection.
+- **AI tools** — `@video-downloader` can download a video or extract a transcript from a chat command.
+
 ## Installation
 
 To use this extension, you must have `yt-dlp` and `ffmpeg` installed on your machine.
@@ -29,14 +39,14 @@ accordingly.
 
 ## Windows Beta
 
-**Install yt-dlp**
- Use the built-in Windows package manager, `winget`, or alternatives like Scoop or Chocolatey. `yt-dlp` includes `ffmpeg` and `ffprobe` binaries.
+### Install yt-dlp
+Use the built-in Windows package manager, `winget`, or alternatives like Scoop or Chocolatey. `yt-dlp` includes `ffmpeg` and `ffprobe` binaries.
 
 ```bash
 winget install --id=yt-dlp.yt-dlp -e
 ```
 
-**Update Extension Preferences - Optional**
+### Update Extension Preferences (Optional)
 
 Extension will detect the paths automatically. But you can Copy the paths from the below commands and set them in the extension's preferences.
 
@@ -67,3 +77,11 @@ Absolutely\! Our extension supports downloading full videos, clips, and even You
 ### **How do I download a YouTube video with a manipulated URL?**
 
 Our downloader handles various URL formats. Just paste the link, and we'll take care of the rest.
+
+### **Why does an X/Twitter link fail with "Bad guest token"?**
+
+X rate-limits anonymous access, which can intermittently fail. Set the _Use Cookies from Browser_ preference to the browser you're signed in to X with, and the download will use your logged-in session. The _Try Again_ action also clears most transient failures, and _Update Libraries_ keeps yt-dlp current.
+
+### **Can I download a whole playlist?**
+
+Yes. When you paste a playlist URL, a _Download entire playlist_ checkbox appears below the format. Leave it unchecked to download only the linked video; check it to download the full playlist.

--- a/extensions/video-downloader/package-lock.json
+++ b/extensions/video-downloader/package-lock.json
@@ -7,28 +7,28 @@
       "name": "video-downloader",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.103.10",
-        "@raycast/utils": "^2.2.2",
+        "@raycast/api": "^1.104.19",
+        "@raycast/utils": "^2.2.5",
         "@types/validator": "^13.15.10",
-        "date-fns": "^4.1.0",
-        "execa": "^9.6.0",
+        "date-fns": "^4.4.0",
+        "execa": "^9.6.1",
         "pretty-bytes": "^6.1.1",
         "srt-parser-2": "^1.2.3",
-        "validator": "^13.15.23"
+        "validator": "^13.15.35"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
         "@types/node": "22.13.9",
-        "@types/react": "^19.2.0",
+        "@types/react": "^19.2.16",
         "eslint": "^9.36.0",
-        "prettier": "^3.6.2",
+        "prettier": "^3.8.3",
         "typescript": "^5.8.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -122,9 +122,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -154,9 +154,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -202,9 +202,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -218,9 +218,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -234,9 +234,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -266,9 +266,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -282,9 +282,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -314,9 +314,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -346,9 +346,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -362,9 +362,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -394,9 +394,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -426,9 +426,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -1008,9 +1008,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.0.tgz",
-      "integrity": "sha512-jteNUQKgJHLHFbbz806aGZqf+RJJ7t4gwF4MYa8fCwCxQ8/klJNWc0MvaJiBebk7Mc+J39mdlsB4XraaCKznFw==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.4.tgz",
+      "integrity": "sha512-URwiQ5ALx/sJ2iH4vzXEd+H4K6NAI7LRs6Jag3hrgKEpGmaE6alfRC8qjO4GIgb6A3ACaJumqP9twi/M9ywdHQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -1023,11 +1023,11 @@
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
-        "minimatch": "^9.0.5",
-        "semver": "^7.7.3",
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
         "string-width": "^4.2.3",
         "supports-color": "^8",
-        "tinyglobby": "^0.2.14",
+        "tinyglobby": "^0.2.16",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -1036,25 +1036,37 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1076,9 +1088,9 @@
       }
     },
     "node_modules/@oclif/plugin-autocomplete": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.39.tgz",
-      "integrity": "sha512-OwAZNnSpuDjKyhAwoOJkFWxGswPFKBB4hpNIMsj6PUtbKwGBPmD+2wGGPgTsDioVwLmUELSb2bZ+1dxHfvXmvg==",
+      "version": "3.2.50",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.50.tgz",
+      "integrity": "sha512-SQRIJSYue/1tIn7X55W/97gTb8UkSoHeFAcBng2r2YMJyWj8uB1DtFl28D8BDXPQXPTiPK89hQGejoT7RdkR2w==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
@@ -1091,9 +1103,9 @@
       }
     },
     "node_modules/@oclif/plugin-help": {
-      "version": "6.2.36",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.36.tgz",
-      "integrity": "sha512-NBQIg5hEMhvdbi4mSrdqRGl5XJ0bqTAHq6vDCCCDXUcfVtdk3ZJbSxtRVWyVvo9E28vwqu6MZyHOJylevqcHbA==",
+      "version": "6.2.50",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.50.tgz",
+      "integrity": "sha512-rNCG4hUm+kPXFbhJfAVk/fZ3OdWJYwBDASlyX8CqOLP0MssjIGl7iEgfZz7TMuZFa+KucupKU5NRSc0KWfPTQA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4"
@@ -1103,13 +1115,13 @@
       }
     },
     "node_modules/@oclif/plugin-not-found": {
-      "version": "3.2.73",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.73.tgz",
-      "integrity": "sha512-2bQieTGI9XNFe9hKmXQjJmHV5rZw+yn7Rud1+C5uLEo8GaT89KZbiLTJgL35tGILahy/cB6+WAs812wjw7TK6w==",
+      "version": "3.2.87",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.87.tgz",
+      "integrity": "sha512-lKyZ4INrx5vB14HNWIkM6Vla/4rWVhOA2U7uCAj6gEBg36/KVmwYXxpZ9ckzZS0+jtLE84TVqS8NCYEhQiQojw==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",
-        "@oclif/core": "^4.8.0",
+        "@oclif/core": "^4.11.4",
         "ansis": "^3.17.0",
         "fast-levenshtein": "^3.0.0"
       },
@@ -1127,28 +1139,28 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.103.10",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.103.10.tgz",
-      "integrity": "sha512-FOxqq47+YVCo4+Eq8eU8+esoLNwcxHHBVhw/JmZwsViTqMB3DF8WorXL+ZwrXW/8srruuzyyx9+ACyRdZ+zbSg==",
+      "version": "1.104.19",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.19.tgz",
+      "integrity": "sha512-SAVg56BAzxZGy/OPQ0jekUG3pJaoX5pCqleALvFo9JRE7P2tvKoglWnYRcIJArRhLlvV8FtFNMDafd+NNwXXCw==",
       "license": "MIT",
       "dependencies": {
-        "@oclif/core": "^4.5.4",
-        "@oclif/plugin-autocomplete": "^3.2.35",
-        "@oclif/plugin-help": "^6.2.33",
-        "@oclif/plugin-not-found": "^3.2.68",
-        "@types/node": "22.13.10",
+        "@oclif/core": "^4.8.4",
+        "@oclif/plugin-autocomplete": "^3.2.40",
+        "@oclif/plugin-help": "^6.2.37",
+        "@oclif/plugin-not-found": "^3.2.74",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
-        "esbuild": "^0.25.10",
+        "esbuild": "^0.27.3",
         "react": "19.0.0"
       },
       "bin": {
         "ray": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.14.0"
+        "node": ">=22.22.2"
       },
       "peerDependencies": {
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "react-devtools": "6.1.1"
       },
@@ -1165,12 +1177,12 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@raycast/api/node_modules/@types/react": {
@@ -1181,6 +1193,12 @@
       "dependencies": {
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@raycast/api/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@raycast/eslint-config": {
       "version": "2.1.1",
@@ -1228,9 +1246,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.2.tgz",
-      "integrity": "sha512-tZcyWCHZvz4L/i1CGEnSZkBoK6wwX1pzlTKjcWWugbrQyG0QCMOxjKJfRC/iNkD+hHaqhMWUj4Y0LNo/NknvFw==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.5.tgz",
+      "integrity": "sha512-1o6zGRECh1KNe6CBx68iMPOrNYbV56opqs4zUtDr6Wmq4F7Ww3d8uLTXKVzXlGyJmpAys/Eliw6cKIP7dPdFfw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1288,13 +1306,13 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
+      "version": "19.2.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/validator": {
@@ -1823,14 +1841,15 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1891,9 +1910,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1903,32 +1922,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2165,9 +2184,9 @@
       }
     },
     "node_modules/execa": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
-      "integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
@@ -2276,18 +2295,18 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2432,9 +2451,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2917,9 +2936,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3051,9 +3070,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3169,13 +3188,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3306,6 +3325,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -3331,9 +3351,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.23",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
-      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"

--- a/extensions/video-downloader/package.json
+++ b/extensions/video-downloader/package.json
@@ -14,7 +14,8 @@
     "litomore",
     "anwarulislam",
     "yusifaliyevpro",
-    "xilopaint"
+    "xilopaint",
+    "chrismessina"
   ],
   "categories": [
     "Applications",
@@ -93,7 +94,7 @@
       "title": "Auto Load URL from Clipboard",
       "description": "Automatically load the URL from the clipboard when the command is executed",
       "type": "checkbox",
-      "label": "Enable",
+      "label": "Load URL from clipboard",
       "default": false,
       "required": false
     },
@@ -102,7 +103,7 @@
       "title": "Auto Load URL from Selected Text",
       "description": "Automatically load the URL from the selected text when the command is executed",
       "type": "checkbox",
-      "label": "Enable",
+      "label": "Load URL from selected text",
       "default": false,
       "required": false
     },
@@ -111,18 +112,36 @@
       "title": "Enable Browser Extension Support",
       "description": "Enable browser extension support for reading video URLs from the browser",
       "type": "checkbox",
-      "label": "Enable",
+      "label": "Read video URLs from the browser",
       "default": false,
       "required": false
     },
     {
       "name": "forceIpv4",
-      "title": "Force IPv4 (Experimental)",
-      "description": "Force IPv4 for network requests, this can be useful if you have some network issues. But this should be a temporary solution. We might remove this option in the future.",
+      "title": "Force IPv4",
+      "description": "Route requests over IPv4. Helps when downloads fail with bot-check or 403 errors (common on YouTube over IPv6) or when your network's IPv6 is unreliable.",
       "type": "checkbox",
-      "label": "Enable",
+      "label": "Force IPv4 for network requests",
       "default": false,
       "required": false
+    },
+    {
+      "name": "cookiesFromBrowser",
+      "title": "Use Cookies from Browser",
+      "description": "Work around auth-protected media, age restrictions, and CAPTCHAs by passing your logged-in browser's cookies.",
+      "type": "dropdown",
+      "default": "none",
+      "required": false,
+      "data": [
+        { "title": "None", "value": "none" },
+        { "title": "Safari", "value": "safari" },
+        { "title": "Chrome", "value": "chrome" },
+        { "title": "Brave", "value": "brave" },
+        { "title": "Microsoft Edge", "value": "edge" },
+        { "title": "Firefox", "value": "firefox" },
+        { "title": "Opera", "value": "opera" },
+        { "title": "Vivaldi", "value": "vivaldi" }
+      ]
     }
   ],
   "ai": {
@@ -179,21 +198,21 @@
     ]
   },
   "dependencies": {
-    "@raycast/api": "^1.103.10",
-    "@raycast/utils": "^2.2.2",
+    "@raycast/api": "^1.104.19",
+    "@raycast/utils": "^2.2.5",
     "@types/validator": "^13.15.10",
-    "date-fns": "^4.1.0",
-    "execa": "^9.6.0",
+    "date-fns": "^4.4.0",
+    "execa": "^9.6.1",
     "pretty-bytes": "^6.1.1",
     "srt-parser-2": "^1.2.3",
-    "validator": "^13.15.23"
+    "validator": "^13.15.35"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",
     "@types/node": "22.13.9",
-    "@types/react": "^19.2.0",
+    "@types/react": "^19.2.16",
     "eslint": "^9.36.0",
-    "prettier": "^3.6.2",
+    "prettier": "^3.8.3",
     "typescript": "^5.8.2"
   },
   "scripts": {

--- a/extensions/video-downloader/src/index.tsx
+++ b/extensions/video-downloader/src/index.tsx
@@ -14,6 +14,7 @@ import {
   showHUD,
   showToast,
   Toast,
+  useNavigation,
 } from "@raycast/api";
 import { useEffect, useMemo, useState } from "react";
 import { useForm, usePromise } from "@raycast/utils";
@@ -26,6 +27,11 @@ import {
   getFormatTitle,
   getFormatValue,
   getytdlPath,
+  getCommonArgs,
+  copyToClipboardAction,
+  describeYtdlpError,
+  looksLikeFilePath,
+  hasPlaylist,
   isMac,
   isValidHHMM,
   isValidUrl,
@@ -37,15 +43,11 @@ import { MP3_FORMAT_ID } from "./utils.js";
 import Installer from "./views/installer.js";
 import Updater from "./views/updater.js";
 
-const {
-  downloadPath,
-  autoLoadUrlFromClipboard,
-  autoLoadUrlFromSelectedText,
-  enableBrowserExtensionSupport,
-  forceIpv4,
-} = getPreferenceValues<ExtensionPreferences>();
+const { downloadPath, autoLoadUrlFromClipboard, autoLoadUrlFromSelectedText, enableBrowserExtensionSupport } =
+  getPreferenceValues<ExtensionPreferences>();
 
 export default function DownloadVideo() {
+  const { push } = useNavigation();
   const [error, setError] = useState(0);
   const [warning, setWarning] = useState("");
 
@@ -61,6 +63,11 @@ export default function DownloadVideo() {
       if (!values.format) return;
       const options = ["-o", path.join(downloadPath, `${video?.title || "video"} (%(id)s).%(ext)s`)];
       const [downloadFormat, recodeFormat] = values.format.split("#");
+
+      // The metadata preview is always for the single video, so default to
+      // --no-playlist; only pull the whole list when the user opted in via the
+      // "Download entire playlist" checkbox (shown only for playlist URLs).
+      options.push(values.downloadPlaylist ? "--yes-playlist" : "--no-playlist");
 
       options.push("--ffmpeg-location", ffmpegPath);
 
@@ -82,11 +89,16 @@ export default function DownloadVideo() {
       options.push("--progress");
       options.push("--print", "after_move:filepath");
 
-      const downloadProcess = spawn(ytdlPath, [...options, values.url], {
+      const downloadProcess = spawn(ytdlPath, [...getCommonArgs(), ...options, values.url], {
         env: { ...globalThis.process.env, PYTHONUNBUFFERED: "1" },
       });
 
       let filePath = "";
+      // Accumulate the full stderr stream so a failure can surface complete logs
+      // via "Copy Logs". `lastErrorLine` is the most useful single line to show
+      // in the toast body when the download fails.
+      const logLines: string[] = [];
+      let lastErrorLine = "";
 
       downloadProcess.stdout.on("data", (data) => {
         const line = data.toString() as string;
@@ -101,27 +113,60 @@ export default function DownloadVideo() {
           toast.message = `${Math.floor(progress)}%`;
         }
 
-        if (isMac ? line.startsWith("/") : line.match(/^[a-zA-Z]:\\/)) {
+        if (looksLikeFilePath(line)) {
           filePath = line.trim();
         }
       });
 
       downloadProcess.stderr.on("data", (data) => {
         const line = data.toString();
+        logLines.push(line);
 
+        // Surface warnings inline, and remember the last error line for the
+        // failure toast — but do NOT touch toast.message here: the running toast
+        // is reserved for download progress (stderr would otherwise clobber it
+        // on every chunk). The exit code in `close` is the real failure verdict.
         if (line.startsWith("WARNING:")) {
           setWarning(line);
         }
-
         if (line.startsWith("ERROR:")) {
-          toast.title = "Download Failed";
-          toast.style = Toast.Style.Failure;
+          lastErrorLine = line.trim();
         }
-        toast.message = line;
       });
 
-      downloadProcess.on("close", () => {
-        if (toast.style === Toast.Style.Failure) {
+      downloadProcess.on("close", (code) => {
+        // The exit code is the sole success/failure verdict: 0 is success,
+        // anything else (including null, i.e. killed by a signal) is a failure.
+        if (code !== 0) {
+          const reason = code === null ? "yt-dlp was terminated" : `yt-dlp exited with code ${code}`;
+          toast.title = "Download Failed";
+          toast.style = Toast.Style.Failure;
+          toast.message = lastErrorLine || reason;
+
+          const logs = logLines.join("").trim() || reason;
+          toast.primaryAction = copyToClipboardAction("Copy Logs", logs, "Copied Logs to Clipboard");
+
+          // If a file actually landed on disk before the non-zero exit (e.g. a
+          // non-fatal postprocessor failure), still let the user open it.
+          if (filePath) {
+            toast.secondaryAction = {
+              title: isMac ? "Open in Finder" : "Open in Explorer",
+              shortcut: { modifiers: ["cmd", "shift"], key: "o" },
+              onAction: () => {
+                open(path.dirname(filePath));
+              },
+            };
+          } else {
+            // "Bad guest token" and similar extractor failures are often resolved
+            // by a newer yt-dlp, so offer a one-key jump to the update view.
+            toast.secondaryAction = {
+              title: "Update Libraries",
+              shortcut: { modifiers: ["cmd", "shift"], key: "u" },
+              onAction: () => {
+                push(<Updater />);
+              },
+            };
+          }
           return;
         }
 
@@ -177,20 +222,19 @@ export default function DownloadVideo() {
     },
   });
 
-  const { data: video, isLoading } = usePromise(
+  const {
+    data: video,
+    isLoading,
+    error: videoError,
+    revalidate,
+  } = usePromise(
     async (url: string) => {
       if (!url) return;
       if (!isValidUrl(url)) return;
 
       const result = await execa(
         ytdlPath,
-        [
-          forceIpv4 ? "--force-ipv4" : "",
-          "--no-playlist",
-          "--dump-json",
-          "--format-sort=resolution,ext,tbr",
-          url,
-        ].filter(Boolean),
+        [...getCommonArgs({ throttle: true }), "--no-playlist", "--dump-json", "--format-sort=res,ext,tbr", url],
         {
           env: {
             ...process.env,
@@ -205,16 +249,26 @@ export default function DownloadVideo() {
     [values.url],
     {
       onError(error) {
+        const friendly = describeYtdlpError(error);
+        // "Try Again" is the primary action only when retrying could help
+        // (transient/rate-limit failures); for an unsupported or unavailable
+        // URL it would be misleading, so Copy Logs leads instead. Copy Logs
+        // always copies the full raw error for debugging, not the summary.
+        const copyLogs = copyToClipboardAction("Copy Logs", error.message, "Copied Logs to Clipboard");
         showToast({
           style: Toast.Style.Failure,
-          title: "Video not found with the provided URL",
-          message: error.message,
-          primaryAction: {
-            title: "Copy to Clipboard",
-            onAction: () => {
-              Clipboard.copy(error.message);
-            },
-          },
+          title: friendly.title,
+          message: friendly.message,
+          primaryAction: friendly.retryable
+            ? {
+                title: "Try Again",
+                shortcut: { modifiers: ["cmd"], key: "r" },
+                onAction: () => {
+                  revalidate();
+                },
+              }
+            : copyLogs,
+          secondaryAction: friendly.retryable ? copyLogs : undefined,
         });
       },
     },
@@ -276,6 +330,17 @@ export default function DownloadVideo() {
 
   const formats = useMemo(() => getFormats(video), [video]);
 
+  // Classify the load error once so the placeholder, the Title row, and the
+  // Try Again action all agree on whether a retry would help.
+  const friendlyError = videoError ? describeYtdlpError(videoError) : null;
+
+  // Friendlier, state-aware placeholder for the Title row. Em dash means "no URL
+  // queried yet". On a retryable error, nudge toward Try Again; otherwise show
+  // the reason (e.g. "Unsupported Site") since retrying won't help.
+  const titlePlaceholder =
+    video?.title ??
+    (friendlyError ? (friendlyError.retryable ? "Couldn't load — press ⌘R to try again" : friendlyError.title) : "—");
+
   if (missingExecutable) {
     return <Installer executable={missingExecutable} onRefresh={() => setError(error + 1)} />;
   }
@@ -294,6 +359,19 @@ export default function DownloadVideo() {
                 handleSubmit({ ...values, copyToClipboard: false } as DownloadOptions);
               }}
             />
+            {/* Only offer Try Again when revalidating could actually help: a
+                retryable fetch error, or a valid URL that hasn't loaded yet.
+                Invalid URLs (no-op re-query) and non-retryable errors like
+                "Unsupported Site" are excluded. */}
+            {((friendlyError?.retryable ?? false) ||
+              (!video && !isLoading && !videoError && isValidUrl(values.url))) && (
+              <Action
+                icon={Icon.ArrowClockwise}
+                title="Try Again"
+                shortcut={{ modifiers: ["cmd"], key: "r" }}
+                onAction={() => revalidate()}
+              />
+            )}
           </ActionPanel.Section>
           <ActionPanel.Section>
             <Action.Push icon={Icon.Hammer} title="Update Libraries" target={<Updater />} />
@@ -307,7 +385,7 @@ export default function DownloadVideo() {
         />
       }
     >
-      <Form.Description title="Title" text={video?.title ?? "Video not found"} />
+      <Form.Description title="Title" text={titlePlaceholder} />
       <Form.TextField
         {...itemProps.url}
         autoFocus
@@ -329,6 +407,14 @@ export default function DownloadVideo() {
             </Form.Dropdown.Section>
           ))}
         </Form.Dropdown>
+      )}
+      {hasPlaylist(values.url) && (
+        <Form.Checkbox
+          {...itemProps.downloadPlaylist}
+          title="Playlist"
+          label="Download entire playlist"
+          info="This URL is part of a playlist. Leave unchecked to download only the video shown above."
+        />
       )}
     </Form>
   );

--- a/extensions/video-downloader/src/tools/download-video.ts
+++ b/extensions/video-downloader/src/tools/download-video.ts
@@ -3,10 +3,11 @@ import {
   getFormatValue,
   getFormats,
   downloadPath,
-  forceIpv4,
   getytdlPath,
   getffmpegPath,
   getffprobePath,
+  getCommonArgs,
+  looksLikeFilePath,
   sanitizeVideoTitle,
 } from "../utils.js";
 import fs from "node:fs";
@@ -36,13 +37,16 @@ export default async function tool(input: Input) {
     throw new Error("ffprobe is not installed");
   }
 
-  // Get video info and available formats
-  const videoInfo = await execa(
-    ytdlPath,
-    [forceIpv4 ? "--force-ipv4" : "", "--dump-json", "--format-sort=resolution,ext,tbr", input.url].filter((x) =>
-      Boolean(x),
-    ),
-  );
+  // Get video info and available formats. --no-playlist keeps this to a single
+  // video so --dump-json emits one JSON object (a playlist would emit one per
+  // line and break JSON.parse below).
+  const videoInfo = await execa(ytdlPath, [
+    ...getCommonArgs({ throttle: true }),
+    "--no-playlist",
+    "--dump-json",
+    "--format-sort=res,ext,tbr",
+    input.url,
+  ]);
 
   const video = JSON.parse(videoInfo.stdout) as Video;
 
@@ -51,8 +55,9 @@ export default async function tool(input: Input) {
     throw new Error("Live streams are not supported");
   }
 
-  // Set up download options
-  const options: string[] = ["-P", downloadPath];
+  // Set up download options. --no-playlist matches the single-video metadata
+  // fetched above, so a playlist URL downloads just the requested video.
+  const options: string[] = [...getCommonArgs(), "--no-playlist", "-P", downloadPath];
 
   // Getet the best video+audio format
   const formats = getFormats(video);
@@ -74,8 +79,8 @@ export default async function tool(input: Input) {
     throw new Error(`Failed to download video: ${result.stderr}`);
   }
 
-  // Extract file path from output
-  const filePath = result.stdout.split("\n").find((line) => line.startsWith("/"));
+  // Extract file path from output (cross-platform: POSIX path or Windows drive path)
+  const filePath = result.stdout.split("\n").find((line) => looksLikeFilePath(line.trim()));
 
   if (!filePath) {
     throw new Error("Could not determine downloaded file path");

--- a/extensions/video-downloader/src/transcript.ts
+++ b/extensions/video-downloader/src/transcript.ts
@@ -2,7 +2,7 @@ import { execa } from "execa";
 import fs from "node:fs";
 import path from "path";
 import { Video } from "./types.js";
-import { downloadPath, forceIpv4, getffmpegPath, getytdlPath, sanitizeVideoTitle } from "./utils.js";
+import { downloadPath, getffmpegPath, getytdlPath, getCommonArgs, sanitizeVideoTitle } from "./utils.js";
 import SRTParser from "srt-parser-2";
 
 export default async function extractTranscript(url: string, language: string = "en") {
@@ -18,7 +18,7 @@ export default async function extractTranscript(url: string, language: string = 
   }
 
   // First get video info to get the title
-  const videoInfo = await execa(ytdlPath, [forceIpv4 ? "--force-ipv4" : "", "--dump-json", url].filter(Boolean));
+  const videoInfo = await execa(ytdlPath, [...getCommonArgs({ throttle: true }), "--dump-json", url]);
 
   const video = JSON.parse(videoInfo.stdout) as Video;
 
@@ -36,6 +36,7 @@ export default async function extractTranscript(url: string, language: string = 
   try {
     // Download subtitles using yt-dlp
     const subtitleResult = await execa(ytdlPath, [
+      ...getCommonArgs({ throttle: true }),
       "--write-sub", // Write subtitle file
       "--write-auto-sub", // Write automatically generated subtitles
       "--skip-download", // Don't download the video
@@ -54,12 +55,28 @@ export default async function extractTranscript(url: string, language: string = 
       throw new Error("Failed to download subtitles");
     }
 
-    // Find the downloaded subtitle file
-    const files = fs.readdirSync(tmpDir);
-    const subtitleFile = files.find((f) => f.endsWith(".srt"));
+    // Find the downloaded subtitle file. yt-dlp names files `<id>.<lang>.srt`
+    // (e.g. `abc.en.srt`, `abc.en-US.srt`, `abc.en-orig.srt`). Match the
+    // requested language (and its regional/auto variants) so we don't return a
+    // fallback-language track as if it were the requested transcript.
+    const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith(".srt"));
+    const wanted = language.toLowerCase();
+    const subtitleFile = files.find((f) => {
+      const lang = f.slice(0, -".srt".length).split(".").pop()?.toLowerCase() ?? "";
+      return lang === wanted || lang.startsWith(`${wanted}-`);
+    });
 
     if (!subtitleFile) {
-      throw new Error(`No ${language} subtitles found for this video`);
+      // Surface the languages we did get, to make the failure actionable.
+      const available = files
+        .map((f) => f.slice(0, -".srt".length).split(".").pop())
+        .filter(Boolean)
+        .join(", ");
+      throw new Error(
+        available
+          ? `No ${language} subtitles found for this video (available: ${available})`
+          : `No ${language} subtitles found for this video`,
+      );
     }
 
     // Read and parse the subtitle file

--- a/extensions/video-downloader/src/utils.ts
+++ b/extensions/video-downloader/src/utils.ts
@@ -73,7 +73,16 @@ export function describeYtdlpError(error: unknown): FriendlyError {
   if (lower.includes("unable to download") && lower.includes("404")) {
     return { title: "Video Not Found", message: "This video doesn't exist or has been removed.", retryable: false };
   }
-  if (lower.includes("private") || lower.includes("members-only") || lower.includes("sign in")) {
+  // yt-dlp emits "members only" (with a space, e.g. "Premium members only",
+  // "Channel members only"), not "members-only"; also covers private videos,
+  // login prompts, and channel-membership gates.
+  if (
+    lower.includes("private") ||
+    lower.includes("members only") ||
+    lower.includes("sign in") ||
+    lower.includes("login required") ||
+    lower.includes("join this channel")
+  ) {
     return {
       title: "Video Requires Sign-In",
       message: "This video is private or restricted. Try the “Use Cookies from Browser” preference.",

--- a/extensions/video-downloader/src/utils.ts
+++ b/extensions/video-downloader/src/utils.ts
@@ -83,7 +83,9 @@ export function describeYtdlpError(error: unknown): FriendlyError {
   if (lower.includes("unavailable") || lower.includes("removed") || lower.includes("deleted")) {
     return { title: "Video Unavailable", message: "This video is no longer available.", retryable: false };
   }
-  if (lower.includes("bad guest token") || lower.includes("rate") || lower.includes("429")) {
+  // Match real rate-limiting messages with a word boundary so "bitrate",
+  // "framerate", "sample rate", etc. don't get misclassified as transient.
+  if (lower.includes("bad guest token") || /\brate[ -]?limit/.test(lower) || lower.includes("429")) {
     return {
       title: "Temporary Rate Limit",
       message: "The site is rate-limiting requests. Try again, or set the “Use Cookies from Browser” preference.",

--- a/extensions/video-downloader/src/utils.ts
+++ b/extensions/video-downloader/src/utils.ts
@@ -1,4 +1,4 @@
-import { getPreferenceValues } from "@raycast/api";
+import { Clipboard, getPreferenceValues, showHUD, Toast } from "@raycast/api";
 import { formatDuration, intervalToDuration } from "date-fns";
 import validator from "validator";
 import { Format, Video } from "./types.js";
@@ -7,6 +7,106 @@ import { execSync } from "child_process";
 
 export const isWindows = process.platform === "win32";
 export const isMac = process.platform === "darwin";
+
+// A downloaded file path is reported by yt-dlp's `--print after_move:filepath`
+// on stdout. Detect it cross-platform: an absolute POSIX path on macOS/Linux,
+// or a drive-letter path (e.g. C:\...) on Windows.
+export function looksLikeFilePath(line: string): boolean {
+  return isWindows ? /^[a-zA-Z]:\\/.test(line) : line.startsWith("/");
+}
+
+// Whether a URL points at (or into) a playlist. YouTube and most sites carry a
+// `list=` query param on playlist/“watch in playlist” URLs. Used to offer an
+// opt-in "download entire playlist" choice; without it we pass --no-playlist so
+// a single shared link doesn't pull down the whole list.
+export function hasPlaylist(url: string): boolean {
+  try {
+    return new URL(url).searchParams.has("list");
+  } catch {
+    // Not a fully-qualified URL (validator allows protocol-less input) — fall
+    // back to a substring check on the query portion.
+    return /[?&]list=/.test(url);
+  }
+}
+
+// Pull the raw yt-dlp output from an error. execa puts the command line in
+// `error.message`/`shortMessage` (noise we don't want to show) and the actual
+// yt-dlp output in `error.stderr` — prefer that.
+function getYtdlpStderr(error: unknown): string {
+  if (error && typeof error === "object" && "stderr" in error && typeof error.stderr === "string") {
+    return error.stderr;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+export type FriendlyError = {
+  title: string;
+  message: string;
+  // Whether retrying the same URL could plausibly help. Transient failures
+  // (rate limits, network) are retryable; "unsupported site" / "unavailable"
+  // are not, so the UI can hide a misleading "Try Again".
+  retryable: boolean;
+};
+
+// Turn a raw yt-dlp/execa failure into a human-readable title + message and a
+// retryable flag, instead of dumping the full `execa` command line at the user.
+export function describeYtdlpError(error: unknown): FriendlyError {
+  const stderr = getYtdlpStderr(error);
+  // yt-dlp prints the real cause on a line starting with "ERROR:"; surface that
+  // rather than the "Command failed with exit code 1: /opt/homebrew/bin/…" line.
+  const errorLine =
+    stderr
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => l.startsWith("ERROR:"))
+      ?.replace(/^ERROR:\s*/, "") ?? stderr.trim();
+
+  const lower = errorLine.toLowerCase();
+
+  if (lower.includes("unsupported url")) {
+    return {
+      title: "Unsupported Site",
+      message: "This URL isn't from a site Video Downloader can download from. Check the supported sites list.",
+      retryable: false,
+    };
+  }
+  if (lower.includes("unable to download") && lower.includes("404")) {
+    return { title: "Video Not Found", message: "This video doesn't exist or has been removed.", retryable: false };
+  }
+  if (lower.includes("private") || lower.includes("members-only") || lower.includes("sign in")) {
+    return {
+      title: "Video Requires Sign-In",
+      message: "This video is private or restricted. Try the “Use Cookies from Browser” preference.",
+      retryable: false,
+    };
+  }
+  if (lower.includes("unavailable") || lower.includes("removed") || lower.includes("deleted")) {
+    return { title: "Video Unavailable", message: "This video is no longer available.", retryable: false };
+  }
+  if (lower.includes("bad guest token") || lower.includes("rate") || lower.includes("429")) {
+    return {
+      title: "Temporary Rate Limit",
+      message: "The site is rate-limiting requests. Try again, or set the “Use Cookies from Browser” preference.",
+      retryable: true,
+    };
+  }
+
+  // Unknown failure: show the cleaned error line and allow a retry.
+  return { title: "Couldn't Load Video", message: errorLine || "yt-dlp could not read this URL.", retryable: true };
+}
+
+// Standard "copy to clipboard" toast action, shared so the shortcut, HUD, and
+// wording stay consistent across the failure/success toasts.
+export function copyToClipboardAction(title: string, text: string, hud = "Copied to Clipboard"): Toast.ActionOptions {
+  return {
+    title,
+    shortcut: { modifiers: ["cmd", "shift"], key: "c" },
+    onAction: () => {
+      Clipboard.copy(text);
+      showHUD(hud);
+    },
+  };
+}
 
 function sanitizeWindowsPath(path: string): string {
   return path.replace(/\r/g, "").replace(/\n/g, "").trim();
@@ -19,6 +119,7 @@ export const {
   autoLoadUrlFromSelectedText,
   enableBrowserExtensionSupport,
   forceIpv4,
+  cookiesFromBrowser,
   ytdlPath: ytdlPathPreference,
   ffmpegPath: ffmpegPathPreference,
   ffprobePath: ffprobePathPreference,
@@ -90,7 +191,40 @@ export type DownloadOptions = {
   copyToClipboard: boolean;
   startTime?: string;
   endTime?: string;
+  downloadPlaylist?: boolean;
 };
+
+// Shared yt-dlp arguments applied to every invocation (metadata, download,
+// transcript). Centralizes the network/extractor resilience flags so they stay
+// consistent across call sites.
+//
+// Why these flags:
+// - X/Twitter rate-limits anonymous "guest token" access, surfacing as
+//   "Bad guest token". `--cookies-from-browser` makes yt-dlp use the user's
+//   logged-in session instead, which is the durable fix. (Opt-in preference.)
+// - `--extractor-retries` retries known extractor errors. Gated behind
+//   `throttle` so a genuinely-failing *download* doesn't retry the extractor
+//   three times before reporting failure (the interactive download already has
+//   a manual "Try Again"); metadata lookups keep the retries.
+// - `--sleep-requests` spaces out *API* requests to avoid tripping rate limits.
+//   Also gated behind `throttle`: it must NOT be applied to downloads, where it
+//   would sleep before every media segment (e.g. +1s × hundreds of HLS
+//   segments). Use `throttle: true` only for extractor/metadata calls, where
+//   the retries and throttling actually help.
+export function getCommonArgs({ throttle = false }: { throttle?: boolean } = {}): string[] {
+  const args: string[] = [];
+
+  if (forceIpv4) args.push("--force-ipv4");
+  if (cookiesFromBrowser && cookiesFromBrowser !== "none") {
+    args.push("--cookies-from-browser", cookiesFromBrowser);
+  }
+  if (throttle) {
+    args.push("--extractor-retries", "3");
+    args.push("--sleep-requests", "1");
+  }
+
+  return args;
+}
 
 export function formatHHMM(seconds: number) {
   const duration = intervalToDuration({ start: 0, end: seconds * 1000 });
@@ -228,17 +362,16 @@ export function sanitizeVideoTitle(name: string): string {
   // Replace double or more spaces with single space
   safe = safe.replace(/\s+/g, " ");
 
-  // Hard truncate to max length
-  safe = safe.slice(0, maxLen);
-
-  // Truncate to max length at a sensible boundary if possible (like a punctuation mark)
-  const cutoffSymbols = /[.!?]/g;
-  const match = [...safe.matchAll(cutoffSymbols)]
-    .map((m) => m.index)
-    .filter((idx) => idx !== undefined && idx <= maxLen);
-
-  if (match.length > 0) {
-    safe = safe.slice(0, match[match.length - 1]);
+  // Cap the length. If we have to cut, prefer the last word boundary before the
+  // limit so we don't slice mid-word — but only when the title actually exceeds
+  // maxLen. (The previous version cut at the last ".!?" anywhere in the title,
+  // which truncated "Dr. Mehmet Oz…" to "Dr" and "U.S. Economy" to "U.S".)
+  if (safe.length > maxLen) {
+    safe = safe.slice(0, maxLen);
+    const lastSpace = safe.lastIndexOf(" ");
+    if (lastSpace > 0) {
+      safe = safe.slice(0, lastSpace);
+    }
   }
 
   return safe.trim() || "untitled";

--- a/extensions/video-downloader/src/views/updater.tsx
+++ b/extensions/video-downloader/src/views/updater.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Action, ActionPanel, Clipboard, Detail, Icon, Toast, getPreferenceValues, useNavigation } from "@raycast/api";
 import { execa } from "execa";
+import { format } from "date-fns";
 import { getWingetPath, isMac, isWindows } from "../utils.js";
 
 const { homebrewPath } = getPreferenceValues<ExtensionPreferences>();
@@ -13,6 +14,8 @@ export default function Updater() {
   const [outdated, setOutdated] = useState<Record<string, string>>(
     isMac ? { "yt-dlp": "", ffmpeg: "" } : { "yt-dlp": "" },
   );
+  const [lastChecked, setLastChecked] = useState<Date | null>(null);
+  const [checkError, setCheckError] = useState<string>("");
   const [upgradingMessage, setUpgradingMessage] = useState<string>("");
 
   const allUpToDate = Object.values(outdated).every((version) => !version);
@@ -21,15 +24,21 @@ export default function Updater() {
     if (upgradingMessage) return;
     const toast = new Toast({ style: Toast.Style.Animated, title: "Checking versions..." });
     toast.show();
+    setLastChecked(null); // reset so the timestamp/loading state reflect this run, not a prior one
+    setCheckError("");
 
     Promise.all([getVersions(), getOutdated()])
       .then(([versions, outdated]) => {
         toast.hide();
         setVersions(versions);
         setOutdated(outdated);
+        setLastChecked(new Date());
       })
       .catch((error) => {
         const errorMessage = error instanceof Error ? error.message : "An unknown error occurred";
+        // Record the error so the Detail body shows it and stops loading —
+        // otherwise the view would sit on a permanent "Checking…" spinner.
+        setCheckError(errorMessage);
         toast.style = Toast.Style.Failure;
         toast.title = "Failed to check versions";
         toast.message = errorMessage;
@@ -44,18 +53,32 @@ export default function Updater() {
       });
   }, [upgradingMessage]);
 
+  const checked = Boolean(lastChecked);
+  const versionLines = Object.entries(versions)
+    .map(([cli, version]) => {
+      // A failed check shows an em dash (the error block below explains why),
+      // rather than a permanent "Checking…".
+      if (checkError) return `${cli}: —`;
+      // Until the check resolves, show only "Checking…" with no status — the
+      // previous code rendered "(up to date)" before results came back.
+      if (!checked) return `${cli}: Checking…`;
+      // An empty version means the check couldn't determine it (e.g. winget
+      // parse miss) — don't assert "(up to date)" for an unknown version.
+      if (!version) return `${cli}: Unknown`;
+      const status = outdated[cli] ? `(update available: ${outdated[cli]})` : "(up to date)";
+      return `${cli}: ${version} ${status}`;
+    })
+    .join("\n\n");
+
+  // A timestamp makes the instantaneous check legible: the result is real, just
+  // fast. Better than a fake spinner delay.
+  const checkedAt = checked ? `_Checked at ${format(lastChecked as Date, "h:mm a 'on' MMM d")}_` : "";
+  const errorBlock = checkError ? `> ⚠️ Couldn't check versions: ${checkError}` : "";
+
   return (
     <Detail
-      markdown={[
-        "## Versions",
-        Object.entries(versions)
-          .map(
-            ([cli, version]) =>
-              `${cli}: ${version === "" ? "Checking..." : version} ${outdated[cli] ? `(outdated: ${outdated[cli]})` : "(up to date)"}`,
-          )
-          .join("\n\n"),
-        upgradingMessage,
-      ]
+      isLoading={!checked && !checkError && !upgradingMessage}
+      markdown={["## Versions", versionLines, checkedAt, errorBlock, upgradingMessage]
         .filter((x) => Boolean(x))
         .join("\n\n")}
       actions={


### PR DESCRIPTION
## Description

Reliability and UX improvements to the Video Downloader extension, focused on failure handling and a few common pain points.

**Networking / extractor resilience**
- New **Use Cookies from Browser** preference (Safari/Chrome/Brave/Edge/Firefox/Opera/Vivaldi). Passes `--cookies-from-browser` so sites that rate-limit anonymous access — notably X/Twitter's "Bad guest token" error — use your logged-in session. Also helps with age-restricted and private posts.
- Metadata/extractor lookups retry and space out requests (`--extractor-retries`, `--sleep-requests`); these are deliberately **not** applied to media downloads (where per-segment sleeps would add minutes).
- Refreshed the **Force IPv4** preference copy (it helps with YouTube IPv6 bot-check/403 errors).

**Error handling & recovery**
- Failures now show plain-language messages (e.g. "Unsupported Site", "Video Unavailable") instead of the raw `yt-dlp` command line, and only offer **Try Again** (⌘R) when a retry could actually help.
- Added **Copy Logs** and **Update Libraries** actions to failure toasts.
- Download success/failure is now determined by the `yt-dlp` exit code; a file that downloaded despite a non-fatal post-processing error stays openable.
- Download progress in the toast is no longer overwritten by background log output.

**Other fixes**
- Opt-in **Download entire playlist** checkbox for playlist URLs (defaults to just the linked video).
- Fixed video titles being truncated at the first `.`/`!`/`?` (e.g. "Dr. Mehmet Oz…" became "Dr").
- Transcript extraction returns the requested language instead of a fallback track.
- Fixed download file-path detection on Windows.
- The Update Libraries view shows a "checked at" timestamp and a real error state instead of spinning forever.
- Updated dependencies.

## Screencast

N/A — behavioral/reliability changes; no new visual UI beyond the playlist checkbox and the cookies preference.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build for issues](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that this change does not break existing functionality (default behavior is unchanged; new preferences are opt-in)
- [x] I checked that the extension's `CHANGELOG.md` entry uses the `{PR_MERGE_DATE}` placeholder