### PR TITLE
Update tokentrack extension

### DIFF
--- a/extensions/tokentrack/CHANGELOG.md
+++ b/extensions/tokentrack/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Token Track Changelog
 
+## [Claude Code chat titles and Open Chat] - {PR_MERGE_DATE}
+
+- Fix Claude Code conversation names to match the app sidebar: prefer `/rename` custom titles, then `ai-title` lines from session JSONL.
+- Attribute subagent and forked-session usage to the parent chat so View Details totals match the dashboard.
+- Fix **Open Chat** to resume the session via `claude://resume?session={uuid}&cwd={path}` (falls back to `claude://code/{uuid}`).
+
 ## [Quick usage commands] - 2026-06-06
 
 - Add **Quick Usage Claude Code**, **Quick Usage Codex**, and **Quick Usage Cursor** no-view commands that show a toast with estimated spend against your configured budget cap.

--- a/extensions/tokentrack/CHANGELOG.md
+++ b/extensions/tokentrack/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Token Track Changelog
 
-## [Budget Menu Bar] - {PR_MERGE_DATE}
+## [Budget Menu Bar] - 2026-06-07
 
 - Add **Budget Menu Bar** command: glanceable spend vs cap for Claude Code, Codex, and Cursor with provider-colored progress bars.
 - Opt-in command (`disabledByDefault`); run it once from Raycast to pin the menu bar item. Background refresh every 15 minutes (enable in command preferences).
 
-## [Claude Code chat titles and Open Chat] - {PR_MERGE_DATE}
+## [Claude Code chat titles and Open Chat] - 2026-06-07
 
 - Fix Claude Code conversation names to match the app sidebar: prefer `/rename` custom titles, then `ai-title` lines from session JSONL.
 - Attribute subagent and forked-session usage to the parent chat so View Details totals match the dashboard.

--- a/extensions/tokentrack/CHANGELOG.md
+++ b/extensions/tokentrack/CHANGELOG.md
@@ -28,11 +28,6 @@
 
 ## [Major dashboard update] - 2026-06-06
 
-![Codex week usage and token chart](metadata/tokentrack-1.png)
-![Codex month usage and token chart](metadata/tokentrack-2.png)
-![Cursor monthly budget progress](metadata/tokentrack-3.png)
-![Cursor conversation details](metadata/tokentrack-4.png)
-
 - Rework dashboard around **Week** and **Month** calendar periods (Sunday → today, 1st → today); removed the Today row.
 - Add a dedicated **Budget** row with native monthly caps (Claude, Cursor) or a **rolling 7-day Codex window** (first-use anchored, matching Codex CLI) and an SVG progress bar in the detail panel.
 - Show cost and token counts as colored list accessories; budget row shows spend and cap separately.

--- a/extensions/tokentrack/CHANGELOG.md
+++ b/extensions/tokentrack/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Token Track Changelog
 
+## [Budget Menu Bar] - {PR_MERGE_DATE}
+
+- Add **Budget Menu Bar** command: glanceable spend vs cap for Claude Code, Codex, and Cursor with provider-colored progress bars.
+- Opt-in command (`disabledByDefault`); run it once from Raycast to pin the menu bar item. Background refresh every 15 minutes (enable in command preferences).
+
 ## [Claude Code chat titles and Open Chat] - {PR_MERGE_DATE}
 
 - Fix Claude Code conversation names to match the app sidebar: prefer `/rename` custom titles, then `ai-title` lines from session JSONL.

--- a/extensions/tokentrack/package.json
+++ b/extensions/tokentrack/package.json
@@ -48,6 +48,14 @@
       "title": "Quick Usage Cursor",
       "description": "Show Cursor spend against your monthly budget.",
       "mode": "no-view"
