### PR TITLE
fix: keep easy ocr fallback text

### DIFF
--- a/extensions/easy-ocr/CHANGELOG.md
+++ b/extensions/easy-ocr/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Tesseract OCR Changelog
 
+## [Bug Fixes] - 2026-06-23
+
+- Kept the first OCR result when autodetected languages are not installed in Tesseract
+
 ## [Enhancements] - 2025-04-15
 
 - Added automatic language detection option with either Raycast AI, Franc, LanguageDetect or Tinyld

--- a/extensions/easy-ocr/package.json
+++ b/extensions/easy-ocr/package.json
@@ -1,95 +1,98 @@
 {
-    "$schema": "https://www.raycast.com/schemas/extension.json",
-    "name": "easy-ocr",
-    "title": "Easy OCR",
-    "description": "Use Tesseract OCR to extract text from screenshot",
-    "icon": "command-icon.png",
-    "author": "Rafo94",
-    "contributors": [
-        "quiknull"
-    ],
-    "categories": [
-        "Productivity"
-    ],
-    "license": "MIT",
-    "commands": [
-        {
-            "name": "index",
-            "title": "Area OCR",
-            "description": "Select screen area which you want to extract the text",
-            "mode": "no-view"
-        }
-    ],
-    "preferences": [
-        {
-            "name": "tesseract_path",
-            "type": "textfield",
-            "required": false,
-            "title": "Tesseract binary path",
-            "description": "Absolute path to your tesseract binary - check documentation if default path is not correct",
-            "placeholder": "Tesseract binary path",
-            "default": "/opt/homebrew/bin/tesseract"
-        },
-        {
-            "name": "autodetect_lang",
-            "title": "Autodetect language",
-            "label": "Enable language autodetect",
-            "description": "Enable auto detection fo language, Tesseract language will be used as a fallback language if autodetect fails or doesn't find suitable lang",
-            "type": "checkbox",
-            "required": true,
-            "default": false
-        },
-        {
-            "name": "tesseract_lang",
-            "type": "textfield",
-            "required": false,
-            "title": "Tesseract language",
-            "description": "Language which will be used for OCR. Run tesseract --list-langs in your terminal for list of available languages.",
-            "placeholder": "Tesseract language",
-            "default": "eng"
-        },
-        {
-            "name": "newLine",
-            "type": "dropdown",
-            "required": false,
-            "title": "How to treat new lines (\\n)?",
-            "description": "OCR engines can read new lines and they interpret them as \\n, this option gives you ability to swap them out",
-            "data": [
-                {
-                    "title": "Replace with empty space",
-                    "value": "replaceSpace"
-                },
-                {
-                    "title": "Don't change anything",
-                    "value": "keep"
-                },
-                {
-                    "title": "Replace with <br>",
-                    "value": "replaceBreak"
-                }
-            ],
-            "default": "replaceSpace"
-        }
-    ],
-    "dependencies": {
-        "@raycast/api": "^1.56.1",
-        "@raycast/utils": "^1.10.0",
-        "node-tesseract-ocr": "^2.2.1",
-        "raycast-language-detector": "^0.2.3"
-    },
-    "devDependencies": {
-        "@raycast/eslint-config": "1.0.5",
-        "@types/node": "18.8.3",
-        "@types/react": "18.0.9",
-        "eslint": "^7.32.0",
-        "prettier": "^2.5.1",
-        "typescript": "^4.4.3"
-    },
-    "scripts": {
-        "build": "ray build -e dist",
-        "dev": "ray develop",
-        "fix-lint": "ray lint --fix",
-        "lint": "ray lint",
-        "publish": "npx @raycast/api@latest publish"
+  "$schema": "https://www.raycast.com/schemas/extension.json",
+  "name": "easy-ocr",
+  "title": "Easy OCR",
+  "description": "Use Tesseract OCR to extract text from screenshot",
+  "icon": "command-icon.png",
+  "author": "Rafo94",
+  "contributors": [
+    "quiknull"
+  ],
+  "categories": [
+    "Productivity"
+  ],
+  "license": "MIT",
+  "commands": [
+    {
+      "name": "index",
+      "title": "Area OCR",
+      "description": "Select screen area which you want to extract the text",
+      "mode": "no-view"
     }
+  ],
+  "preferences": [
+    {
+      "name": "tesseract_path",
+      "type": "textfield",
+      "required": false,
+      "title": "Tesseract binary path",
+      "description": "Absolute path to your tesseract binary - check documentation if default path is not correct",
+      "placeholder": "Tesseract binary path",
+      "default": "/opt/homebrew/bin/tesseract"
+    },
+    {
+      "name": "autodetect_lang",
+      "title": "Autodetect language",
+      "label": "Enable language autodetect",
+      "description": "Enable auto detection fo language, Tesseract language will be used as a fallback language if autodetect fails or doesn't find suitable lang",
+      "type": "checkbox",
+      "required": true,
+      "default": false
+    },
+    {
+      "name": "tesseract_lang",
+      "type": "textfield",
+      "required": false,
+      "title": "Tesseract language",
+      "description": "Language which will be used for OCR. Run tesseract --list-langs in your terminal for list of available languages.",
+      "placeholder": "Tesseract language",
+      "default": "eng"
+    },
+    {
+      "name": "newLine",
+      "type": "dropdown",
+      "required": false,
+      "title": "How to treat new lines (\\n)?",
+      "description": "OCR engines can read new lines and they interpret them as \\n, this option gives you ability to swap them out",
+      "data": [
+        {
+          "title": "Replace with empty space",
+          "value": "replaceSpace"
+        },
+        {
+          "title": "Don't change anything",
+          "value": "keep"
+        },
+        {
+          "title": "Replace with <br>",
+          "value": "replaceBreak"
+        }
+      ],
+      "default": "replaceSpace"
+    }
+  ],
+  "dependencies": {
+    "@raycast/api": "^1.56.1",
+    "@raycast/utils": "^1.10.0",
+    "node-tesseract-ocr": "^2.2.1",
+    "raycast-language-detector": "^0.2.3"
+  },
+  "devDependencies": {
+    "@raycast/eslint-config": "1.0.5",
+    "@types/node": "18.8.3",
+    "@types/react": "18.0.9",
+    "eslint": "^7.32.0",
+    "prettier": "^2.5.1",
+    "typescript": "^4.4.3"
+  },
+  "scripts": {
+    "build": "ray build -e dist",
+    "dev": "ray develop",
+    "fix-lint": "ray lint --fix",
+    "lint": "ray lint",
+    "publish": "npx @raycast/api@latest publish"
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/easy-ocr/src/index.tsx
+++ b/extensions/easy-ocr/src/index.tsx
@@ -46,13 +46,17 @@ export default async function main() {
     if (
       autodetectLanguage?.languageCode &&
       utils.isValidLanguage(autodetectLanguage?.languageCode) &&
+      (await utils.isInstalledLanguage(autodetectLanguage?.languageCode)) &&
       autodetectLanguage?.languageCode !== defaultLangCode
     ) {
-      text = await tesseractOcr(filePath, autodetectLanguage?.languageCode);
-      text = utils.handleNewLines(text);
+      try {
+        text = await tesseractOcr(filePath, autodetectLanguage?.languageCode);
+        text = utils.handleNewLines(text);
+        languageUsed = autodetectLanguage?.languageName ?? languageUsed;
+      } catch {
+        // Keep the first OCR result when the autodetected language cannot be loaded by Tesseract.
+      }
     }
-
-    languageUsed = autodetectLanguage?.languageName ?? languageUsed;
 
     await Clipboard.copy(text);
     await showToast({

--- a/extensions/easy-ocr/src/utils.ts
+++ b/extensions/easy-ocr/src/utils.ts
@@ -1,6 +1,11 @@
 import { getPreferenceValues } from "@raycast/api";
+import { execFile } from "child_process";
 import fs from "fs";
+import { promisify } from "util";
 import { languages } from "./lib/languages";
+
+const execFileAsync = promisify(execFile);
+const installedLanguagesByBinary = new Map<string, Promise<Set<string> | undefined>>();
 
 function handleNewLines(text: string) {
   const newLine = getPreferenceValues<Preferences>().newLine;
@@ -23,8 +28,43 @@ const isValidLanguage = (lang: string) => {
   return lang in languages;
 };
 
+const getInstalledLanguages = async () => {
+  const tesseractPath = getPreferenceValues<Preferences>().tesseract_path;
+
+  if (!installedLanguagesByBinary.has(tesseractPath)) {
+    installedLanguagesByBinary.set(
+      tesseractPath,
+      execFileAsync(tesseractPath, ["--list-langs"])
+        .then(({ stdout, stderr }) => {
+          const languages = new Set(
+            `${stdout}\n${stderr}`
+              .split(/\r?\n/)
+              .map((line) => line.trim())
+              .filter((line) => line && !line.startsWith("List of available languages"))
+          );
+
+          return languages.size ? languages : undefined;
+        })
+        .catch(() => undefined)
+    );
+  }
+
+  return installedLanguagesByBinary.get(tesseractPath);
+};
+
+const isInstalledLanguage = async (lang: string) => {
+  if (!isValidLanguage(lang)) {
+    return false;
+  }
+
+  const installedLanguages = await getInstalledLanguages();
+
+  return !installedLanguages || installedLanguages.has(lang);
+};
+
 const utils = {
   handleNewLines,
+  isInstalledLanguage,
   isTesseractInstalled,
   isValidLanguage,
 };


### PR DESCRIPTION
## Problem
Easy OCR can successfully read text with the configured fallback language, then fail the whole command when autodetect picks a language that Tesseract cannot load locally. That drops the first successful OCR result and shows a generic failure toast instead.

Fixes #28934.

## Solution
I added a cached installed-language check using `tesseract --list-langs` before running the autodetected second pass. If Tesseract cannot list languages, the extension keeps the previous behavior. If the second pass still fails, the command now keeps the first OCR result instead of failing the whole flow.

## Testing
- `npm ci --ignore-scripts`
- `npx eslint src\index.tsx src\utils.ts`
- `npx prettier --check src\index.tsx src\utils.ts CHANGELOG.md`
- `git diff --check`

I also tried the normal Raycast CLI paths. `npm ci` fails during `@raycast/api` postinstall on Windows because `bin/ray npm-post-install` is invoked through `cmd.exe`, and invoking `ray lint` through Git Bash downloads an x86 binary that Windows cannot execute. `npx tsc --noEmit` is blocked because the generated Raycast `Preferences` global type is not present outside the Raycast build flow.