### PR TITLE
Update quarantine-manager extension

### DIFF
--- a/extensions/quarantine-manager/.gitignore
+++ b/extensions/quarantine-manager/.gitignore
@@ -3,6 +3,7 @@ dist/
 .DS_Store
 
 .claude/
+CLAUDE.md
 
 # Raycast specific files
 .raycast-swift-build

--- a/extensions/quarantine-manager/CHANGELOG.md
+++ b/extensions/quarantine-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quarantine Manager
 
-## [Scan apps and folders] - {PR_MERGE_DATE}
+## [Scan apps and folders] - 2026-06-08
 
 ### Added
 

--- a/extensions/quarantine-manager/CHANGELOG.md
+++ b/extensions/quarantine-manager/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Quarantine Manager
 
+## [Scan apps and folders] - {PR_MERGE_DATE}
+
+### Added
+
+- Scan directories for quarantined files: `.app` bundles are scanned recursively (they often contain many internal quarantined files), while plain folders are scanned one level deep so large trees stay responsive
+- **Check Quarantine Status** lists every quarantined item found inside an app or folder
+- **Remove Quarantine** shows an aggregate summary and clears `com.apple.quarantine` from a whole bundle or folder at once (recursive), plus a recursive "Remove All Attributes" option
+
 ## [Initial Release] - 2026-03-12
 
 ### Added

--- a/extensions/quarantine-manager/README.md
+++ b/extensions/quarantine-manager/README.md
@@ -12,16 +12,6 @@ Developers and power users frequently need to check and clear this flag — for 
 
 ---
 
-## Screenshots
-
-<img src="metadata/quarantine-manager-1.png" width="800" alt="Remove Quarantine command">
-<img src="metadata/quarantine-manager-2.png" width="800" alt="Quarantine details view">
-<img src="metadata/quarantine-manager-3.png" width="800" alt="Extended attributes list">
-<img src="metadata/quarantine-manager-4.png" width="800" alt="Check Quarantine Status command">
-<img src="metadata/quarantine-manager-5.png" width="800" alt="Attribute detail view">
-
----
-
 ## Commands
 
 ### Remove Quarantine

--- a/extensions/quarantine-manager/README.md
+++ b/extensions/quarantine-manager/README.md
@@ -1,10 +1,26 @@
 # Quarantine Manager
 
