### PR TITLE
Fix Raycast Arcade Dino cactus spawn crash

### DIFF
--- a/extensions/raycast-arcade/CHANGELOG.md
+++ b/extensions/raycast-arcade/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Raycast Arcade Changelog
 
+## [Fix Dino Cactus Spawning] - {PR_MERGE_DATE}
+
+- Fixed a Chrome Dinosaur crash that could happen when spawning a cactus after old cactus entries were cleaned up.
+
 ## [Snake and 2048 Update] - 2023-08-13
 
 ✨ It's update time! Get ready for new features, new games, fixes, and more...

--- a/extensions/raycast-arcade/src/dino.jsx
+++ b/extensions/raycast-arcade/src/dino.jsx
@@ -124,6 +124,14 @@ export default function ChromeDino() {
     return Math.floor(Math.random() * (max - min + 1)) + min;
   }
 
+  function spawnCactus() {
+    activeCacti.current.push({
+      x: boardWidth,
+      shape: cactiShapes[Math.floor(Math.random() * cactiShapes.length)],
+      time: time.current,
+    });
+  }
+
   useEffect(() => {
     if (!isTicking.current) {
       tick();
@@ -141,27 +149,17 @@ export default function ChromeDino() {
     if (status.current === Status.PLAYING) {
       dinoStatus.current.y = Math.round(Math.max(dinoStatus.current.y + dinoStatus.current.gravity, 0));
       if (time.current === 60) {
-        activeCacti.current.push({
-          x: boardWidth,
-          shape: cactiShapes[Math.floor(Math.random() * cactiShapes.length)],
-          time: time.current,
-        });
+        spawnCactus();
       }
-      if (time.current > 60 && time.current - activeCacti.current.at(-1).time > 40) {
+      let lastCactus = activeCacti.current.at(-1);
+      if (time.current > 60 && lastCactus && time.current - lastCactus.time > 40) {
         if (Math.random() < 0.02) {
-          activeCacti.current.push({
-            x: boardWidth,
-            shape: cactiShapes[Math.floor(Math.random() * cactiShapes.length)],
-            time: time.current,
-          });
+          spawnCactus();
         }
       }
-      if (time.current > 60 && time.current - activeCacti.current.at(-1).time > 100) {
-        activeCacti.current.push({
-          x: boardWidth,
-          shape: cactiShapes[Math.floor(Math.random() * cactiShapes.length)],
-          time: time.current,
-        });
+      lastCactus = activeCacti.current.at(-1);
+      if (time.current > 60 && (!lastCactus || time.current - lastCactus.time > 100)) {
+        spawnCactus();
       }
 
       if (time.current % 70 === 0) {


### PR DESCRIPTION
## Summary

Fixes #27470.

The Chrome Dino game could crash after old cactus entries were removed because the spawn logic read `activeCacti.current.at(-1).time` without checking that a cactus still existed. This refactors cactus creation into `spawnCactus()` and guards the last-cactus lookup. If the list is empty after cleanup, the forced spawn path creates a new cactus instead of crashing.

## Checks

- `npm run lint`
- `npx prettier --check src/dino.jsx`
- `npm run build`

---
Written by an agent for Federicorao (GPT-5).
