### PR TITLE
[Karakeep] Fix bookmark preview image rendering

### DIFF
--- a/extensions/karakeep/CHANGELOG.md
+++ b/extensions/karakeep/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Karakeep Changelog
 
-## [2.3.2] - {PR_MERGE_DATE}
+## [2.3.2] - 2026-06-05
 
 - Fixed bookmark preview images not rendering by caching previews locally and escaping local image paths in Markdown
 

--- a/extensions/karakeep/CHANGELOG.md
+++ b/extensions/karakeep/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Karakeep Changelog
 
+## [2.3.2] - {PR_MERGE_DATE}
+
+- Fixed bookmark preview images not rendering by caching previews locally and escaping local image paths in Markdown
+
 ## [2.3.1] - 2026-04-01
 
 - Fixed an issue where typing an existing tag name in the Add New Tag picker would not add it to the Tags list

--- a/extensions/karakeep/package-lock.json
+++ b/extensions/karakeep/package-lock.json
@@ -1152,6 +1152,7 @@
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.7.tgz",
       "integrity": "sha512-EeBg7zU1OjJlfoPlb88T1G1K4rZuD46gvLr6bWqPALGPfNDvkkBFz7G+9cq+Zayq8Ex7k4vjp/ZibC24j7xnzA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.5.4",
         "@oclif/plugin-autocomplete": "^3.2.35",
