### PR TITLE
[Apple Reminders] Tighten optional reminder tool fields

### DIFF
--- a/extensions/apple-reminders/CHANGELOG.md
+++ b/extensions/apple-reminders/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Apple Reminders Changelog
 
+## [Tighten AI reminder defaults] - {PR_MERGE_DATE}
+
+- Prevent AI tool calls from defaulting title-only reminders to dated, prioritized, or recurring reminders.
+- Add AI eval coverage for title-only Backlog/default-list reminder creation.
+
 ## [Fix Create Reminder close shortcut] - 2026-05-19
 
 - Restored the Shift+Command+Enter shortcut for creating a reminder and closing the window.

--- a/extensions/apple-reminders/CHANGELOG.md
+++ b/extensions/apple-reminders/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Apple Reminders Changelog
 
-## [Tighten AI reminder defaults] - {PR_MERGE_DATE}
+## [Tighten AI reminder defaults] - 2026-06-16
 
 - Prevent AI tool calls from defaulting title-only reminders to dated, prioritized, or recurring reminders.
 - Add AI eval coverage for title-only Backlog/default-list reminder creation.

--- a/extensions/apple-reminders/package.json
+++ b/extensions/apple-reminders/package.json
@@ -285,7 +285,7 @@
     }
   ],
   "ai": {
-    "instructions": "Always make reminders markdown links using the open URL. Example: Instead of saying \"I have set a reminder for you to walk the dog tomorrow at 8 AM.\", say \"I have set a reminder for you to [walk the dog](x-apple-reminderkit://REMCDReminder/reminder-id) tomorrow at 8 AM.\"\\n- Never add the recurrence field unless the user explicitly asks for a repeating reminder (for example: every day, weekly, monthly, yearly, weekdays, weekends).\\n- If the user does not explicitly ask for recurrence, omit recurrence entirely.\\n- Requests like \"today\", \"tomorrow\", or a specific date without recurrence keywords must be treated as one-off reminders (no recurrence field).\\n- Example: \"ask uncle for car today\" should call create-reminder without recurrence.\\n- When creating recurring reminders, ensure a due date is specified, if none is provided, use today's date\\n- Always include a calendar date in dueDate; time-only values (e.g., \"10:00:00\") are invalid. If the user mentions a day or recurrence (e.g., \"every Sunday at 10\"), pick the next occurrence and provide an ISO date/time.\\n- Do not ask for optional information if not necessary for the task\\n- Keep reminder titles concise and clear\\n- For locations, only suggest addresses that exist in the saved locations list\\n- Do not ask which list to use if there is only one list available",
+    "instructions": "Always make reminders markdown links using the open URL. Example: Instead of saying \"I have set a reminder for you to walk the dog tomorrow at 8 AM.\", say \"I have set a reminder for you to [walk the dog](x-apple-reminderkit://REMCDReminder/reminder-id) tomorrow at 8 AM.\"\\n- Never add the recurrence field unless the user explicitly asks for a repeating reminder (for example: every day, weekly, monthly, yearly, weekdays, weekends).\\n- If the user does not explicitly ask for recurrence, omit recurrence entirely.\\n- Requests like \"today\", \"tomorrow\", or a specific date without recurrence keywords must be treated as one-off reminders (no recurrence field).\\n- Example: \"ask uncle for car today\" should call create-reminder without recurrence.\\n- Only include dueDate, priority, or recurrence when the user's request explicitly contains a corresponding date/time word, priority word such as urgent or important, an exclamation mark, or a recurrence word. Otherwise omit the field entirely. Never default priority to low.\\n- For title-only, Inbox, Backlog, or generic capture reminders, call create-reminder with only the title and any explicitly requested list.\\n- When creating recurring reminders, ensure a due date is specified, if none is provided, use today's date\\n- Always include a calendar date in dueDate; time-only values (e.g., \"10:00:00\") are invalid. If the user mentions a day or recurrence (e.g., \"every Sunday at 10\"), pick the next occurrence and provide an ISO date/time.\\n- Do not ask for optional information if not necessary for the task\\n- Keep reminder titles concise and clear\\n- For locations, only suggest addresses that exist in the saved locations list\\n- Do not ask which list to use if there is only one list available",
     "evals": [
       {
         "input": "@apple-reminders Walk the dog tomorrow at 8am",
@@ -360,6 +360,109 @@
           },
           {
             "meetsCriteria": "The reminder is created as a one-off reminder with no recurrence."
+          }
+        ]
+      },
+      {
+        "input": "@apple-reminders Create a Backlog Test reminder in Backlog",
+        "mocks": {
+          "get-lists": [
+            {
+              "id": "reminders",
+              "title": "Reminders",
+              "isDefault": true
+            },
+            {
+              "id": "backlog",
+              "title": "Backlog",
+              "isDefault": false
+            }
+          ],
+          "create-reminder": {
+            "openUrl": "x-apple-reminderkit://REMCDReminder/backlog-test",
+            "title": "Backlog Test",
+            "id": "backlog-test",
+            "isCompleted": false,
+            "list": {
+              "id": "backlog",
+              "title": "Backlog"
+            }
+          }
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "arguments": {
+                "listId": "backlog",
+                "title": "Backlog Test"
+              },
+              "name": "create-reminder"
+            }
+          },
+          {
+            "meetsCriteria": "The reminder is created without dueDate, priority, or recurrence because the user only asked for a title and list."
+          }
+        ]
+      },
+      {
+        "input": "@apple-reminders remind me to call John",
+        "mocks": {
+          "get-lists": [
+            {
+              "id": "reminders",
+              "title": "Reminders",
+              "isDefault": true
+            }
+          ],
+          "create-reminder": {
+            "openUrl": "x-apple-reminderkit://REMCDReminder/call-john",
+            "title": "Call John",
+            "id": "call-john",
+            "isCompleted": false
+          }
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "arguments": {
+                "title": "Call John"
+              },
+              "name": "create-reminder"
+            }
+          },
+          {
+            "meetsCriteria": "The reminder is created without dueDate, priority, or recurrence because the user gave no date, priority, or recurrence cue."
+          }
+        ]
+      },
+      {
+        "input": "@apple-reminders remind me to water the plants",
+        "mocks": {
+          "get-lists": [
+            {
+              "id": "reminders",
+              "title": "Reminders",
+              "isDefault": true
+            }
+          ],
+          "create-reminder": {
+            "openUrl": "x-apple-reminderkit://REMCDReminder/water-plants",
+            "title": "Water the plants",
+            "id": "water-plants",
+            "isCompleted": false
+          }
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "arguments": {
+                "title": "Water the plants"
+              },
+              "name": "create-reminder"
+            }
+          },
+          {
+            "meetsCriteria": "Priority is omitted; only the title is sent."
           }
         ]
       },

