### PR TITLE
[Slack] Add deep link arguments to Set Status

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Changelog
 
+## [Add deep link arguments to Set Status] - 2026-06-09
+
+- The **Set Status** command now accepts optional `statusText` and `emoji` arguments, so a deep link or Quicklink can set your status in one step (e.g. `raycast://extensions/mommertf/slack/set-status?arguments=%7B%22statusText%22%3A%22Lunch%22%2C%22emoji%22%3A%22%3Ahamburger%3A%22%7D`).
+
 ## [Fix AI Tool for Channel History Failing] - 2026-06-03
 
 - Add fallback to attachment text for the Channel History AI tool.

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Add deep link arguments to Set Status] - {PR_MERGE_DATE}
+## [Add deep link arguments to Set Status] - 2026-06-09
 
 - The **Set Status** command now accepts optional `statusText` and `emoji` arguments, so a deep link or Quicklink can set your status in one step (e.g. `raycast://extensions/mommertf/slack/set-status?arguments=%7B%22statusText%22%3A%22Lunch%22%2C%22emoji%22%3A%22%3Ahamburger%3A%22%7D`).
 

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Add deep link arguments to Set Status] - 2026-06-09
+## [Add deep link arguments to Set Status] - {PR_MERGE_DATE}
 
 - The **Set Status** command now accepts optional `statusText` and `emoji` arguments, so a deep link or Quicklink can set your status in one step (e.g. `raycast://extensions/mommertf/slack/set-status?arguments=%7B%22statusText%22%3A%22Lunch%22%2C%22emoji%22%3A%22%3Ahamburger%3A%22%7D`).
 

--- a/extensions/slack/README.md
+++ b/extensions/slack/README.md
@@ -9,6 +9,25 @@ This Raycast extension is the perfect companion for Slack users. It allows you t
 - Set your presence status
 - Set your status
 
+## Set your status from a deep link
+
+The **Set Status** command accepts two optional arguments, `statusText` and `emoji`, so you can build a deep link (or a [Quicklink](https://manual.raycast.com/quicklinks)) that sets your status in one step:
+
+```
+raycast://extensions/mommertf/slack/set-status?arguments=%7B%22statusText%22%3A%22Lunch%22%2C%22emoji%22%3A%22%3Ahamburger%3A%22%7D
+```
+
+The `arguments` query parameter is a URL-encoded JSON object, for example:
+
+```json
+{ "statusText": "Lunch", "emoji": ":hamburger:" }
+```
+
+- Either argument may be omitted; only the one you provide is changed.
+- `emoji` accepts a Slack emoji name with or without colons (`hamburger` or `:hamburger:`).
+
+Statuses set this way don't auto-expire. To pick an expiration, open the command and use the **Set New Status** form.
+
 ## How to get an access token?
 
 If you don't want to log in through OAuth, you can use an access token instead. Here's how to get one:

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -100,7 +100,21 @@
       "title": "Set Status",
       "subtitle": "Slack",
       "description": "Set your status.",
-      "mode": "view"
+      "mode": "view",
+      "arguments": [
+        {
+          "name": "statusText",
+          "placeholder": "Status text",
+          "type": "text",
+          "required": false
+        },
+        {
+          "name": "emoji",
+          "placeholder": ":rocket:",
+          "type": "text",
+          "required": false
+        }
+      ]
     }
   ],
   "preferences": [

--- a/extensions/slack/src/set-status.tsx
+++ b/extensions/slack/src/set-status.tsx
@@ -1,16 +1,28 @@
 import { useCachedPromise } from "@raycast/utils";
 import { SlackClient, useMe } from "./shared/client";
 import { withSlackClient } from "./shared/withSlackClient";
-import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import { Action, ActionPanel, closeMainWindow, Icon, LaunchProps, List, popToRoot } from "@raycast/api";
 import { SLACK_EMOJI_CODE_MAP } from "./constants/emoji.constants";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { type SlackStatusForm, StatusForm } from "./components/set-status/status-form.component";
 import { EmojiPicker } from "./components/set-status/emoji-picker.component";
 import { getDurationOptionFromTimestamp, getTextForExpiration } from "./utils/set-status/expiration.util";
 import { showToastWithPromise } from "./utils/toast.util";
 import SetAiStatusForm from "./components/set-status/set-ai-status-form.component";
 
-function SlackStatusList() {
+// Slack stores status emoji in `:name:` form. Accept either `rocket` or `:rocket:` from a deep link argument.
+function normalizeEmoji(emoji?: string): string | undefined {
+  const trimmed = emoji?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return `:${trimmed.replace(/^:+|:+$/g, "")}:`;
+}
+
+function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>) {
+  const { statusText: statusTextArgument, emoji: emojiArgument } = props.arguments;
+
   const { data: me, isLoading: isFetchMeLoading } = useMe();
   const {
     data: profile,
@@ -167,6 +179,42 @@ function SlackStatusList() {
       },
     );
   }, [mutate, profile]);