@@ -1279,6 +1280,7 @@
       "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1289,6 +1291,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1349,6 +1352,7 @@
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -1554,6 +1558,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1918,6 +1923,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2774,6 +2780,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3014,6 +3021,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3078,6 +3086,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/karakeep/package.json
+++ b/extensions/karakeep/package.json
@@ -8,7 +8,8 @@
   "contributors": [
     "kdurek",
     "edequalsawesome",
-    "chrismessina"
+    "chrismessina",
+    "mitsimi"
   ],
   "categories": [
     "Web"

--- a/extensions/karakeep/src/components/BookmarkDetail.tsx
+++ b/extensions/karakeep/src/components/BookmarkDetail.tsx
@@ -15,6 +15,7 @@ import {
 import { useConfig } from "../hooks/useConfig";
 import { useTranslation } from "../hooks/useTranslation";
 import { Bookmark } from "../types";
+import { markdownImage } from "../utils/markdown";
 import { getScreenshot } from "../utils/screenshot";
 import { runWithToast } from "../utils/toast";
 import { BookmarkEdit } from "./BookmarkEdit";
@@ -182,7 +183,7 @@ export function BookmarkDetail({ bookmark: initialBookmark, onRefresh }: Bookmar
     switch (bookmark.content.type) {
       case "link":
         if (images.screenshot !== DEFAULT_SCREENSHOT_FILENAME) {
-          parts.push(`![${bookmark.content.title}](${images.screenshot})`);
+          parts.push(markdownImage(images.screenshot, bookmark.content.title));
         }
         addTitle(displayTitle);
         break;
@@ -202,7 +203,7 @@ export function BookmarkDetail({ bookmark: initialBookmark, onRefresh }: Bookmar
 
         if (assetType === "image") {
           if (images.asset !== DEFAULT_SCREENSHOT_FILENAME) {
-            parts.push(`\n![${fileName}](${images.asset})`);
+            parts.push(`\n${markdownImage(images.asset, fileName)}`);
           }
           addTitle(assetDisplayTitle || "");
           addFileName(fileName || "", "🖼️");

--- a/extensions/karakeep/src/components/BookmarkItem.tsx
+++ b/extensions/karakeep/src/components/BookmarkItem.tsx
@@ -12,7 +12,6 @@ import {
 } from "../constants";
 import { useTranslation } from "../hooks/useTranslation";
 import { Bookmark, Config } from "../types";
-import { markdownImage } from "../utils/markdown";
 import { getScreenshot } from "../utils/screenshot";
 import { BookmarkDetail } from "./BookmarkDetail";
 import { BookmarkEdit } from "./BookmarkEdit";
@@ -595,7 +594,7 @@ export function BookmarkItem({
       icon={getIcon()}
       detail={
         <List.Item.Detail
-          markdown={previewImage ? markdownImage(previewImage, getDisplayTitle()) : ""}
+          markdown={previewImage ? `<img src="${previewImage}" center width="300" />` : ""}
           metadata={<BookmarkMetadata bookmark={bookmark} config={config} t={t} />}
         />
       }

--- a/extensions/karakeep/src/components/BookmarkItem.tsx
+++ b/extensions/karakeep/src/components/BookmarkItem.tsx
@@ -595,11 +595,7 @@ export function BookmarkItem({
       icon={getIcon()}
       detail={
         <List.Item.Detail
-          markdown={
-            previewImage
-              ? markdownImage(previewImage, getDisplayTitle(), { raycastWidth: 250, raycastHeight: 250 })
-              : ""
-          }
+          markdown={previewImage ? markdownImage(previewImage, getDisplayTitle(), { raycastWidth: 300 }) : ""}
           metadata={<BookmarkMetadata bookmark={bookmark} config={config} t={t} />}
         />
       }

--- a/extensions/karakeep/src/components/BookmarkItem.tsx
+++ b/extensions/karakeep/src/components/BookmarkItem.tsx
@@ -12,6 +12,7 @@ import {
 } from "../constants";
 import { useTranslation } from "../hooks/useTranslation";
 import { Bookmark, Config } from "../types";
+import { markdownImage } from "../utils/markdown";
 import { getScreenshot } from "../utils/screenshot";
 import { BookmarkDetail } from "./BookmarkDetail";
 import { BookmarkEdit } from "./BookmarkEdit";
@@ -19,6 +20,7 @@ import { NoteEdit } from "./NoteEdit";
 
 const log = logger.child("[BookmarkItem]");
 const { Metadata } = List.Item.Detail;
+
 interface BookmarkItemProps {
   bookmark: Bookmark;
   config: Config;
@@ -534,6 +536,7 @@ export function BookmarkItem({
     Boolean(isSelected) &&
     ((bookmark.content.type === "link" && config.displayBookmarkPreview) ||
       (bookmark.content.type === "asset" && bookmark.content.assetType === "image"));
+
   const images = useBookmarkImages(bookmark, shouldPrewarmPreview);
 
   const handlers = useBookmarkHandlers({
@@ -592,7 +595,7 @@ export function BookmarkItem({
       icon={getIcon()}
       detail={
         <List.Item.Detail
-          markdown={previewImage ? `<img src="${previewImage}" center width="300" />` : ""}
+          markdown={previewImage ? markdownImage(previewImage, getDisplayTitle()) : ""}
           metadata={<BookmarkMetadata bookmark={bookmark} config={config} t={t} />}
         />
       }

--- a/extensions/karakeep/src/components/BookmarkItem.tsx
+++ b/extensions/karakeep/src/components/BookmarkItem.tsx
@@ -12,6 +12,7 @@ import {
 } from "../constants";
 import { useTranslation } from "../hooks/useTranslation";
 import { Bookmark, Config } from "../types";
+import { markdownImage } from "../utils/markdown";
 import { getScreenshot } from "../utils/screenshot";
 import { BookmarkDetail } from "./BookmarkDetail";
 import { BookmarkEdit } from "./BookmarkEdit";
@@ -594,7 +595,11 @@ export function BookmarkItem({
       icon={getIcon()}
       detail={
         <List.Item.Detail
-          markdown={previewImage ? `<img src="${previewImage}" center width="300" />` : ""}
+          markdown={
+            previewImage
+              ? markdownImage(previewImage, getDisplayTitle(), { raycastWidth: 250, raycastHeight: 250 })
+              : ""
+          }
           metadata={<BookmarkMetadata bookmark={bookmark} config={config} t={t} />}
         />
       }

--- a/extensions/karakeep/src/utils/markdown.ts
+++ b/extensions/karakeep/src/utils/markdown.ts
@@ -1,0 +1,5 @@
+export function markdownImage(src: string, alt = "Preview") {
+  const safeAlt = alt.replace(/[[\]]/g, "");
+  const safeSrc = /\s/.test(src) ? `<${src.replace(/>/g, "%3E")}>` : src;
+  return `![${safeAlt}](${safeSrc})`;
+}

--- a/extensions/karakeep/src/utils/markdown.ts
+++ b/extensions/karakeep/src/utils/markdown.ts
@@ -1,5 +1,27 @@
-export function markdownImage(src: string, alt = "Preview") {
+interface MarkdownImageOptions {
+  raycastWidth?: number;
+  raycastHeight?: number;
+}
+
+function withRaycastImageSize(src: string, options?: MarkdownImageOptions) {
+  const params = new URLSearchParams();
+  if (options?.raycastWidth) {
+    params.set("raycast-width", String(options.raycastWidth));
+  }
+  if (options?.raycastHeight) {
+    params.set("raycast-height", String(options.raycastHeight));
+  }
+
+  const query = params.toString();
+  if (!query) return src;
+
+  const separator = src.includes("?") ? "&" : "?";
+  return `${src}${separator}${query}`;
+}
+
+export function markdownImage(src: string, alt = "Preview", options?: MarkdownImageOptions) {
   const safeAlt = alt.replace(/[[\]]/g, "");
-  const safeSrc = /\s/.test(src) ? `<${src.replace(/</g, "%3C").replace(/>/g, "%3E")}>` : src;
+  const sizedSrc = withRaycastImageSize(src, options);
+  const safeSrc = /\s/.test(sizedSrc) ? `<${sizedSrc.replace(/</g, "%3C").replace(/>/g, "%3E")}>` : sizedSrc;
   return `![${safeAlt}](${safeSrc})`;
 }

--- a/extensions/karakeep/src/utils/markdown.ts
+++ b/extensions/karakeep/src/utils/markdown.ts
@@ -1,5 +1,5 @@
 export function markdownImage(src: string, alt = "Preview") {
   const safeAlt = alt.replace(/[[\]]/g, "");
-  const safeSrc = /\s/.test(src) ? `<${src.replace(/>/g, "%3E")}>` : src;
+  const safeSrc = /\s/.test(src) ? `<${src.replace(/</g, "%3C").replace(/>/g, "%3E")}>` : src;
   return `![${safeAlt}](${safeSrc})`;
 }

--- a/extensions/karakeep/src/utils/screenshot.ts
+++ b/extensions/karakeep/src/utils/screenshot.ts
@@ -1,9 +1,11 @@
 import { environment } from "@raycast/api";
-import { mkdir, rename, stat, writeFile } from "fs/promises";
+import { mkdir, readdir, rename, stat, unlink, writeFile } from "fs/promises";
 import path from "path";
 import { getApiConfig } from "./config";
 
+const CACHE_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 14; // 14 days
 const IMAGE_EXTENSIONS = ["jpg", "png", "gif", "webp", "img"];
+let lastCacheSweep = 0;
 
 function extensionFromContentType(contentType: string) {
   if (contentType.includes("jpeg") || contentType.includes("jpg")) return "jpg";
@@ -13,6 +15,31 @@ function extensionFromContentType(contentType: string) {
   return "img";
 }
 
+async function sweepExpiredCacheEntries(imageCacheDirectory: string) {
+  const now = Date.now();
+  if (now - lastCacheSweep < CACHE_MAX_AGE_MS) return;
+  lastCacheSweep = now;
+
+  try {
+    const entries = await readdir(imageCacheDirectory);
+    await Promise.all(
+      entries.map(async (entry) => {
+        const entryPath = path.join(imageCacheDirectory, entry);
+        try {
+          const cached = await stat(entryPath);
+          if (cached.isFile() && now - cached.mtimeMs > CACHE_MAX_AGE_MS) {
+            await unlink(entryPath);
+          }
+        } catch {
+          // Ignore races with other preview loads or user cleanup.
+        }
+      }),
+    );
+  } catch {
+    // Cache cleanup should never block preview loading.
+  }
+}
+
 export async function getScreenshot(id: string) {
   const { apiUrl, apiKey } = await getApiConfig();
   const encodedUrl = encodeURIComponent(`/api/assets/${id}`);
@@ -20,6 +47,7 @@ export async function getScreenshot(id: string) {
   const imageCacheDirectory = path.join(environment.supportPath, "preview-images");
 
   await mkdir(imageCacheDirectory, { recursive: true });
+  void sweepExpiredCacheEntries(imageCacheDirectory);
 
   for (const extension of IMAGE_EXTENSIONS) {
     const cachedPath = path.join(imageCacheDirectory, `${id}.${extension}`);

--- a/extensions/karakeep/src/utils/screenshot.ts
+++ b/extensions/karakeep/src/utils/screenshot.ts
@@ -15,6 +15,10 @@ function extensionFromContentType(contentType: string) {
   return "img";
 }
 
+function cacheKeyFromAssetId(id: string) {
+  return id.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
 async function sweepExpiredCacheEntries(imageCacheDirectory: string) {
   const now = Date.now();
   if (now - lastCacheSweep < CACHE_MAX_AGE_MS) return;
@@ -45,12 +49,13 @@ export async function getScreenshot(id: string) {
   const encodedUrl = encodeURIComponent(`/api/assets/${id}`);
   const imageUrl = `${apiUrl}/_next/image?url=${encodedUrl}&w=1200&q=75`;
   const imageCacheDirectory = path.join(environment.supportPath, "preview-images");
+  const cacheKey = cacheKeyFromAssetId(id);
 
   await mkdir(imageCacheDirectory, { recursive: true });
   void sweepExpiredCacheEntries(imageCacheDirectory);
 
   for (const extension of IMAGE_EXTENSIONS) {
-    const cachedPath = path.join(imageCacheDirectory, `${id}.${extension}`);
+    const cachedPath = path.join(imageCacheDirectory, `${cacheKey}.${extension}`);
     try {
       const cached = await stat(cachedPath);
       if (cached.size > 0) return cachedPath;
@@ -78,7 +83,7 @@ export async function getScreenshot(id: string) {
 
   const bytes = Buffer.from(await response.arrayBuffer());
   const extension = extensionFromContentType(contentType);
-  const imagePath = path.join(imageCacheDirectory, `${id}.${extension}`);
+  const imagePath = path.join(imageCacheDirectory, `${cacheKey}.${extension}`);
   const temporaryPath = `${imagePath}.${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`;
 
   await writeFile(temporaryPath, bytes);

--- a/extensions/karakeep/src/utils/screenshot.ts
+++ b/extensions/karakeep/src/utils/screenshot.ts
@@ -1,18 +1,59 @@
-import { fetchWithAuth } from "../apis";
+import { environment } from "@raycast/api";
+import { mkdir, rename, stat, writeFile } from "fs/promises";
+import path from "path";
 import { getApiConfig } from "./config";
+
+const IMAGE_EXTENSIONS = ["jpg", "png", "gif", "webp", "img"];
+
+function extensionFromContentType(contentType: string) {
+  if (contentType.includes("jpeg") || contentType.includes("jpg")) return "jpg";
+  if (contentType.includes("png")) return "png";
+  if (contentType.includes("gif")) return "gif";
+  if (contentType.includes("webp")) return "webp";
+  return "img";
+}
 
 export async function getScreenshot(id: string) {
   const { apiUrl, apiKey } = await getApiConfig();
   const encodedUrl = encodeURIComponent(`/api/assets/${id}`);
   const imageUrl = `${apiUrl}/_next/image?url=${encodedUrl}&w=1200&q=75`;
+  const imageCacheDirectory = path.join(environment.supportPath, "preview-images");
 
-  // hack: Make an authenticated image URL request in the background to display the image in Raycast.
-  await fetchWithAuth(imageUrl, {
+  await mkdir(imageCacheDirectory, { recursive: true });
+
+  for (const extension of IMAGE_EXTENSIONS) {
+    const cachedPath = path.join(imageCacheDirectory, `${id}.${extension}`);
+    try {
+      const cached = await stat(cachedPath);
+      if (cached.size > 0) return cachedPath;
+    } catch {
+      // cache miss
+    }
+  }
+
+  const response = await fetch(imageUrl, {
     headers: {
-      Accept: "image/*",
+      Accept: "image/png,image/jpeg;q=0.9,*/*;q=0.1",
       Authorization: `Bearer ${apiKey}`,
     },
   });
 
-  return imageUrl;
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`HTTP ${response.status}: ${body}`);
+  }
+
+  const contentType = response.headers.get("content-type") || "image/png";
+  if (!contentType.startsWith("image/")) {
+    throw new Error(`Expected image response, got ${contentType}`);
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer());
+  const extension = extensionFromContentType(contentType);
+  const imagePath = path.join(imageCacheDirectory, `${id}.${extension}`);
+  const temporaryPath = `${imagePath}.${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`;
+
+  await writeFile(temporaryPath, bytes);
+  await rename(temporaryPath, imagePath);
+  return imagePath;
 }


### PR DESCRIPTION
## Description

Fixes Karakeep bookmark preview images not rendering in the Bookmarks/List preview pane by caching authenticated preview images locally and rendering them with Markdown image syntax.

Local image paths are escaped correctly for Markdown, and the preview pane now uses Raycast’s `raycast-width` / `raycast-height` image parameters to size bookmark previews instead of raw HTML image attributes.

May fix #24966.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that this change does not break existing functionality
