### PR TITLE
[Skills] Add copy skill contents action

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Copy Skill Contents] - {PR_MERGE_DATE}
+## [Copy Skill Contents] - 2026-06-06
 
 - Add a "Copy Skill Contents" action to copy a skill's full SKILL.md to the clipboard from search results, skill details, and installed skills, so it can be pasted into tools like ChatGPT or Claude without installing the skill
 - Move the "Copy Install Command" action to `⌘ ⇧ I` so the canonical copy shortcut (`⌘ ⇧ C`) copies the skill contents

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Skills Changelog
 
+## [Copy Skill Contents] - {PR_MERGE_DATE}
+
+- Add a "Copy Skill Contents" action to copy a skill's full SKILL.md to the clipboard from search results, skill details, and installed skills, so it can be pasted into tools like ChatGPT or Claude without installing the skill
+- Move the "Copy Install Command" action to `⌘ ⇧ I` so the canonical copy shortcut (`⌘ ⇧ C`) copies the skill contents
+
 ## [Fix Confirmation Dialog Icon] - 2026-06-05
 
 - Show a relevant icon in the Update, Install, and Remove confirmation dialogs instead of falling back to the oversized extension icon on Windows

--- a/extensions/skills/src/components/InstalledSkillListItem.tsx
+++ b/extensions/skills/src/components/InstalledSkillListItem.tsx
@@ -13,6 +13,7 @@ import {
 } from "../shared";
 import type { MutateSkills } from "../hooks/useInstalledSkills";
 import { formatAuditStatus, getAuditFallbackText } from "../utils/skill-audit-display";
+import { CopySkillContentsAction } from "./actions/CopySkillContentsAction";
 import { OpenSecurityAuditActions } from "./actions/OpenSecurityAuditActions";
 import { RemoveSkillAction } from "./actions/RemoveSkillAction";
 import { UpdateSkillAction } from "./actions/UpdateSkillAction";
