### PR TITLE
[Unsplash] Add Windows support for wallpaper, clipboard, and save

### DIFF
--- a/extensions/unsplash/CHANGELOG.md
+++ b/extensions/unsplash/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unsplash Changelog
 
-## [Windows Support] - {PR_MERGE_DATE}
+## [Windows Support] - 2026-06-29
 
 - Added Windows support for setting wallpaper, copying images to clipboard, and saving images
 - Wallpaper: uses PowerShell + Win32 SystemParametersInfo on Windows

--- a/extensions/unsplash/CHANGELOG.md
+++ b/extensions/unsplash/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unsplash Changelog
 
+## [Windows Support] - {PR_MERGE_DATE}
+
+- Added Windows support for setting wallpaper, copying images to clipboard, and saving images
+- Wallpaper: uses PowerShell + Win32 SystemParametersInfo on Windows
+- Clipboard: uses PowerShell System.Windows.Forms on Windows
+- Save: downloads to Desktop on Windows (folder picker is macOS-only)
+
 ## [Modernize & OAuth Setup Guide] - 2026-05-28
 
 - Added OAuth setup guide shown before login — displays the required redirect URI and a Connect button so users can set up their Unsplash app without confusion

--- a/extensions/unsplash/package.json
+++ b/extensions/unsplash/package.json
@@ -9,7 +9,8 @@
     "Kang",
     "yug2005",
     "xmok",
-    "alexi.build"
+    "alexi.build",
+    "arinbalyan"
   ],
   "license": "MIT",
   "keywords": [
@@ -333,6 +334,7 @@
     "publish": "npx @raycast/api@latest publish"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ]
 }

--- a/extensions/unsplash/src/functions/copyFileToClipboard.ts
+++ b/extensions/unsplash/src/functions/copyFileToClipboard.ts
@@ -1,6 +1,10 @@
 import { showToast, Toast, environment } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
+import { exec } from "child_process";
+import { promisify } from "util";
 import { existsSync } from "fs";
