### PR TITLE
[Copy Notion Markdown Link] Fix URL validation for notion.com domain

### DIFF
--- a/extensions/copy-notion-markdown-link/CHANGELOG.md
+++ b/extensions/copy-notion-markdown-link/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Copy Notion Markdown Link Changelog
 
+## [Support notion.com domain] - {PR_MERGE_DATE}
+
+- Fix URL validation to accept `notion.com`, as Notion migrated to the new domain.
+
 ## [Remove tracking query parameter] - 2026-04-23
 
 - Remove `source=copy_link` tracking query parameter from copied Notion URLs to produce cleaner markdown links.

--- a/extensions/copy-notion-markdown-link/CHANGELOG.md
+++ b/extensions/copy-notion-markdown-link/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Copy Notion Markdown Link Changelog
 
-## [Support notion.com domain] - {PR_MERGE_DATE}
+## [Support notion.com domain] - 2026-06-15
 
 - Fix URL validation to accept `notion.com`, as Notion migrated to the new domain.
 

--- a/extensions/copy-notion-markdown-link/src/get-notion-page-as-markdown-link.ts
+++ b/extensions/copy-notion-markdown-link/src/get-notion-page-as-markdown-link.ts
@@ -78,7 +78,7 @@ export default async function main() {
     const linkUrl = parts[1];
 
     // URL validation
-    if (!linkUrl || !linkUrl.includes("notion.so")) {
+    if (!linkUrl || !linkUrl.includes("notion.com")) {
       await showHUD("Failed to copy Notion link. Please try again.");
       if (previousClipboard) {
         await Clipboard.copy(previousClipboard);


### PR DESCRIPTION
## Summary

The extension fails to copy Notion pages as markdown links because Notion changed their URL domain from `notion.so` to `app.notion.com`. The URL validation only checked for `notion.so`, rejecting all new-style URLs.

>Today we finished migrating to app.notion.com.

Following what the post says, I suppose "notion.so" URLs are no longer produced. 
**Reference:** https://x.com/NotionHQ/status/2061890374780768292

## Changes

- **`src/get-notion-page-as-markdown-link.ts`** — Updated URL validation from `notion.so` to `notion.com` for future-proof domain matching.
- **`CHANGELOG.md`** — Added entry for this fix.