### PR TITLE
fix(windsurf): support Devin app name after rename

### DIFF
--- a/extensions/windsurf/CHANGELOG.md
+++ b/extensions/windsurf/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Support Devin (formerly Windsurf) app name] - {PR_MERGE_DATE}
+## [Support Devin (formerly Windsurf) app name] - 2026-06-19
 
 - Detect and launch the renamed "Devin" app, with fallback to "Windsurf" for older installations
 

--- a/extensions/windsurf/CHANGELOG.md
+++ b/extensions/windsurf/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Support Devin (formerly Windsurf) app name] - {PR_MERGE_DATE}
+
+- Detect and launch the renamed "Devin" app, with fallback to "Windsurf" for older installations
+
 ## [1.0.0] - 2025-06-30
 
 ### Added

--- a/extensions/windsurf/package.json
+++ b/extensions/windsurf/package.json
@@ -4,7 +4,10 @@
   "title": "Windsurf Extension",
   "description": "Quick Raycast actions for Windsurf: open files/folders in Windsurf and manage Windsurf projects.",
   "icon": "./extension-icon.png",
-  "categories": ["Developer Tools", "Productivity"],
+  "categories": [
+    "Developer Tools",
+    "Productivity"
+  ],
   "author": "vikas-bansal",
   "license": "MIT",
   "repository": {
@@ -44,5 +47,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/windsurf/src/utils/windsurf.ts
+++ b/extensions/windsurf/src/utils/windsurf.ts
@@ -27,9 +27,9 @@ export async function openInWindsurf(filePath: string): Promise<boolean> {
     const stats = fs.statSync(normalizedPath);
     const isDirectory = stats.isDirectory();
 
-    // Open in Windsurf with proper shell escaping
     const escapedPath = normalizedPath.replace(/'/g, "'\"'\"'");
-    await execAsync(`open -a "Windsurf" '${escapedPath}'`);
+    const appName = await getAppName();
+    await execAsync(`open -a "${appName}" '${escapedPath}'`);
 
     // Only save folders to recent projects (not files)
     if (isDirectory) {
@@ -55,17 +55,30 @@ export async function openInWindsurf(filePath: string): Promise<boolean> {
   }
 }
 
+async function getAppName(): Promise<string> {
+  try {
+    await execAsync("ls /Applications/Devin.app");
+    return "Devin";
+  } catch {
+    return "Windsurf";
+  }
+}
+
 export async function checkWindsurfInstalled(): Promise<boolean> {
   try {
     await execAsync("which windsurf");
     return true;
   } catch {
     try {
-      // Check if Windsurf app exists in Applications
-      await execAsync("ls /Applications/Windsurf.app");
+      await execAsync("ls /Applications/Devin.app");
       return true;
     } catch {
-      return false;
+      try {
+        await execAsync("ls /Applications/Windsurf.app");
+        return true;
+      } catch {
+        return false;
+      }
     }
   }
 }

--- a/extensions/windsurf/src/utils/windsurf.ts
+++ b/extensions/windsurf/src/utils/windsurf.ts
@@ -28,8 +28,13 @@ export async function openInWindsurf(filePath: string): Promise<boolean> {
     const isDirectory = stats.isDirectory();
 
     const escapedPath = normalizedPath.replace(/'/g, "'\"'\"'");
-    const appName = await getAppName();
-    await execAsync(`open -a "${appName}" '${escapedPath}'`);
+    const cli = await getCliName();
+    if (cli) {
+      await execAsync(`${cli} '${escapedPath}'`);
+    } else {
+      const appName = await getAppName();
+      await execAsync(`open -a "${appName}" '${escapedPath}'`);
+    }
 
     // Only save folders to recent projects (not files)
     if (isDirectory) {
@@ -55,6 +60,18 @@ export async function openInWindsurf(filePath: string): Promise<boolean> {
   }
 }
 
+async function getCliName(): Promise<string | null> {
+  for (const name of ["devin", "windsurf"]) {
+    try {
+      await execAsync(`which ${name}`);
+      return name;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
 async function getAppName(): Promise<string> {
   try {
     await execAsync("ls /Applications/Devin.app");
@@ -65,20 +82,16 @@ async function getAppName(): Promise<string> {
 }
 
 export async function checkWindsurfInstalled(): Promise<boolean> {
+  if (await getCliName()) return true;
   try {
-    await execAsync("which windsurf");
+    await execAsync("ls /Applications/Devin.app");
     return true;
   } catch {
     try {
-      await execAsync("ls /Applications/Devin.app");
+      await execAsync("ls /Applications/Windsurf.app");
       return true;
     } catch {
-      try {
-        await execAsync("ls /Applications/Windsurf.app");
-        return true;
-      } catch {
-        return false;
-      }
+      return false;
     }
   }
 }


### PR DESCRIPTION
## Description

Windsurf was recently renamed to Devin, so the extension fails with `Unable to find application named 'Windsurf'` for anyone on the new version.

This checks for `Devin.app` first and falls back to `Windsurf` so both old and new installs work.

## Checklist
- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder

Fixes #28838