### PR TITLE
Update dev-servers extension

### DIFF
--- a/extensions/dev-servers/CHANGELOG.md
+++ b/extensions/dev-servers/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dev Servers Changelog
 
-## [Shopify support, faster polling, new actions] - {PR_MERGE_DATE}
+## [Shopify support, faster polling, new actions] - 2026-06-10
 
 ### Shopify
 

--- a/extensions/dev-servers/CHANGELOG.md
+++ b/extensions/dev-servers/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Dev Servers Changelog
 
+## [Shopify support, faster polling, new actions] - {PR_MERGE_DATE}
+
+### Shopify
+
+- Detect running Shopify CLI dev servers launched globally, including `shopify theme dev`, `shopify app dev`, and `shopify hydrogen dev`, so they appear in the dashboard even when the process is outside `node_modules`. Shopify-specific tool tags: Shopify Theme, Shopify App, and Hydrogen.
+- **Start Dev Server now works for Shopify themes**, which have no `package.json` at all. A folder containing `layout/theme.liquid` (or `shopify.theme.toml`) resolves as a theme root and starts with `shopify theme dev`; a folder with `shopify.app.toml` and no dev script falls back to `shopify app dev`. Restart on a detected theme server works through the same path. Scaffolded Shopify apps and Hydrogen storefronts already start via their `dev` scripts, so all three project types are now coherent across detect → start → restart.
+- The Start picker tags Shopify projects (theme, app, Hydrogen) so they're recognizable among your recents.
+- First-run note: the Shopify CLI prompts for login and store selection when it has no remembered state, which a detached spawn can't answer; run `shopify theme dev --store <store>` once in a terminal and the extension starts it cleanly from then on. The captured startup log shows the prompt if this happens.
+
+### Performance
+
+- The portless lookup no longer spawns a zsh login shell (re-sourcing `~/.zshrc`) on every refresh. The portless binary and login PATH are resolved once, persisted in Raycast's cache, and the binary is executed directly from then on: roughly 1s → 100ms per poll on a typical nvm setup, and the dominant cost of every refresh cycle.
+- Per-process metadata (working directory, framework, runtime) is now cached for the lifetime of each PID, so steady-state polls skip the second `lsof` query and the tool-detection regexes entirely. Guarded against PID reuse via process start time.
+- Git project info is cached per directory and invalidated by the `HEAD` file's mtime (which changes on every checkout, per worktree), replacing a `git rev-parse` spawn per project per poll with a single `stat`.
+- Branch switches now show up in the dashboard immediately: the change-detection that skips redundant re-renders compares branches too, instead of waiting for a PID change.
+
+### New actions and preferences
+
+- **Open in Editor** (`⌘E`): a new shared **Editor App** preference (VS Code, Cursor, Zed, …) adds an Open in Editor action to dashboard rows and recent-project rows. Hidden until the preference is set.
+- **Copy Network URL** (`⌘⌥C`): when a server is bound beyond loopback and your Mac has a LAN address, copy `http://<lan-ip>:<port>` for testing on a phone or another machine. Only offered when the server is actually reachable that way.
+- **Copy Port** (`⌘⌥P`): copy just the port number, for env files and config.
+- The startup log view now follows the file while open (live tail every 2s), so a slow boot or crash loop streams in without mashing refresh.
+
 ## [Start Dev Server] - 2026-06-01
 
 Adds a `Start Dev Server` command for spinning up dev servers without leaving Raycast. Works from a Finder selection, from a list of recently-seen projects, or from a native folder picker.

--- a/extensions/dev-servers/README.md
+++ b/extensions/dev-servers/README.md
@@ -9,7 +9,7 @@ A keyboard-first way to manage and start your local dev servers from Raycast. Se
 
 ## Dev Servers (dashboard)
 
