### PR TITLE
[Skills] Add icons to skill confirmation dialogs

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Fix Confirmation Dialog Icon] - {PR_MERGE_DATE}
+## [Fix Confirmation Dialog Icon] - 2026-06-05
 
 - Show a relevant icon in the Update, Install, and Remove confirmation dialogs instead of falling back to the oversized extension icon on Windows
 

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Skills Changelog
 
+## [Fix Confirmation Dialog Icon] - {PR_MERGE_DATE}
+
+- Show a relevant icon in the Update, Install, and Remove confirmation dialogs instead of falling back to the oversized extension icon on Windows
+
 ## [Fix Global Skill Updates] - 2026-06-04
 
 - Run skill update actions against global installs, matching the global skill list shown in Manage Skills

--- a/extensions/skills/src/components/actions/InstallSkillAction.tsx
+++ b/extensions/skills/src/components/actions/InstallSkillAction.tsx
@@ -145,6 +145,7 @@ function buildConfirmation({
   ].join("\n\n");
 
   return {
+    icon: hasAuditRisk ? { source: Icon.Warning, tintColor: Color.Red } : Icon.Download,
     title: `${operation} "${skill.name}"${TITLE_SUFFIX_BY_RISK[auditRisk]}?`,
     message,
     primaryAction: {
@@ -204,7 +205,7 @@ function AgentPickerInstallForm({
     }
 
     const auditResult = await resolveAuditResult(skill, prefetchedAuditResult);
-    const { title, message, primaryAction } = buildConfirmation({
+    const { icon, title, message, primaryAction } = buildConfirmation({
       skill,
       auditResult,
       selectedAgents,
@@ -213,6 +214,7 @@ function AgentPickerInstallForm({
     });
 
     const confirmed = await confirmAlert({
+      icon,
       title,
       message,
       primaryAction,

--- a/extensions/skills/src/components/actions/RemoveSkillAction.tsx
+++ b/extensions/skills/src/components/actions/RemoveSkillAction.tsx
@@ -50,6 +50,7 @@ function AgentPickerForm({ skill, mutate }: RemoveSkillActionProps) {
     const label = isAll ? "all agents" : agents.join(", ");
 
     const confirmed = await confirmAlert({
+      icon: { source: Icon.Trash, tintColor: Color.Red },
       title: isAll ? `Remove "${skill.name}"?` : `Remove "${skill.name}" from ${label}?`,
       message: isAll
         ? "This will remove the skill from all agents."
@@ -134,6 +135,7 @@ export function RemoveSkillAction({ skill, mutate }: RemoveSkillActionProps) {
       onAction={() =>
         withSkillAction({
           confirm: {
+            icon: { source: Icon.Trash, tintColor: Color.Red },
             title: `Remove "${skill.name}"?`,
             message: "This will remove the skill from all agents.",
             primaryAction: { title: "Remove", style: Alert.ActionStyle.Destructive },

--- a/extensions/skills/src/components/actions/UpdateSkillAction.tsx
+++ b/extensions/skills/src/components/actions/UpdateSkillAction.tsx
@@ -1,4 +1,4 @@
-import { Action, Alert, Icon } from "@raycast/api";
+import { Action, Alert, Color, Icon } from "@raycast/api";
 import { updateAllSkills, updateSkill } from "../../utils/skills-cli";
 import { withSkillAction } from "../../utils/with-skill-action";
 import type { MutateSkills } from "../../hooks/useInstalledSkills";
@@ -19,6 +19,7 @@ export function UpdateSkillAction({ skillName, mutate }: UpdateSkillActionProps)
       onAction={() =>
         withSkillAction({
           confirm: {
+            icon: { source: Icon.ArrowClockwise, tintColor: Color.Orange },
             title: isSingle ? `Update "${skillName}"?` : "Update All Skills?",
             message: isSingle
               ? `This will update "${skillName}" to the latest version.`

--- a/extensions/skills/src/utils/with-skill-action.ts
+++ b/extensions/skills/src/utils/with-skill-action.ts
@@ -1,8 +1,9 @@
-import { confirmAlert, Alert, showToast, Toast } from "@raycast/api";
+import { confirmAlert, Alert, Image, showToast, Toast } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 
 interface WithSkillActionOptions<T> {
   confirm?: {
+    icon?: Image.ImageLike;
     title: string;
     message: string;
     primaryAction?: { title: string; style: Alert.ActionStyle };
@@ -25,6 +26,7 @@ export async function withSkillAction<T = void>({
 }: WithSkillActionOptions<T>): Promise<void> {
   if (confirmOpts) {
     const confirmed = await confirmAlert({
+      icon: confirmOpts.icon,
       title: confirmOpts.title,
       message: confirmOpts.message,
       primaryAction: confirmOpts.primaryAction ?? { title: "Confirm", style: Alert.ActionStyle.Default },


### PR DESCRIPTION
## Description

Fixes #28560. 

On Raycast for Windows, if a `confirmAlert` doesn't have a specific `icon`, it defaults to showing the extension's icon at a large size. This caused the Update, Install, and Remove confirmation popups to display an unexpectedly oversized logo. On macOS, the icon area is just blank, which is why this went unnoticed.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
