### PR TITLE
Add stefan.imbesi to package.json contributors

### DIFF
--- a/extensions/qrcode-generator/CHANGELOG.md
+++ b/extensions/qrcode-generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # QR Code Generator Changelog
 
+## [Add contributor] - {PR_MERGE_DATE}
+
+- Added stefan.imbesi to the contributors list
+
 ## [Custom colors, distinct icons, link shortening & UTM] - 2026-06-07
 
 - Fixed error toasts showing "[object Object]" instead of the actual error message (#27569)

--- a/extensions/qrcode-generator/CHANGELOG.md
+++ b/extensions/qrcode-generator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # QR Code Generator Changelog
 
-## [Add contributor] - {PR_MERGE_DATE}
+## [Add contributor] - 2026-06-16
 
 - Added stefan.imbesi to the contributors list
 

--- a/extensions/qrcode-generator/package.json
+++ b/extensions/qrcode-generator/package.json
@@ -13,7 +13,7 @@
     "MatteoGauthier",
     "seewhy",
     "ridemountainpig",
-    "dangkhoipro"
+    "dangkhoipro",
     "stefan.imbesi"
   ],
   "license": "MIT",

--- a/extensions/qrcode-generator/package.json
+++ b/extensions/qrcode-generator/package.json
@@ -14,6 +14,7 @@
     "seewhy",
     "ridemountainpig",
     "dangkhoipro"
+    "stefan.imbesi"
   ],
   "license": "MIT",
   "commands": [


### PR DESCRIPTION
Adds my Raycast username (`stefan.imbesi`) to the `contributors` array for the QR Code Generator extension. I contributed the recent bug fix and features in #28599 but missed adding myself to the contributors list, so I'm not currently credited on the store page — this adds it.