### PR TITLE
[Music] Fix album search by artist

### DIFF
--- a/extensions/music/CHANGELOG.md
+++ b/extensions/music/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Apple Music Changelog
 
-## [Fix Library Album Search] - {PR_MERGE_DATE}
+## [Fix Library Album Search] - 2026-06-15
 
 - Fixed `Play Library Album` so searching by artist name shows matching albums from the library.
 

--- a/extensions/music/CHANGELOG.md
+++ b/extensions/music/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Apple Music Changelog
 
+## [Fix Library Album Search] - {PR_MERGE_DATE}
+
+- Fixed `Play Library Album` so searching by artist name shows matching albums from the library.
+
 ## [Just Play Command] - 2026-04-04
 
 - Added a new "Just Play" no-view command that takes a text query and immediately plays the best matching track from your library, with HUD feedback.

--- a/extensions/music/src/util/apple-script.ts
+++ b/extensions/music/src/util/apple-script.ts
@@ -15,6 +15,12 @@ export const runScript = (command: string) =>
 export const tell = (application: string, command: string) =>
   runScript(`tell application "${application}" to ${command}`);
 
+export const escapeAppleScriptString = (value: string) =>
+  value
+    .replace(/[\r\n]+/g, " ")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
+
 /**
  * Transforms an object to a querystring concatened in apple-script.
  * @example

--- a/extensions/music/src/util/scripts/albums.ts
+++ b/extensions/music/src/util/scripts/albums.ts
@@ -45,7 +45,7 @@ export const search = (search: string) => {
 			set results to (every track of library playlist 1 whose (album contains "${escapedSearch}" or artist contains "${escapedSearch}"))
 			repeat with aTrack in results
 				set albumName to the album of aTrack
-				set trackCount to count (every track of library playlist 1 whose album contains albumName)
+				set trackCount to count (every track of library playlist 1 whose album is albumName)
 				tell album of aTrack to if albumList does not contain it then
 					set end of albumList to it
 					set trackId to the id of aTrack

--- a/extensions/music/src/util/scripts/albums.ts
+++ b/extensions/music/src/util/scripts/albums.ts
@@ -1,7 +1,7 @@
 import { pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/TaskEither";
 
-import { createQueryString, runScript } from "../apple-script";
+import { createQueryString, escapeAppleScriptString, runScript } from "../apple-script";
 
 import { general } from ".";
 
@@ -30,6 +30,7 @@ export const getAll = runScript(`
 `);
 
 export const search = (search: string) => {
+  const escapedSearch = escapeAppleScriptString(search);
   const query = createQueryString({
     id: "trackId",
     name: "albumName",
@@ -41,10 +42,10 @@ export const search = (search: string) => {
 		set output to ""
 		set albumList to {}
 		tell application "Music"
-			set results to (search (library playlist 1) for "${search}")
+			set results to (every track of library playlist 1 whose album contains "${escapedSearch}" or artist contains "${escapedSearch}")
 			repeat with aTrack in results
 				set albumName to the album of aTrack
-				set trackCount to count (every track of playlist 1 whose album contains albumName)
+				set trackCount to count (every track of library playlist 1 whose album contains albumName)
 				tell album of aTrack to if albumList does not contain it then
 					set end of albumList to it
 					set trackId to the id of aTrack

--- a/extensions/music/src/util/scripts/albums.ts
+++ b/extensions/music/src/util/scripts/albums.ts
@@ -42,7 +42,7 @@ export const search = (search: string) => {
 		set output to ""
 		set albumList to {}
 		tell application "Music"
-			set results to (every track of library playlist 1 whose album contains "${escapedSearch}" or artist contains "${escapedSearch}")
+			set results to (every track of library playlist 1 whose (album contains "${escapedSearch}" or artist contains "${escapedSearch}"))
 			repeat with aTrack in results
 				set albumName to the album of aTrack
 				set trackCount to count (every track of library playlist 1 whose album contains albumName)


### PR DESCRIPTION
## Description

Fixes #28777.

`Play Library Album` previously delegated album lookup to Music.app's generic `search` command, which can miss artist-only queries for library albums. This updates the album search script to filter the library by album or artist, keeps the album count scoped to the library, and escapes the search text before embedding it into AppleScript.

## Screencast

I could not manually exercise this against a populated Apple Music library from this environment. I did validate the updated AppleScript shape with `osacompile`, and the extension builds successfully.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

Validation:
- `npm run lint` (passes with the existing `Volume up` title-case warning)
- `npm run build`
- `git diff --check`
- `osacompile` syntax check for the updated album search AppleScript
