### PR TITLE
Remo: note editing, AI Extension, and performance

### DIFF
--- a/extensions/remo-notes/CHANGELOG.md
+++ b/extensions/remo-notes/CHANGELOG.md
@@ -1,3 +1,12 @@
 # Remo Changelog
 
+## [Note editing, AI Extension and performance] - {PR_MERGE_DATE}
+
+- Added a Raycast AI Extension: Raycast AI can now search your notes and answer questions from them
+- Edit a note's title, tags and folder directly from Raycast
+- Move notes to a folder and delete notes to trash without leaving Raycast
+- AI formatting for Quick Capture is now enabled by default (can be turned off in extension preferences)
+- Pinning and unpinning notes now updates instantly
+- Notes, folders and search now load faster and stay fresh thanks to local caching
+
 ## [Initial Version] - 2026-04-27

--- a/extensions/remo-notes/CHANGELOG.md
+++ b/extensions/remo-notes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Remo Changelog
 
-## [Note editing, AI Extension and performance] - {PR_MERGE_DATE}
+## [Note editing, AI Extension and performance] - 2026-06-15
 
 - Added a Raycast AI Extension: Raycast AI can now search your notes and answer questions from them
 - Edit a note's title, tags and folder directly from Raycast

--- a/extensions/remo-notes/package-lock.json
+++ b/extensions/remo-notes/package-lock.json
@@ -8,6 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.3",
+        "@raycast/utils": "^2.2.6",
         "turndown": "^7.2.2"
       },
       "devDependencies": {
@@ -489,9 +490,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -570,9 +571,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1064,9 +1065,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@oclif/core": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.10.5.tgz",
-      "integrity": "sha512-qcdCF7NrdWPfme6Kr34wwljRCXbCVpL1WVxiNy0Ep6vbWKjxAjFQwuhqkoyL0yjI+KdwtLcOCGn5z2yzdijc8w==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.4.tgz",
+      "integrity": "sha512-URwiQ5ALx/sJ2iH4vzXEd+H4K6NAI7LRs6Jag3hrgKEpGmaE6alfRC8qjO4GIgb6A3ACaJumqP9twi/M9ywdHQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -1080,10 +1081,10 @@
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
         "minimatch": "^10.2.5",
-        "semver": "^7.7.3",
+        "semver": "^7.8.1",
         "string-width": "^4.2.3",
         "supports-color": "^8",
-        "tinyglobby": "^0.2.14",
+        "tinyglobby": "^0.2.16",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -1093,9 +1094,9 @@
       }
     },
     "node_modules/@oclif/plugin-autocomplete": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.45.tgz",
-      "integrity": "sha512-ENrUg8rbVCjh40uvi3MC9kGbiUoEf11nyqE59RBzegeeLpRXNo/Zp27L9j1tUmPEqGgfS2/wvHPihNzkpK1FDw==",
+      "version": "3.2.50",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.50.tgz",
+      "integrity": "sha512-SQRIJSYue/1tIn7X55W/97gTb8UkSoHeFAcBng2r2YMJyWj8uB1DtFl28D8BDXPQXPTiPK89hQGejoT7RdkR2w==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
@@ -1108,9 +1109,9 @@
       }
     },
     "node_modules/@oclif/plugin-help": {
-      "version": "6.2.44",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.44.tgz",
-      "integrity": "sha512-x03Se2LtlOOlGfTuuubt5C4Z8NHeR4zKXtVnfycuLU+2VOMu2WpsGy9nbs3nYuInuvsIY1BizjVaTjUz060Sig==",
+      "version": "6.2.50",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.50.tgz",
+      "integrity": "sha512-rNCG4hUm+kPXFbhJfAVk/fZ3OdWJYwBDASlyX8CqOLP0MssjIGl7iEgfZz7TMuZFa+KucupKU5NRSc0KWfPTQA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4"
@@ -1120,13 +1121,13 @@
       }
     },
     "node_modules/@oclif/plugin-not-found": {
-      "version": "3.2.80",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.80.tgz",
-      "integrity": "sha512-yTLjWvR1r/Rd/cO2LxHdMCDoL5sQhBYRUcOMCmxZtWVWhx4rAZ8KVUPDVsb+SvjJDV5ADTDBgt1H52fFx7YWqg==",
+      "version": "3.2.87",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.87.tgz",
+      "integrity": "sha512-lKyZ4INrx5vB14HNWIkM6Vla/4rWVhOA2U7uCAj6gEBg36/KVmwYXxpZ9ckzZS0+jtLE84TVqS8NCYEhQiQojw==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",
-        "@oclif/core": "^4.10.5",
+        "@oclif/core": "^4.11.4",
         "ansis": "^3.17.0",
         "fast-levenshtein": "^3.0.0"
       },
@@ -1222,10 +1223,28 @@
         "eslint": ">=8.23.0"
       }
     },
+    "node_modules/@raycast/utils": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.6.tgz",
+      "integrity": "sha512-/6NUftsaNjboTOhTiadRhQ+hgfsg9AxKdYCpGGbwfUghTX9M+ljbGBesCxQ+X5GBIBM+9lH3ma7GMwZPSPzJgw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@raycast/api": ">=1.99.4",
+        "react": ">=19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1263,17 +1282,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
-      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
+      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.0",
-        "@typescript-eslint/type-utils": "8.59.0",
-        "@typescript-eslint/utils": "8.59.0",
-        "@typescript-eslint/visitor-keys": "8.59.0",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/type-utils": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1286,7 +1305,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.0",
+        "@typescript-eslint/parser": "^8.61.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1302,16 +1321,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
-      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
+      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.0",
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/typescript-estree": "8.59.0",
-        "@typescript-eslint/visitor-keys": "8.59.0",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1327,14 +1346,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
-      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
+      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.0",
-        "@typescript-eslint/types": "^8.59.0",
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1349,14 +1368,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
-      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/visitor-keys": "8.59.0"
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1367,9 +1386,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
-      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
+      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1384,15 +1403,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
-      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
+      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/typescript-estree": "8.59.0",
-        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1409,9 +1428,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
-      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1423,16 +1442,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
-      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.0",
-        "@typescript-eslint/tsconfig-utils": "8.59.0",
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/visitor-keys": "8.59.0",
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1451,16 +1470,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
-      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
+      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.0",
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/typescript-estree": "8.59.0"
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1475,13 +1494,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
-      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/types": "8.61.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1506,9 +1525,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1529,9 +1548,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1616,9 +1635,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1778,6 +1797,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -1967,9 +1995,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2158,9 +2186,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2406,10 +2434,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2654,9 +2692,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2680,10 +2718,10 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
-      "dev": true,
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2706,9 +2744,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2807,9 +2845,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -2888,16 +2926,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
-      "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
+      "integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.0",
-        "@typescript-eslint/parser": "8.59.0",
-        "@typescript-eslint/typescript-estree": "8.59.0",
-        "@typescript-eslint/utils": "8.59.0"
+        "@typescript-eslint/eslint-plugin": "8.61.0",
+        "@typescript-eslint/parser": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/extensions/remo-notes/package.json
+++ b/extensions/remo-notes/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "remo-notes",
   "title": "Remo",
-  "description": "Simple, fast, and portable note-taking. Capture ideas instantly, stay organized, and turn notes into action with AI-powered workflows.",
+  "description": "Remo is a simple, fast AI note-taking app. Capture ideas instantly, stay organized, and use AI to turn notes into action — on web and Raycast.",
   "icon": "extension-icon.png",
   "author": "alfredmouelle",
   "platforms": [
@@ -28,7 +28,7 @@
       "label": "Auto-format with AI",
       "title": "AI Formatting",
       "description": "Automatically format captured text using AI",
-      "default": false
+      "default": true
     }
   ],
   "commands": [
@@ -88,15 +88,28 @@
       "mode": "view"
     }
   ],