-Inspect and manage extended attributes on macOS files and applications — without opening Terminal.
+<img src="assets/extension-icon.png" width="64" align="right" alt="Quarantine Manager icon">
+
+A [Raycast](https://raycast.com) extension to inspect and manage extended attributes on macOS files and apps — without opening Terminal.
 
 When you download an app outside the Mac App Store, macOS tags it with a `com.apple.quarantine` extended attribute. This triggers a Gatekeeper prompt on first launch: _"This app was downloaded from the internet. Are you sure you want to open it?"_
 
 Developers and power users frequently need to check and clear this flag — for apps built locally, tools distributed via direct download, or utilities that Gatekeeper misidentifies. This extension gives you a fast, readable way to do that from Raycast.
+
+<a title="Install quarantine-manager Raycast Extension" href="https://www.raycast.com/nurkamol/quarantine-manager"><img src="https://www.raycast.com/nurkamol/quarantine-manager/install_button@2x.png?v=1.1" height="64" style="height: 64px;" alt=""></a>
+
+---
+
+## Screenshots
+
+<img src="metadata/quarantine-manager-1.png" width="800" alt="Remove Quarantine command">
+<img src="metadata/quarantine-manager-2.png" width="800" alt="Quarantine details view">
+<img src="metadata/quarantine-manager-3.png" width="800" alt="Extended attributes list">
+<img src="metadata/quarantine-manager-4.png" width="800" alt="Check Quarantine Status command">
+<img src="metadata/quarantine-manager-5.png" width="800" alt="Attribute detail view">
+
+---
 
 ## Commands
 
@@ -31,14 +47,48 @@ Opens a file picker (or uses your current Finder selection), then shows a full b
 
 Lists every extended attribute on a file in a searchable list view. Tap any attribute to see its full value — useful for understanding exactly what metadata macOS has attached to a file.
 
+### Apps & folders
+
+Both commands also accept directories:
+
+- **Apps (`.app`)** are scanned **recursively** — bundles often hold many internal quarantined files, and you'll see each one listed (and can clear them all at once).
+- **Plain folders** are scanned **one level deep** (immediate contents only), so large directories like Downloads stay fast.
+
+When removing on a directory, the extension runs the recursive `xattr -dr` after a confirmation that tells you how many items are affected.
+
+---
+
 ## Tips
 
 - **Select a file in Finder first** — if you already have a file selected, the command skips the picker entirely and loads it immediately
 - **Protected files** — if the file requires elevated permissions, the extension will prompt for your admin password via a standard macOS dialog
-- **The xattr command** — use "Copy xattr Command" to get the terminal equivalent if you prefer to run it manually or use it in a script
+- **The xattr command** — use "Copy Xattr Command" to get the terminal equivalent if you prefer to run it manually or use it in a script
+
+---
 
 ## Requirements
 
 - macOS 12.0 or later
-- Raycast 1.50.0 or later
+- [Raycast](https://raycast.com) 1.50.0 or later
 - Raycast must have Automation permission for Finder: **System Settings → Privacy & Security → Automation**
+
+---
+
+## Installation
+
+Install directly from the [Raycast Store](https://www.raycast.com/nurkamol/quarantine-manager).
+
+Or clone and run locally:
+
+```bash
+git clone https://github.com/nurkamol/quarantine-manager
+cd quarantine-manager
+npm install
+npm run dev
+```
+
+---
+
+## License
+
+MIT

--- a/extensions/quarantine-manager/src/check-quarantine.tsx
+++ b/extensions/quarantine-manager/src/check-quarantine.tsx
@@ -11,11 +11,14 @@ import {
 } from "@raycast/api";
 import { useEffect, useRef, useState } from "react";
 import {
+  DirectoryScan,
   getFinderSelection,
   getQuarantineStatus,
+  isDirectory,
   parseQuarantineData,
   parseQuarantineFlags,
   QuarantineStatus,
+  scanDirectory,
   XattrInfo,
 } from "./utils";
 
@@ -23,6 +26,7 @@ type State =
   | { type: "selecting" }
   | { type: "loading" }
   | { type: "ready"; status: QuarantineStatus }
+  | { type: "ready-dir"; scan: DirectoryScan }
   | { type: "error"; message: string };
 
 function buildQuarantineMarkdown(attr: XattrInfo): string {
@@ -86,6 +90,16 @@ function buildGenericMarkdown(attr: XattrInfo): string {
   }
 
   return md;
+}
+
+/** Wraps a raw com.apple.quarantine value as an XattrInfo for AttributeDetail. */
+function entryToXattr(value: string): XattrInfo {
+  return {
+    name: "com.apple.quarantine",
+    value,
+    isQuarantine: true,
+    isDangerous: true,
+  };
 }
 
 function AttributeDetail({
@@ -205,14 +219,23 @@ export default function CheckQuarantine() {
 
   async function loadFile(filePath: string) {
     setState({ type: "loading" });
+    const scanningDir = isDirectory(filePath);
     const toast = await showToast({
       style: Toast.Style.Animated,
-      title: "Reading attributes…",
+      title: scanningDir
+        ? "Scanning for quarantined files…"
+        : "Reading attributes…",
     });
     try {
-      const status = getQuarantineStatus(filePath);
-      await toast.hide();
-      setState({ type: "ready", status });
+      if (scanningDir) {
+        const scan = scanDirectory(filePath);
+        await toast.hide();
+        setState({ type: "ready-dir", scan });
+      } else {
+        const status = getQuarantineStatus(filePath);
+        await toast.hide();
+        setState({ type: "ready", status });
+      }
     } catch (err) {
       await toast.hide();
       const message = err instanceof Error ? err.message : String(err);
@@ -263,6 +286,152 @@ export default function CheckQuarantine() {
           </ActionPanel>
         }
       />
+    );
+  }
+
+  // ─── Directory scan state ─────────────────────────────────────────────────
+
+  if (state.type === "ready-dir") {
+    const { scan } = state;
+    const kind = scan.isApp ? "app" : "folder";
+    const scopeNote =
+      scan.scanMode === "recursive"
+        ? "recursive scan"
+        : "immediate contents only";
+    const total = scan.entries.length + (scan.rootQuarantineData ? 1 : 0);
+
+    const selectDifferentFileDir: Action.Props = {
+      title: "Select Different File",
+      icon: Icon.Folder,
+      shortcut: { modifiers: ["cmd"], key: "o" },
+      onAction: () => selectFile(true),
+    };
+
+    return (
+      <List searchBarPlaceholder="Filter quarantined items…">
+        <List.Section title="Summary">
+          <List.Item
+            title={scan.name}
+            subtitle={scan.path}
+            icon={
+              total > 0
+                ? { source: Icon.Lock, tintColor: Color.Red }
+                : { source: Icon.Checkmark, tintColor: Color.Green }
+            }
+            accessories={[
+              {
+                tag: {
+                  value: total > 0 ? `${total} quarantined` : "No quarantine",
+                  color: total > 0 ? Color.Red : Color.Green,
+                },
+              },
+              { text: `${kind} · ${scopeNote}` },
+            ]}
+            actions={
+              <ActionPanel>
+                <Action.CopyToClipboard title="Copy Path" content={scan.path} />
+                <Action.CopyToClipboard
+                  title="Copy Recursive Remove Command"
+                  content={`xattr -dr com.apple.quarantine "${scan.path}"`}
+                />
+                <Action {...selectDifferentFileDir} />
+              </ActionPanel>
+            }
+          />
+        </List.Section>
+
+        {scan.rootQuarantineData && (
+          <List.Section title={scan.isApp ? "Bundle" : "Folder"}>
+            <List.Item
+              title={`${scan.name} (itself)`}
+              subtitle={parseQuarantineFlags(scan.rootQuarantineData)}
+              icon={{ source: Icon.Lock, tintColor: Color.Red }}
+              accessories={[{ tag: { value: "Security", color: Color.Red } }]}
+              actions={
+                <ActionPanel>
+                  <Action.Push
+                    title="View Details"
+                    icon={Icon.Eye}
+                    target={
+                      <AttributeDetail
+                        attr={entryToXattr(scan.rootQuarantineData)}
+                        filePath={scan.path}
+                      />
+                    }
+                  />
+                  <Action.CopyToClipboard
+                    title="Copy Value"
+                    content={scan.rootQuarantineData}
+                  />
+                  <Action {...selectDifferentFileDir} />
+                </ActionPanel>
+              }
+            />
+          </List.Section>
+        )}
+
+        {scan.entries.length > 0 ? (
+          <List.Section title={`Quarantined Files (${scan.entries.length})`}>
+            {scan.entries.map((entry) => (
+              <List.Item
+                key={entry.path}
+                title={entry.relativePath}
+                subtitle={
+                  entry.quarantineData
+                    ? parseQuarantineFlags(entry.quarantineData)
+                    : undefined
+                }
+                icon={{ source: Icon.Lock, tintColor: Color.Red }}
+                accessories={[
+                  { tag: { value: "Quarantined", color: Color.Red } },
+                ]}
+                actions={
+                  <ActionPanel>
+                    <Action.Push
+                      title="View Details"
+                      icon={Icon.Eye}
+                      target={
+                        <AttributeDetail
+                          attr={entryToXattr(entry.quarantineData ?? "")}
+                          filePath={entry.path}
+                        />
+                      }
+                    />
+                    <Action.CopyToClipboard
+                      title="Copy Path"
+                      content={entry.path}
+                    />
+                    <Action.CopyToClipboard
+                      title="Copy Remove Command"
+                      content={`xattr -d com.apple.quarantine "${entry.path}"`}
+                    />
+                    <Action {...selectDifferentFileDir} />
+                  </ActionPanel>
+                }
+              />
+            ))}
+          </List.Section>
+        ) : (
+          !scan.rootQuarantineData && (
+            <List.Section title="Result">
+              <List.Item
+                title={`No quarantined files found in this ${kind}`}
+                subtitle={
+                  scan.scanMode === "shallow"
+                    ? "Only immediate contents were scanned"
+                    : undefined
+                }
+                icon={{ source: Icon.Checkmark, tintColor: Color.Green }}
+                actions={
+                  <ActionPanel>
+                    <Action {...selectDifferentFileDir} />
+                  </ActionPanel>
+                }
+              />
+            </List.Section>
+          )
+        )}
+      </List>
     );
   }
 

--- a/extensions/quarantine-manager/src/remove-quarantine.tsx
+++ b/extensions/quarantine-manager/src/remove-quarantine.tsx
@@ -121,7 +121,7 @@ function buildDirMarkdown(scan: DirectoryScan): string {
   }
 
   if (total > 0) {
-    md += `> Use **Remove Quarantine (recursive)** to clear \`com.apple.quarantine\` from `;
+    md += `> Use **Remove Quarantine (Recursive)** to clear \`com.apple.quarantine\` from `;
     md += `${scan.isApp ? "the entire bundle" : "this folder and its contents"} at once.\n`;
   }
 

--- a/extensions/quarantine-manager/src/remove-quarantine.tsx
+++ b/extensions/quarantine-manager/src/remove-quarantine.tsx
@@ -12,18 +12,22 @@ import {
 } from "@raycast/api";
 import { useEffect, useRef, useState } from "react";
 import {
+  DirectoryScan,
   getFinderSelection,
   getQuarantineStatus,
+  isDirectory,
   parseQuarantineData,
   QuarantineStatus,
   removeAllAttributes,
   removeQuarantine,
+  scanDirectory,
 } from "./utils";
 
 type State =
   | { type: "selecting" }
   | { type: "loading"; path: string }
   | { type: "ready"; status: QuarantineStatus }
+  | { type: "ready-dir"; scan: DirectoryScan }
   | { type: "error"; message: string };
 
 function buildMarkdown(status: QuarantineStatus): string {
@@ -73,6 +77,57 @@ function buildMarkdown(status: QuarantineStatus): string {
   return md;
 }
 
+function buildDirMarkdown(scan: DirectoryScan): string {
+  const kind = scan.isApp ? "Application bundle" : "Folder";
+  const total = scan.entries.length + (scan.rootQuarantineData ? 1 : 0);
+  const statusIcon = total > 0 ? "🔒" : "✅";
+  const statusText =
+    total > 0
+      ? `**${total} quarantined item${total !== 1 ? "s" : ""}**`
+      : "**Clean** — no quarantine";
+
+  let md = `# ${statusIcon} ${scan.name}\n\n`;
+  md += `| Property | Value |\n|---|---|\n`;
+  md += `| Status | ${statusText} |\n`;
+  md += `| Type | ${kind} |\n`;
+  md += `| Scan | ${scan.scanMode === "recursive" ? "Recursive (entire bundle)" : "Immediate contents only"} |\n`;
+  md += `| Modified | ${scan.lastModified} |\n`;
+  md += `| Path | \`${scan.path}\` |\n\n`;
+
+  if (scan.rootQuarantineData) {
+    const parsed = parseQuarantineData(scan.rootQuarantineData);
+    md += `## The ${scan.isApp ? "bundle" : "folder"} itself is quarantined\n\n`;
+    if (parsed) {
+      md += `> ✦ Source: **${parsed.source}** · ${parsed.date}\n\n`;
+    }
+  }
+
+  if (scan.entries.length > 0) {
+    md += `## Quarantined Files (${scan.entries.length})\n\n`;
+    md += `| File | Source | Downloaded |\n|---|---|---|\n`;
+    for (const entry of scan.entries) {
+      const parsed = entry.quarantineData
+        ? parseQuarantineData(entry.quarantineData)
+        : null;
+      md += `| \`${entry.relativePath}\` | ${parsed?.source ?? "—"} | ${parsed?.date ?? "—"} |\n`;
+    }
+    md += `\n`;
+  } else if (!scan.rootQuarantineData) {
+    md += `*No quarantined files found`;
+    md +=
+      scan.scanMode === "shallow"
+        ? " in the immediate contents.*\n\n"
+        : ".*\n\n";
+  }
+
+  if (total > 0) {
+    md += `> Use **Remove Quarantine (recursive)** to clear \`com.apple.quarantine\` from `;
+    md += `${scan.isApp ? "the entire bundle" : "this folder and its contents"} at once.\n`;
+  }
+
+  return md;
+}
+
 export default function RemoveQuarantine() {
   const [state, setState] = useState<State>({ type: "selecting" });
   const didMount = useRef(false);
@@ -96,14 +151,23 @@ export default function RemoveQuarantine() {
 
   async function loadFile(filePath: string) {
     setState({ type: "loading", path: filePath });
+    const scanningDir = isDirectory(filePath);
     const toast = await showToast({
       style: Toast.Style.Animated,
-      title: "Reading attributes…",
+      title: scanningDir
+        ? "Scanning for quarantined files…"
+        : "Reading attributes…",
     });
     try {
-      const status = getQuarantineStatus(filePath);
-      await toast.hide();
-      setState({ type: "ready", status });
+      if (scanningDir) {
+        const scan = scanDirectory(filePath);
+        await toast.hide();
+        setState({ type: "ready-dir", scan });
+      } else {
+        const status = getQuarantineStatus(filePath);
+        await toast.hide();
+        setState({ type: "ready", status });
+      }
     } catch (err) {
       await toast.hide();
       const message = err instanceof Error ? err.message : String(err);
@@ -178,6 +242,72 @@ export default function RemoveQuarantine() {
     }
   }
 
+  async function handleRemoveQuarantineDir(scan: DirectoryScan) {
+    const total = scan.entries.length + (scan.rootQuarantineData ? 1 : 0);
+    const confirmed = await confirmAlert({
+      title: "Remove Quarantine (Recursive)",
+      message: `Remove the quarantine flag from ${total} item${total !== 1 ? "s" : ""} in "${scan.name}"?\n\nThis runs xattr -dr on ${scan.isApp ? "the entire bundle" : "this folder and its contents"}.`,
+      primaryAction: { title: "Remove", style: Alert.ActionStyle.Destructive },
+    });
+    if (!confirmed) return;
+
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: "Removing quarantine…",
+    });
+    const result = removeQuarantine(scan.path);
+    await toast.hide();
+
+    if (result.success) {
+      await showToast({
+        style: Toast.Style.Success,
+        title: "Quarantine removed",
+        message: result.usedAdmin ? `${scan.name} (required admin)` : scan.name,
+      });
+      void loadFile(scan.path);
+    } else {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Could not remove quarantine",
+        message: result.error ?? "Unknown error",
+      });
+    }
+  }
+
+  async function handleRemoveAllAttributesDir(scan: DirectoryScan) {
+    const confirmed = await confirmAlert({
+      title: "Remove All Extended Attributes (Recursive)",
+      message: `Remove ALL xattr data from "${scan.name}" and everything inside it?\n\nThis clears quarantine, download source info, and any other extended attributes via xattr -cr.`,
+      primaryAction: {
+        title: "Remove All",
+        style: Alert.ActionStyle.Destructive,
+      },
+    });
+    if (!confirmed) return;
+
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: "Removing attributes…",
+    });
+    const result = removeAllAttributes(scan.path, true);
+    await toast.hide();
+
+    if (result.success) {
+      await showToast({
+        style: Toast.Style.Success,
+        title: "All attributes removed",
+        message: scan.name,
+      });
+      void loadFile(scan.path);
+    } else {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Could not remove attributes",
+        message: result.error ?? "Unknown error",
+      });
+    }
+  }
+
   // ─── Selecting state (no Finder selection) ───────────────────────────────
 
   if (state.type === "selecting") {
@@ -217,6 +347,87 @@ export default function RemoveQuarantine() {
               title="Try Again"
               icon={Icon.RotateClockwise}
               onAction={selectFile}
+            />
+          </ActionPanel>
+        }
+      />
+    );
+  }
+
+  // ─── Directory scan state ─────────────────────────────────────────────────
+
+  if (state.type === "ready-dir") {
+    const { scan } = state;
+    const total = scan.entries.length + (scan.rootQuarantineData ? 1 : 0);
+    return (
+      <Detail
+        markdown={buildDirMarkdown(scan)}
+        metadata={
+          <Detail.Metadata>
+            <Detail.Metadata.Label
+              title="Quarantine Status"
+              text={total > 0 ? `${total} quarantined` : "Clean"}
+              icon={
+                total > 0
+                  ? { source: Icon.Lock, tintColor: Color.Red }
+                  : { source: Icon.Checkmark, tintColor: Color.Green }
+              }
+            />
+            <Detail.Metadata.Separator />
+            <Detail.Metadata.Label title="Name" text={scan.name} />
+            <Detail.Metadata.Label
+              title="Type"
+              text={scan.isApp ? "Application" : "Folder"}
+            />
+            <Detail.Metadata.Label
+              title="Scan"
+              text={
+                scan.scanMode === "recursive"
+                  ? "Recursive"
+                  : "Immediate contents"
+              }
+            />
+            <Detail.Metadata.Label
+              title="Quarantined Files"
+              text={String(scan.entries.length)}
+            />
+            <Detail.Metadata.Label
+              title="Last Modified"
+              text={scan.lastModified}
+            />
+          </Detail.Metadata>
+        }
+        actions={
+          <ActionPanel>
+            {total > 0 && (
+              <Action
+                title="Remove Quarantine (recursive)"
+                icon={{ source: Icon.LockUnlocked, tintColor: Color.Green }}
+                onAction={() => handleRemoveQuarantineDir(scan)}
+              />
+            )}
+            {total > 0 && (
+              <Action
+                title="Remove All Attributes (recursive)"
+                icon={{ source: Icon.Trash, tintColor: Color.Orange }}
+                onAction={() => handleRemoveAllAttributesDir(scan)}
+              />
+            )}
+            <Action
+              title="Select Different File"
+              icon={Icon.Folder}
+              shortcut={{ modifiers: ["cmd"], key: "o" }}
+              onAction={() => selectFile(true)}
+            />
+            <Action.CopyToClipboard
+              title="Copy Path"
+              content={scan.path}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+            />
+            <Action.CopyToClipboard
+              title="Copy Recursive Remove Command"
+              content={`xattr -dr com.apple.quarantine "${scan.path}"`}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "x" }}
             />
           </ActionPanel>
         }

--- a/extensions/quarantine-manager/src/utils.ts
+++ b/extensions/quarantine-manager/src/utils.ts
@@ -28,6 +28,30 @@ export function isApp(filePath: string): boolean {
   return filePath.endsWith(".app") || filePath.includes(".app/");
 }
 
+export function isDirectory(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True if a decoded attribute value contains non-printable control bytes or the
+ * Unicode replacement char — i.e. it's raw binary that should be shown as hex
+ * rather than printed directly (which would render as � / □).
+ */
+function looksBinary(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const c = value.charCodeAt(i);
+    // Allow tab (9), newline (10), carriage return (13).
+    if (c === 9 || c === 10 || c === 13) continue;
+    // Other C0 control chars or the Unicode replacement char => binary.
+    if (c < 0x20 || c === 0xfffd) return true;
+  }
+  return false;
+}
+
 export function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -91,6 +115,17 @@ export function getQuarantineStatus(filePath: string): QuarantineStatus {
           } catch {
             value = "(unable to read)";
           }
+        }
+      } else if (looksBinary(raw)) {
+        // Raw binary (e.g. com.apple.macl, com.apple.provenance) — show as hex
+        // instead of letting non-printable bytes render as � / □.
+        try {
+          value = execFileSync("xattr", ["-px", attrName, filePath], {
+            encoding: "utf8",
+            timeout: 5000,
+          }).trim();
+        } catch {
+          value = "(binary data)";
         }
       } else {
         value = raw.trim();
@@ -181,13 +216,18 @@ export function removeQuarantine(filePath: string): {
     }
   }
 }
