### PR TITLE
[iTerm] Fix profile parsing for plists with Infinity floats

### DIFF
--- a/extensions/iterm/CHANGELOG.md
+++ b/extensions/iterm/CHANGELOG.md
@@ -1,6 +1,6 @@
 # iTerm Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-06-19
 
 - Fixed `Open iTerm Profile` failing when profiles contain values not representable in JSON (e.g. Infinity floats from status bar config)
 

--- a/extensions/iterm/CHANGELOG.md
+++ b/extensions/iterm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # iTerm Changelog
 
+## [Bug Fixes] - {PR_MERGE_DATE}
+
+- Fixed `Open iTerm Profile` failing when profiles contain values not representable in JSON (e.g. Infinity floats from status bar config)
+
 ## [Bug Fixes] - 2026-06-16
 
 - Fixed `Open iTerm Profile` if parts of a user's iTerm preferences plist other than profiles cannot be converted to JSON

--- a/extensions/iterm/package-lock.json
+++ b/extensions/iterm/package-lock.json
@@ -9,11 +9,13 @@
       "dependencies": {
         "@raycast/api": "^1.104.11",
         "@raycast/utils": "^2.2.3",
-        "file-url": "^4.0.0"
+        "file-url": "^4.0.0",
+        "plist": "^3.1.0"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
         "@types/node": "25.5.2",
+        "@types/plist": "^3.0.5",
         "@types/react": "19.2.14",
         "eslint": "^10.2.0",
         "prettier": "^3.8.1",
@@ -1157,6 +1159,17 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/plist": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1410,6 +1423,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1512,6 +1534,26 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
@@ -2432,6 +2474,20 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/plist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2739,6 +2795,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/extensions/iterm/package.json
+++ b/extensions/iterm/package.json
@@ -197,12 +197,14 @@
   },
   "dependencies": {
     "@raycast/api": "^1.104.11",
+    "@raycast/utils": "^2.2.3",
     "file-url": "^4.0.0",
-    "@raycast/utils": "^2.2.3"
+    "plist": "^3.1.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",
     "@types/node": "25.5.2",
+    "@types/plist": "^3.0.5",
     "@types/react": "19.2.14",
     "eslint": "^10.2.0",
     "prettier": "^3.8.1",

--- a/extensions/iterm/src/core/get-iterm-profiles.tsx
+++ b/extensions/iterm/src/core/get-iterm-profiles.tsx
@@ -1,6 +1,7 @@
 import { execFileSync } from "child_process";
 import { homedir } from "os";
 import { join } from "path";
+import plist from "plist";
 
 export interface ItermProfile {
   name: string;
@@ -18,7 +19,6 @@ type CapitalizeKeys<Type> = {
   [Property in keyof Type as Capitalize<string & Property>]: Type[Property];
 };
 
-/** A profile representation in the iTerm preferences file (via JSON conversion) */
 type PlistProfile = CapitalizeKeys<ItermProfile>;
 
 function isPlistProfile(entry: unknown): entry is PlistProfile {
@@ -35,9 +35,8 @@ function isPlistProfile(entry: unknown): entry is PlistProfile {
 export function getItermProfiles(): ItermProfile[] {
   // prettier-ignore
   const plutilArgs = [
-    "-extract", PlistPreferences.Keys.PROFILES, "json",
-    "-expect", "array",
-    "-o", "-", // Output to stdout
+    "-extract", PlistPreferences.Keys.PROFILES, "xml1",
+    "-o", "-",
     join(homedir(), PlistPreferences.USER_REL_PATH),
   ];
 
@@ -46,7 +45,12 @@ export function getItermProfiles(): ItermProfile[] {
       encoding: "utf-8",
       maxBuffer: 10 * 1024 * 1024,
     });
-    const profiles = JSON.parse(output) as unknown[]; // Safe assertion due to `-expect array`
+    const profiles = plist.parse(output);
+
+    if (!Array.isArray(profiles)) {
+      console.error("Expected an array of profiles from iTerm preferences");
+      return [];
+    }
 
     return profiles.filter(isPlistProfile).map((profile) => ({ name: profile.Name, guid: profile.Guid }));
   } catch (error) {


### PR DESCRIPTION
## Description

`plutil -extract "New Bookmarks" json` (introduced in #28166, refined in #28723) fails when iTerm profiles contain IEEE 754 `Infinity` float values. iTerm stores `+infinity` as the `maxwidth` knob for status bar components with no width limit — a common default configuration.

```
$ plutil -extract 'New Bookmarks' json -o - ~/Library/Preferences/com.googlecode.iterm2.plist
Invalid object in plist for JSON format
```

This PR switches from `json` to `xml1` format for the `plutil -extract` call and uses the `plist` npm package to parse the XML output. The `xml1` format handles all plist types including `<real>+infinity</real>`.

### Changes

- `get-iterm-profiles.tsx`: Replace `plutil -extract ... json` + `JSON.parse` with `plutil -extract ... xml1` + `plist.parse`
- `package.json`: Add `plist` and `@types/plist` dependencies
- `CHANGELOG.md`: Add bug fix entry

Fixes #28863

## Screencast

Tested locally with 12 profiles, all containing status bar components with `+infinity` maxwidth values. All profiles now appear correctly.