### PR TITLE
World Cup: limit menu bar dropdown to a day window around today

### DIFF
--- a/extensions/world-cup/CHANGELOG.md
+++ b/extensions/world-cup/CHANGELOG.md
@@ -1,6 +1,6 @@
 # World Cup Changelog
 
-## [Menu Bar Day Filter] - {PR_MERGE_DATE}
+## [Menu Bar Day Filter] - 2026-06-19
 
 - The **World Cup Menu Bar** dropdown now lists only the day's fixtures by default, with a new **Days to Show** preference that widens the window symmetrically around today (Today only, Yesterday to tomorrow, Last & next 3 days/week, or All matches)
 - Each match in the dropdown now opens its own FIFA match centre page instead of all linking to the ESPN scoreboard

--- a/extensions/world-cup/CHANGELOG.md
+++ b/extensions/world-cup/CHANGELOG.md
@@ -1,5 +1,10 @@
 # World Cup Changelog
 
+## [Menu Bar Day Filter] - 2026-06-19
+
+- The **World Cup Menu Bar** dropdown now lists only the day's fixtures by default, with a new **Days to Show** preference that widens the window symmetrically around today (Today only, Yesterday to tomorrow, Last & next 3 days/week, or All matches)
+- Each match in the dropdown now opens its own FIFA match centre page instead of all linking to the ESPN scoreboard
+
 ## [AI Match Questions] - 2026-06-17
 
 - Added AI tools for asking about World Cup schedules, country matchups, and goal totals by country or player

--- a/extensions/world-cup/CHANGELOG.md
+++ b/extensions/world-cup/CHANGELOG.md
@@ -1,6 +1,6 @@
 # World Cup Changelog
 
-## [Menu Bar Day Filter] - 2026-06-19
+## [Menu Bar Day Filter] - {PR_MERGE_DATE}
 
 - The **World Cup Menu Bar** dropdown now lists only the day's fixtures by default, with a new **Days to Show** preference that widens the window symmetrically around today (Today only, Yesterday to tomorrow, Last & next 3 days/week, or All matches)
 - Each match in the dropdown now opens its own FIFA match centre page instead of all linking to the ESPN scoreboard

--- a/extensions/world-cup/CHANGELOG.md
+++ b/extensions/world-cup/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The **World Cup Menu Bar** dropdown now lists only the day's fixtures by default, with a new **Days to Show** preference that widens the window symmetrically around today (Today only, Yesterday to tomorrow, Last & next 3 days/week, or All matches)
 - Each match in the dropdown now opens its own FIFA match centre page instead of all linking to the ESPN scoreboard
+- Use the `×` separator between teams for upcoming matches, in both the menu bar and the Matches list
 
 ## [AI Match Questions] - 2026-06-17
 

--- a/extensions/world-cup/package.json
+++ b/extensions/world-cup/package.json
@@ -27,9 +27,26 @@
       "name": "menubar",
       "title": "World Cup Menu Bar",
       "subtitle": "FIFA World Cup",
-      "description": "Shows the live match score in the menu bar with a dropdown of every fixture",
+      "description": "Shows the live match score in the menu bar with a dropdown of the day's fixtures",
       "mode": "menu-bar",
-      "interval": "1m"
+      "interval": "1m",
+      "preferences": [
+        {
+          "name": "daysToShow",
+          "title": "Days to Show",
+          "description": "How wide a window of fixtures to list in the dropdown, centered on today.",
+          "type": "dropdown",
+          "required": false,
+          "default": "0",
+          "data": [
+            { "title": "Today only", "value": "0" },
+            { "title": "Yesterday to tomorrow", "value": "1" },
+            { "title": "Last & next 3 days", "value": "3" },
+            { "title": "Last & next week", "value": "7" },
+            { "title": "All matches", "value": "all" }
+          ]
+        }
+      ]
     },
     {
       "name": "score-subtitle",

--- a/extensions/world-cup/src/index.tsx
+++ b/extensions/world-cup/src/index.tsx
@@ -213,7 +213,7 @@ export default function Command() {
                   }}
                   subtitle={!isFinishedMatch(match) ? capitalizeFirstLetter(getTime(match)) : ""}
                   keywords={[teamName(Home), teamName(Away)]}
