### PR TITLE
[blip-raycast] Add Windows cross-platform support

### DIFF
--- a/extensions/blip-raycast/CHANGELOG.md
+++ b/extensions/blip-raycast/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Blip Changelog
 
+## [Added Windows support] - 2026-06-04
+
+- Added cross-platform support for Windows via PowerShell automation
+- File Explorer selection detection on Windows using Shell.Application COM automation
+- Blip invocation on Windows via registered shell context menu verb
+- Platform-aware UI strings: "Finder" on macOS, "File Explorer" on Windows
+
 ## [Bug Fixes] - 2026-05-05
 
 - Fix triggering Blip from Finder Services on localized macOS systems.

--- a/extensions/blip-raycast/CHANGELOG.md
+++ b/extensions/blip-raycast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Blip Changelog
 
-## [Added Windows support] - {PR_MERGE_DATE}
+## [Added Windows support] - 2026-06-04
 
 - Added cross-platform support for Windows via PowerShell automation
 - File Explorer selection detection on Windows using Shell.Application COM automation

--- a/extensions/blip-raycast/CHANGELOG.md
+++ b/extensions/blip-raycast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Blip Changelog
 
-## [Added Windows support] - 2026-06-04
+## [Added Windows support] - {PR_MERGE_DATE}
 
 - Added cross-platform support for Windows via PowerShell automation
 - File Explorer selection detection on Windows using Shell.Application COM automation

--- a/extensions/blip-raycast/package-lock.json
+++ b/extensions/blip-raycast/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.99.3"
+        "@raycast/api": "^1.99.3",
+        "@raycast/utils": "^2.2.5"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.0.8",
@@ -1207,6 +1208,24 @@
         "eslint": ">=8.23.0"
       }
     },
+    "node_modules/@raycast/utils": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.5.tgz",
+      "integrity": "sha512-1o6zGRECh1KNe6CBx68iMPOrNYbV56opqs4zUtDr6Wmq4F7Ww3d8uLTXKVzXlGyJmpAys/Eliw6cKIP7dPdFfw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@raycast/api": ">=1.99.4",
+        "react": ">=19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1227,7 +1246,6 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1287,7 +1305,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -1492,7 +1509,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1761,6 +1777,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -1841,7 +1866,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2619,7 +2643,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2643,7 +2666,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2850,7 +2872,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/blip-raycast/package-lock.json
+++ b/extensions/blip-raycast/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.99.3",
-        "@raycast/utils": "^2.2.5"
+        "@raycast/api": "^1.99.3"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.0.8",
@@ -1208,24 +1207,6 @@
         "eslint": ">=8.23.0"
       }
     },
-    "node_modules/@raycast/utils": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.5.tgz",
-      "integrity": "sha512-1o6zGRECh1KNe6CBx68iMPOrNYbV56opqs4zUtDr6Wmq4F7Ww3d8uLTXKVzXlGyJmpAys/Eliw6cKIP7dPdFfw==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      },
-      "peerDependencies": {
-        "@raycast/api": ">=1.99.4",
-        "react": ">=19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1246,6 +1227,7 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1305,6 +1287,7 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -1509,6 +1492,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1614,9 +1598,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1777,15 +1761,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -1866,6 +1841,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2643,6 +2619,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2666,6 +2643,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2872,6 +2850,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/blip-raycast/package.json
+++ b/extensions/blip-raycast/package.json
@@ -16,7 +16,8 @@
   "title": "Blip",
   "icon": "blip-icon.png",
   "dependencies": {
-    "@raycast/api": "^1.99.3"
+    "@raycast/api": "^1.99.3",
+    "@raycast/utils": "^2.2.5"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.0.8",
@@ -38,12 +39,16 @@
     },
     {
       "name": "send-selected-finder-item",
-      "title": "Send Selected Finder Item to Blip",
-      "description": "Send the current Finder selection to Blip. Requires Raycast Accessibility permission.",
+      "title": "Send Selected File to Blip",
+      "description": "Send the current file manager selection to Blip. Requires Raycast Accessibility permission.",
       "mode": "no-view"
     }
   ],
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
+  ],
+  "contributors": [
+    "brunocbreis"
   ]
 }

