### PR TITLE
[amphetamine] Forget "Until Time" dates

### DIFF
--- a/extensions/amphetamine/CHANGELOG.md
+++ b/extensions/amphetamine/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Require a fresh until-time on each launch] - {PR_MERGE_DATE}
+## [Require a fresh until-time on each launch] - 2026-06-15
 
 - The configurable session command no longer restores a past until-time. The Until Time mode
   now starts empty and requires you to choose a future time.

--- a/extensions/amphetamine/CHANGELOG.md
+++ b/extensions/amphetamine/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Require a fresh until-time on each launch] - {PR_MERGE_DATE}
+
+- The configurable session command no longer restores a past until-time. The Until Time mode
+  now starts empty and requires you to choose a future time.
+
 ## [Add until-time option for configurable sessions] - 2026-05-25
 
 - Add an until-time option to the configurable session command.

--- a/extensions/amphetamine/package-lock.json
+++ b/extensions/amphetamine/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amphetamine",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amphetamine",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.18",

--- a/extensions/amphetamine/package.json
+++ b/extensions/amphetamine/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "amphetamine",
   "title": "Amphetamine",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Control Amphetamine sleep sessions from Raycast",
   "icon": "icon.png",
   "author": "gstvds",

--- a/extensions/amphetamine/src/amp-duration.tsx
+++ b/extensions/amphetamine/src/amp-duration.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import type { ComponentProps, ComponentType } from "react";
 import { Form, ActionPanel, Action, Toast, popToRoot, Icon } from "@raycast/api";
 import ampStart from "./amp-start";
-import { formatDateTime, getDefaultTarget, getSessionTime } from "./session-time";
+import { formatDateTime, getSessionTime } from "./session-time";
 
 /** Next whole minute; used as DatePicker `min` so only future times are valid (and built-in "Now" is typically omitted). */
 function getMinimumUntilDate(): Date {
@@ -34,7 +34,8 @@ export default function SessionWithDuration() {
   const [sessionType, setSessionType] = useState<SessionType>(SessionType.duration);
   const [interval, setDurationUnit] = useState<keyof typeof Intervals>(Intervals.minutes);
   const [duration, setDuration] = useState<string>(DefaultDuration.minutes);
-  const [target, setTarget] = useState<Date>(getDefaultTarget);
+  const [target, setTarget] = useState<Date | null>(null);
+  const [targetError, setTargetError] = useState<string | undefined>();
   const [earliestTarget, setEarliestTarget] = useState(getMinimumUntilDate);
 
   useEffect(() => {
@@ -47,12 +48,13 @@ export default function SessionWithDuration() {
     return () => clearInterval(intervalId);
   }, [sessionType]);
 
-  useEffect(() => {
-    if (sessionType !== SessionType.time) return;
-    setTarget((t) => (t.getTime() < earliestTarget.getTime() ? getDefaultTarget() : t));
-  }, [sessionType, earliestTarget]);
+  function validateTarget(value: Date | null) {
+    const parsed = value ? getSessionTime(value) : undefined;
+    setTargetError(parsed ? undefined : "Choose a future date and time.");
+    return parsed;
+  }
 
-  const parsedTime = getSessionTime(target);
+  const parsedTime = target ? getSessionTime(target) : undefined;
   const timeInfo = parsedTime
     ? `Starts a session until ${formatDateTime(parsedTime.target)}.`
     : "Choose a future date and time.";
@@ -66,7 +68,7 @@ export default function SessionWithDuration() {
     toast.show();
 
     if (sessionType === SessionType.time) {
-      const parsed = getSessionTime(target);
+      const parsed = validateTarget(target);
       if (!parsed) {
         toast.title = "Failed to initialize a session.";
         toast.message = "Choose a future date and time.";
@@ -166,8 +168,12 @@ export default function SessionWithDuration() {
           type={Form.DatePicker.Type.DateTime}
           min={earliestTarget}
           info={timeInfo}
-          storeValue
-          onChange={(value) => setTarget(value ?? getDefaultTarget())}
+          error={targetError}
+          onChange={(value) => {
+            setTarget(value);
+            if (value && getSessionTime(value)) setTargetError(undefined);
+          }}
+          onBlur={(event) => validateTarget(event.target.value ?? null)}
         />
       ) : null}
     </Form>

--- a/extensions/amphetamine/src/amp-duration.tsx
+++ b/extensions/amphetamine/src/amp-duration.tsx
@@ -171,7 +171,7 @@ export default function SessionWithDuration() {
           error={targetError}
           onChange={(value) => {
             setTarget(value);
-            if (value && getSessionTime(value)) setTargetError(undefined);
+            validateTarget(value);
           }}
           onBlur={(event) => validateTarget(event.target.value ?? null)}
         />

--- a/extensions/amphetamine/src/session-time.ts
+++ b/extensions/amphetamine/src/session-time.ts
@@ -3,13 +3,6 @@ export interface ParsedTime {
   durationMinutes: number;
 }
 
-export function getDefaultTarget(): Date {
-  const defaultTarget = new Date();
-  defaultTarget.setHours(defaultTarget.getHours() + 1, 0, 0, 0);
-
-  return defaultTarget;
-}
-
 export function formatDateTime(date: Date): string {
   return date.toLocaleString([], { dateStyle: "medium", timeStyle: "short" });
 }


### PR DESCRIPTION
## Description

Changes the "Configure New Session" command so the Until Time mode stops restoring a stale absolute time. The picker used `storeValue`, which re-filled the exact datetime from a past session on each launch. That time has already passed, so it was never a useful default.

The picker now starts empty and requires a future time. Blur and submit both validate it, showing an inline error otherwise. For Duration mode is untouched. It still remembers your last duration and interval, which is the behavior people want there.

## Screencast

<img width="862" height="587" alt="Screenshot 2026-06-12 at 12 16 45" src="https://github.com/user-attachments/assets/4b1c15d2-a081-42a6-92d1-be8b2c7a3a62" />

<img width="862" height="587" alt="Screenshot 2026-06-12 at 12 16 49" src="https://github.com/user-attachments/assets/37db8d99-cfa6-482b-846d-eed4a9570321" />


## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
