### PR TITLE
[Toggl Track] Add Quickstart New Timer command

### DIFF
--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Toggl Track Changelog
 
+## [Quickstart New Timer] - {PR_MERGE_DATE}
+
+- Add a "Quickstart New Timer" command that opens the new time entry form directly, skipping the recent-entries list — assign it a global hotkey to start a timer from anywhere with one keystroke. On submit, Raycast closes immediately.
+
 ## [Bug Fixes] - 2026-05-15
 
 - Fixed "Resume Time Entry" on recent entries: use `Action` with `onAction` instead of `Action.SubmitForm`, which is for form submission and was incorrect in the list action panel

--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Toggl Track Changelog
 
-## [Quickstart New Timer] - {PR_MERGE_DATE}
+## [Quickstart New Timer] - 2026-06-17
 
 - Add a "Quickstart New Timer" command that opens the new time entry form directly, skipping the recent-entries list — assign it a global hotkey to start a timer from anywhere with one keystroke. On submit, Raycast closes immediately.
 

--- a/extensions/toggl-track/README.md
+++ b/extensions/toggl-track/README.md
@@ -18,6 +18,14 @@ Select "Create a new time entry" and pressing enter will bring you to the time e
 
 <img width="600" alt="Start/Stop Time Entry Command Form" src="./assets/new-entry.png">
 
+### Quickstart New Timer
+
+Opens the new time entry form directly, skipping the recent-entries list. Assign
+it a global hotkey to start a timer from anywhere with one keystroke. On submit,
+Raycast closes immediately and is ready for your next command.
+
+<img width="600" alt="Quickstart New Timer Command" src="./assets/new-entry.png">
+
 ### Manage Tags
 
 This command list all the tags you have access to. You can create, rename, and delete them, assuming you have the appropriate permissions.

--- a/extensions/toggl-track/package.json
+++ b/extensions/toggl-track/package.json
@@ -34,6 +34,12 @@
       "mode": "view"
     },
     {
+      "name": "createTimeEntry",
+      "title": "Quickstart New Timer",
+      "description": "Start a new time entry from a global hotkey.",
+      "mode": "view"
+    },
+    {
       "name": "updateTimeEntry",
       "title": "Update Time Entry",
       "description": "Update the description, project, tags of recent time entries.",

--- a/extensions/toggl-track/src/components/CreateTimeEntryForm.tsx
+++ b/extensions/toggl-track/src/components/CreateTimeEntryForm.tsx
@@ -10,6 +10,9 @@ import {
   showToast,
   useNavigation,
   confirmAlert,
+  closeMainWindow,
+  PopToRootType,
+  showHUD,
 } from "@raycast/api";
 import { useCachedState, showFailureToast } from "@raycast/utils";
 import { useMemo, useState } from "react";
@@ -22,12 +25,19 @@ interface CreateTimeEntryFormParams {
   revalidateRunningTimeEntry: () => void;
   revalidateTimeEntries: () => void;
   initialValues?: TimeEntry & TimeEntryMetaData;
+  /**
+   * When true, close the Raycast window outright after a successful submit
+   * (used by the standalone "Quickstart New Timer" command). When false — the
+   * default for the time-entries list — pop back to the list instead.
+   */
+  closeWindowOnSubmit?: boolean;
 }
 
 function CreateTimeEntryForm({
   revalidateRunningTimeEntry,
   revalidateTimeEntries,
   initialValues,
+  closeWindowOnSubmit = false,
 }: CreateTimeEntryFormParams) {
   const navigation = useNavigation();
   const { me, isLoadingMe } = useMe();
@@ -74,17 +84,27 @@ function CreateTimeEntryForm({
         tags: showTagsInForm ? selectedTags : [],
         taskId: showTasksInForm ? selectedTask?.id : undefined,
       });
-
-      await showToast(Toast.Style.Success, "Started time entry");
-
-      navigation.pop();
-
-      revalidateRunningTimeEntry();
-      revalidateTimeEntries();
-      launchCommand({ name: "menuBar", type: LaunchType.Background }).catch(() => {});
-      await clearSearchBar();
     } catch {
       await showToast(Toast.Style.Failure, "Failed to start time entry");
+      return;
+    }
+
+    // The entry is created; post-success UI lives outside the try so a window/HUD
+    // hiccup can't surface a misleading "Failed to start time entry" toast.
+    revalidateRunningTimeEntry();
+    revalidateTimeEntries();
+    launchCommand({ name: "menuBar", type: LaunchType.Background }).catch(() => {});
+
+    if (closeWindowOnSubmit) {
+      // Quickstart command: the form is the root view, so close the window outright.
+      await closeMainWindow({ popToRootType: PopToRootType.Immediate });
+      await showHUD("Started time entry");
+    } else {
+      // Launched from the time-entries list: return to it instead of closing.
+      // clearSearchBar only applies to that list view, not the standalone form.
+      navigation.pop();
+      await clearSearchBar();
+      await showToast(Toast.Style.Success, "Started time entry");
     }
   }
 

--- a/extensions/toggl-track/src/createTimeEntry.tsx
+++ b/extensions/toggl-track/src/createTimeEntry.tsx
@@ -1,0 +1,17 @@
+import CreateTimeEntryForm from "@/components/CreateTimeEntryForm";
+import { ExtensionContextProvider } from "@/context/ExtensionContext";
+
+export default function Command() {
+  return (
+    <ExtensionContextProvider>
+      <CreateTimeEntryForm
+        // Standalone "Quickstart New Timer" command: there's no mounted list view
+        // to refresh, so the list-cache revalidators are no-ops, and we close the
+        // window on submit (closeWindowOnSubmit) since the form is the root view.
+        revalidateRunningTimeEntry={() => {}}
+        revalidateTimeEntries={() => {}}
+        closeWindowOnSubmit
+      />
+    </ExtensionContextProvider>
+  );
+}


### PR DESCRIPTION
## Description

Adds a **Quickstart New Timer** command that opens the new time entry form directly, skipping the recent-entries list. Assigned a global hotkey, it lets you start a timer from anywhere with a single keystroke; on submit, Raycast closes immediately and shows a HUD.

The change is intentionally small and additive:

- New `createTimeEntry` command (`src/createTimeEntry.tsx`) that renders the existing `CreateTimeEntryForm`.
- `CreateTimeEntryForm` gains an optional `closeWindowOnSubmit` prop (default `false`). Only the new command passes `true` (→ `closeMainWindow` + HUD on submit); every existing call site is untouched and behaves exactly as before (pops back to the list).
- README and CHANGELOG entries.

No new dependencies, and no behavior change for any existing command.

## Screencast

_Screencast to follow._

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and used the extension in development mode
- [x] I ran `npm run lint` and it passed (ESLint + Prettier)
- [x] I added a `CHANGELOG.md` entry using `{PR_MERGE_DATE}` as the date