+  "tools": [
+    {
+      "name": "search-notes",
+      "title": "Search Notes",
+      "description": "Search the user's Remo notes by keyword or semantic meaning and return matching notes."
+    },
+    {
+      "name": "ask-ai",
+      "title": "Ask Notes",
+      "description": "Answer a natural-language question using the user's Remo notes as context, with citations."
+    }
+  ],
   "dependencies": {
     "@raycast/api": "^1.104.3",
+    "@raycast/utils": "^2.2.6",
     "turndown": "^7.2.2"
   },
   "devDependencies": {
-    "@types/turndown": "^5.0.6",
     "@raycast/eslint-config": "^2.0.4",
     "@types/node": "22.13.10",
     "@types/react": "19.2.0",
+    "@types/turndown": "^5.0.6",
     "eslint": "^9.22.0",
     "prettier": "^3.5.3",
     "react": "^19.2.0",

--- a/extensions/remo-notes/src/components/EditNoteForm.tsx
+++ b/extensions/remo-notes/src/components/EditNoteForm.tsx
@@ -1,0 +1,67 @@
+import { Action, ActionPanel, Form, Icon, showToast, Toast, useNavigation } from "@raycast/api";
+import { useState } from "react";
+import type { Folder, Note } from "../types";
+import { remoApi } from "../utils/api";
+import { handleError } from "../utils/errors";
+
+interface EditNoteFormProps {
+  note: Note;
+  folders: Folder[];
+  onSaved: () => void;
+}
+
+interface EditNoteValues {
+  title: string;
+  tags: string;
+  folderId: string;
+}
+
+export function EditNoteForm({ note, folders, onSaved }: EditNoteFormProps) {
+  const { pop } = useNavigation();
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleSubmit(values: EditNoteValues) {
+    setIsLoading(true);
+    try {
+      const tags = values.tags
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter(Boolean);
+
+      await remoApi.updateNote(note._id, {
+        title: values.title.trim() || "Untitled",
+        tags,
+        folderId: values.folderId === "" ? null : values.folderId,
+      });
+
+      showToast({ style: Toast.Style.Success, title: "Note updated" });
+      onSaved();
+      pop();
+    } catch (error) {
+      handleError(error, "Failed to update note");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Form
+      isLoading={isLoading}
+      navigationTitle="Edit Note"
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Save" icon={Icon.Check} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField id="title" title="Title" defaultValue={note.title} />
+      <Form.TextField id="tags" title="Tags" placeholder="comma, separated" defaultValue={note.tags.join(", ")} />
+      <Form.Dropdown id="folderId" title="Folder" defaultValue={note.folderId ?? ""}>
+        <Form.Dropdown.Item value="" title="No folder (Inbox)" icon={Icon.Tray} />
+        {folders.map((folder) => (
+          <Form.Dropdown.Item key={folder._id} value={folder._id} title={folder.name} icon={Icon.Folder} />
+        ))}
+      </Form.Dropdown>
+    </Form>
+  );
+}

--- a/extensions/remo-notes/src/components/NoteListItem.tsx
+++ b/extensions/remo-notes/src/components/NoteListItem.tsx
@@ -1,8 +1,11 @@
-import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import { Action, ActionPanel, Alert, confirmAlert, Icon, List, showToast, Toast } from "@raycast/api";
+import type { MutatePromise } from "@raycast/utils";
+import { EditNoteForm } from "./EditNoteForm";
 import { buildAppUrl } from "../config";
-import type { Note } from "../types";
+import type { Folder, Note } from "../types";
 import { remoApi } from "../utils/api";
 import { handleError } from "../utils/errors";
+import { sortByPinned } from "../utils/notes";
 import { stripHtml } from "../utils/stripHtml";
 import { toMarkdown } from "../utils/toMarkdown";
 
@@ -11,10 +14,66 @@ interface NoteListItemProps {
   onRefresh: () => void;
   isShowingDetail: boolean;
   onToggleDetail: () => void;
+  mutate?: MutatePromise<Note[] | undefined>;
+  folders?: Folder[];
 }
 
-export function NoteListItem({ note, onRefresh, isShowingDetail, onToggleDetail }: NoteListItemProps) {
+export function NoteListItem({ note, onRefresh, isShowingDetail, onToggleDetail, mutate, folders }: NoteListItemProps) {
   const webUrl = buildAppUrl(`/notes/${note._id}`);
+  const canEdit = !note.isLocked && !note.isE2E && !note.deletedAt;
+
+  const handleTogglePin = async () => {
+    try {
+      if (mutate) {
+        await mutate(remoApi.togglePin(note._id), {
+          optimisticUpdate: (data) =>
+            sortByPinned((data ?? []).map((n) => (n._id === note._id ? { ...n, isPinned: !n.isPinned } : n))),
+        });
+      } else {
+        await remoApi.togglePin(note._id);
+        onRefresh();
+      }
+    } catch (error) {
+      handleError(error, note.isPinned ? "Failed to unpin note" : "Failed to pin note");
+    }
+  };
+
+  const handleMove = async (folderId: string | null) => {
+    try {
+      if (mutate) {
+        await mutate(remoApi.updateNote(note._id, { folderId }));
+      } else {
+        await remoApi.updateNote(note._id, { folderId });
+        onRefresh();
+      }
+      showToast({ style: Toast.Style.Success, title: "Note moved" });
+    } catch (error) {
+      handleError(error, "Failed to move note");
+    }
+  };
+
+  const handleDelete = async () => {
+    const confirmed = await confirmAlert({
+      title: "Delete to Trash",
+      message: `Move "${note.title || "Untitled"}" to trash?`,
+      primaryAction: { title: "Delete", style: Alert.ActionStyle.Destructive },
+    });
+    if (!confirmed) return;
+
+    try {
+      if (mutate) {
+        await mutate(remoApi.softDeleteNote(note._id), {
+          optimisticUpdate: (data) => (data ?? []).filter((n) => n._id !== note._id),
+        });
+      } else {
+        await remoApi.softDeleteNote(note._id);
+        onRefresh();
+      }
+      showToast({ style: Toast.Style.Success, title: "Moved to trash" });
+    } catch (error) {
+      handleError(error, "Failed to delete note");
+    }
+  };
 
   return (
     <List.Item
@@ -75,19 +134,46 @@ export function NoteListItem({ note, onRefresh, isShowingDetail, onToggleDetail 
             shortcut={{ modifiers: ["cmd"], key: "d" }}
           />
           <Action.OpenInBrowser url={webUrl} title="Open in Web App" />
+          {canEdit && (
+            <Action.Push
+              title="Edit Note"
+              icon={Icon.Pencil}
+              shortcut={{ modifiers: ["cmd"], key: "e" }}
+              target={<EditNoteForm note={note} folders={folders ?? []} onSaved={onRefresh} />}
+            />
+          )}
+          {canEdit && folders && folders.length > 0 && (
+            <ActionPanel.Submenu
+              title="Move to Folder"
+              icon={Icon.Folder}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "m" }}
+            >
+              <Action title="No Folder (Inbox)" icon={Icon.Tray} onAction={() => handleMove(null)} />
+              {folders.map((folder) => (
+                <Action
+                  key={folder._id}
+                  title={folder.name}
+                  icon={Icon.Folder}
+                  onAction={() => handleMove(folder._id)}
+                />
+              ))}
+            </ActionPanel.Submenu>
+          )}
           <Action
             title={note.isPinned ? "Unpin Note" : "Pin Note"}
             icon={note.isPinned ? Icon.PinDisabled : Icon.Pin}
             shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
-            onAction={async () => {
-              try {
-                await remoApi.togglePin(note._id);
-                onRefresh();
-              } catch (error) {
-                handleError(error, note.isPinned ? "Failed to unpin note" : "Failed to pin note");
-              }
-            }}
+            onAction={handleTogglePin}
           />
+          {canEdit && (
+            <Action
+              title="Delete to Trash"
+              icon={Icon.Trash}
+              style={Action.Style.Destructive}
+              shortcut={{ modifiers: ["ctrl"], key: "x" }}
+              onAction={handleDelete}
+            />
+          )}
           {note.isLocked || note.isE2E || !note.content ? null : (
             <Action.CopyToClipboard
               content={toMarkdown(note.content)}

--- a/extensions/remo-notes/src/pinned-notes.tsx
+++ b/extensions/remo-notes/src/pinned-notes.tsx
@@ -1,34 +1,25 @@
 import { Icon, MenuBarExtra, open } from "@raycast/api";
-import { useEffect, useState } from "react";
+import { useCachedPromise } from "@raycast/utils";
 import { buildAppUrl, buildWebUrl } from "./config";
 import type { Note } from "./types";
 import { remoApi } from "./utils/api";
-import { handleError } from "./utils/errors";
 import { stripHtml } from "./utils/stripHtml";
+import { handleError } from "./utils/errors";
 
 export default function Command() {
-  const [isLoading, setIsLoading] = useState(true);
-  const [notes, setNotes] = useState<Note[]>([]);
+  const { isLoading, data } = useCachedPromise(
+    async () => {
+      const result = await remoApi.listNotes({ limit: 50 });
+      return result.filter((n: Note) => n.isPinned);
+    },
+    [],
+    { onError: (error) => handleError(error, "Failed to fetch pinned notes") },
+  );
 
-  useEffect(() => {
-    async function fetchNotes() {
-      setIsLoading(true);
-      try {
-        const result = await remoApi.listNotes({ limit: 50 });
-        const pinned = result.filter((n: Note) => n.isPinned);
-        setNotes(pinned);
-      } catch (error) {
-        handleError(error, "Failed to fetch pinned notes");
-      } finally {
-        setIsLoading(false);
-      }
-    }
-
-    fetchNotes();
-  }, []);
+  const notes = data ?? [];
 
   return (
-    <MenuBarExtra icon={Icon.Pencil} isLoading={isLoading} tooltip="Remo Pinned Notes">
+    <MenuBarExtra icon={Icon.Pin} isLoading={isLoading} tooltip="Remo Pinned Notes">
       {notes.length === 0 ? (
         <MenuBarExtra.Item title="No pinned notes" />
       ) : (

--- a/extensions/remo-notes/src/search-folders.tsx
+++ b/extensions/remo-notes/src/search-folders.tsx
@@ -1,27 +1,18 @@
 import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
-import { useCallback, useEffect, useState } from "react";
+import { useCachedPromise } from "@raycast/utils";
+import { useState } from "react";
 import { NoteListItem } from "./components/NoteListItem";
 import type { Folder, Note } from "./types";
 import { remoApi } from "./utils/api";
 import { handleError } from "./utils/errors";
+import { sortByPinned } from "./utils/notes";
 
 export default function SearchFolders() {
-  const [isLoading, setIsLoading] = useState(true);
-  const [folders, setFolders] = useState<Folder[]>([]);
+  const { isLoading, data } = useCachedPromise(() => remoApi.listFolders(), [], {
+    onError: (error) => handleError(error, "Failed to fetch folders"),
+  });
 
-  useEffect(() => {
-    async function fetchFolders() {
-      try {
-        const result = await remoApi.listFolders();
-        setFolders(result);
-      } catch (error) {
-        handleError(error, "Failed to fetch folders");
-      } finally {
-        setIsLoading(false);
-      }
-    }
-    fetchFolders();
-  }, []);
+  const folders = data ?? [];
 
   return (
     <List isLoading={isLoading} searchBarPlaceholder="Search folders...">
@@ -119,70 +110,43 @@ function FolderNotesList({
   folderId?: string;
   title: string;
 }) {
-  const [isLoading, setIsLoading] = useState(true);
-  const [notes, setNotes] = useState<Note[]>([]);
   const [isShowingDetail, setIsShowingDetail] = useState(false);
 
-  // We pass a refresh function to NoteListItem, reusing the logic
-  const fetchNotes = useCallback(async () => {
-    setIsLoading(true);
-    try {
+  const {
+    isLoading,
+    data,
+    revalidate: fetchNotes,
+    mutate,
+  } = useCachedPromise(
+    async (type: typeof filterType, fid?: string) => {
       let result: Note[] = [];
 
-      if (filterType === "trash") {
-        const deletedNotes = await remoApi.listNotes({
-          includeDeleted: true,
-          limit: 50,
-        });
+      if (type === "trash") {
+        const deletedNotes = await remoApi.listNotes({ includeDeleted: true, limit: 50 });
         result = deletedNotes.filter((note: Note) => note.deletedAt !== undefined);
-      } else if (filterType === "quickCapture") {
-        result = await remoApi.listNotes({
-          quickCapturedOnly: true,
-          limit: 50,
-        });
-      } else if (filterType === "inbox") {
-        result = await remoApi.listNotes({
-          folderId: "inbox",
-          limit: 50,
-        });
-      } else if (filterType === "locked") {
-        result = await remoApi.listNotes({
-          lockedOnly: true,
-          limit: 50,
-        });
-      } else if (filterType === "vault") {
-        result = await remoApi.listNotes({
-          e2eOnly: true,
-          limit: 50,
-        });
-      } else if (filterType === "shared") {
-        result = await remoApi.listNotes({
-          sharedOnly: true,
-          limit: 50,
-        });
+      } else if (type === "quickCapture") {
+        result = await remoApi.listNotes({ quickCapturedOnly: true, limit: 50 });
+      } else if (type === "inbox") {
+        result = await remoApi.listNotes({ folderId: "inbox", limit: 50 });
+      } else if (type === "locked") {
+        result = await remoApi.listNotes({ lockedOnly: true, limit: 50 });
+      } else if (type === "vault") {
+        result = await remoApi.listNotes({ e2eOnly: true, limit: 50 });
+      } else if (type === "shared") {
+        result = await remoApi.listNotes({ sharedOnly: true, limit: 50 });
       } else {
-        result = await remoApi.listNotes({
-          folderId: folderId as Folder["_id"],
-          limit: 50,
-        });
+        result = await remoApi.listNotes({ folderId: fid as Folder["_id"], limit: 50 });
       }
 
-      // Sort pinned first
-      const sortedResult = result.sort((a: Note, b: Note) => {
-        if (a.isPinned === b.isPinned) return 0;
-        return a.isPinned ? -1 : 1;
-      });
-      setNotes(sortedResult);
-    } catch (error) {
-      handleError(error, "Failed to fetch notes");
-    } finally {
-      setIsLoading(false);
-    }
-  }, [filterType, folderId]);
+      return sortByPinned(result);
+    },
+    [filterType, folderId],
+    { onError: (error) => handleError(error, "Failed to fetch notes") },
+  );
 
-  useEffect(() => {
-    fetchNotes();
-  }, [fetchNotes]);
+  const { data: folders } = useCachedPromise(() => remoApi.listFolders(), []);
+
+  const notes = data ?? [];
 
   return (
     <List
@@ -199,6 +163,8 @@ function FolderNotesList({
             key={note._id}
             note={note}
             onRefresh={fetchNotes}
+            mutate={mutate}
+            folders={folders}
             isShowingDetail={isShowingDetail}
             onToggleDetail={() => setIsShowingDetail((prev) => !prev)}
           />

--- a/extensions/remo-notes/src/search-notes.tsx
+++ b/extensions/remo-notes/src/search-notes.tsx
@@ -1,42 +1,30 @@
 import { List } from "@raycast/api";
-import { useCallback, useEffect, useState } from "react";
+import { useCachedPromise } from "@raycast/utils";
+import { useState } from "react";
 import { NoteListItem } from "./components/NoteListItem";
-import type { Note } from "./types";
 import { remoApi } from "./utils/api";
 import { handleError } from "./utils/errors";
+import { sortByPinned } from "./utils/notes";
 
 export default function SearchNotes() {
-  const [isLoading, setIsLoading] = useState(true);
-  const [notes, setNotes] = useState<Note[]>([]);
   const [searchText, setSearchText] = useState("");
   const [isShowingDetail, setIsShowingDetail] = useState(false);
 
-  const fetchNotes = useCallback(async (text: string) => {
-    setIsLoading(true);
-    try {
-      let result: Note[] = [];
+  const { isLoading, data, revalidate, mutate } = useCachedPromise(
+    async (text: string) => {
+      const result = text.trim() === "" ? await remoApi.recentNotes(20) : await remoApi.searchNotes(text);
+      return sortByPinned(result);
+    },
+    [searchText],
+    {
+      keepPreviousData: true,
+      onError: (error) => handleError(error, "Failed to fetch notes"),
+    },
+  );
 
-      if (text.trim() === "") {
-        result = await remoApi.recentNotes(20);
-      } else {
-        result = await remoApi.searchNotes(text);
-      }
+  const { data: folders } = useCachedPromise(() => remoApi.listFolders(), []);
 
-      const sortedResult = result.sort((a: Note, b: Note) => {
-        if (a.isPinned === b.isPinned) return 0;
-        return a.isPinned ? -1 : 1;
-      });
-      setNotes(sortedResult);
-    } catch (error) {
-      handleError(error, "Failed to fetch notes");
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchNotes(searchText);
-  }, [searchText, fetchNotes]);
+  const notes = data ?? [];
 
   return (
     <List
@@ -56,7 +44,9 @@ export default function SearchNotes() {
         <NoteListItem
           key={note._id}
           note={note}
-          onRefresh={() => fetchNotes(searchText)}
+          onRefresh={revalidate}
+          mutate={mutate}
+          folders={folders}
           isShowingDetail={isShowingDetail}
           onToggleDetail={() => setIsShowingDetail((prev) => !prev)}
         />

--- a/extensions/remo-notes/src/tools/ask-ai.ts
+++ b/extensions/remo-notes/src/tools/ask-ai.ts
@@ -1,0 +1,27 @@
+import { remoApi } from "../utils/api";
+
+type Input = {
+  /**
+   * The natural-language question to answer using the user's notes.
+   */
+  question: string;
+};
+
+/**
+ * Answer a question using the user's Remo notes as context. Returns an answer with citations
+ * and the source notes it relied on. Locked notes are excluded from the answer.
+ */
+export default async function tool(input: Input) {
+  const result = await remoApi.askAi(input.question);
+
+  return {
+    answer: result.answer,
+    citations: result.citations,
+    sources: result.matches.map((match) => ({
+      id: match.noteId,
+      title: match.title,
+      score: match.score,
+      snippet: match.snippet,
+    })),
+  };
+}

--- a/extensions/remo-notes/src/tools/search-notes.ts
+++ b/extensions/remo-notes/src/tools/search-notes.ts
@@ -1,0 +1,24 @@
+import { remoApi } from "../utils/api";
+import { stripHtml } from "../utils/stripHtml";
+
+type Input = {
+  /**
+   * The search query. Can be keywords or a natural-language description of what to find.
+   */
+  query: string;
+};
+
+/**
+ * Search the user's Remo notes by keyword or semantic meaning and return the matching notes.
+ */
+export default async function tool(input: Input) {
+  const notes = await remoApi.searchNotes(input.query);
+
+  return notes.slice(0, 20).map((note) => ({
+    id: note._id,
+    title: note.title || "Untitled",
+    isLocked: note.isLocked ?? false,
+    updatedAt: new Date(note.updatedAt).toISOString(),
+    snippet: note.summary || stripHtml(note.content || "").slice(0, 200),
+  }));
+}

--- a/extensions/remo-notes/src/trash.tsx
+++ b/extensions/remo-notes/src/trash.tsx
@@ -1,5 +1,6 @@
 import { Action, ActionPanel, Alert, Color, confirmAlert, Icon, List, showToast, Toast } from "@raycast/api";
-import { useCallback, useEffect, useState } from "react";
+import { useCachedPromise } from "@raycast/utils";
+import { useState } from "react";
 import { buildAppUrl } from "./config";
 import type { Note } from "./types";
 import { remoApi } from "./utils/api";
@@ -8,28 +9,24 @@ import { stripHtml } from "./utils/stripHtml";
 import { toMarkdown } from "./utils/toMarkdown";
 
 export default function Trash() {
-  const [isLoading, setIsLoading] = useState(true);
-  const [notes, setNotes] = useState<Note[]>([]);
   const [isShowingDetail, setIsShowingDetail] = useState(false);
 
-  const fetchTrash = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const result = await remoApi.listNotes({
-        includeDeleted: true,
-      });
-      const deletedNotes = result.filter((n: Note) => n.deletedAt !== undefined);
-      setNotes(deletedNotes.sort((a: Note, b: Note) => (b.deletedAt ?? b.updatedAt) - (a.deletedAt ?? a.updatedAt)));
-    } catch (error) {
-      handleError(error, "Failed to fetch trash");
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+  const {
+    isLoading,
+    data,
+    revalidate: fetchTrash,
+  } = useCachedPromise(
+    async () => {
+      const result = await remoApi.listNotes({ includeDeleted: true });
+      return result
+        .filter((n: Note) => n.deletedAt !== undefined)
+        .sort((a: Note, b: Note) => (b.deletedAt ?? b.updatedAt) - (a.deletedAt ?? a.updatedAt));
+    },
+    [],
+    { onError: (error) => handleError(error, "Failed to fetch trash") },
+  );
 
-  useEffect(() => {
-    fetchTrash();
-  }, [fetchTrash]);
+  const notes = data ?? [];
 
   async function handleRestore(noteId: Note["_id"]) {
     try {
@@ -112,13 +109,15 @@ export default function Trash() {
                 />
                 <Action.OpenInBrowser title="Open in Web App" url={buildAppUrl(`/notes/${note._id}`)} />
                 <Action title="Restore Note" icon={Icon.RotateAntiClockwise} onAction={() => handleRestore(note._id)} />
-                <Action
-                  title="Delete Permanently"
-                  icon={Icon.Xmark}
-                  style={Action.Style.Destructive}
-                  shortcut={{ modifiers: ["ctrl"], key: "x" }}
-                  onAction={() => handlePermanentDelete(note._id)}
-                />
+                {!note.isLocked && !note.isE2E && (
+                  <Action
+                    title="Delete Permanently"
+                    icon={Icon.Xmark}
+                    style={Action.Style.Destructive}
+                    shortcut={{ modifiers: ["ctrl"], key: "x" }}
+                    onAction={() => handlePermanentDelete(note._id)}
+                  />
+                )}
               </ActionPanel>
             }
           />

--- a/extensions/remo-notes/src/types.ts
+++ b/extensions/remo-notes/src/types.ts
@@ -14,6 +14,7 @@ export interface Note {
   isPinned?: boolean;
   isE2E?: boolean;
   deletedAt?: number;
+  folderId?: Id<"folders">;
 }
 
 export type NoteId = string;

--- a/extensions/remo-notes/src/utils/api.ts
+++ b/extensions/remo-notes/src/utils/api.ts
@@ -188,10 +188,24 @@ export const remoApi = {
     });
   },
 
-  permanentDelete(noteId: string, password?: string) {
+  permanentDelete(noteId: string) {
     return request<{ success: boolean }>("/notes/permanent-delete", {
       method: "POST",
-      body: JSON.stringify({ noteId, password }),
+      body: JSON.stringify({ noteId }),
+    });
+  },
+
+  updateNote(noteId: string, payload: { title?: string; tags?: string[]; folderId?: string | null }) {
+    return request<{ noteId: string }>("/notes/update", {
+      method: "POST",
+      body: JSON.stringify({ noteId, ...payload }),
+    });
+  },
+
+  softDeleteNote(noteId: string) {
+    return request<{ success: boolean }>("/notes/delete", {
+      method: "POST",
+      body: JSON.stringify({ noteId }),
     });
   },
 

--- a/extensions/remo-notes/src/utils/notes.ts
+++ b/extensions/remo-notes/src/utils/notes.ts
@@ -1,0 +1,8 @@
+import type { Note } from "../types";
+
+export function sortByPinned(notes: Note[]): Note[] {
+  return [...notes].sort((a, b) => {
+    if (a.isPinned === b.isPinned) return 0;
+    return a.isPinned ? -1 : 1;
+  });
+}


### PR DESCRIPTION
## Description

Update to the **Remo** extension.

New features:
- **AI Extension** — Raycast AI can now search your notes and answer questions from them (two tools: `search-notes`, `ask-ai`).
- **Note editing** — edit a note's title, tags and folder directly from Raycast.
- **Organize** — move notes to a folder and send notes to trash without leaving Raycast. Locked and encrypted notes stay web-only.
- **Quick Capture** — AI formatting is now enabled by default (still toggleable in preferences).

Improvements:
- Pinning/unpinning is now instant (optimistic updates).
- All list commands migrated to `@raycast/utils` `useCachedPromise`: local caching, race-condition-safe search, faster reopen.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that screenshots and metadata are up to date
- [x] I updated the `CHANGELOG.md` with a new entry