### PR TITLE
Update no-more-caffeine(Fix blank caffeine amount on initial open)

### DIFF
--- a/extensions/no-more-caffeine/CHANGELOG.md
+++ b/extensions/no-more-caffeine/CHANGELOG.md
@@ -1,6 +1,6 @@
 # No More Caffeine Changelog
 
-## [Fix Default Caffeine Amount] - {PR_MERGE_DATE}
+## [Fix Default Caffeine Amount] - 2026-06-09
 
 ### 🐛 Bug Fixes
 

--- a/extensions/no-more-caffeine/CHANGELOG.md
+++ b/extensions/no-more-caffeine/CHANGELOG.md
@@ -1,5 +1,11 @@
 # No More Caffeine Changelog
 
+## [Fix Default Caffeine Amount] - 2026-06-10
+
+### 🐛 Bug Fixes
+
+- **Log Caffeine** - Caffeine amount is now pre-filled when opening the command or after logging another drink
+
 ## [Initial Version] - 2026-03-11
 
 ### ✨ Features

--- a/extensions/no-more-caffeine/CHANGELOG.md
+++ b/extensions/no-more-caffeine/CHANGELOG.md
@@ -1,6 +1,6 @@
 # No More Caffeine Changelog
 
-## [Fix Default Caffeine Amount] - 2026-06-10
+## [Fix Default Caffeine Amount] - {PR_MERGE_DATE}
 
 ### 🐛 Bug Fixes
 

--- a/extensions/no-more-caffeine/src/log-caffeine.tsx
+++ b/extensions/no-more-caffeine/src/log-caffeine.tsx
@@ -19,8 +19,8 @@ interface FormValues {
 }
 
 export default function Command() {
-  const [drinkType, setDrinkType] = useState<string>("");
-  const [caffeineAmount, setCaffeineAmount] = useState<string>("");
+  const [drinkType, setDrinkType] = useState<string>(BUILT_IN_PRESETS[0]?.name ?? "");
+  const [caffeineAmount, setCaffeineAmount] = useState<string>(BUILT_IN_PRESETS[0]?.defaultCaffeineMg.toString() ?? "");
   const [submitted, setSubmitted] = useState(false);
   const [calculation, setCalculation] = useState<CaffeineCalculation | null>(null);
 
@@ -128,8 +128,8 @@ ${calculation.status === "safe" ? "✅ **Safe:** You can consume this caffeine w
               onAction={() => {
                 setSubmitted(false);
                 setCalculation(null);
-                setDrinkType("");
-                setCaffeineAmount("");
+                setDrinkType(BUILT_IN_PRESETS[0]?.name ?? "");
+                setCaffeineAmount(BUILT_IN_PRESETS[0]?.defaultCaffeineMg.toString() ?? "");
               }}
             />
           </ActionPanel>


### PR DESCRIPTION
## Description

Fixes a bug where the **Caffeine Amount** field was always blank when opening the Log Caffeine command (and after tapping "Log Another").

**Root cause:** Both `drinkType` and `caffeineAmount` were initialised to `""`. The `useEffect` that auto-fills the amount from the selected preset has an early-return for `!drinkType`, so it never ran on first render — even though the dropdown visually showed "Coffee" (Raycast renders the first item by default, but React state was still `""`). The same reset-to-`""` bug existed in the "Log Another" action.

**Fix:** Initialise both states directly from `BUILT_IN_PRESETS[0]` so the correct values are present from the very first render, before any effects fire.

## Screenshots
| Before | After |
| -- | -- |
| <img width="785" height="506" alt="image" src="https://github.com/user-attachments/assets/dc2391c5-566c-41bd-bda1-963f486d7f9c" /> |  <img width="786" height="488" alt="image" src="https://github.com/user-attachments/assets/95c1a5a9-1dde-4d50-9d0b-598d9df722d7" /> |


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
