### PR TITLE
Update raycast-mimo-tts extension

### DIFF
--- a/extensions/raycast-mimo-tts/.eslintrc.json
+++ b/extensions/raycast-mimo-tts/.eslintrc.json
@@ -1,4 +1,0 @@
-{
-  "root": true,
-  "extends": ["@raycast"]
-}

--- a/extensions/raycast-mimo-tts/.eslintrc.json
+++ b/extensions/raycast-mimo-tts/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": ["@raycast"]
+}

--- a/extensions/raycast-mimo-tts/CHANGELOG.md
+++ b/extensions/raycast-mimo-tts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # MiMo TTS Changelog
 
-## [Fix Setup Form Reset] - {PR_MERGE_DATE}
+## [Fix Setup Form Reset] - 2026-06-19
 
 - Fix "Reset to Preferences" in Setup MiMo Voice Defaults: resetting now syncs the model dropdown and voice filter, so a later Save no longer silently re-saves the pre-reset model and recreates the override that was just cleared.
 

--- a/extensions/raycast-mimo-tts/CHANGELOG.md
+++ b/extensions/raycast-mimo-tts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MiMo TTS Changelog
 
+## [Fix Setup Form Reset] - {PR_MERGE_DATE}
+
+- Fix "Reset to Preferences" in Setup MiMo Voice Defaults: resetting now syncs the model dropdown and voice filter, so a later Save no longer silently re-saves the pre-reset model and recreates the override that was just cleared.
+
 ## [Initial Release] - 2026-06-19
 
 - Extract MiMo TTS into a standalone Raycast extension from AI Voice Studio.

--- a/extensions/raycast-mimo-tts/package-lock.json
+++ b/extensions/raycast-mimo-tts/package-lock.json
@@ -1149,7 +1149,6 @@
       "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1209,7 +1208,6 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -1414,7 +1412,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1709,7 +1706,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -2407,7 +2403,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2431,7 +2426,6 @@
       "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2615,7 +2609,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/raycast-mimo-tts/src/components/provider-setup-form.tsx
+++ b/extensions/raycast-mimo-tts/src/components/provider-setup-form.tsx
@@ -101,6 +101,7 @@ export default function SetupVoiceDefaults() {
     await Promise.all([clearMimoSettingsOverrides(), clearQuickReadVoiceOverride(), clearSpeedOverride()]);
     const fresh = await getMimoSettings();
     setSettings(fresh);
+    setSelectedModel(fresh.model);
     setHasOverrides(false);
     await showToast({ style: Toast.Style.Success, title: "Voice defaults reset" });
   }, []);


### PR DESCRIPTION
## Description

Maintenance fix for the already-published **MiMo TTS** extension.

Fixes a bug flagged in automated review after the initial PR (#28369) merged: in **Setup MiMo Voice Defaults**, the "Reset to Preferences" action cleared the saved override but never resynced `selectedModel`. Because the model `Form.Dropdown` is uncontrolled (`defaultValue` only), the dropdown and the voice filter kept showing the pre-reset model, and a subsequent "Save Voice Defaults" re-saved that stale model — silently recreating the override that was just cleared.

The fix adds `setSelectedModel(fresh.model)` right after `setSettings(fresh)` in `handleReset`, so the form state, dropdown, and voice filter all follow the reset.

- `src/components/provider-setup-form.tsx` — one-line state sync in `handleReset`
- `CHANGELOG.md` — new entry
- `package-lock.json` — incidental metadata sync from `npm install`

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` (and `ray lint` — both pass clean)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