+
+const execP = promisify(exec);
 
 interface CopyFileToClipboardProps {
   url: string;
@@ -14,6 +18,22 @@ export const copyFileToClipboard = async ({ url, id }: CopyFileToClipboardProps)
   const fixedPathName = selectedPath.endsWith("/") ? `${selectedPath}${id}.jpg` : `${selectedPath}/${id}.jpg`;
 
   try {
+    if (process.platform === "win32") {
+      if (!existsSync(fixedPathName)) {
+        await execP(`curl.exe -s -o "${fixedPathName}" "${url}"`);
+      }
+      const ps = `
+Add-Type -AssemblyName System.Windows.Forms
+$img = [System.Drawing.Image]::FromFile('${fixedPathName.replace(/'/g, "''")}')
+[System.Windows.Forms.Clipboard]::SetImage($img)
+$img.Dispose()`;
+      const encoded = Buffer.from(ps.trim(), "utf16le").toString("base64");
+      await execP(`powershell -NoProfile -EncodedCommand ${encoded}`);
+      toast.style = Toast.Style.Success;
+      toast.title = "Image copied to the clipboard!";
+      return;
+    }
+
     const actualPath = fixedPathName;
 
     const command = !existsSync(actualPath)

--- a/extensions/unsplash/src/functions/copyFileToClipboard.ts
+++ b/extensions/unsplash/src/functions/copyFileToClipboard.ts
@@ -29,7 +29,7 @@ $img = [System.Drawing.Image]::FromFile('${fixedPathName.replace(/'/g, "''")}')
 [System.Windows.Forms.Clipboard]::SetImage($img)
 $img.Dispose()`;
       const encoded = Buffer.from(ps.trim(), "utf16le").toString("base64");
-      await execFileP("powershell", ["-NoProfile", "-EncodedCommand", encoded]);
+      await execFileP("powershell", ["-NoProfile", "-STA", "-EncodedCommand", encoded]);
       toast.style = Toast.Style.Success;
       toast.title = "Image copied to the clipboard!";
       return;

--- a/extensions/unsplash/src/functions/copyFileToClipboard.ts
+++ b/extensions/unsplash/src/functions/copyFileToClipboard.ts
@@ -20,7 +20,7 @@ export const copyFileToClipboard = async ({ url, id }: CopyFileToClipboardProps)
   try {
     if (process.platform === "win32") {
       if (!existsSync(fixedPathName)) {
-        await execFileP("curl.exe", ["-s", "-o", fixedPathName, url]);
+        await execFileP("curl.exe", ["-s", "--fail", "-o", fixedPathName, url]);
       }
       const ps = `
 Add-Type -AssemblyName System.Drawing

--- a/extensions/unsplash/src/functions/copyFileToClipboard.ts
+++ b/extensions/unsplash/src/functions/copyFileToClipboard.ts
@@ -2,7 +2,7 @@ import { showToast, Toast, environment } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
 import { execFile } from "child_process";
 import { promisify } from "util";
-import { existsSync } from "fs";
+import { existsSync, unlinkSync } from "fs";
 
 const execFileP = promisify(execFile);
 
@@ -20,7 +20,16 @@ export const copyFileToClipboard = async ({ url, id }: CopyFileToClipboardProps)
   try {
     if (process.platform === "win32") {
       if (!existsSync(fixedPathName)) {
-        await execFileP("curl.exe", ["-s", "--fail", "-o", fixedPathName, url]);
+        try {
+          await execFileP("curl.exe", ["-s", "--fail", "-o", fixedPathName, url]);
+        } catch (err) {
+          try {
+            unlinkSync(fixedPathName);
+          } catch {
+            // ignore cleanup error
+          }
+          throw err;
+        }
       }
       const ps = `
 Add-Type -AssemblyName System.Drawing

--- a/extensions/unsplash/src/functions/copyFileToClipboard.ts
+++ b/extensions/unsplash/src/functions/copyFileToClipboard.ts
@@ -1,10 +1,10 @@
 import { showToast, Toast, environment } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 import { existsSync } from "fs";
 
-const execP = promisify(exec);
+const execFileP = promisify(execFile);
 
 interface CopyFileToClipboardProps {
   url: string;
@@ -20,15 +20,16 @@ export const copyFileToClipboard = async ({ url, id }: CopyFileToClipboardProps)
   try {
     if (process.platform === "win32") {
       if (!existsSync(fixedPathName)) {
-        await execP(`curl.exe -s -o "${fixedPathName}" "${url}"`);
+        await execFileP("curl.exe", ["-s", "-o", fixedPathName, url]);
       }
       const ps = `
+Add-Type -AssemblyName System.Drawing
 Add-Type -AssemblyName System.Windows.Forms
 $img = [System.Drawing.Image]::FromFile('${fixedPathName.replace(/'/g, "''")}')
 [System.Windows.Forms.Clipboard]::SetImage($img)
 $img.Dispose()`;
       const encoded = Buffer.from(ps.trim(), "utf16le").toString("base64");
-      await execP(`powershell -NoProfile -EncodedCommand ${encoded}`);
+      await execFileP("powershell", ["-NoProfile", "-EncodedCommand", encoded]);
       toast.style = Toast.Style.Success;
       toast.title = "Image copied to the clipboard!";
       return;

--- a/extensions/unsplash/src/functions/saveImage.ts
+++ b/extensions/unsplash/src/functions/saveImage.ts
@@ -1,11 +1,11 @@
 import { getPreferenceValues, showHUD } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 import { join } from "path";
 import { homedir } from "os";
 
-const execP = promisify(exec);
+const execFileP = promisify(execFile);
 
 interface SaveImageProps {
   url: string;
@@ -18,7 +18,8 @@ export const saveImage = async ({ url, id }: SaveImageProps) => {
   try {
     if (process.platform === "win32") {
       const dest = join(homedir(), "Desktop", `${id}-${downloadSize}.jpg`);
-      await execP(`curl.exe -s -o "${dest}" "${url}"`);
+      await execFileP("curl.exe", ["-s", "-o", dest, url]);
+      await showHUD(`Image saved to Desktop`);
       return;
     }
 

--- a/extensions/unsplash/src/functions/saveImage.ts
+++ b/extensions/unsplash/src/functions/saveImage.ts
@@ -16,13 +16,14 @@ export const saveImage = async ({ url, id }: SaveImageProps) => {
 
   try {
     if (process.platform === "win32") {
+      await showHUD("Downloading image...");
       const desktopResult = await execFileP("powershell", [
         "-NoProfile",
         "-Command",
         "[Environment]::GetFolderPath('Desktop')",
       ]);
       const dest = join(desktopResult.stdout.trim(), `${id}-${downloadSize}.jpg`);
-      await execFileP("curl.exe", ["-s", "-o", dest, url]);
+      await execFileP("curl.exe", ["-s", "--fail", "-o", dest, url]);
       await showHUD(`Image saved to Desktop`);
       return;
     }

--- a/extensions/unsplash/src/functions/saveImage.ts
+++ b/extensions/unsplash/src/functions/saveImage.ts
@@ -3,7 +3,6 @@ import { runAppleScript } from "@raycast/utils";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { join } from "path";
-import { homedir } from "os";
 
 const execFileP = promisify(execFile);
 
@@ -17,7 +16,12 @@ export const saveImage = async ({ url, id }: SaveImageProps) => {
 
   try {
     if (process.platform === "win32") {
-      const dest = join(homedir(), "Desktop", `${id}-${downloadSize}.jpg`);
+      const desktopResult = await execFileP("powershell", [
+        "-NoProfile",
+        "-Command",
+        "[Environment]::GetFolderPath('Desktop')",
+      ]);
+      const dest = join(desktopResult.stdout.trim(), `${id}-${downloadSize}.jpg`);
       await execFileP("curl.exe", ["-s", "-o", dest, url]);
       await showHUD(`Image saved to Desktop`);
       return;

--- a/extensions/unsplash/src/functions/saveImage.ts
+++ b/extensions/unsplash/src/functions/saveImage.ts
@@ -1,5 +1,11 @@
 import { getPreferenceValues, showHUD } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
+import { exec } from "child_process";
+import { promisify } from "util";
+import { join } from "path";
+import { homedir } from "os";
+
+const execP = promisify(exec);
 
 interface SaveImageProps {
   url: string;
@@ -10,6 +16,12 @@ export const saveImage = async ({ url, id }: SaveImageProps) => {
   const { downloadSize } = getPreferenceValues<Preferences>();
 
   try {
+    if (process.platform === "win32") {
+      const dest = join(homedir(), "Desktop", `${id}-${downloadSize}.jpg`);
+      await execP(`curl.exe -s -o "${dest}" "${url}"`);
+      return;
+    }
+
     await showHUD("Please select a location to save the image...");
 
     await runAppleScript(`

--- a/extensions/unsplash/src/functions/setWallpaper.ts
+++ b/extensions/unsplash/src/functions/setWallpaper.ts
@@ -1,7 +1,11 @@
 import { showToast, Toast, environment, getPreferenceValues, showHUD } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
+import { exec } from "child_process";
+import { promisify } from "util";
 import { existsSync } from "fs";
 import { resolveHome } from "./utils";
+
+const execP = promisify(exec);
 
 interface SetWallpaperProps {
   url: string;
@@ -15,6 +19,20 @@ const displayMessage = async (msg: string, type: "hud" | "toast") => {
   if (type === "hud") await showHUD(msg);
   else return await showToast(Toast.Style.Animated, msg);
 };
+
+async function setWallpaperWindows(imagePath: string) {
+  const ps = `$c=@"
+using System.Runtime.InteropServices;
+public class W {
+  [DllImport("user32.dll",CharSet=CharSet.Auto)]
+  public static extern int SystemParametersInfo(int a,int b,string c,int d);
+}
+"@
+Add-Type -TypeDefinition $c
+[W]::SystemParametersInfo(20,0,'${imagePath.replace(/'/g, "''")}',2)`;
+  const encoded = Buffer.from(ps, "utf16le").toString("base64");
+  await execP(`powershell -NoProfile -EncodedCommand ${encoded}`);
+}
 
 export const setWallpaper = async ({ url, id, every, useHud = false, isBackground = false }: SetWallpaperProps) => {
   const { downloadSize, wallpaperPath } = getPreferenceValues<Preferences>();
@@ -38,6 +56,20 @@ export const setWallpaper = async ({ url, id, every, useHud = false, isBackgroun
     : `${selectedPath}/${id}-${downloadSize}.jpg`;
 
   try {
+    if (process.platform === "win32") {
+      if (!existsSync(fixedPathName)) {
+        await execP(`curl.exe -s -o "${fixedPathName}" "${url}"`);
+      }
+      await setWallpaperWindows(fixedPathName);
+      if (useHud) {
+        if (!isBackground) await showHUD("Wallpaper set!");
+      } else if (toast) {
+        toast.style = Toast.Style.Success;
+        toast.title = "Wallpaper set!";
+      }
+      return true;
+    }
+
     const actualPath = fixedPathName;
 
     const command = !existsSync(actualPath)

--- a/extensions/unsplash/src/functions/setWallpaper.ts
+++ b/extensions/unsplash/src/functions/setWallpaper.ts
@@ -1,11 +1,11 @@
 import { showToast, Toast, environment, getPreferenceValues, showHUD } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 import { existsSync } from "fs";
 import { resolveHome } from "./utils";
 
-const execP = promisify(exec);
+const execFileP = promisify(execFile);
 
 interface SetWallpaperProps {
   url: string;
@@ -31,7 +31,7 @@ public class W {
 Add-Type -TypeDefinition $c
 [W]::SystemParametersInfo(20,0,'${imagePath.replace(/'/g, "''")}',2)`;
   const encoded = Buffer.from(ps, "utf16le").toString("base64");
-  await execP(`powershell -NoProfile -EncodedCommand ${encoded}`);
+  await execFileP("powershell", ["-NoProfile", "-EncodedCommand", encoded]);
 }
 
 export const setWallpaper = async ({ url, id, every, useHud = false, isBackground = false }: SetWallpaperProps) => {
@@ -58,7 +58,7 @@ export const setWallpaper = async ({ url, id, every, useHud = false, isBackgroun
   try {
     if (process.platform === "win32") {
       if (!existsSync(fixedPathName)) {
-        await execP(`curl.exe -s -o "${fixedPathName}" "${url}"`);
+        await execFileP("curl.exe", ["-s", "-o", fixedPathName, url]);
       }
       await setWallpaperWindows(fixedPathName);
       if (useHud) {

--- a/extensions/unsplash/src/functions/setWallpaper.ts
+++ b/extensions/unsplash/src/functions/setWallpaper.ts
@@ -29,7 +29,8 @@ public class W {
 }
 "@
 Add-Type -TypeDefinition $c
-[W]::SystemParametersInfo(20,0,'${imagePath.replace(/'/g, "''")}',3)`;
+$r = [W]::SystemParametersInfo(20,0,'${imagePath.replace(/'/g, "''")}',3)
+if ($r -eq 0) { throw "SystemParametersInfo returned 0" }`;
   const encoded = Buffer.from(ps, "utf16le").toString("base64");
   await execFileP("powershell", ["-NoProfile", "-EncodedCommand", encoded]);
 }
@@ -57,6 +58,7 @@ export const setWallpaper = async ({ url, id, every, useHud = false, isBackgroun
 
   try {
     if (process.platform === "win32") {
+      // Windows: SPI sets wallpaper on all monitors; `every` is always true
       if (!existsSync(fixedPathName)) {
         await execFileP("curl.exe", ["-s", "-o", fixedPathName, url]);
       }

--- a/extensions/unsplash/src/functions/setWallpaper.ts
+++ b/extensions/unsplash/src/functions/setWallpaper.ts
@@ -60,7 +60,7 @@ export const setWallpaper = async ({ url, id, every, useHud = false, isBackgroun
     if (process.platform === "win32") {
       // Windows: SPI sets wallpaper on all monitors; `every` is always true
       if (!existsSync(fixedPathName)) {
-        await execFileP("curl.exe", ["-s", "-o", fixedPathName, url]);
+        await execFileP("curl.exe", ["-s", "--fail", "-o", fixedPathName, url]);
       }
       await setWallpaperWindows(fixedPathName);
       if (useHud) {

--- a/extensions/unsplash/src/functions/setWallpaper.ts
+++ b/extensions/unsplash/src/functions/setWallpaper.ts
@@ -2,7 +2,7 @@ import { showToast, Toast, environment, getPreferenceValues, showHUD } from "@ra
 import { runAppleScript } from "@raycast/utils";
 import { execFile } from "child_process";
 import { promisify } from "util";
-import { existsSync } from "fs";
+import { existsSync, unlinkSync } from "fs";
 import { resolveHome } from "./utils";
 
 const execFileP = promisify(execFile);
@@ -60,7 +60,16 @@ export const setWallpaper = async ({ url, id, every, useHud = false, isBackgroun
     if (process.platform === "win32") {
       // Windows: SPI sets wallpaper on all monitors; `every` is always true
       if (!existsSync(fixedPathName)) {
-        await execFileP("curl.exe", ["-s", "--fail", "-o", fixedPathName, url]);
+        try {
+          await execFileP("curl.exe", ["-s", "--fail", "-o", fixedPathName, url]);
+        } catch (err) {
+          try {
+            unlinkSync(fixedPathName);
+          } catch {
+            // ignore cleanup error
+          }
+          throw err;
+        }
       }
       await setWallpaperWindows(fixedPathName);
       if (useHud) {

--- a/extensions/unsplash/src/functions/setWallpaper.ts
+++ b/extensions/unsplash/src/functions/setWallpaper.ts
@@ -29,7 +29,7 @@ public class W {
 }
 "@
 Add-Type -TypeDefinition $c
-[W]::SystemParametersInfo(20,0,'${imagePath.replace(/'/g, "''")}',2)`;
+[W]::SystemParametersInfo(20,0,'${imagePath.replace(/'/g, "''")}',3)`;
   const encoded = Buffer.from(ps, "utf16le").toString("base64");
   await execFileP("powershell", ["-NoProfile", "-EncodedCommand", encoded]);
 }


### PR DESCRIPTION
## Description

Adds Windows support to the Unsplash extension. macOS code paths are untouched -- early-return `process.platform === "win32"` branches were added before the original AppleScript code in each function.

- Wallpaper: PowerShell + Win32 SystemParametersInfo
- Clipboard: PowerShell System.Windows.Forms  
- Save: downloads to Desktop (macOS keeps the folder picker)
- package.json updated to include "Windows" in platforms
- CHANGELOG.md updated with {PR_MERGE_DATE}

## Screencast

N/A -- platform-conditional code, no UI changes.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder