### PR TITLE
ado-search: add Windows support

### DIFF
--- a/extensions/ado-search/CHANGELOG.md
+++ b/extensions/ado-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Azure DevOps Repository Search
 
-## [Add Windows support] - {PR_MERGE_DATE}
+## [Add Windows support] - 2026-06-15
 Declared the extension as cross-platform (macOS and Windows). All commands rely only on cross-platform APIs; the work item "Show in Finder" action now reads "Show in Explorer" on Windows.
 
 ## [Add My Work Items command] - 2026-06-04

--- a/extensions/ado-search/CHANGELOG.md
+++ b/extensions/ado-search/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Azure DevOps Repository Search
 
+## [Add Windows support] - {PR_MERGE_DATE}
+Declared the extension as cross-platform (macOS and Windows). All commands rely only on cross-platform APIs; the work item "Show in Finder" action now reads "Show in Explorer" on Windows.
+
 ## [Add My Work Items command] - 2026-06-04
 Added a "My Work Items" command: browse work items assigned to you across projects, filter and group by state/type/project, change state on single or multiple items, view descriptions with inline images plus acceptance criteria, repro steps, comments and attachments, create new work items, and create branches linked to a work item.
 

--- a/extensions/ado-search/package.json
+++ b/extensions/ado-search/package.json
@@ -114,6 +114,7 @@
     "publish": "npx @raycast/api@latest publish"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ]
 }

--- a/extensions/ado-search/src/my-work-items.tsx
+++ b/extensions/ado-search/src/my-work-items.tsx
@@ -803,7 +803,7 @@ function WorkItemView({ item, onUpdated }: { item: WorkItem; onUpdated?: (update
                     />
                   )}
                   <Action.ShowInFinder
-                    title="Show in Finder"
+                    title={process.platform === "win32" ? "Show in Explorer" : "Show in Finder"}
                     path={img.localPath}
                     shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
                   />


### PR DESCRIPTION
## Description

Declares the **Azure DevOps Repositories Search** (`ado-search`) extension as cross-platform — `platforms: ["macOS", "Windows"]`.

This is a small follow-up to the recently merged **My Work Items** command. All commands rely only on cross-platform APIs:

- **Repositories / Pipelines / My Pull Requests / My PBIs / Menu Bar** — network requests + `List`/`MenuBarExtra` + `open(<web URL>)` only; no macOS-specific code.
- **My Work Items** — uses `fs`/`path` with `pathToFileURL` for inline images (already Windows-path safe). The one macOS-specific label was made OS-aware: the attachment action now reads **"Show in Explorer"** on Windows and **"Show in Finder"** on macOS.

No dependency or behavioral changes on macOS.

## Note for the maintainer

I've verified `build` + `lint` pass and audited each command's APIs, but I don't have a Windows machine to smoke-test on. The **menu-bar** command in particular is worth a quick check on a real Raycast-for-Windows build. Happy to adjust if anything misbehaves there.

## Checklist
- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] Changes limited to `extensions/ado-search/`