### PR TITLE
fix(nextcloud): use correct URL format for opening files

### DIFF
--- a/extensions/nextcloud/CHANGELOG.md
+++ b/extensions/nextcloud/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nextcloud Changelog
 
-## [Fix Open File URL format] - {PR_MERGE_DATE}
+## [Fix Open File URL format] - 2026-06-19
 
 - Use the correct Nextcloud URL format for opening files, fixing 403 errors
 

--- a/extensions/nextcloud/CHANGELOG.md
+++ b/extensions/nextcloud/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Nextcloud Changelog
 
+## [Fix Open File URL format] - {PR_MERGE_DATE}
+
+- Use the correct Nextcloud URL format for opening files, fixing 403 errors
+
 ## [Fix Search when username is different] - 2025-12-13
 - Robust handling for hostname in `Preferences` (it should no longer crash even if user enters full URL) (ref: [Issue #23263](https://github.com/raycast/extensions/issues/23263))
 - Allow setting a custom username for files owner (ref: [Issue #23510](https://github.com/raycast/extensions/issues/23510))

--- a/extensions/nextcloud/src/favorites/Favorites.tsx
+++ b/extensions/nextcloud/src/favorites/Favorites.tsx
@@ -19,8 +19,8 @@ export function Favorites() {
 
 function Item({ result }: { result: Favorite }) {
   const url = path.extname(result.filename)
-    ? `${BASE_URL}/apps/files/?dir=${encodeURI(result.dirname)}&view=files`
-    : `${BASE_URL}/apps/files/?dir=${encodeURI(result.fullpath)}&view=files`;
+    ? `${BASE_URL}/apps/files/?dir=${encodeURIComponent(result.dirname)}&view=files`
+    : `${BASE_URL}/apps/files/?dir=${encodeURIComponent(result.fullpath)}&view=files`;
 
   return (
     <List.Item

--- a/extensions/nextcloud/src/search/Search.tsx
+++ b/extensions/nextcloud/src/search/Search.tsx
@@ -20,7 +20,7 @@ export function Search() {
 
 function Item({ result }: { result: SearchResult }) {
   const url = result.contentType
-    ? `${BASE_URL}/apps/files/?dir=${encodeURI(result.dirname)}&openfile=${result.fileId}`
+    ? `${BASE_URL}/index.php/apps/files/files/${result.fileId}?dir=${encodeURI(result.dirname)}&editing=false&openfile=true`
     : `${BASE_URL}/apps/files/?dir=${encodeURI(result.fullpath)}&view=files`;
   const approxFileSize = filesize(result.size).human("si");
 

--- a/extensions/nextcloud/src/search/Search.tsx
+++ b/extensions/nextcloud/src/search/Search.tsx
@@ -20,8 +20,8 @@ export function Search() {
 
 function Item({ result }: { result: SearchResult }) {
   const url = result.contentType
-    ? `${BASE_URL}/index.php/apps/files/files/${result.fileId}?dir=${encodeURI(result.dirname)}&editing=false&openfile=true`
-    : `${BASE_URL}/apps/files/?dir=${encodeURI(result.fullpath)}&view=files`;
+    ? `${BASE_URL}/index.php/apps/files/files/${result.fileId}?dir=${encodeURIComponent(result.dirname)}&editing=false&openfile=true`
+    : `${BASE_URL}/apps/files/?dir=${encodeURIComponent(result.fullpath)}&view=files`;
   const approxFileSize = filesize(result.size).human("si");
 
   return (


### PR DESCRIPTION
## Description

Opening a file from search results gives a 403 because the URL format changed in newer Nextcloud versions.

Old: `/apps/files/?dir=<path>&openfile=<id>`
New: `/index.php/apps/files/files/<id>?dir=<path>&editing=false&openfile=true`

## Checklist
- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder

Fixes #28837