--- a/extensions/blip-raycast/package.json
+++ b/extensions/blip-raycast/package.json
@@ -16,8 +16,7 @@
   "title": "Blip",
   "icon": "blip-icon.png",
   "dependencies": {
-    "@raycast/api": "^1.99.3",
-    "@raycast/utils": "^2.2.5"
+    "@raycast/api": "^1.99.3"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.0.8",

--- a/extensions/blip-raycast/src/blip.ts
+++ b/extensions/blip-raycast/src/blip.ts
@@ -1,8 +1,11 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { promisify } from "node:util";
+import { runPowerShellScript } from "@raycast/utils";
+import { isMac } from "./platform";
 
 const execFileAsync = promisify(execFile);
+
 const ACCESSIBILITY_SETTINGS_PATH = "System Settings > Privacy & Security > Accessibility";
 const ACCESSIBILITY_ERROR_PREFIX = "Raycast needs Accessibility permission to trigger Blip via Finder Services.";
 const SERVICES_SETTINGS_PATH = "System Settings > Keyboard > Keyboard Shortcuts > Services";
@@ -18,6 +21,14 @@ export async function sendPathToBlip(path: string) {
     throw new Error(`Path does not exist: ${path}`);
   }
 
+  if (isMac) {
+    await sendPathToBlipMac(path);
+  } else {
+    await sendPathToBlipWindows(path);
+  }
+}
+
+async function sendPathToBlipMac(path: string) {
   const script = buildBlipFinderServiceScript(path);
 
   try {
@@ -29,6 +40,50 @@ export async function sendPathToBlip(path: string) {
     const details = error instanceof Error ? error.message : "Unknown AppleScript failure.";
     throw new Error(buildAppleScriptError(details));
   }
+}
+
+async function sendPathToBlipWindows(path: string) {
+  // Invoke the "Blip" context menu verb via PowerShell Shell.Application COM automation.
+  // This mirrors the macOS Services approach: find the registered Blip shell verb and execute it.
+  const escapedPath = path.replace(/'/g, "''");
+  const script = `
+try {
+  $filePath = '${escapedPath}'
+  $folder = Split-Path $filePath -Parent
+  $file = Split-Path $filePath -Leaf
+  $shell = New-Object -ComObject Shell.Application
+  $shellFolder = $shell.NameSpace($folder)
+  if ($null -eq $shellFolder) { throw 'folder_not_found' }
+  $shellFile = $shellFolder.ParseName($file)
+  if ($null -eq $shellFile) { throw 'file_not_found' }
+  $blipVerb = @($shellFile.Verbs() | Where-Object { $_.Name -match 'Blip' })
+  if ($blipVerb.Count -eq 0) { throw 'blip_not_found' }
+  $blipVerb[0].DoIt()
+} catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}`;
+
+  try {
+    await runPowerShellScript(script);
+  } catch (error) {
+    const details = error instanceof Error ? error.message : "Unknown error.";
+    throw new Error(buildWindowsError(details));
+  }
+}
+
+function buildWindowsError(details: string): string {
+  const normalized = details.toLowerCase();
+
+  if (normalized.includes("blip_not_found")) {
+    return "Blip's Windows context menu was not found. Make sure Blip is installed and its shell extension is enabled.";
+  }
+
+  if (normalized.includes("folder_not_found") || normalized.includes("file_not_found")) {
+    return "Could not access the selected file. Make sure it exists and you have permission to read it.";
+  }
+
+  return `Blip could not be triggered. ${details}`;
 }
 
 function buildBlipFinderServiceScript(path: string) {

--- a/extensions/blip-raycast/src/blip.ts
+++ b/extensions/blip-raycast/src/blip.ts
@@ -1,8 +1,8 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { promisify } from "node:util";
-import { runPowerShellScript } from "@raycast/utils";
 import { isMac } from "./platform";
+import { buildWindowsBlipVerbScript, getWindowsPowerShellArguments } from "./windows-scripts";
 
 const execFileAsync = promisify(execFile);
 
@@ -43,29 +43,10 @@ async function sendPathToBlipMac(path: string) {
 }
 
 async function sendPathToBlipWindows(path: string) {
-  // Invoke the "Blip" context menu verb via PowerShell Shell.Application COM automation.
-  // This mirrors the macOS Services approach: find the registered Blip shell verb and execute it.
-  const escapedPath = path.replace(/'/g, "''");
-  const script = `
-try {
-  $filePath = '${escapedPath}'
-  $folder = Split-Path $filePath -Parent
-  $file = Split-Path $filePath -Leaf
-  $shell = New-Object -ComObject Shell.Application
-  $shellFolder = $shell.NameSpace($folder)
-  if ($null -eq $shellFolder) { throw 'folder_not_found' }
-  $shellFile = $shellFolder.ParseName($file)
-  if ($null -eq $shellFile) { throw 'file_not_found' }
-  $blipVerb = @($shellFile.Verbs() | Where-Object { $_.Name -match 'Blip' })
-  if ($blipVerb.Count -eq 0) { throw 'blip_not_found' }
-  $blipVerb[0].DoIt()
-} catch {
-  Write-Error $_.Exception.Message
-  exit 1
-}`;
+  const script = buildWindowsBlipVerbScript(path);
 
   try {
-    await runPowerShellScript(script);
+    await execFileAsync("powershell.exe", getWindowsPowerShellArguments(script), { timeout: 10000 });
   } catch (error) {
     const details = error instanceof Error ? error.message : "Unknown error.";
     throw new Error(buildWindowsError(details));

--- a/extensions/blip-raycast/src/finder.ts
+++ b/extensions/blip-raycast/src/finder.ts
@@ -1,6 +1,10 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { getSelectedFinderItems } from "@raycast/api";
-import { runPowerShellScript } from "@raycast/utils";
 import { fileManagerName, isMac } from "./platform";
+import { buildSelectedExplorerPathScript, getWindowsPowerShellArguments } from "./windows-scripts";
+
+const execFileAsync = promisify(execFile);
 
 export async function getFirstSelectedFilePath(): Promise<string> {
   if (isMac) {
@@ -15,22 +19,11 @@ export async function getFirstSelectedFilePath(): Promise<string> {
 }
 
 async function getFirstSelectedExplorerPath(): Promise<string> {
-  const script = `
-try {
-  $shell = New-Object -ComObject Shell.Application
-  $windows = @($shell.Windows())
-  $exp = @($windows | Where-Object { $_ -ne $null -and $_.Name -match 'Explorer' })
-  if ($exp.Count -eq 0) { throw 'no_window' }
-  $items = @($exp[0].Document.SelectedItems())
-  if ($items.Count -eq 0) { throw 'no_selection' }
-  Write-Output $items[0].Path
-} catch {
-  Write-Error $_.Exception.Message
-  exit 1
-}`;
+  const script = buildSelectedExplorerPathScript();
 
   try {
-    const path = (await runPowerShellScript(script)).trim();
+    const { stdout } = await execFileAsync("powershell.exe", getWindowsPowerShellArguments(script), { timeout: 10000 });
+    const path = stdout.trim();
     if (!path) throw new Error("no_selection");
     return path;
   } catch (error) {

--- a/extensions/blip-raycast/src/finder.ts
+++ b/extensions/blip-raycast/src/finder.ts
@@ -1,11 +1,39 @@
 import { getSelectedFinderItems } from "@raycast/api";
+import { runPowerShellScript } from "@raycast/utils";
+import { fileManagerName, isMac } from "./platform";
 
-export async function getFirstSelectedFinderPath() {
-  const selectedItems = await getSelectedFinderItems();
-
-  if (selectedItems.length === 0) {
-    throw new Error("No Finder item is selected.");
+export async function getFirstSelectedFilePath(): Promise<string> {
+  if (isMac) {
+    const selectedItems = await getSelectedFinderItems();
+    if (selectedItems.length === 0) {
+      throw new Error(`No ${fileManagerName} item is selected.`);
+    }
+    return selectedItems[0].path;
   }
 
-  return selectedItems[0].path;
+  return getFirstSelectedExplorerPath();
+}
+
+async function getFirstSelectedExplorerPath(): Promise<string> {
+  const script = `
+try {
+  $shell = New-Object -ComObject Shell.Application
+  $windows = @($shell.Windows())
+  $exp = @($windows | Where-Object { $_ -ne $null -and $_.Name -match 'Explorer' })
+  if ($exp.Count -eq 0) { throw 'no_window' }
+  $items = @($exp[0].Document.SelectedItems())
+  if ($items.Count -eq 0) { throw 'no_selection' }
+  Write-Output $items[0].Path
+} catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}`;
+
+  try {
+    const path = (await runPowerShellScript(script)).trim();
+    if (!path) throw new Error();
+    return path;
+  } catch {
+    throw new Error(`No ${fileManagerName} item is selected.`);
+  }
 }

--- a/extensions/blip-raycast/src/finder.ts
+++ b/extensions/blip-raycast/src/finder.ts
@@ -31,9 +31,13 @@ try {
 
   try {
     const path = (await runPowerShellScript(script)).trim();
-    if (!path) throw new Error();
+    if (!path) throw new Error("no_selection");
     return path;
-  } catch {
-    throw new Error(`No ${fileManagerName} item is selected.`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("no_selection") || message.includes("no_window")) {
+      throw new Error(`No ${fileManagerName} item is selected.`);
+    }
+    throw new Error(`Failed to read ${fileManagerName} selection: ${message}`);
   }
 }

--- a/extensions/blip-raycast/src/platform.ts
+++ b/extensions/blip-raycast/src/platform.ts
@@ -1,3 +1,2 @@
 export const isMac = process.platform === "darwin";
-export const isWindows = process.platform === "win32";
 export const fileManagerName = isMac ? "Finder" : "File Explorer";

--- a/extensions/blip-raycast/src/platform.ts
+++ b/extensions/blip-raycast/src/platform.ts
@@ -1,0 +1,3 @@
+export const isMac = process.platform === "darwin";
+export const isWindows = process.platform === "win32";
+export const fileManagerName = isMac ? "Finder" : "File Explorer";

--- a/extensions/blip-raycast/src/send-selected-finder-item.ts
+++ b/extensions/blip-raycast/src/send-selected-finder-item.ts
@@ -1,16 +1,18 @@
 import { closeMainWindow, popToRoot, showHUD, showToast, Toast } from "@raycast/api";
-import { getFirstSelectedFinderPath } from "./finder";
 import { sendPathToBlip } from "./blip";
+import { getFirstSelectedFilePath } from "./finder";
+import { fileManagerName } from "./platform";
 
 export default async function command() {
   try {
     await closeMainWindow();
-    const path = await getFirstSelectedFinderPath();
+    const path = await getFirstSelectedFilePath();
     await sendPathToBlip(path);
     await popToRoot();
     await showHUD("Sent to Blip");
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unable to send the selected Finder item to Blip.";
+    const message =
+      error instanceof Error ? error.message : `Unable to send the selected ${fileManagerName} item to Blip.`;
     await showToast({
       style: Toast.Style.Failure,
       title: "Blip send failed",

--- a/extensions/blip-raycast/src/send-to-blip.tsx
+++ b/extensions/blip-raycast/src/send-to-blip.tsx
@@ -1,7 +1,8 @@
 import { Action, ActionPanel, Form, Icon, Toast, showToast } from "@raycast/api";
 import { useEffect, useState } from "react";
 import { sendPathToBlip } from "./blip";
-import { getFirstSelectedFinderPath } from "./finder";
+import { getFirstSelectedFilePath } from "./finder";
+import { fileManagerName, isMac } from "./platform";
 
 type Values = {
   path: string[];
@@ -14,14 +15,14 @@ export default function Command() {
   useEffect(() => {
     let isMounted = true;
 
-    async function loadFinderSelection() {
+    async function loadSelection() {
       try {
-        const path = await getFirstSelectedFinderPath();
+        const path = await getFirstSelectedFilePath();
         if (isMounted) {
           setSelectedPaths([path]);
         }
       } catch {
-        // Finder selection is optional for this command.
+        // File manager selection is optional for this command.
       } finally {
         if (isMounted) {
           setIsLoading(false);
@@ -29,7 +30,7 @@ export default function Command() {
       }
     }
 
-    loadFinderSelection();
+    loadSelection();
 
     return () => {
       isMounted = false;
@@ -55,6 +56,10 @@ export default function Command() {
     }
   }
 
+  const servicesDescription = isMac
+    ? "Raycast needs Accessibility permission to trigger Blip's Finder Services action."
+    : "Raycast needs Accessibility permission to trigger Blip's context menu action.";
+
   return (
     <Form
       isLoading={isLoading}
@@ -64,7 +69,9 @@ export default function Command() {
         </ActionPanel>
       }
     >
-      <Form.Description text="Choose a file or folder to send. If Finder has a current selection, it will appear here automatically. Raycast needs Accessibility permission to trigger Blip's Finder Services action." />
+      <Form.Description
+        text={`Choose a file or folder to send. If ${fileManagerName} has a current selection, it will appear here automatically. ${servicesDescription}`}
+      />
       <Form.FilePicker
         id="path"
         title="File or Folder"

--- a/extensions/blip-raycast/src/windows-scripts.ts
+++ b/extensions/blip-raycast/src/windows-scripts.ts
@@ -1,0 +1,92 @@
+export function buildSelectedExplorerPathScript() {
+  return `
+try {
+  $shell = New-Object -ComObject Shell.Application
+  $windows = @($shell.Windows() | Where-Object { $_ -ne $null -and $_.FullName -match '[\\\\/]explorer\\.exe$' })
+  if ($windows.Count -eq 0) { throw 'no_window' }
+
+  $foregroundWindow = 0
+  try {
+    Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class User32 {
+  [DllImport("user32.dll")]
+  public static extern IntPtr GetForegroundWindow();
+}
+"@
+    $foregroundWindow = [User32]::GetForegroundWindow().ToInt64()
+  } catch {}
+
+  $foregroundExplorers = @($windows | Where-Object { $_.HWND -eq $foregroundWindow })
+  $otherExplorers = @($windows | Where-Object { $_.HWND -ne $foregroundWindow })
+  $explorers = @($foregroundExplorers + $otherExplorers)
+
+  foreach ($window in $explorers) {
+    try {
+      $items = @($window.Document.SelectedItems())
+      if ($items.Count -gt 0 -and $items[0].Path) {
+        Write-Output $items[0].Path
+        exit 0
+      }
+    } catch {}
+  }
+
+  Add-Type -AssemblyName System.Windows.Forms
+  $previousClipboard = $null
+  $hadClipboard = [System.Windows.Forms.Clipboard]::ContainsData("Preferred DropEffect") -or
+    [System.Windows.Forms.Clipboard]::ContainsFileDropList() -or
+    [System.Windows.Forms.Clipboard]::ContainsText()
+  if ($hadClipboard) {
+    $previousClipboard = [System.Windows.Forms.Clipboard]::GetDataObject()
+  }
+
+  try {
+    [System.Windows.Forms.SendKeys]::SendWait("^c")
+    Start-Sleep -Milliseconds 250
+    $fileDropList = [System.Windows.Forms.Clipboard]::GetFileDropList()
+    if ($fileDropList.Count -gt 0) {
+      Write-Output $fileDropList[0]
+      exit 0
+    }
+  } finally {
+    if ($previousClipboard -ne $null) {
+      [System.Windows.Forms.Clipboard]::SetDataObject($previousClipboard, $true)
+    } elseif (-not $hadClipboard) {
+      [System.Windows.Forms.Clipboard]::Clear()
+    }
+  }
+
+  throw 'no_selection'
+} catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}`;
+}
+
+export function getWindowsPowerShellArguments(script?: string) {
+  return ["-NoLogo", "-NoProfile", "-NonInteractive", "-STA", "-ExecutionPolicy", "Bypass", "-Command", script ?? "-"];
+}
+
+export function buildWindowsBlipVerbScript(path: string) {
+  const escapedPath = path.replace(/'/g, "''");
+
+  return `
+try {
+  $filePath = '${escapedPath}'
+  $folder = Split-Path $filePath -Parent
+  $file = Split-Path $filePath -Leaf
+  $shell = New-Object -ComObject Shell.Application
+  $shellFolder = $shell.NameSpace($folder)
+  if ($null -eq $shellFolder) { throw 'folder_not_found' }
+  $shellFile = $shellFolder.ParseName($file)
+  if ($null -eq $shellFile) { throw 'file_not_found' }
+  $blipVerb = @($shellFile.Verbs() | Where-Object { $_.Name -match 'Blip' })
+  if ($blipVerb.Count -eq 0) { throw 'blip_not_found' }
+  $blipVerb[0].DoIt()
+  Start-Sleep -Milliseconds 500
+} catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}`;
+}

--- a/extensions/blip-raycast/src/windows-scripts.ts
+++ b/extensions/blip-raycast/src/windows-scripts.ts
@@ -32,31 +32,6 @@ public static class User32 {
     } catch {}
   }
 
-  Add-Type -AssemblyName System.Windows.Forms
-  $previousClipboard = $null
-  $hadClipboard = [System.Windows.Forms.Clipboard]::ContainsData("Preferred DropEffect") -or
-    [System.Windows.Forms.Clipboard]::ContainsFileDropList() -or
-    [System.Windows.Forms.Clipboard]::ContainsText()
-  if ($hadClipboard) {
-    $previousClipboard = [System.Windows.Forms.Clipboard]::GetDataObject()
-  }
-
-  try {
-    [System.Windows.Forms.SendKeys]::SendWait("^c")
-    Start-Sleep -Milliseconds 250
-    $fileDropList = [System.Windows.Forms.Clipboard]::GetFileDropList()
-    if ($fileDropList.Count -gt 0) {
-      Write-Output $fileDropList[0]
-      exit 0
-    }
-  } finally {
-    if ($previousClipboard -ne $null) {
-      [System.Windows.Forms.Clipboard]::SetDataObject($previousClipboard, $true)
-    } elseif (-not $hadClipboard) {
-      [System.Windows.Forms.Clipboard]::Clear()
-    }
-  }
-
   throw 'no_selection'
 } catch {
   Write-Error $_.Exception.Message


### PR DESCRIPTION
## Summary

- Adds OS detection via `process.platform` — no Raycast API exists for this, so Node's built-in is the right approach
- On **Windows**, gets the selected File Explorer item via PowerShell `Shell.Application` COM automation, since `getSelectedFinderItems()` is macOS-only with no Windows equivalent in the Raycast API
- On **Windows**, triggers Blip by invoking its registered shell context menu verb via PowerShell — the direct equivalent of how macOS Services work
- Uses `runPowerShellScript` from `@raycast/utils` for both PowerShell calls (the Raycast-idiomatic approach)
- All "Finder" UI strings are now platform-aware: "Finder" on macOS, "File Explorer" on Windows
- `package.json`: added `"Windows"` to `platforms`, updated command title and description to be generic

## Test plan

- [ ] macOS: both commands still work as before (no behaviour change on macOS)
- [ ] Windows: "Send to Blip" pre-fills with active File Explorer selection
- [ ] Windows: "Send Selected File to Blip" sends the selected Explorer item directly
- [ ] Windows: UI description text shows "File Explorer" instead of "Finder"
- [ ] Windows: clear error shown if Blip's shell extension is not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)