### PR TITLE
fix(quit-applications): resolve performance timeouts, crashes, and security vulnerabilities

### DIFF
--- a/extensions/quit-applications/CHANGELOG.md
+++ b/extensions/quit-applications/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quit Applications Changelog
 
-## [Bugfix & Performance] - 2026-06-07
+## [Bugfix & Performance] - {PR_MERGE_DATE}
 
 - Migrated running apps query to ASObjC (NSWorkspace) to prevent 5-second execution timeouts and process retrieval crashes.
 - Prevented system helper processes from cluttering the application list.

--- a/extensions/quit-applications/CHANGELOG.md
+++ b/extensions/quit-applications/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Quit Applications Changelog
 
+## [Bugfix & Performance] - 2026-06-07
+
+- Migrated running apps query to ASObjC (NSWorkspace) to prevent 5-second execution timeouts and process retrieval crashes.
+- Prevented system helper processes from cluttering the application list.
+- Patched AppleScript string injection vulnerabilities.
+- Resolved React duplicate key warnings and state synchronization bugs by targeting applications using absolute paths.
+- Fixed a crash in "Quit All" when `excludeApplications` preference is empty/undefined.
+
 ## [Bugfix] - 2026-05-28
 
 - Added timeout handling and fallback app discovery when loading running applications.