@@ -247,6 +248,7 @@ function BaseInstalledSkillListItem({
           </ActionPanel.Section>
           {audits && <OpenSecurityAuditActions audits={audits.results} />}
           <ActionPanel.Section title="Copy">
+            <CopySkillContentsAction loadContent={() => readFile(join(skill.path, "SKILL.md"), "utf-8")} />
             <Action.CopyToClipboard
               title="Copy Skill Name"
               content={skill.name}

--- a/extensions/skills/src/components/SkillDetailView.tsx
+++ b/extensions/skills/src/components/SkillDetailView.tsx
@@ -15,6 +15,8 @@ import { useSkillContent } from "../hooks/useSkillContent";
 import { useInstalledSkillMatches } from "../hooks/useInstalledSkillMatches";
 import { formatAuditStatus, getAuditFallbackText } from "../utils/skill-audit-display";
 import { showSkillAuditErrorToast } from "../utils/skill-audit-error-toast";
+import { fetchSkillContent } from "../hooks/skill-content";
+import { CopySkillContentsAction } from "./actions/CopySkillContentsAction";
 import { InstallSkillAction } from "./actions/InstallSkillAction";
 import { OpenSecurityAuditActions } from "./actions/OpenSecurityAuditActions";
 import { joinMetadataSections, type MetadataSection } from "./_common/metadata";
@@ -27,7 +29,7 @@ interface SkillDetailViewProps {
 export function SkillDetailView({ skill, onSkillInstalled }: SkillDetailViewProps) {
   const { getInstalledMatch, revalidate: revalidateInstalledSkillMatches } = useInstalledSkillMatches();
   const installedMatch = getInstalledMatch(skill);
-  const { content, frontmatter, isLoading } = useSkillContent(skill, true);
+  const { content, rawContent, frontmatter, isLoading } = useSkillContent(skill, true);
   const { stats } = useRepoStats(skill, true);
   const audits = useSkillAudits(skill, {
     shouldFetch: true,
@@ -235,11 +237,15 @@ ${installCommand}
             prefetchedAuditResult={audits.result}
             onSkillInstalled={refreshSkillStatus}
           />
+          <CopySkillContentsAction
+            content={rawContent}
+            loadContent={() => fetchSkillContent(skill).then((result) => result?.raw)}
+          />
           <Action.CopyToClipboard
             title="Copy Install Command"
             content={buildInstallCommand(skill)}
             icon={Icon.Terminal}
-            shortcut={Keyboard.Shortcut.Common.Copy}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "i" }}
           />
           <Action.OpenInBrowser
             title="Open on skills.sh"

--- a/extensions/skills/src/components/SkillListItem.tsx
+++ b/extensions/skills/src/components/SkillListItem.tsx
@@ -1,6 +1,8 @@
 import { Action, ActionPanel, Color, Icon, Keyboard, List } from "@raycast/api";
 import { buildInstallCommand, buildSkillUrl, formatInstalls, type Skill } from "../shared";
 import { type InstalledSkillMatch } from "../hooks/useInstalledSkillMatches";
+import { fetchSkillContent } from "../hooks/skill-content";
+import { CopySkillContentsAction } from "./actions/CopySkillContentsAction";
 import { InstallSkillAction } from "./actions/InstallSkillAction";
 import { SkillDetailView } from "./SkillDetailView";
 
@@ -58,11 +60,12 @@ export function SkillListItem({
             onPush={() => onViewedSkillChange(skill.id)}
           />
           <InstallSkillAction skill={skill} installedMatch={installedMatch} onSkillInstalled={onSkillInstalled} />
+          <CopySkillContentsAction loadContent={() => fetchSkillContent(skill).then((result) => result?.raw)} />
           <Action.CopyToClipboard
             title="Copy Install Command"
             content={buildInstallCommand(skill)}
             icon={Icon.Terminal}
-            shortcut={Keyboard.Shortcut.Common.Copy}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "i" }}
           />
           <Action.OpenInBrowser
             title="Open on skills.sh"

--- a/extensions/skills/src/components/actions/CopySkillContentsAction.tsx
+++ b/extensions/skills/src/components/actions/CopySkillContentsAction.tsx
@@ -1,0 +1,69 @@
+import { Action, Clipboard, Icon, Keyboard, showHUD, showToast, Toast } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+
+interface CopySkillContentsActionProps {
+  /**
+   * Full SKILL.md content. When provided, the action copies it instantly.
+   * Used by views that already have the content loaded (e.g. the detail view).
+   */
+  content?: string;
+  /**
+   * Loader used to fetch the content on demand when it is not already loaded
+   * (e.g. list items). Should resolve to the full SKILL.md content, or
+   * `undefined` if no content could be found.
+   */
+  loadContent?: () => Promise<string | undefined>;
+}
+
+/**
+ * Copies the full SKILL.md content (frontmatter + body) to the clipboard so it
+ * can be pasted into other tools such as ChatGPT or Claude without installing
+ * the skill. Copies instantly when `content` is preloaded; otherwise fetches it
+ * on demand via `loadContent` while showing progress and failure toasts.
+ *
+ * Both paths mirror the native copy behaviour: the main window is closed and a
+ * HUD is shown once the content lands on the clipboard, matching the
+ * "copy, then paste elsewhere" flow this action exists for.
+ */
+export function CopySkillContentsAction({ content, loadContent }: CopySkillContentsActionProps) {
+  if (content) {
+    return (
+      <Action.CopyToClipboard
+        title="Copy Skill Contents"
+        content={content}
+        icon={Icon.CopyClipboard}
+        shortcut={Keyboard.Shortcut.Common.Copy}
+      />
+    );
+  }
+
+  if (!loadContent) return null;
+
+  const load = loadContent;
+
+  async function handleCopy() {
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Fetching Skill Contents…" });
+    try {
+      const fetched = await load();
+      if (!fetched?.trim()) {
+        toast.style = Toast.Style.Failure;
+        toast.title = "No Skill Contents Found";
+        return;
+      }
+      await Clipboard.copy(fetched);
+      await showHUD("Copied Skill Contents to Clipboard");
+    } catch (error) {
+      await toast.hide();
+      await showFailureToast(error, { title: "Failed to Copy Skill Contents" });
+    }
+  }
+
+  return (
+    <Action
+      title="Copy Skill Contents"
+      icon={Icon.CopyClipboard}
+      shortcut={Keyboard.Shortcut.Common.Copy}
+      onAction={handleCopy}
+    />
+  );
+}

--- a/extensions/skills/src/hooks/skill-content.ts
+++ b/extensions/skills/src/hooks/skill-content.ts
@@ -3,6 +3,7 @@ import { type Skill, type SkillFrontmatter, parseFrontmatter } from "../shared";
 type SkillContentResult = {
   frontmatter: SkillFrontmatter;
   body: string;
+  raw: string;
 };
 
 function buildSkillContentUrls(skill: Skill) {
@@ -38,7 +39,7 @@ export async function fetchSkillContent(skill: Skill): Promise<SkillContentResul
     const response = await fetch(url);
     if (response.ok && !response.headers.get("content-type")?.includes("text/html")) {
       const text = await response.text();
-      return parseFrontmatter(text);
+      return { ...parseFrontmatter(text), raw: text };
     }
     throw new Error(`Failed to fetch ${url}`);
   };

--- a/extensions/skills/src/hooks/useSkillContent.ts
+++ b/extensions/skills/src/hooks/useSkillContent.ts
@@ -14,6 +14,7 @@ export function useSkillContent(skill: Skill, execute = true) {
 
   return {
     content: data?.body,
+    rawContent: data?.raw,
     frontmatter: data?.frontmatter ?? {},
     isLoading,
   };


### PR DESCRIPTION
## Description

Closes #28550.

This adds a "Copy Skill Contents" action that copies a skill's complete SKILL.md to the clipboard. You can then paste it into tools like ChatGPT or Claude without needing to install the skill.

## Screencast

<img width="1504" height="950" alt="2026-06-05 at 10 30 15" src="https://github.com/user-attachments/assets/f7eaaf0a-0025-41e0-97d4-6859e819df8a" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
