### PR TITLE
[GitLab] Reduce MR list detail memory usage

### DIFF
--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitLab Changelog
 
+## [Reduce MR list detail memory usage] - {PR_MERGE_DATE}
+
+- Reduce extra detail fetching in merge request list previews
+
 ## [Add option to hide archived projects in Menu Bar Commands] - 2026-05-25
 
 - Add "Hide Archived Projects" option to Issues Menu Bar settings

--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitLab Changelog
 
-## [Reduce MR list detail memory usage] - {PR_MERGE_DATE}
+## [Reduce MR list detail memory usage] - 2026-06-16
 
 - Reduce extra detail fetching in merge request list previews
 

--- a/extensions/gitlab/src/components/mr.tsx
+++ b/extensions/gitlab/src/components/mr.tsx
@@ -177,21 +177,18 @@ export function MRDetail(props: { mr: MergeRequest }) {
 
 export function MRListDetail(props: { mr: MergeRequest; subtitle: string; expandDetails: boolean }) {
   const mr = props.mr;
-  const { mrdetail, error, isLoading } = useDetail(props.mr.id);
-  if (error) {
-    showErrorToast(error, "Could not get Merge Request Details");
-  }
 
   const lines: string[] = [];
   lines.push(`# ${mr.title}`);
 
-  const desc = mrdetail?.description ?? props.mr.description ?? "";
-  lines.push(optimizeMarkdownText(desc, mrdetail?.projectWebUrl));
+  const desc = props.mr.description ?? "";
+  const projectWebUrlIndex = mr.web_url.indexOf("/-/");
+  const projectWebUrl = projectWebUrlIndex > 1 ? mr.web_url.substring(0, projectWebUrlIndex) : undefined;
+  lines.push(optimizeMarkdownText(desc, projectWebUrl));
 
   return (
     <List.Item.Detail
       markdown={lines.join("\n")}
-      isLoading={isLoading}
       metadata={
         props.expandDetails ? (
           <List.Item.Detail.Metadata>


### PR DESCRIPTION
## Description

Reduces memory and network work in the GitLab merge request list detail preview by rendering the preview from the merge request data that is already available on the row.

Previously each rendered MR detail preview started an additional GraphQL detail request and kept that response state around. The full merge request detail screen still fetches enriched details when opened directly; this change only keeps the list preview lightweight.

The preview still derives the project URL from the MR web URL so relative links in markdown descriptions can continue to be resolved.

Fixes #28698

## Screencast

N/A - no visual change expected.

## Checklist

- [x] I read the extension guidelines
- [x] I ran `npm run lint`
- [x] I ran `npm run build`