### PR TITLE
fix(spotify-player): fix stale seek position in menu bar skip/back actions

### DIFF
--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Spotify Player Changelog
 
+## [Fix stale seek position in menu bar] - {PR_MERGE_DATE}
+
+- Skip/back 15 seconds in the menu bar now estimates the current playback position using elapsed time since the last API fetch, instead of using the stale cached value.
+
 ## [See Which Playlists Contain the Current Song] - 2026-06-16
 
 - All "Add to Playlist" interactions now show a checkmark on playlists that already contain the song

--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Spotify Player Changelog
 
-## [Fix stale seek position in menu bar] - {PR_MERGE_DATE}
+## [Fix stale seek position in menu bar] - 2026-06-20
 
 - Skip/back 15 seconds in the menu bar now estimates the current playback position using elapsed time since the last API fetch, instead of using the stale cached value.
 

--- a/extensions/spotify-player/src/nowPlayingMenuBar.tsx
+++ b/extensions/spotify-player/src/nowPlayingMenuBar.tsx
@@ -220,7 +220,10 @@ function NowPlayingMenuBarCommand({ launchType }: LaunchProps) {
           title="Skip 15 seconds"
           onAction={async () => {
             try {
-              const currentPositionSeconds = (currentlyPlayingData?.progress_ms || 0) / 1000;
+              const elapsed = isPlaying && currentlyPlayingData?.timestamp
+                ? Date.now() - currentlyPlayingData.timestamp
+                : 0;
+              const currentPositionSeconds = ((currentlyPlayingData?.progress_ms || 0) + elapsed) / 1000;
               await seek(currentPositionSeconds + 15, currentlyPlayingData?.item?.duration_ms);
               await currentlyPlayingRevalidate();
             } catch (err) {
@@ -234,8 +237,11 @@ function NowPlayingMenuBarCommand({ launchType }: LaunchProps) {
           title="Back 15 seconds"
           onAction={async () => {
             try {
-              const currentPositionSeconds = (currentlyPlayingData?.progress_ms || 0) / 1000;
-              await seek(currentPositionSeconds - 15, currentlyPlayingData?.item?.duration_ms);
+              const elapsed = isPlaying && currentlyPlayingData?.timestamp
+                ? Date.now() - currentlyPlayingData.timestamp
+                : 0;
+              const currentPositionSeconds = ((currentlyPlayingData?.progress_ms || 0) + elapsed) / 1000;
+              await seek(Math.max(currentPositionSeconds - 15, 0), currentlyPlayingData?.item?.duration_ms);
               await currentlyPlayingRevalidate();
             } catch (err) {
               const error = getErrorMessage(err);


### PR DESCRIPTION
The menu bar "Skip 15 seconds" and "Back 15 seconds" actions for podcast episodes use `currentlyPlayingData.progress_ms` to compute the seek target. This value comes from the last API fetch, which could be minutes old. The longer since the last fetch, the further off the seek lands.

For example: if the episode was at 0:30 when last fetched and the user clicks "Skip 15s" a minute later, it seeks to 0:45 instead of the expected ~1:45.

The standalone `skip15.ts` and `back15.ts` commands don't have this issue because they fetch fresh data right before seeking. The menu bar uses cached React state instead.

**Fix:** When the track is playing, estimate the real position by adding `Date.now() - timestamp` (time elapsed since the Spotify API generated the response) to `progress_ms`. When paused, `progress_ms` is already accurate since playback isn't advancing.