+    },
+    {
+      "name": "menu-bar-budget",
+      "title": "Budget Menu Bar",
+      "description": "Show Claude, Codex, and Cursor budget usage in the menu bar.",
+      "mode": "menu-bar",
+      "interval": "15m",
+      "disabledByDefault": true
     }
   ],
   "preferences": [

--- a/extensions/tokentrack/src/dashboard.tsx
+++ b/extensions/tokentrack/src/dashboard.tsx
@@ -3,7 +3,7 @@ import {
   ActionPanel,
   Color,
   Icon,
-  Image,
+  LaunchProps,
   List,
   getPreferenceValues,
   openExtensionPreferences,
@@ -33,12 +33,12 @@ import {
   renderTokenUsageChartMarkdown,
   type UsageBucket,
 } from "./lib/token-chart";
+import { PROVIDERS } from "./lib/provider-meta";
 import type { SourceProviderKey } from "./lib/types";
 import { COST_COLOR, DATE_COLOR } from "./lib/ui-colors";
 import { clearUsageSnapshotCache, loadUsage } from "./lib/usage";
 import { UsageDetailsView } from "./usage-details";
 
-const CURSOR_BRAND_HEX = "#A8DFB6";
 const BUDGET_ITEM_ID = "budget";
 const BUDGET_PACE_ITEM_ID = "budget-pace";
 
@@ -46,32 +46,6 @@ type SelectionId =
   | PeriodKey
   | typeof BUDGET_ITEM_ID
   | typeof BUDGET_PACE_ITEM_ID;
-
-const providersMeta: readonly {
-  key: SourceProviderKey;
-  title: string;
-  brandColor: string;
-  dropdownIcon: Image.ImageLike;
-}[] = [
-  {
-    key: "claude",
-    title: "Claude Code",
-    brandColor: "#D97757",
-    dropdownIcon: "provider-claude.png",
-  },
-  {
-    key: "codex",
-    title: "Codex",
-    brandColor: "#2D8EFF",
-    dropdownIcon: "provider-codex.png",
-  },
-  {
-    key: "cursor",
-    title: "Cursor",
-    brandColor: CURSOR_BRAND_HEX,
-    dropdownIcon: "provider-cursor.png",
-  },
-];
 
 const periodListTitles: Record<PeriodKey, string> = {
   week: "Week",
@@ -98,6 +72,9 @@ function isCursorWarning(text: string): boolean {
   return text.startsWith("Cursor");
 }
 
+const CURSOR_BRAND_HEX =
+  PROVIDERS.find((p) => p.key === "cursor")?.brandColor ?? "#A8DFB6";
+
 function usageAccentColor(pct: number, brandHex: string): Color.ColorLike {
   if (pct >= 0.9) return Color.Red;
   if (pct >= 0.6) return Color.Yellow;
@@ -123,15 +100,26 @@ function isPeriodKey(id: string): id is PeriodKey {
   return PERIOD_KEYS.includes(id as PeriodKey);
 }
 
-export default function Command() {
-  const prefs = getPreferenceValues<Preferences>();
-  const currency = prefs.currency || "USD";
-  const defaultSource: SourceProviderKey = providersMeta.some(
-    (p) => p.key === prefs.defaultSource,
-  )
+function resolveInitialProvider(
+  prefs: Preferences,
+  launchProvider?: SourceProviderKey,
+): SourceProviderKey {
+  if (launchProvider && PROVIDERS.some((p) => p.key === launchProvider)) {
+    return launchProvider;
+  }
+  return PROVIDERS.some((p) => p.key === prefs.defaultSource)
     ? prefs.defaultSource
     : "claude";
-  const [tab, setTab] = useState<SourceProviderKey>(defaultSource);
+}
+
+export default function Command(
+  props: LaunchProps<{ launchContext?: { provider?: SourceProviderKey } }>,
+) {
+  const prefs = getPreferenceValues<Preferences>();
+  const currency = prefs.currency || "USD";
+  const [tab, setTab] = useState<SourceProviderKey>(() =>
+    resolveInitialProvider(prefs, props.launchContext?.provider),
+  );
   const [selectedPeriod, setSelectedPeriod] = useState<PeriodKey>("week");
   const [selectedItemId, setSelectedItemId] = useState<SelectionId>("week");
 
@@ -156,7 +144,7 @@ export default function Command() {
     };
   }, [revalidate]);
 
-  const activeProvider = providersMeta.find((p) => p.key === tab)!;
+  const activeProvider = PROVIDERS.find((p) => p.key === tab)!;
   const nativeBudget = getProviderBudgetAmount(prefs, tab);
   const errors = data?.errors ?? [];
 
@@ -317,7 +305,7 @@ export default function Command() {
           value={tab}
           onChange={(v) => setTab(v as SourceProviderKey)}
         >
-          {providersMeta.map((p) => (
+          {PROVIDERS.map((p) => (
             <List.Dropdown.Item
               key={p.key}
               title={p.title}

--- a/extensions/tokentrack/src/dashboard.tsx
+++ b/extensions/tokentrack/src/dashboard.tsx
@@ -468,7 +468,6 @@ export default function Command(
               : []
           }
           detail={<List.Item.Detail metadata={budgetPaceDetailMetadata} />}
-          actions={refreshAction}
         />
       </List.Section>
 

--- a/extensions/tokentrack/src/lib/conversation-details.ts
+++ b/extensions/tokentrack/src/lib/conversation-details.ts
@@ -62,6 +62,9 @@ export function groupEventsByConversation(
 }
 
 function fallbackTitle(event: UsageEvent): string {
+  if (event.conversationKey?.startsWith("claude:")) {
+    return "Untitled chat";
+  }
   if (event.sourcePath?.endsWith(".jsonl")) {
     const base = event.sourcePath.split("/").pop() ?? event.sourcePath;
     const withoutExt = base.replace(/\.jsonl$/i, "");

--- a/extensions/tokentrack/src/lib/menu-bar-progress.ts
+++ b/extensions/tokentrack/src/lib/menu-bar-progress.ts
@@ -1,0 +1,30 @@
+import type { Image } from "@raycast/api";
+import { chartFillHex } from "./chart-color";
+
+const BAR_W = 96;
+const BAR_H = 10;
+const TRACK = "#3A3A3C";
+
+/** Compact horizontal progress bar for MenuBarExtra.Item icons. */
+export function menuBarProgressIcon(
+  spend: number,
+  cap: number,
+  brandHex: string,
+): Image.ImageLike {
+  const pct = cap > 0 ? Math.min(spend / cap, 1) : 0;
+  const fillW = pct > 0 ? Math.max(BAR_W * pct, 3) : 0;
+  const fill = chartFillHex(brandHex);
+  const r = BAR_H / 2;
+
+  const svg = [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${BAR_W}" height="${BAR_H}" viewBox="0 0 ${BAR_W} ${BAR_H}">`,
+    `<rect width="${BAR_W}" height="${BAR_H}" rx="${r}" fill="${TRACK}" fill-opacity="0.9"/>`,
+    fillW > 0
+      ? `<rect width="${fillW.toFixed(1)}" height="${BAR_H}" rx="${r}" fill="${fill}"/>`
+      : "",
+    `</svg>`,
+  ].join("");
+
+  const b64 = Buffer.from(svg, "utf-8").toString("base64");
+  return { source: `data:image/svg+xml;base64,${b64}` };
+}

--- a/extensions/tokentrack/src/lib/open-conversation.ts
+++ b/extensions/tokentrack/src/lib/open-conversation.ts
@@ -31,8 +31,6 @@ const CODEX_ROLLOUT_ID_RE =
 const CLAUDE_SESSION_ID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-const CLAUDE_PROJECT_CWD_RE = /\/\.claude\/projects\/([^/]+)\//;
-
 export type OpenConversationResult = { ok: boolean; reason?: string };
 
 /** Cursor has deeplinks for prompts/MCP/BugBot, but not to open a local chat by composerId. */
@@ -64,11 +62,24 @@ function claudeSessionId(
   return CLAUDE_SESSION_ID_RE.test(id) ? id : undefined;
 }
 
-/** `projects/-Users-foo-bar/` → `/Users/foo/bar`. */
-function claudeCwdFromSourcePath(sourcePath: string): string | undefined {
-  const encoded = CLAUDE_PROJECT_CWD_RE.exec(sourcePath)?.[1];
-  if (!encoded?.startsWith("-")) return undefined;
-  return `/${encoded.slice(1).replace(/-/g, "/")}`;
+/** Authoritative `cwd` from session transcript — folder names are lossy to decode. */
+function loadClaudeCwdFromSessionFile(sessionFile: string): string | undefined {
+  if (!sessionFile.endsWith(".jsonl") || !existsSync(sessionFile)) {
+    return undefined;
+  }
+
+  try {
+    for (const line of readFileSync(sessionFile, "utf8")
+      .split(/\r?\n/)
+      .slice(0, 20)) {
+      if (!line.trim()) continue;
+      const row = JSON.parse(line) as { cwd?: string };
+      if (typeof row.cwd === "string") return row.cwd;
+    }
+  } catch {
+    // optional transcript field
+  }
+  return undefined;
 }
 
 function loadClaudeSessionCwd(sessionId: string): string | undefined {
@@ -98,7 +109,7 @@ function resolveClaudeSessionCwd(
 ): string | undefined {
   return (
     loadClaudeSessionCwd(sessionId) ??
-    (sourcePath ? claudeCwdFromSourcePath(sourcePath) : undefined)
+    (sourcePath ? loadClaudeCwdFromSessionFile(sourcePath) : undefined)
   );
 }
 

--- a/extensions/tokentrack/src/lib/open-conversation.ts
+++ b/extensions/tokentrack/src/lib/open-conversation.ts
@@ -5,15 +5,18 @@ import {
   showToast,
   Toast,
 } from "@raycast/api";
-import { dirname } from "node:path";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { CLAUDE_DATA_PATH } from "./source-paths";
+import { expandHome } from "./sources/shared";
 import type { ConversationUsageSummary, SourceProviderKey } from "./types";
 
 /**
  * Verified macOS URL schemes (Jun 2026):
  * - Codex: `codex://threads/{session-uuid}` — OpenAI Codex app docs
- * - Claude: `claude://code/{session-uuid}` — Claude mobile/desktop Code tab links
- * - Cursor: no public deeplink to open a local composer by id (cursor-deeplink
- *   handles MCP, BugBot, cloud agents, prompts — not local composerId)
+ * - Claude Desktop Code: `claude://resume?session={uuid}&cwd={path}` opens the
+ *   session; `claude://code/{uuid}` opens the Code tab (may not jump to session)
+ * - Cursor: no public deeplink to open a local composer by id
  */
 const APP_BUNDLES: Record<SourceProviderKey, string> = {
   claude: "com.anthropic.claudefordesktop",
@@ -24,6 +27,11 @@ const APP_BUNDLES: Record<SourceProviderKey, string> = {
 /** Matches `src/lib/sources/codex.ts` — rollout filename trailing UUID. */
 const CODEX_ROLLOUT_ID_RE =
   /-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/i;
+
+const CLAUDE_SESSION_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const CLAUDE_PROJECT_CWD_RE = /\/\.claude\/projects\/([^/]+)\//;
 
 export type OpenConversationResult = { ok: boolean; reason?: string };
 
@@ -44,10 +52,54 @@ export function openConversationTooltip(
 function claudeSessionId(
   summary: ConversationUsageSummary,
 ): string | undefined {
+  if (summary.key.startsWith("claude:")) {
+    const id = summary.key.slice("claude:".length);
+    if (CLAUDE_SESSION_ID_RE.test(id)) return id;
+  }
+
   const path = summary.sourcePath ?? summary.key;
   const base = path.split("/").pop() ?? "";
   if (!base.endsWith(".jsonl")) return undefined;
-  return base.replace(/\.jsonl$/i, "");
+  const id = base.replace(/\.jsonl$/i, "");
+  return CLAUDE_SESSION_ID_RE.test(id) ? id : undefined;
+}
+
+/** `projects/-Users-foo-bar/` → `/Users/foo/bar`. */
+function claudeCwdFromSourcePath(sourcePath: string): string | undefined {
+  const encoded = CLAUDE_PROJECT_CWD_RE.exec(sourcePath)?.[1];
+  if (!encoded?.startsWith("-")) return undefined;
+  return `/${encoded.slice(1).replace(/-/g, "/")}`;
+}
+
+function loadClaudeSessionCwd(sessionId: string): string | undefined {
+  const sessionsDir = join(expandHome(CLAUDE_DATA_PATH), "sessions");
+  if (!existsSync(sessionsDir)) return undefined;
+
+  for (const name of readdirSync(sessionsDir)) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      const row = JSON.parse(readFileSync(join(sessionsDir, name), "utf8")) as {
+        sessionId?: string;
+        cwd?: string;
+      };
+      if (row.sessionId === sessionId && typeof row.cwd === "string") {
+        return row.cwd;
+      }
+    } catch {
+      // optional registry
+    }
+  }
+  return undefined;
+}
+
+function resolveClaudeSessionCwd(
+  sessionId: string,
+  sourcePath?: string,
+): string | undefined {
+  return (
+    loadClaudeSessionCwd(sessionId) ??
+    (sourcePath ? claudeCwdFromSourcePath(sourcePath) : undefined)
+  );
 }
 
 function codexSessionId(summary: ConversationUsageSummary): string | undefined {
@@ -60,8 +112,46 @@ async function isAppInstalled(bundleId: string): Promise<boolean> {
   return apps.some((app) => app.bundleId === bundleId);
 }
 
-async function openDeeplink(url: string, bundleId: string): Promise<void> {
-  await open(url, bundleId);
+function claudeDeepLinks(sessionId: string, cwd?: string): string[] {
+  const links: string[] = [];
+  if (cwd) {
+    const resume = new URL("claude://resume");
+    resume.searchParams.set("session", sessionId);
+    resume.searchParams.set("cwd", cwd);
+    links.push(resume.toString());
+  }
+  links.push(`claude://code/${sessionId}`);
+  return links;
+}
+
+async function openClaudeSession(
+  sessionId: string,
+  cwd: string | undefined,
+  bundleId: string,
+): Promise<void> {
+  const links = claudeDeepLinks(sessionId, cwd);
+  let lastError: unknown;
+
+  for (const link of links) {
+    try {
+      // Let Launch Services route the URL; forcing bundleId can foreground the
+      // app without handing off the session path.
+      await open(link);
+      return;
+    } catch (error) {
+      lastError = error;
+      try {
+        await open(link, bundleId);
+        return;
+      } catch (bundleError) {
+        lastError = bundleError;
+      }
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Failed to open Claude session");
 }
 
 export async function openConversation(
@@ -89,7 +179,7 @@ export async function openConversation(
       if (!(await isAppInstalled(bundleId))) {
         return { ok: false, reason: "Codex app is not installed" };
       }
-      await openDeeplink(`codex://threads/${sessionId}`, bundleId);
+      await open(`codex://threads/${sessionId}`, bundleId);
       return { ok: true };
     }
 
@@ -101,7 +191,8 @@ export async function openConversation(
 
       if (sessionId && appInstalled) {
         try {
-          await openDeeplink(`claude://code/${sessionId}`, bundleId);
+          const cwd = resolveClaudeSessionCwd(sessionId, path);
+          await openClaudeSession(sessionId, cwd, bundleId);
           return { ok: true };
         } catch {
           // Desktop may not route to the session — fall back to Finder.

--- a/extensions/tokentrack/src/lib/open-conversation.ts
+++ b/extensions/tokentrack/src/lib/open-conversation.ts
@@ -167,7 +167,7 @@ export async function openConversation(
       await open("cursor://", bundleId);
       return {
         ok: true,
-        reason: "Cursor opened. Find this chat in Previous Chats",
+        reason: "Find this chat in Cursor's Previous Chats",
       };
     }
     if (provider === "codex") {

--- a/extensions/tokentrack/src/lib/provider-meta.ts
+++ b/extensions/tokentrack/src/lib/provider-meta.ts
@@ -1,0 +1,30 @@
+import type { Image } from "@raycast/api";
+import type { SourceProviderKey } from "./types";
+
+export type ProviderMeta = {
+  key: SourceProviderKey;
+  title: string;
+  brandColor: string;
+  dropdownIcon: Image.ImageLike;
+};
+
+export const PROVIDERS: readonly ProviderMeta[] = [
+  {
+    key: "claude",
+    title: "Claude Code",
+    brandColor: "#D97757",
+    dropdownIcon: "provider-claude.png",
+  },
+  {
+    key: "codex",
+    title: "Codex",
+    brandColor: "#2D8EFF",
+    dropdownIcon: "provider-codex.png",
+  },
+  {
+    key: "cursor",
+    title: "Cursor",
+    brandColor: "#A8DFB6",
+    dropdownIcon: "provider-cursor.png",
+  },
+];

--- a/extensions/tokentrack/src/lib/sources/claude.ts
+++ b/extensions/tokentrack/src/lib/sources/claude.ts
@@ -14,15 +14,30 @@ import { expandHome, isInRange, safeNumber } from "./shared";
 
 type ClaudeFileTitles = {
   customTitle?: string;
+  /** From `{"type":"ai-title","aiTitle":"…"}` — sidebar title in Claude Desktop. */
   aiTitle?: string;
   firstUserMessage?: string;
 };
 
+type ClaudeSessionIndexEntry = {
+  customTitle?: string;
+  firstPrompt?: string;
+  summary?: string;
+  fullPath?: string;
+};
+
+type ClaudeSessionIndex = Map<string, ClaudeSessionIndexEntry>;
+
+/** Titles keyed by session UUID — survives stale paths in sessions-index. */
+type ClaudeSessionTitles = Map<string, ClaudeFileTitles>;
+
 type ClaudeRecord = {
   type?: string;
   timestamp?: string;
-  aiTitle?: string;
+  sessionId?: string;
+  isSidechain?: boolean;
   customTitle?: string;
+  aiTitle?: string;
   /** Top-level Anthropic request id (`req_…`); pairs with `message.id` to dedupe. */
   requestId?: string;
   message?: {
@@ -61,6 +76,13 @@ const CLAUDE_READ_CONCURRENCY = 2;
 /** Skip JSONL files not touched since before the window (sessions can span days). */
 const CLAUDE_FILE_BACKDATE_MS = 7 * 24 * 60 * 60 * 1000;
 
+const CLAUDE_SESSION_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Main session logs live at `projects/<cwd>/<uuid>.jsonl` — not `subagents/`. */
+const CLAUDE_MAIN_SESSION_FILE_RE =
+  /\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i;
+
 export async function readClaudeUsage(
   basePath: string,
   range: DateRange,
@@ -80,9 +102,10 @@ export async function readClaudeUsage(
 
   try {
     const files = await findJsonl(projectRoot, range);
-    const fileTitles = new Map<string, ClaudeFileTitles>();
+    const sessionIndex = loadClaudeSessionsIndex(projectRoot);
+    const sessionTitles = preloadClaudeSessionTitles(projectRoot);
     await runWithConcurrency(files, CLAUDE_READ_CONCURRENCY, (file) =>
-      readClaudeFile(file, range, sink, seen, fileTitles),
+      readClaudeFile(file, range, sink, seen, sessionTitles, sessionIndex),
     );
   } catch {
     errors.push("Claude: read error");
@@ -118,10 +141,19 @@ export function readClaudeUsageSync(basePath: string, range: DateRange) {
 
   if (!existsSync(projectRoot)) return { events, errors };
 
-  const fileTitles = new Map<string, ClaudeFileTitles>();
+  const sessionIndex = loadClaudeSessionsIndex(projectRoot);
+  const sessionTitles = preloadClaudeSessionTitles(projectRoot);
+  const files = findJsonlSync(projectRoot, range);
   try {
-    for (const file of findJsonlSync(projectRoot, range)) {
-      readClaudeFileSync(file, range, events, seen, fileTitles);
+    for (const file of files) {
+      readClaudeFileSync(
+        file,
+        range,
+        events,
+        seen,
+        sessionTitles,
+        sessionIndex,
+      );
     }
   } catch {
     errors.push("Claude: read error");
@@ -135,7 +167,8 @@ async function readClaudeFile(
   range: DateRange,
   sink: UsageReaderSink,
   seen: Set<string>,
-  fileTitles: Map<string, ClaudeFileTitles>,
+  sessionTitles: ClaudeSessionTitles,
+  sessionIndex: ClaudeSessionIndex,
 ) {
   const reader = createInterface({
     input: createReadStream(file, { encoding: "utf8" }),
@@ -145,8 +178,16 @@ async function readClaudeFile(
   let lineNumber = 0;
   for await (const line of reader) {
     lineNumber += 1;
-    noteClaudeSessionLine(file, line, fileTitles);
-    pushClaudeLine(file, line, lineNumber, range, sink, seen, fileTitles);
+    pushClaudeLine(
+      file,
+      line,
+      lineNumber,
+      range,
+      sink,
+      seen,
+      sessionTitles,
+      sessionIndex,
+    );
   }
 }
 
@@ -155,12 +196,12 @@ function readClaudeFileSync(
   range: DateRange,
   events: UsageEvent[],
   seen: Set<string>,
-  fileTitles: Map<string, ClaudeFileTitles>,
+  sessionTitles: ClaudeSessionTitles,
+  sessionIndex: ClaudeSessionIndex,
 ) {
   readFileSync(file, "utf8")
     .split(/\r?\n/)
     .forEach((line, index) => {
-      noteClaudeSessionLine(file, line, fileTitles);
       pushClaudeLine(
         file,
         line,
@@ -168,7 +209,8 @@ function readClaudeFileSync(
         range,
         { event: (e) => events.push(e) },
         seen,
-        fileTitles,
+        sessionTitles,
+        sessionIndex,
       );
     });
 }
@@ -177,64 +219,186 @@ const TIMESTAMP_RE = /"timestamp"\s*:\s*"([^"]+)"/;
 
 const CLAUDE_TITLE_MAX = 80;
 
-const CLAUDE_AI_TITLE_RE = /"aiTitle"\s*:\s*"((?:\\.|[^"\\])*)"/;
-const CLAUDE_CUSTOM_TITLE_RE = /"customTitle"\s*:\s*"((?:\\.|[^"\\])*)"/;
+function isMainClaudeSessionFile(file: string): boolean {
+  return CLAUDE_MAIN_SESSION_FILE_RE.test(file);
+}
 
-function decodeClaudeTitleField(raw: string): string {
-  try {
-    return JSON.parse(`"${raw}"`) as string;
-  } catch {
-    return raw.replace(/\\n/g, " ").replace(/\\"/g, '"');
+function sessionIdFromMainSessionFile(file: string): string | undefined {
+  if (!isMainClaudeSessionFile(file)) return undefined;
+  const base = file.split("/").pop() ?? "";
+  const id = base.replace(/\.jsonl$/i, "");
+  return CLAUDE_SESSION_ID_RE.test(id) ? id : undefined;
+}
+
+function mainSessionPathForFile(
+  file: string,
+  sessionId: string,
+  sessionIndex: ClaudeSessionIndex,
+): string {
+  const indexed = sessionIndex.get(sessionId)?.fullPath;
+  if (indexed) return indexed;
+
+  if (isMainClaudeSessionFile(file)) return file;
+
+  const marker = `/${sessionId}/`;
+  const subagentIdx = file.indexOf(marker);
+  if (subagentIdx >= 0) {
+    return `${file.slice(0, subagentIdx)}/${sessionId}.jsonl`;
   }
+
+  const dir = file.split("/").slice(0, -1).join("/");
+  const candidate = join(dir, `${sessionId}.jsonl`);
+  return existsSync(candidate) ? candidate : file;
 }
 
 /**
- * Claude Code stores two title types in each JSONL: `custom-title` (rename, Plan
- * mode, `-n`) beats background `ai-title`. Keep the last of each while scanning.
+ * Claude Desktop sidebar: `/rename` custom title, then `ai-title` lines in the
+ * session JSONL, then `sessions-index.json` when present.
  */
-function noteClaudeSessionLine(
-  file: string,
-  line: string,
-  fileTitles: Map<string, ClaudeFileTitles>,
-) {
+function loadClaudeSessionsIndex(projectRoot: string): ClaudeSessionIndex {
+  const index: ClaudeSessionIndex = new Map();
+  if (!existsSync(projectRoot)) return index;
+
+  for (const entry of readdirSync(projectRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const indexPath = join(projectRoot, entry.name, "sessions-index.json");
+    if (!existsSync(indexPath)) continue;
+
+    try {
+      const raw = JSON.parse(readFileSync(indexPath, "utf8")) as {
+        entries?: Array<{
+          sessionId?: string;
+          customTitle?: string;
+          firstPrompt?: string;
+          summary?: string;
+          fullPath?: string;
+          isSidechain?: boolean;
+        }>;
+      };
+      for (const row of raw.entries ?? []) {
+        if (typeof row.sessionId !== "string" || row.isSidechain) continue;
+        const customTitle =
+          typeof row.customTitle === "string" && row.customTitle.trim()
+            ? truncateClaudeTitle(row.customTitle)
+            : undefined;
+        const firstPrompt =
+          typeof row.firstPrompt === "string" && row.firstPrompt.trim()
+            ? truncateClaudeTitle(row.firstPrompt)
+            : undefined;
+        const summary =
+          typeof row.summary === "string" && row.summary.trim()
+            ? truncateClaudeTitle(row.summary)
+            : undefined;
+        const fullPath =
+          typeof row.fullPath === "string" ? row.fullPath : undefined;
+        const existing = index.get(row.sessionId);
+        index.set(row.sessionId, {
+          customTitle: customTitle ?? existing?.customTitle,
+          firstPrompt: firstPrompt ?? existing?.firstPrompt,
+          summary: summary ?? existing?.summary,
+          fullPath: fullPath ?? existing?.fullPath,
+        });
+      }
+    } catch {
+      // index is optional and may be stale
+    }
+  }
+
+  return index;
+}
+
+/** Main sessions only: `projects/<cwd>/<uuid>.jsonl` (never `subagents/`). */
+function findMainSessionJsonl(projectRoot: string): string[] {
+  if (!existsSync(projectRoot)) return [];
+
+  return readdirSync(projectRoot, { withFileTypes: true }).flatMap((entry) => {
+    if (!entry.isDirectory()) return [];
+    const dir = join(projectRoot, entry.name);
+    try {
+      return readdirSync(dir, { withFileTypes: true }).flatMap((file) => {
+        if (!file.isFile() || !file.name.endsWith(".jsonl")) return [];
+        const sessionId = file.name.replace(/\.jsonl$/i, "");
+        if (!CLAUDE_SESSION_ID_RE.test(sessionId)) return [];
+        return [join(dir, file.name)];
+      });
+    } catch {
+      return [];
+    }
+  });
+}
+
+function preloadClaudeSessionTitles(projectRoot: string): ClaudeSessionTitles {
+  const titles: ClaudeSessionTitles = new Map();
+
+  for (const file of findMainSessionJsonl(projectRoot)) {
+    const sessionId = sessionIdFromMainSessionFile(file);
+    if (!sessionId) continue;
+
+    let state = titles.get(sessionId);
+    if (!state) {
+      state = {};
+      titles.set(sessionId, state);
+    }
+
+    try {
+      for (const line of readFileSync(file, "utf8").split(/\r?\n/)) {
+        noteClaudeSessionLine(line, state);
+      }
+    } catch {
+      // optional metadata
+    }
+  }
+
+  return titles;
+}
+
+function noteClaudeSessionLine(line: string, state: ClaudeFileTitles) {
   if (line.length > 4_000) return;
+  if (
+    !line.includes('"custom-title"') &&
+    !line.includes('"ai-title"') &&
+    !line.includes('"type":"user"')
+  )
+    return;
 
-  let state = fileTitles.get(file);
-  if (!state) {
-    state = {};
-    fileTitles.set(file, state);
+  const record = parseLine(line);
+  if (!record) return;
+
+  if (record.type === "custom-title" && record.customTitle) {
+    const title = truncateClaudeTitle(record.customTitle);
+    if (title) state.customTitle = title;
+    return;
   }
 
-  if (line.includes('"custom-title"')) {
-    const match = CLAUDE_CUSTOM_TITLE_RE.exec(line);
-    if (match) {
-      const title = truncateClaudeTitle(decodeClaudeTitleField(match[1]));
-      if (title) state.customTitle = title;
-    }
+  if (record.type === "ai-title" && record.aiTitle) {
+    const title = truncateClaudeTitle(record.aiTitle);
+    if (title) state.aiTitle = title;
+    return;
   }
 
-  if (line.includes('"ai-title"')) {
-    const match = CLAUDE_AI_TITLE_RE.exec(line);
-    if (match) {
-      const title = truncateClaudeTitle(decodeClaudeTitleField(match[1]));
-      if (title) state.aiTitle = title;
-    }
-  }
+  if (record.isSidechain || record.type !== "user") return;
 
-  if (!state.firstUserMessage && line.includes('"type":"user"')) {
-    const record = parseLine(line);
-    if (record?.type === "user") {
-      const text = firstClaudeUserText(record);
-      if (text) state.firstUserMessage = truncateClaudeTitle(text);
-    }
+  if (!state.firstUserMessage) {
+    const text = firstClaudeUserText(record);
+    if (text) state.firstUserMessage = truncateClaudeTitle(text);
   }
 }
 
 function resolveClaudeSessionTitle(
-  state: ClaudeFileTitles | undefined,
+  sessionId: string,
+  sessionTitles: ClaudeSessionTitles,
+  sessionIndex: ClaudeSessionIndex,
 ): string | undefined {
-  if (!state) return undefined;
-  return state.customTitle ?? state.aiTitle ?? state.firstUserMessage;
+  const indexed = sessionIndex.get(sessionId);
+  const fileState = sessionTitles.get(sessionId);
+  return (
+    indexed?.customTitle ??
+    fileState?.customTitle ??
+    fileState?.aiTitle ??
+    indexed?.summary ??
+    indexed?.firstPrompt ??
+    fileState?.firstUserMessage
+  );
 }
 
 function firstClaudeUserText(record: ClaudeRecord): string | undefined {
@@ -242,9 +406,9 @@ function firstClaudeUserText(record: ClaudeRecord): string | undefined {
   if (typeof content === "string" && content.trim()) return content.trim();
   if (!Array.isArray(content)) return undefined;
   for (const part of content) {
+    if (!part || typeof part !== "object") continue;
+    if (part.type === "tool_result") continue;
     if (
-      part &&
-      typeof part === "object" &&
       part.type === "text" &&
       typeof part.text === "string" &&
       part.text.trim()
@@ -270,7 +434,8 @@ function pushClaudeLine(
   range: DateRange,
   sink: UsageReaderSink,
   seen: Set<string>,
-  fileTitles: Map<string, ClaudeFileTitles>,
+  sessionTitles: ClaudeSessionTitles,
+  sessionIndex: ClaudeSessionIndex,
 ) {
   if (!line.includes('"usage"')) return;
 
@@ -337,6 +502,15 @@ function pushClaudeLine(
     estimatedTokens: false,
   });
 
+  const sessionId =
+    (typeof record.sessionId === "string" &&
+      CLAUDE_SESSION_ID_RE.test(record.sessionId) &&
+      record.sessionId) ||
+    sessionIdFromMainSessionFile(file);
+  if (!sessionId) return;
+
+  const mainSessionPath = mainSessionPathForFile(file, sessionId, sessionIndex);
+
   sink.event?.({
     id: dedupKey ? `claude:${dedupKey}` : `claude:${file}:${lineNumber}`,
     provider: "claude",
@@ -349,9 +523,13 @@ function pushClaudeLine(
     totalTokens,
     estimatedCost,
     estimatedTokens: false,
-    sourcePath: file,
-    conversationKey: file,
-    conversationTitle: resolveClaudeSessionTitle(fileTitles.get(file)),
+    sourcePath: mainSessionPath,
+    conversationKey: `claude:${sessionId}`,
+    conversationTitle: resolveClaudeSessionTitle(
+      sessionId,
+      sessionTitles,
+      sessionIndex,
+    ),
   });
 }
 

--- a/extensions/tokentrack/src/lib/sources/claude.ts
+++ b/extensions/tokentrack/src/lib/sources/claude.ts
@@ -103,7 +103,7 @@ export async function readClaudeUsage(
   try {
     const files = await findJsonl(projectRoot, range);
     const sessionIndex = loadClaudeSessionsIndex(projectRoot);
-    const sessionTitles = preloadClaudeSessionTitles(projectRoot);
+    const sessionTitles = preloadClaudeSessionTitles(projectRoot, range);
     await runWithConcurrency(files, CLAUDE_READ_CONCURRENCY, (file) =>
       readClaudeFile(file, range, sink, seen, sessionTitles, sessionIndex),
     );
@@ -142,7 +142,7 @@ export function readClaudeUsageSync(basePath: string, range: DateRange) {
   if (!existsSync(projectRoot)) return { events, errors };
 
   const sessionIndex = loadClaudeSessionsIndex(projectRoot);
-  const sessionTitles = preloadClaudeSessionTitles(projectRoot);
+  const sessionTitles = preloadClaudeSessionTitles(projectRoot, range);
   const files = findJsonlSync(projectRoot, range);
   try {
     for (const file of files) {
@@ -308,8 +308,9 @@ function loadClaudeSessionsIndex(projectRoot: string): ClaudeSessionIndex {
 }
 
 /** Main sessions only: `projects/<cwd>/<uuid>.jsonl` (never `subagents/`). */
-function findMainSessionJsonl(projectRoot: string): string[] {
+function findMainSessionJsonl(projectRoot: string, range: DateRange): string[] {
   if (!existsSync(projectRoot)) return [];
+  const cutoffMs = range.start.getTime() - CLAUDE_FILE_BACKDATE_MS;
 
   return readdirSync(projectRoot, { withFileTypes: true }).flatMap((entry) => {
     if (!entry.isDirectory()) return [];
@@ -319,7 +320,13 @@ function findMainSessionJsonl(projectRoot: string): string[] {
         if (!file.isFile() || !file.name.endsWith(".jsonl")) return [];
         const sessionId = file.name.replace(/\.jsonl$/i, "");
         if (!CLAUDE_SESSION_ID_RE.test(sessionId)) return [];
-        return [join(dir, file.name)];
+        const path = join(dir, file.name);
+        try {
+          if (statSync(path).mtimeMs < cutoffMs) return [];
+        } catch {
+          return [];
+        }
+        return [path];
       });
     } catch {
       return [];
@@ -327,10 +334,13 @@ function findMainSessionJsonl(projectRoot: string): string[] {
   });
 }
 
-function preloadClaudeSessionTitles(projectRoot: string): ClaudeSessionTitles {
+function preloadClaudeSessionTitles(
+  projectRoot: string,
+  range: DateRange,
+): ClaudeSessionTitles {
   const titles: ClaudeSessionTitles = new Map();
 
-  for (const file of findMainSessionJsonl(projectRoot)) {
+  for (const file of findMainSessionJsonl(projectRoot, range)) {
     const sessionId = sessionIdFromMainSessionFile(file);
     if (!sessionId) continue;
 

--- a/extensions/tokentrack/src/menu-bar-budget.tsx
+++ b/extensions/tokentrack/src/menu-bar-budget.tsx
@@ -1,0 +1,125 @@
+import {
+  Icon,
+  MenuBarExtra,
+  getPreferenceValues,
+  launchCommand,
+  LaunchType,
+  openExtensionPreferences,
+} from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import {
+  budgetPeriodLabel,
+  budgetSpendForProvider,
+  formatBudgetCapCompact,
+  getProviderBudgetAmount,
+} from "./lib/budget";
+import { getCodexBudgetLoadRange } from "./lib/codex-budget";
+import { formatCurrencyMoney, getUsageLoadRange } from "./lib/format";
+import { menuBarProgressIcon } from "./lib/menu-bar-progress";
+import { PROVIDERS } from "./lib/provider-meta";
+import type { SourceProviderKey } from "./lib/types";
+import { clearUsageSnapshotCache, loadUsage } from "./lib/usage";
+import type { ProviderUsageSnapshot } from "./lib/usage-snapshot";
+
+async function loadAllBudgetData(): Promise<
+  Record<SourceProviderKey, ProviderUsageSnapshot>
+> {
+  const entries = await Promise.all(
+    PROVIDERS.map(async ({ key }) => {
+      const range =
+        key === "codex" ? getCodexBudgetLoadRange() : getUsageLoadRange();
+      const data = await loadUsage(range, key);
+      return [key, data] as const;
+    }),
+  );
+  return Object.fromEntries(entries) as Record<
+    SourceProviderKey,
+    ProviderUsageSnapshot
+  >;
+}
+
+function formatBudgetPercent(spend: number, cap: number): string {
+  if (cap <= 0) return "0%";
+  return `${Math.round((spend / cap) * 100).toLocaleString(undefined, { maximumFractionDigits: 0 })}%`;
+}
+
+export default function Command() {
+  const prefs = getPreferenceValues<Preferences>();
+  const currency = prefs.currency || "USD";
+
+  const { isLoading, data, revalidate } = useCachedPromise(
+    loadAllBudgetData,
+    [],
+    { keepPreviousData: true },
+  );
+
+  const handleRefresh = () => {
+    clearUsageSnapshotCache();
+    revalidate();
+  };
+
+  const snapshots =
+    data ??
+    (Object.create(null) as Record<SourceProviderKey, ProviderUsageSnapshot>);
+
+  return (
+    <MenuBarExtra
+      icon="extension-icon.png"
+      tooltip="Token Track Budgets"
+      isLoading={isLoading && !data}
+    >
+      <MenuBarExtra.Section>
+        {PROVIDERS.map(({ key, title, brandColor }) => {
+          const snapshot = snapshots[key];
+          const cap = getProviderBudgetAmount(prefs, key);
+          const spend = snapshot
+            ? budgetSpendForProvider(
+                key,
+                snapshot.periods,
+                snapshot.codexBudget,
+              )
+            : 0;
+          const spendStr = formatCurrencyMoney(spend, currency);
+          const capStr = formatBudgetCapCompact(cap, currency);
+          const inactive =
+            key === "codex" &&
+            snapshot?.codexBudget &&
+            !snapshot.codexBudget.windowActive;
+
+          return (
+            <MenuBarExtra.Item
+              key={key}
+              title={title}
+              subtitle={
+                inactive
+                  ? "Starts on next use"
+                  : `${spendStr} / ${capStr} · ${formatBudgetPercent(spend, cap)}`
+              }
+              icon={menuBarProgressIcon(spend, cap, brandColor)}
+              tooltip={`${title} · ${budgetPeriodLabel(key)}`}
+              onAction={() =>
+                launchCommand({
+                  name: "dashboard",
+                  type: LaunchType.UserInitiated,
+                  context: { provider: key },
+                })
+              }
+            />
+          );
+        })}
+      </MenuBarExtra.Section>
+      <MenuBarExtra.Section>
+        <MenuBarExtra.Item
+          title="Refresh"
+          icon={Icon.ArrowClockwise}
+          onAction={handleRefresh}
+        />
+        <MenuBarExtra.Item
+          title="Preferences…"
+          icon={Icon.Gear}
+          onAction={openExtensionPreferences}
+        />
+      </MenuBarExtra.Section>
+    </MenuBarExtra>
+  );
+}

--- a/extensions/tokentrack/src/usage-details.tsx
+++ b/extensions/tokentrack/src/usage-details.tsx
@@ -84,9 +84,9 @@ export function UsageDetailsView({
     return (
       <List navigationTitle={`${providerTitle} · ${periodLabel}`}>
         <List.EmptyView
-          icon={Icon.ExclamationMark}
-          title="Details unavailable"
-          description="No per-chat breakdown is available for this period."
+          icon={Icon.Message}
+          title="No chats"
+          description="Nothing in this period."
         />
       </List>
     );


### PR DESCRIPTION
## Description

Follow-up update for **Token Track** — Claude Code fixes, menu bar budget glance, and small polish.

**Budget Menu Bar**
- Add **Budget Menu Bar** command: glanceable spend vs cap for Claude Code, Codex, and Cursor with provider-colored progress bars.
- Opt-in command (`disabledByDefault`); run it once from Raycast to pin the menu bar item. Background refresh every 15 minutes (enable in command preferences).
- Extract shared provider metadata so the dashboard and menu bar stay in sync; menu bar can open the dashboard pre-filtered to a provider.

**Claude Code chat titles**
- Match Claude Desktop sidebar naming: prefer `/rename` custom titles, then `ai-title` lines from session JSONL, with `sessions-index.json` as fallback.
- Group conversations by session UUID (`claude:{uuid}`) instead of log file path.
- Attribute subagent and forked-session usage to the parent chat so **View Details** totals align with the dashboard.
- Scope title preload to the active date range so large Claude log histories stay within Raycast's memory cap.

**Open Chat**
- Resume sessions via `claude://resume?session={uuid}&cwd={path}` (falls back to `claude://code/{uuid}`).
- Resolve working directory from Claude's session registry or the project path encoded in log file paths.
- Shorten Cursor **Open Chat** toast to "Find this chat in Cursor's Previous Chats".

**View Details**
- Softer empty state when no chats exist in the selected period ("No chats" instead of "Details unavailable").

## Screencast

N/A — behavioral fixes and a new opt-in menu bar command; no store metadata or screenshot updates.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that this change does not break existing functionality
- [x] I checked that the extension's `CHANGELOG.md` entry uses the `{PR_MERGE_DATE}` placeholder