### PR TITLE
[Slack] Fix Set Status deep link erroring on raw emoji

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Fix Set Status deep link with raw emoji] - {PR_MERGE_DATE}
+## [Fix Set Status deep link with raw emoji] - 2026-06-13
 
 - Fix the **Set Status** command erroring with `profile_status_set_failed_not_valid_emoji` when the `emoji` argument is a raw emoji (e.g. 👈) inserted by Raycast's emoji picker. Raw emoji are now mapped back to their Slack `:name:` code.
 

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Changelog
 
+## [Fix Set Status deep link with raw emoji] - {PR_MERGE_DATE}
+
+- Fix the **Set Status** command erroring with `profile_status_set_failed_not_valid_emoji` when the `emoji` argument is a raw emoji (e.g. 👈) inserted by Raycast's emoji picker. Raw emoji are now mapped back to their Slack `:name:` code.
+
 ## [Add deep link arguments to Set Status] - 2026-06-09
 
 - The **Set Status** command now accepts optional `statusText` and `emoji` arguments, so a deep link or Quicklink can set your status in one step (e.g. `raycast://extensions/mommertf/slack/set-status?arguments=%7B%22statusText%22%3A%22Lunch%22%2C%22emoji%22%3A%22%3Ahamburger%3A%22%7D`).

--- a/extensions/slack/src/set-status.tsx
+++ b/extensions/slack/src/set-status.tsx
@@ -10,14 +10,34 @@ import { getDurationOptionFromTimestamp, getTextForExpiration } from "./utils/se
 import { showToastWithPromise } from "./utils/toast.util";
 import SetAiStatusForm from "./components/set-status/set-ai-status-form.component";
 
-// Slack stores status emoji in `:name:` form. Accept either `rocket` or `:rocket:` from a deep link argument.
+// Reverse of SLACK_EMOJI_CODE_MAP: raw emoji glyph -> `:name:`. Raycast's argument field attaches an
+// emoji auto-picker that inserts a raw Unicode glyph (e.g. 👈) rather than its name, so we map it back.
+// The variation-selector-stripped key is added as a fallback so e.g. both `☝️` and `☝` resolve.
+const EMOJI_NAME_BY_CHAR: Record<string, string> = (() => {
+  const map: Record<string, string> = {};
+  for (const [name, char] of Object.entries(SLACK_EMOJI_CODE_MAP)) {
+    if (!(char in map)) map[char] = name;
+    const stripped = char.replace(/️/g, "");
+    if (!(stripped in map)) map[stripped] = name;
+  }
+  return map;
+})();
+
+// Slack stores status emoji in `:name:` form. Accept `rocket`/`:rocket:` text or a raw emoji glyph
+// (👈) from a deep link argument; the latter must be mapped back to its name or Slack rejects it.
 function normalizeEmoji(emoji?: string): string | undefined {
   const trimmed = emoji?.trim();
   if (!trimmed) {
     return undefined;
   }
 
-  return `:${trimmed.replace(/^:+|:+$/g, "")}:`;
+  // ASCII input is already a Slack emoji name (with or without colons) — just normalize the colons.
+  if (/^[\x20-\x7E]+$/.test(trimmed)) {
+    return `:${trimmed.replace(/^:+|:+$/g, "")}:`;
+  }
+
+  // Otherwise it's a raw Unicode glyph; map it to its `:name:`, falling back to the FE0F-stripped form.
+  return EMOJI_NAME_BY_CHAR[trimmed] ?? EMOJI_NAME_BY_CHAR[trimmed.replace(/️/g, "")];
 }
 
 function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>) {

--- a/extensions/slack/src/set-status.tsx
+++ b/extensions/slack/src/set-status.tsx
@@ -200,7 +200,10 @@ function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>)
     );
   }, [mutate, profile]);
 
-  const hasLaunchArguments = Boolean(statusTextArgument?.trim() || normalizeEmoji(emojiArgument));
+  // Gate on whether arguments were *passed*, not on whether the emoji resolves — an emoji we can't
+  // map still needs to reach the effect so it can report the failure instead of silently no-op-ing.
+  const hasEmojiArgument = Boolean(emojiArgument?.trim());
+  const hasLaunchArguments = Boolean(statusTextArgument?.trim() || hasEmojiArgument);
   const didAutoSetStatus = useRef(false);
 
   useEffect(() => {
@@ -211,6 +214,16 @@ function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>)
 
     const statusText = statusTextArgument?.trim() || undefined;
     const emoji = normalizeEmoji(emojiArgument);
+
+    // The emoji was provided but couldn't be mapped to a Slack `:name:` (e.g. a composite/ZWJ glyph
+    // absent from SLACK_EMOJI_CODE_MAP). Surface it rather than silently dropping the launch.
+    if (hasEmojiArgument && emoji === undefined) {
+      didAutoSetStatus.current = true;
+      showFailureToast(new Error(`"${emojiArgument?.trim()}" isn't a recognized Slack emoji.`), {
+        title: "Failed to set status",
+      });
+      return;
+    }
 
     // Preserving the field that wasn't passed relies on the current profile. If it failed to
     // load, setting only one field would clear the other, so bail with feedback instead.
@@ -243,7 +256,16 @@ function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>)
         }),
       },
     );
-  }, [hasLaunchArguments, isFetchMeLoading, isFetchProfileLoading, profile, mutate, statusTextArgument, emojiArgument]);
+  }, [
+    hasLaunchArguments,
+    hasEmojiArgument,
+    isFetchMeLoading,
+    isFetchProfileLoading,
+    profile,
+    mutate,
+    statusTextArgument,
+    emojiArgument,
+  ]);
 
   return (
     <List isLoading={isLoading}>


### PR DESCRIPTION
## Description

Follow-up bug fix to #28669, which added optional `statusText` and `emoji` deep link arguments to the **Set Status** command.

That PR didn't account for how the **base Set Status command** renders the new `emoji` argument. Raycast attaches its built-in **emoji auto-picker** to a text argument field, so picking from it inserts a **raw Unicode emoji** (e.g. 👈) rather than the `:name:` text the command was written to expect. `normalizeEmoji` then colon-wrapped the glyph into `":👈:"`, which Slack's `users.profile.set` rejects with `profile_status_set_failed_not_valid_emoji` — so the command errored out for anyone who used the picker (the natural way to fill the field).

### Fix

`normalizeEmoji` now detects a raw emoji glyph and maps it back to its Slack `:name:` code via a reverse of `SLACK_EMOJI_CODE_MAP` (with a variation-selector fallback so e.g. `☝️` resolves). ASCII input (`rocket` / `:rocket:`) keeps the existing colon-normalizing path, so the Quicklink/deep-link examples from #28669 keep working unchanged.

### Before — raw emoji from the picker errors out

https://github.com/user-attachments/assets/6c82aaab-6dd5-491b-ad87-f6eb3429f70b


### After — raw emoji is mapped to its `:name:` and the status is set


https://github.com/user-attachments/assets/84c2960c-718d-4831-8c11-3671a41bb929



### Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that screenshots/recordings are up to date