### PR TITLE
Warp: Scope Open Directory search to configurable root folders

### DIFF
--- a/extensions/warp/CHANGELOG.md
+++ b/extensions/warp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Warp Changelog
 
-## [Scoped Directory Search] - {PR_MERGE_DATE}
+## [Scoped Directory Search] - 2026-06-21
 
 - "Open Directory" search is now scoped to a configurable list of root folders instead of searching your whole system.
 - Added "Add Search Folder" and "Manage Search Folders" actions to add folders with a native picker (multi-select) and remove them; folders persist automatically.

--- a/extensions/warp/CHANGELOG.md
+++ b/extensions/warp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Warp Changelog
 
+## [Scoped Directory Search] - {PR_MERGE_DATE}
+
+- "Open Directory" search is now scoped to a configurable list of root folders instead of searching your whole system.
+- Added "Add Search Folder" and "Manage Search Folders" actions to add folders with a native picker (multi-select) and remove them; folders persist automatically.
+- When no folders are configured, search defaults to your Home folder.
+
 ## [Tab Config Support] - 2026-05-28
 
 - Added Tab Config support to the config launcher, with legacy Launch Configurations as a fallback.

--- a/extensions/warp/package-lock.json
+++ b/extensions/warp/package-lock.json
@@ -9,7 +9,6 @@
       "dependencies": {
         "@raycast/api": "^1.79.0",
         "@raycast/utils": "^1.4.8",
-        "node-spotlight": "^1.0.0",
         "yaml": "^2.2.1"
       },
       "devDependencies": {
@@ -1225,7 +1224,6 @@
       "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1296,7 +1294,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -1458,7 +1455,6 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1612,11 +1608,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/bsplit2": {
-      "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/derhuerst/bsplit2.git#71e44f40e0c6d74b67f28437e9fde85d764f32b8",
-      "license": "Apache-2.0"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -1904,7 +1895,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -2844,18 +2834,6 @@
         }
       }
     },
