### PR TITLE
Fix discogs extension data display issues

### DIFF
--- a/extensions/discogs/CHANGELOG.md
+++ b/extensions/discogs/CHANGELOG.md
@@ -9,3 +9,9 @@ Added new functions:
 - Search for any release (original is Vinyl only)
 - Search by Barcode
 - Search by ReleaseNumber (CatNo)
+
+## [Bug Fixes and quality of life improvements] - 2026-06-14
+- Display release date as string without timezone conversion
+- Remove catalog number from labels field, show name only
+- Deduplicate barcodes by removing spaces before comparison
+- Reordered release detail fields to present information in a more logical sequence

--- a/extensions/discogs/CHANGELOG.md
+++ b/extensions/discogs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # discogs Changelog
 
-## [Bug Fixes and quality of life improvements] - {PR_MERGE_DATE}
+## [Bug Fixes and quality of life improvements] - 2026-06-16
 - Display release date as string without timezone conversion
 - Remove catalog number from labels field, show name only
 - Deduplicate barcodes by removing spaces before comparison

--- a/extensions/discogs/CHANGELOG.md
+++ b/extensions/discogs/CHANGELOG.md
@@ -1,6 +1,10 @@
 # discogs Changelog
 
-## [Initial Version] - 2024-01-15
+## [Bug Fixes and quality of life improvements] - {PR_MERGE_DATE}
+- Display release date as string without timezone conversion
+- Remove catalog number from labels field, show name only
+- Deduplicate barcodes by removing spaces before comparison
+- Reordered release detail fields to present information in a more logical sequence
 
 ## [Windows Support and New Features] - 2026-03-03
 Added Windows support config.
@@ -10,8 +14,4 @@ Added new functions:
 - Search by Barcode
 - Search by ReleaseNumber (CatNo)
 
-## [Bug Fixes and quality of life improvements] - 2026-06-14
-- Display release date as string without timezone conversion
-- Remove catalog number from labels field, show name only
-- Deduplicate barcodes by removing spaces before comparison
-- Reordered release detail fields to present information in a more logical sequence
+## [Initial Version] - 2024-01-15

--- a/extensions/discogs/src/utils.tsx
+++ b/extensions/discogs/src/utils.tsx
@@ -66,12 +66,7 @@ export function ReleaseDetail({ release }: { release: DiscogsResult }) {
     };
   }, [release.resource_url]);
 
-  const releaseDateSource = detail?.released_formatted ?? detail?.released;
-
-  const releaseDate =
-    releaseDateSource && !Number.isNaN(Date.parse(releaseDateSource))
-      ? new Date(releaseDateSource).toISOString().slice(0, 10)
-      : releaseDateSource;
+  const releaseDate = detail?.released;
   const year = detail?.year ?? release.year;
 
   const country = detail?.country ?? release.country;
@@ -82,11 +77,7 @@ export function ReleaseDetail({ release }: { release: DiscogsResult }) {
   const formats = release.format?.join(", ");
   const primaryLabelEntry = detail?.labels?.[0];
   const primaryLabelName = primaryLabelEntry?.name?.trim();
-  const primaryLabelCatno = primaryLabelEntry?.catno?.trim();
-  const labels =
-    primaryLabelName && primaryLabelCatno
-      ? `${primaryLabelName} (${primaryLabelCatno})`
-      : (primaryLabelName ?? release.label?.[0]);
+  const labels = primaryLabelName ?? release.label?.[0];
   const artistValues =
     detail?.artists
       ?.map((artist) => artist.name?.trim())
@@ -99,7 +90,8 @@ export function ReleaseDetail({ release }: { release: DiscogsResult }) {
     detail?.identifiers
       ?.filter((identifier) => identifier.type?.toLowerCase() === "barcode")
       .map((identifier) => identifier.value?.trim())
-      .filter((value): value is string => Boolean(value)) ?? [];
+      .filter((value): value is string => Boolean(value))
+      .map((value) => value.replace(/\s+/g, "")) ?? [];
   const barcodes =
     barcodeValues.length > 0
       ? Array.from(new Set(barcodeValues)).join(", ")
@@ -127,14 +119,14 @@ export function ReleaseDetail({ release }: { release: DiscogsResult }) {
   const rows = [
     { label: "Title", value: title },
     { label: "Artists", value: artists },
-    { label: "Year", value: year ? String(year) : undefined },
-    { label: "Release Date", value: releaseDate },
-    { label: "Country", value: country },
-    { label: "Catalog Number", value: catno },
-    { label: "Formats", value: formats },
-    { label: "Labels", value: labels },
     { label: "Genres", value: genres },
     { label: "Styles", value: styles },
+    { label: "Year", value: year ? String(year) : undefined },
+    { label: "Formats", value: formats },
+    { label: "Labels", value: labels },
+    { label: "Catalog Number", value: catno },
+    { label: "Country", value: country },
+    { label: "Release Date", value: releaseDate },
     { label: "Barcodes", value: barcodes },
     { label: "Resource URL", value: resourceUrl, url: resourceUrl },
     { label: "Discogs URL", value: discogsUrl, url: discogsUrl },


### PR DESCRIPTION
## Description

Bug fixes and quality of life improvements:
- Display release date as string without timezone conversion
- Remove catalog number from labels field, show name only
- Deduplicate barcodes by removing spaces before comparison
- Reordered release detail fields to present information in a more logical sequence

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
