### PR TITLE
[Image Modification] Fix Optimize command failing when the assets path contains spaces

### DIFF
--- a/extensions/sips/CHANGELOG.md
+++ b/extensions/sips/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Image Modification Changelog
 
+## [Fix Optimize Command on Asset Paths Containing Spaces] - {PR_MERGE_DATE}
+
+- Fixed the Optimize command failing for PNG, GIF, BMP, TGA, WebP, and AVIF images when the extension's assets path contains a space (e.g. `~/Library/Application Support/...`). The bundled binary paths (`pngout`, `cwebp`, `avifdec`, `avifenc`) are now quoted before being passed to the shell.
+
 ## [Security Maintenance] - 2026-05-21
 
 - Updated the extension to address security advisories.

--- a/extensions/sips/CHANGELOG.md
+++ b/extensions/sips/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Image Modification Changelog
 
-## [Fix Commands on Asset Paths Containing Spaces] - {PR_MERGE_DATE}
+## [Fix Commands on Asset Paths Containing Spaces] - 2026-06-23
 
 - Fixed the Optimize, Convert, and Remove Background commands failing for PNG, GIF, BMP, TGA, WebP, AVIF, and SVG images when the extension's assets path contains a space (e.g. `~/Library/Application Support/...`). The bundled binary paths (`pngout`, `dwebp`, `cwebp`, `avifdec`, `avifenc`, `potrace`) are now quoted before being passed to the shell.
 

--- a/extensions/sips/CHANGELOG.md
+++ b/extensions/sips/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Image Modification Changelog
 
-## [Fix Optimize Command on Asset Paths Containing Spaces] - {PR_MERGE_DATE}
+## [Fix Commands on Asset Paths Containing Spaces] - {PR_MERGE_DATE}
 
-- Fixed the Optimize command failing for PNG, GIF, BMP, TGA, WebP, and AVIF images when the extension's assets path contains a space (e.g. `~/Library/Application Support/...`). The bundled binary paths (`pngout`, `cwebp`, `avifdec`, `avifenc`) are now quoted before being passed to the shell.
+- Fixed the Optimize, Convert, and Remove Background commands failing for PNG, GIF, BMP, TGA, WebP, AVIF, and SVG images when the extension's assets path contains a space (e.g. `~/Library/Application Support/...`). The bundled binary paths (`pngout`, `dwebp`, `cwebp`, `avifdec`, `avifenc`, `potrace`) are now quoted before being passed to the shell.
 
 ## [Security Maintenance] - 2026-05-21
 

--- a/extensions/sips/assets/webp/README.md
+++ b/extensions/sips/assets/webp/README.md
@@ -27,20 +27,20 @@ PATENTS.
 
 ## Files
 
-*   bin/cwebp : encoding tool
-*   bin/dwebp : decoding tool
-*   bin/gif2webp : gif conversion tool
-*   bin/img2webp : animation creation tool
-*   bin/vwebp : webp visualization tool
-*   bin/webpinfo : webp analysis tool
-*   bin/webpmux : webp muxing tool
-*   bin/anim\_diff : webp file comparison tool
-*   bin/anim\_dump : tool for dumping animation frames
-*   bin/get\_disto : tool for calculating file distortion
-*   bin/webp\_quality : webp quality estimation tool
-*   doc/ : manual in HTML and text formats
-*   lib/ : static libraries
-*   include/webp : headers
+- bin/cwebp : encoding tool
+- bin/dwebp : decoding tool
+- bin/gif2webp : gif conversion tool
+- bin/img2webp : animation creation tool
+- bin/vwebp : webp visualization tool
+- bin/webpinfo : webp analysis tool
+- bin/webpmux : webp muxing tool
+- bin/anim_diff : webp file comparison tool
+- bin/anim_dump : tool for dumping animation frames
+- bin/get_disto : tool for calculating file distortion
+- bin/webp_quality : webp quality estimation tool
+- doc/ : manual in HTML and text formats
+- lib/ : static libraries
+- include/webp : headers
 
 ## Encoding and Decoding Tools
 

--- a/extensions/sips/package-lock.json
+++ b/extensions/sips/package-lock.json
@@ -1204,6 +1204,7 @@
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.7.tgz",
       "integrity": "sha512-EeBg7zU1OjJlfoPlb88T1G1K4rZuD46gvLr6bWqPALGPfNDvkkBFz7G+9cq+Zayq8Ex7k4vjp/ZibC24j7xnzA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.5.4",
         "@oclif/plugin-autocomplete": "^3.2.35",
