### PR TITLE
Update Quarantine Manager: multi-target selection with one admin prompt

### DIFF
--- a/extensions/quarantine-manager/CHANGELOG.md
+++ b/extensions/quarantine-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quarantine Manager
 
-## [Multi-target selection] - {PR_MERGE_DATE}
+## [Multi-target selection] - 2026-06-16
 
 ### Fixed
 

--- a/extensions/quarantine-manager/CHANGELOG.md
+++ b/extensions/quarantine-manager/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Quarantine Manager
 
+## [Multi-target selection] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Removing quarantine from several apps no longer triggers a separate admin prompt per app. You can now select **multiple** files/apps/folders at once (in the picker or via the Finder selection); they're scanned into one list and cleared in a single pass with at most one admin prompt.
+
+### Added
+
+- The picker remembers your **last selection** and defaults to it, so re-checking the same folder is one keystroke (`⌘R` to re-scan).
+
+### Changed
+
+- The per-row Select/Deselect toggle moved from `⌘S` to `⌘↵`, matching Raycast's uninstall command.
+
 ## [Single command with batch select] - 2026-06-10
 
 ### Changed

--- a/extensions/quarantine-manager/README.md
+++ b/extensions/quarantine-manager/README.md
@@ -16,7 +16,7 @@ Developers and power users frequently need to check and clear this flag — for 
 
 ### Manage Quarantine
 
-A single command that does it all. Opens a file picker (or uses your current Finder selection), scans the target, and lets you inspect **and** clear quarantine from the same place — no switching commands.
+A single command that does it all. Opens a file picker (or uses your current Finder selection — including **multiple** items at once), scans the targets, and lets you inspect **and** clear quarantine from the same place — no switching commands. The picker remembers your **last selection**, so re-checking the same folder is one keystroke (`⌘R`).
 
 **What it shows:**
 
@@ -35,18 +35,19 @@ A single command that does it all. Opens a file picker (or uses your current Fin
 
 ### Apps & folders — select & batch-remove
 
-Point it at a directory and you get an uninstaller-style checklist:
+Point it at one or more directories/apps (or a mix of files and folders) and you get an uninstaller-style checklist:
 
 - **Apps (`.app`)** are scanned **recursively** — bundles often hold many internal quarantined files, and each one is listed.
 - **Plain folders** are scanned **one level deep** (immediate contents only), so large directories like Downloads stay fast.
+- **Select several apps at once** and they're scanned together into a single list.
 
-Every quarantined item is shown as a **selectable row** (all selected by default). Toggle individual files with `⌘S`, **Select All** `⌘⇧A` / **Deselect All** `⌘⇧D`, sort by path / source / date, then press **Enter** on **Remove Quarantine from Selected** to clear exactly the files you picked in one pass — or remove just one. The section header tracks `N of M selected`.
+Every quarantined item is shown as a **selectable row** (all selected by default). Toggle individual files with `⌘↵`, **Select All** `⌘⇧A` / **Deselect All** `⌘⇧D`, sort by path / source / date, then press **Enter** on **Remove Quarantine from Selected** to clear exactly the files you picked. The whole selection is cleared in **one pass with at most one admin prompt** — no per-app password dialogs. The section header tracks `N of M selected`.
 
 ---
 
 ## Tips
 
-- **Select a file in Finder first** — if you already have a file selected, the command skips the picker entirely and loads it immediately
+- **Select files in Finder first** — if you already have one or more items selected, the command skips the picker entirely and scans them immediately
 - **Protected files** — if the file requires elevated permissions, the extension will prompt for your admin password via a standard macOS dialog
 - **The xattr command** — use "Copy Remove Command" to get the terminal equivalent if you prefer to run it manually or use it in a script
 

--- a/extensions/quarantine-manager/src/manage-quarantine.tsx
+++ b/extensions/quarantine-manager/src/manage-quarantine.tsx
@@ -14,6 +14,7 @@ import {
 } from "@raycast/api";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  existingPaths,
   getFileName,
   getFinderSelections,
   getQuarantineStatus,
@@ -138,9 +139,12 @@ async function readLastSelection(): Promise<string[]> {
     const raw = await LocalStorage.getItem<string>(LAST_SELECTION_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed)
+    const strings = Array.isArray(parsed)
       ? parsed.filter((p): p is string => typeof p === "string")
       : [];
+    // Drop paths that have since moved/been deleted (mirrors getFinderSelections)
+    // so ghost paths never reach the picker default or "Re-scan Last Selection".
+    return existingPaths(strings);
   } catch {
     return [];
   }
@@ -362,8 +366,14 @@ export default function ManageQuarantine() {
         : "Scanning for quarantined files…",
     });
     try {
-      void LocalStorage.setItem(LAST_SELECTION_KEY, JSON.stringify(paths));
-      setLastSelection(paths);
+      // Best-effort persistence: keep in-memory and stored selection in sync,
+      // but never let a storage failure abort the scan.
+      try {
+        await LocalStorage.setItem(LAST_SELECTION_KEY, JSON.stringify(paths));
+        setLastSelection(paths);
+      } catch {
+        // ignore — last-selection memory is a convenience, not critical
+      }
 
       if (inspectingFile) {
         const status = getQuarantineStatus(paths[0]);

--- a/extensions/quarantine-manager/src/manage-quarantine.tsx
+++ b/extensions/quarantine-manager/src/manage-quarantine.tsx
@@ -8,13 +8,14 @@ import {
   Form,
   Icon,
   List,
+  LocalStorage,
   showToast,
   Toast,
 } from "@raycast/api";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  DirectoryScan,
-  getFinderSelection,
+  getFileName,
+  getFinderSelections,
   getQuarantineStatus,
   isDirectory,
   parseQuarantineData,
@@ -27,21 +28,122 @@ import {
   XattrInfo,
 } from "./utils";
 
+const LAST_SELECTION_KEY = "lastSelection";
+
 type State =
   | { type: "selecting" }
   | { type: "loading" }
   | { type: "ready"; status: QuarantineStatus }
-  | { type: "ready-dir"; scan: DirectoryScan }
+  | { type: "ready-group"; group: ScanGroup }
   | { type: "error"; message: string };
 
 type SortKey = "path" | "source" | "date";
 
-/** A single quarantined target inside a directory scan (the root or a child). */
+/** A single quarantined item — a directly-selected target or something inside one. */
 interface Target {
   path: string;
   title: string;
   quarantineData: string | null;
-  isRoot: boolean;
+  /** Directly selected (sorts to top, gets a kind tag) vs. found inside a scan */
+  isTopLevel: boolean;
+  /** Directory/bundle — controls recursive "remove all" and the kind tag */
+  isDir: boolean;
+  kindLabel: string;
+}
+
+/** The result of scanning one or more selected paths, flattened for multi-select. */
+interface ScanGroup {
+  /** The originally selected paths, used to re-scan after an action */
+  sources: string[];
+  targets: Target[];
+  scannedCount: number;
+  /** Short label for the navigation title (a name, or "N items") */
+  label: string;
+  /** Context line for the section header, e.g. "app · recursive scan" */
+  contextNote: string;
+  multiSource: boolean;
+}
+
+/**
+ * Scans every selected path and flattens the quarantined items into one list.
+ * Directories/apps are scanned (apps recursively); plain files contribute a
+ * single target when quarantined. Pure so it stays easy to reason about/test.
+ */
+function buildGroup(paths: string[]): ScanGroup {
+  const multiSource = paths.length > 1;
+  const targets: Target[] = [];
+  let scannedCount = 0;
+  let contextNote = multiSource ? `across ${paths.length} selected items` : "";
+
+  for (const p of paths) {
+    if (isDirectory(p)) {
+      const scan = scanDirectory(p);
+      scannedCount += scan.scannedCount;
+      if (!multiSource) {
+        contextNote = scan.isApp
+          ? "app · recursive scan"
+          : "folder · immediate contents only";
+      }
+      if (scan.rootQuarantineData) {
+        targets.push({
+          path: scan.path,
+          title: multiSource ? scan.name : `${scan.name} (itself)`,
+          quarantineData: scan.rootQuarantineData,
+          isTopLevel: true,
+          isDir: true,
+          kindLabel: scan.isApp ? "App" : "Folder",
+        });
+      }
+      for (const entry of scan.entries) {
+        targets.push({
+          path: entry.path,
+          title: multiSource
+            ? `${scan.name} › ${entry.relativePath}`
+            : entry.relativePath,
+          quarantineData: entry.quarantineData,
+          isTopLevel: false,
+          isDir: isDirectory(entry.path),
+          kindLabel: "File",
+        });
+      }
+    } else {
+      scannedCount += 1;
+      const status = getQuarantineStatus(p);
+      if (status.hasQuarantine) {
+        targets.push({
+          path: status.path,
+          title: status.name,
+          quarantineData: status.quarantineData,
+          isTopLevel: true,
+          isDir: false,
+          kindLabel: status.isApp ? "App" : "File",
+        });
+      }
+    }
+  }
+
+  return {
+    sources: paths,
+    targets,
+    scannedCount,
+    label: paths.length === 1 ? getFileName(paths[0]) : `${paths.length} items`,
+    contextNote,
+    multiSource,
+  };
+}
+
+/** Restores the last picked paths from storage (empty if none/invalid). */
+async function readLastSelection(): Promise<string[]> {
+  try {
+    const raw = await LocalStorage.getItem<string>(LAST_SELECTION_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((p): p is string => typeof p === "string")
+      : [];
+  } catch {
+    return [];
+  }
 }
 
 // ─── Detail view (inspecting a single attribute) ────────────────────────────
@@ -213,54 +315,69 @@ function AttributeDetail({
 
 export default function ManageQuarantine() {
   const [state, setState] = useState<State>({ type: "selecting" });
-  // Set of selected target paths (directory-scan multi-select).
+  // Set of selected target paths (multi-select removal).
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [sortKey, setSortKey] = useState<SortKey>("path");
+  // Last picked paths, restored from storage so the picker can default to them.
+  const [lastSelection, setLastSelection] = useState<string[]>([]);
   const didMount = useRef(false);
 
   useEffect(() => {
     if (didMount.current) return;
     didMount.current = true;
-    selectFile();
+    void (async () => {
+      const finder = getFinderSelections();
+      if (finder.length > 0) {
+        await loadFiles(finder);
+        return;
+      }
+      const stored = await readLastSelection();
+      setLastSelection(stored);
+      setState({ type: "selecting" });
+    })();
   }, []);
 
   function selectFile(forceDialog = false) {
     if (!forceDialog) {
-      const finderPath = getFinderSelection();
-      if (finderPath) {
-        void loadFile(finderPath);
+      const finder = getFinderSelections();
+      if (finder.length > 0) {
+        void loadFiles(finder);
         return;
       }
     }
     setState({ type: "selecting" });
   }
 
-  async function loadFile(filePath: string) {
+  async function loadFiles(paths: string[]) {
+    if (paths.length === 0) {
+      setState({ type: "selecting" });
+      return;
+    }
     setState({ type: "loading" });
-    const scanningDir = isDirectory(filePath);
+    const inspectingFile = paths.length === 1 && !isDirectory(paths[0]);
     const toast = await showToast({
       style: Toast.Style.Animated,
-      title: scanningDir
-        ? "Scanning for quarantined files…"
-        : "Reading attributes…",
+      title: inspectingFile
+        ? "Reading attributes…"
+        : "Scanning for quarantined files…",
     });
     try {
-      if (scanningDir) {
-        const scan = scanDirectory(filePath);
-        await toast.hide();
-        // Default to all quarantined targets selected (uninstaller behaviour).
-        const allPaths = [
-          ...(scan.rootQuarantineData ? [scan.path] : []),
-          ...scan.entries.map((e) => e.path),
-        ];
-        setSelected(new Set(allPaths));
-        setState({ type: "ready-dir", scan });
-      } else {
-        const status = getQuarantineStatus(filePath);
+      void LocalStorage.setItem(LAST_SELECTION_KEY, JSON.stringify(paths));
+      setLastSelection(paths);
+
+      if (inspectingFile) {
+        const status = getQuarantineStatus(paths[0]);
         await toast.hide();
         setSelected(new Set());
         setState({ type: "ready", status });
+        return;
       }
+
+      const group = buildGroup(paths);
+      await toast.hide();
+      // Default to all quarantined targets selected (uninstaller behaviour).
+      setSelected(new Set(group.targets.map((t) => t.path)));
+      setState({ type: "ready-group", group });
     } catch (err) {
       await toast.hide();
       const message = err instanceof Error ? err.message : String(err);
@@ -270,7 +387,7 @@ export default function ManageQuarantine() {
 
   // ─── Removal handlers ─────────────────────────────────────────────────────
 
-  async function handleRemoveSelected(targets: Target[], scanPath: string) {
+  async function handleRemoveSelected(targets: Target[], sources: string[]) {
     const paths = targets
       .filter((t) => selected.has(t.path))
       .map((t) => t.path);
@@ -305,7 +422,7 @@ export default function ManageQuarantine() {
           ? `${paths.length} item${paths.length !== 1 ? "s" : ""} (required admin)`
           : `${paths.length} item${paths.length !== 1 ? "s" : ""}`,
       });
-      void loadFile(scanPath);
+      void loadFiles(sources);
     } else {
       await showToast({
         style: Toast.Style.Failure,
@@ -315,7 +432,7 @@ export default function ManageQuarantine() {
     }
   }
 
-  async function handleRemoveOne(target: Target, scanPath: string) {
+  async function handleRemoveOne(target: Target, sources: string[]) {
     const confirmed = await confirmAlert({
       title: "Remove Quarantine",
       message: `Remove the quarantine flag from "${target.title}"?`,
@@ -338,7 +455,7 @@ export default function ManageQuarantine() {
           ? `${target.title} (required admin)`
           : target.title,
       });
-      void loadFile(scanPath);
+      void loadFiles(sources);
     } else {
       await showToast({
         style: Toast.Style.Failure,
@@ -371,7 +488,7 @@ export default function ManageQuarantine() {
           ? `${status.name} (required admin)`
           : status.name,
       });
-      void loadFile(status.path);
+      void loadFiles([status.path]);
     } else {
       await showToast({
         style: Toast.Style.Failure,
@@ -385,6 +502,7 @@ export default function ManageQuarantine() {
     filePath: string,
     name: string,
     recursive: boolean,
+    sources: string[],
   ) {
     const confirmed = await confirmAlert({
       title: recursive
@@ -411,7 +529,7 @@ export default function ManageQuarantine() {
         title: "All attributes removed",
         message: name,
       });
-      void loadFile(filePath);
+      void loadFiles(sources);
     } else {
       await showToast({
         style: Toast.Style.Failure,
@@ -451,20 +569,29 @@ export default function ManageQuarantine() {
         actions={
           <ActionPanel>
             <Action.SubmitForm
-              title="Inspect File"
+              title="Scan Selection"
               icon={Icon.Eye}
               onSubmit={(values: { file: string[] }) => {
-                if (values.file?.[0]) void loadFile(values.file[0]);
+                if (values.file?.length) void loadFiles(values.file);
               }}
             />
+            {lastSelection.length > 0 && (
+              <Action
+                title={`Re-scan Last Selection (${lastSelection.length})`}
+                icon={Icon.Clock}
+                shortcut={{ modifiers: ["cmd"], key: "r" }}
+                onAction={() => void loadFiles(lastSelection)}
+              />
+            )}
           </ActionPanel>
         }
       >
         <Form.FilePicker
           id="file"
-          title="File or App"
-          allowMultipleSelection={false}
+          title="Files, Apps, or Folders"
+          allowMultipleSelection={true}
           canChooseDirectories={true}
+          defaultValue={lastSelection}
         />
       </Form>
     );
@@ -489,12 +616,12 @@ export default function ManageQuarantine() {
     );
   }
 
-  // ─── Directory scan state (multi-select list) ─────────────────────────────
+  // ─── Grouped scan state (multi-select list) ───────────────────────────────
 
-  if (state.type === "ready-dir") {
+  if (state.type === "ready-group") {
     return (
-      <DirectoryList
-        scan={state.scan}
+      <SelectionList
+        group={state.group}
         selected={selected}
         sortKey={sortKey}
         onSortChange={setSortKey}
@@ -564,7 +691,9 @@ export default function ManageQuarantine() {
                       title="Remove All Attributes"
                       icon={{ source: Icon.Trash, tintColor: Color.Orange }}
                       onAction={() =>
-                        handleRemoveAll(status.path, status.name, false)
+                        handleRemoveAll(status.path, status.name, false, [
+                          status.path,
+                        ])
                       }
                     />
                   )}
@@ -688,8 +817,8 @@ export default function ManageQuarantine() {
 
 // ─── Directory multi-select list ────────────────────────────────────────────
 
-function DirectoryList({
-  scan,
+function SelectionList({
+  group,
   selected,
   sortKey,
   onSortChange,
@@ -700,44 +829,26 @@ function DirectoryList({
   onRemoveAll,
   onSelectDifferent,
 }: {
-  scan: DirectoryScan;
+  group: ScanGroup;
   selected: Set<string>;
   sortKey: SortKey;
   onSortChange: (key: SortKey) => void;
   onToggle: (path: string) => void;
   onSetAll: (paths: string[], on: boolean) => void;
-  onRemoveSelected: (targets: Target[], scanPath: string) => void;
-  onRemoveOne: (target: Target, scanPath: string) => void;
-  onRemoveAll: (filePath: string, name: string, recursive: boolean) => void;
+  onRemoveSelected: (targets: Target[], sources: string[]) => void;
+  onRemoveOne: (target: Target, sources: string[]) => void;
+  onRemoveAll: (
+    filePath: string,
+    name: string,
+    recursive: boolean,
+    sources: string[],
+  ) => void;
   onSelectDifferent: () => void;
 }) {
-  const kind = scan.isApp ? "app" : "folder";
-  const scopeNote =
-    scan.scanMode === "recursive"
-      ? "recursive scan"
-      : "immediate contents only";
-
-  // Flatten the root (if quarantined) + child entries into one target list.
-  const targets = useMemo<Target[]>(() => {
-    const list: Target[] = [];
-    if (scan.rootQuarantineData) {
-      list.push({
-        path: scan.path,
-        title: `${scan.name} (itself)`,
-        quarantineData: scan.rootQuarantineData,
-        isRoot: true,
-      });
-    }
-    for (const entry of scan.entries) {
-      list.push({
-        path: entry.path,
-        title: entry.relativePath,
-        quarantineData: entry.quarantineData,
-        isRoot: false,
-      });
-    }
-    return sortTargets(list, sortKey);
-  }, [scan, sortKey]);
+  const targets = useMemo<Target[]>(
+    () => sortTargets(group.targets, sortKey),
+    [group, sortKey],
+  );
 
   const allPaths = targets.map((t) => t.path);
   const selectedCount = allPaths.filter((p) => selected.has(p)).length;
@@ -747,8 +858,12 @@ function DirectoryList({
     return (
       <List searchBarPlaceholder="Filter quarantined items…">
         <List.EmptyView
-          title={`No quarantine found in this ${kind}`}
-          description={cleanScanSummary(scan)}
+          title={
+            group.multiSource
+              ? "No quarantine found in the selection"
+              : `No quarantine found in ${group.label}`
+          }
+          description={cleanGroupSummary(group)}
           icon={{ source: Icon.Checkmark, tintColor: Color.Green }}
           actions={
             <ActionPanel>
@@ -766,8 +881,8 @@ function DirectoryList({
 
   return (
     <List
-      navigationTitle={scan.name}
-      searchBarPlaceholder={`Filter quarantined items in ${scan.name}…`}
+      navigationTitle={group.label}
+      searchBarPlaceholder={`Filter quarantined items in ${group.label}…`}
       searchBarAccessory={
         <List.Dropdown
           tooltip="Sort by"
@@ -781,7 +896,7 @@ function DirectoryList({
       }
     >
       <List.Section
-        title={`${selectedCount} of ${total} selected · ${kind} · ${scopeNote}`}
+        title={`${selectedCount} of ${total} selected · ${group.contextNote}`}
       >
         {targets.map((target) => {
           const isSelected = selected.has(target.path);
@@ -797,11 +912,11 @@ function DirectoryList({
               }
               icon={{ source: Icon.Lock, tintColor: Color.Red }}
               accessories={[
-                ...(target.isRoot
+                ...(target.isTopLevel
                   ? [
                       {
                         tag: {
-                          value: scan.isApp ? "Bundle" : "Folder",
+                          value: target.kindLabel,
                           color: Color.Orange,
                         },
                       },
@@ -819,12 +934,12 @@ function DirectoryList({
                   <Action
                     title={`Remove Quarantine from Selected (${selectedCount})`}
                     icon={{ source: Icon.LockUnlocked, tintColor: Color.Green }}
-                    onAction={() => onRemoveSelected(targets, scan.path)}
+                    onAction={() => onRemoveSelected(targets, group.sources)}
                   />
                   <Action
                     title={isSelected ? "Deselect" : "Select"}
                     icon={isSelected ? Icon.Circle : Icon.CheckCircle}
-                    shortcut={{ modifiers: ["cmd"], key: "s" }}
+                    shortcut={{ modifiers: ["cmd"], key: "return" }}
                     onAction={() => onToggle(target.path)}
                   />
                   <ActionPanel.Section>
@@ -859,17 +974,22 @@ function DirectoryList({
                         source: Icon.LockUnlocked,
                         tintColor: Color.Green,
                       }}
-                      onAction={() => onRemoveOne(target, scan.path)}
+                      onAction={() => onRemoveOne(target, group.sources)}
                     />
                     <Action
                       title={
-                        target.isRoot
+                        target.isDir
                           ? "Remove All Attributes (recursive)"
                           : "Remove All Attributes"
                       }
                       icon={{ source: Icon.Trash, tintColor: Color.Orange }}
                       onAction={() =>
-                        onRemoveAll(target.path, target.title, target.isRoot)
+                        onRemoveAll(
+                          target.path,
+                          target.title,
+                          target.isDir,
+                          group.sources,
+                        )
                       }
                     />
                   </ActionPanel.Section>
@@ -901,22 +1021,21 @@ function DirectoryList({
   );
 }
 
-/** One-line scope summary shown when a directory scan finds nothing quarantined. */
-function cleanScanSummary(scan: DirectoryScan): string {
-  const n = scan.scannedCount;
+/** One-line scope summary shown when a scan finds nothing quarantined. */
+function cleanGroupSummary(group: ScanGroup): string {
+  const n = group.scannedCount;
   const items = `${n} item${n !== 1 ? "s" : ""}`;
-  const scope =
-    scan.scanMode === "shallow"
-      ? `${items} (immediate contents only)`
-      : `${items} in the bundle`;
+  const scope = group.multiSource
+    ? `${items} across ${group.sources.length} selected`
+    : `${items} (${group.contextNote})`;
   return `Scanned ${scope} · 0 quarantined`;
 }
 
 function sortTargets(targets: Target[], key: SortKey): Target[] {
   const sorted = [...targets];
   sorted.sort((a, b) => {
-    // The directory/bundle itself always stays on top.
-    if (a.isRoot !== b.isRoot) return a.isRoot ? -1 : 1;
+    // Directly-selected items (apps/folders/files) always stay on top.
+    if (a.isTopLevel !== b.isTopLevel) return a.isTopLevel ? -1 : 1;
     if (key === "path") {
       return a.title.localeCompare(b.title);
     }

--- a/extensions/quarantine-manager/src/utils.ts
+++ b/extensions/quarantine-manager/src/utils.ts
@@ -327,30 +327,35 @@ export function removeAllAttributes(
 }
 
 /**
- * Returns the currently selected file in Finder, or null if nothing is selected.
- * Uses spawnSync to avoid blocking React's event loop.
+ * Returns every item currently selected in Finder (empty if nothing is selected).
+ * Uses spawnSync to avoid blocking React's event loop. One POSIX path per line.
  */
-export function getFinderSelection(): string | null {
+export function getFinderSelections(): string[] {
   const result = spawnSync(
     "osascript",
     [
       "-e",
       `tell application "Finder"`,
       "-e",
-      `set sel to selection`,
+      `set out to ""`,
       "-e",
-      `if (count of sel) > 0 then return POSIX path of (item 1 of sel as alias)`,
+      `repeat with anItem in (get selection)`,
+      "-e",
+      `set out to out & POSIX path of (anItem as alias) & linefeed`,
+      "-e",
+      `end repeat`,
+      "-e",
+      `return out`,
       "-e",
       `end tell`,
     ],
     { encoding: "utf8", timeout: 5000 },
   );
 
-  const selected = (result.stdout ?? "").trim();
-  if (selected.length > 0 && fs.existsSync(selected)) {
-    return selected;
-  }
-  return null;
+  return (result.stdout ?? "")
+    .split("\n")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0 && fs.existsSync(p));
 }
 
 export interface ParsedQuarantine {

--- a/extensions/quarantine-manager/src/utils.ts
+++ b/extensions/quarantine-manager/src/utils.ts
@@ -358,6 +358,11 @@ export function getFinderSelections(): string[] {
     .filter((p) => p.length > 0 && fs.existsSync(p));
 }
 
+/** Keeps only the paths that still exist on disk. */
+export function existingPaths(paths: string[]): string[] {
+  return paths.filter((p) => fs.existsSync(p));
+}
+
 export interface ParsedQuarantine {
   source: string;
   date: string;


### PR DESCRIPTION
## Description

Update to the existing **Quarantine Manager** extension, addressing follow-up feedback on the previous update ([#28685](https://github.com/raycast/extensions/pull/28685)).

### What's new

- **Fix: clearing several apps no longer prompts for admin once per app.** The picker and the Finder selection now accept **multiple** files/apps/folders at once. They're scanned into a single combined multi-select list, and the chosen items are cleared in one pass via the existing batched `removeQuarantineFromPaths` — **at most one admin prompt** for the whole selection, instead of one per app.
- **Remember last selection.** The last picked paths are stored (`LocalStorage`) and the picker defaults to them, with a `⌘R` *Re-scan Last Selection* action — re-checking the same folder is one keystroke.
- **Toggle shortcut moved `⌘S` → `⌘↵`** to match Raycast's uninstall command (Enter remains the primary *Remove Quarantine from Selected*).

Single-file inspection and per-item actions are unchanged. The multi-target scan flattens each selected app/folder (apps recursively, folders one level deep) plus any selected files into one list; directly-selected items sort to the top with an App/Folder/File tag.

Resolves the follow-up feedback in [#28685](https://github.com/raycast/extensions/pull/28685) (cc @texastoland).

## Screencast

Tested locally via `npm run dev` (and a `npm run build` distribution build) in Raycast:
- **Multiple apps** selected at once → one combined list of every quarantined item across them; *Remove Quarantine from Selected* clears all in a single pass. Verified against two `.app` bundles (with internal quarantined files) that the whole set is cleared in one operation.
- **Re-scan Last Selection** (`⌘R`) re-loads the previously picked paths.
- Single file / single folder behavior unchanged.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
