### PR TITLE
[Tempo] Enable to set the estimate remaining duration on worklogs

### DIFF
--- a/extensions/tempo/CHANGELOG.md
+++ b/extensions/tempo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Tempo Changelog
 
+## [Add Remaining Estimate Validation] - {PR_MERGE_DATE}
+
+- Add validation for remaining estimate field based on global configuration
+
 ## [Add Autofocus to Worklog Duration] - 2026-06-05
 
 - Autofocus the Time Spent field when opening the Add Worklog form

--- a/extensions/tempo/CHANGELOG.md
+++ b/extensions/tempo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tempo Changelog
 
-## [Add Remaining Estimate Validation] - {PR_MERGE_DATE}
+## [Add Remaining Estimate Validation] - 2026-06-22
 
 - Add validation for remaining estimate field based on global configuration
 

--- a/extensions/tempo/package-lock.json
+++ b/extensions/tempo/package-lock.json
@@ -1061,7 +1061,6 @@
     "node_modules/@raycast/api": {
       "version": "1.103.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.5.4",
         "@oclif/plugin-autocomplete": "^3.2.35",
@@ -1151,7 +1150,6 @@
     "node_modules/@types/node": {
       "version": "22.13.10",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1203,7 +1201,6 @@
       "version": "8.46.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -1389,7 +1386,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1703,7 +1699,6 @@
       "version": "9.38.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2459,7 +2454,6 @@
       "version": "3.6.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2677,7 +2671,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2736,7 +2729,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/tempo/src/add-worklog.tsx
+++ b/extensions/tempo/src/add-worklog.tsx
@@ -8,7 +8,8 @@ import {
   Icon,
   Color,
   getPreferenceValues,
-  open,
+  launchCommand,
+  LaunchType,
 } from "@raycast/api";
 import { showFailureToast, useCachedState } from "@raycast/utils";
 import { useState, useEffect } from "react";
@@ -248,20 +249,26 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
   // Fetch details of the selected issue
   useEffect(() => {
     async function loadIssue() {
-      try {
-        setIsLoading(true);
-        const [fetchedIssue, globalConfiguration] = await Promise.all([
-          getIssueByKey(issueKey),
-          fetchFromTempoAPI("/globalconfiguration") as Promise<TempoGlobalConfiguration>,
-        ]);
+      setIsLoading(true);
 
-        setIssue(fetchedIssue);
-        setIsRemainingEstimateRequired(globalConfiguration.remainingEstimateOptional === false);
-      } catch (error) {
-        console.error("Failed to load issue:", error);
-      } finally {
-        setIsLoading(false);
-      }
+      const issuePromise = getIssueByKey(issueKey)
+        .then(setIssue)
+        .catch((error) => {
+          console.error("Failed to load issue:", error);
+        });
+
+      const configPromise = fetchFromTempoAPI("/globalconfiguration")
+        .then((config) => {
+          const globalConfiguration = config as TempoGlobalConfiguration;
+          setIsRemainingEstimateRequired(globalConfiguration.remainingEstimateOptional === false);
+        })
+        .catch((error) => {
+          console.error("Failed to load global configuration:", error);
+          setIsRemainingEstimateRequired(false);
+        });
+
+      await Promise.all([issuePromise, configPromise]);
+      setIsLoading(false);
     }
     loadIssue();
   }, [issueKey]);
@@ -413,7 +420,7 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
         primaryAction: {
           title: "View Worklogs",
           onAction: async () => {
-            await open("raycast://extensions/darchen_gautier/tempo/list-worklogs");
+            await launchCommand({ name: "list-worklogs", type: LaunchType.UserInitiated });
           },
         },
       });

--- a/extensions/tempo/src/add-worklog.tsx
+++ b/extensions/tempo/src/add-worklog.tsx
@@ -39,12 +39,17 @@ type Values = {
   date: string;
   customDate?: string;
   timeSpent: string;
+  remainingEstimate?: string;
   useTimeRange?: boolean;
   startTime?: string;
   endTime?: string;
 };
 
 const USE_TIME_RANGE_STORAGE_KEY = "add-worklog-use-time-range";