+
+  const hasLaunchArguments = Boolean(statusTextArgument?.trim() || normalizeEmoji(emojiArgument));
+  const didAutoSetStatus = useRef(false);
+
+  useEffect(() => {
+    // When launched via deep link or a Quicklink with arguments, set the status directly and close.
+    if (!hasLaunchArguments || didAutoSetStatus.current || isFetchMeLoading || isFetchProfileLoading) {
+      return;
+    }
+    didAutoSetStatus.current = true;
+
+    const statusText = statusTextArgument?.trim() || undefined;
+    const emoji = normalizeEmoji(emojiArgument);
+
+    showToastWithPromise(
+      async () => {
+        await SlackClient.setStatus({
+          statusText,
+          emoji,
+          expiration: 0,
+          originProfile: profile,
+        });
+        await mutate();
+        await popToRoot();
+        await closeMainWindow();
+      },
+      {
+        loading: "The status is changing...",
+        error: "An error occurred while changing the state.",
+        success: () => ({
+          title: "Set status",
+          message: [emoji, statusText].filter(Boolean).join(" "),
+        }),
+      },
+    );
+  }, [hasLaunchArguments, isFetchMeLoading, isFetchProfileLoading, profile, mutate, statusTextArgument, emojiArgument]);
 
   return (
     <List isLoading={isLoading}>

--- a/extensions/slack/src/set-status.tsx
+++ b/extensions/slack/src/set-status.tsx
@@ -1,4 +1,4 @@
-import { useCachedPromise } from "@raycast/utils";
+import { showFailureToast, useCachedPromise } from "@raycast/utils";
 import { SlackClient, useMe } from "./shared/client";
 import { withSlackClient } from "./shared/withSlackClient";
 import { Action, ActionPanel, closeMainWindow, Icon, LaunchProps, List, popToRoot } from "@raycast/api";
@@ -188,10 +188,19 @@ function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>)
     if (!hasLaunchArguments || didAutoSetStatus.current || isFetchMeLoading || isFetchProfileLoading) {
       return;
     }
-    didAutoSetStatus.current = true;
 
     const statusText = statusTextArgument?.trim() || undefined;
     const emoji = normalizeEmoji(emojiArgument);
+
+    // Preserving the field that wasn't passed relies on the current profile. If it failed to
+    // load, setting only one field would clear the other, so bail with feedback instead.
+    if ((statusText === undefined || emoji === undefined) && !profile) {
+      didAutoSetStatus.current = true;
+      showFailureToast(new Error("Couldn't load your current Slack status."), { title: "Failed to set status" });
+      return;
+    }
+
+    didAutoSetStatus.current = true;
 
     showToastWithPromise(
       async () => {


### PR DESCRIPTION
## Description

Adds two optional arguments — `statusText` and `emoji` — to the **Set Status** command so it can be driven by a deep link or [Quicklink](https://manual.raycast.com/quicklinks). When the command is launched with either argument, it sets the status directly and closes the window; launched without arguments, it behaves exactly as before (shows the status list/form).

This lets you create one-tap Quicklinks like “Lunch 🍔” or “Heads down 🎧”:

```
raycast://extensions/mommertf/slack/set-status?arguments=%7B%22statusText%22%3A%22Lunch%22%2C%22emoji%22%3A%22%3Ahamburger%3A%22%7D
```

where `arguments` decodes to `{ "statusText": "Lunch", "emoji": ":hamburger:" }`.

### Notes
- Either argument may be omitted; only the field you provide is changed (the other is preserved from your current status).
- `emoji` accepts a Slack emoji name with or without colons (`hamburger` or `:hamburger:`).
- Statuses set this way don't auto-expire; the in-app **Set New Status** form is still the way to choose an expiration.

## Screencast / Screenshots

_Behavior is identical to the existing command when launched with no arguments; the new path is the deep-link/Quicklink flow described above._

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder