### PR TITLE
World Cup: add menu bar and live score commands

### DIFF
--- a/extensions/world-cup/CHANGELOG.md
+++ b/extensions/world-cup/CHANGELOG.md
@@ -1,5 +1,10 @@
 # World Cup Changelog
 
+## [Menu Bar & Live Score] - {PR_MERGE_DATE}
+
+- Added a **World Cup Menu Bar** command showing the live score in the menu bar with a dropdown of every fixture, and a quick toggle to mute goal alerts
+- Added a **World Cup Live Score** background command that keeps the live score under the command name and posts a HUD when a goal is scored (celebratory, or commiserating if it's against your team)
+
 ## [Update for FIFA World Cup 2026] - 2026-05-26
 
 - Updated season and match count for the 2026 World Cup (48 teams, 104 matches)

--- a/extensions/world-cup/CHANGELOG.md
+++ b/extensions/world-cup/CHANGELOG.md
@@ -1,6 +1,6 @@
 # World Cup Changelog
 
-## [Menu Bar & Live Score] - {PR_MERGE_DATE}
+## [Menu Bar & Live Score] - 2026-06-17
 
 - Added a **World Cup Menu Bar** command showing the live score in the menu bar with a dropdown of every fixture, and a quick toggle to mute goal alerts
 - Added a **World Cup Live Score** background command that keeps the live score under the command name and posts a HUD when a goal is scored (celebratory, or commiserating if it's against your team)

--- a/extensions/world-cup/package-lock.json
+++ b/extensions/world-cup/package-lock.json
@@ -1187,7 +1187,6 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1237,7 +1236,6 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -1442,7 +1440,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1763,7 +1760,6 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2488,7 +2484,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2512,7 +2507,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2700,7 +2694,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3443,7 +3436,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -3478,7 +3470,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -3585,8 +3576,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -3791,7 +3781,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4257,8 +4246,7 @@
     "picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "peer": true
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -4270,8 +4258,7 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "punycode": {
       "version": "2.3.1",
@@ -4379,8 +4366,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "typescript-eslint": {
       "version": "8.60.0",

--- a/extensions/world-cup/package.json
+++ b/extensions/world-cup/package.json
@@ -7,7 +7,8 @@
   "author": "isma",
   "contributors": [
     "djpowers",
-    "pernielsentikaer"
+    "pernielsentikaer",
+    "brunocbreis"
   ],
   "categories": [
     "News",
@@ -21,6 +22,84 @@
       "subtitle": "FIFA World Cup",
       "description": "See all matches calendar and results",
       "mode": "view"
+    },
+    {
+      "name": "menubar",
+      "title": "World Cup Menu Bar",
+      "subtitle": "FIFA World Cup",
+      "description": "Shows the live match score in the menu bar with a dropdown of every fixture",
+      "mode": "menu-bar",
+      "interval": "1m"
+    },
+    {
+      "name": "score-subtitle",
+      "title": "World Cup Live Score",
+      "subtitle": "FIFA World Cup",
+      "description": "Shows the live score under the command name, and alerts you when a goal is scored",
+      "mode": "no-view",
+      "interval": "1m",
+      "preferences": [
+        {
+          "name": "country",
+          "title": "Your Country",
+          "description": "Goals are celebratory (⚽🎉) unless scored against this team (⚽😭)",
+          "type": "dropdown",
+          "required": false,
+          "default": "",
+          "data": [
+            { "title": "None", "value": "" },
+            { "title": "Argentina", "value": "ARG" },
+            { "title": "Australia", "value": "AUS" },
+            { "title": "Austria", "value": "AUT" },
+            { "title": "Belgium", "value": "BEL" },
+            { "title": "Brazil", "value": "BRA" },
+            { "title": "Canada", "value": "CAN" },
+            { "title": "Cape Verde", "value": "CPV" },
+            { "title": "Chile", "value": "CHI" },
+            { "title": "Colombia", "value": "COL" },
+            { "title": "Costa Rica", "value": "CRC" },
+            { "title": "Croatia", "value": "CRO" },
+            { "title": "Côte d'Ivoire", "value": "CIV" },
+            { "title": "Czechia", "value": "CZE" },
+            { "title": "Denmark", "value": "DEN" },
+            { "title": "Ecuador", "value": "ECU" },
+            { "title": "Egypt", "value": "EGY" },
+            { "title": "England", "value": "ENG" },
+            { "title": "France", "value": "FRA" },
+            { "title": "Germany", "value": "GER" },
+            { "title": "Ghana", "value": "GHA" },
+            { "title": "Iran", "value": "IRN" },
+            { "title": "Italy", "value": "ITA" },
+            { "title": "Japan", "value": "JPN" },
+            { "title": "Jordan", "value": "JOR" },
+            { "title": "Mexico", "value": "MEX" },
+            { "title": "Morocco", "value": "MAR" },
+            { "title": "Netherlands", "value": "NED" },
+            { "title": "New Zealand", "value": "NZL" },
+            { "title": "Nigeria", "value": "NGA" },
+            { "title": "Norway", "value": "NOR" },
+            { "title": "Panama", "value": "PAN" },
+            { "title": "Paraguay", "value": "PAR" },
+            { "title": "Peru", "value": "PER" },
+            { "title": "Poland", "value": "POL" },
+            { "title": "Portugal", "value": "POR" },
+            { "title": "Qatar", "value": "QAT" },
+            { "title": "Saudi Arabia", "value": "KSA" },
+            { "title": "Scotland", "value": "SCO" },
+            { "title": "Senegal", "value": "SEN" },
+            { "title": "Serbia", "value": "SRB" },
+            { "title": "South Africa", "value": "RSA" },
+            { "title": "South Korea", "value": "KOR" },
+            { "title": "Spain", "value": "ESP" },
+            { "title": "Switzerland", "value": "SUI" },
+            { "title": "Tunisia", "value": "TUN" },
+            { "title": "United States", "value": "USA" },
+            { "title": "Uruguay", "value": "URU" },
+            { "title": "Uzbekistan", "value": "UZB" },
+            { "title": "Wales", "value": "WAL" }
+          ]
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/extensions/world-cup/src/lib/worldcup.ts
+++ b/extensions/world-cup/src/lib/worldcup.ts
@@ -1,0 +1,115 @@
+import { LocalStorage } from "@raycast/api";
+import fetch from "cross-fetch";
+import flags from "../flags";
+
+const ENDPOINT = "https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard";
+
+const GOALS_KEY = "goalsEnabled";
+
+/** Flag emoji for a FIFA tricode, falling back to ⚽ for anything unmapped. */
+function flag(tricode: string): string {
+  return flags[tricode?.toUpperCase()] ?? "⚽";
+}
+
+/** Whether goal notifications are on. Defaults to true until the user toggles it off. */
+export async function goalsEnabled(): Promise<boolean> {
+  const v = await LocalStorage.getItem<string>(GOALS_KEY);
+  return v == null ? true : v === "true";
+}
+
+export async function setGoalsEnabled(on: boolean): Promise<void> {
+  await LocalStorage.setItem(GOALS_KEY, String(on));
+}
+
+export type MatchState = "pre" | "in" | "post";
+
+export interface Match {
+  id: string;
+  home: string; // abbreviation, e.g. "ESP"
+  away: string;
+  homeName: string; // full name, e.g. "Spain"
+  awayName: string;
+  homeScore: string;
+  awayScore: string;
+  state: MatchState;
+  /** Short status: "25'", "HT", "FT", "45'+2'" */
+  detail: string;
+  /** ISO kickoff time, useful for pre-match items */
+  date: string;
+}
+
+/**
+ * HUD string for a goal. Celebratory ⚽🎉 by default, but ⚽😭 when the goal is
+ * scored against the user's country (their team is playing and the *other* side scored).
+ */
+export function goalHud(m: Match, scorerCode: string, country: string): string {
+  const involvesMe = !!country && (m.home === country || m.away === country);
+  const against = involvesMe && scorerCode !== country;
+  const mark = against ? "😭" : "🎉";
+  // No score — that's already in the menu bar. Kept punchy since the HUD only
+  // shows for ~1.5s.
+  return `⚽ ${flag(scorerCode)} GOAL!!! ${flag(scorerCode)} ${mark}`;
+}
+
+export async function getMatches(): Promise<Match[]> {
+  const res = await fetch(ENDPOINT);
+  if (!res.ok) throw new Error(`ESPN responded ${res.status}`);
+  const data = (await res.json()) as { events?: EspnEvent[] };
+
+  return (data.events ?? []).map((e) => {
+    const c = e.competitions[0];
+    const home = c.competitors.find((t) => t.homeAway === "home") ?? c.competitors[0];
+    const away = c.competitors.find((t) => t.homeAway === "away") ?? c.competitors[1];
+    return {
+      id: e.id,
+      home: home.team.abbreviation,
+      away: away.team.abbreviation,
+      homeName: home.team.displayName,
+      awayName: away.team.displayName,
+      homeScore: home.score ?? "0",
+      awayScore: away.score ?? "0",
+      state: c.status.type.state,
+      detail: c.status.type.shortDetail,
+      date: e.date,
+    };
+  });
+}
+
+/** The currently in-progress match, if any. */
+export function liveMatch(matches: Match[]): Match | undefined {
+  return matches.find((m) => m.state === "in");
+}
+
+/** Dropdown/subtitle line: "🇨🇻 CPV 0–1 ESP 🇪🇸 · 67'" */
+export function formatLine(m: Match): string {
+  const a = `${flag(m.away)} ${m.away}`;
+  const h = `${m.home} ${flag(m.home)}`;
+  if (m.state === "pre") return `${a} v ${h} · ${kickoff(m.date)}`;
+  return `${a} ${m.awayScore}–${m.homeScore} ${h} · ${m.detail}`;
+}
+
+/** Compact menu-bar title — just flags and the score: "🇨🇻 0–1 🇪🇸" */
+export function menuBarTitle(m: Match): string {
+  return `${flag(m.away)} ${m.awayScore}–${m.homeScore} ${flag(m.home)}`;
+}
+
+function kickoff(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+// --- ESPN response shapes (only the fields we read) ---
+interface EspnEvent {
+  id: string;
+  date: string;
+  competitions: {
+    status: { type: { state: MatchState; shortDetail: string } };
+    competitors: {
+      homeAway: "home" | "away";
+      score?: string;
+      team: { abbreviation: string; displayName: string };
+    }[];
+  }[];
+}

--- a/extensions/world-cup/src/lib/worldcup.ts
+++ b/extensions/world-cup/src/lib/worldcup.ts
@@ -1,5 +1,4 @@
 import { LocalStorage } from "@raycast/api";
-import fetch from "cross-fetch";
 import flags from "../flags";
 
 const ENDPOINT = "https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard";

--- a/extensions/world-cup/src/menubar.tsx
+++ b/extensions/world-cup/src/menubar.tsx
@@ -19,7 +19,7 @@ export default function Command() {
 
   // Cache the mute flag so the last known value paints instantly — no "goals
   // on" flash before the async read settles.
-  const { data: goals, mutate: mutateGoals } = useCachedPromise(goalsEnabled);
+  const { data: goals = true, mutate: mutateGoals } = useCachedPromise(goalsEnabled);
 
   const live = liveMatch(matches);
   const title = live ? menuBarTitle(live) : undefined;

--- a/extensions/world-cup/src/menubar.tsx
+++ b/extensions/world-cup/src/menubar.tsx
@@ -1,0 +1,72 @@
+import { MenuBarExtra, open, openCommandPreferences, showHUD } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import {
+  getMatches,
+  liveMatch,
+  formatLine,
+  menuBarTitle,
+  goalsEnabled,
+  setGoalsEnabled,
+  type Match,
+} from "./lib/worldcup";
+
+const SCOREBOARD_URL = "https://www.espn.com/soccer/scoreboard";
+
+export default function Command() {
+  // useCachedPromise paints the last known scores instantly on cold start,
+  // then revalidates against ESPN.
+  const { data: matches = [], isLoading } = useCachedPromise(getMatches);
+
+  // Cache the mute flag so the last known value paints instantly — no "goals
+  // on" flash before the async read settles.
+  const { data: goals, mutate: mutateGoals } = useCachedPromise(goalsEnabled);
+
+  const live = liveMatch(matches);
+  const title = live ? menuBarTitle(live) : undefined;
+
+  async function toggleGoals() {
+    const next = !goals;
+    await mutateGoals(setGoalsEnabled(next), { optimisticUpdate: () => next });
+    // The menu closes on click, so confirm the new state with a HUD.
+    await showHUD(next ? "🔔 Goal alerts on" : "🔕 Goal alerts muted");
+  }
+
+  return (
+    <MenuBarExtra icon={live ? undefined : "⚽"} title={title} isLoading={isLoading} tooltip="World Cup">
+      {matches.length === 0 && <MenuBarExtra.Item title="No fixtures today" />}
+
+      <Section heading="Live" matches={matches.filter((m) => m.state === "in")} />
+      <Section heading="Upcoming" matches={matches.filter((m) => m.state === "pre")} />
+      <Section heading="Finished" matches={matches.filter((m) => m.state === "post")} />
+
+      <MenuBarExtra.Section>
+        <MenuBarExtra.Item
+          icon={goals ? "🔕" : "🔔"}
+          title={goals ? "Mute Goal Alerts" : "Unmute Goal Alerts"}
+          onAction={toggleGoals}
+        />
+        <MenuBarExtra.Item
+          title="Open ESPN Scoreboard"
+          shortcut={{ modifiers: ["cmd"], key: "o" }}
+          onAction={() => open(SCOREBOARD_URL)}
+        />
+        <MenuBarExtra.Item
+          title="Configure…"
+          shortcut={{ modifiers: ["cmd"], key: "," }}
+          onAction={openCommandPreferences}
+        />
+      </MenuBarExtra.Section>
+    </MenuBarExtra>
+  );
+}
+
+function Section({ heading, matches }: { heading: string; matches: Match[] }) {
+  if (matches.length === 0) return null;
+  return (
+    <MenuBarExtra.Section title={heading}>
+      {matches.map((m) => (
+        <MenuBarExtra.Item key={m.id} title={formatLine(m)} onAction={() => open(SCOREBOARD_URL)} />
+      ))}
+    </MenuBarExtra.Section>
+  );
+}

--- a/extensions/world-cup/src/score-subtitle.ts
+++ b/extensions/world-cup/src/score-subtitle.ts
@@ -1,0 +1,48 @@
+import { updateCommandMetadata, LocalStorage, showHUD, getPreferenceValues } from "@raycast/api";
+import { getMatches, liveMatch, formatLine, goalsEnabled, goalHud, type Match } from "./lib/worldcup";
+
+const STORE_KEY = "scores";
+type ScoreMap = Record<string, { h: number; a: number }>;
+
+/**
+ * No-view background command (interval: "1m"). Two jobs:
+ *   1. Rewrite its own subtitle so the live score shows under the command name.
+ *   2. Diff the score against the last run and post a goal notification.
+ */
+export default async function Command() {
+  const enabled = await goalsEnabled();
+  const matches = await getMatches();
+
+  // 1. Subtitle
+  const live = liveMatch(matches);
+  const next = matches.find((m) => m.state === "pre");
+  const subtitle = live ? formatLine(live) : next ? `Next: ${formatLine(next)}` : "No live match";
+  await updateCommandMetadata({ subtitle });
+
+  // 2. Goal detection
+  const prev = JSON.parse((await LocalStorage.getItem<string>(STORE_KEY)) ?? "{}") as ScoreMap;
+  const current: ScoreMap = {};
+  const country = getPreferenceValues<Preferences.ScoreSubtitle>().country ?? "";
+
+  for (const m of matches) {
+    if (m.state === "pre") continue; // nothing to diff before kickoff
+    const a = Number(m.awayScore);
+    const h = Number(m.homeScore);
+    current[m.id] = { a, h };
+
+    const was = prev[m.id];
+    if (!was || !enabled) continue; // skip first sighting to avoid a flood
+
+    if (a > was.a) await notifyGoal(m, "away", country);
+    if (h > was.h) await notifyGoal(m, "home", country);
+  }
+
+  await LocalStorage.setItem(STORE_KEY, JSON.stringify(current));
+}
+
+async function notifyGoal(m: Match, side: "home" | "away", country: string) {
+  const scorerCode = side === "home" ? m.home : m.away;
+  // showHUD is the store-safe way to surface a background event: a brief overlay
+  // that appears even when Raycast isn't focused, no external binary required.
+  await showHUD(goalHud(m, scorerCode, country));
+}


### PR DESCRIPTION
## Description

Adds two commands to the existing **FIFA World Cup 2026™** extension (`isma`), contributing to it rather than shipping a separate extension:

- **World Cup Menu Bar** (`menu-bar`) — shows the live match score in the macOS menu bar with a dropdown of every fixture (live / upcoming / finished), plus a one-click toggle to mute goal alerts and shortcuts to open the ESPN scoreboard.
- **World Cup Live Score** (`no-view`, 1-min interval) — keeps the live score under the command name and posts a HUD when a goal is scored. The HUD is celebratory (⚽🎉) by default, or commiserating (⚽😭) when the goal is against the team set in the per-command **Your Country** preference.

Both commands are self-contained under `src/lib/` and reuse the extension's existing `flags` map, so the existing **Matches** command is untouched. Data comes from the same ESPN `fifa.world` scoreboard endpoint.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] `npm run build` and `npm run lint` pass
- [x] I added a CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)