### PR TITLE
[Coffee] Fix typo in Caffeinate While command description

### DIFF
--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Coffee Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed a typo in the "Caffeinate While" command description ("an certain app" → "a certain app").
+
 ## [Fix] - 2026-06-02
 
 - Fixed the menu bar icon not updating immediately after caffeinating or decaffeinating.

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coffee Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-06-05
 
 - Fixed a typo in the "Caffeinate While" command description ("an certain app" → "a certain app").
 

--- a/extensions/coffee/package.json
+++ b/extensions/coffee/package.json
@@ -16,7 +16,8 @@
     "Visual-Studio-Coder",
     "Katsuba",
     "alexi.build",
-    "mbuvarp"
+    "mbuvarp",
+    "foberm"
   ],
   "platforms": [
     "macOS"
@@ -41,7 +42,7 @@
       "name": "caffeinateWhile",
       "title": "Caffeinate While",
       "subtitle": "Coffee",
-      "description": "Prevent your Mac from sleeping while an certain app is running",
+      "description": "Prevent your Mac from sleeping while a certain app is running",
       "mode": "view"
     },
     {

--- a/extensions/coffee/package.json
+++ b/extensions/coffee/package.json
@@ -17,7 +17,7 @@
     "Katsuba",
     "alexi.build",
     "mbuvarp",
-    "foberm"
+    "frederik_obe"
   ],
   "platforms": [
     "macOS"


### PR DESCRIPTION
## Description

Fixes a small grammatical typo in the **Caffeinate While** command description: "an certain app" → "a certain app".

## Type of change

- [x] Fixed a typo / minor copy fix

## Checklist

- [x] Updated `CHANGELOG.md` (using the `{PR_MERGE_DATE}` placeholder)
- [x] Added myself to the `contributors` list in the manifest
- [x] No functional changes