### PR TITLE
fix(grafana): use encodeURIComponent for Explore link panes parameter

### DIFF
--- a/extensions/grafana/CHANGELOG.md
+++ b/extensions/grafana/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Grafana Changelog
 
-## [Fix Explore link URL encoding] - {PR_MERGE_DATE}
+## [Fix Explore link URL encoding] - 2026-06-19
 
 - Use `encodeURIComponent` for the JSON `panes` query parameter instead of `encodeURI`, which left `{`, `}`, `"`, and `&` unescaped, producing broken Explore URLs.
 - Fix double `&&` typo in the query string.

--- a/extensions/grafana/CHANGELOG.md
+++ b/extensions/grafana/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Grafana Changelog
 
+## [Fix Explore link URL encoding] - {PR_MERGE_DATE}
+
+- Use `encodeURIComponent` for the JSON `panes` query parameter instead of `encodeURI`, which left `{`, `}`, `"`, and `&` unescaped, producing broken Explore URLs.
+- Fix double `&&` typo in the query string.
+
 ## [New command] - 2025-10-03
 
 - Add a new command Pages to go to the most common pages in Grafana

--- a/extensions/grafana/src/helpers/helpers.ts
+++ b/extensions/grafana/src/helpers/helpers.ts
@@ -16,5 +16,5 @@ export const createExploreLink = (datasourceUid: string, query?: string) => {
     },
   };
 
-  return preferences.rootApiUrl + `/explore?${encodeURI(`schemaVersion=1&&panes=${JSON.stringify(URLQuery)}`)}`;
+  return preferences.rootApiUrl + `/explore?schemaVersion=1&panes=${encodeURIComponent(JSON.stringify(URLQuery))}`;
 };


### PR DESCRIPTION
`createExploreLink` builds an Explore URL with a `panes` query parameter containing `JSON.stringify()` output. It uses `encodeURI()` to encode the whole query string, but `encodeURI` does not encode `{`, `}`, `"`, `:`, or `&` -- all of which appear in JSON. This produces broken URLs that Grafana cannot parse.

Also fixes a `&&` typo in the query string (`schemaVersion=1&&panes=...` should be `schemaVersion=1&panes=...`).

**Before:**
```
/explore?schemaVersion=1&&panes={%22zmo%22:{%22datasource%22:%22abc%22}}
```

**After:**
```
/explore?schemaVersion=1&panes=%7B%22zmo%22%3A%7B%22datasource%22%3A%22abc%22%7D%7D
```