### PR TITLE
Update nixpkgs-search extension

### DIFF
--- a/extensions/nixpkgs-search/CHANGELOG.md
+++ b/extensions/nixpkgs-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NixPkgs Search Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-06-15
 
 - Add support for 26.05
 

--- a/extensions/nixpkgs-search/CHANGELOG.md
+++ b/extensions/nixpkgs-search/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NixPkgs Search Changelog
 
+## [Update] - {PR_MERGE_DATE}
+
+- Add support for 26.05
+
 ## [Update] - 2026-01-27
 
 - Add "Open Package Details" action to open the package on search.nixos.org

--- a/extensions/nixpkgs-search/src/api.ts
+++ b/extensions/nixpkgs-search/src/api.ts
@@ -70,7 +70,7 @@ export function buildSearchQuery(searchText: string, searchSize: number) {
 /**
  * Parses the Elasticsearch response and transforms it into SearchResult objects
  */
-export async function parseSearchResponse(response: Response): Promise<SearchResult[]> {
+export async function parseSearchResponse(response: Response, branchName: string): Promise<SearchResult[]> {
   const json = (await response.json()) as ElasticsearchResponse | ElasticsearchError | ElasticsearchCodeError;
 
   if ("code" in json) {
@@ -81,6 +81,8 @@ export async function parseSearchResponse(response: Response): Promise<SearchRes
     throw new Error(response.statusText);
   }
 
+  const githubBaseUrl = `${API_CONFIG.githubNixpkgsBase}/nixos-${branchName}`;
+
   return json.hits.hits.map(({ _source: result, _id: id }) => {
     return {
       id,
@@ -89,8 +91,7 @@ export async function parseSearchResponse(response: Response): Promise<SearchRes
       description: result.package_description,
       version: result.package_pversion,
       homepage: result.package_homepage,
-      source:
-        result.package_position && `${API_CONFIG.githubBaseUrl}/${result.package_position.replace(/:([0-9]+)$/, "")}`,
+      source: result.package_position && `${githubBaseUrl}/${result.package_position.replace(/:([0-9]+)$/, "")}`,
       outputs: result.package_outputs,
       defaultOutput: result.package_default_output,
       platforms: result.package_platforms.filter((platform) =>

--- a/extensions/nixpkgs-search/src/constants.ts
+++ b/extensions/nixpkgs-search/src/constants.ts
@@ -1,6 +1,7 @@
 // Available NixOS branches/versions
 export const AVAILABLE_BRANCHES = [
   { value: "unstable", title: "Unstable (rolling release)" },
+  { value: "26.05", title: "NixOS 26.05" },
   { value: "25.11", title: "NixOS 25.11" },
 ] as const;
 
@@ -46,7 +47,7 @@ export const API_CONFIG = {
   authorization: "Basic YVdWU0FMWHBadjpYOGdQSG56TDUyd0ZFZWt1eHNmUTljU2g=",
   versionUrl: "https://raw.githubusercontent.com/NixOS/nixos-search/main/version.nix",
   searchBaseUrl: "https://search.nixos.org/backend",
-  githubBaseUrl: "https://github.com/NixOS/nixpkgs/blob/nixos-unstable",
+  githubNixpkgsBase: "https://github.com/NixOS/nixpkgs/blob",
 } as const;
 
 // Search Configuration

--- a/extensions/nixpkgs-search/src/index.tsx
+++ b/extensions/nixpkgs-search/src/index.tsx
@@ -45,7 +45,7 @@ export default function Command() {
   );
 
   const [searchText, setSearchText] = useState("");
-  const state = useSearch({ url, searchText, searchSize: +searchSizeNum });
+  const state = useSearch({ url, searchText, searchSize: +searchSizeNum, branchName: selectedBranch });
 
   return (
     <List
@@ -86,7 +86,17 @@ export default function Command() {
   );
 }
 
-function useSearch({ url, searchText, searchSize }: { url?: string; searchText: string; searchSize: number }) {
+function useSearch({
+  url,
+  searchText,
+  searchSize,
+  branchName,
+}: {
+  url?: string;
+  searchText: string;
+  searchSize: number;
+  branchName: string;
+}) {
   const { isLoading, data } = useFetch(url!, {
     method: "POST",
     headers: {
@@ -94,7 +104,7 @@ function useSearch({ url, searchText, searchSize }: { url?: string; searchText: 
       "Content-Type": "application/json",
     },
     body: JSON.stringify(buildSearchQuery(searchText, searchSize)),
-    parseResponse: parseSearchResponse,
+    parseResponse: (r) => parseSearchResponse(r, branchName),
     initialData: [],
     execute: Boolean(url) && searchText.length > 0,
     failureToastOptions: {


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Pretty simple, just adds the 26.05 nixpkgs channel to the extension.

Also fixes the code to open the correct `.nix` file for a given package when the branch isn't `unstable`. 

## Screencast

<img width="1872" height="1320" alt="CleanShot 2026-06-14 at 22 24 03@2x" src="https://github.com/user-attachments/assets/2fa68d41-1239-40d7-8c19-b83588f9f8fb" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
