### PR TITLE
Update gitlab-docs extension

### DIFF
--- a/extensions/gitlab-docs/CHANGELOG.md
+++ b/extensions/gitlab-docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GitLab Docs Changelog
 
+## [Add Detail View] - {PR_MERGE_DATE}
+
+- Add a detail panel to Documentation, Handbook, and Design System results that renders the full page content
+- Toggle the detail panel with "Show Details" / "Hide Details" (Cmd+D); open the page in the browser with Enter while the panel is open
+- Match GitLab icons when searching with spaces or no separator (e.g. "chevron lg" finds "chevron-lg-left")
+
 ## [Fix Search Commands] - 2026-06-22
 
 - Add a "Search Icons" command to browse and copy GitLab SVG icons from design.gitlab.com/svgs

--- a/extensions/gitlab-docs/CHANGELOG.md
+++ b/extensions/gitlab-docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitLab Docs Changelog
 
-## [Add Detail View] - {PR_MERGE_DATE}
+## [Add Detail View] - 2026-06-22
 
 - Add a detail panel to Documentation, Handbook, and Design System results that renders the full page content
 - Toggle the detail panel with "Show Details" / "Hide Details" (Cmd+D); open the page in the browser with Enter while the panel is open

--- a/extensions/gitlab-docs/src/content.ts
+++ b/extensions/gitlab-docs/src/content.ts
@@ -1,0 +1,181 @@
+import { useState, useEffect, useRef } from "react";
+
+// Shared helpers for fetching a GitLab page and rendering its content in a
+// Raycast detail view. Raycast's detail view renders Markdown (not HTML), so
+// the page HTML is converted into the closest Markdown equivalent.
+
+export function usePageContent(url: string | null) {
+  const [content, setContent] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  // Cache fetched content per URL so revisiting an item is instant.
+  const cacheRef = useRef<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    if (!url) {
+      setContent("");
+      setIsLoading(false);
+      return;
+    }
+
+    const cached = cacheRef.current.get(url);
+    if (cached !== undefined) {
+      setContent(cached);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setContent("");
+    setIsLoading(true);
+
+    (async () => {
+      try {
+        const markdown = await fetchPageContent(url);
+        cacheRef.current.set(url, markdown);
+        if (!cancelled) {
+          setContent(markdown);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error("page content error", error);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return { content, isLoading };
+}
+
+async function fetchPageContent(url: string): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+
+  try {
+    const response = await fetch(url, {
+      headers: { "User-Agent": "Mozilla/5.0", Accept: "text/html" },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return "";
+    }
+
+    const html = await response.text();
+    return htmlToMarkdown(extractMain(html), url);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// Extract the server-rendered <main> region, which contains the page content.
+function extractMain(html: string): string {
+  const match = html.match(/<main\b[^>]*>([\s\S]*?)<\/main>/i);
+  return match ? match[1] : html;
+}
+
+function decodeEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&rsquo;/g, "'")
+    .replace(/&lsquo;/g, "'")
+    .replace(/&ldquo;/g, '"')
+    .replace(/&rdquo;/g, '"')
+    .replace(/&nbsp;/g, " ");
+}
+
+function htmlToMarkdown(html: string, baseUrl: string): string {
+  let text = html
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<svg[\s\S]*?<\/svg>/gi, "")
+    .replace(/<(nav|aside|footer)\b[\s\S]*?<\/\1>/gi, "");
+
+  // Drop the page's own <h1>; the detail markdown already adds a title.
+  text = text.replace(/<h1\b[^>]*>[\s\S]*?<\/h1>/i, "");
+
+  // Code blocks and inline code first, so their contents aren't mangled.
+  text = text
+    .replace(
+      /<pre\b[^>]*>([\s\S]*?)<\/pre>/gi,
+      (_, code) => `\n\n\`\`\`\n${decodeEntities(stripTags(code)).trim()}\n\`\`\`\n\n`,
+    )
+    .replace(/<code\b[^>]*>([\s\S]*?)<\/code>/gi, (_, code) => `\`${decodeEntities(stripTags(code))}\``);
+
+  // Images -> Markdown images (resolve relative URLs against the page).
+  text = text.replace(/<img\b[^>]*>/gi, (tag) => {
+    const src = (tag.match(/\bsrc="([^"]+)"/i) || [])[1];
+    const alt = (tag.match(/\balt="([^"]*)"/i) || [])[1] || "";
+    if (!src) return "";
+    return `\n\n![${alt}](${resolveUrl(src, baseUrl)})\n\n`;
+  });
+
+  // Embeds (e.g. Storybook iframes) can't render in Markdown, so expose them
+  // as links to open the live demo in a browser.
+  text = text.replace(/<iframe\b[^>]*>(?:[\s\S]*?<\/iframe>)?/gi, (tag) => {
+    const src = (tag.match(/\bsrc="([^"]+)"/i) || [])[1];
+    const title = (tag.match(/\btitle="([^"]*)"/i) || [])[1] || "Open embed";
+    if (!src) return "";
+    return `\n\n▶ [${title}](${resolveUrl(src, baseUrl)})\n\n`;
+  });
+
+  // Links -> Markdown links.
+  text = text.replace(/<a\b[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi, (_, href, label) => {
+    const linkText = stripTags(label).trim();
+    if (!linkText) return "";
+    return `[${linkText}](${resolveUrl(href, baseUrl)})`;
+  });
+
+  // Emphasis.
+  text = text
+    .replace(/<(strong|b)\b[^>]*>([\s\S]*?)<\/\1>/gi, "**$2**")
+    .replace(/<(em|i)\b[^>]*>([\s\S]*?)<\/\1>/gi, "_$2_");
+
+  // Headings, lists, and block separators.
+  text = text
+    .replace(/<h2\b[^>]*>([\s\S]*?)<\/h2>/gi, "\n\n## $1\n\n")
+    .replace(/<h3\b[^>]*>([\s\S]*?)<\/h3>/gi, "\n\n### $1\n\n")
+    .replace(/<h4\b[^>]*>([\s\S]*?)<\/h4>/gi, "\n\n#### $1\n\n")
+    .replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, "\n- $1")
+    .replace(/<\/(p|div|section|tr|ul|ol|table)>/gi, "\n\n")
+    .replace(/<br\s*\/?>/gi, "\n");
+
+  // Strip any remaining tags and decode entities.
+  text = decodeEntities(text.replace(/<[^>]+>/g, ""));
+
+  // Collapse excess whitespace/newlines and trim leading space per line.
+  return text
+    .replace(/[ \t]{2,}/g, " ")
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function stripTags(value: string): string {
+  return value.replace(/<[^>]+>/g, "");
+}
+
+function resolveUrl(url: string, baseUrl: string): string {
+  try {
+    return new URL(url, baseUrl).href;
+  } catch {
+    return url;
+  }
+}
+
+export function buildDetailMarkdown(name: string, category: string | undefined, body: string): string {
+  return [`# ${name}`, category ? `_${category}_` : "", "", body].join("\n");
+}

--- a/extensions/gitlab-docs/src/docs.tsx
+++ b/extensions/gitlab-docs/src/docs.tsx
@@ -1,6 +1,7 @@
-import { ActionPanel, Action, List, showToast, Toast } from "@raycast/api";
+import { ActionPanel, Action, List, showToast, Toast, Icon } from "@raycast/api";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { LocalStorage } from "@raycast/api";
+import { usePageContent, buildDetailMarkdown } from "./content";
 
 // GitLab migrated their docs search from Algolia DocSearch to Elasticsearch
 // (Elastic Cloud). These values are published in the page source of
@@ -26,28 +27,92 @@ const apiUrl = getSearchUrl();
 
 export default function Command() {
   const { state, search } = useSearch();
+  const [isShowingDetail, setIsShowingDetail] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const items = state.results.map((searchResult, index) => ({
+    id: `${index}-${searchResult.url}`,
+    searchResult,
+  }));
+  const selectedUrl = items.find((item) => item.id === selectedId)?.searchResult.url ?? null;
+
+  // Fetch content only for the currently selected item, and only while the
+  // detail panel is open. This avoids every list item fetching at once.
+  const { content, isLoading } = usePageContent(isShowingDetail ? selectedUrl : null);
 
   return (
-    <List isLoading={state.isLoading} onSearchTextChange={search} searchBarPlaceholder="Search GitLab Docs..." throttle>
+    <List
+      isLoading={state.isLoading}
+      onSearchTextChange={search}
+      onSelectionChange={setSelectedId}
+      searchBarPlaceholder="Search GitLab Docs..."
+      isShowingDetail={isShowingDetail}
+      throttle
+    >
       <List.Section title="Results" subtitle={state.results.length + ""}>
-        {state.results.map((searchResult, index) => (
-          <SearchListItem key={index} searchResult={searchResult} />
+        {items.map(({ id, searchResult }) => (
+          <SearchListItem
+            key={id}
+            id={id}
+            searchResult={searchResult}
+            isShowingDetail={isShowingDetail}
+            isSelected={selectedId === id}
+            content={content}
+            isContentLoading={isLoading}
+            onToggleDetail={() => setIsShowingDetail((value) => !value)}
+          />
         ))}
       </List.Section>
     </List>
   );
 }
 
-function SearchListItem({ searchResult }: { searchResult: SearchResult }) {
+function SearchListItem({
+  id,
+  searchResult,
+  isShowingDetail,
+  isSelected,
+  content,
+  isContentLoading,
+  onToggleDetail,
+}: {
+  id: string;
+  searchResult: SearchResult;
+  isShowingDetail: boolean;
+  isSelected: boolean;
+  content: string;
+  isContentLoading: boolean;
+  onToggleDetail: () => void;
+}) {
+  const body = isSelected
+    ? content || (isContentLoading ? "Loading page content…" : "_No content available for this page._")
+    : "";
+
+  const markdown = buildDetailMarkdown(searchResult.name, searchResult.category, body);
+
   return (
     <List.Item
+      id={id}
       icon="docs-icon.png"
       title={searchResult.name}
-      subtitle={searchResult.description}
-      accessoryTitle={searchResult.category}
+      subtitle={isShowingDetail ? undefined : searchResult.description}
+      accessoryTitle={isShowingDetail ? undefined : searchResult.category}
+      detail={<List.Item.Detail isLoading={isShowingDetail && isSelected && isContentLoading} markdown={markdown} />}
       actions={
         <ActionPanel>
-          <Action.OpenInBrowser url={searchResult.url} />
+          {isShowingDetail ? (
+            <>
+              <Action.OpenInBrowser url={searchResult.url} />
+              <Action
+                title="Hide Details"
+                icon={Icon.Sidebar}
+                shortcut={{ modifiers: ["cmd"], key: "d" }}
+                onAction={onToggleDetail}
+              />
+            </>
+          ) : (
+            <Action title="Show Details" icon={Icon.Sidebar} onAction={onToggleDetail} />
+          )}
           <Action.CopyToClipboard title="Copy URL" content={searchResult.url} />
         </ActionPanel>
       }

--- a/extensions/gitlab-docs/src/index.tsx
+++ b/extensions/gitlab-docs/src/index.tsx
@@ -1,6 +1,7 @@
-import { ActionPanel, Action, List, showToast, Toast } from "@raycast/api";
+import { ActionPanel, Action, List, showToast, Toast, Icon } from "@raycast/api";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { LocalStorage } from "@raycast/api";
+import { usePageContent, buildDetailMarkdown } from "./content";
 
 // GitLab's handbook search is powered by Algolia DocSearch. These values are
 // published in the page source of https://handbook.gitlab.com/ and are used by
@@ -13,33 +14,92 @@ const apiUrl = `https://${ALGOLIA_APP_ID}-dsn.algolia.net/1/indexes/${ALGOLIA_IN
 
 export default function Command() {
   const { state, search } = useSearch();
+  const [isShowingDetail, setIsShowingDetail] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const items = state.records.map((searchResult, index) => ({
+    id: searchResult.objectID || `${index}`,
+    searchResult,
+  }));
+  const selectedUrl = items.find((item) => item.id === selectedId)?.searchResult.url ?? null;
+
+  // Fetch content only for the currently selected item, and only while the
+  // detail panel is open. This avoids every list item fetching at once.
+  const { content, isLoading } = usePageContent(isShowingDetail ? selectedUrl : null);
 
   return (
     <List
       isLoading={state.isLoading}
       onSearchTextChange={search}
+      onSelectionChange={setSelectedId}
       searchBarPlaceholder="Search GitLab Handbook..."
+      isShowingDetail={isShowingDetail}
       throttle
     >
       <List.Section title="Results" subtitle={state.records.length + ""}>
-        {state.records.map((searchResult, index) => (
-          <SearchListItem key={searchResult.objectID || index} searchResult={searchResult} />
+        {items.map(({ id, searchResult }) => (
+          <SearchListItem
+            key={id}
+            id={id}
+            searchResult={searchResult}
+            isShowingDetail={isShowingDetail}
+            isSelected={selectedId === id}
+            content={content}
+            isContentLoading={isLoading}
+            onToggleDetail={() => setIsShowingDetail((value) => !value)}
+          />
         ))}
       </List.Section>
     </List>
   );
 }
 
-function SearchListItem({ searchResult }: { searchResult: SearchResult }) {
+function SearchListItem({
+  id,
+  searchResult,
+  isShowingDetail,
+  isSelected,
+  content,
+  isContentLoading,
+  onToggleDetail,
+}: {
+  id: string;
+  searchResult: SearchResult;
+  isShowingDetail: boolean;
+  isSelected: boolean;
+  content: string;
+  isContentLoading: boolean;
+  onToggleDetail: () => void;
+}) {
+  const body = isSelected
+    ? content || (isContentLoading ? "Loading page content…" : "_No content available for this page._")
+    : "";
+
+  const markdown = buildDetailMarkdown(searchResult.name, searchResult.category, body);
+
   return (
     <List.Item
+      id={id}
       icon="handbook-icon.png"
       title={searchResult.name}
-      subtitle={searchResult.description}
-      accessoryTitle={searchResult.category}
+      subtitle={isShowingDetail ? undefined : searchResult.description}
+      accessoryTitle={isShowingDetail ? undefined : searchResult.category}
+      detail={<List.Item.Detail isLoading={isShowingDetail && isSelected && isContentLoading} markdown={markdown} />}
       actions={
         <ActionPanel>
-          <Action.OpenInBrowser url={searchResult.url} />
+          {isShowingDetail ? (
+            <>
+              <Action.OpenInBrowser url={searchResult.url} />
+              <Action
+                title="Hide Details"
+                icon={Icon.Sidebar}
+                shortcut={{ modifiers: ["cmd"], key: "d" }}
+                onAction={onToggleDetail}
+              />
+            </>
+          ) : (
+            <Action title="Show Details" icon={Icon.Sidebar} onAction={onToggleDetail} />
+          )}
           <Action.CopyToClipboard title="Copy URL" content={searchResult.url} />
         </ActionPanel>
       }

--- a/extensions/gitlab-docs/src/pajamas.tsx
+++ b/extensions/gitlab-docs/src/pajamas.tsx
@@ -1,25 +1,42 @@
-import { ActionPanel, Action, List, showToast, Toast } from "@raycast/api";
+import { ActionPanel, Action, List, showToast, Toast, Icon } from "@raycast/api";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { LocalStorage } from "@raycast/api";
 import groupBy from "lodash.groupby";
+import { usePageContent, buildDetailMarkdown } from "./content";
 
 const baseUrl = "https://design.gitlab.com/";
 const apiUrl = `${baseUrl}/_nuxt/search-index/en.json`;
 
 export default function Command() {
   const { state, search } = useSearch();
+  const [isShowingDetail, setIsShowingDetail] = useState(false);
+  const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
+
+  // Fetch content only for the currently selected item, and only while the
+  // detail panel is open. This avoids every list item fetching at once.
+  const { content, isLoading } = usePageContent(isShowingDetail ? selectedUrl : null);
 
   return (
     <List
       isLoading={state.isLoading}
       onSearchTextChange={search}
+      onSelectionChange={setSelectedUrl}
       searchBarPlaceholder="Search GitLab Design System..."
+      isShowingDetail={isShowingDetail}
       throttle
     >
       {Object.entries(groupBy(state.metas, "category")).map(([category, group]) => (
         <List.Section title={category + ""} subtitle={group.length + ""} key={category}>
           {group.map((searchResult) => (
-            <SearchListItem key={searchResult.url} searchResult={searchResult} />
+            <SearchListItem
+              key={searchResult.url}
+              searchResult={searchResult}
+              isShowingDetail={isShowingDetail}
+              isSelected={selectedUrl === searchResult.url}
+              content={content}
+              isContentLoading={isLoading}
+              onToggleDetail={() => setIsShowingDetail((value) => !value)}
+            />
           ))}
         </List.Section>
       ))}
@@ -27,16 +44,50 @@ export default function Command() {
   );
 }
 
-function SearchListItem({ searchResult }: { searchResult: SearchResult }) {
+function SearchListItem({
+  searchResult,
+  isShowingDetail,
+  isSelected,
+  content,
+  isContentLoading,
+  onToggleDetail,
+}: {
+  searchResult: SearchResult;
+  isShowingDetail: boolean;
+  isSelected: boolean;
+  content: string;
+  isContentLoading: boolean;
+  onToggleDetail: () => void;
+}) {
+  const body = isSelected
+    ? content || (isContentLoading ? "Loading page content…" : "_No content available for this page._")
+    : "";
+
+  const markdown = buildDetailMarkdown(searchResult.name, searchResult.category, body);
+
   return (
     <List.Item
+      id={searchResult.url}
       icon="pajamas-icon.png"
       title={searchResult.name}
-      subtitle={searchResult.path}
-      accessoryTitle={searchResult.category}
+      subtitle={isShowingDetail ? undefined : searchResult.path}
+      accessoryTitle={isShowingDetail ? undefined : searchResult.category}
+      detail={<List.Item.Detail isLoading={isShowingDetail && isSelected && isContentLoading} markdown={markdown} />}
       actions={
         <ActionPanel>
-          <Action.OpenInBrowser url={searchResult.url} />
+          {isShowingDetail ? (
+            <>
+              <Action.OpenInBrowser url={searchResult.url} />
+              <Action
+                title="Hide Details"
+                icon={Icon.Sidebar}
+                shortcut={{ modifiers: ["cmd"], key: "d" }}
+                onAction={onToggleDetail}
+              />
+            </>
+          ) : (
+            <Action title="Show Details" icon={Icon.Sidebar} onAction={onToggleDetail} />
+          )}
           <Action.CopyToClipboard title="Copy URL" content={searchResult.url} />
         </ActionPanel>
       }

--- a/extensions/gitlab-docs/src/svgs.tsx
+++ b/extensions/gitlab-docs/src/svgs.tsx
@@ -19,6 +19,7 @@ export default function Command() {
             key={icon.name}
             icon={{ source: icon.dataUri, tintColor: Color.PrimaryText }}
             title={icon.name}
+            keywords={icon.keywords}
             actions={
               <ActionPanel>
                 <Action.CopyToClipboard title="Copy Icon Name" content={icon.name} />
@@ -40,6 +41,7 @@ interface Icon {
   name: string;
   svg: string;
   dataUri: string;
+  keywords: string[];
 }
 
 function useIcons() {
@@ -112,7 +114,12 @@ function parseSprite(sprite: string): Icon[] {
     const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}" fill="#000000">${inner}</svg>`;
     const dataUri = `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;
 
-    icons.push({ name, svg, dataUri });
+    // Allow searching with spaces (or no separator) for hyphenated names,
+    // e.g. "chevron lg" or "chevronlg" should match "chevron-lg-left".
+    const parts = name.split(/[-_]/).filter(Boolean);
+    const keywords = Array.from(new Set([...parts, name.replace(/[-_]/g, " "), name.replace(/[-_]/g, "")]));
+
+    icons.push({ name, svg, dataUri, keywords });
   }
 
   icons.sort((a, b) => a.name.localeCompare(b.name));

--- a/extensions/gitlab-docs/src/svgs.tsx
+++ b/extensions/gitlab-docs/src/svgs.tsx
@@ -10,6 +10,7 @@ const CACHE_KEY = "GitLabSvgs.sprite";
 
 export default function Command() {
   const { icons, isLoading } = useIcons();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   return (
     <Grid
@@ -17,14 +18,16 @@ export default function Command() {
       searchBarPlaceholder="Search GitLab icons..."
       columns={8}
       inset={Grid.Inset.Large}
+      onSelectionChange={setSelectedId}
+      navigationTitle={selectedId ? `GitLab Icons – ${selectedId}` : "GitLab Icons"}
       throttle
     >
       <Grid.Section title="Icons" subtitle={icons.length + ""}>
         {icons.map((icon) => (
           <Grid.Item
             key={icon.name}
+            id={icon.name}
             content={{ source: icon.dataUri, tintColor: Color.PrimaryText }}
-            title={icon.name}
             keywords={icon.keywords}
             actions={
               <ActionPanel>

--- a/extensions/gitlab-docs/src/svgs.tsx
+++ b/extensions/gitlab-docs/src/svgs.tsx
@@ -1,4 +1,4 @@
-import { ActionPanel, Action, List, showToast, Toast, LocalStorage, Color } from "@raycast/api";
+import { ActionPanel, Action, Grid, showToast, Toast, LocalStorage, Color } from "@raycast/api";
 import { useState, useEffect } from "react";
 
 // GitLab's icon set (@gitlab/svgs) is previewed at https://design.gitlab.com/svgs/.
@@ -12,12 +12,18 @@ export default function Command() {
   const { icons, isLoading } = useIcons();
 
   return (
-    <List isLoading={isLoading} searchBarPlaceholder="Search GitLab icons..." throttle>
-      <List.Section title="Icons" subtitle={icons.length + ""}>
+    <Grid
+      isLoading={isLoading}
+      searchBarPlaceholder="Search GitLab icons..."
+      columns={8}
+      inset={Grid.Inset.Large}
+      throttle
+    >
+      <Grid.Section title="Icons" subtitle={icons.length + ""}>
         {icons.map((icon) => (
-          <List.Item
+          <Grid.Item
             key={icon.name}
-            icon={{ source: icon.dataUri, tintColor: Color.PrimaryText }}
+            content={{ source: icon.dataUri, tintColor: Color.PrimaryText }}
             title={icon.name}
             keywords={icon.keywords}
             actions={
@@ -32,8 +38,8 @@ export default function Command() {
             }
           />
         ))}
-      </List.Section>
-    </List>
+      </Grid.Section>
+    </Grid>
   );
 }
 


### PR DESCRIPTION
## Description

  Add detail view to search commands

- Add a detail panel to Documentation, Handbook, and Design System results that renders the full page content
- Hide the detail panel with "Hide Details" (Cmd+D)
- Open the page in the browser with Enter while the panel is open
- Match GitLab icons when searching with spaces or no separator (e.g. "chevron lg" finds "chevron-lg-left")
- Changes Icon search to use `grid` instead of `list` view

## Screencast

<img width="913" height="583" alt="Raycast_DS" src="https://github.com/user-attachments/assets/442d890d-52fe-45e5-a917-a01e5aa961ba" />

<img width="908" height="564" alt="Raycast_Docs" src="https://github.com/user-attachments/assets/b6080787-20ac-4d07-8040-1d9d848a42ab" />

<img width="908" height="564" alt="Raycast_Handbook" src="https://github.com/user-attachments/assets/b40ade30-cb0a-4ab4-9bbf-615a0592b7e9" />

<img width="913" height="583" alt="Raycast_Icons" src="https://github.com/user-attachments/assets/b226b67a-25a2-4cdc-94a0-052cd017edd5" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
