### PR TITLE
[granola] Fix auth for Granola v7+ by reading encrypted token store

### DIFF
--- a/extensions/granola/CHANGELOG.md
+++ b/extensions/granola/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Granola Changelog
 
+## [Read tokens from Granola's encrypted cache] - {PR_MERGE_DATE}
+
+### Bug Fixes
+
+- Fixed Search Notes, Export Transcripts, Get Transcript, and other commands failing with
+  "Could not communicate with the Granola service" / empty or missing transcripts on newer Granola
+  desktop versions (v7.x+). These versions stop maintaining usable plaintext tokens in
+  `supabase.json` / `stored-accounts.json` (the refresh tokens get revoked with `logout_user`) and
+  instead store the live session in an encrypted cache (`*.enc` + `storage.dek`).
+- The extension now reads the access token from the encrypted store on macOS, decrypting it with the
+  "Granola Safe Storage" Keychain key (Chromium `safeStorage` scheme: PBKDF2 + AES-128-CBC to unwrap
+  the data key, then AES-256-GCM for the payload). The existing plaintext token sources are kept as a
+  fallback for older Granola versions, and the error message now guides users to allow the Keychain
+  prompt when needed.
+
 ## [Sortable date prefixes for exports] - 2026-05-29
 
 - Prefix exported note and transcript filenames with ISO-8601 creation date

--- a/extensions/granola/src/utils/getAccessToken.ts
+++ b/extensions/granola/src/utils/getAccessToken.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "fs";
 import { getStoredAccountsPath, getSupabaseConfigPath } from "./granolaConfig";
 import { logGranolaError, logGranolaInfo, logGranolaWarn } from "./errorUtils";
+import { decryptGranolaFile, getKeychainPassword, loadDek } from "./granolaCrypto";
 
 const GRANOLA_API_URL = "https://api.granola.ai/v1";
 const GRANOLA_CLIENT_VERSION = "7.162.1";
@@ -247,6 +248,60 @@ async function getAccessTokenFromPlaintextSupabase(): Promise<string | undefined
   return tryRefreshAndSelectAccessToken(workosTokens, persistWorkOsTokensToSupabase);
 }
 