--- a/extensions/apple-reminders/src/tools/create-reminder.ts
+++ b/extensions/apple-reminders/src/tools/create-reminder.ts
@@ -13,11 +13,11 @@ type Input = {
    */
   notes?: string;
   /**
-   * The due date. Must include a calendar date. Use YYYY-MM-DD for full-day reminders or ISO with time (YYYY-MM-DDTHH:mm:ss.sssZ). Time-only values (e.g. "10:00:00") are invalid and will fail. Use sensible defaults for common timeframes (e.g "8am" for "morning", "1pm" for "afternoon", "6pm" for "evening"). A number with "a" or "p" appended (e.g. "1p" or "8a") should be treated as AM or PM. If the user didn't include a specific time, assume it's a full day reminder.
+   * Optional due date. Only include this when the user explicitly asks for a date, day, time, or schedule, such as "today", "tomorrow", "tonight", "this weekend", "next week", "in 3 days", "end of day", or an explicit clock time. Omit this for title-only, Inbox, Backlog, or generic capture reminders. Must include a calendar date when present. Use YYYY-MM-DD for full-day reminders or ISO with time (YYYY-MM-DDTHH:mm:ss.sssZ). Time-only values (e.g. "10:00:00") are invalid and will fail. When the user mentions a time-of-day word with a date or day, use sensible defaults for that timeframe (e.g "8am" for "morning", "1pm" for "afternoon", "6pm" for "evening"). A number with "a" or "p" appended (e.g. "1p" or "8a") should be treated as AM or PM. If the user includes a date but didn't include a specific time, assume it's a full day reminder.
    */
   dueDate?: string;
   /**
-   * The priority level. Only pick the value from this list: "low", "medium", "high". Use the "high" priority if the task text specifies a word such as "urgent", "important", or an exclamation mark.
+   * Optional priority level. Only include this when the user explicitly asks for a priority or uses wording such as "urgent", "important", or an exclamation mark. Never default unspecified reminders to "low". Only pick the value from this list: "low", "medium", "high".
    */
   priority?: string;
   /**
@@ -39,6 +39,7 @@ type Input = {
   /**
    * The recurrence settings.
    * Only include this when the user explicitly asks for a repeating reminder (for example: "every day", "weekly", "monthly", "yearly", "weekdays", or "weekends").
+   * Omit this for normal one-off reminders, including title-only, Inbox, Backlog, or generic capture reminders.
    */
   recurrence?: {
     /**


### PR DESCRIPTION
## Description

Closes #28763.

This tightens Apple Reminders tool guidance so title-only and generic capture requests do not get scheduled, prioritized, or recurring fields unless the user asks for them. It also adds eval coverage for Backlog/default-list title-only creation so the prompt behavior is guarded.

## Screencast

N/A - prompt/schema metadata change only.

## Checklist

- [x] I read the contribution guidelines
- [x] I ran `npm --prefix extensions/apple-reminders run lint`
- [x] I ran `git diff --check`
- [x] I validated `extensions/apple-reminders/package.json` parses as JSON