-- **Auto-detects** running dev servers including Vite, Next.js, Astro, SvelteKit, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, esbuild, serve, http-server, anything that runs out of `node_modules/`, plus servers running on the Bun runtime
+- **Auto-detects** running dev servers including Vite, Next.js, Astro, SvelteKit, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, esbuild, serve, http-server, Shopify CLI dev servers, anything that runs out of `node_modules/`, plus servers running on the Bun runtime
 - **Custom domain aware** so a dev server fronted by [portless](https://github.com/vercel-labs/portless) shows its named URL (e.g. `myapp.localhost`) as the row title, with the `localhost:PORT` pill alongside for when you still need the raw loopback target
 - **Grouped by project** so servers from the same directory appear under one section
 - **Worktree-aware** so multiple git worktrees of the same repo collapse into one section, with a per-row branch tag to tell them apart. It also surfaces the current branch on single-worktree projects so you can tell which branch a long-running server is on
@@ -18,7 +18,9 @@ A keyboard-first way to manage and start your local dev servers from Raycast. Se
 - **Uptime tracking** shows how long each server has been running. Hover for the exact start time
 - **Smart restart** picks the right package manager (npm, pnpm, yarn, bun) from the project's lockfile, polls until the new server binds a port, and surfaces failures with a link to the log
 - **Start another server** without leaving the dashboard: `⌘N` from any row, or `↵` from the empty state, opens the Start Dev Server picker
-- **View startup logs** with `⌘L` on any row, so you can inspect a server's captured stdout/stderr on demand
+- **View startup logs** with `⌘L` on any row; the view live-tails the captured stdout/stderr while open, so you can watch a slow boot or diagnose a crash in place
+- **Copy Network URL** (`⌘⌥C`) copies `http://<lan-ip>:<port>` for testing on a phone or another device, offered only when the server is actually bound beyond loopback. **Copy Port** (`⌘⌥P`) grabs just the number for env files
+- **Open in your editor** with `⌘E` once you set the Editor App preference (VS Code, Cursor, Zed, …)
 - **Confirm dialogs on bulk-kill** ensure destructive actions ask first, with a "Don't ask again" option for project-scoped kills
 - **Open in your terminal** uses a configurable terminal app preference (Terminal, iTerm, Warp, Ghostty, etc.)
 - **Search and filter** by typing a project name, branch, or port into the search bar; a framework dropdown appears when you have multiple frameworks running
@@ -29,7 +31,7 @@ A keyboard-first way to manage and start your local dev servers from Raycast. Se
 
 Spin up a dev server without opening a terminal. There are three ways in:
 
-- **From Finder**: select a project folder (or any file inside one) and run the command. It walks up to the nearest `package.json`, detects the package manager, picks the right dev script, and starts it. Select several folders to start them together (monorepo siblings, a "frontend + backend" pair). The dashboard opens immediately and a "Starting…" toast tracks each one until it binds a port.
+- **From Finder**: select a project folder (or any file inside one) and run the command. It walks up to the nearest project root (a `package.json`, or a Shopify theme/app root), detects the package manager, picks the right dev script, and starts it. Select several folders to start them together (monorepo siblings, a "frontend + backend" pair). The dashboard opens immediately and a "Starting…" toast tracks each one until it binds a port.
 - **From recents**: run the command with nothing selected and you get a picker over projects the extension has recently seen running. Recents populate automatically from the dashboard, with no bookmarking. Each row shows last-seen time, git branch, a framework tag, and the project's real favicon once it's been seen running. Currently-running projects are hidden here (they live in the dashboard) and reappear once stopped.
 - **From anywhere**: the picker's **Choose Folder…** entry opens the native macOS folder dialog directly, for a one-off project that isn't in your recents.
 
@@ -37,7 +39,9 @@ If a target is already running, you get a single consolidated prompt to restart 
 
 The script picker tries `dev` → `start` → `develop` first, then scans script values for known dev-server tools, so monorepo conventions like `dev:web` and `start:dev` resolve out of the box.
 
-**Picker row actions:** Start (`↵`), Open in Terminal (`⌘T`), Show in Finder (`⌘⇧F`), Copy Path (`⌘C`), Remove from Recents (`⌃X`).
+**Shopify projects** work too: a theme folder (marked by `layout/theme.liquid`, no `package.json` needed) starts with `shopify theme dev`, and an app root (`shopify.app.toml`) without a dev script falls back to `shopify app dev`. Scaffolded Shopify apps and Hydrogen storefronts start through their normal `dev` scripts. One caveat: the Shopify CLI prompts for login and store selection on first use, which a background spawn can't answer; run `shopify theme dev --store <your-store>` once in a terminal, after which the CLI remembers the store and the extension starts it cleanly.
+
+**Picker row actions:** Start (`↵`), Open in Editor (`⌘E`, when the Editor App preference is set), Open in Terminal (`⌘T`), Show in Finder (`⌘⇧F`), Copy Path (`⌘C`), Remove from Recents (`⌃X`).
 
 ## Keyboard Shortcuts
 
@@ -51,6 +55,9 @@ Dashboard (Dev Servers):
 | Kill Server | `⌃` `X` |
 | Copy URL | `⌘` `C` |
 | Copy Localhost URL | `⌘` `⇧` `C` |
+| Copy Network URL | `⌘` `⌥` `C` |
+| Copy Port | `⌘` `⌥` `P` |
+| Open in Editor | `⌘` `E` |
 | Open in Terminal | `⌘` `T` |
 | Show in Finder | `⌘` `⇧` `F` |
 | Start Dev Server | `⌘` `N` |
@@ -64,6 +71,7 @@ Dashboard (Dev Servers):
 **Shared**
 
 - **Terminal App** sets which terminal `⌘T` opens, for both commands. Defaults to macOS Terminal if unset.
+- **Editor App** sets which editor `⌘E` opens a project in (VS Code, Cursor, Zed, …). The action is hidden until this is set.
 
 **Dev Servers**
 

--- a/extensions/dev-servers/package.json
+++ b/extensions/dev-servers/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "dev-servers",
   "title": "Dev Servers",
-  "description": "Project-grouped dashboard to manage dev servers. Detects the framework (Next, Svelte, Astro, Vite) and restarts with the right package manager (npm, pnpm, yarn, bun). Kill individually or by project, open in browser, copy URLs, and track uptime.",
+  "description": "Project-grouped dashboard to manage dev servers. Detects the framework (Next, Svelte, Astro, Vite, Shopify) and restarts with the right package manager (npm, pnpm, yarn, bun). Kill individually or by project, open in browser, copy URLs, and track uptime.",
   "icon": "extension-icon.png",
   "author": "tavlean",
   "categories": [
@@ -10,7 +10,6 @@
   ],
   "keywords": [
     "dev server",
-    "dev servers",
     "localhost",
     "port",
     "ports",
@@ -20,7 +19,8 @@
     "process",
     "dashboard",
     "manage",
-    "monitor"
+    "monitor",
+    "shopify"
   ],
   "platforms": [
     "macOS"
@@ -32,6 +32,13 @@
       "title": "Terminal App",
       "type": "appPicker",
       "description": "Which terminal to open when using \"Open in Terminal\". Defaults to macOS Terminal if unset.",
+      "required": false
+    },
+    {
+      "name": "editorApp",
+      "title": "Editor App",
+      "type": "appPicker",
+      "description": "Which editor to open a project in with \"Open in Editor\" (e.g. VS Code, Cursor, Zed). The action is hidden when unset.",
       "required": false
     }
   ],

--- a/extensions/dev-servers/src/aliases.ts
+++ b/extensions/dev-servers/src/aliases.ts
@@ -1,23 +1,121 @@
+import { Cache } from "@raycast/api";
 import { execFile } from "node:child_process";
+import * as fs from "node:fs";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+
+// Resolution of the portless binary and the login-shell PATH it needs.
+//
+// Earlier versions ran `/bin/zsh -ilc "portless list"` on every poll, which
+// re-sourced ~/.zshrc (nvm init and friends) every few seconds, typically
+// the single most expensive step of a refresh cycle. We now pay the login
+// shell exactly once: resolve the absolute portless path plus the login
+// PATH (still needed at exec time so the script's `#!/usr/bin/env node`
+// shebang can find node), persist both in Raycast's Cache, and exec the
+// binary directly on every subsequent poll.
+interface PortlessResolution {
+  bin: string; // absolute path to the portless executable
+  PATH: string; // login-shell PATH, for the shebang's `env node`
+}
+
+const cache = new Cache();
+const RESOLUTION_KEY = "portless-resolution-v1";
+
+// Module state lives for the duration of one command session.
+let resolution: PortlessResolution | undefined;
+let resolvedThisSession = false;
+// Negative cache: when a probe finds no portless install, don't re-pay the
+// login shell on every poll; wait out the backoff first. portless is an
+// optional enhancement, so staying silent for a few minutes after a fresh
+// install is an acceptable trade for not spawning login shells in a loop.
+let nextProbeAt = 0;
+const PROBE_BACKOFF_MS = 5 * 60_000;
+
+// One login shell, two answers: where portless lives and what PATH looks
+// like. Output is wrapped in sentinel markers because ~/.zshrc is allowed to
+// print arbitrary noise (greeting banners, nvm warnings) around our printf.
+async function resolveViaLoginShell(): Promise<PortlessResolution | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "/bin/zsh",
+      ["-ilc", 'printf "<<%s||%s>>" "$(command -v portless)" "$PATH"'],
+      { timeout: 5000 },
+    );
+    const match = stdout.match(/<<([\s\S]*?)\|\|([\s\S]*?)>>/);
+    if (!match) return null;
+    return { bin: match[1].trim(), PATH: match[2] };
+  } catch {
+    return null;
+  }
+}
+
+async function getResolution(
+  forceRefresh: boolean,
+): Promise<PortlessResolution | null> {
+  if (!forceRefresh) {
+    if (resolution) return resolution;
+    const persisted = cache.get(RESOLUTION_KEY);
+    if (persisted) {
+      try {
+        const parsed = JSON.parse(persisted) as PortlessResolution;
+        // Cheap staleness guard: the binary may have moved since the last
+        // session (reinstall, version-manager switch). A failed exec also
+        // forces a re-probe (see runPortlessList), so this only needs to
+        // catch the common case early.
+        if (parsed.bin && fs.existsSync(parsed.bin)) {
+          resolution = parsed;
+          return parsed;
+        }
+      } catch {
+        // Corrupt cache entry; fall through to a fresh probe.
+      }
+    }
+  }
+  if (Date.now() < nextProbeAt) return null;
+  const fresh = await resolveViaLoginShell();
+  resolvedThisSession = true;
+  if (!fresh || !fresh.bin) {
+    nextProbeAt = Date.now() + PROBE_BACKOFF_MS;
+    resolution = undefined;
+    return null;
+  }
+  resolution = fresh;
+  cache.set(RESOLUTION_KEY, JSON.stringify(fresh));
+  return fresh;
+}
+
+// Run `portless list` via the resolved binary. A stale persisted resolution
+// (binary moved, node dir gone) gets one in-session re-probe; a resolution we
+// built this session that still fails is a real portless failure, so we
+// return null and let the next poll try again.
+async function runPortlessList(): Promise<string | null> {
+  let res = await getResolution(false);
+  for (let attempt = 0; res && attempt < 2; attempt++) {
+    try {
+      const { stdout } = await execFileAsync(res.bin, ["list"], {
+        timeout: 3000,
+        env: { ...process.env, PATH: res.PATH },
+      });
+      return stdout;
+    } catch {
+      if (resolvedThisSession) return null;
+      res = await getResolution(true);
+    }
+  }
+  return null;
+}
 
 // Returns a map from listening port → list of custom URLs registered to that
 // port (e.g. https://myapp.localhost → 3000). Used by the UI to swap the
 // primary row label from `localhost:PORT` to the named domain when one
 // exists.
 //