+function parseAccountsArray(value: unknown): Record<string, unknown>[] | undefined {
+  let parsed: unknown = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return undefined;
+    }
+  }
+  return Array.isArray(parsed) ? (parsed as Record<string, unknown>[]) : undefined;
+}
+
+/**
+ * Read a valid access token from the encrypted `supabase.json.enc`, which newer Granola versions
+ * keep up to date (the plaintext `supabase.json` is left stale). Returns undefined if the file
+ * cannot be decrypted (e.g. non-macOS, keychain access denied) so callers fall back.
+ */
+async function getAccessTokenFromEncryptedSupabase(): Promise<string | undefined> {
+  const jsonData = await decryptGranolaFile("supabase.json");
+  if (!jsonData) return undefined;
+
+  const validToken = selectAccessTokenFromSupabaseData(jsonData);
+  if (validToken) return validToken;
+
+  const workosTokens = parseMaybeJsonRecord(jsonData.workos_tokens);
+  return tryRefreshAndSelectAccessToken(workosTokens, persistWorkOsTokensToSupabase);
+}
+
+/**
+ * Read a valid access token from the encrypted `stored-accounts.json.enc`.
+ */
+async function getAccessTokenFromEncryptedStoredAccounts(): Promise<string | undefined> {
+  const jsonData = await decryptGranolaFile("stored-accounts.json");
+  if (!jsonData) return undefined;
+
+  const accounts = parseAccountsArray(jsonData.accounts);
+  if (!accounts) return undefined;
+
+  for (const account of sortStoredAccounts(accounts)) {
+    try {
+      const parsedTokens = parseMaybeJsonRecord(account.tokens);
+      const token = selectAccessToken(parsedTokens);
+      if (token) return token;
+
+      const refreshedToken = await tryRefreshAndSelectAccessToken(parsedTokens);
+      if (refreshedToken) return refreshedToken;
+    } catch {
+      // Try the next saved account.
+    }
+  }
+
+  return undefined;
+}
+
 export async function getLocalGranolaUserInfo(): Promise<LocalGranolaUserInfo> {
   const plaintextSupabase = await readPlaintextSupabaseConfig();
   if (plaintextSupabase?.user_info) {
@@ -267,6 +322,35 @@ export async function getLocalGranolaUserInfo(): Promise<LocalGranolaUserInfo> {
         return {
           userInfo: requireJsonRecord(account.userInfo, "stored account userInfo"),
           sourceName: "stored accounts",
+        };
+      } catch {
+        // Try the next saved account.
+      }
+    }
+  }
+
+  // Newer Granola versions keep user_info only in the encrypted store.
+  const dek = await loadDek();
+  if (dek) {
+    const encryptedSupabase = await decryptGranolaFile("supabase.json", dek);
+    if (encryptedSupabase?.user_info) {
+      try {
+        return {
+          userInfo: requireJsonRecord(encryptedSupabase.user_info, "encrypted Supabase config user_info"),
+          sourceName: "encrypted Supabase config",
+        };
+      } catch {
+        // Fall through to encrypted stored accounts.
+      }
+    }
+
+    const encryptedStored = await decryptGranolaFile("stored-accounts.json", dek);
+    const encryptedAccounts = encryptedStored ? parseAccountsArray(encryptedStored.accounts) : undefined;
+    for (const account of encryptedAccounts ? sortStoredAccounts(encryptedAccounts) : []) {
+      try {
+        return {
+          userInfo: requireJsonRecord(account.userInfo, "encrypted stored account userInfo"),
+          sourceName: "encrypted stored accounts",
         };
       } catch {
         // Try the next saved account.
@@ -333,20 +417,52 @@ async function getAccessTokenDiagnostics(): Promise<Record<string, unknown>> {
     diagnostics.storedAccountsExists = false;
   }
 
+  // Encrypted store (newer Granola versions). Report presence + whether we can decrypt it.
+  try {
+    await fs.access(getSupabaseConfigPath().replace(/supabase\.json$/, "supabase.json.enc"));
+    diagnostics.encryptedSupabaseExists = true;
+  } catch {
+    diagnostics.encryptedSupabaseExists = false;
+  }
+  diagnostics.keychainPasswordAvailable = Boolean(await getKeychainPassword());
+  const encryptedSupabase = await decryptGranolaFile("supabase.json");
+  diagnostics.encryptedSupabaseDecryptable = Boolean(encryptedSupabase);
+  if (encryptedSupabase) {
+    diagnostics.encryptedSupabaseWorkosTokens = describeTokenRecord(
+      parseMaybeJsonRecord(encryptedSupabase.workos_tokens),
+    );
+  }
+
   return diagnostics;
 }
 
 async function getAccessToken() {
-  const accessToken = (await getAccessTokenFromPlaintextSupabase()) ?? (await getAccessTokenFromStoredAccounts());
+  const accessToken =
+    (await getAccessTokenFromPlaintextSupabase()) ??
+    (await getAccessTokenFromEncryptedSupabase()) ??
+    (await getAccessTokenFromStoredAccounts()) ??
+    (await getAccessTokenFromEncryptedStoredAccounts());
 
   if (!accessToken) {
     const diagnostics = await getAccessTokenDiagnostics();
     const workosExpired = diagnostics.supabaseWorkosTokens as { expired?: boolean } | undefined;
-    const error = new Error(
-      workosExpired?.expired
-        ? "Your Granola access token has expired and could not be refreshed automatically. Open the Granola app while logged in to refresh your session, then try again."
-        : "A usable access token was not found in your local Granola data. Make sure Granola is installed, running, and that you are logged in to the application.",
-    );
+    const encryptedExists = diagnostics.encryptedSupabaseExists === true;
+    const keychainAvailable = diagnostics.keychainPasswordAvailable === true;
+
+    let message: string;
+    if (encryptedExists && process.platform === "darwin" && !keychainAvailable) {
+      // Newer Granola only keeps a usable token in the encrypted store, which needs Keychain access.
+      message =
+        "Granola stores your session in an encrypted file that requires Keychain access. When macOS asks to use the “Granola Safe Storage” keychain item, choose Allow, then try again. Make sure the Granola app is installed and you are logged in.";
+    } else if (workosExpired?.expired) {
+      message =
+        "Your Granola access token has expired and could not be refreshed automatically. Open the Granola app while logged in to refresh your session, then try again.";
+    } else {
+      message =
+        "A usable access token was not found in your local Granola data. Make sure Granola is installed, running, and that you are logged in to the application.";
+    }
+
+    const error = new Error(message);
     logGranolaError("getAccessToken", error, diagnostics);
     throw error;
   }

--- a/extensions/granola/src/utils/granolaCrypto.ts
+++ b/extensions/granola/src/utils/granolaCrypto.ts
@@ -1,0 +1,152 @@
+import { promises as fs } from "fs";
+import crypto from "crypto";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { getGranolaConfigPath } from "./granolaConfig";
+import { logGranolaError, logGranolaInfo, logGranolaWarn } from "./errorUtils";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Reads the live Granola session from the *encrypted* on-disk store.
+ *
+ * Newer Granola desktop versions (v7.x+) no longer keep usable plaintext tokens in
+ * `supabase.json` / `stored-accounts.json`; those files go stale while the app rewrites
+ * encrypted siblings (`*.enc`) plus a wrapped data-encryption key (`storage.dek`).
+ *
+ * The scheme mirrors Chromium's `safeStorage` and the proven `tomelliot/obsidian-granola-sync`
+ * implementation:
+ *   1. `storage.dek` = `v10` prefix + AES-128-CBC(ciphertext), where the wrapping key is
+ *      PBKDF2-HMAC-SHA1 of the "Granola Safe Storage" macOS keychain password. The plaintext is
+ *      base64 of the 32-byte DEK.
+ *   2. Each `<name>.enc` payload is a bare AES-256-GCM blob (12-byte IV + ciphertext + 16-byte
+ *      tag) keyed by that DEK, decrypting to the same JSON shape as the plaintext file.
+ *
+ * Only macOS is supported here (keychain via the `security` CLI). On other platforms these
+ * helpers return `undefined` so callers fall back to the plaintext token sources.
+ */
+
+const KEYCHAIN_SERVICE = "Granola Safe Storage";
+const KEYCHAIN_ACCOUNT = "Granola Key";
+
+const V10_PREFIX = "v10";
+const DEK_LENGTH = 32;
+
+// Chromium macOS OSCrypt KDF parameters.
+const PBKDF2_SALT = "saltysalt";
+const PBKDF2_ITERATIONS = 1003;
+const PBKDF2_KEY_LENGTH = 16;
+const PBKDF2_DIGEST = "sha1";
+const KEYCHAIN_DEK_IV = Buffer.alloc(16, 0x20); // 16 ASCII spaces
+
+// AES-256-GCM on-disk layout for the `.enc` payloads.
+const GCM_IV_LENGTH = 12;
+const GCM_TAG_LENGTH = 16;
+
+function stripV10Prefix(blob: Buffer, source: string): Buffer {
+  if (blob.subarray(0, V10_PREFIX.length).toString("utf8") !== V10_PREFIX) {
+    throw new Error(`${source} does not start with the ${V10_PREFIX} prefix`);
+  }
+  return blob.subarray(V10_PREFIX.length);
+}
+
+/**
+ * Reads the "Granola Safe Storage" password from the macOS keychain via the `security` CLI.
+ * Triggers a one-time OS prompt the first time. Returns `undefined` on any failure (non-macOS,
+ * missing item, denied prompt) so callers can fall through gracefully.
+ */
+export async function getKeychainPassword(): Promise<string | undefined> {
+  if (process.platform !== "darwin") {
+    return undefined;
+  }
+  try {
+    const { stdout, stderr } = await execFileAsync("security", [
+      "find-generic-password",
+      "-w",
+      "-s",
+      KEYCHAIN_SERVICE,
+      "-a",
+      KEYCHAIN_ACCOUNT,
+    ]);
+    const password = stdout.replace(/\n$/, "");
+    if (password.length > 0) {
+      logGranolaInfo("getKeychainPassword", { found: true, passwordLength: password.length });
+      return password;
+    }
+    logGranolaWarn("getKeychainPassword", { found: false, stderr: stderr?.trim().slice(0, 100) });
+    return undefined;
+  } catch (error) {
+    logGranolaError("getKeychainPassword", error);
+    return undefined;
+  }
+}
+
+/**
+ * Unwraps `storage.dek` into the 32-byte data-encryption key. Returns `undefined` if the key
+ * material is unavailable or cannot be decrypted.
+ */
+export async function loadDek(): Promise<Buffer | undefined> {
+  const password = await getKeychainPassword();
+  if (!password) {
+    return undefined;
+  }
+
+  try {
+    const dekBlob = await fs.readFile(getGranolaConfigPath("storage.dek"));
+    const wrappingKey = crypto.pbkdf2Sync(
+      password,
+      PBKDF2_SALT,
+      PBKDF2_ITERATIONS,
+      PBKDF2_KEY_LENGTH,
+      PBKDF2_DIGEST,
+    );
+    const decipher = crypto.createDecipheriv("aes-128-cbc", wrappingKey, KEYCHAIN_DEK_IV);
+    const plaintext = Buffer.concat([decipher.update(stripV10Prefix(dekBlob, "storage.dek")), decipher.final()]);
+    const dek = Buffer.from(plaintext.toString("utf8"), "base64");
+    if (dek.length !== DEK_LENGTH) {
+      throw new Error(`Expected a ${DEK_LENGTH}-byte DEK, got ${dek.length}`);
+    }
+    return dek;
+  } catch (error) {
+    logGranolaError("loadDek", error);
+    return undefined;
+  }
+}
+
+function decryptGcmPayload(dek: Buffer, blob: Buffer): Buffer {
+  if (blob.length < GCM_IV_LENGTH + GCM_TAG_LENGTH) {
+    throw new Error("Encrypted payload is too short to contain an IV and auth tag");
+  }
+  const iv = blob.subarray(0, GCM_IV_LENGTH);
+  const tag = blob.subarray(blob.length - GCM_TAG_LENGTH);
+  const ciphertext = blob.subarray(GCM_IV_LENGTH, blob.length - GCM_TAG_LENGTH);
+  const decipher = crypto.createDecipheriv("aes-256-gcm", dek, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
+/**
+ * Decrypts a Granola encrypted config file (e.g. `supabase.json` -> reads `supabase.json.enc`)
+ * and returns the parsed JSON object, or `undefined` if it cannot be read/decrypted.
+ *
+ * An optional pre-resolved `dek` avoids re-reading the keychain when decrypting several files.
+ */
+export async function decryptGranolaFile(
+  filename: string,
+  dek?: Buffer,
+): Promise<Record<string, unknown> | undefined> {
+  try {
+    const key = dek ?? (await loadDek());
+    if (!key) {
+      return undefined;
+    }
+    const blob = await fs.readFile(getGranolaConfigPath(`${filename}.enc`));
+    const json = decryptGcmPayload(key, blob).toString("utf8");
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    logGranolaInfo("decryptGranolaFile", { filename, keys: Object.keys(parsed) });
+    return parsed;
+  } catch (error) {
+    logGranolaError("decryptGranolaFile", error, { filename });
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Newer Granola desktop versions (v7.x+) no longer maintain usable tokens in the plaintext `supabase.json` / `stored-accounts.json` files. The refresh tokens in those files are revoked (`401 {"error":"logout_user"}`), so all extension commands fail with **"Could not communicate with the Granola service"** and transcripts return empty or missing. Re-logging into the Granola app does not restore the plaintext files.

The current Granola app writes the live session only to encrypted siblings (`supabase.json.enc`, `stored-accounts.json.enc`, `storage.dek`) using the Chromium `safeStorage` scheme.

### Changes

- **New `src/utils/granolaCrypto.ts`** — reads the `Granola Safe Storage` macOS keychain password (via the `security` CLI), unwraps `storage.dek` (PBKDF2-HMAC-SHA1 + AES-128-CBC), and decrypts `*.enc` payloads (AES-256-GCM). macOS-only; returns `undefined` on other platforms so callers fall through to the existing plaintext sources. No new npm dependencies.
- **`src/utils/getAccessToken.ts`** — adds two new encrypted token sources to the chain (encrypted supabase → encrypted stored-accounts), reusing all existing helper functions. Also extends `getLocalGranolaUserInfo` and diagnostics, and improves the error message to guide users to allow the keychain prompt.
- **`CHANGELOG.md`** — new entry describing the fix.

The plaintext token sources are kept as a fallback for users on older Granola versions.

### Verification

Tested locally on macOS with Granola v7.x (plaintext tokens expired/revoked):
- Decryption probe: keychain password found, DEK = 32 bytes, `GET /v2/get-documents` → **200**, 1 doc, 1463 transcript segments ✓
- TypeScript build: clean ✓

Fixes #28227 and the recurring token expiry reports (#27740, #27744, #22674, #22903).

## Test plan

- [ ] Install Granola desktop v7+ and confirm `supabase.json` tokens are stale/expired
- [ ] Run **Search Notes** — notes load (previously "Could not communicate")
- [ ] Run **Export Transcripts** — transcripts export successfully
- [ ] On macOS: first run triggers a one-time OS prompt for "Granola Safe Storage" keychain access; clicking Allow restores full functionality
- [ ] On older Granola (plaintext tokens still valid): extension continues to work via the existing plaintext path

🤖 Generated with [Claude Code](https://claude.com/claude-code)