### PR TITLE
[Hypersonic] Add a create-with-details form with an optional page-body note

### DIFF
--- a/extensions/hypersonic/CHANGELOG.md
+++ b/extensions/hypersonic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Hypersonic Changelog
 
+## [Create tasks with details] - {PR_MERGE_DATE}
+
+#### New
+
+- Added an optional "Create Task with Details" form (`⌘` `⇧` `↵` on a new task) to set status, date, assignee, label, project, and URL in one window, pre-filled from what you typed. The quick natural-language capture in the search bar is unchanged.
+- The form also includes a note that is written to the body of the new Notion page — each line becomes a block, and a line that is only a URL becomes a bookmark (closes #3884).
+
 ## [2.1.1] - 2025-08-04
 
 #### New

--- a/extensions/hypersonic/CHANGELOG.md
+++ b/extensions/hypersonic/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Hypersonic Changelog
 
-## [Create tasks with details] - {PR_MERGE_DATE}
+## [Create tasks with details] - 2026-08-03
 
 #### New
 

--- a/extensions/hypersonic/package.json
+++ b/extensions/hypersonic/package.json
@@ -63,5 +63,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/hypersonic/package.json
+++ b/extensions/hypersonic/package.json
@@ -7,7 +7,8 @@
   "author": "reboot.studio",
   "owner": "reboot",
   "contributors": [
-    "thomasjost"
+    "thomasjost",
+    "profdorly"
   ],
   "access": "public",
   "version": "2.0.4",

--- a/extensions/hypersonic/src/features/todo-list/components/create-todo-with-details-action.tsx
+++ b/extensions/hypersonic/src/features/todo-list/components/create-todo-with-details-action.tsx
@@ -1,0 +1,218 @@
+import { Action, Icon, Form, ActionPanel, useNavigation } from '@raycast/api'
+import { useState } from 'react'
+import { Todo } from '@/types/todo'
+import { Status } from '@/types/status'
+import { Tag } from '@/types/tag'
+import { User } from '@/types/user'
+import { Project } from '@/types/project'
+import { toISOStringWithTimezone } from '../utils/to-iso-string-with-time-zone'
+
+const MAX_NOTE_LENGTH = 2000
+
+type CreateTodoWithDetailsProps = {
+  todo: Todo
+  statuses: Status[]
+  users: User[]
+  tags: Tag[]
+  projects: Project[]
+  hasStatusProperty: boolean
+  hasTagProperty: boolean
+  hasAssigneeProperty: boolean
+  hasProjectProperty: boolean
+  hasUrlProperty: boolean
+  onCreate: (overrides: Partial<Todo>) => Promise<void>
+}
+
+function CreateTodoWithDetailsForm({
+  todo,
+  statuses,
+  users,
+  tags,
+  projects,
+  hasStatusProperty,
+  hasTagProperty,
+  hasAssigneeProperty,
+  hasProjectProperty,
+  hasUrlProperty,
+  onCreate,
+}: CreateTodoWithDetailsProps) {
+  const [title, setTitle] = useState(todo.title)
+  const [note, setNote] = useState('')
+  const [statusId, setStatusId] = useState(todo.status?.id ?? '')
+  const [date, setDate] = useState<Date | null>(todo.date ?? null)
+  const [userId, setUserId] = useState(todo.user?.id ?? '')
+  const [tagId, setTagId] = useState(todo.tag?.id ?? '')
+  const [projectId, setProjectId] = useState(todo.projectId ?? '')
+  const [url, setUrl] = useState(todo.contentUrl ?? '')
+  const [noteError, setNoteError] = useState<string | undefined>()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const { pop } = useNavigation()
+
+  async function handleSubmit() {
+    if (note.length > MAX_NOTE_LENGTH) {
+      setNoteError(`Note must be ${MAX_NOTE_LENGTH} characters or fewer`)
+      return
+    }
+    setIsSubmitting(true)
+    try {
+      const overrides: Partial<Todo> = {
+        title: title.trim() || todo.title,
+        note,
+        date: date ?? null,
+        dateValue: date ? toISOStringWithTimezone(date) : null,
+      }
+      if (hasStatusProperty) {
+        overrides.status = statusId
+          ? statuses.find((s) => s.id === statusId) ?? null
+          : null
+      }
+      if (hasAssigneeProperty) {
+        overrides.user = userId
+          ? users.find((u) => u.id === userId) ?? null
+          : null
+      }
+      if (hasTagProperty) {
+        overrides.tag = tagId ? tags.find((t) => t.id === tagId) ?? null : null
+      }
+      if (hasProjectProperty) {
+        overrides.projectId = projectId || null
+      }
+      if (hasUrlProperty) {
+        overrides.contentUrl = url.trim() || null
+      }
+      await onCreate(overrides)
+      pop()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Form
+      isLoading={isSubmitting}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Create Task" onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField
+        id="title"
+        title="Title"
+        info="The task name"
+        value={title}
+        onChange={setTitle}
+      />
+      {hasStatusProperty ? (
+        <Form.Dropdown
+          id="status"
+          title="Status"
+          info="Sets the task status"
+          value={statusId}
+          onChange={setStatusId}
+        >
+          <Form.Dropdown.Item value="" title="None" />
+          {statuses.map((status) => (
+            <Form.Dropdown.Item
+              key={status.id}
+              value={status.id}
+              title={status.name}
+            />
+          ))}
+        </Form.Dropdown>
+      ) : null}
+      <Form.DatePicker
+        id="date"
+        title="Date"
+        info="Sets the task due date"
+        value={date}
+        onChange={setDate}
+      />
+      {hasAssigneeProperty ? (
+        <Form.Dropdown
+          id="assignee"
+          title="Assignee"
+          info="Assigns the task to a person"
+          value={userId}
+          onChange={setUserId}
+        >
+          <Form.Dropdown.Item value="" title="Unassigned" />
+          {users.map((user) => (
+            <Form.Dropdown.Item
+              key={user.id}
+              value={user.id}
+              title={user.name}
+            />
+          ))}
+        </Form.Dropdown>
+      ) : null}
+      {hasTagProperty ? (
+        <Form.Dropdown
+          id="tag"
+          title="Label"
+          info="Adds a label to the task"
+          value={tagId}
+          onChange={setTagId}
+        >
+          <Form.Dropdown.Item value="" title="None" />
+          {tags.map((tag) => (
+            <Form.Dropdown.Item key={tag.id} value={tag.id} title={tag.name} />
+          ))}
+        </Form.Dropdown>
+      ) : null}
+      {hasProjectProperty ? (
+        <Form.Dropdown
+          id="project"
+          title="Project"
+          info="Links the task to a project"
+          value={projectId}
+          onChange={setProjectId}
+        >
+          <Form.Dropdown.Item value="" title="None" />
+          {projects.map((project) => (
+            <Form.Dropdown.Item
+              key={project.id}
+              value={project.id}
+              title={project.title}
+            />
+          ))}
+        </Form.Dropdown>
+      ) : null}
+      {hasUrlProperty ? (
+        <Form.TextField
+          id="url"
+          title="URL"
+          info="Attaches a URL to the task"
+          placeholder="https://..."
+          value={url}
+          onChange={setUrl}
+        />
+      ) : null}
+      <Form.TextArea
+        id="note"
+        title="Note"
+        info="Saved to the body of the new Notion page. Each line becomes its own block, and a line that is only a URL becomes a bookmark."
+        placeholder="Add a note, links, or details"
+        value={note}
+        error={noteError}
+        onChange={(value) => {
+          if (noteError) {
+            setNoteError(undefined)
+          }
+          setNote(value)
+        }}
+      />
+    </Form>
+  )
+}
+
+export function CreateTodoWithDetailsAction(props: CreateTodoWithDetailsProps) {
+  return (
+    <Action.Push
+      icon={Icon.Paragraph}
+      title="Create Task with Details..."
+      target={<CreateTodoWithDetailsForm {...props} />}
+      shortcut={{ modifiers: ['cmd', 'shift'], key: 'return' }}
+    />
+  )
+}

--- a/extensions/hypersonic/src/features/todo-list/components/create-todo-with-details-action.tsx
+++ b/extensions/hypersonic/src/features/todo-list/components/create-todo-with-details-action.tsx
@@ -6,8 +6,7 @@ import { Tag } from '@/types/tag'
 import { User } from '@/types/user'
 import { Project } from '@/types/project'
 import { toISOStringWithTimezone } from '../utils/to-iso-string-with-time-zone'
-
-const MAX_NOTE_LENGTH = 2000
+import { MAX_NOTE_LENGTH } from '@/services/notion/utils/build-note-blocks'
 
 type CreateTodoWithDetailsProps = {
   todo: Todo

--- a/extensions/hypersonic/src/features/todo-list/components/create-todo-with-details-action.tsx
+++ b/extensions/hypersonic/src/features/todo-list/components/create-todo-with-details-action.tsx
@@ -6,7 +6,11 @@ import { Tag } from '@/types/tag'
 import { User } from '@/types/user'
 import { Project } from '@/types/project'
 import { toISOStringWithTimezone } from '../utils/to-iso-string-with-time-zone'
-import { MAX_NOTE_LENGTH } from '@/services/notion/utils/build-note-blocks'
+import {
+  countNoteBlocks,
+  MAX_NOTE_BLOCKS,
+  MAX_NOTE_LENGTH,
+} from '@/services/notion/utils/build-note-blocks'
 
 type CreateTodoWithDetailsProps = {
   todo: Todo
@@ -50,6 +54,11 @@ function CreateTodoWithDetailsForm({
   async function handleSubmit() {
     if (note.length > MAX_NOTE_LENGTH) {
       setNoteError(`Note must be ${MAX_NOTE_LENGTH} characters or fewer`)
+      return
+    }
+    const blockCount = countNoteBlocks(note)
+    if (blockCount > MAX_NOTE_BLOCKS) {
+      setNoteError(`Note must be ${MAX_NOTE_BLOCKS} lines or fewer`)
       return
     }
     setIsSubmitting(true)

--- a/extensions/hypersonic/src/features/todo-list/components/create-todo-with-details-action.tsx
+++ b/extensions/hypersonic/src/features/todo-list/components/create-todo-with-details-action.tsx
@@ -19,7 +19,7 @@ type CreateTodoWithDetailsProps = {
   hasAssigneeProperty: boolean
   hasProjectProperty: boolean
   hasUrlProperty: boolean
-  onCreate: (overrides: Partial<Todo>) => Promise<void>
+  onCreate: (overrides: Partial<Todo>) => Promise<boolean>
 }
 
 function CreateTodoWithDetailsForm({
@@ -79,8 +79,10 @@ function CreateTodoWithDetailsForm({
       if (hasUrlProperty) {
         overrides.contentUrl = url.trim() || null
       }
-      await onCreate(overrides)
-      pop()
+      const created = await onCreate(overrides)
+      if (created) {
+        pop()
+      }
     } finally {
       setIsSubmitting(false)
     }

--- a/extensions/hypersonic/src/features/todo-list/hooks/use-todo-list.ts
+++ b/extensions/hypersonic/src/features/todo-list/hooks/use-todo-list.ts
@@ -108,12 +108,16 @@ export function useTodoList() {
     }
   }
 
-  const handleCreate = async (action?: 'SHARE' | 'OPEN') => {
+  const handleCreate = async (
+    action?: 'SHARE' | 'OPEN',
+    overrides?: Partial<Todo>
+  ) => {
     try {
       if (!newTodo) return null
 
       const optimisticTodo = {
         ...newTodo,
+        ...overrides,
         id: `fake-id-${Math.random() * 1000}`,
       }
 
@@ -507,6 +511,7 @@ export function useTodoList() {
     hasAssigneeProperty: !!preferences?.properties?.assignee,
     hasProjectProperty: !!preferences?.properties?.project,
     hasTagProperty: !!preferences?.properties?.tag,
+    hasUrlProperty: !!preferences?.properties?.url,
     loading: isLoading,
     handleCreate,
     handleComplete,

--- a/extensions/hypersonic/src/features/todo-list/hooks/use-todo-list.ts
+++ b/extensions/hypersonic/src/features/todo-list/hooks/use-todo-list.ts
@@ -111,9 +111,9 @@ export function useTodoList() {
   const handleCreate = async (
     action?: 'SHARE' | 'OPEN',
     overrides?: Partial<Todo>
-  ) => {
+  ): Promise<boolean> => {
     try {
-      if (!newTodo) return null
+      if (!newTodo) return false
 
       const optimisticTodo = {
         ...newTodo,
@@ -173,8 +173,11 @@ export function useTodoList() {
           await openBrowser(createdTodo.shareUrl)
         }
       }
+
+      return true
     } catch (e: any) {
       showToast(Toast.Style.Failure, e?.message)
+      return false
     }
   }
 

--- a/extensions/hypersonic/src/features/todo-list/todo-list.tsx
+++ b/extensions/hypersonic/src/features/todo-list/todo-list.tsx
@@ -8,6 +8,7 @@ import { RemindAction } from '@/components/remind-todo-action'
 import { CopyToDoAction } from '@/components/copy-todo-action'
 import { DeleteTodoAction } from '@/components/delete-todo-action'
 import { EditTodoTitleAction } from '@/features/todo-list/components/edit-todo-title-action'
+import { CreateTodoWithDetailsAction } from '@/features/todo-list/components/create-todo-with-details-action'
 import { SetProjectAction } from './components/set-todo-project-action'
 import { SetUserAction } from './components/set-todo-user-action'
 import { SetFilter } from './components/set-filter-action'
@@ -29,6 +30,7 @@ export function TodoList() {
     hasAssigneeProperty,
     hasProjectProperty,
     hasTagProperty,
+    hasUrlProperty,
     loading,
     handleCreate,
     handleComplete,
@@ -93,6 +95,21 @@ export function TodoList() {
                 title="Create Task and Open in Notion"
                 onAction={() => handleCreate('OPEN')}
                 shortcut={{ modifiers: ['cmd'], key: 'o' }}
+              />
+              <CreateTodoWithDetailsAction
+                todo={newTodo}
+                statuses={statuses ?? []}
+                users={users ?? []}
+                tags={tags ?? []}
+                projects={projects ?? []}
+                hasStatusProperty={hasStatusProperty}
+                hasTagProperty={hasTagProperty}
+                hasAssigneeProperty={hasAssigneeProperty}
+                hasProjectProperty={hasProjectProperty}
+                hasUrlProperty={hasUrlProperty}
+                onCreate={async (overrides) => {
+                  await handleCreate(undefined, overrides)
+                }}
               />
               <GeneralActions
                 mutatePreferences={mutatePreferences}

--- a/extensions/hypersonic/src/features/todo-list/todo-list.tsx
+++ b/extensions/hypersonic/src/features/todo-list/todo-list.tsx
@@ -108,7 +108,7 @@ export function TodoList() {
                 hasProjectProperty={hasProjectProperty}
                 hasUrlProperty={hasUrlProperty}
                 onCreate={async (overrides) => {
-                  await handleCreate(undefined, overrides)
+                  return handleCreate(undefined, overrides)
                 }}
               />
               <GeneralActions

--- a/extensions/hypersonic/src/services/notion/operations/create-todo.ts
+++ b/extensions/hypersonic/src/services/notion/operations/create-todo.ts
@@ -2,6 +2,7 @@ import { Todo } from '@/types/todo'
 import { notion } from '../client'
 import { loadPreferences } from '@/services/storage'
 import { normalizeTodo } from '../utils/normalize-todo'
+import { buildNoteBlocks } from '../utils/build-note-blocks'
 
 export async function createTodo(
   todo: Todo,
@@ -9,6 +10,7 @@ export async function createTodo(
 ): Promise<Todo> {
   const notionClient = await notion()
   const preferences = await loadPreferences()
+  const children = buildNoteBlocks(todo.note)
 
   const data = await notionClient.pages.create({
     parent: { database_id: databaseId },
@@ -62,6 +64,7 @@ export async function createTodo(
           }
         : {}),
     },
+    ...(children.length > 0 ? { children } : {}),
   })
 
   const normalizedTodo = normalizeTodo({

--- a/extensions/hypersonic/src/services/notion/operations/create-todo.ts
+++ b/extensions/hypersonic/src/services/notion/operations/create-todo.ts
@@ -10,7 +10,7 @@ export async function createTodo(
 ): Promise<Todo> {
   const notionClient = await notion()
   const preferences = await loadPreferences()
-  const children = buildNoteBlocks(todo.note)
+  const noteBlocks = buildNoteBlocks(todo.note)
 
   const data = await notionClient.pages.create({
     parent: { database_id: databaseId },
@@ -64,7 +64,7 @@ export async function createTodo(
           }
         : {}),
     },
-    ...(children.length > 0 ? { children } : {}),
+    ...(noteBlocks.length > 0 ? { children: noteBlocks } : {}),
   })
 
   const normalizedTodo = normalizeTodo({

--- a/extensions/hypersonic/src/services/notion/utils/build-note-blocks.ts
+++ b/extensions/hypersonic/src/services/notion/utils/build-note-blocks.ts
@@ -9,7 +9,7 @@ type BlockObjectRequest = NonNullable<
   Parameters<Client['pages']['create']>[0]['children']
 >[number]
 
-const MAX_NOTE_LENGTH = 2000
+export const MAX_NOTE_LENGTH = 2000
 const MAX_NOTE_BLOCKS = 100
 
 const isBareUrl = (line: string) => /^https?:\/\/\S+$/.test(line)
@@ -21,34 +21,45 @@ const isBareUrl = (line: string) => /^https?:\/\/\S+$/.test(line)
  *   entirely and keep the no-note behaviour byte-for-byte identical.
  * - Each non-empty line becomes a paragraph block; a line that is only a bare URL
  *   becomes a bookmark block so the link renders as a rich preview in Notion.
- * - Capped to MAX_NOTE_LENGTH characters and MAX_NOTE_BLOCKS blocks to keep this a
- *   quick-capture note and to stay within Notion's API limits (2000 characters per
+ * - Limits are enforced at line boundaries: whole lines are kept until the budget
+ *   is reached, and a line that would exceed it stops processing rather than being
+ *   sliced mid-character (which could turn a URL into a broken bookmark). Caps the
+ *   total to MAX_NOTE_LENGTH characters and MAX_NOTE_BLOCKS blocks to keep this a
+ *   quick-capture note and stay within Notion's API limits (2000 characters per
  *   rich-text run, 100 blocks per request).
  */
 export function buildNoteBlocks(note?: string): BlockObjectRequest[] {
   const trimmed = note?.trim()
   if (!trimmed) return []
 
-  return trimmed
-    .slice(0, MAX_NOTE_LENGTH)
+  const lines = trimmed
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
-    .slice(0, MAX_NOTE_BLOCKS)
-    .map(
-      (line): BlockObjectRequest =>
-        isBareUrl(line)
-          ? {
-              object: 'block',
-              type: 'bookmark',
-              bookmark: { url: line },
-            }
-          : {
-              object: 'block',
-              type: 'paragraph',
-              paragraph: {
-                rich_text: [{ type: 'text', text: { content: line } }],
-              },
-            }
-    )
+
+  const blocks: BlockObjectRequest[] = []
+  let usedLength = 0
+
+  for (const line of lines) {
+    if (blocks.length >= MAX_NOTE_BLOCKS) break
+    if (usedLength + line.length > MAX_NOTE_LENGTH) break
+    usedLength += line.length
+
+    const block: BlockObjectRequest = isBareUrl(line)
+      ? {
+          object: 'block',
+          type: 'bookmark',
+          bookmark: { url: line },
+        }
+      : {
+          object: 'block',
+          type: 'paragraph',
+          paragraph: {
+            rich_text: [{ type: 'text', text: { content: line } }],
+          },
+        }
+    blocks.push(block)
+  }
+
+  return blocks
 }

--- a/extensions/hypersonic/src/services/notion/utils/build-note-blocks.ts
+++ b/extensions/hypersonic/src/services/notion/utils/build-note-blocks.ts
@@ -1,0 +1,54 @@
+import { Client } from '@notionhq/client'
+
+/**
+ * The Notion SDK declares `BlockObjectRequest` but does not export it, so we
+ * derive the block-request type from the public `pages.create` signature rather
+ * than deep-importing an internal type.
+ */
+type BlockObjectRequest = NonNullable<
+  Parameters<Client['pages']['create']>[0]['children']
+>[number]
+
+const MAX_NOTE_LENGTH = 2000
+const MAX_NOTE_BLOCKS = 100
+
+const isBareUrl = (line: string) => /^https?:\/\/\S+$/.test(line)
+
+/**
+ * Converts an optional free-text note into Notion block children for a page body.
+ *
+ * - Returns [] when the note is empty/undefined, so callers can omit `children`
+ *   entirely and keep the no-note behaviour byte-for-byte identical.
+ * - Each non-empty line becomes a paragraph block; a line that is only a bare URL
+ *   becomes a bookmark block so the link renders as a rich preview in Notion.
+ * - Capped to MAX_NOTE_LENGTH characters and MAX_NOTE_BLOCKS blocks to keep this a
+ *   quick-capture note and to stay within Notion's API limits (2000 characters per
+ *   rich-text run, 100 blocks per request).
+ */
+export function buildNoteBlocks(note?: string): BlockObjectRequest[] {
+  const trimmed = note?.trim()
+  if (!trimmed) return []
+
+  return trimmed
+    .slice(0, MAX_NOTE_LENGTH)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .slice(0, MAX_NOTE_BLOCKS)
+    .map(
+      (line): BlockObjectRequest =>
+        isBareUrl(line)
+          ? {
+              object: 'block',
+              type: 'bookmark',
+              bookmark: { url: line },
+            }
+          : {
+              object: 'block',
+              type: 'paragraph',
+              paragraph: {
+                rich_text: [{ type: 'text', text: { content: line } }],
+              },
+            }
+    )
+}

--- a/extensions/hypersonic/src/services/notion/utils/build-note-blocks.ts
+++ b/extensions/hypersonic/src/services/notion/utils/build-note-blocks.ts
@@ -12,7 +12,14 @@ type BlockObjectRequest = NonNullable<
 export const MAX_NOTE_LENGTH = 2000
 const MAX_NOTE_BLOCKS = 100
 
-const isBareUrl = (line: string) => /^https?:\/\/\S+$/.test(line)
+const isBareUrl = (line: string) => {
+  try {
+    const url = new URL(line)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
 
 /**
  * Converts an optional free-text note into Notion block children for a page body.

--- a/extensions/hypersonic/src/services/notion/utils/build-note-blocks.ts
+++ b/extensions/hypersonic/src/services/notion/utils/build-note-blocks.ts
@@ -10,7 +10,15 @@ type BlockObjectRequest = NonNullable<
 >[number]
 
 export const MAX_NOTE_LENGTH = 2000
-const MAX_NOTE_BLOCKS = 100
+export const MAX_NOTE_BLOCKS = 100
+
+export function countNoteBlocks(note?: string): number {
+  if (!note) return 0
+  return note
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0).length
+}
 
 const isBareUrl = (line: string) => {
   try {

--- a/extensions/hypersonic/src/types/todo.ts
+++ b/extensions/hypersonic/src/types/todo.ts
@@ -16,4 +16,5 @@ export interface Todo {
   date?: Date | null
   dateValue?: string | null
   status?: Status | Partial<Status> | null
+  note?: string
 }


### PR DESCRIPTION
I use Hypersonic many times a day, and I kept hitting two bits of friction when creating a task:

- I often want to drop a link or a short note into the task's page body (where it came from, some context), but today everything has to go into the title.
- Setting status/date/assignee/label means remembering the natural-language syntax (/, @, l:, dates), and it can't reach fields that syntax doesn't cover.

This adds an optional **"Create Task with Details…"** action (⌘⇧↵) on the new-task row. It opens a small form, pre-filled from whatever you already typed, where you can set title, status, date, assignee, label, project, and URL explicitly — plus a Note that's written into the body of the new Notion page (one block per line; a line that's only a URL becomes a bookmark). The note implements #3884.

Quick capture is untouched: typing in the search bar and pressing Enter behaves exactly as before and creates with no page body. The form is purely an optional alternative path.

Tested locally with npm run dev on my own database: plain Enter create (unchanged), single- and multi-line notes, a URL-only line becoming a bookmark, and changing the dropdowns/date in the form and confirming the values land on the Notion page. npm run build and ray lint pass.

Screenshot:

<img width="765" height="490" alt="Screenshot 2026-06-11 at 00 36 44" src="https://github.com/user-attachments/assets/416e9515-0c9a-4138-8cc8-047e04fdbe96" />