### PR TITLE
[Agent Usage] Respect CLAUDE_CONFIG_DIR for credentials

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Agent Usage Changelog
 
+## [Support Claude Config Directory] - {PR_MERGE_DATE}
+
+- Respect `CLAUDE_CONFIG_DIR` when reading Claude credentials
+
 ## [Add OpenCode Go Provider] - 2026-05-15
 
 - Add OpenCode Go plan usage display

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Support Claude Config Directory] - {PR_MERGE_DATE}
+## [Support Claude Config Directory] - 2026-06-16
 
 - Respect `CLAUDE_CONFIG_DIR` when reading Claude credentials
 

--- a/extensions/agent-usage/src/claude/fetcher.test.ts
+++ b/extensions/agent-usage/src/claude/fetcher.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+
+test("resolveClaudeCredentialsPaths prefers CLAUDE_CONFIG_DIR and keeps the default fallback", async () => {
+  const { resolveClaudeCredentialsPaths } = await import("./fetcher");
+
+  assert.deepEqual(resolveClaudeCredentialsPaths({ CLAUDE_CONFIG_DIR: "/tmp/custom-claude" }), [
+    path.resolve("/tmp/custom-claude", ".credentials.json"),
+    path.join(os.homedir(), ".claude", ".credentials.json"),
+  ]);
+});
+
+test("resolveClaudeCredentialsPaths uses the default Claude config dir when CLAUDE_CONFIG_DIR is blank", async () => {
+  const { resolveClaudeCredentialsPaths } = await import("./fetcher");
+
+  assert.deepEqual(resolveClaudeCredentialsPaths({ CLAUDE_CONFIG_DIR: "   " }), [
+    path.join(os.homedir(), ".claude", ".credentials.json"),
+  ]);
+});
+
+test("resolveClaudeCredentialsPaths de-duplicates CLAUDE_CONFIG_DIR when it matches the default dir", async () => {
+  const { resolveClaudeCredentialsPaths } = await import("./fetcher");
+
+  assert.deepEqual(resolveClaudeCredentialsPaths({ CLAUDE_CONFIG_DIR: path.join(os.homedir(), ".claude/") }), [
+    path.join(os.homedir(), ".claude", ".credentials.json"),
+  ]);
+});

--- a/extensions/agent-usage/src/claude/fetcher.ts
+++ b/extensions/agent-usage/src/claude/fetcher.ts
@@ -5,7 +5,9 @@ import * as path from "node:path";
 import { execSync } from "node:child_process";
 import type { ClaudeUsage, ClaudeError } from "./types";
 
-const CLAUDE_CREDENTIALS_PATH = path.join(os.homedir(), ".claude", ".credentials.json");
+const CLAUDE_CONFIG_DIR_ENV = "CLAUDE_CONFIG_DIR";
+const DEFAULT_CLAUDE_CONFIG_DIR = path.join(os.homedir(), ".claude");
+const CLAUDE_CREDENTIALS_FILE = ".credentials.json";
 const CLAUDE_USAGE_API = "https://api.anthropic.com/api/oauth/usage";
 const KEYCHAIN_SERVICE = "Claude Code-credentials";
 const REQUEST_TIMEOUT = 10000;
@@ -23,6 +25,7 @@ interface ClaudeCredentials {
   rateLimitTier?: string;
   subscriptionType?: string;
   source: CredentialSource;
+  credentialsPath?: string;
   keychainAccount?: string;
   raw: {
     claudeAiOauth?: {
@@ -80,6 +83,13 @@ function pickString(...values: unknown[]): string | undefined {
     }
   }
   return undefined;
+}
+
+export function resolveClaudeCredentialsPaths(env: NodeJS.ProcessEnv = process.env): string[] {
+  const configuredDir = env[CLAUDE_CONFIG_DIR_ENV]?.trim();
+  const configDirs = configuredDir ? [configuredDir, DEFAULT_CLAUDE_CONFIG_DIR] : [DEFAULT_CLAUDE_CONFIG_DIR];
+
+  return [...new Set(configDirs.map((configDir) => path.resolve(configDir, CLAUDE_CREDENTIALS_FILE)))];
 }
 
 function inferPlan(rateLimitTier?: string, subscriptionType?: string): string {
@@ -205,6 +215,7 @@ function writeKeychainPassword(service: string, account: string, value: string):
 function extractCredentials(
   parsed: CredentialsParsed,
   source: CredentialSource,
+  credentialsPath?: string,
   keychainAccount?: string,
 ): { credentials: ClaudeCredentials | null; error: ClaudeError | null } {
   const oauth = parsed.claudeAiOauth;
@@ -244,6 +255,7 @@ function extractCredentials(
       rateLimitTier,
       subscriptionType,
       source,
+      credentialsPath,
       keychainAccount,
       raw: parsed,
     },
@@ -252,13 +264,15 @@ function extractCredentials(
 }
 
 function readClaudeCredentials(): { credentials: ClaudeCredentials | null; error: ClaudeError | null } {
-  // Strategy 1: Try credentials file first
-  if (fs.existsSync(CLAUDE_CREDENTIALS_PATH)) {
+  // Strategy 1: Try configured/default credential paths first
+  for (const credentialsPath of resolveClaudeCredentialsPaths()) {
+    if (!fs.existsSync(credentialsPath)) continue;
+
     try {
-      const text = fs.readFileSync(CLAUDE_CREDENTIALS_PATH, "utf-8");
+      const text = fs.readFileSync(credentialsPath, "utf-8");
       const parsed = tryParseCredentialJSON(text);
       if (parsed?.claudeAiOauth?.accessToken) {
-        return extractCredentials(parsed, "file");
+        return extractCredentials(parsed, "file", credentialsPath);
       }
     } catch {
       // Fall through to keychain
@@ -271,7 +285,7 @@ function readClaudeCredentials(): { credentials: ClaudeCredentials | null; error
     if (keychainValue) {
       const parsed = tryParseCredentialJSON(keychainValue);
       if (parsed?.claudeAiOauth?.accessToken) {
-        return extractCredentials(parsed, "keychain", readKeychainAccount(KEYCHAIN_SERVICE) ?? undefined);
+        return extractCredentials(parsed, "keychain", undefined, readKeychainAccount(KEYCHAIN_SERVICE) ?? undefined);
       }
     }
   }
@@ -309,7 +323,8 @@ function persistRefreshedCredentials(credentials: ClaudeCredentials, refreshed: 
     writeKeychainPassword(KEYCHAIN_SERVICE, credentials.keychainAccount, JSON.stringify(next));
   } else {
     try {
-      fs.writeFileSync(CLAUDE_CREDENTIALS_PATH, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
+      const credentialsPath = credentials.credentialsPath ?? resolveClaudeCredentialsPaths()[0];
+      fs.writeFileSync(credentialsPath, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
     } catch {
       // Best effort; continue with refreshed token in memory
     }


### PR DESCRIPTION
## Description

Fixes #28754.

The Claude usage provider now checks `CLAUDE_CONFIG_DIR` before falling back to the default `~/.claude` directory when reading Claude credentials. Refreshed file-based credentials are written back to the same credentials file that was read, so custom config directories stay consistent after token refresh.

## Screencast

N/A - credential path resolution only.

## Checklist

- [x] I read the extension contribution guidelines
- [x] I ran `node --test --experimental-strip-types src/claude/fetcher.test.ts`
- [x] I ran `npm run lint`
- [x] I ran `npm run build`