-export function removeAllAttributes(filePath: string): {
+
+export function removeAllAttributes(
+  filePath: string,
+  recursive = false,
+): {
   success: boolean;
   usedAdmin: boolean;
   error?: string;
 } {
+  const flag = recursive ? "-cr" : "-c";
   try {
-    execFileSync("xattr", ["-c", filePath], { timeout: 10000 });
+    execFileSync("xattr", [flag, filePath], { timeout: 10000 });
     return { success: true, usedAdmin: false };
   } catch {
     try {
@@ -199,7 +239,7 @@ export function removeAllAttributes(filePath: string): {
           "-e",
           "set p to item 1 of argv",
           "-e",
-          'do shell script "xattr -c " & quoted form of POSIX path p with administrator privileges',
+          `do shell script "xattr ${flag} " & quoted form of POSIX path p with administrator privileges`,
           "-e",
           "end run",
           filePath,
@@ -290,4 +330,124 @@ export function parseQuarantineFlags(rawValue: string): string {
   const parsed = parseQuarantineData(rawValue);
   if (!parsed) return rawValue;
   return `Source: ${parsed.source} | Date: ${parsed.date} | Flags: ${parsed.flags.join(", ")}`;
+}
+
+const QUARANTINE_SUFFIX = ": com.apple.quarantine";
+
+export interface DirEntry {
+  path: string;
+  name: string;
+  relativePath: string;
+  quarantineData: string | null;
+}
+
+export interface DirectoryScan {
+  path: string;
+  name: string;
+  isApp: boolean;
+  /** "recursive" for .app bundles, "shallow" (immediate children) for folders */
+  scanMode: "recursive" | "shallow";
+  /** The directory's own com.apple.quarantine attribute, if any */
+  rootQuarantineData: string | null;
+  /** Quarantined items found inside the directory (excludes the root itself) */
+  entries: DirEntry[];
+  lastModified: string;
+}
+
+/**
+ * Reads the value of com.apple.quarantine for a single path.
+ * Returns the raw value, or null if the attribute is absent.
+ */
+function readQuarantineValue(filePath: string): string | null {
+  const res = spawnSync("xattr", ["-p", "com.apple.quarantine", filePath], {
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  if (res.status === 0) {
+    return (res.stdout ?? "").trim();
+  }
+  return null;
+}
+
+/**
+ * Parses `xattr` listing output (one `<path>: <attr>` line per attribute) and
+ * returns the paths that carry com.apple.quarantine. Matching on the exact
+ * suffix keeps paths containing ": " intact.
+ */
+function collectQuarantinedPaths(
+  stdout: string,
+  excludePath?: string,
+): string[] {
+  const paths: string[] = [];
+  for (const line of stdout.split("\n")) {
+    if (!line.endsWith(QUARANTINE_SUFFIX)) continue;
+    const p = line.slice(0, -QUARANTINE_SUFFIX.length);
+    if (p && p !== excludePath) paths.push(p);
+  }
+  return paths;
+}
+
+/**
+ * Scans a directory for quarantined files. .app bundles are scanned recursively
+ * (they are self-contained); plain folders are scanned one level deep so large
+ * trees stay responsive.
+ */
+export function scanDirectory(dirPath: string): DirectoryScan {
+  const name = getFileName(dirPath);
+  const appFlag = isApp(dirPath);
+  const scanMode: "recursive" | "shallow" = appFlag ? "recursive" : "shallow";
+
+  // The directory's own quarantine flag.
+  const rootQuarantineData = readQuarantineValue(dirPath);
+
+  // List candidate paths in a single batched call.
+  let quarantinedPaths: string[] = [];
+  if (scanMode === "recursive") {
+    const res = spawnSync("xattr", ["-r", dirPath], {
+      encoding: "utf8",
+      timeout: 60000,
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    quarantinedPaths = collectQuarantinedPaths(res.stdout ?? "", dirPath);
+  } else {
+    let children: string[] = [];
+    try {
+      children = fs.readdirSync(dirPath).map((c) => path.join(dirPath, c));
+    } catch {
+      children = [];
+    }
+    if (children.length > 0) {
+      const res = spawnSync("xattr", children, {
+        encoding: "utf8",
+        timeout: 30000,
+        maxBuffer: 64 * 1024 * 1024,
+      });
+      quarantinedPaths = collectQuarantinedPaths(res.stdout ?? "");
+    }
+  }
+
+  // Fetch values only for the (typically small) set of quarantined paths.
+  const entries: DirEntry[] = quarantinedPaths.map((p) => ({
+    path: p,
+    name: getFileName(p),
+    relativePath: path.relative(dirPath, p) || getFileName(p),
+    quarantineData: readQuarantineValue(p),
+  }));
+
+  let lastModified = "unknown";
+  try {
+    lastModified = new Date(fs.statSync(dirPath).mtime).toLocaleString("en-US");
+  } catch {
+    // ignore
+  }
+
+  return {
+    path: dirPath,
+    name,
+    isApp: appFlag,
+    scanMode,
+    rootQuarantineData,
+    entries,
+    lastModified,
+  };
 }

--- a/extensions/quarantine-manager/src/utils.ts
+++ b/extensions/quarantine-manager/src/utils.ts
@@ -416,13 +416,21 @@ export function scanDirectory(dirPath: string): DirectoryScan {
     } catch {
       children = [];
     }
-    if (children.length > 0) {
-      const res = spawnSync("xattr", children, {
+    // Process children in chunks to stay well under ARG_MAX, and append dirPath
+    // as a sentinel so every call has >= 2 path arguments. With a single path,
+    // xattr prints bare attribute names (no "<path>: " prefix); the extra arg
+    // forces the prefixed format so a lone quarantined child is never missed.
+    const CHUNK = 256;
+    for (let i = 0; i < children.length; i += CHUNK) {
+      const batch = children.slice(i, i + CHUNK);
+      const res = spawnSync("xattr", [...batch, dirPath], {
         encoding: "utf8",
         timeout: 30000,
         maxBuffer: 64 * 1024 * 1024,
       });
-      quarantinedPaths = collectQuarantinedPaths(res.stdout ?? "");
+      quarantinedPaths.push(
+        ...collectQuarantinedPaths(res.stdout ?? "", dirPath),
+      );
     }
   }
 


### PR DESCRIPTION
## Description

Update to the existing **Quarantine Manager** extension.

This implements a community feature request from the original submission (#25892): support for checking **apps and folders**, not just single files. macOS app bundles in particular can contain many internal quarantined files that a top-level check would miss.

### What's new

- **Directory scanning in both commands.** Selecting a folder or `.app` now scans its contents for quarantined files:
  - **Apps (`.app`)** are scanned **recursively** (bundles are self-contained), surfacing every internal quarantined file plus the bundle's own flag.
  - **Plain folders** are scanned **one level deep** (immediate contents only) so large directories like `Downloads` stay responsive.
- **Check Quarantine Status** lists each quarantined item found inside an app/folder; you can drill into any of them for details.
- **Remove Quarantine** shows an aggregate summary and clears `com.apple.quarantine` from a whole bundle/folder at once via `xattr -dr`, after a confirmation showing how many items are affected. A recursive "Remove All Attributes" (`xattr -cr`) is also available.
- **Fix:** raw binary attributes (e.g. `com.apple.macl`, `com.apple.provenance`) are now displayed as hex instead of unreadable control characters.

Directory scanning batches `xattr` calls and uses `spawnSync`/`execFileSync` with array arguments (no shell-string interpolation of paths), consistent with the existing hardening.

Resolves the request in #25892.

## Screencast

Tested locally via `npm run dev` and a distribution build (`npm run build`) in Raycast:
- **Check Quarantine Status** on an `.app` → recursive list of internal quarantined files (and the bundle's own flag).
- **Check Quarantine Status** on `~/Downloads` → immediate quarantined children only.
- **Remove Quarantine** on an app/folder → count-confirmation, then recursive clear; re-scan shows clean.
- Single-file behavior unchanged; binary attributes render as hex.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
