### PR TITLE
[Skills] Resolve skill contents for skills in subdirectories

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Skills Changelog
 
+## [Fix Skill Contents for Nested Skills] - {PR_MERGE_DATE}
+
+- Fix skill details and the "Copy Skill Contents" action falling back to the repository README for skills nested under category folders (e.g. `skills/productivity/grill-me/SKILL.md`) by locating the real SKILL.md anywhere in the repository tree
+
 ## [Copy Skill Contents] - 2026-06-06
 
 - Add a "Copy Skill Contents" action to copy a skill's full SKILL.md to the clipboard from search results, skill details, and installed skills, so it can be pasted into tools like ChatGPT or Claude without installing the skill

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Fix Skill Contents for Nested Skills] - {PR_MERGE_DATE}
+## [Fix Skill Contents for Nested Skills] - 2026-06-09
 
 - Fix skill details and the "Copy Skill Contents" action falling back to the repository README for skills nested under category folders (e.g. `skills/productivity/grill-me/SKILL.md`) by locating the real SKILL.md anywhere in the repository tree
 

--- a/extensions/skills/src/hooks/skill-content.ts
+++ b/extensions/skills/src/hooks/skill-content.ts
@@ -1,3 +1,6 @@
+import { withCache } from "@raycast/utils";
+
+import { getGithubToken } from "../preferences";
 import { type Skill, type SkillFrontmatter, parseFrontmatter } from "../shared";
 
 type SkillContentResult = {
@@ -6,52 +9,143 @@ type SkillContentResult = {
   raw: string;
 };
 
-function buildSkillContentUrls(skill: Skill) {
-  const owner = skill.source.split("/")[0];
+type GitTreeEntry = {
+  path: string;
+  type: string;
+  url?: string;
+};
+
+type SkillMdEntry = {
+  path: string;
+  url: string;
+};
+
+function parseSkillContent(text: string): SkillContentResult {
+  return { ...parseFrontmatter(text), raw: text };
+}
+
+function githubHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { Accept: "application/vnd.github+json" };
+  const token = getGithubToken();
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+/**
+ * Folder names a skill may live under, most specific first. skills.sh derives
+ * `skillId`/`name` from the skill's folder name, so matching against the folder
+ * that contains SKILL.md is reliable. The owner-prefix variant mirrors repos
+ * that namespace skills as `owner-skillName`.
+ */
+function candidateSkillDirNames(skill: Skill): string[] {
+  const owner = skill.source.split("/")[0] ?? "";
   const ownerPrefix = owner.split("-")[0] + "-";
   const skillIdWithoutPrefix = skill.skillId.startsWith(ownerPrefix)
     ? skill.skillId.slice(ownerPrefix.length)
     : skill.skillId;
 
-  const skillPaths = [
-    `skills/${skill.skillId}/SKILL.md`,
-    `${skill.skillId}/SKILL.md`,
-    `skills/${skillIdWithoutPrefix}/SKILL.md`,
-    `${skillIdWithoutPrefix}/SKILL.md`,
-    `skills/${skill.name}/SKILL.md`,
-    `${skill.name}/SKILL.md`,
-  ];
+  return [...new Set([skill.skillId, skillIdWithoutPrefix, skill.name].filter(Boolean))];
+}
 
+/**
+ * Common flat layouts fetched straight from raw.githubusercontent so the
+ * typical case costs no GitHub API quota. Skills nested under category folders
+ * (e.g. `skills/productivity/grill-me/SKILL.md`) are resolved by the tree
+ * lookup below instead.
+ */
+function buildFlatSkillUrls(skill: Skill): string[] {
+  const paths = candidateSkillDirNames(skill).flatMap((dir) => [`skills/${dir}/SKILL.md`, `${dir}/SKILL.md`]);
   const branches = ["main", "master"];
 
-  return {
-    skillUrls: branches.flatMap((branch) =>
-      skillPaths.map((path) => `https://raw.githubusercontent.com/${skill.source}/${branch}/${path}`),
-    ),
-    readmeUrls: branches.map((branch) => `https://raw.githubusercontent.com/${skill.source}/${branch}/README.md`),
-  };
+  return branches.flatMap((branch) =>
+    paths.map((path) => `https://raw.githubusercontent.com/${skill.source}/${branch}/${path}`),
+  );
+}
+
+async function fetchRawSkillMd(url: string): Promise<SkillContentResult> {
+  const response = await fetch(url);
+  if (response.ok && !response.headers.get("content-type")?.includes("text/html")) {
+    return parseSkillContent(await response.text());
+  }
+  throw new Error(`Failed to fetch ${url}`);
+}
+
+/**
+ * Every SKILL.md path in a repo, keyed by source and cached so browsing several
+ * skills from the same repository (or copying contents repeatedly) reuses a
+ * single tree request instead of re-downloading it each time. Throws on failure
+ * so a rate-limited or failed request is retried rather than cached as "no
+ * skills". Uses the GitHub API (with the optional token) so it shares the same
+ * rate-limit budget as the repo stats.
+ */
+const fetchRepoSkillMdEntries = withCache(
+  async (source: string): Promise<SkillMdEntry[]> => {
+    const response = await fetch(`https://api.github.com/repos/${source}/git/trees/HEAD?recursive=1`, {
+      headers: githubHeaders(),
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch tree for ${source}: ${response.status}`);
+    }
+
+    const { tree } = (await response.json()) as { tree?: GitTreeEntry[] };
+    return (tree ?? [])
+      .filter((entry): entry is GitTreeEntry & { url: string } =>
+        Boolean(entry.type === "blob" && entry.path.endsWith("/SKILL.md") && entry.url),
+      )
+      .map((entry) => ({ path: entry.path, url: entry.url }));
+  },
+  { maxAge: 10 * 60 * 1000 },
+);
+
+/**
+ * Authoritative lookup: read the repo's SKILL.md index and locate the one whose
+ * enclosing folder matches the skill. Handles skills nested at any depth that
+ * the flat-path guesses can't reach.
+ */
+async function fetchSkillContentFromTree(skill: Skill): Promise<SkillContentResult | undefined> {
+  const entries = await fetchRepoSkillMdEntries(skill.source);
+  const segmentsOf = (entry: SkillMdEntry) => entry.path.split("/");
+  const dirNameOf = (entry: SkillMdEntry) => segmentsOf(entry).at(-2) ?? "";
+  const isHidden = (entry: SkillMdEntry) => segmentsOf(entry).some((segment) => segment.startsWith("."));
+
+  for (const dirName of candidateSkillDirNames(skill)) {
+    // Prefer a visible, shallow path when more than one folder shares the name.
+    const match = entries
+      .filter((entry) => dirNameOf(entry) === dirName)
+      .sort(
+        (a, b) =>
+          Number(isHidden(a)) - Number(isHidden(b)) ||
+          segmentsOf(a).length - segmentsOf(b).length ||
+          a.path.localeCompare(b.path),
+      )[0];
+    if (!match) continue;
+
+    const blobResponse = await fetch(match.url, { headers: githubHeaders() });
+    if (!blobResponse.ok) continue;
+
+    const blob = (await blobResponse.json()) as { content?: string; encoding?: string };
+    if (!blob.content) continue;
+
+    const text = blob.encoding === "base64" ? Buffer.from(blob.content, "base64").toString("utf-8") : blob.content;
+    return parseSkillContent(text);
+  }
+
+  return undefined;
 }
 
 export async function fetchSkillContent(skill: Skill): Promise<SkillContentResult | undefined> {
-  const { skillUrls, readmeUrls } = buildSkillContentUrls(skill);
-
-  const fetchUrl = async (url: string) => {
-    const response = await fetch(url);
-    if (response.ok && !response.headers.get("content-type")?.includes("text/html")) {
-      const text = await response.text();
-      return { ...parseFrontmatter(text), raw: text };
-    }
-    throw new Error(`Failed to fetch ${url}`);
-  };
-
+  // 1. Fast path: typical flat layouts straight from raw.githubusercontent.
   try {
-    return await Promise.any(skillUrls.map((url) => fetchUrl(url)));
+    return await Promise.any(buildFlatSkillUrls(skill).map((url) => fetchRawSkillMd(url)));
   } catch {
-    // All SKILL.md attempts failed, fall back to README.md.
+    // No flat SKILL.md matched, fall through to the authoritative tree lookup.
   }
 
+  // 2. Authoritative path: locate the SKILL.md anywhere in the repo tree.
   try {
-    return await Promise.any(readmeUrls.map((url) => fetchUrl(url)));
+    return await fetchSkillContentFromTree(skill);
   } catch {
     return undefined;
   }

--- a/extensions/skills/src/hooks/skill-content.ts
+++ b/extensions/skills/src/hooks/skill-content.ts
@@ -89,6 +89,9 @@ const fetchRepoSkillMdEntries = withCache(
       throw new Error(`Failed to fetch tree for ${source}: ${response.status}`);
     }
 
+    // For very large repos (>100k git objects) GitHub returns a truncated,
+    // partial tree, so a deeply nested SKILL.md could be missed. Skills repos
+    // are small enough that this isn't a concern in practice.
     const { tree } = (await response.json()) as { tree?: GitTreeEntry[] };
     return (tree ?? [])
       .filter((entry): entry is GitTreeEntry & { url: string } =>
@@ -100,7 +103,7 @@ const fetchRepoSkillMdEntries = withCache(
 );
 
 /**
- * Authoritative lookup: read the repo's SKILL.md index and locate the one whose
+ * Repo-tree lookup: read the repo's SKILL.md index and locate the one whose
  * enclosing folder matches the skill. Handles skills nested at any depth that
  * the flat-path guesses can't reach.
  */
@@ -143,7 +146,7 @@ export async function fetchSkillContent(skill: Skill): Promise<SkillContentResul
     // No flat SKILL.md matched, fall through to the authoritative tree lookup.
   }
 
-  // 2. Authoritative path: locate the SKILL.md anywhere in the repo tree.
+  // 2. Repo-tree path: locate the SKILL.md anywhere in the repo tree.
   try {
     return await fetchSkillContentFromTree(skill);
   } catch {


### PR DESCRIPTION
## Description

When we load a skill's contents, we check a couple of standard GitHub paths: `skills/<id>/SKILL.md` and `<id>/SKILL.md`. These cover single-skill repositories and skills at the top level, but they don't account for skills organized in subdirectories, which is common in multi-skill repos. For instance, in https://github.com/mattpocock/skills, each skill is placed under a category folder, so grill-me is located at `skills/productivity/grill-me/SKILL.md`. This results in every guess returning a 404 error, and the loader defaults to the repo-root README. As a result, the detail view and the "Copy Skill Contents" action end up showing the README instead of the actual skill.

This change maintains the quick flat-path guesses for the usual cases. If those guesses fail, it reads the repo's git tree to locate the real SKILL.md at any depth and fetches it using the blob API. Additionally, it removes the fallback to the repo-root README, so if a SKILL.md is genuinely missing, it will report "No Skill Contents Found" instead of mistakenly copying the wrong file.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
