### PR TITLE
fix(superwhisper): paginate history loading to prevent memory crash

### DIFF
--- a/extensions/superwhisper/CHANGELOG.md
+++ b/extensions/superwhisper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # superwhisper Changelog
 
-## [Paginate Search History to fix memory crash] - {PR_MERGE_DATE}
+## [Paginate Search History to fix memory crash] - 2026-06-09
 
 - Fixed Search History crashing with an out-of-memory error on large recording libraries by loading the list one page at a time instead of reading every `meta.json` up front.
 - Search History now sorts recordings cheaply by modified time and only parses transcripts for the page on screen, with more loaded on scroll.

--- a/extensions/superwhisper/CHANGELOG.md
+++ b/extensions/superwhisper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # superwhisper Changelog
 
-## [Paginate Search History to fix memory crash] - 2026-06-07
+## [Paginate Search History to fix memory crash] - {PR_MERGE_DATE}
 
 - Fixed Search History crashing with an out-of-memory error on large recording libraries by loading the list one page at a time instead of reading every `meta.json` up front.
 - Search History now sorts recordings cheaply by modified time and only parses transcripts for the page on screen, with more loaded on scroll.

--- a/extensions/superwhisper/CHANGELOG.md
+++ b/extensions/superwhisper/CHANGELOG.md
@@ -1,5 +1,10 @@
 # superwhisper Changelog
 
+## [Paginate Search History to fix memory crash] - 2026-06-07
+
+- Fixed Search History crashing with an out-of-memory error on large recording libraries by loading the list one page at a time instead of reading every `meta.json` up front.
+- Search History now sorts recordings cheaply by modified time and only parses transcripts for the page on screen, with more loaded on scroll.
+
 ## [Copy/Paste Last History and fix missing meta files] - 2026-03-08
 
 - Added no-view commands to copy or paste the most recent Superwhisper transcript.

--- a/extensions/superwhisper/src/hooks.ts
+++ b/extensions/superwhisper/src/hooks.ts
@@ -7,6 +7,8 @@ import { getPreferenceValues } from "@raycast/api";
 import { homedir } from "os";
 import { join } from "path";
 
+export const RECORDINGS_PAGE_SIZE = 50;
+
 export type RecordingMeta = {
   rawResult?: string;
   llmResult?: string;
@@ -17,6 +19,12 @@ export type TranscriptVariant = "processed" | "unprocessed";
 export type Recording = {
   directory: string;
   meta: RecordingMeta;
+  timestamp: Date;
+};
+
+export type RecordingRef = {
+  directory: string;
+  metaPath: string;
   timestamp: Date;
 };
 
@@ -178,24 +186,89 @@ export async function getLatestRecordingByVariant(variant: TranscriptVariant): P
   return latestRecording;
 }
 
