### PR TITLE
[Tempo] Add autoFocus on time spent field

### DIFF
--- a/extensions/tempo/CHANGELOG.md
+++ b/extensions/tempo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tempo Changelog
 
-## [Add Autofocus to Worklog Duration] - {PR_MERGE_DATE}
+## [Add Autofocus to Worklog Duration] - 2026-06-05
 
 - Autofocus the Time Spent field when opening the Add Worklog form
 

--- a/extensions/tempo/CHANGELOG.md
+++ b/extensions/tempo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Tempo Changelog
 
+## [Add Autofocus to Worklog Duration] - {PR_MERGE_DATE}
+
+- Autofocus the Time Spent field when opening the Add Worklog form
+
 ## [Worklog Time Range Improvements] - 2026-06-03
 
 - Add optional start and end time entry when logging work and derive the duration automatically

--- a/extensions/tempo/src/add-worklog.tsx
+++ b/extensions/tempo/src/add-worklog.tsx
@@ -428,6 +428,7 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
         <Form.TextField
           id="timeSpent"
           title="Time Spent"
+          autoFocus
           placeholder="1h, 1h30m, 30m"
           defaultValue="1h"
           info="Enter duration in human format: 1h, 1h30m, 2h, 45m, etc."


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

In this pull-request, I simply added an `autoFocus` on the _Time Spent_ field when persisting a new worklog.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

https://github.com/user-attachments/assets/33942b33-6c73-4ed9-a2de-8c14eca86f52

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
