### PR TITLE
Orion: fix Search Tabs showing no open tabs

### DIFF
--- a/extensions/orion/CHANGELOG.md
+++ b/extensions/orion/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Orion Changelog
 
-## [Fix Search Tabs] - {PR_MERGE_DATE}
+## [Fix Search Tabs] - 2026-06-21
 
 - Fix "Search Tabs" showing no tabs on current Orion versions. Orion's AppleScript bridge no longer resolves `URL`/`name` getters on the individual tab objects returned by `window.tabs()`; the failure was silently swallowed, leaving the list empty. Switched to bulk property access (`window.tabs.url()` / `window.tabs.name()`) for listing tabs and indexed tab specifiers (`window.tabs[i]`) for opening and closing them.
 

--- a/extensions/orion/CHANGELOG.md
+++ b/extensions/orion/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Orion Changelog
 
+## [Fix Search Tabs] - {PR_MERGE_DATE}
+
+- Fix "Search Tabs" showing no tabs on current Orion versions. Orion's AppleScript bridge no longer resolves `URL`/`name` getters on the individual tab objects returned by `window.tabs()`; the failure was silently swallowed, leaving the list empty. Switched to bulk property access (`window.tabs.url()` / `window.tabs.name()`) for listing tabs and indexed tab specifiers (`window.tabs[i]`) for opening and closing them.
+
 ## [Profile Support] - 2023-09-07
 
 - Support filtering by profile when searching for bookmarks, history, and reading list. Tabs are not supported.

--- a/extensions/orion/src/components/CloseTabAction.tsx
+++ b/extensions/orion/src/components/CloseTabAction.tsx
@@ -7,11 +7,19 @@ const closeTab = async (tab: Tab) =>
   executeJxa(`
     const orion = Application("${getOrionAppIdentifier()}");
     const window = orion.windows.byId(${tab.window_id});
-    const tab = window.tabs().find(tab => tab.url() === String.raw\`${tab.url}\` && tab.name() === String.raw\`${
-      tab.title
-    }\`);
-    if (tab) {
-      tab.close();
+    const urls = window.tabs.url();
+    const names = window.tabs.name();
+    const targetUrl = String.raw\`${tab.url}\`;
+    const targetName = String.raw\`${tab.title}\`;
+    let index = -1;
+    for (let i = 0; i < urls.length; i++) {
+      if (urls[i] === targetUrl && names[i] === targetName) {
+        index = i;
+        break;
+      }
+    }
+    if (index !== -1) {
+      window.tabs[index].close();
     }
 `);
 

--- a/extensions/orion/src/components/OpenTabAction.tsx
+++ b/extensions/orion/src/components/OpenTabAction.tsx
@@ -7,12 +7,20 @@ const activateTab = async (tab: Tab) =>
   executeJxa(`
     const orion = Application("${getOrionAppIdentifier()}");
     const window = orion.windows.byId(${tab.window_id});
-    const tab = window.tabs().find(tab => tab.url() === String.raw\`${tab.url}\` && tab.name() === String.raw\`${
-      tab.title
-    }\`);
-    if (tab) {
+    const urls = window.tabs.url();
+    const names = window.tabs.name();
+    const targetUrl = String.raw\`${tab.url}\`;
+    const targetName = String.raw\`${tab.title}\`;
+    let index = -1;
+    for (let i = 0; i < urls.length; i++) {
+      if (urls[i] === targetUrl && names[i] === targetName) {
+        index = i;
+        break;
+      }
+    }
+    if (index !== -1) {
       window.index = 1;
-      window.currentTab = tab;
+      window.currentTab = window.tabs[index];
       orion.activate();
     }
   `);

--- a/extensions/orion/src/hooks/useTabs.ts
+++ b/extensions/orion/src/hooks/useTabs.ts
@@ -7,18 +7,30 @@ async function fetchLocalTabs(): Promise<Tab[]> {
   const res = await executeJxa(`
     const orion = Application("${getOrionAppIdentifier()}");
     const tabs = [];
+    const seen = {};
     orion.windows().forEach(window => {
-      const windowTabs = window.tabs();
-      if (windowTabs) {
-        windowTabs.forEach(tab => {
-          if (!tabs.find(existingTab => existingTab.url === tab.url())) {
-            tabs.push({
-              title: tab.name(),
-              url: tab.url() || '',
-              window_id: window.id(),
-            });
-          }
-        })
+      const windowId = window.id();
+      // Orion's scripting bridge fails when reading 'URL'/'name' from the tab
+      // objects returned by window.tabs(), but bulk property access on the tab
+      // collection (window.tabs.url() / .name()) works, so read them that way.
+      let urls, names;
+      try {
+        urls = window.tabs.url();
+        names = window.tabs.name();
+      } catch (e) {
+        return;
+      }
+      const count = Math.min(urls.length, names.length);
+      for (let i = 0; i < count; i++) {
+        const url = urls[i] || '';
+        if (!seen[url]) {
+          seen[url] = true;
+          tabs.push({
+            title: names[i],
+            url: url,
+            window_id: windowId,
+          });
+        }
       }
     });
     tabs


### PR DESCRIPTION
## Description

Fixes the **Search Tabs** command for the Orion extension, which currently shows **no tabs**. Reproduced on Orion 1.0.8 (147.1).

### Root cause

`Search Tabs` enumerates tabs via JXA, reading `URL`/`name` off the individual tab objects returned by `window.tabs()`:

```js
orion.windows().forEach(window => {
  window.tabs().forEach(tab => { ...tab.url()... tab.name()... })
})
```

On current Orion, calling those property getters on the **objects returned by `window.tabs()`** fails with Apple Event errors (`-1700 "Can't convert types"` / `-1728 "Can't get object"`). The first `tab.url()` throws, `executeJxa` swallows the error, and `fetchLocalTabs` falls back to `[]`, so the list is empty. `Open Tab` and `Close Tab` broke the same way — their `.find(t => t.url() === …)` callbacks throw.

The scripting dictionary is unchanged (`tab` still exposes `URL` and `name`); only per-object getter resolution on the evaluated collection is broken.

### Fix

Two access patterns still work reliably:

- **Bulk** property access on the tab collection: `window.tabs.url()` / `window.tabs.name()` (returns arrays)
- **Indexed** tab specifiers: `window.tabs[i]`

Changes:
- `useTabs` lists tabs via bulk access (also fewer Apple Events, so faster).
- `OpenTabAction` / `CloseTabAction` find the matching index from the bulk arrays, then act on `window.tabs[index]`.

Existing behavior (dedupe by URL, keep first occurrence) is preserved.

### Verification

- `ray build` and `ray lint` pass.
- Tested against live Orion 1.0.8 (147.1): listing returns every open tab across all windows (25 tabs / 7 windows here) with correct titles and URLs; the index lookup used by open/close resolves to the correct tab.
