### PR TITLE
[HTTP Status Codes] Fix section label overflow

### DIFF
--- a/extensions/http-status-codes/CHANGELOG.md
+++ b/extensions/http-status-codes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HTTP Status Codes Changelog
 
+## [Fix Section Labels] - {PR_MERGE_DATE}
+
+- Shorten status-code section subtitles so they do not overflow in the list header
+
 ## [Windows Support] - 2026-03-12
 
 - Add support for Windows

--- a/extensions/http-status-codes/CHANGELOG.md
+++ b/extensions/http-status-codes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HTTP Status Codes Changelog
 
-## [Fix Section Labels] - {PR_MERGE_DATE}
+## [Fix Section Labels] - 2026-06-15
 
 - Shorten status-code section subtitles so they do not overflow in the list header
 

--- a/extensions/http-status-codes/src/utils.ts
+++ b/extensions/http-status-codes/src/utils.ts
@@ -77,11 +77,11 @@ export const statusCodeToColor = (status: string): Color => {
 export const getCodeGroupDescription = (firstDigit: string): string => {
   return (
     {
-      1: "Informational response - the request was received, continuing process",
-      2: "Successful - the request was successfully received, understood, and accepted",
-      3: "Redirection - further action needs to be taken in order to complete the request",
-      4: "Client error - the request contains bad syntax or cannot be fulfilled",
-      5: "Server error - the server failed to fulfil an apparently valid request",
+      1: "Informational",
+      2: "Successful",
+      3: "Redirection",
+      4: "Client error",
+      5: "Server error",
     }[firstDigit] || ""
   );
 };


### PR DESCRIPTION
## Description

Fixes #28778.

This shortens the HTTP status code section subtitles so the list headers stay compact and do not overflow next to the `1xx`, `2xx`, `3xx`, `4xx`, and `5xx` labels. The full status descriptions are still available on each status-code row.

## Screencast

The issue screenshot shows the overflowing section labels. This change only shortens the section header subtitles; no command flow or behavior changed.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

Validation:
- `npm run lint`
- `npm run build`
- `git diff --check`