### PR TITLE
toggl-track: Add sum of duration of the running entry's project to menu bar

### DIFF
--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Toggl Track Changelog
 
-## [Show total duration of current project] - {PR_MERGE_DATE}
+## [Show total duration of current project] - 2026-06-18
 
 - In the menu bar, show the total time of all time entries of the current project in addition to the total time of all entries.
 

--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Toggl Track Changelog
 
+## [Show total duration of current project] - {PR_MERGE_DATE}
+
+- In the menu bar, show the total time of all time entries of the current project in addition to the total time of all entries.
+
 ## [Quickstart New Timer] - 2026-06-17
 
 - Add a "Quickstart New Timer" command that opens the new time entry form directly, skipping the recent-entries list — assign it a global hotkey to start a timer from anywhere with one keystroke. On submit, Raycast closes immediately.

--- a/extensions/toggl-track/src/menuBar.tsx
+++ b/extensions/toggl-track/src/menuBar.tsx
@@ -27,6 +27,10 @@ export default function Command() {
   } = useProcessedTimeEntries();
 
   const totalDurationToday = useTotalDurationToday(timeEntries, runningTimeEntry);
+  const totalDurationTodayCurrProj = useTotalDurationToday(
+    timeEntries.filter((entry) => entry && entry.project_id === runningTimeEntry?.project_id),
+    runningTimeEntry,
+  );
   const { resumeTimeEntry, stopRunningTimeEntry } = useTimeEntryActions(
     revalidateRunningTimeEntry,
     revalidateTimeEntries,
@@ -165,8 +169,16 @@ export default function Command() {
       </MenuBarExtra.Section>
 
       <MenuBarExtra.Section title="Today">
+        {runningEntry?.project_id ? (
+          <MenuBarExtra.Item
+            icon={{ source: Icon.Circle, tintColor: runningEntry?.project_color }}
+            title={runningEntry?.project_name || "No Project"}
+            subtitle={isLoading ? "Loading" : formatSeconds(totalDurationTodayCurrProj)}
+          />
+        ) : null}
         <MenuBarExtra.Item
-          title={isLoading ? "Loading" : formatSeconds(totalDurationToday)}
+          title="Total"
+          subtitle={isLoading ? "Loading" : formatSeconds(totalDurationToday)}
           icon={{ source: Icon.Clock }}
         />
       </MenuBarExtra.Section>


### PR DESCRIPTION
## Description

I have added another duration to the "Today" section of the menu bar.
It shows the total duration of time entries with the same project as the one that's currently running.
The purpose of this is to keep an eye on goals, such as "how much did I work today".
This was the simplest, least invasive change I could imagine to implement this.
Hope you're interested :)

## Screencast

<img width="372" height="96" alt="image" src="https://github.com/user-attachments/assets/145fdcb2-ffc3-4ad0-88db-c06bd03d3f7f" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- ~~I checked that files in the `assets` folder are used by the extension itself~~
- ~~I checked that assets used by the `README` are placed outside of the `metadata` folder~~
- [x] I changed nothing to do with any assets.