### PR TITLE
Update linear extension: Add label count preference value

### DIFF
--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Linear Changelog
 
+## [Label Fetching] - {PR_MERGE_DATE}
+
+- Add an "API Label Limit" preference (default 100) so more labels can be fetched per team when creating or editing issues. Increase it if some labels are missing because your team has more than 100 labels.
+
 ## [Confirmation Fixes] - 2026-05-15
 
 - Fix AI tools (e.g. `create-issue`, `update-issue`) failing with confusing "Entity not found" errors when assistants pass empty strings (`""`) for optional ID fields. `formatConfirmation` now treats `""` and `null` the same as `undefined`, displaying `-` in the preview instead of attempting a doomed entity lookup that aborts the tool before its main mutation runs.

--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Linear Changelog
 
-## [Label Fetching] - {PR_MERGE_DATE}
+## [Label Fetching] - 2026-06-09
 
 - Add an "API Label Limit" preference (default 100) so more labels can be fetched per team when creating or editing issues. Increase it if some labels are missing because your team has more than 100 labels.
 

--- a/extensions/linear/package-lock.json
+++ b/extensions/linear/package-lock.json
@@ -1870,9 +1870,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/extensions/linear/package.json
+++ b/extensions/linear/package.json
@@ -17,7 +17,8 @@
     "joeb",
     "itsmingjie",
     "xmok",
-    "0xdhrv"
+    "0xdhrv",
+    "erikjs"
   ],
   "pastContributors": [
     "mathieudutour",
@@ -1583,6 +1584,14 @@
       "description": "The maximum number of issues to fetch from the Linear API at once. Be careful when changing this, as too large a number can cause you to exceed your API rate limit and/or cause heap memory errors.",
       "type": "textfield",
       "default": "50",
+      "required": false
+    },
+    {
+      "name": "labelsLimit",
+      "title": "API Label Limit",
+      "description": "The maximum number of labels to fetch from the Linear API per team. Increase this value if some labels are missing when creating or editing issues.",
+      "type": "textfield",
+      "default": "100",
       "required": false
     },
     {

--- a/extensions/linear/src/api/getLabels.ts
+++ b/extensions/linear/src/api/getLabels.ts
@@ -13,7 +13,7 @@ const preferences = getPreferenceValues<Preferences>();
 function getPageLimits() {
   const limit = preferences.labelsLimit ? +preferences.labelsLimit : DEFAULT_LABELS_LIMIT;
   const pageSize = Math.min(DEFAULT_PAGE_SIZE, limit);
-  const pageLimit = Math.floor(limit / pageSize);
+  const pageLimit = Math.ceil(limit / pageSize);
   return { pageSize, pageLimit };
 }
 

--- a/extensions/linear/src/api/getLabels.ts
+++ b/extensions/linear/src/api/getLabels.ts
@@ -11,7 +11,8 @@ const DEFAULT_LABELS_LIMIT = 100;
 const preferences = getPreferenceValues<Preferences>();
 
 function getPageLimits() {
-  const limit = preferences.labelsLimit ? +preferences.labelsLimit : DEFAULT_LABELS_LIMIT;
+  const parsed = Number(preferences.labelsLimit);
+  const limit = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LABELS_LIMIT;
   const pageSize = Math.min(DEFAULT_PAGE_SIZE, limit);
   const pageLimit = Math.ceil(limit / pageSize);
   return { pageSize, pageLimit };

--- a/extensions/linear/src/api/getLabels.ts
+++ b/extensions/linear/src/api/getLabels.ts
@@ -1,6 +1,21 @@
 import { IssueLabel } from "@linear/sdk";
+import { getPreferenceValues } from "@raycast/api";
 
 import { getLinearClient } from "../api/linearClient";
+
+import { getPaginated, PageInfo } from "./pagination";
+
+const DEFAULT_PAGE_SIZE = 100;
+const DEFAULT_LABELS_LIMIT = 100;
+
+const preferences = getPreferenceValues<Preferences>();
+
+function getPageLimits() {
+  const limit = preferences.labelsLimit ? +preferences.labelsLimit : DEFAULT_LABELS_LIMIT;
+  const pageSize = Math.min(DEFAULT_PAGE_SIZE, limit);
+  const pageLimit = Math.floor(limit / pageSize);
+  return { pageSize, pageLimit };
+}
 
 export type LabelResult = Pick<IssueLabel, "id" | "name" | "color">;
 
@@ -9,28 +24,38 @@ export async function getLabels(teamId?: string) {
     return [];
   }
 
+  const { pageSize, pageLimit } = getPageLimits();
+
   const { graphQLClient } = getLinearClient();
-  // Only the 100 first labels are returned in case a workspace has a lot of labels
-  // TODO: Implement label's name filtering when form fields support onSearchTextChange prop
-  const { data } = await graphQLClient.rawRequest<
-    { team: { labels: { nodes: LabelResult[] } } },
-    Record<string, unknown>
-  >(
-    `
-      query($teamId: String!) {
-        team(id: $teamId) {
-          labels(first: 100) {
-            nodes {
-              id
-              name
-              color
+
+  return getPaginated(
+    async (cursor) =>
+      graphQLClient.rawRequest<
+        { team: { labels: { nodes: LabelResult[]; pageInfo: PageInfo } } },
+        { teamId: string; cursor?: string }
+      >(
+        `
+          query($teamId: String!, $cursor: String) {
+            team(id: $teamId) {
+              labels(first: ${pageSize}, after: $cursor) {
+                nodes {
+                  id
+                  name
+                  color
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
             }
           }
-        }
-      }
-    `,
-    { teamId },
+        `,
+        { teamId, cursor },
+      ),
+    (response) => response.data?.team?.labels?.pageInfo,
+    (accumulator: LabelResult[], response) => accumulator.concat(response.data?.team?.labels?.nodes ?? []),
+    [],
+    pageLimit,
   );
-
-  return data?.team.labels.nodes;
 }

--- a/extensions/linear/src/api/getLabels.ts
+++ b/extensions/linear/src/api/getLabels.ts
@@ -13,7 +13,7 @@ const preferences = getPreferenceValues<Preferences>();
 function getPageLimits() {
   const parsed = Number(preferences.labelsLimit);
   const limit = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LABELS_LIMIT;
-  const pageSize = Math.min(DEFAULT_PAGE_SIZE, limit);
+  const pageSize = Math.floor(Math.min(DEFAULT_PAGE_SIZE, limit));
   const pageLimit = Math.ceil(limit / pageSize);
   return { pageSize, pageLimit };
 }


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Problem: There was a hard-coded limit of 100 issue labels that were retrieved for issue interactions such as creating and editing an issue. This resulted in:
- On issue add or edit: only 100 labels were settable, any further labels where simply not showing up
- On editing: labels that did already exist on the issue, but where not retrieved by the initial getLabels call did not show up on the issue

This PR solves this by mirroring the setup for issue counts. There is now a new preference value "labelsLimit" which controls how many labels are retrieved at a maximum. When a workspace has more than 100 labels, this value can now be increased in order to be able to see and set all labels that exist in the workspace.

Instead of retrieving 100 labels, it paginates through the request until the set limit is reached.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

<img width="328" height="428" alt="Screenshot 2026-06-08 at 11 53 28" src="https://github.com/user-attachments/assets/6a564b44-758e-405c-8c52-2923a3f5026d" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
