### PR TITLE
Add Jellypod to MCP registry

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add Jellypod MCP Server] - {PR_MERGE_DATE}
+## [Add Jellypod MCP Server] - 2026-06-19
 
 Add official Jellypod MCP Server to registry for creating, editing, and publishing conversational AI podcasts (podcasts, hosts, sources, episodes, and analytics). Remote endpoint via mcp-remote.
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Add Jellypod MCP Server] - {PR_MERGE_DATE}
+
+Add official Jellypod MCP Server to registry for creating, editing, and publishing conversational AI podcasts (podcasts, hosts, sources, episodes, and analytics). Remote endpoint via mcp-remote.
+
 ## [Add Olostep MCP Server] - 2026-06-16
 
 Add official Olostep MCP Server to registry for web data access — search, scrape, crawl, batch processing, and cited AI answers.

--- a/extensions/model-context-protocol-registry/README.md
+++ b/extensions/model-context-protocol-registry/README.md
@@ -75,6 +75,7 @@ To add a new MCP registry to the registry, you need to create a new entry in the
 | [Rube](https://rube.composio.dev) |  Rube is a Model‑Context‑Protocol (MCP) server built on the Composio integration platform. It connects AI chat tools to more than 500 business and productivity applications – things like Gmail, Slack, Notion, GitHub, Linear, Airtable, and many others. |
 | [Olostep](https://github.com/olostep/olostep-mcp-server) | A Model Context Protocol server for Olostep, the web data API for AI. Search the web, scrape any URL into clean Markdown/HTML/JSON, crawl entire sites, batch-process up to 10k URLs, and get cited AI answers — all through one API. |
 | [RouteMesh](https://github.com/routemesh/routemesh-mcp) | Query multiple EVM blockchain chains from one MCP server. Pull on-chain data including blocks, transactions, logs, balances, and fees with RouteMesh routing and failover. |
+| [Jellypod](https://www.jellypod.com/mcp) | Jellypod is an AI podcast studio. Its Model Context Protocol (MCP) server lets AI assistants create, edit, and publish conversational AI podcasts, managing podcasts, hosts, sources, episodes, and analytics through natural language. |
 
 ### Community MCP Servers
 

--- a/extensions/model-context-protocol-registry/README.md
+++ b/extensions/model-context-protocol-registry/README.md
@@ -75,7 +75,7 @@ To add a new MCP registry to the registry, you need to create a new entry in the
 | [Rube](https://rube.composio.dev) |  Rube is a Model‑Context‑Protocol (MCP) server built on the Composio integration platform. It connects AI chat tools to more than 500 business and productivity applications – things like Gmail, Slack, Notion, GitHub, Linear, Airtable, and many others. |
 | [Olostep](https://github.com/olostep/olostep-mcp-server) | A Model Context Protocol server for Olostep, the web data API for AI. Search the web, scrape any URL into clean Markdown/HTML/JSON, crawl entire sites, batch-process up to 10k URLs, and get cited AI answers — all through one API. |
 | [RouteMesh](https://github.com/routemesh/routemesh-mcp) | Query multiple EVM blockchain chains from one MCP server. Pull on-chain data including blocks, transactions, logs, balances, and fees with RouteMesh routing and failover. |
-| [Jellypod](https://www.jellypod.com/mcp) | Jellypod is an AI podcast studio. Its Model Context Protocol (MCP) server lets AI assistants create, edit, and publish conversational AI podcasts, managing podcasts, hosts, sources, episodes, and analytics through natural language. |
+| [Jellypod](https://www.jellypod.com/mcp) | Jellypod's Model Context Protocol server lets AI assistants create, edit, and publish conversational AI podcasts and video episodes. |
 
 ### Community MCP Servers
 

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -703,6 +703,18 @@ export const OFFICIAL_ENTRIES: RegistryEntry[] = [
       },
     },
   },
+  {
+    name: "jellypod",
+    title: "Jellypod",
+    description:
+      "Jellypod is an AI podcast studio. Its Model Context Protocol (MCP) server lets AI assistants create, edit, and publish conversational AI podcasts, managing podcasts, hosts, sources, episodes, and analytics through natural language.",
+    icon: "https://www.jellypod.com/assets/app-icon-square.png",
+    homepage: "https://www.jellypod.com/mcp",
+    configuration: {
+      command: "npx",
+      args: ["-y", "mcp-remote", "https://mcp.jellypod.com/mcp"],
+    },
+  },
 ];
 
 export const COMMUNITY_ENTRIES: RegistryEntry[] = [

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -707,7 +707,7 @@ export const OFFICIAL_ENTRIES: RegistryEntry[] = [
     name: "jellypod",
     title: "Jellypod",
     description:
-      "Jellypod is an AI podcast studio. Its Model Context Protocol (MCP) server lets AI assistants create, edit, and publish conversational AI podcasts, managing podcasts, hosts, sources, episodes, and analytics through natural language.",
+      "Jellypod's Model Context Protocol server lets AI assistants create, edit, and publish conversational AI podcasts and video episodes.",
     icon: "https://www.jellypod.com/assets/app-icon-square.png",
     homepage: "https://www.jellypod.com/mcp",
     configuration: {


### PR DESCRIPTION
## Description

Adds Jellypod to the built-in MCP registry (`OFFICIAL_ENTRIES`).

Jellypod is an AI podcast studio. Its MCP server is a remote, hosted, OAuth-authenticated server at `https://mcp.jellypod.com/mcp` that lets an AI assistant create, edit, and publish conversational AI podcasts (managing podcasts, hosts, sources, episodes, and analytics). Raycast connects to it through the `mcp-remote` shim, matching the existing remote entries (e.g. Circleback).

It is first-party (built by Jellypod) and published in the official MCP Registry under the namespace `com.jellypod/jellypod`, so it belongs in `OFFICIAL_ENTRIES` per the extension README ("servers that are officially supported by the companies or makers of the service").

- Server URL: `https://mcp.jellypod.com/mcp`
- Homepage: `https://www.jellypod.com/mcp`

Only `entries.ts` and the auto-generated `README.md` server table were changed (one new row each). The icon uses a hosted URL, so no new asset was added.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our metadata tool
