### PR TITLE
Fix Skills update actions for global installs

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Fix Global Skill Updates] - {PR_MERGE_DATE}
+## [Fix Global Skill Updates] - 2026-06-04
 
 - Run skill update actions against global installs, matching the global skill list shown in Manage Skills
 

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Skills Changelog
 
+## [Fix Global Skill Updates] - {PR_MERGE_DATE}
+
+- Run skill update actions against global installs, matching the global skill list shown in Manage Skills
+
 ## [Default Agents Preference] - 2026-06-01
 
 - Add a "Default Agents" preference to pre-select agents when installing a skill, so frequently-used agents (e.g. Claude Code) are checked automatically without manual selection each time

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -362,13 +362,13 @@ export async function removeSkill(skillName: string, agentDisplayNames?: string[
  * Update all installed skills.
  */
 export async function updateAllSkills(): Promise<void> {
-  await runSkillsCli(["update", "-y"]);
+  await runSkillsCli(["update", "-g", "-y"]);
 }
 
 /**
  * Update a single installed skill by name.
- * Runs `skills update <skill-name> -y` via the resolved package runner (bunx with npx fallback).
+ * Runs `skills update <skill-name> -g -y` via the resolved package runner (bunx with npx fallback).
  */
 export async function updateSkill(skillName: string): Promise<void> {
-  await runSkillsCli(["update", skillName, "-y"]);
+  await runSkillsCli(["update", skillName, "-g", "-y"]);
 }


### PR DESCRIPTION
## Summary

- Make Skills update actions target global skills explicitly
- Keep Manage Skills update behavior aligned with `skills list -g`

## Verification

- `env npm_config_cache=/private/tmp/npm-cache npm run lint`
- `env HOME=/private/tmp/raycast-home XDG_CONFIG_HOME=/private/tmp/raycast-config npm_config_cache=/private/tmp/npm-cache npm run build`

Fixes #28538