-// Resolution path: shell out to `portless list` via a login shell. portless's
-// text output is its public, human-readable interface, far more stable than
-// its internal ~/.portless/ state files. The login shell is required because
-// Raycast's subprocess PATH doesn't include user-installed CLIs (same reason
-// the restart flow in [servers.ts] uses `/bin/zsh -ilc`).
+// portless's text output is its public, human-readable interface, far more
+// stable than its internal ~/.portless/ state files.
 //
-// Hard 3s timeout: this call sits in fetchServers' Promise.all, so a hung
-// portless daemon would otherwise block the entire refresh cycle. On timeout
-// the call rejects and we fall through to the same empty-map fallback as
-// any other failure.
+// Hard 3s timeout on the exec: this call sits in fetchServers' Promise.all,
+// so a hung portless daemon would otherwise block the entire refresh cycle.
 //
 // Any failure (portless not installed, command-not-found, timeout, unexpected
 // output) returns an empty map. Portless is treated as an optional
@@ -25,19 +123,13 @@ const execFileAsync = promisify(execFile);
 // falls back to plain `localhost:PORT` rows, per Raycast's "gracefully
 // degrade" guidance.
 //
-// Cross-platform note: the zsh login-shell pattern is macOS/Linux. Windows
+// Cross-platform note: the login-shell resolution is macOS/Linux. Windows
 // will need its own variant (powershell -c "portless list"), wired up
 // alongside the other platform primitives in [servers.ts].
 export async function fetchAliases(): Promise<Map<number, string[]>> {
   const out = new Map<number, string[]>();
-  let stdout: string;
-  try {
-    ({ stdout } = await execFileAsync("/bin/zsh", ["-ilc", "portless list"], {
-      timeout: 3000,
-    }));
-  } catch {
-    return out;
-  }
+  const stdout = await runPortlessList();
+  if (!stdout) return out;
   // portless list output is one route per line:
   //   "  https://myapp.localhost  ->  localhost:3000  (pid 12345)"
   //   "  https://api.myapp.localhost  ->  localhost:3001  (alias)"

--- a/extensions/dev-servers/src/index.tsx
+++ b/extensions/dev-servers/src/index.tsx
@@ -21,6 +21,7 @@ import {
 } from "@raycast/api";
 import { showFailureToast, useCachedPromise } from "@raycast/utils";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { DEFAULT_TERMINAL } from "./constants";
 import {
@@ -62,13 +63,18 @@ async function openStartCommand(): Promise<void> {
 }
 
 // Shallow equality on the dashboard's view of the server list: same length,
-// and same pid+port in the same positions. ps returns processes in PID order
-// which is stable for the same processes between polls, so position-wise
+// and same pid+port+branch in the same positions. ps returns processes in PID
+// order which is stable for the same processes between polls, so position-wise
 // comparison is enough to catch what we care about (a server starting or
-// dying), and `fetchStableServers` can hand back the previous array reference
-// when nothing changed so React bails out of the re-render.
+// dying, or a branch switch), and `fetchStableServers` can hand back the
+// previous array reference when nothing changed so React bails out of the
+// re-render.
 //
-// Deliberately compares ONLY pid+port, not derived fields like the portless
+// Branch is included because it comes from a local git/HEAD read that's
+// reliable poll-to-poll, and users do switch branches under a running server;
+// without it the row would keep showing the old branch until the PID changed.
+//
+// Deliberately does NOT compare derived fields like the portless
 // `url`/`customUrls`. Those come from a `portless list` shell-out with a 3s
 // timeout that can intermittently miss, so including them made the comparison
 // flap (alias present one poll, absent the next), defeating the dedupe and
@@ -79,9 +85,30 @@ async function openStartCommand(): Promise<void> {
 function sameServers(a: DevServer[], b: DevServer[]): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
-    if (a[i].pid !== b[i].pid || a[i].port !== b[i].port) return false;
+    if (
+      a[i].pid !== b[i].pid ||
+      a[i].port !== b[i].port ||
+      a[i].branch !== b[i].branch
+    )
+      return false;
   }
   return true;
+}
+
+// First non-internal IPv4 address, for "open this on your phone" URLs.
+// Prefer en0/en1 (built-in Wi-Fi / Ethernet on Macs) so a VPN utun or
+// container bridge doesn't win just by sorting first.
+function lanIPv4(): string | undefined {
+  const ifaces = os.networkInterfaces();
+  const pick = (name: string) =>
+    ifaces[name]?.find((a) => a.family === "IPv4" && !a.internal)?.address;
+  const preferred = pick("en0") ?? pick("en1");
+  if (preferred) return preferred;
+  for (const addrs of Object.values(ifaces)) {
+    const hit = addrs?.find((a) => a.family === "IPv4" && !a.internal);
+    if (hit) return hit.address;
+  }
+  return undefined;
 }
 
 // Strip scheme and trailing slash so a primary URL renders cleanly as the row
@@ -190,6 +217,14 @@ function SpawnLogView({ cwd, name }: { cwd: string; name: string }) {
     [logPath],
   );
 
+  // Follow the file while the view is open so a server that's still booting
+  // (or crashing) streams its output in like a live tail, instead of asking
+  // the user to mash ⌘R while diagnosing.
+  useEffect(() => {
+    const id = setInterval(revalidate, 2000);
+    return () => clearInterval(id);
+  }, [revalidate]);
+
   const log = (data ?? "").trim();
   const exists = fs.existsSync(logPath);
   const body = log
@@ -240,6 +275,11 @@ interface ServerItemProps {
   id: string;
   server: DevServer;
   terminalApp: Application;
+  // Unset when the user hasn't picked an editor; the action is hidden then.
+  editorApp?: Application;
+  // This Mac's LAN IPv4, when one exists. Combined with `server.lanExposed`
+  // to offer a network URL other devices on the network can reach.
+  lanIp?: string;
   show: RowVisibility;
   onKill: () => void;
   onKillProject: () => void;
@@ -252,6 +292,8 @@ function ServerItem({
   id,
   server,
   terminalApp,
+  editorApp,
+  lanIp,
   show,
   onKill,
   onKillProject,
@@ -400,8 +442,32 @@ function ServerItem({
                 shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
               />
             )}
+            {/* Network URL is for testing on a phone or another machine on
+             * the same network. Only offered when the server actually binds
+             * beyond loopback, so we never hand out a URL that can't connect. */}
+            {server.lanExposed && lanIp && (
+              <Action.CopyToClipboard
+                title="Copy Network URL"
+                content={`http://${lanIp}:${server.port}`}
+                shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
+              />
+            )}
+            <Action.CopyToClipboard
+              title="Copy Port"
+              content={server.port}
+              shortcut={{ modifiers: ["cmd", "opt"], key: "p" }}
+            />
           </ActionPanel.Section>
           <ActionPanel.Section>
+            {editorApp && (
+              <Action.Open
+                title={`Open in ${editorApp.name}`}
+                icon={Icon.Code}
+                target={server.cwd}
+                application={editorApp}
+                shortcut={{ modifiers: ["cmd"], key: "e" }}
+              />
+            )}
             <Action.Open
               title={`Open in ${terminalApp.name}`}
               icon={Icon.Terminal}
@@ -1002,6 +1068,10 @@ export default function Command(
   }
 
   const terminalApp = prefs.terminalApp ?? DEFAULT_TERMINAL;
+  const editorApp = prefs.editorApp;
+  // Resolved once per mount; a Wi-Fi change mid-session is rare enough that
+  // reopening the command is an acceptable refresh.
+  const lanIp = useMemo(lanIPv4, []);
   const [toolFilter, setToolFilter] = useState<string>("all");
 
   // Visibility prefs default to true so first-time users see everything.
@@ -1127,6 +1197,8 @@ export default function Command(
               id={String(server.pid)}
               server={server}
               terminalApp={terminalApp}
+              editorApp={editorApp}
+              lanIp={lanIp}
               show={show}
               onKill={() => kill(server.pid)}
               onKillProject={() => killProject(projectKey)}

--- a/extensions/dev-servers/src/servers.ts
+++ b/extensions/dev-servers/src/servers.ts
@@ -334,11 +334,22 @@ function hasSvelteConfig(cwd: string): boolean {
 // because configured dev ports (3000, 4321, 5173, 8080) are always below
 // ephemeral ports (32768+); without this the displayed port flickers across
 // refreshes.
-function lowestPortPerPid(listeners: RawListener[]): Map<number, number> {
-  const out = new Map<number, number>();
-  for (const { pid, port } of listeners) {
+//
+// lanExposed is tracked for the CHOSEN port specifically (OR'd across
+// same-port binds, e.g. separate IPv4 and IPv6 sockets), not for any socket
+// of the PID. A loopback-only HTTP server whose HMR socket happens to bind
+// wildcard must not advertise a network URL that can't actually connect.
+function lowestPortPerPid(
+  listeners: RawListener[],
+): Map<number, { port: number; lanExposed: boolean }> {
+  const out = new Map<number, { port: number; lanExposed: boolean }>();
+  for (const { pid, port, lanExposed } of listeners) {
     const cur = out.get(pid);
-    if (cur === undefined || port < cur) out.set(pid, port);
+    if (cur === undefined || port < cur.port) {
+      out.set(pid, { port, lanExposed });
+    } else if (port === cur.port && lanExposed) {
+      cur.lanExposed = true;
+    }
   }
   return out;
 }
@@ -369,13 +380,6 @@ export async function fetchServers(): Promise<DevServer[]> {
   const candidates = procs.filter(isCandidate);
   const portByPid = lowestPortPerPid(listeners);
   const live = candidates.filter((p) => portByPid.has(p.pid));
-
-  // True when any of the PID's listening sockets (lowest-port or not) is
-  // reachable beyond loopback. Wildcard binds show up as "*:PORT".
-  const lanExposedByPid = new Set<number>();
-  for (const l of listeners) {
-    if (l.lanExposed) lanExposedByPid.add(l.pid);
-  }
 
   // Resolve cwds only for PIDs we haven't seen before (or whose lstart says
   // the PID was recycled). On a steady-state poll this list is empty and the
@@ -424,8 +428,9 @@ export async function fetchServers(): Promise<DevServer[]> {
   for (const proc of live) {
     const meta = pidMetaCache.get(proc.pid);
     if (!meta) continue;
-    const port = portByPid.get(proc.pid);
-    if (port === undefined) continue;
+    const listener = portByPid.get(proc.pid);
+    if (listener === undefined) continue;
+    const port = listener.port;
     // Drop the portless proxy daemon itself. It's a node process out of
     // node_modules/portless/ that binds 80/443/1355, and would otherwise
     // appear as a phantom "dev server" row. Child processes spawned by
@@ -454,7 +459,7 @@ export async function fetchServers(): Promise<DevServer[]> {
       projectKey,
       projectName,
       branch: git?.branch || undefined,
-      lanExposed: lanExposedByPid.has(proc.pid),
+      lanExposed: listener.lanExposed,
       startedAt: new Date(proc.lstart),
     });
   }

--- a/extensions/dev-servers/src/servers.ts
+++ b/extensions/dev-servers/src/servers.ts
@@ -31,6 +31,10 @@ interface RawProcess {
 interface RawListener {
   pid: number;
   port: number;
+  // True when the socket is bound beyond loopback (wildcard or a concrete
+  // LAN address), i.e. the server is reachable from other devices on the
+  // network. Drives the "Copy Network URL" action.
+  lanExposed: boolean;
 }
 
 // Capture stdout even when the child exits non-zero (lsof exits 1 if any of
@@ -97,8 +101,17 @@ async function listListeners(): Promise<RawListener[]> {
       currentPid = parseInt(line.slice(1), 10);
     } else if (line[0] === "n" && currentPid > 0) {
       const addr = line.slice(1);
-      const port = parseInt(addr.slice(addr.lastIndexOf(":") + 1), 10);
-      if (port > 0) out.push({ pid: currentPid, port });
+      const colon = addr.lastIndexOf(":");
+      const port = parseInt(addr.slice(colon + 1), 10);
+      if (port > 0) {
+        const host = addr.slice(0, colon);
+        const lanExposed = !(
+          host === "127.0.0.1" ||
+          host === "[::1]" ||
+          host.startsWith("127.")
+        );
+        out.push({ pid: currentPid, port, lanExposed });
+      }
     }
   }
   return out;
@@ -140,9 +153,18 @@ interface GitInfo {
   branch: string;
 }
 
-// Resolve git common-dir and branch for a cwd. Returns undefined when cwd
-// isn't inside a git working tree. One process spawn per call.
-async function getGitInfo(cwd: string): Promise<GitInfo | undefined> {
+interface GitProbe {
+  info: GitInfo | undefined;
+  // Absolute path to the HEAD file that defines `branch` (per-worktree for
+  // linked worktrees). Its mtime changes on every checkout, which makes it a
+  // cheap cache-invalidation signal: see getGitInfoCached.
+  headPath?: string;
+}
+
+// Resolve git common-dir, branch, and HEAD path for a cwd. Returns
+// info: undefined when cwd isn't inside a git working tree. One process
+// spawn per call; callers should go through getGitInfoCached.
+async function probeGit(cwd: string): Promise<GitProbe> {
   try {
     const { stdout } = await execFileAsync("git", [
       "-C",
@@ -151,29 +173,122 @@ async function getGitInfo(cwd: string): Promise<GitInfo | undefined> {
       "--git-common-dir",
       "--abbrev-ref",
       "HEAD",
+      "--git-path",
+      "HEAD",
     ]);
-    const [commonDirRaw, branchRaw] = stdout.trim().split("\n");
-    if (!commonDirRaw) return undefined;
+    // rev-parse prints one line per request, in argument order.
+    const [commonDirRaw, branchRaw, headRaw] = stdout.trim().split("\n");
+    if (!commonDirRaw) return { info: undefined };
     const commonDir = path.isAbsolute(commonDirRaw)
       ? commonDirRaw
       : path.resolve(cwd, commonDirRaw);
     const branch = branchRaw === "HEAD" ? "" : (branchRaw ?? "");
-    return { commonDir, branch };
+    const headPath = headRaw
+      ? path.isAbsolute(headRaw)
+        ? headRaw
+        : path.resolve(cwd, headRaw)
+      : undefined;
+    return { info: { commonDir, branch }, headPath };
   } catch {
-    return undefined;
+    return { info: undefined };
   }
+}
+
+interface GitCacheEntry {
+  probe: GitProbe;
+  headMtimeMs?: number;
+  checkedAt: number;
+}
+
+// Per-cwd git cache. Spawning `git rev-parse` for every project on every
+// poll is the kind of background cost that adds up in a long-lived
+// dashboard session; the data it returns only changes on checkout. The HEAD
+// file's mtime is bumped by every checkout (including in linked worktrees,
+// which each have their own HEAD), so a single statSync per project per poll
+// replaces the spawn. Non-git cwds re-probe on a coarse TTL so a `git init`
+// under a running server is eventually picked up.
+const gitCache = new Map<string, GitCacheEntry>();
+const NON_GIT_RECHECK_MS = 60_000;
+
+async function getGitInfoCached(cwd: string): Promise<GitInfo | undefined> {
+  const entry = gitCache.get(cwd);
+  if (entry) {
+    if (entry.probe.info && entry.probe.headPath) {
+      try {
+        const mtime = fs.statSync(entry.probe.headPath).mtimeMs;
+        if (mtime === entry.headMtimeMs) return entry.probe.info;
+      } catch {
+        // HEAD vanished (repo deleted out from under us); fall through to a
+        // fresh probe.
+      }
+    } else if (Date.now() - entry.checkedAt < NON_GIT_RECHECK_MS) {
+      return entry.probe.info;
+    }
+  }
+  const probe = await probeGit(cwd);
+  let headMtimeMs: number | undefined;
+  if (probe.headPath) {
+    try {
+      headMtimeMs = fs.statSync(probe.headPath).mtimeMs;
+    } catch {
+      // Unreadable HEAD just means we re-probe next poll.
+    }
+  }
+  gitCache.set(cwd, { probe, headMtimeMs, checkedAt: Date.now() });
+  return probe.info;
 }
 
 // ---------------------------------------------------------------------------
 // Pure aggregation (cross-platform)
 // ---------------------------------------------------------------------------
 
+type ShopifyTool = "shopify-theme" | "shopify-app" | "shopify-hydrogen";
+
+function commandBase(token: string): string {
+  return path.basename(token).replace(/\.(?:cmd|exe|ps1)$/i, "");
+}
+
+function shopifyToolFromArgs(
+  tokens: string[],
+  index: number,
+): ShopifyTool | null {
+  const area = tokens[index + 1];
+  const command = tokens[index + 2];
+  if (area === "theme" && command === "dev") return "shopify-theme";
+  if (area === "app" && command === "dev") return "shopify-app";
+  if (area === "hydrogen" && command === "dev") return "shopify-hydrogen";
+  return null;
+}
+
+function detectShopifyTool(command: string): ShopifyTool | null {
+  const tokens = command.trim().split(/\s+/);
+  if (tokens.length < 3) return null;
+
+  if (commandBase(tokens[0]) === "shopify") {
+    return shopifyToolFromArgs(tokens, 0);
+  }
+
+  // Global Shopify CLI installs commonly show up as:
+  //   node /path/to/bin/shopify theme dev
+  // Keep this bounded so wrapper commands like `concurrently ... shopify theme
+  // dev` don't get mislabeled if the wrapper ever owns a listener.
+  if (["node", "nodejs", "bun", "npx"].includes(commandBase(tokens[0]))) {
+    for (let i = 1; i < Math.min(tokens.length - 2, 5); i++) {
+      if (commandBase(tokens[i]) !== "shopify") continue;
+      return shopifyToolFromArgs(tokens, i);
+    }
+  }
+
+  return null;
+}
+
 // A candidate is anything launched from node_modules (broader than .bin/ so
-// we catch `node node_modules/serve/build/main.js` etc.) OR a bare bun
-// process. Over-collection is harmless: only PIDs with a LISTEN socket
-// survive the join below.
+// we catch `node node_modules/serve/build/main.js` etc.), a bare bun process,
+// OR a Shopify CLI dev process. Over-collection is harmless: only PIDs with a
+// LISTEN socket survive the join below.
 function isCandidate(proc: RawProcess): boolean {
   if (/node_modules\//.test(proc.command)) return true;
+  if (detectShopifyTool(proc.command)) return true;
   const exec = proc.command.split(/\s+/, 1)[0];
   return /(\/|^)bun$/.test(exec);
 }
@@ -184,6 +299,9 @@ function detectRuntime(command: string): "node" | "bun" {
 }
 
 function detectTool(command: string, cwd: string): string {
+  const shopifyTool = detectShopifyTool(command);
+  if (shopifyTool) return shopifyTool;
+
   // 1. Prefer the .bin/ name (e.g. node_modules/.bin/vite)
   const bin = command.match(/node_modules\/\.bin\/(\S+)/);
   if (bin) {
@@ -229,6 +347,19 @@ function lowestPortPerPid(listeners: RawListener[]): Map<number, number> {
 // Public API
 // ---------------------------------------------------------------------------
 
+// Per-PID metadata cache. A process's cwd, tool, and runtime are immutable
+// for its lifetime, so we resolve them once per PID and skip the second lsof
+// (cwd lookup) plus the tool-detection regexes on every later poll. Keyed by
+// pid and validated against lstart so a recycled PID can't inherit a dead
+// process's metadata.
+interface PidMeta {
+  lstart: string;
+  cwd: string;
+  tool: string;
+  runtime: "node" | "bun";
+}
+const pidMetaCache = new Map<number, PidMeta>();
+
 export async function fetchServers(): Promise<DevServer[]> {
   const [procs, listeners, aliasesByPort] = await Promise.all([
     listProcesses(),
@@ -237,45 +368,78 @@ export async function fetchServers(): Promise<DevServer[]> {
   ]);
   const candidates = procs.filter(isCandidate);
   const portByPid = lowestPortPerPid(listeners);
-  // Only query cwds for candidates that are actually listening, which keeps the
-  // lsof argument list short and skips dead PIDs.
-  const finalPids = candidates
-    .map((p) => p.pid)
-    .filter((pid) => portByPid.has(pid));
-  const cwdByPid = await listCwds(finalPids);
+  const live = candidates.filter((p) => portByPid.has(p.pid));
 
-  // Look up git info per unique cwd, in parallel. Worktrees of the same repo
-  // share a git common-dir, so we use that path as the project key, which collapses
-  // sibling worktrees into one group while still letting us show the branch on
-  // each row. The project's display name is the basename of the common-dir's
-  // parent (the repo root).
-  const uniqueCwds = [...new Set([...cwdByPid.values()])];
+  // True when any of the PID's listening sockets (lowest-port or not) is
+  // reachable beyond loopback. Wildcard binds show up as "*:PORT".
+  const lanExposedByPid = new Set<number>();
+  for (const l of listeners) {
+    if (l.lanExposed) lanExposedByPid.add(l.pid);
+  }
+
+  // Resolve cwds only for PIDs we haven't seen before (or whose lstart says
+  // the PID was recycled). On a steady-state poll this list is empty and the
+  // lsof cwd query is skipped entirely.
+  const unseen = live.filter(
+    (p) => pidMetaCache.get(p.pid)?.lstart !== p.lstart,
+  );
+  const cwdByPid = await listCwds(unseen.map((p) => p.pid));
+  for (const proc of unseen) {
+    const cwd = cwdByPid.get(proc.pid);
+    if (!cwd) continue; // shouldn't happen for live processes, but be safe
+    pidMetaCache.set(proc.pid, {
+      lstart: proc.lstart,
+      cwd,
+      tool: detectTool(proc.command, cwd),
+      runtime: detectRuntime(proc.command),
+    });
+  }
+  // Evict entries for processes that are gone so the cache stays bounded.
+  const livePids = new Set(live.map((p) => p.pid));
+  for (const pid of pidMetaCache.keys()) {
+    if (!livePids.has(pid)) pidMetaCache.delete(pid);
+  }
+
+  // Look up git info per unique cwd, in parallel (cached by HEAD mtime, see
+  // getGitInfoCached). Worktrees of the same repo share a git common-dir, so
+  // we use that path as the project key, which collapses sibling worktrees
+  // into one group while still letting us show the branch on each row. The
+  // project's display name is the basename of the common-dir's parent (the
+  // repo root).
+  const uniqueCwds = [
+    ...new Set(
+      live
+        .map((p) => pidMetaCache.get(p.pid)?.cwd)
+        .filter((c): c is string => Boolean(c)),
+    ),
+  ];
   const gitByCwd = new Map<string, GitInfo | undefined>();
   await Promise.all(
-    uniqueCwds.map(async (cwd) => gitByCwd.set(cwd, await getGitInfo(cwd))),
+    uniqueCwds.map(async (cwd) =>
+      gitByCwd.set(cwd, await getGitInfoCached(cwd)),
+    ),
   );
 
   const servers: DevServer[] = [];
-  for (const proc of candidates) {
+  for (const proc of live) {
+    const meta = pidMetaCache.get(proc.pid);
+    if (!meta) continue;
     const port = portByPid.get(proc.pid);
     if (port === undefined) continue;
-    const cwd = cwdByPid.get(proc.pid);
-    if (!cwd) continue; // shouldn't happen for live processes, but be safe
-    const tool = detectTool(proc.command, cwd);
     // Drop the portless proxy daemon itself. It's a node process out of
     // node_modules/portless/ that binds 80/443/1355, and would otherwise
     // appear as a phantom "dev server" row. Child processes spawned by
     // portless run their own framework binary (next, vite, …) so they
     // resolve to that tool, not "portless".
-    if (tool === "portless") continue;
-    const git = gitByCwd.get(cwd);
+    if (meta.tool === "portless") continue;
+    const git = gitByCwd.get(meta.cwd);
     // For git projects: key is the shared .git dir path (stable across all
     // worktrees of the repo), name is the basename of its parent (the repo
     // root). For non-git: both fall back to the worktree itself.
     const projectName = git
       ? path.basename(path.dirname(git.commonDir))
-      : path.basename(cwd) || cwd;
-    const projectKey = git ? git.commonDir : cwd;
+      : path.basename(meta.cwd) || meta.cwd;
+    const projectKey = git ? git.commonDir : meta.cwd;
     const customUrls = aliasesByPort.get(port);
     const localUrl = `http://localhost:${port}`;
     servers.push({
@@ -284,12 +448,13 @@ export async function fetchServers(): Promise<DevServer[]> {
       url: customUrls?.[0] ?? localUrl,
       localUrl,
       customUrls,
-      tool,
-      runtime: detectRuntime(proc.command),
-      cwd,
+      tool: meta.tool,
+      runtime: meta.runtime,
+      cwd: meta.cwd,
       projectKey,
       projectName,
       branch: git?.branch || undefined,
+      lanExposed: lanExposedByPid.has(proc.pid),
       startedAt: new Date(proc.lstart),
     });
   }
@@ -395,12 +560,39 @@ export function canonicalCwd(p: string): string {
   }
 }
 
-// Walk up from a filesystem path to the nearest directory containing a
-// package.json. Used to resolve a Finder selection (which may be a file, a
-// subfolder, or the project root itself) to a project root we can spawn in.
-// The returned path is canonicalized so it round-trips through process
-// inspection without symlink-induced mismatches. Returns null when the
-// path isn't inside any Node project.
+// A Shopify theme root. Shopify CLI requires only `layout/theme.liquid` to
+// treat a directory as a theme ("Only a layout directory containing a
+// theme.liquid file is required"), so that's the canonical marker.
+// `shopify.theme.toml` (the CLI's optional environments file) is accepted as
+// a secondary signal for repos that keep one at the root.
+export function isShopifyThemeRoot(dir: string): boolean {
+  return (
+    fs.existsSync(path.join(dir, "layout", "theme.liquid")) ||
+    fs.existsSync(path.join(dir, "shopify.theme.toml"))
+  );
+}
+
+// A Shopify app root. Per Shopify's app-structure docs, shopify.app.toml
+// "represents the root of the app".
+export function isShopifyAppRoot(dir: string): boolean {
+  return fs.existsSync(path.join(dir, "shopify.app.toml"));
+}
+
+function isProjectRoot(dir: string): boolean {
+  return (
+    fs.existsSync(path.join(dir, "package.json")) ||
+    isShopifyThemeRoot(dir) ||
+    isShopifyAppRoot(dir)
+  );
+}
+
+// Walk up from a filesystem path to the nearest directory that looks like a
+// startable project: one containing a package.json, or a Shopify theme/app
+// root (themes have no package.json at all). Used to resolve a Finder
+// selection (which may be a file, a subfolder, or the project root itself)
+// to a project root we can spawn in. The returned path is canonicalized so
+// it round-trips through process inspection without symlink-induced
+// mismatches. Returns null when the path isn't inside any known project.
 export function findProjectRoot(startPath: string): string | null {
   let cur: string;
   try {
@@ -410,7 +602,7 @@ export function findProjectRoot(startPath: string): string | null {
     return null;
   }
   for (;;) {
-    if (fs.existsSync(path.join(cur, "package.json"))) return canonicalCwd(cur);
+    if (isProjectRoot(cur)) return canonicalCwd(cur);
     const parent = path.dirname(cur);
     if (parent === cur) return null;
     cur = parent;
@@ -420,6 +612,37 @@ export function findProjectRoot(startPath: string): string | null {
 // Slugify cwd for use in a temp-dir log filename.
 function cwdSlug(cwd: string): string {
   return cwd.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "") || "root";
+}
+
+// Decide what command starts this project's dev server.
+//
+// 1. A package.json dev script always wins: it's the project's explicit
+//    intent, and scaffolded Shopify apps and Hydrogen storefronts already
+//    ship `dev: shopify app dev` / `shopify hydrogen dev` there, so they
+//    resolve through this branch like any other Node project. Explicit
+//    scripts also cover themes that wrap `shopify theme dev` in
+//    concurrently-style tooling.
+// 2. With no usable script, fall back to the Shopify CLI for theme and app
+//    roots. Themes are the important case: they have no package.json, so
+//    nothing else could ever start (or restart) them.
+//
+// First-run caveat for the Shopify fallbacks: `shopify theme dev` / `app
+// dev` prompt for login and store selection when the CLI has no remembered
+// state. A detached spawn can't answer prompts, so the 15s watchdog fires
+// and the startup log shows the prompt text. After a one-time
+// `shopify theme dev --store <store>` in a terminal, the CLI remembers the
+// store and starts cleanly from here.
+function planSpawn(cwd: string): { cmd: string; args: string[] } | null {
+  const script = pickDevScript(cwd);
+  if (script) {
+    const pm = detectPackageManager(cwd);
+    const [cmd, baseArgs] = PM_RUN[pm];
+    return { cmd, args: [...baseArgs, script] };
+  }
+  if (isShopifyThemeRoot(cwd))
+    return { cmd: "shopify", args: ["theme", "dev"] };
+  if (isShopifyAppRoot(cwd)) return { cmd: "shopify", args: ["app", "dev"] };
+  return null;
 }
 
 // Spawn a dev server for a project. Shared by the Start Dev Server flow
@@ -442,17 +665,15 @@ function cwdSlug(cwd: string): string {
 //   the PID has been replaced by the new server. Use `spawnLogPath(cwd)`
 //   to reach it from error toasts.
 //
-// Throws if pickDevScript can't find a runnable script.
+// Throws if planSpawn can't find a runnable command.
 export async function startDevServer(cwd: string): Promise<void> {
-  const script = pickDevScript(cwd);
-  if (!script) {
+  const plan = planSpawn(cwd);
+  if (!plan) {
     throw new Error(
-      "No dev script found in package.json. Expected one of: dev, start, develop, or a script that invokes a known dev-server tool.",
+      "No way to start this project. Expected a package.json with a dev/start/develop script (or one invoking a known dev-server tool), or a Shopify theme/app root.",
     );
   }
-  const pm = detectPackageManager(cwd);
-  const [cmd, baseArgs] = PM_RUN[pm];
-  const args = [...baseArgs, script];
+  const { cmd, args } = plan;
   const out = fs.openSync(spawnLogPath(cwd), "a");
   const child = spawn("/bin/zsh", ["-ilc", 'exec "$0" "$@"', cmd, ...args], {
     cwd,

--- a/extensions/dev-servers/src/start.tsx
+++ b/extensions/dev-servers/src/start.tsx
@@ -69,11 +69,10 @@ async function maybeConsumeAutoOpenHint(): Promise<boolean> {
 // package.json dependencies. UI tag only. Process inspection is still the
 // source of truth for a running server.
 function guessFramework(cwd: string): string | undefined {
-  // Shopify projects first: themes have no package.json at all, and app /
-  // Hydrogen projects carry framework deps (Remix, Vite) that would
-  // otherwise win below and mislabel them.
+  // Themes first: they have no package.json at all, so nothing below could
+  // ever label them.
   if (isShopifyThemeRoot(cwd)) return "shopify-theme";
-  if (isShopifyAppRoot(cwd)) return "shopify-app";
+  let deps: Record<string, string> = {};
   try {
     const pkg = JSON.parse(
       fs.readFileSync(path.join(cwd, "package.json"), "utf8"),
@@ -81,27 +80,30 @@ function guessFramework(cwd: string): string | undefined {
       dependencies?: Record<string, string>;
       devDependencies?: Record<string, string>;
     };
-    const deps = {
-      ...(pkg.dependencies ?? {}),
-      ...(pkg.devDependencies ?? {}),
-    };
-    if ("@shopify/hydrogen" in deps) return "shopify-hydrogen";
-    if ("next" in deps) return "next";
-    if ("@sveltejs/kit" in deps) return "sveltekit";
-    if ("svelte" in deps) return "svelte";
-    if ("astro" in deps) return "astro";
-    if ("nuxt" in deps || "nuxt3" in deps) return "nuxt";
-    if ("@remix-run/dev" in deps) return "remix";
-    if ("gatsby" in deps) return "gatsby";
-    if ("vite" in deps) return "vite";
-    if ("webpack" in deps) return "webpack";
-    if ("parcel" in deps) return "parcel";
-    if ("turbo" in deps) return "turbo";
-    if ("esbuild" in deps) return "esbuild";
-    return undefined;
+    deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
   } catch {
-    return undefined;
+    // No readable package.json; the marker checks below still apply.
   }
+  // Hydrogen before the app-toml marker: the skeleton ships no
+  // shopify.app.toml today, but if a project ever carries both, the dep is
+  // the more specific signal. Both before the generic deps chain, since
+  // Shopify projects also carry framework deps (Remix, Vite) that would
+  // otherwise win and mislabel them.
+  if ("@shopify/hydrogen" in deps) return "shopify-hydrogen";
+  if (isShopifyAppRoot(cwd)) return "shopify-app";
+  if ("next" in deps) return "next";
+  if ("@sveltejs/kit" in deps) return "sveltekit";
+  if ("svelte" in deps) return "svelte";
+  if ("astro" in deps) return "astro";
+  if ("nuxt" in deps || "nuxt3" in deps) return "nuxt";
+  if ("@remix-run/dev" in deps) return "remix";
+  if ("gatsby" in deps) return "gatsby";
+  if ("vite" in deps) return "vite";
+  if ("webpack" in deps) return "webpack";
+  if ("parcel" in deps) return "parcel";
+  if ("turbo" in deps) return "turbo";
+  if ("esbuild" in deps) return "esbuild";
+  return undefined;
 }
 
 function formatLastSeen(ts: number): string {

--- a/extensions/dev-servers/src/start.tsx
+++ b/extensions/dev-servers/src/start.tsx
@@ -35,7 +35,12 @@ import {
   recordSeenBatch,
   removeRecent,
 } from "./recents";
-import { fetchServers, findProjectRoot } from "./servers";
+import {
+  fetchServers,
+  findProjectRoot,
+  isShopifyAppRoot,
+  isShopifyThemeRoot,
+} from "./servers";
 import { toolColor, toolLabel } from "./tool-display";
 import { DevServer } from "./types";
 
@@ -60,10 +65,15 @@ async function maybeConsumeAutoOpenHint(): Promise<boolean> {
   return true;
 }
 
-// Best-guess framework for a project, read from package.json dependencies.
-// UI tag only. Process inspection is still the source of truth for a
-// running server.
+// Best-guess framework for a project, read from filesystem markers and
+// package.json dependencies. UI tag only. Process inspection is still the
+// source of truth for a running server.
 function guessFramework(cwd: string): string | undefined {
+  // Shopify projects first: themes have no package.json at all, and app /
+  // Hydrogen projects carry framework deps (Remix, Vite) that would
+  // otherwise win below and mislabel them.
+  if (isShopifyThemeRoot(cwd)) return "shopify-theme";
+  if (isShopifyAppRoot(cwd)) return "shopify-app";
   try {
     const pkg = JSON.parse(
       fs.readFileSync(path.join(cwd, "package.json"), "utf8"),
@@ -75,6 +85,7 @@ function guessFramework(cwd: string): string | undefined {
       ...(pkg.dependencies ?? {}),
       ...(pkg.devDependencies ?? {}),
     };
+    if ("@shopify/hydrogen" in deps) return "shopify-hydrogen";
     if ("next" in deps) return "next";
     if ("@sveltejs/kit" in deps) return "sveltekit";
     if ("svelte" in deps) return "svelte";
@@ -171,8 +182,9 @@ async function chooseFolderAndStart(options: {
   const target = resolveTarget(raw);
   if (!target) {
     await showFailureToast(undefined, {
-      title: "No package.json found",
-      message: "That folder isn't inside a Node project.",
+      title: "No project found",
+      message:
+        "That folder isn't inside a Node project or a Shopify theme/app.",
     });
     return;
   }
@@ -186,6 +198,7 @@ interface RowProps {
   recent: RecentProject;
   framework?: string;
   terminalApp: Application;
+  editorApp?: Application;
   autoOpen: boolean;
   onRemove: (cwd: string) => Promise<void>;
 }
@@ -194,6 +207,7 @@ function RecentRow({
   recent,
   framework,
   terminalApp,
+  editorApp,
   autoOpen,
   onRemove,
 }: RowProps) {
@@ -258,6 +272,15 @@ function RecentRow({
         <ActionPanel>
           <Action title="Start Dev Server" icon={Icon.Play} onAction={start} />
           <ActionPanel.Section>
+            {editorApp && (
+              <Action.Open
+                title={`Open in ${editorApp.name}`}
+                icon={Icon.Code}
+                target={recent.cwd}
+                application={editorApp}
+                shortcut={{ modifiers: ["cmd"], key: "e" }}
+              />
+            )}
             <Action.Open
               title={`Open in ${terminalApp.name}`}
               icon={Icon.Terminal}
@@ -293,13 +316,14 @@ function RecentRow({
 interface PickerProps {
   autoOpen: boolean;
   terminalApp: Application;
+  editorApp?: Application;
 }
 
 // Picker view shown when there's no Finder selection. Lists recent
 // projects (excluding currently-running ones, which live in the
 // dashboard) and an always-present "Choose Folder…" entry for one-off
 // picks.
-function PickerView({ autoOpen, terminalApp }: PickerProps) {
+function PickerView({ autoOpen, terminalApp, editorApp }: PickerProps) {
   // Passive migration: every mount triggers an empty recordSeenBatch
   // which canonicalizes any non-symlink-resolved entries left over from
   // earlier builds, so the running-server filter below matches reliably.
@@ -416,6 +440,7 @@ function PickerView({ autoOpen, terminalApp }: PickerProps) {
               recent={r}
               framework={frameworkByCwd[r.cwd]}
               terminalApp={terminalApp}
+              editorApp={editorApp}
               autoOpen={autoOpen}
               onRemove={handleRemove}
             />
@@ -459,6 +484,7 @@ export default function Command(
   const autoOpen = prefs.autoOpenInBrowser ?? false;
   const confirmMulti = prefs.confirmMultiStart ?? true;
   const terminalApp = prefs.terminalApp ?? DEFAULT_TERMINAL;
+  const editorApp = prefs.editorApp;
   const forcePicker = props.launchContext?.forcePicker ?? false;
 
   const [phase, setPhase] = useState<"checking" | "picker">(
@@ -517,7 +543,7 @@ export default function Command(
       }
       if (targets.length === 0) {
         await showFailureToast(undefined, {
-          title: "No package.json in selection",
+          title: "No project in selection",
           message: "Pick a project from your recents instead.",
         });
         setPhase("picker");
@@ -536,7 +562,13 @@ export default function Command(
   }, [autoOpen, confirmMulti, forcePicker]);
 
   if (phase === "picker") {
-    return <PickerView autoOpen={autoOpen} terminalApp={terminalApp} />;
+    return (
+      <PickerView
+        autoOpen={autoOpen}
+        terminalApp={terminalApp}
+        editorApp={editorApp}
+      />
+    );
   }
 
   // Minimal placeholder while we resolve the Finder selection. Just the

--- a/extensions/dev-servers/src/tool-display.ts
+++ b/extensions/dev-servers/src/tool-display.ts
@@ -21,6 +21,9 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   serve: "Serve",
   "http-server": "http-server", // intentionally lowercase per package name
   "live-server": "Live Server",
+  "shopify-theme": "Shopify Theme",
+  "shopify-app": "Shopify App",
+  "shopify-hydrogen": "Hydrogen",
 };
 
 export function toolLabel(tool: string): string {
@@ -56,6 +59,9 @@ export function toolColor(
     svelte: Color.Orange,
     sveltekit: Color.Orange,
     remix: Color.Magenta,
+    "shopify-theme": Color.Green,
+    "shopify-app": Color.Green,
+    "shopify-hydrogen": Color.Green,
     turbo: Color.Blue,
     node: Color.Green,
   };

--- a/extensions/dev-servers/src/types.ts
+++ b/extensions/dev-servers/src/types.ts
@@ -10,5 +10,6 @@ export interface DevServer {
   projectKey: string; // stable id for grouping; cwd, or git common-dir (the .git path) for repos
   projectName: string; // MyProject (display label for the project section)
   branch?: string; // current git branch when cwd is inside any git repo
+  lanExposed: boolean; // true when a listening socket is bound beyond loopback
   startedAt: Date;
 }


### PR DESCRIPTION
## Description

Shopify

- Detect running Shopify CLI dev servers launched globally, including `shopify theme dev`, `shopify app dev`, and `shopify hydrogen dev`, so they appear in the dashboard even when the process is outside `node_modules`. Shopify-specific tool tags: Shopify Theme, Shopify App, and Hydrogen.
- **Start Dev Server now works for Shopify themes**, which have no `package.json` at all. A folder containing `layout/theme.liquid` (or `shopify.theme.toml`) resolves as a theme root and starts with `shopify theme dev`; a folder with `shopify.app.toml` and no dev script falls back to `shopify app dev`. Restart on a detected theme server works through the same path. Scaffolded Shopify apps and Hydrogen storefronts already start via their `dev` scripts, so all three project types are now coherent across detect → start → restart.
- The Start picker tags Shopify projects (theme, app, Hydrogen) so they're recognizable among your recents.
- First-run note: the Shopify CLI prompts for login and store selection when it has no remembered state, which a detached spawn can't answer; run `shopify theme dev --store <store>` once in a terminal and the extension starts it cleanly from then on. The captured startup log shows the prompt if this happens.

### Performance

- The portless lookup no longer spawns a zsh login shell (re-sourcing `~/.zshrc`) on every refresh. The portless binary and login PATH are resolved once, persisted in Raycast's cache, and the binary is executed directly from then on: roughly 1s → 100ms per poll on a typical nvm setup, and the dominant cost of every refresh cycle.
- Per-process metadata (working directory, framework, runtime) is now cached for the lifetime of each PID, so steady-state polls skip the second `lsof` query and the tool-detection regexes entirely. Guarded against PID reuse via process start time.
- Git project info is cached per directory and invalidated by the `HEAD` file's mtime (which changes on every checkout, per worktree), replacing a `git rev-parse` spawn per project per poll with a single `stat`.
- Branch switches now show up in the dashboard immediately: the change-detection that skips redundant re-renders compares branches too, instead of waiting for a PID change.

### New actions and preferences

- **Open in Editor** (`⌘E`): a new shared **Editor App** preference (VS Code, Cursor, Zed, …) adds an Open in Editor action to dashboard rows and recent-project rows. Hidden until the preference is set.
- **Copy Network URL** (`⌘⌥C`): when a server is bound beyond loopback and your Mac has a LAN address, copy `http://<lan-ip>:<port>` for testing on a phone or another machine. Only offered when the server is actually reachable that way.
- **Copy Port** (`⌘⌥P`): copy just the port number, for env files and config.
- The startup log view now follows the file while open (live tail every 2s), so a slow boot or crash loop streams in without mashing refresh.


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
