### PR TITLE
Update microsoft-office extension

### DIFF
--- a/extensions/microsoft-office/CHANGELOG.md
+++ b/extensions/microsoft-office/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Microsoft Office Changelog
 
+## [Unreleased]
+
+- Fix crash when parsing empty timestamps.
+- Fix error when PowerShell returns a single-item array.
+- Support loading recent files from multiple connected Microsoft accounts simultaneously.
+
 ## [Initial Version] - 2026-01-15
 
 - Add initial version

--- a/extensions/microsoft-office/eslint.config.js
+++ b/extensions/microsoft-office/eslint.config.js
@@ -1,6 +1,4 @@
 const { defineConfig } = require("eslint/config");
 const raycastConfig = require("@raycast/eslint-config");
 
-module.exports = defineConfig([
-  ...raycastConfig,
-]);
+module.exports = defineConfig([...raycastConfig]);

--- a/extensions/microsoft-office/package-lock.json
+++ b/extensions/microsoft-office/package-lock.json
@@ -1103,6 +1103,7 @@
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.103.10.tgz",
       "integrity": "sha512-FOxqq47+YVCo4+Eq8eU8+esoLNwcxHHBVhw/JmZwsViTqMB3DF8WorXL+ZwrXW/8srruuzyyx9+ACyRdZ+zbSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.5.4",
         "@oclif/plugin-autocomplete": "^3.2.35",
@@ -1205,6 +1206,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1263,6 +1265,7 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -1467,6 +1470,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1818,6 +1822,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2573,6 +2578,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2596,6 +2602,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2802,6 +2809,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/microsoft-office/package.json
+++ b/extensions/microsoft-office/package.json
@@ -57,5 +57,8 @@
     "build": "ray build",
     "publish": "npx @raycast/api@latest publish",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1"
-  }
+  },
+  "contributors": [
+    "firewall-code"
+  ]
 }

--- a/extensions/microsoft-office/src/lib/office.ts
+++ b/extensions/microsoft-office/src/lib/office.ts
@@ -93,7 +93,7 @@ export async function recentMSOfficeFiles(): Promise<Result> {
 }
 
 function powershellDateStringToDate(dateString: string): Date {
-  if (!dateString) return new Date();
+  if (!dateString) return new Date(0);
   const ms = parseInt(dateString.replace(/\D/g, ""), 10);
   const date = new Date(ms);
   return date;

--- a/extensions/microsoft-office/src/lib/office.ts
+++ b/extensions/microsoft-office/src/lib/office.ts
@@ -49,22 +49,51 @@ export interface ExcelFiles {
   excelExecutable?: string;
 }
 
-export async function recentMSOfficeFiles() {
+export async function recentMSOfficeFiles(): Promise<Result> {
   try {
     const data = fs.readFileSync(environment.assetsPath + "/office.ps1", "utf8");
     const result = await runPowerShellScript(data);
     const j = JSON.parse(result) as OfficeResult;
-    const adalKey = Object.keys(j).filter((key) => key.startsWith("ADAL"));
-    if (!adalKey || adalKey.length <= 0) {
+    const adalKeys = Object.keys(j).filter((key) => key.startsWith("ADAL"));
+    if (!adalKeys || adalKeys.length <= 0) {
       throw new Error("No ADAL key found in the result");
     }
-    return j[adalKey[0]];
+
+    const combinedFiles: RecentPowerpointFile[] = [];
+    let PPTPath: string | undefined;
+    let WORDPath: string | undefined;
+    let EXCELPath: string | undefined;
+    let OfficeVersion = "";
+
+    for (const key of adalKeys) {
+      const item = j[key];
+      if (item.Files) {
+        if (Array.isArray(item.Files)) {
+          combinedFiles.push(...item.Files);
+        } else {
+          combinedFiles.push(item.Files as unknown as RecentPowerpointFile);
+        }
+      }
+      if (item.PPTPath) PPTPath = item.PPTPath;
+      if (item.WORDPath) WORDPath = item.WORDPath;
+      if (item.EXCELPath) EXCELPath = item.EXCELPath;
+      if (item.OfficeVersion) OfficeVersion = item.OfficeVersion;
+    }
+
+    return {
+      Files: combinedFiles,
+      PPTPath,
+      WORDPath,
+      EXCELPath,
+      OfficeVersion,
+    };
   } catch {
     throw new Error("Could not read Office files");
   }
 }
 
 function powershellDateStringToDate(dateString: string): Date {
+  if (!dateString) return new Date();
   const ms = parseInt(dateString.replace(/\D/g, ""), 10);
   const date = new Date(ms);
   return date;


### PR DESCRIPTION
## Description

Fixes bugs that caused the extension to crash or fail to show recent files on Windows.

Specifically, this PR addresses three issues:
1. **Multiple ADAL Keys**: The PowerShell script could return multiple `ADAL_` keys if the user has multiple Microsoft accounts connected. The code now iterates and combines files from all valid accounts instead of just checking the first one (which might be empty).
2. **Flattened Arrays from PowerShell**: Fixed an issue where PowerShell's `ConvertTo-Json` flattens a single-item `Files` array into an object. This caused `data.Files.map` to throw an error. The code now forces it into an array when necessary.
3. **Missing Timestamps**: Added a fallback for missing or empty `TimestampUTC` values to prevent `dateString.replace` from throwing a TypeError.

## Screencast

N/A (Backend logic fixes on Windows)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
