### PR TITLE
Update translate extension

### DIFF
--- a/extensions/google-translate/CHANGELOG.md
+++ b/extensions/google-translate/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Translate Changelog
 
-## [Feature] - {PR_MERGE_DATE}
+## [Feature] - 2026-06-18
 
 - Added preferences for "Translate from" (source), "Primary Language" (target), and "Secondary Language" (fallback target)
 - Added automatic swap to the secondary target language if the detected source language matches the primary target language

--- a/extensions/google-translate/CHANGELOG.md
+++ b/extensions/google-translate/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Google Translate Changelog
 
+## [Feature] - {PR_MERGE_DATE}
+
+- Added preferences for "Translate from" (source), "Primary Language" (target), and "Secondary Language" (fallback target)
+- Added automatic swap to the secondary target language if the detected source language matches the primary target language
+- Prioritized cross-language translations over same-language translations in both the Translate and Quick Translate screens
+
 ## [Security Maintenance] - 2026-05-21
 
 - Updated the extension to address security advisories.

--- a/extensions/google-translate/package.json
+++ b/extensions/google-translate/package.json
@@ -72,8 +72,8 @@
   ],
   "preferences": [
     {
-      "name": "lang1",
-      "title": "Primary Language",
+      "name": "langFrom",
+      "title": "Translate from",
       "description": "Preferred language to translate from",
       "required": true,
       "type": "dropdown",
@@ -1082,9 +1082,1019 @@
       ]
     },
     {
+      "name": "lang1",
+      "title": "Primary Language",
+      "description": "Preferred primary language to translate to",
+      "required": true,
+      "type": "dropdown",
+      "default": "en",
+      "data": [
+        {
+          "title": "Auto-Detect",
+          "value": "auto"
+        },
+        {
+          "title": "Abkhaz",
+          "value": "ab"
+        },
+        {
+          "title": "Acehnese",
+          "value": "ace"
+        },
+        {
+          "title": "Acholi",
+          "value": "ach"
+        },
+        {
+          "title": "Afar",
+          "value": "aa"
+        },
+        {
+          "title": "Afrikaans",
+          "value": "af"
+        },
+        {
+          "title": "Albanian",
+          "value": "sq"
+        },
+        {
+          "title": "Alur",
+          "value": "alz"
+        },
+        {
+          "title": "Amharic",
+          "value": "am"
+        },
+        {
+          "title": "Arabic",
+          "value": "ar"
+        },
+        {
+          "title": "Armenian",
+          "value": "hy"
+        },
+        {
+          "title": "Assamese",
+          "value": "as"
+        },
+        {
+          "title": "Avar",
+          "value": "av"
+        },
+        {
+          "title": "Awadhi",
+          "value": "awa"
+        },
+        {
+          "title": "Aymara",
+          "value": "ay"
+        },
+        {
+          "title": "Azerbaijani",
+          "value": "az"
+        },
+        {
+          "title": "Balinese",
+          "value": "ban"
+        },
+        {
+          "title": "Baluchi",
+          "value": "bal"
+        },
+        {
+          "title": "Bambara",
+          "value": "bm"
+        },
+        {
+          "title": "Baoulé",
+          "value": "bci"
+        },
+        {
+          "title": "Bashkir",
+          "value": "ba"
+        },
+        {
+          "title": "Basque",
+          "value": "eu"
+        },
+        {
+          "title": "Batak Karo",
+          "value": "btx"
+        },
+        {
+          "title": "Batak Simalungun",
+          "value": "bts"
+        },
+        {
+          "title": "Batak Toba",
+          "value": "bbc"
+        },
+        {
+          "title": "Belarusian",
+          "value": "be"
+        },
+        {
+          "title": "Bemba",
+          "value": "bem"
+        },
+        {
+          "title": "Bengali",
+          "value": "bn"
+        },
+        {
+          "title": "Betawi",
+          "value": "bew"
+        },
+        {
+          "title": "Bhojpuri",
+          "value": "bho"
+        },
+        {
+          "title": "Bikol",
+          "value": "bik"
+        },
+        {
+          "title": "Bosnian",
+          "value": "bs"
+        },
+        {
+          "title": "Breton",
+          "value": "br"
+        },
+        {
+          "title": "Bulgarian",
+          "value": "bg"
+        },
+        {
+          "title": "Buryat",
+          "value": "bua"
+        },
+        {
+          "title": "Cantonese",
+          "value": "yue"
+        },
+        {
+          "title": "Catalan",
+          "value": "ca"
+        },
+        {
+          "title": "Cebuano",
+          "value": "ceb"
+        },
+        {
+          "title": "Chamorro",
+          "value": "ch"
+        },
+        {
+          "title": "Chechen",
+          "value": "ce"
+        },
+        {
+          "title": "Chichewa",
+          "value": "ny"
+        },
+        {
+          "title": "Chinese (Simplified)",
+          "value": "zh-CN"
+        },
+        {
+          "title": "Chinese (Traditional)",
+          "value": "zh-TW"
+        },
+        {
+          "title": "Chuukese",
+          "value": "chk"
+        },
+        {
+          "title": "Chuvash",
+          "value": "cv"
+        },
+        {
+          "title": "Corsican",
+          "value": "co"
+        },
+        {
+          "title": "Crimean Tatar (Cyrillic)",
+          "value": "crh"
+        },
+        {
+          "title": "Crimean Tatar (Latin)",
+          "value": "crh-Latn"
+        },
+        {
+          "title": "Croatian",
+          "value": "hr"
+        },
+        {
+          "title": "Czech",
+          "value": "cs"
+        },
+        {
+          "title": "Danish",
+          "value": "da"
+        },
+        {
+          "title": "Dari",
+          "value": "fa-AF"
+        },
+        {
+          "title": "Dhivehi",
+          "value": "dv"
+        },
+        {
+          "title": "Dinka",
+          "value": "din"
+        },
+        {
+          "title": "Dogri",
+          "value": "doi"
+        },
+        {
+          "title": "Dombe",
+          "value": "dov"
+        },
+        {
+          "title": "Dutch",
+          "value": "nl"
+        },
+        {
+          "title": "Dyula",
+          "value": "dyu"
+        },
+        {
+          "title": "Dzongkha",
+          "value": "dz"
+        },
+        {
+          "title": "English",
+          "value": "en"
+        },
+        {
+          "title": "Esperanto",
+          "value": "eo"
+        },
+        {
+          "title": "Estonian",
+          "value": "et"
+        },
+        {
+          "title": "Ewe",
+          "value": "ee"
+        },
+        {
+          "title": "Faroese",
+          "value": "fo"
+        },
+        {
+          "title": "Fijian",
+          "value": "fj"
+        },
+        {
+          "title": "Filipino",
+          "value": "tl"
+        },
+        {
+          "title": "Finnish",
+          "value": "fi"
+        },
+        {
+          "title": "Fon",
+          "value": "fon"
+        },
+        {
+          "title": "French",
+          "value": "fr"
+        },
+        {
+          "title": "French (Canada)",
+          "value": "fr-CA"
+        },
+        {
+          "title": "Frisian",
+          "value": "fy"
+        },
+        {
+          "title": "Friulian",
+          "value": "fur"
+        },
+        {
+          "title": "Fulani",
+          "value": "ff"
+        },
+        {
+          "title": "Ga",
+          "value": "gaa"
+        },
+        {
+          "title": "Galician",
+          "value": "gl"
+        },
+        {
+          "title": "Georgian",
+          "value": "ka"
+        },
+        {
+          "title": "German",
+          "value": "de"
+        },
+        {
+          "title": "Greek",
+          "value": "el"
+        },
+        {
+          "title": "Guarani",
+          "value": "gn"
+        },
+        {
+          "title": "Gujarati",
+          "value": "gu"
+        },
+        {
+          "title": "Haitian Creole",
+          "value": "ht"
+        },
+        {
+          "title": "Hakha Chin",
+          "value": "cnh"
+        },
+        {
+          "title": "Hausa",
+          "value": "ha"
+        },
+        {
+          "title": "Hawaiian",
+          "value": "haw"
+        },
+        {
+          "title": "Hebrew",
+          "value": "iw"
+        },
+        {
+          "title": "Hiligaynon",
+          "value": "hil"
+        },
+        {
+          "title": "Hindi",
+          "value": "hi"
+        },
+        {
+          "title": "Hmong",
+          "value": "hmn"
+        },
+        {
+          "title": "Hungarian",
+          "value": "hu"
+        },
+        {
+          "title": "Hunsrik",
+          "value": "hrx"
+        },
+        {
+          "title": "Iban",
+          "value": "iba"
+        },
+        {
+          "title": "Icelandic",
+          "value": "is"
+        },
+        {
+          "title": "Igbo",
+          "value": "ig"
+        },
+        {
+          "title": "Ilocano",
+          "value": "ilo"
+        },
+        {
+          "title": "Indonesian",
+          "value": "id"
+        },
+        {
+          "title": "Inuktut (Latin)",
+          "value": "iu-Latn"
+        },
+        {
+          "title": "Inuktut (Syllabics)",
+          "value": "iu"
+        },
+        {
+          "title": "Irish",
+          "value": "ga"
+        },
+        {
+          "title": "Italian",
+          "value": "it"
+        },
+        {
+          "title": "Jamaican Patois",
+          "value": "jam"
+        },
+        {
+          "title": "Japanese",
+          "value": "ja"
+        },
+        {
+          "title": "Javanese",
+          "value": "jv"
+        },
+        {
+          "title": "Jingpo",
+          "value": "kac"
+        },
+        {
+          "title": "Kalaallisut",
+          "value": "kl"
+        },
+        {
+          "title": "Kannada",
+          "value": "kn"
+        },
+        {
+          "title": "Kanuri",
+          "value": "kr"
+        },
+        {
+          "title": "Kapampangan",
+          "value": "pam"
+        },
+        {
+          "title": "Kazakh",
+          "value": "kk"
+        },
+        {
+          "title": "Khasi",
+          "value": "kha"
+        },
+        {
+          "title": "Khmer",
+          "value": "km"
+        },
+        {
+          "title": "Kiga",
+          "value": "cgg"
+        },
+        {
+          "title": "Kikongo",
+          "value": "kg"
+        },
+        {
+          "title": "Kinyarwanda",
+          "value": "rw"
+        },
+        {
+          "title": "Kituba",
+          "value": "ktu"
+        },
+        {
+          "title": "Kokborok",
+          "value": "trp"
+        },
+        {
+          "title": "Komi",
+          "value": "kv"
+        },
+        {
+          "title": "Konkani",
+          "value": "gom"
+        },
+        {
+          "title": "Korean",
+          "value": "ko"
+        },
+        {
+          "title": "Krio",
+          "value": "kri"
+        },
+        {
+          "title": "Kurdish (Kurmanji)",
+          "value": "ku"
+        },
+        {
+          "title": "Kurdish (Sorani)",
+          "value": "ckb"
+        },
+        {
+          "title": "Kyrgyz",
+          "value": "ky"
+        },
+        {
+          "title": "Lao",
+          "value": "lo"
+        },
+        {
+          "title": "Latgalian",
+          "value": "ltg"
+        },
+        {
+          "title": "Latin",
+          "value": "la"
+        },
+        {
+          "title": "Latvian",
+          "value": "lv"
+        },
+        {
+          "title": "Ligurian",
+          "value": "lij"
+        },
+        {
+          "title": "Limburgish",
+          "value": "li"
+        },
+        {
+          "title": "Lingala",
+          "value": "ln"
+        },
+        {
+          "title": "Lithuanian",
+          "value": "lt"
+        },
+        {
+          "title": "Lombard",
+          "value": "lmo"
+        },
+        {
+          "title": "Luganda",
+          "value": "lg"
+        },
+        {
+          "title": "Luo",
+          "value": "luo"
+        },
+        {
+          "title": "Luxembourgish",
+          "value": "lb"
+        },
+        {
+          "title": "Macedonian",
+          "value": "mk"
+        },
+        {
+          "title": "Madurese",
+          "value": "mad"
+        },
+        {
+          "title": "Maithili",
+          "value": "mai"
+        },
+        {
+          "title": "Makassar",
+          "value": "mak"
+        },
+        {
+          "title": "Malagasy",
+          "value": "mg"
+        },
+        {
+          "title": "Malay",
+          "value": "ms"
+        },
+        {
+          "title": "Malay (Jawi)",
+          "value": "ms-Arab"
+        },
+        {
+          "title": "Malayalam",
+          "value": "ml"
+        },
+        {
+          "title": "Maltese",
+          "value": "mt"
+        },
+        {
+          "title": "Mam",
+          "value": "mam"
+        },
+        {
+          "title": "Manx",
+          "value": "gv"
+        },
+        {
+          "title": "Maori",
+          "value": "mi"
+        },
+        {
+          "title": "Marathi",
+          "value": "mr"
+        },
+        {
+          "title": "Marshallese",
+          "value": "mh"
+        },
+        {
+          "title": "Marwadi",
+          "value": "mwr"
+        },
+        {
+          "title": "Mauritian Creole",
+          "value": "mfe"
+        },
+        {
+          "title": "Meadow Mari",
+          "value": "chm"
+        },
+        {
+          "title": "Meiteilon (Manipuri)",
+          "value": "mni-Mtei"
+        },
+        {
+          "title": "Minang",
+          "value": "min"
+        },
+        {
+          "title": "Mizo",
+          "value": "lus"
+        },
+        {
+          "title": "Mongolian",
+          "value": "mn"
+        },
+        {
+          "title": "Myanmar (Burmese)",
+          "value": "my"
+        },
+        {
+          "title": "NKo",
+          "value": "bm-Nkoo"
+        },
+        {
+          "title": "Nahuatl (Eastern Huasteca)",
+          "value": "nhe"
+        },
+        {
+          "title": "Ndau",
+          "value": "ndc-ZW"
+        },
+        {
+          "title": "Ndebele (South)",
+          "value": "nr"
+        },
+        {
+          "title": "Nepalbhasa (Newari)",
+          "value": "new"
+        },
+        {
+          "title": "Nepali",
+          "value": "ne"
+        },
+        {
+          "title": "Norwegian",
+          "value": "no"
+        },
+        {
+          "title": "Nuer",
+          "value": "nus"
+        },
+        {
+          "title": "Occitan",
+          "value": "oc"
+        },
+        {
+          "title": "Odia (Oriya)",
+          "value": "or"
+        },
+        {
+          "title": "Oromo",
+          "value": "om"
+        },
+        {
+          "title": "Ossetian",
+          "value": "os"
+        },
+        {
+          "title": "Pangasinan",
+          "value": "pag"
+        },
+        {
+          "title": "Papiamento",
+          "value": "pap"
+        },
+        {
+          "title": "Pashto",
+          "value": "ps"
+        },
+        {
+          "title": "Persian",
+          "value": "fa"
+        },
+        {
+          "title": "Polish",
+          "value": "pl"
+        },
+        {
+          "title": "Portuguese (Brazil)",
+          "value": "pt"
+        },
+        {
+          "title": "Portuguese (Portugal)",
+          "value": "pt-PT"
+        },
+        {
+          "title": "Punjabi (Gurmukhi)",
+          "value": "pa"
+        },
+        {
+          "title": "Punjabi (Shahmukhi)",
+          "value": "pa-Arab"
+        },
+        {
+          "title": "Quechua",
+          "value": "qu"
+        },
+        {
+          "title": "Qʼeqchiʼ",
+          "value": "kek"
+        },
+        {
+          "title": "Romani",
+          "value": "rom"
+        },
+        {
+          "title": "Romanian",
+          "value": "ro"
+        },
+        {
+          "title": "Rundi",
+          "value": "rn"
+        },
+        {
+          "title": "Russian",
+          "value": "ru"
+        },
+        {
+          "title": "Sami (North)",
+          "value": "se"
+        },
+        {
+          "title": "Samoan",
+          "value": "sm"
+        },
+        {
+          "title": "Sango",
+          "value": "sg"
+        },
+        {
+          "title": "Sanskrit",
+          "value": "sa"
+        },
+        {
+          "title": "Santali (Latin)",
+          "value": "sat-Latn"
+        },
+        {
+          "title": "Santali (Ol Chiki)",
+          "value": "sat"
+        },
+        {
+          "title": "Scots Gaelic",
+          "value": "gd"
+        },
+        {
+          "title": "Sepedi",
+          "value": "nso"
+        },
+        {
+          "title": "Serbian",
+          "value": "sr"
+        },
+        {
+          "title": "Sesotho",
+          "value": "st"
+        },
+        {
+          "title": "Seychellois Creole",
+          "value": "crs"
+        },
+        {
+          "title": "Shan",
+          "value": "shn"
+        },
+        {
+          "title": "Shona",
+          "value": "sn"
+        },
+        {
+          "title": "Sicilian",
+          "value": "scn"
+        },
+        {
+          "title": "Silesian",
+          "value": "szl"
+        },
+        {
+          "title": "Sindhi",
+          "value": "sd"
+        },
+        {
+          "title": "Sinhala",
+          "value": "si"
+        },
+        {
+          "title": "Slovak",
+          "value": "sk"
+        },
+        {
+          "title": "Slovenian",
+          "value": "sl"
+        },
+        {
+          "title": "Somali",
+          "value": "so"
+        },
+        {
+          "title": "Spanish",
+          "value": "es"
+        },
+        {
+          "title": "Sundanese",
+          "value": "su"
+        },
+        {
+          "title": "Susu",
+          "value": "sus"
+        },
+        {
+          "title": "Swahili",
+          "value": "sw"
+        },
+        {
+          "title": "Swati",
+          "value": "ss"
+        },
+        {
+          "title": "Swedish",
+          "value": "sv"
+        },
+        {
+          "title": "Tahitian",
+          "value": "ty"
+        },
+        {
+          "title": "Tajik",
+          "value": "tg"
+        },
+        {
+          "title": "Tamazight",
+          "value": "ber-Latn"
+        },
+        {
+          "title": "Tamazight (Tifinagh)",
+          "value": "ber"
+        },
+        {
+          "title": "Tamil",
+          "value": "ta"
+        },
+        {
+          "title": "Tatar",
+          "value": "tt"
+        },
+        {
+          "title": "Telugu",
+          "value": "te"
+        },
+        {
+          "title": "Tetum",
+          "value": "tet"
+        },
+        {
+          "title": "Thai",
+          "value": "th"
+        },
+        {
+          "title": "Tibetan",
+          "value": "bo"
+        },
+        {
+          "title": "Tigrinya",
+          "value": "ti"
+        },
+        {
+          "title": "Tiv",
+          "value": "tiv"
+        },
+        {
+          "title": "Tok Pisin",
+          "value": "tpi"
+        },
+        {
+          "title": "Tongan",
+          "value": "to"
+        },
+        {
+          "title": "Tshiluba",
+          "value": "lua"
+        },
+        {
+          "title": "Tsonga",
+          "value": "ts"
+        },
+        {
+          "title": "Tswana",
+          "value": "tn"
+        },
+        {
+          "title": "Tulu",
+          "value": "tcy"
+        },
+        {
+          "title": "Tumbuka",
+          "value": "tum"
+        },
+        {
+          "title": "Turkish",
+          "value": "tr"
+        },
+        {
+          "title": "Turkmen",
+          "value": "tk"
+        },
+        {
+          "title": "Tuvan",
+          "value": "tyv"
+        },
+        {
+          "title": "Twi",
+          "value": "ak"
+        },
+        {
+          "title": "Udmurt",
+          "value": "udm"
+        },
+        {
+          "title": "Ukrainian",
+          "value": "uk"
+        },
+        {
+          "title": "Urdu",
+          "value": "ur"
+        },
+        {
+          "title": "Uyghur",
+          "value": "ug"
+        },
+        {
+          "title": "Uzbek",
+          "value": "uz"
+        },
+        {
+          "title": "Venda",
+          "value": "ve"
+        },
+        {
+          "title": "Venetian",
+          "value": "vec"
+        },
+        {
+          "title": "Vietnamese",
+          "value": "vi"
+        },
+        {
+          "title": "Waray",
+          "value": "war"
+        },
+        {
+          "title": "Welsh",
+          "value": "cy"
+        },
+        {
+          "title": "Wolof",
+          "value": "wo"
+        },
+        {
+          "title": "Xhosa",
+          "value": "xh"
+        },
+        {
+          "title": "Yakut",
+          "value": "sah"
+        },
+        {
+          "title": "Yiddish",
+          "value": "yi"
+        },
+        {
+          "title": "Yoruba",
+          "value": "yo"
+        },
+        {
+          "title": "Yucatec Maya",
+          "value": "yua"
+        },
+        {
+          "title": "Zapotec",
+          "value": "zap"
+        },
+        {
+          "title": "Zulu",
+          "value": "zu"
+        }
+      ]
+    },
+    {
       "name": "lang2",
       "title": "Secondary Language",
-      "description": "Preferred language to translate to",
+      "description": "Preferred secondary language to translate to",
       "required": true,
       "type": "dropdown",
       "default": "en",

--- a/extensions/google-translate/src/QuickTranslate/QuickTranslateListItem.tsx
+++ b/extensions/google-translate/src/QuickTranslate/QuickTranslateListItem.tsx
@@ -1,65 +1,26 @@
 import React from "react";
-import { ActionPanel, List, Toast, showToast } from "@raycast/api";
-import { usePromise } from "@raycast/utils";
+import { ActionPanel, List } from "@raycast/api";
 import { supportedLanguagesByCode } from "../languages";
-import { simpleTranslate } from "../simple-translate";
-import { LanguageCodeSet } from "../types";
+import { SimpleTranslateResult } from "../simple-translate";
 import { ConfigurableCopyPasteActions, OpenOnGoogleTranslateWebsiteAction, ToggleFullTextAction } from "../actions";
 
 export function QuickTranslateListItem(props: {
   debouncedText: string;
-  languageSet: LanguageCodeSet;
+  result: SimpleTranslateResult;
   isShowingDetail: boolean;
   setIsShowingDetail: (isShowingDetail: boolean) => void;
-  setIsLoading: (isLoading: boolean) => void;
+  originalSourceLanguage: string;
 }) {
-  let langFrom = supportedLanguagesByCode[props.languageSet.langFrom];
-  const langTo = supportedLanguagesByCode[props.languageSet.langTo[0]];
+  const langFrom = supportedLanguagesByCode[props.result.langFrom];
+  const langTo = supportedLanguagesByCode[props.result.langTo];
 
-  const { data: result, isLoading: isLoading } = usePromise(simpleTranslate, [props.debouncedText, props.languageSet], {
-    onWillExecute() {
-      props.setIsLoading(true);
-    },
-    onData() {
-      props.setIsLoading(false);
-    },
-    onError(error) {
-      props.setIsLoading(false);
-      showToast({
-        style: Toast.Style.Failure,
-        title: `Could not translate to ${langTo.name}`,
-        message: error.toString(),
-      });
-    },
-  });
-
-  if (isLoading) {
-    return (
-      <List.Item
-        title={`Translating to ${langTo.name}...`}
-        accessories={[
-          {
-            text: langTo.name,
-            tooltip: `${langFrom.name} -> ${langTo.name}`,
-          },
-        ]}
-      />
-    );
-  }
-
-  if (!result) {
-    return null;
-  }
-
-  // Reassigning langFrom to the detected language in case it was auto-detected
-  langFrom = supportedLanguagesByCode[result.langFrom];
-
-  const pronunciationMarkdown = result.pronunciationText ? `\`\`\`\n${result.pronunciationText}\n\`\`\`\n\n` : "";
+  const pronunciationMarkdown = props.result.pronunciationText
+    ? `\`\`\`\n${props.result.pronunciationText}\n\`\`\`\n\n`
+    : "";
 
   return (
     <List.Item
-      key={langTo.code}
-      title={result.translatedText}
+      title={props.result.translatedText}
       accessories={[
         {
           text: langTo.name,
@@ -68,11 +29,11 @@ export function QuickTranslateListItem(props: {
       ]}
       detail={
         <List.Item.Detail
-          markdown={result.translatedText + "\n\n\n" + pronunciationMarkdown}
+          markdown={props.result.translatedText + "\n\n\n" + pronunciationMarkdown}
           metadata={
             <List.Item.Detail.Metadata>
               <List.Item.Detail.Metadata.TagList title="Source Language">
-                {props.languageSet.langFrom === "auto" && (
+                {props.originalSourceLanguage === "auto" && (
                   <List.Item.Detail.Metadata.TagList.Item text={supportedLanguagesByCode.auto.name} color={"#FECD57"} />
                 )}
                 <List.Item.Detail.Metadata.TagList.Item text={langFrom.name} color={"#A0D468"} />
@@ -87,9 +48,9 @@ export function QuickTranslateListItem(props: {
       actions={
         <ActionPanel>
           <ActionPanel.Section>
-            <ConfigurableCopyPasteActions defaultActionsPrefix="Translation" value={result.translatedText} />
+            <ConfigurableCopyPasteActions defaultActionsPrefix="Translation" value={props.result.translatedText} />
             <ToggleFullTextAction onAction={() => props.setIsShowingDetail(!props.isShowingDetail)} />
-            <OpenOnGoogleTranslateWebsiteAction translationText={props.debouncedText} translation={result} />
+            <OpenOnGoogleTranslateWebsiteAction translationText={props.debouncedText} translation={props.result} />
           </ActionPanel.Section>
         </ActionPanel>
       }

--- a/extensions/google-translate/src/hooks.ts
+++ b/extensions/google-translate/src/hooks.ts
@@ -51,8 +51,8 @@ export const useSelectedLanguagesSet = () => {
   const [selectedLanguageSet, setSelectedLanguageSet] = useCachedState<_StoredLanguageCodeSet>(
     "selectedLanguageSet",
     unifyLegacyLanguageSet({
-      langFrom: preferences.lang1,
-      langTo: preferences.lang2,
+      langFrom: preferences.langFrom,
+      langTo: preferences.lang1,
     }),
   );
 
@@ -61,7 +61,10 @@ export const useSelectedLanguagesSet = () => {
 
 export const usePreferencesLanguageSet = () => {
   const preferences = usePreferences();
-  const preferencesLanguageSet: LanguageCodeSet = { langFrom: preferences.lang1, langTo: [preferences.lang2] };
+  const preferencesLanguageSet: LanguageCodeSet = {
+    langFrom: preferences.langFrom,
+    langTo: [preferences.lang1, preferences.lang2],
+  };
   return preferencesLanguageSet;
 };
 

--- a/extensions/google-translate/src/instant-translate.tsx
+++ b/extensions/google-translate/src/instant-translate.tsx
@@ -33,8 +33,9 @@ export async function showExtendedHUD(message: string, minDurationMs = MIN_HUD_D
 export async function baseInstantTranslate(onTranslated: (translatedText: string) => Promise<void>) {
   try {
     const preferences = getPreferenceValues<ExtensionPreferences>();
-    const targetLanguage = preferences.lang2; // Use secondary language as target
-    const sourceLanguage = preferences.lang1;
+    const sourceLanguage = preferences.langFrom;
+    const targetLanguage = preferences.lang1;
+    const secondaryTarget = preferences.lang2;
     const proxy = preferences.proxy;
 
     // Get the selected text from any active application
@@ -52,7 +53,7 @@ export async function baseInstantTranslate(onTranslated: (translatedText: string
 
     const result = await simpleTranslate(selectedText, {
       langFrom: sourceLanguage as LanguageCode,
-      langTo: [targetLanguage as LanguageCode],
+      langTo: [targetLanguage as LanguageCode, secondaryTarget as LanguageCode],
       proxy: proxy,
     });
 

--- a/extensions/google-translate/src/quick-translate.tsx
+++ b/extensions/google-translate/src/quick-translate.tsx
@@ -1,9 +1,10 @@
 import { List } from "@raycast/api";
+import { usePromise } from "@raycast/utils";
 import { ReactElement, useState } from "react";
 import { LanguageDropdown } from "./QuickTranslate/LanguageDropdown";
 import { QuickTranslateListItem } from "./QuickTranslate/QuickTranslateListItem";
 import { useDebouncedValue, usePreferences, useSourceLanguage, useTargetLanguages, useTextState } from "./hooks";
-import { LanguageCode } from "./languages";
+import { multiTranslate } from "./simple-translate";
 
 export default function QuickTranslate(): ReactElement {
   const [sourceLanguage] = useSourceLanguage();
@@ -13,32 +14,32 @@ export default function QuickTranslate(): ReactElement {
   const [text, setText] = useTextState();
   const debouncedText = useDebouncedValue(text, 500).trim();
 
-  const [loadingStates, setLoadingStates] = useState(new Map(targetLanguages.map((lang) => [lang, false])));
-
-  const isAnyLoading = Array.from(loadingStates.values()).some((isLoading) => isLoading);
-
-  function setIsLoading(lang: LanguageCode, isLoading: boolean) {
-    setLoadingStates((prev) => new Map(prev).set(lang, isLoading));
-  }
+  const { data: results, isLoading } = usePromise(
+    async (txt, src, targets) => {
+      if (!txt) return [];
+      return await multiTranslate(txt, { langFrom: src, langTo: targets, proxy });
+    },
+    [debouncedText, sourceLanguage, targetLanguages],
+  );
 
   return (
     <List
       searchBarPlaceholder="Enter text to translate"
       searchText={text}
       onSearchTextChange={setText}
-      isLoading={isAnyLoading}
+      isLoading={isLoading}
       isShowingDetail={isShowingDetail}
       searchBarAccessory={<LanguageDropdown />}
     >
-      {debouncedText
-        ? targetLanguages.map((targetLanguage) => (
+      {debouncedText && results
+        ? results.map((result) => (
             <QuickTranslateListItem
-              key={targetLanguage}
+              key={result.langTo}
               debouncedText={debouncedText}
-              languageSet={{ langFrom: sourceLanguage, langTo: [targetLanguage], proxy }}
+              result={result}
               isShowingDetail={isShowingDetail}
               setIsShowingDetail={setIsShowingDetail}
-              setIsLoading={(isLoading) => setIsLoading(targetLanguage, isLoading)}
+              originalSourceLanguage={sourceLanguage}
             />
           ))
         : null}

--- a/extensions/google-translate/src/simple-translate.ts
+++ b/extensions/google-translate/src/simple-translate.ts
@@ -26,6 +26,14 @@ const extractPronounceTextFromRaw = (raw: string) => {
   return raw?.[0]?.[1]?.[2];
 };
 
+function isSameLanguage(lang1: string, lang2: string): boolean {
+  if (!lang1 || !lang2) return false;
+  const l1 = lang1.toLowerCase();
+  const l2 = lang2.toLowerCase();
+  if (l1 === l2) return true;
+  return l1.split("-")[0] === l2.split("-")[0];
+}
+
 export async function simpleTranslate(text: string, options: LanguageCodeSet): Promise<SimpleTranslateResult> {
   try {
     if (!text) {
@@ -38,19 +46,38 @@ export async function simpleTranslate(text: string, options: LanguageCodeSet): P
       };
     }
 
-    const translated = await translate(text, {
+    let targetLang = options.langTo[0];
+
+    if (options.langFrom !== AUTO_DETECT && isSameLanguage(options.langFrom, targetLang) && options.langTo.length > 1) {
+      targetLang = options.langTo[1];
+    }
+
+    let translated = await translate(text, {
       from: options.langFrom,
-      to: options.langTo[0],
+      to: targetLang,
       raw: true,
       proxy: options.proxy,
     });
+
+    let detectedLangFrom = translated?.from?.language?.iso as LanguageCode;
+
+    if (options.langFrom === AUTO_DETECT && isSameLanguage(detectedLangFrom, targetLang) && options.langTo.length > 1) {
+      targetLang = options.langTo[1];
+      translated = await translate(text, {
+        from: detectedLangFrom,
+        to: targetLang,
+        raw: true,
+        proxy: options.proxy,
+      });
+      detectedLangFrom = translated?.from?.language?.iso as LanguageCode;
+    }
 
     return {
       originalText: text,
       translatedText: translated.text,
       pronunciationText: extractPronounceTextFromRaw(translated?.raw),
-      langFrom: translated?.from?.language?.iso as LanguageCode,
-      langTo: options.langTo[0],
+      langFrom: detectedLangFrom,
+      langTo: targetLang,
     };
   } catch (err) {
     if (err instanceof Error) {
@@ -71,6 +98,35 @@ export async function simpleTranslate(text: string, options: LanguageCodeSet): P
   }
 }
 
+export async function multiTranslate(text: string, options: LanguageCodeSet): Promise<SimpleTranslateResult[]> {
+  if (!text) {
+    return [];
+  }
+
+  const results = await Promise.all(
+    options.langTo.map((langTo) =>
+      simpleTranslate(text, {
+        langFrom: options.langFrom,
+        langTo: [langTo],
+        proxy: options.proxy,
+      }),
+    ),
+  );
+
+  const validResults = results.filter(Boolean) as SimpleTranslateResult[];
+
+  // Prioritize actual translations (where langFrom !== langTo) over same-language translations
+  validResults.sort((a, b) => {
+    const aIsSame = isSameLanguage(a.langFrom, a.langTo);
+    const bIsSame = isSameLanguage(b.langFrom, b.langTo);
+    if (aIsSame && !bIsSame) return 1;
+    if (!aIsSame && bIsSame) return -1;
+    return 0;
+  });
+
+  return validResults;
+}
+
 export async function doubleWayTranslate(text: string, options: LanguageCodeSet) {
   if (!text) {
     return [];
@@ -85,7 +141,7 @@ export async function doubleWayTranslate(text: string, options: LanguageCodeSet)
 
     if (translated1?.langFrom) {
       const translated2 = await simpleTranslate(translated1.translatedText, {
-        langFrom: options.langTo[0],
+        langFrom: translated1.langTo,
         langTo: [translated1.langFrom],
         proxy: options.proxy,
       });
@@ -95,14 +151,18 @@ export async function doubleWayTranslate(text: string, options: LanguageCodeSet)
 
     return [];
   } else {
+    let targetLang = options.langTo[0];
+    if (isSameLanguage(options.langFrom, targetLang) && options.langTo.length > 1) {
+      targetLang = options.langTo[1];
+    }
     return await Promise.all([
       simpleTranslate(text, {
         langFrom: options.langFrom,
-        langTo: options.langTo,
+        langTo: [targetLang],
         proxy: options.proxy,
       }),
       simpleTranslate(text, {
-        langFrom: options.langTo[0],
+        langFrom: targetLang,
         langTo: [options.langFrom],
         proxy: options.proxy,
       }),

--- a/extensions/google-translate/src/translate.tsx
+++ b/extensions/google-translate/src/translate.tsx
@@ -11,7 +11,7 @@ import {
 } from "./hooks";
 import { supportedLanguagesByCode } from "./languages";
 import { LanguageManagerListDropdown } from "./LanguagesManager";
-import { doubleWayTranslate, simpleTranslate, playTTS } from "./simple-translate";
+import { doubleWayTranslate, multiTranslate, playTTS } from "./simple-translate";
 import { ConfigurableCopyPasteActions, OpenOnGoogleTranslateWebsiteAction, ToggleFullTextAction } from "./actions";
 import { LanguageCodeSet } from "./types";
 
@@ -127,12 +127,12 @@ const DoubleWayTranslateItem: React.FC<{
   );
 };
 
-const TranslateItem: React.FC<{
+const MultiTranslateItems: React.FC<{
   value: string;
   selectedLanguageSet: LanguageCodeSet;
   toggleShowingDetail: () => void;
 }> = ({ toggleShowingDetail, value, selectedLanguageSet }) => {
-  const { data: result, isLoading } = usePromise(simpleTranslate, [value, selectedLanguageSet], {
+  const { data: results, isLoading } = usePromise(multiTranslate, [value, selectedLanguageSet], {
     onError(error) {
       showToast({
         style: Toast.Style.Failure,
@@ -142,39 +142,61 @@ const TranslateItem: React.FC<{
     },
   });
 
-  const langFromCode = result?.langFrom ?? selectedLanguageSet.langFrom;
-  const langToCode = result?.langTo ?? selectedLanguageSet.langTo[0];
-
-  const langFrom = supportedLanguagesByCode[langFromCode];
-  const langTo = supportedLanguagesByCode[langToCode];
-  const languages = `${langFrom.name} -> ${langTo.name}`;
-  const tooltip = `${langFrom?.name} -> ${langTo?.name}`;
+  if (isLoading) {
+    return <List.EmptyView icon={Icon.Hourglass} title="Translating..." />;
+  }
 
   return (
-    <List.Item
-      title={result?.translatedText ?? ""}
-      subtitle={isLoading ? "Translating..." : undefined}
-      accessories={[{ text: languages, tooltip: tooltip }]}
-      detail={<List.Item.Detail markdown={result?.translatedText ?? ""} />}
-      actions={
-        <ActionPanel>
-          <ActionPanel.Section>
-            <ConfigurableCopyPasteActions defaultActionsPrefix="Translation" value={result?.translatedText ?? ""} />
-            <ToggleFullTextAction onAction={() => toggleShowingDetail()} />
-            {result && (
-              <Action
-                title="Play Text-To-Speech"
-                icon={Icon.Play}
-                shortcut={{ macOS: { modifiers: ["cmd"], key: "t" }, Windows: { modifiers: ["ctrl"], key: "t" } }}
-                onAction={() => playTTS(result.translatedText, langToCode)}
+    <>
+      {results?.map((r, index) => {
+        const langFrom = supportedLanguagesByCode[r.langFrom];
+        const langTo = supportedLanguagesByCode[r.langTo];
+        const languages = `${langFrom.name} -> ${langTo.name}`;
+        const tooltip = `${langFrom?.name} -> ${langTo?.name}`;
+        return (
+          <React.Fragment key={index}>
+            <List.Item
+              title={r.translatedText}
+              accessories={[{ text: languages, tooltip: tooltip }]}
+              detail={<List.Item.Detail markdown={r.translatedText} />}
+              actions={
+                <ActionPanel>
+                  <ActionPanel.Section>
+                    <ConfigurableCopyPasteActions defaultActionsPrefix="Translation" value={r.translatedText} />
+                    <ToggleFullTextAction onAction={() => toggleShowingDetail()} />
+                    <Action
+                      title="Play Text-To-Speech"
+                      icon={Icon.Play}
+                      shortcut={{ macOS: { modifiers: ["cmd"], key: "t" }, Windows: { modifiers: ["ctrl"], key: "t" } }}
+                      onAction={() => playTTS(r.translatedText, r.langTo)}
+                    />
+                    <OpenOnGoogleTranslateWebsiteAction translationText={value} translation={r} />
+                  </ActionPanel.Section>
+                  <QuickLanguageSetShifterActions />
+                </ActionPanel>
+              }
+            />
+            {r.pronunciationText && (
+              <List.Item
+                title={r.pronunciationText}
+                accessories={[{ text: languages, tooltip: tooltip }]}
+                detail={<List.Item.Detail markdown={r.pronunciationText} />}
+                actions={
+                  <ActionPanel>
+                    <ActionPanel.Section>
+                      <ConfigurableCopyPasteActions value={r.pronunciationText} />
+                      <ToggleFullTextAction onAction={() => toggleShowingDetail()} />
+                      <OpenOnGoogleTranslateWebsiteAction translationText={value} translation={r} />
+                    </ActionPanel.Section>
+                    <QuickLanguageSetShifterActions />
+                  </ActionPanel>
+                }
               />
             )}
-            {result && <OpenOnGoogleTranslateWebsiteAction translationText={value} translation={result} />}
-          </ActionPanel.Section>
-          <QuickLanguageSetShifterActions />
-        </ActionPanel>
-      }
-    />
+          </React.Fragment>
+        );
+      })}
+    </>
   );
 };
 
@@ -205,14 +227,11 @@ export default function Translate(): ReactElement {
           toggleShowingDetail={() => setIsShowingDetail(!isShowingDetail)}
         />
       ) : (
-        selectedLanguageSet.langTo.map((langTo, index) => (
-          <TranslateItem
-            key={`${index} ${langTo}`}
-            value={debouncedValue}
-            selectedLanguageSet={{ langFrom: selectedLanguageSet.langFrom, langTo: [langTo], proxy }}
-            toggleShowingDetail={() => setIsShowingDetail(!isShowingDetail)}
-          />
-        ))
+        <MultiTranslateItems
+          value={debouncedValue}
+          selectedLanguageSet={{ langFrom: selectedLanguageSet.langFrom, langTo: selectedLanguageSet.langTo, proxy }}
+          toggleShowingDetail={() => setIsShowingDetail(!isShowingDetail)}
+        />
       )}
     </List>
   );


### PR DESCRIPTION
## Description

- Added preferences for "Translate from" (source), "Primary Language" (target), and "Secondary Language" (fallback target)
- Added automatic swap to the secondary target language if the detected source language matches the primary target language
- Prioritized cross-language translations over same-language translations in both the Translate and Quick Translate screens
- Addressing [issue ](https://github.com/raycast/extensions/issues/25077#issue-3886121008)

## Screencast
<img width="548" height="401" alt="image" src="https://github.com/user-attachments/assets/b1f526fa-9cc0-40fd-a68c-9ab3aa448b1d" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