+async function listRecordingRefs(customRecordingsPath?: string): Promise<RecordingRef[]> {
+  const isInstalled = await isSuperwhisperInstalled();
+  if (!isInstalled) {
+    throw new Error("Superwhisper is not installed");
+  }
+
+  const recordingsPath = customRecordingsPath ?? join(homedir(), "Documents", "superwhisper", "recordings");
+  if (!existsSync(recordingsPath)) {
+    throw new Error("Recording directory not found. Please make a recording first.");
+  }
+
+  const dirNames = readdirSync(recordingsPath).filter((dir) => /^\d+$/.test(dir));
+  if (dirNames.length === 0) {
+    throw new Error("No recordings found. Please make a recording first.");
+  }
+
+  const refs: RecordingRef[] = [];
+  for (const dirName of dirNames) {
+    const metaPath = join(recordingsPath, dirName, "meta.json");
+    try {
+      const stats = statSync(metaPath);
+      refs.push({ directory: dirName, metaPath, timestamp: stats.mtime });
+    } catch {
+      // meta.json missing or unreadable; skip this folder.
+    }
+  }
+
+  refs.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+  return refs;
+}
+
+function loadRecordingsForRefs(refs: RecordingRef[]): Recording[] {
+  const recordings: Recording[] = [];
+  for (const ref of refs) {
+    const meta = parseRecordingMeta(ref.metaPath);
+    if (!meta) {
+      continue;
+    }
+    recordings.push({ directory: ref.directory, meta, timestamp: ref.timestamp });
+  }
+  return recordings;
+}
+
 export function useRecordings(customRecordingsPath?: string) {
   const {
     data: recordings,
     isLoading,
+    pagination,
     error,
-  } = useCachedPromise(getRecordings, [customRecordingsPath], {
-    failureToastOptions: {
-      title: `Failed to fetch recordings`,
-      message: "Check if Superwhisper is installed and the recording directory is correct.",
-      primaryAction: {
-        title: "Install from superwhisper.com",
-        onAction: async (toast) => {
-          await open("https://superwhisper.com");
-          await toast.hide();
+  } = useCachedPromise(
+    (path?: string) => {
+      let cachedRefs: RecordingRef[] | undefined;
+      return async (options: { page: number }) => {
+        if (!cachedRefs) {
+          cachedRefs = await listRecordingRefs(path);
+        }
+        const start = options.page * RECORDINGS_PAGE_SIZE;
+        const slice = cachedRefs.slice(start, start + RECORDINGS_PAGE_SIZE);
+        const data = loadRecordingsForRefs(slice);
+        const hasMore = start + RECORDINGS_PAGE_SIZE < cachedRefs.length;
+        return { data, hasMore };
+      };
+    },
+    [customRecordingsPath],
+    {
+      failureToastOptions: {
+        title: `Failed to fetch recordings`,
+        message: "Check if Superwhisper is installed and the recording directory is correct.",
+        primaryAction: {
+          title: "Install from superwhisper.com",
+          onAction: async (toast) => {
+            await open("https://superwhisper.com");
+            await toast.hide();
+          },
         },
       },
     },
-  });
+  );
 
-  return { recordings, isLoading: (!recordings && !error) || isLoading, error };
+  return {
+    recordings,
+    isLoading: (!recordings && !error) || isLoading,
+    pagination,
+    error,
+  };
 }

--- a/extensions/superwhisper/src/search-history.tsx
+++ b/extensions/superwhisper/src/search-history.tsx
@@ -2,12 +2,12 @@ import { List, ActionPanel, Action, Icon, Color, getPreferenceValues } from "@ra
 import { homedir } from "os";
 import { join } from "path";
 import { format } from "date-fns";
-import { getRecordingPrimaryText, useRecordings } from "./hooks";
+import { getRecordingPrimaryText, Recording, useRecordings } from "./hooks";
 
 export default function Command() {
   const { recordingDir } = getPreferenceValues<Preferences.SearchHistory>();
   const recordingsPath = recordingDir || join(homedir(), "Documents", "superwhisper", "recordings");
-  const { recordings, isLoading, error } = useRecordings(recordingsPath);
+  const { recordings, isLoading, pagination, error } = useRecordings(recordingsPath);
   const latestHistoryText = recordings?.[0] ? getRecordingPrimaryText(recordings[0].meta) : "";
 
   if (error) {
@@ -23,65 +23,81 @@ export default function Command() {
   }
 
   return (
-    <List isLoading={isLoading} isShowingDetail>
-      {recordings?.map((recording) => {
-        const rawResult = recording.meta.rawResult?.trim() ?? "";
-        const llmResult = recording.meta.llmResult?.trim() ?? "";
-        const primaryResult = getRecordingPrimaryText(recording.meta);
-        const detailMarkdown = llmResult
-          ? `### LLM Result
+    <List isLoading={isLoading} isShowingDetail pagination={pagination}>
+      {recordings?.map((recording) => (
+        <RecordingListItem
+          key={recording.directory}
+          recording={recording}
+          recordingsPath={recordingsPath}
+          latestHistoryText={latestHistoryText}
+        />
+      ))}
+    </List>
+  );
+}
+
+function RecordingListItem({
+  recording,
+  recordingsPath,
+  latestHistoryText,
+}: {
+  recording: Recording;
+  recordingsPath: string;
+  latestHistoryText: string;
+}) {
+  const rawResult = recording.meta.rawResult?.trim() ?? "";
+  const llmResult = recording.meta.llmResult?.trim() ?? "";
+  const primaryResult = getRecordingPrimaryText(recording.meta);
+  const detailMarkdown = llmResult
+    ? `### LLM Result
 ${llmResult}
 
 ### Raw Result
 ${rawResult || "_No raw result available._"}`
-          : `### Result
+    : `### Result
 ${rawResult || "_No result available._"}`;
 
-        return (
-          <List.Item
-            key={recording.directory}
-            icon={Icon.Document}
-            title={format(recording.timestamp, "yyyy/MM/dd HH:mm:ss")}
-            detail={<List.Item.Detail markdown={detailMarkdown} />}
-            actions={
-              <ActionPanel>
-                {latestHistoryText ? (
-                  <Action.CopyToClipboard
-                    title="Copy Last History"
-                    content={latestHistoryText}
-                    shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
-                  />
-                ) : null}
-                {primaryResult ? (
-                  <>
-                    <Action.Paste title="Paste Result" content={primaryResult} />
-                    <Action.CopyToClipboard title="Copy Result" content={primaryResult} />
-                  </>
-                ) : null}
-                {llmResult ? (
-                  <>
-                    <Action.Paste
-                      title="Paste Raw Result"
-                      content={rawResult}
-                      shortcut={{ modifiers: ["cmd", "shift"], key: "enter" }}
-                    />
-                    <Action.CopyToClipboard
-                      title="Copy Raw Result"
-                      content={rawResult}
-                      shortcut={{ modifiers: ["cmd", "opt"], key: "enter" }}
-                    />
-                  </>
-                ) : null}
-                <Action.ShowInFinder
-                  title="Show in Finder"
-                  path={join(recordingsPath, recording.directory)}
-                  shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
-                />
-              </ActionPanel>
-            }
+  return (
+    <List.Item
+      icon={Icon.Document}
+      title={format(recording.timestamp, "yyyy/MM/dd HH:mm:ss")}
+      detail={<List.Item.Detail markdown={detailMarkdown} />}
+      actions={
+        <ActionPanel>
+          {latestHistoryText ? (
+            <Action.CopyToClipboard
+              title="Copy Last History"
+              content={latestHistoryText}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
+            />
+          ) : null}
+          {primaryResult ? (
+            <>
+              <Action.Paste title="Paste Result" content={primaryResult} />
+              <Action.CopyToClipboard title="Copy Result" content={primaryResult} />
+            </>
+          ) : null}
+          {llmResult ? (
+            <>
+              <Action.Paste
+                title="Paste Raw Result"
+                content={rawResult}
+                shortcut={{ modifiers: ["cmd", "shift"], key: "enter" }}
+              />
+              <Action.CopyToClipboard
+                title="Copy Raw Result"
+                content={rawResult}
+                shortcut={{ modifiers: ["cmd", "opt"], key: "enter" }}
+              />
+            </>
+          ) : null}
+          <Action.ShowInFinder
+            title="Show in Finder"
+            path={join(recordingsPath, recording.directory)}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
           />
-        );
-      })}
-    </List>
+        </ActionPanel>
+      }
+    />
   );
 }


### PR DESCRIPTION
## Summary

Search History crashed with `JS heap out of memory` on large recordings libraries. `getRecordings` read every `meta.json` synchronously on mount and `search-history.tsx` pre-built detail markdown for every list item up front. Heap exceeded the 100 MB extension limit on the first selection-change.

Heap trace before this PR (captured on a large library):

```
worker:start: 20.7 MB
initialize:done: 24.3 MB
onSelectionChange:start: 87.0 MB
onSelectionChange:start: 95.8 MB
[killed at 100 MB]
```

This refactors the load into a paginated `useCachedPromise` (page size 50) and moves detail markdown into a per-item `RecordingListItem` component. Only the visible page worth of metadata is held in memory.

## Changes

- `src/hooks.ts`: new `listRecordingRefs` (cheap directory listing + mtime) and `loadRecordingsForRefs` (parses meta for the requested slice only). `useRecordings` now uses `useCachedPromise` paginated.
- `src/search-history.tsx`: `RecordingListItem` component, lazy detail markdown.
- `getLatestRecordingByVariant` signature intentionally unchanged.

## Notes

- Pattern mirrors `extensions/wispr-flow/src/search-transcripts.tsx`'s paginated `useCachedPromise` shape.
- Verified locally on a large recordings library: Search History no longer crashes.

## Type of change

- [x] Bug fix

## Checklist

- [x] CHANGELOG entry added
- [x] `npm run build` clean
- [x] `npm run lint` clean