+
+type TempoGlobalConfiguration = {
+  remainingEstimateOptional?: boolean;
+};
 
 function IssueSelector({ onSelect }: { onSelect: (issueKey: string) => void }) {
   const [favoriteIssues, setFavoriteIssues] = useState<FavoriteIssue[]>([]);
@@ -238,14 +243,20 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
   const [isLoading, setIsLoading] = useState(true);
   const [selectedDate, setSelectedDate] = useState<string>(formatDateToString(new Date()));
   const [useTimeRange, setUseTimeRange] = useCachedState<boolean>(USE_TIME_RANGE_STORAGE_KEY, false);
+  const [isRemainingEstimateRequired, setIsRemainingEstimateRequired] = useState(false);
 
   // Fetch details of the selected issue
   useEffect(() => {
     async function loadIssue() {
       try {
         setIsLoading(true);
-        const fetchedIssue = await getIssueByKey(issueKey);
+        const [fetchedIssue, globalConfiguration] = await Promise.all([
+          getIssueByKey(issueKey),
+          fetchFromTempoAPI("/globalconfiguration") as Promise<TempoGlobalConfiguration>,
+        ]);
+
         setIssue(fetchedIssue);
+        setIsRemainingEstimateRequired(globalConfiguration.remainingEstimateOptional === false);
       } catch (error) {
         console.error("Failed to load issue:", error);
       } finally {
@@ -294,6 +305,7 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
       let submittedDuration = values.timeSpent;
       let startTime: string;
       let timeSpentSeconds: number;
+      let remainingEstimateSeconds: number | undefined;
 
       if (values.useTimeRange) {
         if (!values.startTime || !values.endTime) {
@@ -339,6 +351,26 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
         }
       }
 
+      if (isRemainingEstimateRequired && values.remainingEstimate?.trim()) {
+        remainingEstimateSeconds = parseDuration(values.remainingEstimate);
+
+        if (remainingEstimateSeconds === 0) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Invalid remaining estimate",
+            message: "Please enter a valid remaining estimate (e.g., 1h, 1h30m, 30m)",
+          });
+          return;
+        }
+      } else if (isRemainingEstimateRequired) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Remaining estimate required",
+          message: "Your Tempo workspace requires an estimated remaining time for new worklogs",
+        });
+        return;
+      }
+
       // Check if issue was loaded successfully
       if (!issue) {
         await showToast({
@@ -361,6 +393,7 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
           startDate: dateStr,
           startTime,
           description: values.description || "",
+          ...(remainingEstimateSeconds !== undefined ? { remainingEstimateSeconds } : {}),
         }),
       });
 
@@ -380,7 +413,7 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
         primaryAction: {
           title: "View Worklogs",
           onAction: async () => {
-            await open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/darchen_gautier/tempo/list-worklogs`);
+            await open("raycast://extensions/darchen_gautier/tempo/list-worklogs");
           },
         },
       });
@@ -432,6 +465,14 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
           placeholder="1h, 1h30m, 30m"
           defaultValue="1h"
           info="Enter duration in human format: 1h, 1h30m, 2h, 45m, etc."
+        />
+      )}
+      {isRemainingEstimateRequired && (
+        <Form.TextField
+          id="remainingEstimate"
+          title="Remaining Estimate"
+          placeholder="Required: 1h, 1h30m, 30m"
+          info="Required by your Tempo workspace. Enter the estimated remaining time after this worklog."
         />
       )}
       <Form.Dropdown id="date" title="Date" value={selectedDate} onChange={setSelectedDate}>


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Fixes https://github.com/raycast/extensions/issues/28856

In this pull-request, I added an optional field when persisting a new worklog, based on the Tempo workspace global configuration.

It makes it possible to set the estimate remaining duration when persisting a worklog.

## Screencast


<img width="913" height="518" alt="file-d9c0aaeea8c5454927edd06dc45de179" src="https://github.com/user-attachments/assets/9ed2164d-b3ac-4520-9275-1a2b76ea9244" />



<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
