### PR TITLE
[ccusage] Fix usage-limits rate-limit freeze

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [Honor server rate-limit backoff] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Usage Limits no longer freeze after the Claude API returns a rate-limit response. The fetch now honors the server's `retry-after` window, coordinates one backoff across the menu bar and main view, and shows the real wait time
+- An expired token in `~/.claude/.credentials.json` no longer shadows a fresh Keychain token
+
 ## [Tolerate dateless sessions] - 2026-06-03
 
 ### Fixed

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [Honor server rate-limit backoff] - {PR_MERGE_DATE}
+## [Honor server rate-limit backoff] - 2026-06-10
 
 ### Fixed
 

--- a/extensions/ccusage/src/components/UsageLimits.tsx
+++ b/extensions/ccusage/src/components/UsageLimits.tsx
@@ -13,8 +13,22 @@ import { STANDARD_ACCESSORIES } from "./common/accessories";
 import { ReactNode } from "react";
 
 export function UsageLimits() {
-  const { data, isLoading, error, isStale, isRateLimited, lastFetched, revalidate, isUsageLimitsAvailable } =
-    useClaudeUsageLimits();
+  const {
+    data,
+    isLoading,
+    error,
+    isStale,
+    isRateLimited,
+    rateLimitedUntil,
+    lastFetched,
+    revalidate,
+    isUsageLimitsAvailable,
+  } = useClaudeUsageLimits();
+
+  const rateLimitRetryIn =
+    rateLimitedUntil && rateLimitedUntil > Date.now()
+      ? formatTimeRemaining(new Date(rateLimitedUntil).toISOString())
+      : null;
 
   if (!isUsageLimitsAvailable) {
     return null;
@@ -27,7 +41,12 @@ export function UsageLimits() {
     error && !data
       ? STANDARD_ACCESSORIES.ERROR
       : isRateLimited && !data
-        ? [{ icon: Icon.Clock, text: "Rate limited" }]
+        ? [
+            {
+              icon: Icon.Clock,
+              text: rateLimitRetryIn ? `Rate limited · retry in ${rateLimitRetryIn}` : "Rate limited",
+            },
+          ]
         : !data
           ? STANDARD_ACCESSORIES.LOADING
           : isStale && !isLoading
@@ -53,8 +72,10 @@ export function UsageLimits() {
     if (isRateLimited && !data) {
       return (
         <ErrorMetadata
-          noDataMessage="Rate limited by Anthropic API"
-          noDataSubMessage="Retrying automatically — click Refresh to try now"
+          noDataMessage={
+            rateLimitRetryIn ? `Rate limited — retry in ${rateLimitRetryIn}` : "Rate limited by Anthropic API"
+          }
+          noDataSubMessage="Click Refresh to try now"
         />
       );
     }

--- a/extensions/ccusage/src/components/UsageLimits.tsx
+++ b/extensions/ccusage/src/components/UsageLimits.tsx
@@ -8,6 +8,7 @@ import {
   calculateAverageUsage,
   createProgressBar,
 } from "../utils/usage-limits-formatter";
+import { formatDuration } from "../utils/data-formatter";
 import { ErrorMetadata } from "./ErrorMetadata";
 import { STANDARD_ACCESSORIES } from "./common/accessories";
 import { ReactNode } from "react";
@@ -26,9 +27,7 @@ export function UsageLimits() {
   } = useClaudeUsageLimits();
 
   const rateLimitRetryIn =
-    rateLimitedUntil && rateLimitedUntil > Date.now()
-      ? formatTimeRemaining(new Date(rateLimitedUntil).toISOString())
-      : null;
+    rateLimitedUntil && rateLimitedUntil > Date.now() ? formatDuration(rateLimitedUntil - Date.now()) : null;
 
   if (!isUsageLimitsAvailable) {
     return null;

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -234,7 +234,7 @@ export default function MenuBarccusage() {
                   )}
                 </>
               )}
-              {!limitsData && !limitsError && limitsLoading && (
+              {!limitsData && !limitsError && !limitsRateLimited && limitsLoading && (
                 <MenuBarExtra.Item title="Loading limits..." icon={Icon.Clock} />
               )}
             </MenuBarExtra.Section>

--- a/extensions/ccusage/src/utils/claude-api-client.ts
+++ b/extensions/ccusage/src/utils/claude-api-client.ts
@@ -2,8 +2,24 @@ import { UsageLimitData, UsageLimitDataSchema } from "../types/usage-types";
 
 export type UsageLimitsResult =
   | { status: "ok"; data: UsageLimitData }
-  | { status: "rate_limited" }
+  | { status: "rate_limited"; retryAfterMs: number | null }
   | { status: "error"; message: string };
+
+const parseRetryAfter = (headerValue: string | null): number | null => {
+  if (!headerValue) return null;
+
+  const trimmed = headerValue.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return Math.max(0, parseInt(trimmed, 10) * 1000);
+  }
+
+  const dateMs = Date.parse(trimmed);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+
+  return null;
+};
 
 export const fetchClaudeUsageLimits = async (accessToken: string): Promise<UsageLimitsResult> => {
   try {
@@ -17,7 +33,7 @@ export const fetchClaudeUsageLimits = async (accessToken: string): Promise<Usage
     });
 
     if (response.status === 429) {
-      return { status: "rate_limited" };
+      return { status: "rate_limited", retryAfterMs: parseRetryAfter(response.headers.get("retry-after")) };
     }
 
     if (!response.ok) {

--- a/extensions/ccusage/src/utils/keychain-access.ts
+++ b/extensions/ccusage/src/utils/keychain-access.ts
@@ -9,7 +9,17 @@ const execAsync = promisify(exec);
 type ClaudeCredentials = {
   claudeAiOauth?: {
     accessToken?: string;
+    expiresAt?: number;
   };
+};
+
+const TOKEN_EXPIRY_SKEW_MS = 60 * 1000;
+
+const isUsable = (creds: ClaudeCredentials | null): boolean => {
+  const oauth = creds?.claudeAiOauth;
+  if (!oauth?.accessToken || oauth.accessToken.trim().length === 0) return false;
+  if (oauth.expiresAt === undefined) return true;
+  return oauth.expiresAt - Date.now() > TOKEN_EXPIRY_SKEW_MS;
 };
 
 const readCredentialsFile = async (): Promise<ClaudeCredentials | null> => {
@@ -33,8 +43,12 @@ const readCredentialsKeychain = async (): Promise<ClaudeCredentials | null> => {
 
 export const getClaudeCredentials = async (): Promise<ClaudeCredentials | null> => {
   const fromFile = await readCredentialsFile();
-  if (fromFile?.claudeAiOauth?.accessToken) return fromFile;
-  return readCredentialsKeychain();
+  if (isUsable(fromFile)) return fromFile;
+
+  const fromKeychain = await readCredentialsKeychain();
+  if (isUsable(fromKeychain)) return fromKeychain;
+
+  return fromFile ?? fromKeychain;
 };
 
 export const getClaudeAccessToken = async (): Promise<string | null> => {

--- a/extensions/ccusage/src/utils/usage-limits-cache.ts
+++ b/extensions/ccusage/src/utils/usage-limits-cache.ts
@@ -20,6 +20,7 @@ type Listener = (state: CacheState) => void;
 
 const raycastCache = new Cache();
 const LIMITS_CACHE_KEY = "usage-limits-data";
+const RATE_LIMITED_UNTIL_KEY = "usage-limits-rate-limited-until";
 
 const restoredData = ((): UsageLimitData | null => {
   const cached = raycastCache.get(LIMITS_CACHE_KEY);
@@ -31,24 +32,38 @@ const restoredData = ((): UsageLimitData | null => {
   }
 })();
 
+const restoredRateLimitedUntil = ((): number | null => {
+  const cached = raycastCache.get(RATE_LIMITED_UNTIL_KEY);
+  if (!cached) return null;
+  const parsed = parseInt(cached, 10);
+  if (Number.isNaN(parsed) || parsed <= Date.now()) return null;
+  return parsed;
+})();
+
 let cacheState: CacheState = {
   data: restoredData,
   error: null,
-  isLoading: true,
+  isLoading: restoredRateLimitedUntil === null,
   isStale: restoredData !== null,
-  isRateLimited: false,
+  isRateLimited: restoredRateLimitedUntil !== null,
   isUsageLimitsAvailable: false,
   lastFetched: null,
-  rateLimitedUntil: null,
+  rateLimitedUntil: restoredRateLimitedUntil,
   nextRefreshAt: null,
 };
 
 const RATE_LIMIT_BACKOFF_MS = 5 * 60 * 1000;
+const RATE_LIMIT_MAX_BACKOFF_MS = 60 * 60 * 1000;
+
+const clampBackoff = (retryAfterMs: number | null): number => {
+  const requested = retryAfterMs ?? RATE_LIMIT_BACKOFF_MS;
+  return Math.min(RATE_LIMIT_MAX_BACKOFF_MS, Math.max(RATE_LIMIT_BACKOFF_MS, requested));
+};
 
 const listeners = new Set<Listener>();
 let fetchInterval: NodeJS.Timeout | null = null;
 let isFetching = false;
-let rateLimitedUntil: number | null = null;
+let rateLimitedUntil: number | null = restoredRateLimitedUntil;
 let fetchIntervalMs = 60 * 1000;
 
 const notifyListeners = (): void => {
@@ -86,6 +101,7 @@ const fetchUsageLimits = async (): Promise<void> => {
 
     if (result.status === "ok") {
       rateLimitedUntil = null;
+      raycastCache.remove(RATE_LIMITED_UNTIL_KEY);
       raycastCache.set(LIMITS_CACHE_KEY, JSON.stringify(result.data));
       cacheState = {
         data: result.data,
@@ -99,7 +115,8 @@ const fetchUsageLimits = async (): Promise<void> => {
         nextRefreshAt: Date.now() + fetchIntervalMs,
       };
     } else if (result.status === "rate_limited") {
-      rateLimitedUntil = Date.now() + RATE_LIMIT_BACKOFF_MS;
+      rateLimitedUntil = Date.now() + clampBackoff(result.retryAfterMs);
+      raycastCache.set(RATE_LIMITED_UNTIL_KEY, String(rateLimitedUntil));
       cacheState = {
         ...cacheState,
         data: previousData,
@@ -189,5 +206,6 @@ export const getUsageLimitsState = (): CacheState => cacheState;
 
 export const revalidateUsageLimits = async (): Promise<void> => {
   rateLimitedUntil = null;
+  raycastCache.remove(RATE_LIMITED_UNTIL_KEY);
   await fetchUsageLimits();
 };


### PR DESCRIPTION
## Description

Fixes the Usage Limits tab freezing after `https://api.anthropic.com/api/oauth/usage` returns `429`. Actual usage (cost and tokens, read from the `ccusage` CLI) keeps working because only the direct OAuth call fails. The extension turned a transient `429` into a permanent freeze: it discarded the `retry-after` header and backed off a fixed 5 minutes, retrying before the server's window closed, and the menu-bar and main-view commands each kept their own uncoordinated backoff.

### Changes

- Reads the `retry-after` header on `429` in `claude-api-client.ts`. `parseRetryAfter` handles both the delay-seconds and HTTP-date forms and carries the result as `retryAfterMs`.
- Honors that value in `usage-limits-cache.ts` through `clampBackoff`, with a 5-minute floor and a 1-hour cap so a malformed header cannot freeze the tab indefinitely.
- Persists `rateLimitedUntil` to the shared Raycast `Cache`, so the menu-bar and main-view processes respect one backoff window instead of two. The key clears on a successful fetch and on manual Refresh.
- Stops an expired credential in `~/.claude/.credentials.json` from shadowing a fresh Keychain token. `getClaudeCredentials` now prefers the file token only when it is present and not within 60s of `expiresAt`, otherwise it falls back to the Keychain. The extension only reads stored credentials, so this changes which stored credential it picks. Token refresh still happens when Claude Code runs.
- Surfaces the real wait (`Rate limited · retry in 29m`) in both the main view and the menu bar, replacing the vague "will retry".

## Screencast

N/A. The only visible change is the rate-limited state, which now reads `Rate limited · retry in 29m` instead of `Rate limited`.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