@@ -1306,6 +1307,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1376,6 +1378,7 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -1581,6 +1584,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2135,6 +2139,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3082,6 +3087,7 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3334,9 +3340,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -3402,6 +3408,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3475,6 +3482,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/sips/package.json
+++ b/extensions/sips/package.json
@@ -1086,7 +1086,7 @@
   },
   "version": "1.11.2",
   "scripts": {
-    "build": "ray build -e dist",
+    "build": "ray build",
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",

--- a/extensions/sips/src/operations/convertOperation.ts
+++ b/extensions/sips/src/operations/convertOperation.ts
@@ -86,9 +86,9 @@ export default async function convert(
         // AVIF -> PNG -> WebP
         const { decoderPath } = await getAVIFEncPaths();
         await using pngFile = await getScopedTempFile("tmp", "png");
-        execSync(`${decoderPath} '${item}' '${pngFile.path}'`);
+        execSync(`'${decoderPath}' '${item}' '${pngFile.path}'`);
         execSync(
-          `${cwebpPath} ${preferences.useLosslessConversion ? "-lossless" : ""} '${pngFile.path}' -o '${newPath}'`,
+          `'${cwebpPath}' ${preferences.useLosslessConversion ? "-lossless" : ""} '${pngFile.path}' -o '${newPath}'`,
         );
       } else if (originalType.toLowerCase() == "pdf") {
         // PDF -> PNG -> WebP
@@ -102,12 +102,12 @@ export default async function convert(
         const pngFiles = readdirSync(folderPath).map((file) => path.join(folderPath, file));
         for (const pngFile of pngFiles) {
           execSync(
-            `${cwebpPath} ${preferences.useLosslessConversion ? "-lossless" : ""} '${pngFile}' -o '${pngFile.replace(".png", ".webp")}'`,
+            `'${cwebpPath}' ${preferences.useLosslessConversion ? "-lossless" : ""} '${pngFile}' -o '${pngFile.replace(".png", ".webp")}'`,
           );
           await addItemToRemove(pngFile);
         }
       } else {
-        execSync(`${cwebpPath} ${preferences.useLosslessConversion ? "-lossless" : ""} '${item}' -o '${newPath}'`);
+        execSync(`'${cwebpPath}' ${preferences.useLosslessConversion ? "-lossless" : ""} '${item}' -o '${newPath}'`);
       }
     } else if (originalType.toLowerCase() == "svg") {
       if (["AVIF", "PDF", "WEBP"].includes(desiredType)) {
@@ -122,14 +122,14 @@ export default async function convert(
       }
     } else if (desiredType == "SVG") {
       await using bmpFile = await getScopedTempFile("tmp", "bmp");
-      execSync(`chmod +x ${environment.assetsPath}/potrace/potrace`);
+      execSync(`chmod +x '${environment.assetsPath}/potrace/potrace'`);
       if (originalType.toLowerCase() == "webp") {
         // WebP -> PNG -> BMP -> SVG
         await using pngFile = await getScopedTempFile("tmp", "png");
         const [dwebpPath] = await getWebPBinaryPath();
-        execSync(`${dwebpPath} '${item}' -o '${pngFile.path}'`);
+        execSync(`'${dwebpPath}' '${item}' -o '${pngFile.path}'`);
         execSync(
-          `sips --setProperty format "bmp" '${pngFile.path}' --out '${bmpFile.path}' && ${environment.assetsPath}/potrace/potrace -s --tight -o '${newPath}' '${bmpFile.path}'`,
+          `sips --setProperty format "bmp" '${pngFile.path}' --out '${bmpFile.path}' && '${environment.assetsPath}/potrace/potrace' -s --tight -o '${newPath}' '${bmpFile.path}'`,
         );
       } else if (originalType.toLowerCase() == "pdf") {
         // PDF -> PNG -> BMP -> SVG
@@ -143,16 +143,16 @@ export default async function convert(
         const pngFiles = readdirSync(folderPath).map((file) => path.join(folderPath, file));
         for (const pngFile of pngFiles) {
           execSync(
-            `sips --setProperty format "bmp" '${pngFile}' --out '${bmpFile.path}' && ${
+            `sips --setProperty format "bmp" '${pngFile}' --out '${bmpFile.path}' && '${
               environment.assetsPath
-            }/potrace/potrace -s --tight -o '${pngFile.replace(".png", ".svg")}' '${bmpFile.path}'`,
+            }/potrace/potrace' -s --tight -o '${pngFile.replace(".png", ".svg")}' '${bmpFile.path}'`,
           );
           await addItemToRemove(pngFile);
         }
       } else {
         // Input Format -> BMP -> SVG
         execSync(
-          `sips --setProperty format "bmp" '${item}' --out '${bmpFile.path}' && ${environment.assetsPath}/potrace/potrace -s --tight -o '${newPath}' '${bmpFile.path}'`,
+          `sips --setProperty format "bmp" '${item}' --out '${bmpFile.path}' && '${environment.assetsPath}/potrace/potrace' -s --tight -o '${newPath}' '${bmpFile.path}'`,
         );
       }
     } else if (desiredType == "AVIF") {
@@ -172,7 +172,7 @@ export default async function convert(
           .filter((file) => file.endsWith(".png"));
         for (const pngFile of pngFiles) {
           execSync(
-            `${encoderPath} ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100 " : ""}'${pngFile}' '${pngFile.replace(".png", ".avif")}'`,
+            `'${encoderPath}' ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100 " : ""}'${pngFile}' '${pngFile.replace(".png", ".avif")}'`,
           );
           await addItemToRemove(pngFile);
         }
@@ -180,13 +180,13 @@ export default async function convert(
         await using pngFile = await getScopedTempFile("tmp", "png");
         await convert([item], "PNG", [pngFile.path], true);
         execSync(
-          `${encoderPath} ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100 " : ""}'${pngFile.path}' '${newPath}'`,
+          `'${encoderPath}' ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100 " : ""}'${pngFile.path}' '${newPath}'`,
         );
       }
     } else if (originalType.toLowerCase() == "webp") {
       // WebP -> PNG -> Desired Format
       const [dwebpPath] = await getWebPBinaryPath();
-      execSync(`${dwebpPath} '${item}' -o '${newPath}'`);
+      execSync(`'${dwebpPath}' '${item}' -o '${newPath}'`);
       execSync(`sips --setProperty format ${desiredType.toLowerCase()} '${newPath}'`);
     } else if (originalType.toLowerCase() == "pdf") {
       // PDF -> Desired Format
@@ -199,7 +199,7 @@ export default async function convert(
       // AVIF -> PNG -> Desired Format
       const { decoderPath } = await getAVIFEncPaths();
       await using pngFile = await getScopedTempFile("tmp", "png");
-      execSync(`${decoderPath} '${item}' '${pngFile.path}'`);
+      execSync(`'${decoderPath}' '${item}' '${pngFile.path}'`);
       return await convert([pngFile.path], desiredType, [newPath]);
     } else {
       // General Input Format -> Desired Format

--- a/extensions/sips/src/operations/convertOperation.ts
+++ b/extensions/sips/src/operations/convertOperation.ts
@@ -13,7 +13,7 @@ import path from "path";
 
 import { environment, getPreferenceValues } from "@raycast/api";
 
-import { getAVIFEncPaths } from "../utilities/avif";
+import { getAVIFEncPaths, losslessAvifEncArgs } from "../utilities/avif";
 import {
   addItemToRemove,
   convertPDF,
@@ -24,23 +24,6 @@ import {
   getWebPBinaryPath,
   moveImageResultsToFinalDestination,
 } from "../utilities/utils";
-
-const losslessAvifEncArgs = [
-  "-s",
-  "0",
-  "--min",
-  "0",
-  "--max",
-  "0",
-  "--minalpha",
-  "0",
-  "--maxalpha",
-  "0",
-  "--qcolor",
-  "100",
-  "--qalpha",
-  "100",
-];
 
 function cwebpCommandArgs(inputPath: string, outputPath: string, lossless: boolean): string[] {
   return [...(lossless ? ["-lossless"] : []), inputPath, "-o", outputPath];

--- a/extensions/sips/src/operations/convertOperation.ts
+++ b/extensions/sips/src/operations/convertOperation.ts
@@ -7,7 +7,7 @@
  * Created at     : 2023-07-dd 00:19:37
  */
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { readdirSync } from "fs";
 import path from "path";
 
@@ -24,6 +24,31 @@ import {
   getWebPBinaryPath,
   moveImageResultsToFinalDestination,
 } from "../utilities/utils";
+
+const losslessAvifEncArgs = [
+  "-s",
+  "0",
+  "--min",
+  "0",
+  "--max",
+  "0",
+  "--minalpha",
+  "0",
+  "--maxalpha",
+  "0",
+  "--qcolor",
+  "100",
+  "--qalpha",
+  "100",
+];
+
+function cwebpCommandArgs(inputPath: string, outputPath: string, lossless: boolean): string[] {
+  return [...(lossless ? ["-lossless"] : []), inputPath, "-o", outputPath];
+}
+
+function potraceBinaryPath(): string {
+  return path.join(environment.assetsPath, "potrace/potrace");
+}
 
 /**
  * All supported image formats for conversion.
@@ -86,28 +111,27 @@ export default async function convert(
         // AVIF -> PNG -> WebP
         const { decoderPath } = await getAVIFEncPaths();
         await using pngFile = await getScopedTempFile("tmp", "png");
-        execSync(`'${decoderPath}' '${item}' '${pngFile.path}'`);
-        execSync(
-          `'${cwebpPath}' ${preferences.useLosslessConversion ? "-lossless" : ""} '${pngFile.path}' -o '${newPath}'`,
-        );
+        execFileSync(decoderPath, [item, pngFile.path]);
+        execFileSync(cwebpPath, cwebpCommandArgs(pngFile.path, newPath, preferences.useLosslessConversion));
       } else if (originalType.toLowerCase() == "pdf") {
         // PDF -> PNG -> WebP
         const folderPath = path.join(
           newPath.split("/").slice(0, -1).join("/"),
           path.basename(newPath, ".webp") + " WebP",
         );
-        execSync(`mkdir -p '${folderPath}'`);
+        execFileSync("mkdir", ["-p", folderPath]);
         await convertPDF("PNG", item, folderPath);
 
         const pngFiles = readdirSync(folderPath).map((file) => path.join(folderPath, file));
         for (const pngFile of pngFiles) {
-          execSync(
-            `'${cwebpPath}' ${preferences.useLosslessConversion ? "-lossless" : ""} '${pngFile}' -o '${pngFile.replace(".png", ".webp")}'`,
+          execFileSync(
+            cwebpPath,
+            cwebpCommandArgs(pngFile, pngFile.replace(".png", ".webp"), preferences.useLosslessConversion),
           );
           await addItemToRemove(pngFile);
         }
       } else {
-        execSync(`'${cwebpPath}' ${preferences.useLosslessConversion ? "-lossless" : ""} '${item}' -o '${newPath}'`);
+        execFileSync(cwebpPath, cwebpCommandArgs(item, newPath, preferences.useLosslessConversion));
       }
     } else if (originalType.toLowerCase() == "svg") {
       if (["AVIF", "PDF", "WEBP"].includes(desiredType)) {
@@ -122,38 +146,33 @@ export default async function convert(
       }
     } else if (desiredType == "SVG") {
       await using bmpFile = await getScopedTempFile("tmp", "bmp");
-      execSync(`chmod +x '${environment.assetsPath}/potrace/potrace'`);
+      execFileSync("chmod", ["+x", potraceBinaryPath()]);
       if (originalType.toLowerCase() == "webp") {
         // WebP -> PNG -> BMP -> SVG
         await using pngFile = await getScopedTempFile("tmp", "png");
         const [dwebpPath] = await getWebPBinaryPath();
-        execSync(`'${dwebpPath}' '${item}' -o '${pngFile.path}'`);
-        execSync(
-          `sips --setProperty format "bmp" '${pngFile.path}' --out '${bmpFile.path}' && '${environment.assetsPath}/potrace/potrace' -s --tight -o '${newPath}' '${bmpFile.path}'`,
-        );
+        execFileSync(dwebpPath, [item, "-o", pngFile.path]);
+        execFileSync("sips", ["--setProperty", "format", "bmp", pngFile.path, "--out", bmpFile.path]);
+        execFileSync(potraceBinaryPath(), ["-s", "--tight", "-o", newPath, bmpFile.path]);
       } else if (originalType.toLowerCase() == "pdf") {
         // PDF -> PNG -> BMP -> SVG
         const folderPath = path.join(
           newPath.split("/").slice(0, -1).join("/"),
           path.basename(newPath, ".svg") + " SVG",
         );
-        execSync(`mkdir -p '${folderPath}'`);
+        execFileSync("mkdir", ["-p", folderPath]);
         await convertPDF("PNG", item, folderPath);
 
         const pngFiles = readdirSync(folderPath).map((file) => path.join(folderPath, file));
         for (const pngFile of pngFiles) {
-          execSync(
-            `sips --setProperty format "bmp" '${pngFile}' --out '${bmpFile.path}' && '${
-              environment.assetsPath
-            }/potrace/potrace' -s --tight -o '${pngFile.replace(".png", ".svg")}' '${bmpFile.path}'`,
-          );
+          execFileSync("sips", ["--setProperty", "format", "bmp", pngFile, "--out", bmpFile.path]);
+          execFileSync(potraceBinaryPath(), ["-s", "--tight", "-o", pngFile.replace(".png", ".svg"), bmpFile.path]);
           await addItemToRemove(pngFile);
         }
       } else {
         // Input Format -> BMP -> SVG
-        execSync(
-          `sips --setProperty format "bmp" '${item}' --out '${bmpFile.path}' && '${environment.assetsPath}/potrace/potrace' -s --tight -o '${newPath}' '${bmpFile.path}'`,
-        );
+        execFileSync("sips", ["--setProperty", "format", "bmp", item, "--out", bmpFile.path]);
+        execFileSync(potraceBinaryPath(), ["-s", "--tight", "-o", newPath, bmpFile.path]);
       }
     } else if (desiredType == "AVIF") {
       // Input Format -> PNG -> AVIF
@@ -164,46 +183,50 @@ export default async function convert(
           newPath.split("/").slice(0, -1).join("/"),
           path.basename(newPath, ".avif") + " AVIF",
         );
-        execSync(`mkdir -p '${folderPath}'`);
+        execFileSync("mkdir", ["-p", folderPath]);
         await convertPDF("PNG", item, folderPath);
 
         const pngFiles = readdirSync(folderPath)
           .map((file) => path.join(folderPath, file))
           .filter((file) => file.endsWith(".png"));
         for (const pngFile of pngFiles) {
-          execSync(
-            `'${encoderPath}' ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100 " : ""}'${pngFile}' '${pngFile.replace(".png", ".avif")}'`,
-          );
+          execFileSync(encoderPath, [
+            ...(preferences.useLosslessConversion ? losslessAvifEncArgs : []),
+            pngFile,
+            pngFile.replace(".png", ".avif"),
+          ]);
           await addItemToRemove(pngFile);
         }
       } else {
         await using pngFile = await getScopedTempFile("tmp", "png");
         await convert([item], "PNG", [pngFile.path], true);
-        execSync(
-          `'${encoderPath}' ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100 " : ""}'${pngFile.path}' '${newPath}'`,
-        );
+        execFileSync(encoderPath, [
+          ...(preferences.useLosslessConversion ? losslessAvifEncArgs : []),
+          pngFile.path,
+          newPath,
+        ]);
       }
     } else if (originalType.toLowerCase() == "webp") {
       // WebP -> PNG -> Desired Format
       const [dwebpPath] = await getWebPBinaryPath();
-      execSync(`'${dwebpPath}' '${item}' -o '${newPath}'`);
-      execSync(`sips --setProperty format ${desiredType.toLowerCase()} '${newPath}'`);
+      execFileSync(dwebpPath, [item, "-o", newPath]);
+      execFileSync("sips", ["--setProperty", "format", desiredType.toLowerCase(), newPath]);
     } else if (originalType.toLowerCase() == "pdf") {
       // PDF -> Desired Format
       const itemName = path.basename(item);
       const folderName = `${itemName?.substring(0, itemName.lastIndexOf("."))} ${desiredType}`;
       const folderPath = path.join(newPath.split("/").slice(0, -1).join("/"), folderName);
-      execSync(`mkdir -p '${folderPath}'`);
+      execFileSync("mkdir", ["-p", folderPath]);
       await convertPDF(desiredType, item, folderPath);
     } else if (originalType.toLowerCase() == "avif") {
       // AVIF -> PNG -> Desired Format
       const { decoderPath } = await getAVIFEncPaths();
       await using pngFile = await getScopedTempFile("tmp", "png");
-      execSync(`'${decoderPath}' '${item}' '${pngFile.path}'`);
+      execFileSync(decoderPath, [item, pngFile.path]);
       return await convert([pngFile.path], desiredType, [newPath]);
     } else {
       // General Input Format -> Desired Format
-      execSync(`sips --setProperty format ${desiredType.toLowerCase()} '${item}' --out '${newPath}'`);
+      execFileSync("sips", ["--setProperty", "format", desiredType.toLowerCase(), item, "--out", newPath]);
     }
 
     resultPaths.push(newPath);

--- a/extensions/sips/src/operations/optimizeOperation.ts
+++ b/extensions/sips/src/operations/optimizeOperation.ts
@@ -63,7 +63,7 @@ const optimizeWEBP = async (webpPath: string, amount: number) => {
 
   const [, cwebpPath] = await getWebPBinaryPath();
   execSync(
-    `${cwebpPath} ${preferences.useLosslessConversion ? "-lossless" : ""} -q ${amount} "${webpPath}" -o "${newPath}"`,
+    `"${cwebpPath}" ${preferences.useLosslessConversion ? "-lossless" : ""} -q ${amount} "${webpPath}" -o "${newPath}"`,
   );
   return newPath;
 };
@@ -93,8 +93,8 @@ const optimizePNG = async (pngPath: string, optimizationAmount: number) => {
   const newPath = (await getDestinationPaths([optimizedPath]))[0];
 
   const pngoutPath = `${environment.assetsPath}/pngout/pngout`;
-  execSync(`chmod +x ${pngoutPath}`);
-  execSync(`${pngoutPath} -s${strategy} -y -force "${pngPath}" "${newPath}"`);
+  execSync(`chmod +x "${pngoutPath}"`);
+  execSync(`"${pngoutPath}" -s${strategy} -y -force "${pngPath}" "${newPath}"`);
   return newPath;
 };
 
@@ -130,14 +130,14 @@ export default async function optimize(sourcePaths: string[], amount: number) {
 
       // Convert to JPEG
       await using jpegFile = await getScopedTempFile("tmp", "jpeg");
-      execSync(`${decoderPath} -q ${amount} "${imgPath}" "${jpegFile.path}"`);
+      execSync(`"${decoderPath}" -q ${amount} "${imgPath}" "${jpegFile.path}"`);
 
       // Convert back to AVIF
       let newPath = newPaths[expandedPaths.indexOf(imgPath)];
       newPath = path.join(path.dirname(newPath), path.basename(newPath, path.extname(newPath)) + "-optimized.avif");
       resultPaths.push(newPath);
       execSync(
-        `${encoderPath} ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100" : ""} "${jpegFile.path}" "${newPath}"`,
+        `"${encoderPath}" ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100" : ""} "${jpegFile.path}" "${newPath}"`,
       );
     } else if (imgPath.toLowerCase().endsWith("pdf")) {
       // PDF -> JPEG -> PDF

--- a/extensions/sips/src/operations/optimizeOperation.ts
+++ b/extensions/sips/src/operations/optimizeOperation.ts
@@ -15,7 +15,7 @@ import { environment, getPreferenceValues } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
 import { optimize as svgoOptimize } from "svgo";
 
-import { getAVIFEncPaths } from "../utilities/avif";
+import { getAVIFEncPaths, losslessAvifEncArgs } from "../utilities/avif";
 import {
   expandTilde,
   getDestinationPaths,
@@ -23,23 +23,6 @@ import {
   getWebPBinaryPath,
   moveImageResultsToFinalDestination,
 } from "../utilities/utils";
-
-const losslessAvifEncArgs = [
-  "-s",
-  "0",
-  "--min",
-  "0",
-  "--max",
-  "0",
-  "--minalpha",
-  "0",
-  "--maxalpha",
-  "0",
-  "--qcolor",
-  "100",
-  "--qalpha",
-  "100",
-];
 
 /**
  * Optimizes a JPEG image by applying lossy compression.

--- a/extensions/sips/src/operations/optimizeOperation.ts
+++ b/extensions/sips/src/operations/optimizeOperation.ts
@@ -7,7 +7,7 @@
  * Created at     : 2023-07-05 23:49:16
  */
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import * as fs from "fs";
 import path from "path";
 
@@ -23,6 +23,23 @@ import {
   getWebPBinaryPath,
   moveImageResultsToFinalDestination,
 } from "../utilities/utils";
+
+const losslessAvifEncArgs = [
+  "-s",
+  "0",
+  "--min",
+  "0",
+  "--max",
+  "0",
+  "--minalpha",
+  "0",
+  "--maxalpha",
+  "0",
+  "--qcolor",
+  "100",
+  "--qalpha",
+  "100",
+];
 
 /**
  * Optimizes a JPEG image by applying lossy compression.
@@ -62,9 +79,14 @@ const optimizeWEBP = async (webpPath: string, amount: number) => {
   const newPath = (await getDestinationPaths([optimizedPath]))[0];
 
   const [, cwebpPath] = await getWebPBinaryPath();
-  execSync(
-    `"${cwebpPath}" ${preferences.useLosslessConversion ? "-lossless" : ""} -q ${amount} "${webpPath}" -o "${newPath}"`,
-  );
+  execFileSync(cwebpPath, [
+    ...(preferences.useLosslessConversion ? ["-lossless"] : []),
+    "-q",
+    String(amount),
+    webpPath,
+    "-o",
+    newPath,
+  ]);
   return newPath;
 };
 
@@ -93,8 +115,8 @@ const optimizePNG = async (pngPath: string, optimizationAmount: number) => {
   const newPath = (await getDestinationPaths([optimizedPath]))[0];
 
   const pngoutPath = `${environment.assetsPath}/pngout/pngout`;
-  execSync(`chmod +x "${pngoutPath}"`);
-  execSync(`"${pngoutPath}" -s${strategy} -y -force "${pngPath}" "${newPath}"`);
+  execFileSync("chmod", ["+x", pngoutPath]);
+  execFileSync(pngoutPath, [`-s${strategy}`, "-y", "-force", pngPath, newPath]);
   return newPath;
 };
 
@@ -130,15 +152,17 @@ export default async function optimize(sourcePaths: string[], amount: number) {
 
       // Convert to JPEG
       await using jpegFile = await getScopedTempFile("tmp", "jpeg");
-      execSync(`"${decoderPath}" -q ${amount} "${imgPath}" "${jpegFile.path}"`);
+      execFileSync(decoderPath, ["-q", String(amount), imgPath, jpegFile.path]);
 
       // Convert back to AVIF
       let newPath = newPaths[expandedPaths.indexOf(imgPath)];
       newPath = path.join(path.dirname(newPath), path.basename(newPath, path.extname(newPath)) + "-optimized.avif");
       resultPaths.push(newPath);
-      execSync(
-        `"${encoderPath}" ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100" : ""} "${jpegFile.path}" "${newPath}"`,
-      );
+      execFileSync(encoderPath, [
+        ...(preferences.useLosslessConversion ? losslessAvifEncArgs : []),
+        jpegFile.path,
+        newPath,
+      ]);
     } else if (imgPath.toLowerCase().endsWith("pdf")) {
       // PDF -> JPEG -> PDF
       throw new Error(
@@ -163,7 +187,7 @@ export default async function optimize(sourcePaths: string[], amount: number) {
 
       await optimizeJPEG(imgPath, jpegFile.path, amount);
       const format = path.extname(newPath).slice(1).toLowerCase();
-      execSync(`sips --setProperty format ${format} "${jpegFile.path}" --out "${newPath}"`);
+      execFileSync("sips", ["--setProperty", "format", format, jpegFile.path, "--out", newPath]);
     }
   }
   await moveImageResultsToFinalDestination(resultPaths);

--- a/extensions/sips/src/operations/removeBgOperation.ts
+++ b/extensions/sips/src/operations/removeBgOperation.ts
@@ -133,13 +133,13 @@ export default async function removeBg(sourcePaths: string[], bgColorString?: st
 
       const [dwebpPath, cwebpPath] = await getWebPBinaryPath();
       execSync(
-        `${dwebpPath} ${preferences.useLosslessConversion ? "-lossless" : ""} "${imagePath}" -o "${tempPNGfromWEBP.path}"`,
+        `"${dwebpPath}" ${preferences.useLosslessConversion ? "-lossless" : ""} "${imagePath}" -o "${tempPNGfromWEBP.path}"`,
       );
       await runRemoveBgScript(tempPNGfromWEBP.path, tempPNGnoBG.path, bgColor, crop);
 
       if (preferences.preserveFormat) {
         execSync(
-          `${cwebpPath} ${preferences.useLosslessConversion ? "-lossless" : ""} "${tempPNGnoBG.path}" -o "${newPath}"`,
+          `"${cwebpPath}" ${preferences.useLosslessConversion ? "-lossless" : ""} "${tempPNGnoBG.path}" -o "${newPath}"`,
         );
       } else {
         newPath = path.join(path.dirname(newPath), path.basename(newPath, ".webp") + ".png");
@@ -155,9 +155,9 @@ export default async function removeBg(sourcePaths: string[], bgColorString?: st
       await runRemoveBgScript(tempPNGfromSVG.path, tempPNGnoBG.path, bgColor, crop);
 
       if (preferences.preserveFormat) {
-        execSync(`chmod +x ${environment.assetsPath}/potrace/potrace`);
+        execSync(`chmod +x "${environment.assetsPath}/potrace/potrace"`);
         execSync(
-          `sips --setProperty format bmp "${tempPNGnoBG.path}" --out "${tempSVG.path}" && ${environment.assetsPath}/potrace/potrace -s --tight -o "${newPath}" "${tempSVG.path}"`,
+          `sips --setProperty format bmp "${tempPNGnoBG.path}" --out "${tempSVG.path}" && "${environment.assetsPath}/potrace/potrace" -s --tight -o "${newPath}" "${tempSVG.path}"`,
         );
       } else {
         newPath = path.join(path.dirname(newPath), path.basename(newPath, ".svg") + ".png");
@@ -170,12 +170,12 @@ export default async function removeBg(sourcePaths: string[], bgColorString?: st
       await using tempPNGnoBG = await getScopedTempFile("sips-remove-bg-2", "png");
 
       const { encoderPath, decoderPath } = await getAVIFEncPaths();
-      execSync(`${decoderPath} "${imagePath}" "${tempPNGfromAVIF.path}"`);
+      execSync(`"${decoderPath}" "${imagePath}" "${tempPNGfromAVIF.path}"`);
       await runRemoveBgScript(tempPNGfromAVIF.path, tempPNGnoBG.path, bgColor, crop);
 
       if (preferences.preserveFormat) {
         execSync(
-          `${encoderPath} ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100" : ""}  "${tempPNGnoBG.path}" "${newPath}"`,
+          `"${encoderPath}" ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100" : ""}  "${tempPNGnoBG.path}" "${newPath}"`,
         );
       } else {
         newPath = path.join(path.dirname(newPath), path.basename(newPath, ".avif") + ".png");

--- a/extensions/sips/src/operations/removeBgOperation.ts
+++ b/extensions/sips/src/operations/removeBgOperation.ts
@@ -11,7 +11,7 @@ import {
 } from "../utilities/utils";
 import { runAppleScript } from "@raycast/utils";
 import { Color, Colors } from "../utilities/types";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { environment, getPreferenceValues } from "@raycast/api";
 import { getAVIFEncPaths } from "../utilities/avif";
 import path from "path";
@@ -132,18 +132,24 @@ export default async function removeBg(sourcePaths: string[], bgColorString?: st
       await using tempPNGnoBG = await getScopedTempFile("sips-remove-bg-2", "png");
 
       const [dwebpPath, cwebpPath] = await getWebPBinaryPath();
-      execSync(
-        `"${dwebpPath}" ${preferences.useLosslessConversion ? "-lossless" : ""} "${imagePath}" -o "${tempPNGfromWEBP.path}"`,
-      );
+      execFileSync(dwebpPath, [
+        ...(preferences.useLosslessConversion ? ["-lossless"] : []),
+        imagePath,
+        "-o",
+        tempPNGfromWEBP.path,
+      ]);
       await runRemoveBgScript(tempPNGfromWEBP.path, tempPNGnoBG.path, bgColor, crop);
 
       if (preferences.preserveFormat) {
-        execSync(
-          `"${cwebpPath}" ${preferences.useLosslessConversion ? "-lossless" : ""} "${tempPNGnoBG.path}" -o "${newPath}"`,
-        );
+        execFileSync(cwebpPath, [
+          ...(preferences.useLosslessConversion ? ["-lossless"] : []),
+          tempPNGnoBG.path,
+          "-o",
+          newPath,
+        ]);
       } else {
         newPath = path.join(path.dirname(newPath), path.basename(newPath, ".webp") + ".png");
-        execSync(`mv "${tempPNGnoBG.path}" "${newPath}"`);
+        execFileSync("mv", [tempPNGnoBG.path, newPath]);
       }
       resultPaths.push(newPath);
     } else if (imagePath.toLowerCase().endsWith(".svg")) {
@@ -155,13 +161,13 @@ export default async function removeBg(sourcePaths: string[], bgColorString?: st
       await runRemoveBgScript(tempPNGfromSVG.path, tempPNGnoBG.path, bgColor, crop);
 
       if (preferences.preserveFormat) {
-        execSync(`chmod +x "${environment.assetsPath}/potrace/potrace"`);
-        execSync(
-          `sips --setProperty format bmp "${tempPNGnoBG.path}" --out "${tempSVG.path}" && "${environment.assetsPath}/potrace/potrace" -s --tight -o "${newPath}" "${tempSVG.path}"`,
-        );
+        const potracePath = path.join(environment.assetsPath, "potrace/potrace");
+        execFileSync("chmod", ["+x", potracePath]);
+        execFileSync("sips", ["--setProperty", "format", "bmp", tempPNGnoBG.path, "--out", tempSVG.path]);
+        execFileSync(potracePath, ["-s", "--tight", "-o", newPath, tempSVG.path]);
       } else {
         newPath = path.join(path.dirname(newPath), path.basename(newPath, ".svg") + ".png");
-        execSync(`mv "${tempPNGnoBG.path}" "${newPath}"`);
+        execFileSync("mv", [tempPNGnoBG.path, newPath]);
       }
       resultPaths.push(newPath);
     } else if (imagePath.toLowerCase().endsWith(".avif")) {
@@ -170,16 +176,35 @@ export default async function removeBg(sourcePaths: string[], bgColorString?: st
       await using tempPNGnoBG = await getScopedTempFile("sips-remove-bg-2", "png");
 
       const { encoderPath, decoderPath } = await getAVIFEncPaths();
-      execSync(`"${decoderPath}" "${imagePath}" "${tempPNGfromAVIF.path}"`);
+      execFileSync(decoderPath, [imagePath, tempPNGfromAVIF.path]);
       await runRemoveBgScript(tempPNGfromAVIF.path, tempPNGnoBG.path, bgColor, crop);
 
       if (preferences.preserveFormat) {
-        execSync(
-          `"${encoderPath}" ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100" : ""}  "${tempPNGnoBG.path}" "${newPath}"`,
-        );
+        execFileSync(encoderPath, [
+          ...(preferences.useLosslessConversion
+            ? [
+                "-s",
+                "0",
+                "--min",
+                "0",
+                "--max",
+                "0",
+                "--minalpha",
+                "0",
+                "--maxalpha",
+                "0",
+                "--qcolor",
+                "100",
+                "--qalpha",
+                "100",
+              ]
+            : []),
+          tempPNGnoBG.path,
+          newPath,
+        ]);
       } else {
         newPath = path.join(path.dirname(newPath), path.basename(newPath, ".avif") + ".png");
-        execSync(`mv "${tempPNGnoBG.path}" "${newPath}"`);
+        execFileSync("mv", [tempPNGnoBG.path, newPath]);
       }
       resultPaths.push(newPath);
     } else if (imagePath.toLowerCase().endsWith(".pdf")) {
@@ -205,7 +230,7 @@ export default async function removeBg(sourcePaths: string[], bgColorString?: st
         resultPaths.push(newPath);
       } else {
         const newDirPath = path.join(path.dirname(newPath), path.basename(newPath, ".pdf") + "-pngs");
-        execSync(`mv "${tempPNGnoBGDir.path}" "${newDirPath}"`);
+        execFileSync("mv", [tempPNGnoBGDir.path, newDirPath]);
         const finalPNGs = (await readdir(newDirPath)).map((file) => path.join(newDirPath, file));
         resultPaths.push(...finalPNGs);
       }
@@ -219,10 +244,10 @@ export default async function removeBg(sourcePaths: string[], bgColorString?: st
       await runRemoveBgScript(imagePath, tempPng.path, bgColor, crop);
 
       if (preferences.preserveFormat) {
-        execSync(`sips -s format ${originalFormat.toLowerCase()} "${tempPng.path}" --out "${newPath}"`);
+        execFileSync("sips", ["-s", "format", originalFormat.toLowerCase(), tempPng.path, "--out", newPath]);
       } else {
         newPath = path.join(path.dirname(newPath), path.basename(newPath, ".png") + ".png");
-        execSync(`mv "${tempPng.path}" "${newPath}"`);
+        execFileSync("mv", [tempPng.path, newPath]);
       }
       resultPaths.push(newPath);
     }

--- a/extensions/sips/src/operations/removeBgOperation.ts
+++ b/extensions/sips/src/operations/removeBgOperation.ts
@@ -13,7 +13,7 @@ import { runAppleScript } from "@raycast/utils";
 import { Color, Colors } from "../utilities/types";
 import { execFileSync } from "child_process";
 import { environment, getPreferenceValues } from "@raycast/api";
-import { getAVIFEncPaths } from "../utilities/avif";
+import { getAVIFEncPaths, losslessAvifEncArgs } from "../utilities/avif";
 import path from "path";
 import { readdir } from "fs/promises";
 import { makePDF } from "../utilities/pdf";
@@ -132,12 +132,7 @@ export default async function removeBg(sourcePaths: string[], bgColorString?: st
       await using tempPNGnoBG = await getScopedTempFile("sips-remove-bg-2", "png");
 
       const [dwebpPath, cwebpPath] = await getWebPBinaryPath();
-      execFileSync(dwebpPath, [
-        ...(preferences.useLosslessConversion ? ["-lossless"] : []),
-        imagePath,
-        "-o",
-        tempPNGfromWEBP.path,
-      ]);
+      execFileSync(dwebpPath, [imagePath, "-o", tempPNGfromWEBP.path]);
       await runRemoveBgScript(tempPNGfromWEBP.path, tempPNGnoBG.path, bgColor, crop);
 
       if (preferences.preserveFormat) {
@@ -181,24 +176,7 @@ export default async function removeBg(sourcePaths: string[], bgColorString?: st
 
       if (preferences.preserveFormat) {
         execFileSync(encoderPath, [
-          ...(preferences.useLosslessConversion
-            ? [
-                "-s",
-                "0",
-                "--min",
-                "0",
-                "--max",
-                "0",
-                "--minalpha",
-                "0",
-                "--maxalpha",
-                "0",
-                "--qcolor",
-                "100",
-                "--qalpha",
-                "100",
-              ]
-            : []),
+          ...(preferences.useLosslessConversion ? losslessAvifEncArgs : []),
           tempPNGnoBG.path,
           newPath,
         ]);

--- a/extensions/sips/src/utilities/avif.ts
+++ b/extensions/sips/src/utilities/avif.ts
@@ -13,6 +13,23 @@ import { LocalStorage, Toast, confirmAlert, showToast } from "@raycast/api";
 import { showErrorToast } from "./utils";
 import { existsSync } from "fs";
 
+export const losslessAvifEncArgs = [
+  "-s",
+  "0",
+  "--min",
+  "0",
+  "--max",
+  "0",
+  "--minalpha",
+  "0",
+  "--maxalpha",
+  "0",
+  "--qcolor",
+  "100",
+  "--qalpha",
+  "100",
+];
+
 /**
  * Attempts to install the AVIF encoder using Homebrew.
  *

--- a/extensions/sips/src/utilities/avif.ts
+++ b/extensions/sips/src/utilities/avif.ts
@@ -101,15 +101,23 @@ async function verifyInstall() {
  *
  * @returns An promise resolving to an object containing the encoder/decoder paths.
  */
-export async function getAVIFEncPaths() {
-  let encoderPath = await LocalStorage.getItem("avifEncoderPath");
-  let decoderPath = await LocalStorage.getItem("avifDecoderPath");
+export async function getAVIFEncPaths(): Promise<{ encoderPath: string; decoderPath: string }> {
+  let encoderPath = await LocalStorage.getItem<string>("avifEncoderPath");
+  let decoderPath = await LocalStorage.getItem<string>("avifDecoderPath");
 
   if (!encoderPath || !decoderPath) {
     // Get the path to the AVIF encoder
     try {
       encoderPath = execSync(`/bin/zsh -lc 'realpath "$(which avifenc)"'`).toString().trim();
       decoderPath = execSync(`/bin/zsh -lc 'realpath "$(which avifdec)"'`).toString().trim();
+
+      // Cache the discovered paths for future use
+      if (encoderPath) {
+        await LocalStorage.setItem("avifEncoderPath", encoderPath);
+      }
+      if (decoderPath) {
+        await LocalStorage.setItem("avifDecoderPath", decoderPath);
+      }
     } catch (error) {
       // If the AVIF encoder is not found, prompt the user to install it
       if (await installAVIFEnc()) {
@@ -134,6 +142,11 @@ export async function getAVIFEncPaths() {
       }
     }
   }
+
+  if (typeof encoderPath !== "string" || typeof decoderPath !== "string") {
+    throw new Error("AVIF encoder and decoder paths could not be resolved.");
+  }
+
   return {
     encoderPath,
     decoderPath,

--- a/extensions/sips/src/utilities/utils.ts
+++ b/extensions/sips/src/utilities/utils.ts
@@ -242,8 +242,8 @@ export const getWebPBinaryPath = async () => {
 
   if (cpuType == "arm") {
     // Make sure the arm binaries are executable
-    execSync(`chmod +x ${environment.assetsPath}/webp/arm/dwebp`);
-    execSync(`chmod +x ${environment.assetsPath}/webp/arm/cwebp`);
+    execSync(`chmod +x "${environment.assetsPath}/webp/arm/dwebp"`);
+    execSync(`chmod +x "${environment.assetsPath}/webp/arm/cwebp"`);
     // Remove x86 binaries if they exist
     if (fs.existsSync(`${environment.assetsPath}/webp/x86/dwebp`)) {
       await fs.promises.rm(`${environment.assetsPath}/webp/x86/dwebp`);
@@ -254,8 +254,8 @@ export const getWebPBinaryPath = async () => {
     return [`${environment.assetsPath}/webp/arm/dwebp`, `${environment.assetsPath}/webp/arm/cwebp`];
   } else {
     // Make sure the x86 binaries are executable
-    execSync(`chmod +x ${environment.assetsPath}/webp/x86/dwebp`);
-    execSync(`chmod +x ${environment.assetsPath}/webp/x86/cwebp`);
+    execSync(`chmod +x "${environment.assetsPath}/webp/x86/dwebp"`);
+    execSync(`chmod +x "${environment.assetsPath}/webp/x86/cwebp"`);
 
     // Remove arm binaries if they exist
     if (fs.existsSync(`${environment.assetsPath}/webp/arm/dwebp`)) {

--- a/extensions/sips/src/utilities/utils.ts
+++ b/extensions/sips/src/utilities/utils.ts
@@ -283,7 +283,7 @@ export const execSIPSCommandOnWebP = async (command: string, webpPath: string): 
   const [dwebpPath, cwebpPath] = await getWebPBinaryPath();
 
   execSync(
-    `${dwebpPath} "${webpPath}" -o "${tmpFile.path}" && ${command} "${tmpFile.path}" && ${cwebpPath} ${preferences.useLosslessConversion ? "-lossless" : ""} "${tmpFile.path}" -o "${newPath}"`,
+    `"${dwebpPath}" "${webpPath}" -o "${tmpFile.path}" && ${command} "${tmpFile.path}" && "${cwebpPath}" ${preferences.useLosslessConversion ? "-lossless" : ""} "${tmpFile.path}" -o "${newPath}"`,
   );
   return newPath;
 };
@@ -301,7 +301,7 @@ export const execSIPSCommandOnAVIF = async (command: string, avifPath: string): 
 
   const { encoderPath, decoderPath } = await getAVIFEncPaths();
   execSync(
-    `${decoderPath} "${avifPath}" "${tmpFile.path}" && ${command} "${tmpFile.path}" && ${encoderPath} ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100" : ""}  "${tmpFile.path}" "${newPath}"`,
+    `"${decoderPath}" "${avifPath}" "${tmpFile.path}" && ${command} "${tmpFile.path}" && "${encoderPath}" ${preferences.useLosslessConversion ? "-s 0 --min 0 --max 0 --minalpha 0 --maxalpha 0 --qcolor 100 --qalpha 100" : ""}  "${tmpFile.path}" "${newPath}"`,
   );
   return newPath;
 };
@@ -317,9 +317,9 @@ export const execSIPSCommandOnSVG = async (command: string, svgPath: string): Pr
   const newPath = (await getDestinationPaths([svgPath]))[0];
 
   await convertSVG("BMP", svgPath, tmpFile.path);
-  execSync(`chmod +x ${environment.assetsPath}/potrace/potrace`);
+  execSync(`chmod +x "${environment.assetsPath}/potrace/potrace"`);
   execSync(
-    `${command} "${tmpFile.path}" && ${environment.assetsPath}/potrace/potrace -s --tight -o "${newPath}" "${tmpFile.path}"`,
+    `${command} "${tmpFile.path}" && "${environment.assetsPath}/potrace/potrace" -s --tight -o "${newPath}" "${tmpFile.path}"`,
   );
   return newPath;
 };


### PR DESCRIPTION
## Description

The **Optimize** command never works for installed users on PNG, GIF, BMP, TGA, WebP, and AVIF images. JPEG and SVG are unaffected.

### Root cause

`optimizeOperation.ts` shells out to bundled binaries (`pngout`, `cwebp`, `avifdec`, `avifenc`) with the binary path interpolated **unquoted** into `execSync()`:

```ts
execSync(`chmod +x ${pngoutPath}`);
execSync(`${pngoutPath} -s${strategy} -y -force "${pngPath}" "${newPath}"`);
```

For installed extensions, `environment.assetsPath` resolves under `~/Library/Application Support/com.raycast.macos/...` — which contains a space. The shell splits on it, so `chmod` and the binary invocation fail and the whole command throws. It works in `ray develop` only because the dev checkout path usually has no space, which is why this slipped through.

The same unquoted pattern affected the `cwebp` chmod in `getWebPBinaryPath` (`utils.ts`), which is on the optimize-WebP path. JPEG (`NSBitmapImageRep` via AppleScript) and SVG (SVGO, in-process) don't shell out to a bundled binary, so they were never broken — matching user reports that "optimize does nothing" specifically on PNGs.

Related reports: #17617 (Unable to optimize PNG files), #18630 (webp/avif convert failing).

### Fix

Quote the bundled-binary paths everywhere the Optimize command uses them — consistent with the already-quoted `supportPath` in `stripEXIFOperation.ts`. One-line-per-call mechanical change, no behavior change beyond surviving spaces.

### Verification

Reproduced deterministically: with an `assetsPath` containing a space, the current unquoted `execSync` throws `command not found`; the quoted version runs `pngout` and writes the optimized file. `npx ray lint` and `npx ray build` (TypeScript check) both pass.

> Note: the same unquoted-binary pattern still exists in `removeBgOperation.ts` (potrace/cwebp/avif) and the `dwebp` chmod. Happy to fold those into this PR or open a follow-up — let me know your preference.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] `npm run build` and `ray lint` pass
- [x] I added a CHANGELOG entry (`{PR_MERGE_DATE}` placeholder)
- [x] I checked that assets are properly linked
