### PR TITLE
Update raycast-ollama extension

### DIFF
--- a/extensions/raycast-ollama/CHANGELOG.md
+++ b/extensions/raycast-ollama/CHANGELOG.md
@@ -1,6 +1,6 @@
 # raycast-ollama Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-06-16
 
 - [Fix] Command "Chat with Ollama" and "Answer" commands: fixed a bug in the thinking rendering during streaming. The thinking text could stop updating mid-generation while the stream continued and the final answer appeared. The root cause was a missing flush of the pending `textThinkingBuffer` on stream termination (`emitDone`) combined with a `else if` in the throttle path that prevented symmetric flushing of thinking and content buffers.
 

--- a/extensions/raycast-ollama/CHANGELOG.md
+++ b/extensions/raycast-ollama/CHANGELOG.md
@@ -1,5 +1,9 @@
 # raycast-ollama Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- [Fix] Command "Chat with Ollama" and "Answer" commands: fixed a bug in the thinking rendering during streaming. The thinking text could stop updating mid-generation while the stream continued and the final answer appeared. The root cause was a missing flush of the pending `textThinkingBuffer` on stream termination (`emitDone`) combined with a `else if` in the throttle path that prevented symmetric flushing of thinking and content buffers.
+
 ## [Improvement] - 2026-05-26
 
 - Command "Chat with Ollama": new system prompt with current date and system information in the context.

--- a/extensions/raycast-ollama/src/lib/ollama/ollama.ts
+++ b/extensions/raycast-ollama/src/lib/ollama/ollama.ts
@@ -690,6 +690,10 @@ export class Ollama {
                 }
 
                 const emitDone = () => {
+                  if (textThinkingBuffer.length > 0) {
+                    e.emit("thinking", textThinkingBuffer);
+                    textThinkingBuffer = "";
+                  }
                   if (textContentBuffer.length > 0) e.emit("data", textContentBuffer);
                   e.emit("done", json);
                 };
@@ -700,7 +704,8 @@ export class Ollama {
                     if (textThinkingBuffer !== "") {
                       e.emit("thinking", textThinkingBuffer);
                       textThinkingBuffer = "";
-                    } else if (textContentBuffer !== "") {
+                    }
+                    if (textContentBuffer !== "") {
                       e.emit("data", textContentBuffer);
                       textContentBuffer = "";
                     }


### PR DESCRIPTION
## Description

- [Fix] Command "Chat with Ollama" and "Answer" commands: fixed a bug in the thinking rendering during streaming. The thinking text could stop updating mid-generation while the stream continued and the final answer appeared. The root cause was a missing flush of the pending `textThinkingBuffer` on stream termination (`emitDone`) combined with a `else if` in the throttle path that prevented symmetric flushing of thinking and content buffers.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