-    "node_modules/node-spotlight": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-spotlight/-/node-spotlight-1.0.0.tgz",
-      "integrity": "sha512-GSf5zkikqrW3//u7sQWoA6ySJ4yivEcffoVW3HNc03j2HcCzxqX/V5BhtYr2RcvIkJrukb6DCf8Puh/QQ82lpQ==",
-      "license": "ISC",
-      "dependencies": {
-        "bsplit2": "github:derhuerst/bsplit2#1.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
@@ -3399,7 +3377,6 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/warp/package.json
+++ b/extensions/warp/package.json
@@ -77,7 +77,6 @@
   "dependencies": {
     "@raycast/api": "^1.79.0",
     "@raycast/utils": "^1.4.8",
-    "node-spotlight": "^1.0.0",
     "yaml": "^2.2.1"
   },
   "devDependencies": {

--- a/extensions/warp/src/hooks/useLocalStorage.ts
+++ b/extensions/warp/src/hooks/useLocalStorage.ts
@@ -1,9 +1,10 @@
 import { LocalStorage } from "@raycast/api";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export default function useLocalStorage<T>(key: string, initialValue?: T) {
   const [isLoading, setIsLoading] = useState(true);
   const [data, setData] = useState(initialValue || ({} as T));
+  const hasLoaded = useRef(false);
 
   useEffect(() => {
     setIsLoading(true);
@@ -18,11 +19,18 @@ export default function useLocalStorage<T>(key: string, initialValue?: T) {
         setData(json as T);
       })
       .finally(() => {
+        hasLoaded.current = true;
         setIsLoading(false);
       });
   }, []);
 
   useEffect(() => {
+    // Don't persist until the stored value has been read, otherwise the initial
+    // value would overwrite a previously saved value on mount.
+    if (!hasLoaded.current) {
+      return;
+    }
+
     setLocalStorageValue(data);
   }, [data]);
 

--- a/extensions/warp/src/index.d.ts
+++ b/extensions/warp/src/index.d.ts
@@ -1,1 +1,0 @@
-declare module "node-spotlight";

--- a/extensions/warp/src/manage-roots.tsx
+++ b/extensions/warp/src/manage-roots.tsx
@@ -1,0 +1,97 @@
+import os from "node:os";
+import { Action, ActionPanel, Form, Icon, Keyboard, List, useNavigation } from "@raycast/api";
+
+function displayPath(path: string): string {
+  return path.replace(os.homedir(), "~");
+}
+
+function AddRootAction(props: { onAdd: (paths: string[]) => void }) {
+  return (
+    <Action.Push
+      title="Add Folder"
+      icon={Icon.Plus}
+      shortcut={Keyboard.Shortcut.Common.New}
+      target={<AddRootForm onAdd={props.onAdd} />}
+    />
+  );
+}
+
+/**
+ * Form with a native folder picker (multi-select) used to add one or more root
+ * folders to the search scope.
+ */
+export function AddRootForm(props: { onAdd: (paths: string[]) => void }) {
+  const { pop } = useNavigation();
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm
+            title="Add Folders"
+            icon={Icon.Plus}
+            onSubmit={(values: { folders: string[] }) => {
+              props.onAdd(values.folders ?? []);
+              pop();
+            }}
+          />
+        </ActionPanel>
+      }
+    >
+      <Form.FilePicker
+        id="folders"
+        title="Folders"
+        allowMultipleSelection
+        canChooseDirectories
+        canChooseFiles={false}
+        info="Directory search results will be limited to the folders you add here."
+      />
+    </Form>
+  );
+}
+
+/**
+ * List of configured root folders with actions to add more or remove existing
+ * ones. With no folders configured, search defaults to the user's home folder.
+ */
+export function ManageRoots(props: {
+  roots: string[];
+  onAdd: (paths: string[]) => void;
+  onRemove: (path: string) => void;
+}) {
+  const { roots, onAdd, onRemove } = props;
+
+  return (
+    <List searchBarPlaceholder="Filter folders...">
+      <List.EmptyView
+        icon={Icon.Folder}
+        title="No Search Folders"
+        description="Add a folder to scope your search. With none added, search defaults to your Home folder."
+        actions={
+          <ActionPanel>
+            <AddRootAction onAdd={onAdd} />
+          </ActionPanel>
+        }
+      />
+      {roots.map((root) => (
+        <List.Item
+          key={root}
+          icon={Icon.Folder}
+          title={displayPath(root)}
+          actions={
+            <ActionPanel>
+              <Action
+                title="Remove Folder"
+                icon={Icon.Trash}
+                style={Action.Style.Destructive}
+                shortcut={Keyboard.Shortcut.Common.Remove}
+                onAction={() => onRemove(root)}
+              />
+              <AddRootAction onAdd={onAdd} />
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
+  );
+}

--- a/extensions/warp/src/open-directory.tsx
+++ b/extensions/warp/src/open-directory.tsx
@@ -29,11 +29,15 @@ export default function Command() {
         return;
       }
 
-      const found = isWindows
-        ? await searchDirectoriesWindows(query, searchRoots, maxResults, abortable.current?.signal)
-        : await searchDirectoriesMac(query, searchRoots, maxResults, abortable.current?.signal);
+      // Capture this search's signal so a newer search replacing
+      // `abortable.current` can't trick us into committing stale results.
+      const signal = abortable.current?.signal;
 
-      if (abortable.current?.signal.aborted) return;
+      const found = isWindows
+        ? await searchDirectoriesWindows(query, searchRoots, maxResults, signal)
+        : await searchDirectoriesMac(query, searchRoots, maxResults, signal);
+
+      if (signal?.aborted) return;
 
       setResults(found);
     },

--- a/extensions/warp/src/open-directory.tsx
+++ b/extensions/warp/src/open-directory.tsx
@@ -1,84 +1,67 @@
-import os from "node:os";
-import { execFile } from "node:child_process";
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { ActionPanel, Action, List, Icon, showToast, Toast, Keyboard } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
 import { Category, SearchResult } from "./types";
 import useLocalStorage from "./hooks/useLocalStorage";
 import { getNewTabUri, getNewWindowUri } from "./uri";
 import { getAppName } from "./constants";
+import { getEffectiveRoots, searchDirectoriesMac, searchDirectoriesWindows } from "./search-directories";
+import { AddRootForm, ManageRoots } from "./manage-roots";
 
 const isWindows = process.platform === "win32";
-
-function searchDirectoriesWindows(query: string, maxResults: number): Promise<SearchResult[]> {
-  return new Promise((resolve) => {
-    const psCommand = `Get-ChildItem -Path $env:USERPROFILE -Directory -Recurse -Depth 5 -ErrorAction SilentlyContinue | Where-Object { $_.Name -like ('*' + $env:WARP_SEARCH_QUERY + '*') } | Select-Object -First ${maxResults} -ExpandProperty FullName`;
-    const env = { ...process.env, WARP_SEARCH_QUERY: query };
-    execFile("powershell", ["-NoProfile", "-Command", psCommand], { timeout: 15000, env }, (error, stdout) => {
-      if (error || !stdout) {
-        resolve([]);
-        return;
-      }
-      const results = stdout
-        .trim()
-        .split(/\r?\n/)
-        .filter(Boolean)
-        .map((p) => ({ name: p.trim().replace(os.homedir(), "~"), path: p.trim() }));
-      resolve(results);
-    });
-  });
-}
 
 export default function Command() {
   const [searchText, setSearchText] = useState("");
   const [category, setCategory] = useState<Category>(Category.ALL);
   const [results, setResults] = useState<SearchResult[]>([]);
   const { data: pins, setData: setPins, isLoading: isPinsLoading } = useLocalStorage<SearchResult[]>("pinnedDirs", []);
+  const { data: roots, setData: setRoots, isLoading: isRootsLoading } = useLocalStorage<string[]>("searchRoots", []);
   const abortable = useRef<AbortController>();
 
   const maxResults = 250;
 
+  const effectiveRoots = useMemo(() => getEffectiveRoots(roots), [roots]);
+
   const { isLoading: isSearchResultsLoading } = usePromise(
-    async (query) => {
-      if (searchText === "") {
+    async (query: string, searchRoots: string[]) => {
+      if (query === "") {
         setResults([]);
-        return [];
+        return;
       }
 
-      if (isWindows) {
-        setResults([]);
-        const thisAbort = abortable.current;
-        const windowsResults = await searchDirectoriesWindows(searchText, maxResults);
-        if (thisAbort?.signal.aborted) return;
-        setResults(windowsResults);
-      } else {
-        const spotlight = (await import("node-spotlight")).default;
-        const results = await spotlight(query);
+      const found = isWindows
+        ? await searchDirectoriesWindows(query, searchRoots, maxResults, abortable.current?.signal)
+        : await searchDirectoriesMac(query, searchRoots, maxResults, abortable.current?.signal);
 
-        setResults([]);
+      if (abortable.current?.signal.aborted) return;
 
-        let resultsCount = 0;
-
-        for await (const result of results) {
-          setResults((state) => [...state, { name: result.path.replace(os.homedir(), "~"), path: result.path }]);
-
-          resultsCount++;
-
-          if (resultsCount >= maxResults) {
-            abortable?.current?.abort();
-            break;
-          }
-        }
-      }
+      setResults(found);
     },
-    [isWindows ? searchText : `kind:folders ${searchText}`],
+    [searchText, effectiveRoots],
     {
+      // Wait until persisted roots have loaded so the first search isn't scoped
+      // to the home-folder fallback before the user's folders are available.
+      execute: !isRootsLoading,
       abortable,
     }
   );
 
   function onCategoryChange(newValue: Category) {
     setCategory(newValue);
+  }
+
+  function addRoots(paths: string[]) {
+    setRoots((state) => {
+      const next = [...state];
+      for (const path of paths) {
+        if (!next.includes(path)) next.push(path);
+      }
+      return next;
+    });
+  }
+
+  function removeRoot(path: string) {
+    setRoots((state) => state.filter((root) => root !== path));
   }
 
   async function onPin(searchResult: SearchResult) {
@@ -115,6 +98,8 @@ export default function Command() {
     };
   }
 
+  const rootActions = <RootFolderActions roots={roots} onAddRoots={addRoots} onRemoveRoot={removeRoot} />;
+
   const filteredResults =
     category === Category.ALL ? results.filter((result) => !pins.find((pinned) => pinned.path === result.path)) : [];
 
@@ -122,7 +107,7 @@ export default function Command() {
     ? pins.filter((pinned) => pinned.name.toLowerCase().includes(searchText.toLowerCase()))
     : pins;
 
-  const isLoading = isSearchResultsLoading || isPinsLoading;
+  const isLoading = isSearchResultsLoading || isPinsLoading || isRootsLoading;
 
   return (
     <List
@@ -132,11 +117,18 @@ export default function Command() {
       throttle={true}
       onSearchTextChange={setSearchText}
     >
-      {searchText && <List.EmptyView title="No directories found" description="Try refining your search" />}
+      {searchText && (
+        <List.EmptyView
+          title="No directories found"
+          description="Try refining your search or adding a search folder"
+          actions={<ActionPanel>{rootActions}</ActionPanel>}
+        />
+      )}
       {!searchText && (
         <List.EmptyView
           title="Search for a directory"
           description={`Open a directory on your computer in ${getAppName()}`}
+          actions={<ActionPanel>{rootActions}</ActionPanel>}
         />
       )}
       <List.Section title={Category.PINNED}>
@@ -148,6 +140,7 @@ export default function Command() {
             validRearrangeDirections={getValidRearrangeDirections(searchResult)}
             onPin={() => onPin(searchResult)}
             onRearrange={onRearrange}
+            extraActions={rootActions}
           />
         ))}
       </List.Section>
@@ -158,6 +151,7 @@ export default function Command() {
             searchResult={searchResult}
             isPinned={false}
             onPin={() => onPin(searchResult)}
+            extraActions={rootActions}
           />
         ))}
       </List.Section>
@@ -176,14 +170,38 @@ function CategoryDropdown(props: { onCategoryChange: (newValue: Category) => voi
   );
 }
 
+function RootFolderActions(props: {
+  roots: string[];
+  onAddRoots: (paths: string[]) => void;
+  onRemoveRoot: (path: string) => void;
+}) {
+  return (
+    <ActionPanel.Section title="Search Folders">
+      <Action.Push
+        title="Add Search Folder"
+        icon={Icon.NewFolder}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "a" }}
+        target={<AddRootForm onAdd={props.onAddRoots} />}
+      />
+      <Action.Push
+        title="Manage Search Folders"
+        icon={Icon.Folder}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "m" }}
+        target={<ManageRoots roots={props.roots} onAdd={props.onAddRoots} onRemove={props.onRemoveRoot} />}
+      />
+    </ActionPanel.Section>
+  );
+}
+
 function SearchListItem(props: {
   searchResult: SearchResult;
   isPinned: boolean;
   validRearrangeDirections?: { up: boolean; down: boolean };
   onPin: () => void;
   onRearrange?: (searchResult: SearchResult, direction: "up" | "down") => void;
+  extraActions?: JSX.Element;
 }) {
-  const { searchResult, isPinned, validRearrangeDirections, onPin, onRearrange } = props;
+  const { searchResult, isPinned, validRearrangeDirections, onPin, onRearrange, extraActions } = props;
 
   return (
     <List.Item
@@ -247,6 +265,7 @@ function SearchListItem(props: {
               </>
             )}
           </ActionPanel.Section>
+          {extraActions}
         </ActionPanel>
       }
     />

--- a/extensions/warp/src/search-directories.ts
+++ b/extensions/warp/src/search-directories.ts
@@ -87,7 +87,7 @@ export function searchDirectoriesWindows(
   return new Promise((resolve) => {
     const psCommand = [
       "$roots = $env:WARP_SEARCH_ROOTS -split '\\|';",
-      "Get-ChildItem -Path $roots -Directory -Recurse -Depth 5 -ErrorAction SilentlyContinue |",
+      "Get-ChildItem -LiteralPath $roots -Directory -Recurse -Depth 5 -ErrorAction SilentlyContinue |",
       "Where-Object { $_.Name -like ('*' + $env:WARP_SEARCH_QUERY + '*') } |",
       `Select-Object -First ${maxResults} -ExpandProperty FullName`,
     ].join(" ");

--- a/extensions/warp/src/search-directories.ts
+++ b/extensions/warp/src/search-directories.ts
@@ -1,0 +1,115 @@
+import os from "node:os";
+import { execFile } from "node:child_process";
+import { SearchResult } from "./types";
+
+// Absolute path so the lookup doesn't depend on the user's PATH.
+const MDFIND_PATH = "/usr/bin/mdfind";
+
+// Windows paths can't contain "|", so it's a safe separator for passing the
+// configured roots to PowerShell through an environment variable.
+const WINDOWS_ROOT_DELIMITER = "|";
+
+/**
+ * The folders directory search should be scoped to. Falls back to the user's
+ * home directory when no root folders have been configured, so search is never
+ * system-wide.
+ */
+export function getEffectiveRoots(roots: string[]): string[] {
+  const cleaned = roots.map((root) => root.trim()).filter(Boolean);
+  return cleaned.length > 0 ? cleaned : [os.homedir()];
+}
+
+function toSearchResult(path: string): SearchResult {
+  return { name: path.replace(os.homedir(), "~"), path };
+}
+
+/**
+ * macOS: query Spotlight (mdfind) scoped to each root via `-onlyin`. mdfind
+ * accepts only one `-onlyin` per invocation, so we run one search per root in
+ * parallel and merge the results. A missing or unreadable root resolves to an
+ * empty list rather than failing the whole search.
+ */
+export function searchDirectoriesMac(
+  query: string,
+  roots: string[],
+  maxResults: number,
+  signal?: AbortSignal
+): Promise<SearchResult[]> {
+  const runForRoot = (root: string) =>
+    new Promise<string[]>((resolve) => {
+      execFile(
+        MDFIND_PATH,
+        ["-onlyin", root, `kind:folders ${query}`],
+        { maxBuffer: 16 * 1024 * 1024, timeout: 15000, signal },
+        (error, stdout) => {
+          if (error || !stdout) {
+            resolve([]);
+            return;
+          }
+          resolve(
+            stdout
+              .split("\n")
+              .map((line) => line.trim())
+              .filter(Boolean)
+          );
+        }
+      );
+    });
+
+  return Promise.all(roots.map(runForRoot)).then((perRoot) => {
+    const seen = new Set<string>();
+    const merged: SearchResult[] = [];
+
+    for (const paths of perRoot) {
+      for (const path of paths) {
+        if (seen.has(path)) continue;
+        seen.add(path);
+        merged.push(toSearchResult(path));
+        if (merged.length >= maxResults) return merged;
+      }
+    }
+
+    return merged;
+  });
+}
+
+/**
+ * Windows: recursively list directories under each configured root with
+ * PowerShell. Roots and the query are passed via environment variables so paths
+ * never get interpolated into the command string.
+ */
+export function searchDirectoriesWindows(
+  query: string,
+  roots: string[],
+  maxResults: number,
+  signal?: AbortSignal
+): Promise<SearchResult[]> {
+  return new Promise((resolve) => {
+    const psCommand = [
+      "$roots = $env:WARP_SEARCH_ROOTS -split '\\|';",
+      "Get-ChildItem -Path $roots -Directory -Recurse -Depth 5 -ErrorAction SilentlyContinue |",
+      "Where-Object { $_.Name -like ('*' + $env:WARP_SEARCH_QUERY + '*') } |",
+      `Select-Object -First ${maxResults} -ExpandProperty FullName`,
+    ].join(" ");
+
+    const env = {
+      ...process.env,
+      WARP_SEARCH_QUERY: query,
+      WARP_SEARCH_ROOTS: roots.join(WINDOWS_ROOT_DELIMITER),
+    };
+
+    execFile("powershell", ["-NoProfile", "-Command", psCommand], { timeout: 15000, env, signal }, (error, stdout) => {
+      if (error || !stdout) {
+        resolve([]);
+        return;
+      }
+      resolve(
+        stdout
+          .trim()
+          .split(/\r?\n/)
+          .filter(Boolean)
+          .map((path) => toSearchResult(path.trim()))
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

The **Open Directory** command previously searched the whole system — on macOS via a whole-index Spotlight query (`mdfind "kind:folders …"`) and on Windows by recursing from the user profile. This PR scopes the search to a user-managed list of **root folders** so it no longer trawls the entire machine.

### What changed

- **Configurable root folders** — new **Add Search Folder** (`⌘⇧A`) and **Manage Search Folders** (`⌘⇧M`) actions open a native folder picker (multi-select) and let you remove folders. The list persists automatically in `LocalStorage`.
- **Sensible default** — when no folders are configured, search falls back to the Home folder (`~`), so it works out of the box and is never system-wide.
- **macOS** — replaced `node-spotlight` with scoped `mdfind -onlyin <root>` calls (one per root, run in parallel and merged, capped at 250 results). This keeps Spotlight's fast index while honoring the configured scope. The `node-spotlight` dependency is removed.
- **Windows** — `Get-ChildItem` now recurses over the configured roots (passed via environment variables, so paths are never interpolated into the command string) instead of `$USERPROFILE`.

Pinned directories are unchanged — they are favorites within results, orthogonal to search scope.

### Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] `npm run build` and `npm run lint` succeed locally
- [x] I updated the `CHANGELOG.md` with a new entry
- [x] I removed the now-unused `node-spotlight` dependency
