### PR TITLE
fix(iterm): Load profiles when entire prefs plist cannot convert as JSON

### DIFF
--- a/extensions/iterm/CHANGELOG.md
+++ b/extensions/iterm/CHANGELOG.md
@@ -1,6 +1,6 @@
 # iTerm Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-06-16
 
 - Fixed `Open iTerm Profile` if parts of a user's iTerm preferences plist other than profiles cannot be converted to JSON
 

--- a/extensions/iterm/CHANGELOG.md
+++ b/extensions/iterm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # iTerm Changelog
 
+## [Bug Fixes] - {PR_MERGE_DATE}
+
+- Fixed `Open iTerm Profile` if parts of a user's iTerm preferences plist other than profiles cannot be converted to JSON
+
 ## [Add Edit in iTerm open behavior] - 2026-05-27
 
 - Added a preference to open `Edit in iTerm` in a new window or a new tab.

--- a/extensions/iterm/package.json
+++ b/extensions/iterm/package.json
@@ -11,7 +11,8 @@
     "jose-elias-alvarez",
     "luka_nola",
     "thomas",
-    "metrovoc"
+    "metrovoc",
+    "ches"
   ],
   "license": "MIT",
   "categories": [

--- a/extensions/iterm/src/core/get-iterm-profiles.tsx
+++ b/extensions/iterm/src/core/get-iterm-profiles.tsx
@@ -38,8 +38,8 @@ export function getItermProfiles(): ItermProfile[] {
     "-extract", PlistPreferences.Keys.PROFILES, "json",
     "-expect", "array",
     "-o", "-", // Output to stdout
-    join(homedir(), PlistPreferences.USER_REL_PATH)
-  ]
+    join(homedir(), PlistPreferences.USER_REL_PATH),
+  ];
 
   try {
     const output = execFileSync("/usr/bin/plutil", plutilArgs, {

--- a/extensions/iterm/src/core/get-iterm-profiles.tsx
+++ b/extensions/iterm/src/core/get-iterm-profiles.tsx
@@ -7,44 +7,48 @@ export interface ItermProfile {
   guid: string;
 }
 
-type ItermPreferences = {
-  "New Bookmarks"?: unknown;
+const PlistPreferences = {
+  USER_REL_PATH: "Library/Preferences/com.googlecode.iterm2.plist",
+  Keys: {
+    PROFILES: "New Bookmarks",
+  },
 };
 
-type ItermProfileEntry = {
-  Name?: unknown;
-  Guid?: unknown;
+type CapitalizeKeys<Type> = {
+  [Property in keyof Type as Capitalize<string & Property>]: Type[Property];
 };
 
-function isItermProfileEntry(entry: unknown): entry is ItermProfileEntry {
-  return typeof entry === "object" && entry !== null;
+/** A profile representation in the iTerm preferences file (via JSON conversion) */
+type PlistProfile = CapitalizeKeys<ItermProfile>;
+
+function isPlistProfile(entry: unknown): entry is PlistProfile {
+  return (
+    typeof entry === "object" &&
+    entry !== null &&
+    "Name" in entry &&
+    "Guid" in entry &&
+    typeof (entry as PlistProfile).Name === "string" &&
+    typeof (entry as PlistProfile).Guid === "string"
+  );
 }
 
 export function getItermProfiles(): ItermProfile[] {
-  const plistPath = join(homedir(), "Library/Preferences/com.googlecode.iterm2.plist");
+  // prettier-ignore
+  const plutilArgs = [
+    "-extract", PlistPreferences.Keys.PROFILES, "json",
+    "-expect", "array",
+    "-o", "-", // Output to stdout
+    join(homedir(), PlistPreferences.USER_REL_PATH)
+  ]
 
   try {
-    const output = execFileSync("/usr/bin/plutil", ["-convert", "json", "-o", "-", plistPath], {
+    const output = execFileSync("/usr/bin/plutil", plutilArgs, {
       encoding: "utf-8",
       maxBuffer: 10 * 1024 * 1024,
     });
-    const preferences = JSON.parse(output) as ItermPreferences;
-    const bookmarks = preferences["New Bookmarks"];
+    const profiles = JSON.parse(output) as unknown[]; // Safe assertion due to `-expect array`
 
-    if (!Array.isArray(bookmarks)) {
-      return [];
-    }
-
-    return bookmarks.flatMap((entry) => {
-      if (!isItermProfileEntry(entry)) {
-        return [];
-      }
-
-      const name = typeof entry.Name === "string" ? entry.Name.trim() : "";
-      const guid = typeof entry.Guid === "string" ? entry.Guid.trim() : "";
-
-      return name && guid ? [{ name, guid }] : [];
-    });
+    return profiles.filter(isPlistProfile).map((profile) => ({ name: profile.Name, guid: profile.Guid }));
   } catch (error) {
     console.error("Failed to read iTerm profiles:", error);
     return [];


### PR DESCRIPTION
## Description

In #28166, parsing of profiles from iTerm's preferences plist was improved to use `plutil` with JSON conversion. For some users though, their iTerm prefs are not convertible to JSON in entirety. The `Open iTerm Profile` command was executing this under the hood:

```
plutil -convert json -o - ~/Library/Preferences/com.googlecode.iterm2.plist
/Users/ches/Library/Preferences/com.googlecode.iterm2.plist: Invalid object in plist for JSON format
```

This change uses `plutil -extract KEY json` instead to get only the prefs key for the profiles, which (hopefully) avoids this issue for more complex configs.

That's the essential piece. The change includes some opportunistic refactorings while touching the code, sorry for stretching the scope of the diff but I felt they were worthwhile and not a ton to review. Mainly it moves defensive programming in case data isn't in the expected format into the type predicate function that already existed, so it checks a stronger type and makes its use sites simpler.

This whole feature might be a candidate to migrate to the scripting API in the future like some recent features that use `it2api`, but that's a more substantial change, and I don't have it set up myself at the moment (I'd want to add a configuration field to this extension for an explicit path to a `python` executable where the `iterm` library is installed, maintaining Python environments is a headache when they mix purposes).

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder

_This is not a new extension submission so some of those are not especially relevant_ ☝🏼