-                  title={`${home}  vs  ${away}`}
+                  title={`${home}  ×  ${away}`}
                   accessories={[
                     isLiveMatch(match) || isFinishedMatch(match)
                       ? { text: isLiveMatch(match) ? getScore(match) : `${score.home ?? 0} : ${score.away ?? 0}` }

--- a/extensions/world-cup/src/lib/worldcup.ts
+++ b/extensions/world-cup/src/lib/worldcup.ts
@@ -170,7 +170,7 @@ export function formatLine(match: Match): string {
   const away = teamLabel(match.Away);
   const state = matchState(match);
 
-  if (state === "pre") return `${home} v ${away} · ${kickoff(match.Date)}`;
+  if (state === "pre") return `${home} × ${away} · ${kickoff(match.Date)}`;
 
   const score = formatScore(match);
   const detail = state === "in" ? match.MatchTime || "Live" : "Finished";

--- a/extensions/world-cup/src/lib/worldcup.ts
+++ b/extensions/world-cup/src/lib/worldcup.ts
@@ -81,6 +81,29 @@ export function getMatchCenterUrl(match: Pick<Match, "IdCompetition" | "IdSeason
   return `https://www.fifa.com/fifaplus/en/match-centre/match/${match.IdCompetition}/${match.IdSeason}/${match.IdStage}/${match.IdMatch}`;
 }
 
+/**
+ * Keep only matches whose kickoff falls within a window of `radius` calendar
+ * days on either side of today (so `radius === 0` is today only, `radius === 1`
+ * is yesterday through tomorrow). A negative `radius` returns everything, for
+ * an "All matches" option.
+ */
+export function matchesAroundToday(matches: Match[], radius: number): Match[] {
+  if (!Number.isFinite(radius) || radius < 0) return matches;
+
+  const start = new Date();
+  start.setHours(0, 0, 0, 0);
+  start.setDate(start.getDate() - radius);
+
+  const end = new Date();
+  end.setHours(0, 0, 0, 0);
+  end.setDate(end.getDate() + radius + 1);
+
+  return matches.filter((m) => {
+    const date = new Date(m.Date).getTime();
+    return date >= start.getTime() && date < end.getTime();
+  });
+}
+
 /** The currently in-progress match, if any. */
 export function liveMatch(matches: Match[]): Match | undefined {
   return matches.find((m) => matchState(m) === "in");

--- a/extensions/world-cup/src/menubar.tsx
+++ b/extensions/world-cup/src/menubar.tsx
@@ -1,7 +1,9 @@
-import { MenuBarExtra, open, openCommandPreferences, showHUD } from "@raycast/api";
+import { MenuBarExtra, getPreferenceValues, open, openCommandPreferences, showHUD } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import {
   getMatches,
+  getMatchCenterUrl,
+  matchesAroundToday,
   liveMatch,
   formatLine,
   menuBarTitle,
@@ -15,6 +17,13 @@ import {
 
 const SCOREBOARD_URL = "https://www.espn.com/soccer/scoreboard";
 
+/** "all" -> show every match (radius -1); otherwise the window radius in days around today. */
+function windowRadius(): number {
+  const value = getPreferenceValues<Preferences.Menubar>().daysToShow;
+  if (value === "all") return -1;
+  return Number(value) || 0;
+}
+
 export default function Command() {
   // useCachedPromise paints the last known scores instantly on cold start,
   // then revalidates against ESPN.
@@ -24,8 +33,13 @@ export default function Command() {
   // on" flash before the async read settles.
   const { data: goals = true, mutate: mutateGoals } = useCachedPromise(goalsEnabled);
 
+  // The title tracks the live match regardless of the dropdown window (a live
+  // match is always today, so it's always in range anyway).
   const live = liveMatch(matches);
   const title = live ? menuBarTitle(live) : undefined;
+
+  const radius = windowRadius();
+  const visible = matchesAroundToday(matches, radius);
 
   async function toggleGoals() {
     const next = !goals;
@@ -36,11 +50,11 @@ export default function Command() {
 
   return (
     <MenuBarExtra icon={live ? undefined : "⚽"} title={title} isLoading={isLoading} tooltip="World Cup">
-      {matches.length === 0 && <MenuBarExtra.Item title="No fixtures today" />}
+      {visible.length === 0 && <MenuBarExtra.Item title={radius === 0 ? "No fixtures today" : "No fixtures"} />}
 
-      <Section heading="Live" matches={matches.filter(isLiveMatch)} />
-      <Section heading="Upcoming" matches={matches.filter(isUpcomingMatch)} />
-      <Section heading="Finished" matches={matches.filter(isFinishedMatch)} />
+      <Section heading="Live" matches={visible.filter(isLiveMatch)} />
+      <Section heading="Upcoming" matches={visible.filter(isUpcomingMatch)} />
+      <Section heading="Finished" matches={visible.filter(isFinishedMatch)} />
 
       <MenuBarExtra.Section>
         <MenuBarExtra.Item
@@ -68,7 +82,7 @@ function Section({ heading, matches }: { heading: string; matches: Match[] }) {
   return (
     <MenuBarExtra.Section title={heading}>
       {matches.map((m) => (
-        <MenuBarExtra.Item key={m.IdMatch} title={formatLine(m)} onAction={() => open(SCOREBOARD_URL)} />
+        <MenuBarExtra.Item key={m.IdMatch} title={formatLine(m)} onAction={() => open(getMatchCenterUrl(m))} />
       ))}
     </MenuBarExtra.Section>
   );


### PR DESCRIPTION
## Description

Follow-up fix to the **World Cup Menu Bar** command. After it shipped, the dropdown started listing the entire 104-match calendar, which is hard to scan, and every match item opened the same generic ESPN scoreboard.

This restores a focused, scorecard-style menu bar:

- **New "Days to Show" preference** (default **Today only**) that windows the dropdown symmetrically around today: Today only · Yesterday to tomorrow · Last & next 3 days · Last & next week · All matches. Today always shows every match (finished, live and upcoming).
- **Each match now opens its own FIFA match centre page** via the existing `getMatchCenterUrl`, instead of all linking to the ESPN scoreboard.
- The menu-bar **title still always tracks the live match**, regardless of the dropdown window.

No new dependencies. The day-window logic lives in `src/lib/worldcup.ts` (`matchesAroundToday`).

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I ran `npm run lint` (`npx ray lint`) and it passed
- [x] I checked that the extension works in the dev build
- [x] I added a CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
