### PR TITLE
fix(todoist): guard against empty sync response arrays

### DIFF
--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Todoist Changelog
 
+## [Guard against empty sync response arrays] - {PR_MERGE_DATE}
+
+- Prevent cache corruption when the Todoist Sync API returns an empty array for projects, items, labels, filters, or notes during incremental sync mutations.
+
 ## [Keep recurrence when rescheduling] - 2026-06-19
 
 - **Recurring tasks keep their repeat rule** when you change the due date from task actions or the menu bar (including shortcuts like Today, Tomorrow, Next Week, and Next Weekend).

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Todoist Changelog
 
-## [Guard against empty sync response arrays] - {PR_MERGE_DATE}
+## [Guard against empty sync response arrays] - 2026-06-19
 
 - Prevent cache corruption when the Todoist Sync API returns an empty array for projects, items, labels, filters, or notes during incremental sync mutations.
 

--- a/extensions/todoist/src/api.ts
+++ b/extensions/todoist/src/api.ts
@@ -194,6 +194,8 @@ export async function updateProject(args: UpdateProjectArgs, { setData }: Cached
     ],
   });
 
+  if (updatedData.projects.length === 0) return;
+
   mergeIntoCachedData(setData, (prev) => ({
     ...prev,
     projects: prev.projects.map((p) => (p.id === args.id ? updatedData.projects[0] : p)),
@@ -461,6 +463,8 @@ export async function moveTask(args: MoveTaskArgs, { setData }: CachedDataParams
     ],
   });
 
+  if (updatedData.items.length === 0) return;
+
   mergeIntoCachedData(setData, (prev) => ({
     ...prev,
     items: prev.items.map((i) => (i.id === args.id ? updatedData.items[0] : i)),
@@ -606,6 +610,8 @@ export async function addLabel(args: AddLabelArgs, { setData }: CachedDataParams
       ],
     });
 
+    if (addedData.labels.length === 0) return;
+
     mergeIntoCachedData(setData, (prev) => ({
       ...prev,
       labels: [...prev.labels, addedData.labels[0]],
@@ -638,6 +644,8 @@ export async function updateLabel(args: UpdateLabelArgs, { setData }: CachedData
       },
     ],
   });
+
+  if (updatedData.labels.length === 0) return;
 
   mergeIntoCachedData(setData, (prev) => ({
     ...prev,
@@ -696,6 +704,8 @@ export async function updateFilter(args: UpdateFilterArgs, { setData }: CachedDa
       },
     ],
   });
+
+  if (updatedData.filters.length === 0) return;
 
   mergeIntoCachedData(setData, (prev) => ({
     ...prev,
@@ -797,6 +807,8 @@ export async function updateComment(args: UpdateCommentArgs, { setData }: Cached
       },
     ],
   });
+
+  if (updatedData.notes.length === 0) return;
 
   mergeIntoCachedData(setData, (prev) => ({
     ...prev,


### PR DESCRIPTION
Several Sync API mutation functions access `[0]` on response arrays without checking if the array is empty. If the Todoist Sync API returns an empty array (network hiccup, server-side delay, eventual consistency), `undefined` gets merged into the cached data, corrupting the UI state and causing downstream crashes when React tries to render the `undefined` entry.

`updateTask` already has this guard (`updatedData.items.length === 0` early return) -- this PR adds the same pattern to the 6 functions that were missing it:

- `updateProject` -- `updatedData.projects[0]`
- `moveTask` -- `updatedData.items[0]`
- `addLabel` -- `addedData.labels[0]`
- `updateLabel` -- `updatedData.labels[0]`
- `updateFilter` -- `updatedData.filters[0]`
- `updateComment` -- `updatedData.notes[0]`