--- a/extensions/quit-applications/src/index.tsx
+++ b/extensions/quit-applications/src/index.tsx
@@ -20,13 +20,19 @@ function applicationNameFromPath(path: string): string {
   /* Example:
    * '/Applications/Visual Studio Code.app' -> 'Visual Studio Code'
    */
-
   const pathParts = path.split("/");
   const appName = pathParts[pathParts.length - 1];
   if (!appName) {
     throw new Error("appName not found");
   }
   return appName.replace(".app", "");
+}
+
+/**
+ * Escapes a string to be safe for interpolation inside AppleScript double quotes
+ */
+function escapeAppleScriptString(str: string): string {
+  return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
 async function getRunningAppsPaths(): Promise<string[]> {
@@ -40,7 +46,20 @@ async function getRunningAppsPaths(): Promise<string[]> {
     for (const line of outputLines) {
       const match = line.match(/(.+\.app)\/Contents\/MacOS\//);
       if (match && match[1]) {
-        appSet.add(match[1]);
+        const appPath = match[1];
+        // Exclude system services and helper processes in /System/Library/ (except /System/Applications/)
+        if (appPath.startsWith("/System/Library/") && !appPath.startsWith("/System/Applications/")) {
+          continue;
+        }
+        // Exclude helper/system items in /Library/
+        if (appPath.startsWith("/Library/")) {
+          continue;
+        }
+        // Exclude internal helpers inside application bundles (e.g. appName.app/Contents/Frameworks/helper.app)
+        if (appPath.includes(".app/Contents/")) {
+          continue;
+        }
+        appSet.add(appPath);
       }
     }
 
@@ -50,40 +69,46 @@ async function getRunningAppsPaths(): Promise<string[]> {
   try {
     const result = await runAppleScript(
       `
-      set appPaths to {}
-      tell application "System Events"
-        repeat with aProcess in (every process whose background only is false)
-          try
-            set processPath to POSIX path of (file of aProcess)
-            set end of appPaths to processPath
-          end try
-        end repeat
-      end tell
+      use AppleScript version "2.4"
+      use framework "Foundation"
+      use framework "AppKit"
+      use scripting additions
 
-      return appPaths
-    `,
+      set theWorkspace to current application's NSWorkspace's sharedWorkspace()
+      set runningApps to theWorkspace's runningApplications()
+
+      set thePredicate to current application's NSPredicate's predicateWithFormat:"activationPolicy == 0"
+      set regularApps to runningApps's filteredArrayUsingPredicate:thePredicate
+
+      set appPaths to {}
+      repeat with anApp in (regularApps as list)
+        try
+          set bundleURL to anApp's bundleURL()
+          if bundleURL is not missing value then
+            set end of appPaths to (bundleURL's |path|()) as text
+          end if
+        end try
+      end repeat
+
+      set AppleScript's text item delimiters to linefeed
+      return appPaths as text
+      `,
       { timeout: APPLESCRIPT_TIMEOUT_MS },
     );
 
-    return result.split(", ").map((appPath: string) => appPath.trim());
+    return result
+      .split("\n")
+      .map((appPath: string) => appPath.trim())
+      .filter(Boolean);
   } catch (error: unknown) {
-    const message = typeof error === "string" ? error : (error as Error)?.message ?? "";
-    const isTimedOut =
-      typeof error === "object" &&
-      error !== null &&
-      "timedOut" in error &&
-      (error as { timedOut: unknown }).timedOut === true;
-    if (message.includes("Not authorized to send Apple events") || isTimedOut) {
-      try {
-        const fallbackPaths = getRunningAppsPathsWithPs();
-        if (fallbackPaths.length > 0) {
-          return fallbackPaths;
-        }
-      } catch {
-        // ignore and fall-through to rethrow below
+    // Attempt fallback for ANY failure of AppleScript execution for maximum resilience
+    try {
+      const fallbackPaths = getRunningAppsPathsWithPs();
+      if (fallbackPaths.length > 0) {
+        return fallbackPaths;
       }
-      // If we reach here, fallback failed as well; rethrow
-      throw error;
+    } catch {
+      // Ignore and throw original error below if fallback fails as well
     }
     throw error;
   }
@@ -92,7 +117,7 @@ async function getRunningAppsPaths(): Promise<string[]> {
 function quitApp(app: string) {
   return runAppleScript(
     `try
-  tell application "${app}" to quit
+  tell application "${escapeAppleScriptString(app)}" to quit
   on error error_message number error_number
       if error_number is equal to -128 then
       -- the user cancelled the action. no need to error
@@ -106,7 +131,7 @@ end try`,
 
 function restartApp(app: string) {
   return runAppleScript(
-    `tell application "${app}"
+    `tell application "${escapeAppleScriptString(app)}"
                             repeat while its running
                               quit
                               delay 0.5
@@ -117,35 +142,35 @@ function restartApp(app: string) {
   );
 }
 
-async function quitAppWithToast(app: string): Promise<boolean> {
+async function quitAppWithToast(app: string, displayName = app): Promise<boolean> {
   try {
     await quitApp(app);
     showToast({
       style: Toast.Style.Success,
-      title: `Quit ${app}`,
+      title: `Quit ${displayName}`,
     });
     return true;
   } catch {
     showToast({
       style: Toast.Style.Failure,
-      title: `Unable to quit ${app}`,
+      title: `Unable to quit ${displayName}`,
     });
     return false;
   }
 }
 
-async function restartAppWithToast(app: string): Promise<boolean> {
+async function restartAppWithToast(app: string, displayName = app): Promise<boolean> {
   try {
     await restartApp(app);
     showToast({
       style: Toast.Style.Success,
-      title: `Restarted ${app}`,
+      title: `Restarted ${displayName}`,
     });
     return true;
   } catch {
     showToast({
       style: Toast.Style.Failure,
-      title: `Unable to restart ${app}`,
+      title: `Unable to restart ${displayName}`,
     });
     return false;
   }
@@ -172,6 +197,7 @@ export default function Command({ launchContext }: CommandProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [searchText, setSearchText] = useState("");
+
   useEffect(() => {
     if (launchContext && launchContext.appName && launchContext.action) {
       const { appName, action } = launchContext;
@@ -245,21 +271,22 @@ export default function Command({ launchContext }: CommandProps) {
                 title="Quit All"
                 onAction={async () => {
                   let remainingApps = [...apps];
+                  const excludedNames = preferences.excludeApplications ? preferences.excludeApplications : "";
+                  const excludedList = excludedNames
+                    .split(",")
+                    .map((name: string) => name.trim().toLowerCase())
+                    .filter(Boolean);
 
                   for (const app of apps) {
-                    if (
-                      preferences.excludeApplications
-                        .split(",")
-                        .map((name: string) => name.trim())
-                        .includes(app.name)
-                    ) {
+                    if (excludedList.includes(app.name.toLowerCase())) {
                       continue;
                     }
 
-                    const success = await quitAppWithToast(app.name);
+                    // Pass path for accurate targetting, name for the toast display
+                    const success = await quitAppWithToast(app.path, app.name);
 
                     if (success) {
-                      remainingApps = remainingApps.filter((a) => a.name !== app.name);
+                      remainingApps = remainingApps.filter((a) => a.path !== app.path);
                     }
                   }
 
@@ -269,7 +296,7 @@ export default function Command({ launchContext }: CommandProps) {
                     clearSearchBar();
                   }
 
-                  if (remainingApps.length == 0) {
+                  if (remainingApps.length === 0) {
                     popToRoot({ clearSearchBar: true });
                   }
                 }}
@@ -281,7 +308,7 @@ export default function Command({ launchContext }: CommandProps) {
       {apps.map((app) => (
         <List.Item
           title={app.name}
-          key={app.name}
+          key={app.path}
           id={app.path}
           icon={{ fileIcon: app.path }}
           actions={
@@ -289,11 +316,11 @@ export default function Command({ launchContext }: CommandProps) {
               <Action
                 title="Quit"
                 onAction={async () => {
-                  const success = await quitAppWithToast(app.name);
+                  // Pass path for accurate targetting, name for the toast display
+                  const success = await quitAppWithToast(app.path, app.name);
 
                   if (success) {
-                    const removedAppIndex = apps.findIndex((a) => a.name === app.name);
-                    setApps((apps) => apps.toSpliced(removedAppIndex, 1));
+                    setApps((apps) => apps.filter((a) => a.path !== app.path));
                   }
 
                   if (searchText) {
@@ -304,7 +331,8 @@ export default function Command({ launchContext }: CommandProps) {
               <Action
                 title="Restart"
                 onAction={async () => {
-                  await restartAppWithToast(app.name);
+                  // Pass path for accurate targetting, name for the toast display
+                  await restartAppWithToast(app.path, app.name);
                 }}
               />
               <Action.CreateQuicklink

--- a/extensions/quit-applications/src/index.tsx
+++ b/extensions/quit-applications/src/index.tsx
@@ -47,8 +47,8 @@ async function getRunningAppsPaths(): Promise<string[]> {
       const match = line.match(/(.+\.app)\/Contents\/MacOS\//);
       if (match && match[1]) {
         const appPath = match[1];
-        // Exclude system services and helper processes in /System/Library/ (except /System/Applications/)
-        if (appPath.startsWith("/System/Library/") && !appPath.startsWith("/System/Applications/")) {
+        // Exclude system services and helper processes in /System/Library/
+        if (appPath.startsWith("/System/Library/")) {
           continue;
         }
         // Exclude helper/system items in /Library/
@@ -176,14 +176,14 @@ async function restartAppWithToast(app: string, displayName = app): Promise<bool
   }
 }
 
-function getQuickLinkForApp(appName: string, action: string): string {
-  const context = JSON.stringify({ appName, action });
+function getQuickLinkForApp(appPath: string, appName: string, action: string): string {
+  const context = JSON.stringify({ appPath, appName, action });
   const encodedContext = encodeURIComponent(context);
   return `raycast://extensions/mackopes/quit-applications/index?context=${encodedContext}`;
 }
 
 type CommandProps = {
-  launchContext?: { appName: string; action: string /* quit | restart */ };
+  launchContext?: { appPath?: string; appName: string; action: string /* quit | restart */ };
 };
 
 export default function Command({ launchContext }: CommandProps) {
@@ -199,13 +199,14 @@ export default function Command({ launchContext }: CommandProps) {
   const [searchText, setSearchText] = useState("");
 
   useEffect(() => {
-    if (launchContext && launchContext.appName && launchContext.action) {
-      const { appName, action } = launchContext;
+    if (launchContext && launchContext.action) {
+      const { appPath, appName, action } = launchContext;
+      const target = appPath || appName;
 
       if (action === "quit") {
-        void quitAppWithToast(appName);
+        void quitAppWithToast(target, appName);
       } else if (action === "restart") {
-        void restartAppWithToast(appName);
+        void restartAppWithToast(target, appName);
       }
       return;
     }
@@ -337,11 +338,11 @@ export default function Command({ launchContext }: CommandProps) {
               />
               <Action.CreateQuicklink
                 title="Create Quit Quicklink"
-                quicklink={{ link: getQuickLinkForApp(app.name, "quit"), name: `Quit ${app.name}` }}
+                quicklink={{ link: getQuickLinkForApp(app.path, app.name, "quit"), name: `Quit ${app.name}` }}
               />
               <Action.CreateQuicklink
                 title="Create Restart Quicklink"
-                quicklink={{ link: getQuickLinkForApp(app.name, "restart"), name: `Restart ${app.name}` }}
+                quicklink={{ link: getQuickLinkForApp(app.path, app.name, "restart"), name: `Restart ${app.name}` }}
               />
             </ActionPanel>
           }


### PR DESCRIPTION
## Description

This PR stabilizes and optimizes the `quit-applications` extension by addressing a series of critical bugs, performance issues, and security vulnerabilities:

### 1. Performance & Timeout Fix (AppleScript API Migration)
* **Issue**: The original AppleScript looped over every running process to extract paths. In systems with many running processes, this took **over 8 seconds** (exceeding Raycast's 5-second `osascript` timeout) causing the extension to hang and fail on launch.
* **Fix**: Migrated the AppleScript query to AppleScript Objective-C (ASObjC), directly querying `NSWorkspace.sharedWorkspace().runningApplications()`. This runs in **~700ms**, eliminating timeouts.
* **Closes** #28274

### 2. Elimination of System Process Clutter
* **Issue**: When the previous AppleScript timed out, it fell back to a `ps` command matching `.app/Contents/MacOS/`. This fallback listed critical background system processes (e.g., `loginwindow`, `WindowManager`, `WiFiAgent`) as GUI applications.
* **Fix**:
  1. The optimized AppleScript no longer times out, ensuring only user-facing GUI apps (`activationPolicy == 0`) are listed.
  2. The `ps` fallback logic was refined to explicitly exclude items under `/System/Library/` (except `/System/Applications/`), `/Library/`, and helper bundles ending in `.app/Contents/`.

### 3. AppleScript Injection Prevention (Security)
* **Issue**: In `quitApp` and `restartApp`, the application identifier (path/name) was interpolated directly into AppleScript double quotes, allowing potential arbitrary command execution if an application name contained escape characters/double quotes.
* **Fix**: Added `escapeAppleScriptString` to escape double quotes and backslashes in all interpolated AppleScript strings.

### 4. React State & Target Integrity
* **Issue**: Quitting or restarting applications targeted items by `app.name`. If a user had multiple processes with the same app name running from different paths, it caused React duplicate key warnings and state synchronization bugs (removing the wrong item from the view).
* **Fix**: Switched the React `key` and target identifiers to `app.path` (which is unique). Passed the absolute path directly to AppleScript (which natively supports POSIX paths), ensuring precise app targeting.
* **Closes** #26580

### 5. "Quit All" Optional Preference Crash & Permission Failures
* **Issue**: 
  1. Calling `.split(",")` on `preferences.excludeApplications` crashed the extension if the preference was empty/undefined.
  2. The permission error check was hardcoded to US spelling (`"Not authorized"`), failing to trigger the `ps` fallback on machines with UK/intl locales returning `"Not authorised"`.
* **Fix**: 
  1. Added safe fallback parsing for `excludeApplications`.
  2. Catch any AppleScript error to trigger the `ps` fallback, resolving permission checking bugs.
* **Closes** #28258

---

## Screencast

<details>
    <summary><b>Before (Showing system processes & helpers)</b></summary>
<img width="1500" height="948" alt="CleanShot 2026-06-07 at 14 26 52@2x" src="https://github.com/user-attachments/assets/b1df0a8a-2241-4bb3-9584-60af066959d4" />

 
</details>

<details>
    <summary><b>After (Clean list showing only user-facing GUI apps)</b></summary>
<img width="1496" height="956" alt="CleanShot 2026-06-07 at 15 31 36@2x" src="https://github.com/user-attachments/assets/6b5cd654-7068-46e9-888d-d1fa0dfc496c" />


</details>

---

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
