### PR TITLE
Fix UniRate API key signup link

### DIFF
--- a/extensions/unirate-currency/CHANGELOG.md
+++ b/extensions/unirate-currency/CHANGELOG.md
@@ -1,5 +1,10 @@
 # UniRate Currency Changelog
 
+## [Fixed API key signup link] - {PR_MERGE_DATE}
+
+- Replaced dead UniRate dashboard signup URL with the current registration URL
+- Updated extension preference description and README setup instructions
+
 ## [Initial Release] - 2026-05-21
 
 - Convert command with optional historical date picker (back to 1999-01-04)

--- a/extensions/unirate-currency/CHANGELOG.md
+++ b/extensions/unirate-currency/CHANGELOG.md
@@ -1,6 +1,6 @@
 # UniRate Currency Changelog
 
-## [Fixed API key signup link] - {PR_MERGE_DATE}
+## [Fixed API key signup link] - 2026-06-10
 
 - Replaced dead UniRate dashboard signup URL with the current registration URL
 - Updated extension preference description and README setup instructions

--- a/extensions/unirate-currency/README.md
+++ b/extensions/unirate-currency/README.md
@@ -22,7 +22,7 @@ A list view of the latest rates against a base currency. Search by ISO code, cop
 
 ## Setup
 
-1. Sign up for a free key at <https://unirateapi.com/dashboard>.
+1. Sign up for a free key at <https://unirateapi.com/register>.
 2. Open the extension preferences and paste it under **UniRate API Key**.
 
 ### Plan limits (UniRateAPI)
@@ -36,7 +36,7 @@ If you try a Pro-only feature with a free key, the extension shows a clear "Pro 
 
 | Preference            | What it does                                     | Default |
 | --------------------- | ------------------------------------------------ | ------- |
-| UniRate API Key       | Your key from `unirateapi.com/dashboard`         | —       |
+| UniRate API Key       | Your key from `unirateapi.com/register`          | —       |
 | Default Base Currency | Three-letter ISO code used as the initial _From_ | `USD`   |
 | Decimals              | Decimal places shown for converted amounts       | `4`     |
 

--- a/extensions/unirate-currency/package.json
+++ b/extensions/unirate-currency/package.json
@@ -32,7 +32,7 @@
       "type": "password",
       "required": true,
       "title": "UniRate API Key",
-      "description": "Free API key from https://unirateapi.com/dashboard. The free tier covers latest-rate endpoints; historical and commodities require a Pro key.",
+      "description": "Free API key from https://unirateapi.com/register. The free tier covers latest-rate endpoints; historical and commodities require a Pro key.",
       "placeholder": "Your UniRate API key"
     },
     {


### PR DESCRIPTION
## Summary
- replace the dead UniRate dashboard signup URL with the current `/register` URL
- update the extension preference description and README setup/preference text

## Verification
- `python3 -m json.tool extensions/unirate-currency/package.json >/dev/null`
- `git diff --check`
- `rg -n "unirateapi.com/dashboard|unirateapi.com/register" extensions/unirate-currency`
- `curl -LsS -o /dev/null -w 'dashboard %{http_code} %{url_effective}\n' 'https://unirateapi.com/dashboard'` -> `404 https://unirateapi.com/dashboard`
- `curl -LsS -o /dev/null -w 'register %{http_code} %{url_effective}\n' 'https://unirateapi.com/register'` -> `200 https://unirateapi.com/register`
- `npm ci`
- `npm run lint`

Fixes #28661
