### PR TITLE
Update Bookface extension

### DIFF
--- a/extensions/bookface/CHANGELOG.md
+++ b/extensions/bookface/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Bookface Changelog
 
-## [Initial Version] - 2026-06-08
+## [New commands and YC CLI 0.0.14 support] - {PR_MERGE_DATE}
+
+- Added a `Log out of YC` command that clears stored YC CLI credentials (with a confirmation prompt).
+- Detect when the YC CLI is too old to run and route to an in-app **Update Required** screen that runs `yc update` for you, instead of failing with a raw error.
+- Render Knowledge Base articles in search results (previously dropped silently).
+- Show what the YC agent searched ("What the agent did") beneath each Ask answer.
+- Export or copy the full set of search results for a selected type as CSV (`⌘⇧E` / `⌘⇧C`), reaching every match rather than just the displayed page.
+- Fixed large searches (e.g. "stripe") returning no results — the CLI's output is now captured reliably regardless of size.
+- Added a **Check Again** action to the signed-out screens so you can refresh after logging in, plus a Verbose Logging preference for diagnostics.
+
+## [Initial Version] - {PR_MERGE_DATE}
 
 - Added `Search YC` command — search Bookface across people, YC and non-YC companies, schools, posts, deals, employers, and Startup Library articles, with a type-filter dropdown and per-type secondary actions.
 - Added `Ask YC` command — ask the YC agent questions and read the markdown response inline; recent questions are remembered for one-click reuse.

--- a/extensions/bookface/CHANGELOG.md
+++ b/extensions/bookface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Bookface Changelog
 
-## [New commands and YC CLI 0.0.14 support] - {PR_MERGE_DATE}
+## [New commands and YC CLI 0.0.14 support] - 2026-06-23
 
 - Added a `Log out of YC` command that clears stored YC CLI credentials (with a confirmation prompt).
 - Detect when the YC CLI is too old to run and route to an in-app **Update Required** screen that runs `yc update` for you, instead of failing with a raw error.

--- a/extensions/bookface/CHANGELOG.md
+++ b/extensions/bookface/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fixed large searches (e.g. "stripe") returning no results — the CLI's output is now captured reliably regardless of size.
 - Added a **Check Again** action to the signed-out screens so you can refresh after logging in, plus a Verbose Logging preference for diagnostics.
 
-## [Initial Version] - {PR_MERGE_DATE}
+## [Initial Version] - 2026-06-08
 
 - Added `Search YC` command — search Bookface across people, YC and non-YC companies, schools, posts, deals, employers, and Startup Library articles, with a type-filter dropdown and per-type secondary actions.
 - Added `Ask YC` command — ask the YC agent questions and read the markdown response inline; recent questions are remembered for one-click reuse.

--- a/extensions/bookface/README.md
+++ b/extensions/bookface/README.md
@@ -8,9 +8,10 @@ You need a Bookface account to use the CLI and this extension.
 
 ## What can it do?
 
-- **Ask YC Agent** — ask the YC agent questions about the network, investors, fundraising, and more.
-- **Search YC** — search Bookface for people, YC and non-YC companies, posts, deals, schools, employers, and Startup Library articles. Filter by type, toggle a sidebar preview, or see posts and company descriptions in Raycast.
+- **Ask YC Agent** — ask the YC agent questions about the network, investors, fundraising, and more. Each answer shows what the agent searched to ground its response.
+- **Search YC** — search Bookface for people, YC and non-YC companies, posts, deals, schools, employers, Startup Library articles, and Knowledge Base entries. Filter by type, toggle a sidebar preview, or export a type's full result set as CSV.
 - **YC Account** — show the currently logged-in Bookface user.
+- **Log out of YC** — clear your stored YC CLI credentials (with a confirmation).
 
 ## Who can use it?
 
@@ -40,13 +41,14 @@ This opens your browser for OAuth (with a `--device` flag for headless/remote sh
 
 ### 3. Open Raycast
 
-Run **Search YC**, **Ask YC Agent**, or **My YC Account**. If the extension can't find the binary or you're not logged in, every command surfaces a clear empty state with the right command to copy and paste.
+Run **Search YC**, **Ask YC Agent**, or **YC Account**. If the extension can't find the binary or you're not logged in, every command surfaces a clear empty state with the right command to copy and paste.
 
 ## Preferences
 
-| Preference      | Description                                                                                                                                                                          |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **yc CLI Path** | Optional absolute path to the `yc` binary. If empty, the extension searches `$PATH` for `yc` or `ycp`, then falls back to `~/.local/bin`, `/opt/homebrew/bin`, and `/usr/local/bin`. |
+| Preference          | Description                                                                                                                                                                          |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **yc CLI Path**     | Optional absolute path to the `yc` binary. If empty, the extension searches `$PATH` for `yc` or `ycp`, then falls back to `~/.local/bin`, `/opt/homebrew/bin`, and `/usr/local/bin`. |
+| **Verbose Logging** | Logs each `yc` invocation, output size, and parse results to the Raycast console for diagnostics. Sensitive values are redacted. Off by default.                                     |
 
 Set it from Raycast → Extensions → Bookface if you've installed the binary somewhere unusual.
 
@@ -55,6 +57,7 @@ Set it from Raycast → Extensions → Bookface if you've installed the binary s
 - ⌘⇧⏎ toggles a Markdown sidebar with type-specific details for the selected result.
 - ⌘D pushes a full-screen Markdown view of post bodies, company descriptions, and Startup Library articles.
 - ⌘⇧. copies the Bookface URL; ⌘⇧M copies it as a Markdown link.
+- With a type filter selected in Search, ⌘⇧E exports that type's full result set as CSV (⌘⇧C copies it) — useful for pulling every matching company, founder, or deal, not just the first page.
 - The "Search YC" command remembers your recent searches; "Ask YC Agent" remembers your recent questions.
 
 ## Troubleshooting

--- a/extensions/bookface/package-lock.json
+++ b/extensions/bookface/package-lock.json
@@ -7,16 +7,26 @@
       "name": "bookface",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.103.0",
-        "@raycast/utils": "^2.2.1"
+        "@chrismessina/raycast-logger": "^1.2.4",
+        "@raycast/api": "^1.104.20",
+        "@raycast/utils": "^2.2.6"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.0.4",
         "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "eslint": "^9.22.0",
-        "prettier": "^3.5.3",
+        "prettier": "^3.8.4",
         "typescript": "^5.8.2"
+      }
+    },
+    "node_modules/@chrismessina/raycast-logger": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@chrismessina/raycast-logger/-/raycast-logger-1.2.4.tgz",
+      "integrity": "sha512-LJyh7yv8rJ1GjdzjeAkxzDdeo2K7VXwdK/dZy0YInf9CtyJh6law7UodfI4GFRnm168BNq9fGcNK/NuOd6uiKg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@raycast/api": "^1.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1127,9 +1137,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.15",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.15.tgz",
-      "integrity": "sha512-jQK0J1E8MRrjIDoG1QP/Py+eMdDRfxS2wRHd8z40Fa8bBxUQyDr+A4zJ+7s61V8vPCzqiGgET6pvH61AYmR25g==",
+      "version": "1.104.20",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.20.tgz",
+      "integrity": "sha512-Hcvt0OVjdjBFLtb9rNQjRBL7FAZBF3mlU17y2TgCdNolkeGixfJdMb7idfiILfgoNa94gj4C+M/MZn1tf/q4Dg==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
@@ -1197,9 +1207,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.4.tgz",
-      "integrity": "sha512-XkxW5bUZACxl2zP4M6Qtkj9a1nbOKcRBm96BLkJ6O4Q7L/vFSnc+3pPJ/i0ZLVOExx5LJMJY0jnNPo91xqJnFQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.6.tgz",
+      "integrity": "sha512-/6NUftsaNjboTOhTiadRhQ+hgfsg9AxKdYCpGGbwfUghTX9M+ljbGBesCxQ+X5GBIBM+9lH3ma7GMwZPSPzJgw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1600,9 +1610,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2399,10 +2409,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2647,9 +2667,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/extensions/bookface/package.json
+++ b/extensions/bookface/package.json
@@ -42,6 +42,13 @@
       "description": "Show the currently logged-in Bookface account.",
       "mode": "view",
       "subtitle": "Bookface"
+    },
+    {
+      "name": "logout",
+      "title": "Log out of YC",
+      "description": "Log out and clear stored YC CLI credentials from ~/.yc.",
+      "mode": "no-view",
+      "subtitle": "Bookface"
     }
   ],
   "preferences": [
@@ -52,18 +59,28 @@
       "title": "yc CLI Path",
       "description": "Optional absolute path to the yc binary. If empty, the extension searches $PATH for yc or ycp, then falls back to ~/.local/bin, /opt/homebrew/bin, and /usr/local/bin.",
       "placeholder": "/Users/you/.local/bin/yc"
+    },
+    {
+      "name": "verboseLogging",
+      "type": "checkbox",
+      "required": false,
+      "default": false,
+      "title": "Verbose Logging",
+      "label": "Enable verbose logging",
+      "description": "Sensitive values are redacted. Useful for diagnosing search issues."
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.103.0",
-    "@raycast/utils": "^2.2.1"
+    "@chrismessina/raycast-logger": "^1.2.4",
+    "@raycast/api": "^1.104.20",
+    "@raycast/utils": "^2.2.6"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.0.4",
     "@types/node": "22.19.17",
     "@types/react": "19.0.10",
     "eslint": "^9.22.0",
-    "prettier": "^3.5.3",
+    "prettier": "^3.8.4",
     "typescript": "^5.8.2"
   },
   "scripts": {

--- a/extensions/bookface/src/account.tsx
+++ b/extensions/bookface/src/account.tsx
@@ -23,6 +23,8 @@ export default function Command() {
       return <MissingCliDetail onRetry={revalidate} />;
     if (data.kind === "not-authed")
       return <NotAuthedDetail onRetry={revalidate} />;
+    if (data.kind === "update-required")
+      return <UpdateYcCli gate={data.gate} onRetry={revalidate} />;
     return <ErrorDetail message={data.message} onRetry={revalidate} />;
   }
 

--- a/extensions/bookface/src/ask.tsx
+++ b/extensions/bookface/src/ask.tsx
@@ -21,8 +21,9 @@ import {
   MissingCliDetail,
   NotAuthedDetail,
 } from "./lib/empty-states";
+import { UpdateYcCli } from "./views/updater";
 import { useRecentSearches } from "./hooks/use-recent-searches";
-import type { AgentResponse } from "./lib/types";
+import type { AgentResponse, AgentToolCall } from "./lib/types";
 
 const RECENT_QUESTIONS_KEY = "ask-recents";
 const RECENT_QUESTION_TITLE_MAX = 80;
@@ -30,6 +31,23 @@ const RECENT_QUESTION_TITLE_MAX = 80;
 const LOADING_BODY = `_Compiling your response…_
 
 The YC agent searches Bookface across people, companies, posts, and deals to ground its answer.`;
+
+// Render the steps the agent took (e.g. "Searching the forum for …") as a small
+// trailing section, so the answer is transparent about what it grounded on. The
+// CLI provides a ready `display_message`; fall back to entity/query if absent.
+function toolCallsMarkdown(calls: AgentToolCall[] | undefined): string {
+  if (!calls || calls.length === 0) return "";
+  const lines = calls.map((c) => {
+    const a = c.arguments;
+    const text =
+      a?.display_message ??
+      (a?.entity && a?.query
+        ? `Searched ${a.entity} for "${a.query}"`
+        : c.name);
+    return `- ${text}`;
+  });
+  return ["\n---\n", "**What the agent did**", "", ...lines].join("\n");
+}
 
 function raycastAIChatUrl(question: string, response: string): string {
   const text = `Context from the YC Agent (which searches Bookface, YC's internal network):
@@ -148,12 +166,15 @@ function AnswerView({ question }: { question: string }) {
       return <MissingCliDetail onRetry={revalidate} />;
     if (data.kind === "not-authed")
       return <NotAuthedDetail onRetry={revalidate} />;
+    if (data.kind === "update-required")
+      return <UpdateYcCli gate={data.gate} onRetry={revalidate} />;
     return <ErrorDetail message={data.message} onRetry={revalidate} />;
   }
 
   const response = data?.ok ? data.data.response : null;
+  const toolCalls = data?.ok ? data.data.tool_calls : undefined;
   const markdown = response
-    ? `**You:** ${question}\n\n---\n\n${response}`
+    ? `**You:** ${question}\n\n---\n\n${response}${toolCallsMarkdown(toolCalls)}`
     : `**You:** ${question}\n\n---\n\n${LOADING_BODY}`;
   const continueYcUrl = `https://messages.ycombinator.com/messages/new?type=agent&prompt=${encodeURIComponent(question)}`;
 

--- a/extensions/bookface/src/hooks/use-recent-searches.ts
+++ b/extensions/bookface/src/hooks/use-recent-searches.ts
@@ -27,6 +27,11 @@ function isRecentSearch(value: unknown): value is RecentSearch {
 export function useRecentSearches(
   storageKey: string,
   limit = 25,
+  // When true, adding a query drops any existing recent that is a strict prefix
+  // of it — right for search-as-you-type (where "S","Stri","Stripe" are stages
+  // of one search), wrong for Ask (where entries are deliberate submissions and
+  // "safe" must survive a later "safe financing"). Opt-in; defaults off.
+  collapsePrefixes = false,
 ): UseRecentSearchesResult {
   const [recentSearches, setRecentSearches] = useState<RecentSearch[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -69,7 +74,18 @@ export function useRecentSearches(
       const trimmed = query.trim();
       if (!trimmed) return;
       try {
-        const filtered = recentSearches.filter((s) => s.query !== trimmed);
+        const lower = trimmed.toLowerCase();
+        const filtered = recentSearches.filter((s) => {
+          const sl = s.query.toLowerCase();
+          // Always drop an exact duplicate (re-added at the front).
+          if (sl === lower) return false;
+          // Optionally collapse typed-toward prefixes: a search-as-you-type
+          // session produces "S","St","Stri",… so when a longer query lands,
+          // remove the shorter prefixes it superseded. Off for Ask, where each
+          // recent is a deliberate question that must not be eaten by a longer one.
+          if (collapsePrefixes && lower.startsWith(sl)) return false;
+          return true;
+        });
         const next = [
           { query: trimmed, timestamp: Date.now() },
           ...filtered,
@@ -82,7 +98,7 @@ export function useRecentSearches(
         await showFailureToast(err, { title: "Failed to save recent" });
       }
     },
-    [recentSearches, limit, persist],
+    [recentSearches, limit, persist, collapsePrefixes],
   );
 
   const removeRecentSearch = useCallback(

--- a/extensions/bookface/src/hooks/use-yc-version-gate.ts
+++ b/extensions/bookface/src/hooks/use-yc-version-gate.ts
@@ -1,0 +1,39 @@
+import { useCachedPromise } from "@raycast/utils";
+import { runYc, type VersionGate } from "../lib/yc";
+import type { Me } from "../lib/types";
+
+export type VersionGateState = {
+  /** True once the mount probe has resolved (success or failure). */
+  checked: boolean;
+  isLoading: boolean;
+  /** Set when the CLI refused to run because it's too old. */
+  updateRequired: boolean;
+  gate: VersionGate | undefined;
+  revalidate: () => void;
+};
+
+// Probe the CLI version the moment a command mounts, independent of whatever
+// the command's own data fetch does. The version gate fires on any real API
+// call, so a cheap authed `yc me` is enough to detect a too-old binary — this
+// lets a command (e.g. Search) bounce straight to the update screen instead of
+// showing a working-looking empty state that silently returns nothing.
+//
+// Only the update-required signal is surfaced here; auth/missing-cli are left
+// to the command's primary fetch so we don't duplicate every empty state.
+export function useYcVersionGate(): VersionGateState {
+  const { data, isLoading, revalidate } = useCachedPromise(
+    () => runYc<Me>(["me", "--json"]),
+    [],
+    { keepPreviousData: true },
+  );
+
+  const updateRequired = data?.ok === false && data.kind === "update-required";
+
+  return {
+    checked: data !== undefined,
+    isLoading,
+    updateRequired,
+    gate: updateRequired ? data.gate : undefined,
+    revalidate,
+  };
+}

--- a/extensions/bookface/src/lib/empty-states.tsx
+++ b/extensions/bookface/src/lib/empty-states.tsx
@@ -1,5 +1,50 @@
-import { Action, ActionPanel, Detail, Icon, List } from "@raycast/api";
-import { INSTALL_COMMAND, LOGIN_COMMAND } from "./yc";
+import {
+  Action,
+  ActionPanel,
+  Detail,
+  Icon,
+  Keyboard,
+  List,
+} from "@raycast/api";
+import {
+  INSTALL_COMMAND,
+  LOGIN_COMMAND,
+  UPDATE_COMMAND,
+  stripAnsi,
+  type VersionGate,
+} from "./yc";
+import { UpdateYcCli } from "../views/updater";
+
+// Shared title + lead so the List (EmptyView) and Detail variants of the
+// "update required" state read as the same screen across all three commands.
+// "YC CLI" is the product in prose; `yc` stays lowercase as the literal binary.
+const UPDATE_REQUIRED_TITLE = "Update Required";
+const UPDATE_REQUIRED_LEAD =
+  "This version of the YC CLI is no longer supported. Update it to keep using the extension.";
+
+function gateSummary(gate?: VersionGate): string {
+  if (!gate) return "";
+  const parts: string[] = [];
+  if (gate.current) parts.push(`current ${gate.current}`);
+  if (gate.minimum) parts.push(`requires ${gate.minimum}+`);
+  return parts.join(", ");
+}
+
+function UpdateCliPush({
+  gate,
+  onRetry,
+}: {
+  gate?: VersionGate;
+  onRetry?: () => void;
+}) {
+  return (
+    <Action.Push
+      title="Update YC CLI"
+      icon={Icon.Download}
+      target={<UpdateYcCli gate={gate} onRetry={onRetry} />}
+    />
+  );
+}
 
 function CopyInstall() {
   return (
@@ -19,9 +64,38 @@ function CopyLogin() {
   );
 }
 
+function CopyUpdate() {
+  return (
+    <Action.CopyToClipboard
+      title="Copy Update Command"
+      content={UPDATE_COMMAND}
+    />
+  );
+}
+
+// Auth recovery: Raycast has no window-focus hook, so we can't auto-detect the
+// user returning from a browser login. A clearly-labeled primary "Check Again"
+// re-runs the command's fetch — one keystroke once they've authenticated, with
+// no idle polling against the rate-limited CLI.
+function CheckAgainAction({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Action
+      title="Check Again"
+      icon={Icon.ArrowClockwise}
+      shortcut={Keyboard.Shortcut.Common.Refresh}
+      onAction={onRetry}
+    />
+  );
+}
+
 function ReloadAction({ onRetry }: { onRetry: () => void }) {
   return (
-    <Action title="Reload" icon={Icon.ArrowClockwise} onAction={onRetry} />
+    <Action
+      title="Reload"
+      icon={Icon.ArrowClockwise}
+      shortcut={Keyboard.Shortcut.Common.Refresh}
+      onAction={onRetry}
+    />
   );
 }
 
@@ -29,8 +103,8 @@ export function MissingCliEmpty() {
   return (
     <List.EmptyView
       icon={Icon.ExclamationMark}
-      title="yc CLI Not Found"
-      description="Install the yc CLI to use this extension."
+      title="YC CLI Not Found"
+      description="Install the YC CLI to use this extension."
       actions={
         <ActionPanel>
           <CopyInstall />
@@ -40,14 +114,15 @@ export function MissingCliEmpty() {
   );
 }
 
-export function NotAuthedEmpty() {
+export function NotAuthedEmpty({ onRetry }: { onRetry?: () => void }) {
   return (
     <List.EmptyView
       icon={Icon.ExclamationMark}
       title="Not Logged In"
-      description={`Run "${LOGIN_COMMAND}" in your terminal.`}
+      description={`Run "${LOGIN_COMMAND}" in your terminal, then check again.`}
       actions={
         <ActionPanel>
+          {onRetry ? <CheckAgainAction onRetry={onRetry} /> : null}
           <CopyLogin />
         </ActionPanel>
       }
@@ -55,15 +130,46 @@ export function NotAuthedEmpty() {
   );
 }
 
+export function UpdateRequiredEmpty({
+  gate,
+  onRetry,
+}: {
+  gate?: VersionGate;
+  onRetry?: () => void;
+}) {
+  // EmptyView gives one description line, so fold the version context inline.
+  const summary = gateSummary(gate);
+  return (
+    <List.EmptyView
+      icon={Icon.Download}
+      title={UPDATE_REQUIRED_TITLE}
+      description={
+        summary
+          ? `This version of the YC CLI is no longer supported (${summary}).`
+          : UPDATE_REQUIRED_LEAD
+      }
+      actions={
+        <ActionPanel>
+          <UpdateCliPush gate={gate} onRetry={onRetry} />
+          <CopyUpdate />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
 export function ErrorEmpty({ message }: { message: string }) {
+  // Strip at the sink so no caller can leak raw CLI ANSI control bytes
+  // (the `Ø[K` artifact) into the surface.
+  const clean = stripAnsi(message);
   return (
     <List.EmptyView
       icon={Icon.ExclamationMark}
       title="Search Failed"
-      description={message}
+      description={clean}
       actions={
         <ActionPanel>
-          <Action.CopyToClipboard title="Copy Error" content={message} />
+          <Action.CopyToClipboard title="Copy Error" content={clean} />
         </ActionPanel>
       }
     />
@@ -71,9 +177,9 @@ export function ErrorEmpty({ message }: { message: string }) {
 }
 
 export function MissingCliDetail({ onRetry }: { onRetry?: () => void }) {
-  const markdown = `# yc CLI Not Found
+  const markdown = `# YC CLI Not Found
 
-The Y Combinator extension shells out to the \`yc\` CLI, which doesn't appear to be installed.
+The Bookface extension shells out to the \`yc\` CLI, which doesn't appear to be installed.
 
 ## Install it
 
@@ -99,15 +205,18 @@ Then run \`${LOGIN_COMMAND}\` once in your terminal to authenticate.`;
 export function NotAuthedDetail({ onRetry }: { onRetry?: () => void }) {
   const markdown = `# Not Logged In
 
-Run \`${LOGIN_COMMAND}\` in your terminal to authenticate with Bookface, then try again.`;
+Run \`${LOGIN_COMMAND}\` in your terminal to authenticate with Bookface, then **Check Again**.`;
 
   return (
     <Detail
       markdown={markdown}
       actions={
         <ActionPanel>
+          {/* Check Again is primary: the user authenticates elsewhere, returns,
+              and one keystroke re-checks — no window-focus hook exists to do it
+              automatically, and polling would hit the CLI rate limit. */}
+          {onRetry ? <CheckAgainAction onRetry={onRetry} /> : null}
           <CopyLogin />
-          {onRetry ? <ReloadAction onRetry={onRetry} /> : null}
         </ActionPanel>
       }
     />
@@ -121,13 +230,16 @@ export function ErrorDetail({
   message: string;
   onRetry?: () => void;
 }) {
-  const markdown = `# Something went wrong\n\n\`\`\`\n${message}\n\`\`\``;
+  // Strip at the sink so no caller can leak raw CLI ANSI control bytes
+  // (the `Ø[K` artifact) into the surface.
+  const clean = stripAnsi(message);
+  const markdown = `# Something went wrong\n\n\`\`\`\n${clean}\n\`\`\``;
   return (
     <Detail
       markdown={markdown}
       actions={
         <ActionPanel>
-          <Action.CopyToClipboard title="Copy Error" content={message} />
+          <Action.CopyToClipboard title="Copy Error" content={clean} />
           {onRetry ? <ReloadAction onRetry={onRetry} /> : null}
         </ActionPanel>
       }

--- a/extensions/bookface/src/lib/items.tsx
+++ b/extensions/bookface/src/lib/items.tsx
@@ -1,19 +1,40 @@
-import { Action, ActionPanel, Color, Icon, Image, List } from "@raycast/api";
-import type { ReactElement } from "react";
+import {
+  Action,
+  ActionPanel,
+  Clipboard,
+  Color,
+  Icon,
+  Image,
+  List,
+  Toast,
+  showInFinder,
+  showToast,
+} from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { createContext, useContext, type ReactElement } from "react";
 import { UpdateYcCli } from "../views/updater";
 import type {
   CompanyAttributes,
   DealAttributes,
   EmployerAttributes,
+  KnowledgeBaseAttributes,
   PostAttributes,
   Position,
   SchoolAttributes,
   SearchItem,
+  SearchItemType,
   StartupLibraryAttributes,
   UserAttributes,
 } from "./types";
-import { SEARCH_TYPE_ICONS, SEARCH_TYPE_LABELS } from "./types";
-import { truncate } from "./yc";
+import {
+  CLI_SEARCH_TYPE,
+  SEARCH_TYPE_ICONS,
+  SEARCH_TYPE_LABELS,
+} from "./types";
+import { runYcCsv, truncate } from "./yc";
+import { writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { MarkdownPreview } from "../views/preview";
 
 function avatarIcon(
@@ -62,6 +83,119 @@ function ycBatchOf(positions: Position[]): string | undefined {
     (p) => p.company_yc && p.company_batches && p.company_batches.length > 0,
   );
   return ycPos?.company_batches?.[0];
+}
+
+// Carries the active query and dropdown filter down to per-item actions (e.g.
+// CSV export) without threading them through all eight renderer signatures. The
+// search command wraps its list body in the provider. `filterType` is the
+// selected type, or undefined when the dropdown is on "All".
+export const SearchContext = createContext<{
+  query: string;
+  filterType?: SearchItemType;
+}>({ query: "" });
+
+// Slugify a query for a filename: keep word chars, collapse the rest to hyphens.
+function csvFileName(query: string, cliType: string): string {
+  const slug =
+    query
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 40) || "search";
+  return `yc-${slug}-${cliType}.csv`;
+}
+
+// Export the FULL matching set for the active dropdown filter via
+// `yc search --type`, which returns CSV (and the true total, not just the
+// displayed page). Offers saving to ~/Downloads and copying the raw CSV.
+//
+// Keyed off the dropdown filter, NOT the hovered item: a typed export only makes
+// sense for a single type, so these actions render only when the dropdown is on
+// a specific type (not "All") — then "Export Deals" unambiguously matches what's
+// on screen. Also suppressed when the filter has no clean 1:1 CLI mapping
+// (non_yc_company, startup_library), since exporting via the shared CLI type
+// would include the sibling's rows that aren't shown.
+//
+// Returns a fragment of two sibling actions; each fetches on demand (Raycast
+// doesn't keep this around, so there's no state to cache between them).
+function ExportCsvActions() {
+  const { query, filterType } = useContext(SearchContext);
+  // Bail (render nothing) unless the filter has a clean 1:1 CLI type. Capturing
+  // the narrowed value as a `string`-typed const lets the nested closures use it
+  // without re-narrowing (TS doesn't carry the early-return guard into them).
+  const cliType: string | null = filterType
+    ? CLI_SEARCH_TYPE[filterType]
+    : null;
+  if (!filterType || !cliType) return null;
+  const exportType: string = cliType;
+  const type = filterType;
+  const label = SEARCH_TYPE_LABELS[type];
+
+  async function fetchCsv(): Promise<
+    { csv: string; total: number } | undefined
+  > {
+    if (!query.trim()) return undefined;
+    const result = await runYcCsv(query, exportType);
+    if (!result.ok) {
+      await showFailureToast(new Error(result.message), {
+        title: "Export failed",
+      });
+      return undefined;
+    }
+    return result.data;
+  }
+
+  async function save() {
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: `Exporting ${label}…`,
+    });
+    const data = await fetchCsv();
+    if (!data) return;
+    const path = join(homedir(), "Downloads", csvFileName(query, exportType));
+    try {
+      await writeFile(path, data.csv, "utf8");
+    } catch (error) {
+      await showFailureToast(error, { title: "Could not write CSV file" });
+      return;
+    }
+    toast.style = Toast.Style.Success;
+    toast.title = `Exported ${data.total} ${label}`;
+    toast.message = path.replace(homedir(), "~");
+    toast.primaryAction = {
+      title: "Show in Finder",
+      onAction: () => showInFinder(path),
+    };
+  }
+
+  async function copy() {
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: `Copying ${label}…`,
+    });
+    const data = await fetchCsv();
+    if (!data) return;
+    await Clipboard.copy(data.csv);
+    toast.style = Toast.Style.Success;
+    toast.title = `Copied ${data.total} ${label} as CSV`;
+  }
+
+  return (
+    <>
+      <Action
+        title={`Export ${label} as CSV`}
+        icon={Icon.Download}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "e" }}
+        onAction={save}
+      />
+      <Action
+        title={`Copy ${label} as CSV`}
+        icon={Icon.Clipboard}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+        onAction={copy}
+      />
+    </>
+  );
 }
 
 type RenderProps = {
@@ -128,7 +262,16 @@ export function renderItem({
         toggleDetail,
       );
     case "startup_library":
-      return renderStartupLibrary(
+      return renderArticle(
+        "startup_library",
+        item.path,
+        item.displayed_attributes,
+        isShowingDetail,
+        toggleDetail,
+      );
+    case "knowledge_base":
+      return renderArticle(
+        "knowledge_base",
         item.path,
         item.displayed_attributes,
         isShowingDetail,
@@ -173,6 +316,8 @@ function UniversalActions({
         content={markdownLink(title, url)}
         shortcut={{ modifiers: ["cmd", "shift"], key: "m" }}
       />
+      {/* Renders only when the dropdown is filtered to a specific type. */}
+      <ExportCsvActions />
       <Action.Push
         title="Update YC CLI"
         icon={Icon.Download}
@@ -645,29 +790,35 @@ function renderEmployer(
   );
 }
 
-function startupLibraryMarkdown(a: StartupLibraryAttributes): string {
+// Startup Library and Knowledge Base are the same "article" content shape, so
+// one renderer serves both — parameterized by `type` for the label/icon/key.
+type ArticleAttributes = StartupLibraryAttributes | KnowledgeBaseAttributes;
+type ArticleType = "startup_library" | "knowledge_base";
+
+function articleMarkdown(a: ArticleAttributes): string {
   const lines = [`# ${a.title}`];
   if (a.description) lines.push("", `*${a.description}*`);
   if (a.body) lines.push("", a.body);
   return lines.join("\n");
 }
 
-function renderStartupLibrary(
+function renderArticle(
+  type: ArticleType,
   path: string,
-  a: StartupLibraryAttributes,
+  a: ArticleAttributes,
   isShowingDetail: boolean,
   toggleDetail: () => void,
 ): ReactElement {
   const accessories: List.Item.Accessory[] = [];
   const cat = a.categories?.[0] ?? a.parents?.[0]?.title;
   if (cat) accessories.push({ text: cat });
-  accessories.push({ tag: { value: SEARCH_TYPE_LABELS.startup_library } });
-  const md = startupLibraryMarkdown(a);
+  accessories.push({ tag: { value: SEARCH_TYPE_LABELS[type] } });
+  const md = articleMarkdown(a);
 
   return (
     <List.Item
-      key={`lib-${a.id}`}
-      icon={SEARCH_TYPE_ICONS.startup_library}
+      key={`${type}-${a.id}`}
+      icon={SEARCH_TYPE_ICONS[type]}
       title={a.title}
       subtitle={
         isShowingDetail

--- a/extensions/bookface/src/lib/items.tsx
+++ b/extensions/bookface/src/lib/items.tsx
@@ -10,7 +10,6 @@ import {
   showInFinder,
   showToast,
 } from "@raycast/api";
-import { showFailureToast } from "@raycast/utils";
 import { createContext, useContext, type ReactElement } from "react";
 import { UpdateYcCli } from "../views/updater";
 import type {
@@ -131,18 +130,21 @@ function ExportCsvActions() {
   const type = filterType;
   const label = SEARCH_TYPE_LABELS[type];
 
-  async function fetchCsv(): Promise<
-    { csv: string; total: number } | undefined
-  > {
-    if (!query.trim()) return undefined;
+  async function fetchCsv(): Promise<{ csv: string; total: number }> {
+    if (!query.trim()) {
+      throw new Error("Enter a search query first.");
+    }
     const result = await runYcCsv(query, exportType);
     if (!result.ok) {
-      await showFailureToast(new Error(result.message), {
-        title: "Export failed",
-      });
-      return undefined;
+      throw new Error(result.message);
     }
     return result.data;
+  }
+
+  function failToast(toast: Toast, title: string, error: unknown) {
+    toast.style = Toast.Style.Failure;
+    toast.title = title;
+    toast.message = error instanceof Error ? error.message : String(error);
   }
 
   async function save() {
@@ -150,22 +152,25 @@ function ExportCsvActions() {
       style: Toast.Style.Animated,
       title: `Exporting ${label}…`,
     });
-    const data = await fetchCsv();
-    if (!data) return;
-    const path = join(homedir(), "Downloads", csvFileName(query, exportType));
     try {
-      await writeFile(path, data.csv, "utf8");
+      const data = await fetchCsv();
+      const path = join(homedir(), "Downloads", csvFileName(query, exportType));
+      try {
+        await writeFile(path, data.csv, "utf8");
+      } catch (error) {
+        failToast(toast, "Could not write CSV file", error);
+        return;
+      }
+      toast.style = Toast.Style.Success;
+      toast.title = `Exported ${data.total} ${label}`;
+      toast.message = path.replace(homedir(), "~");
+      toast.primaryAction = {
+        title: "Show in Finder",
+        onAction: () => showInFinder(path),
+      };
     } catch (error) {
-      await showFailureToast(error, { title: "Could not write CSV file" });
-      return;
+      failToast(toast, "Export failed", error);
     }
-    toast.style = Toast.Style.Success;
-    toast.title = `Exported ${data.total} ${label}`;
-    toast.message = path.replace(homedir(), "~");
-    toast.primaryAction = {
-      title: "Show in Finder",
-      onAction: () => showInFinder(path),
-    };
   }
 
   async function copy() {
@@ -173,11 +178,14 @@ function ExportCsvActions() {
       style: Toast.Style.Animated,
       title: `Copying ${label}…`,
     });
-    const data = await fetchCsv();
-    if (!data) return;
-    await Clipboard.copy(data.csv);
-    toast.style = Toast.Style.Success;
-    toast.title = `Copied ${data.total} ${label} as CSV`;
+    try {
+      const data = await fetchCsv();
+      await Clipboard.copy(data.csv);
+      toast.style = Toast.Style.Success;
+      toast.title = `Copied ${data.total} ${label} as CSV`;
+    } catch (error) {
+      failToast(toast, "Copy failed", error);
+    }
   }
 
   return (

--- a/extensions/bookface/src/lib/types.ts
+++ b/extensions/bookface/src/lib/types.ts
@@ -9,9 +9,22 @@ export type Me = {
   yc_companies?: Array<{ id: number; name: string; batch: string }>;
 };
 
+// A step the YC agent took while answering (e.g. searching the forum). The CLI
+// pre-formats a human-readable `display_message`; we fall back to entity/query
+// if a future shape omits it.
+export type AgentToolCall = {
+  name: string;
+  arguments?: {
+    entity?: string;
+    query?: string;
+    display_message?: string;
+  };
+};
+
 export type AgentResponse = {
   query: string;
   response: string;
+  tool_calls?: AgentToolCall[];
 };
 
 export type Position = {
@@ -145,6 +158,17 @@ export type StartupLibraryAttributes = {
   root_id?: number;
 };
 
+// Knowledge-base articles share the Startup Library attribute shape exactly
+// (id/title/body/description/categories/parents/view_access/root_id). Kept as a
+// distinct alias so the union stays honest and a future shape drift is catchable
+// independently — but `description` can be null here, unlike Startup Library.
+export type KnowledgeBaseAttributes = Omit<
+  StartupLibraryAttributes,
+  "description"
+> & {
+  description: string | null;
+};
+
 export type SearchItem =
   | { type: "user"; path: string; displayed_attributes: UserAttributes }
   | {
@@ -165,6 +189,11 @@ export type SearchItem =
       type: "startup_library";
       path: string;
       displayed_attributes: StartupLibraryAttributes;
+    }
+  | {
+      type: "knowledge_base";
+      path: string;
+      displayed_attributes: KnowledgeBaseAttributes;
     };
 
 export type SearchItemType = SearchItem["type"];
@@ -182,6 +211,33 @@ export const SEARCH_TYPE_LABELS: Record<SearchItemType, string> = {
   deal: "Deals",
   employer: "Employers",
   startup_library: "Startup Library",
+  knowledge_base: "Knowledge Base",
+};
+
+// Maps our result-item types to the CLI's `yc search --type <X>` vocabulary,
+// used only for CSV export. The `--type` endpoint returns a different,
+// CSV-oriented envelope (not our rich `items[]`), so it's unsuitable for
+// rendering — but it exposes the full matching set (total_count, not just the
+// displayed page), which makes it a good "export everything that matched" path.
+// `user` → founders and `post` → forum because the CLI names the source table,
+// not our display label. Verified against yc 0.0.14.
+//
+// `null` for the LOSSY siblings: `non_yc_company` and `yc_company` both come
+// from the CLI's `companies` action, and `startup_library`/`knowledge_base`
+// both from `knowledge_base`. Exporting `non_yc_company` via `companies` would
+// silently include YC companies (and vice versa for the library/KB pair), so
+// the export is offered only for the canonical type (yc_company, knowledge_base)
+// — the sibling maps to null and its export action is suppressed.
+export const CLI_SEARCH_TYPE: Record<SearchItemType, string | null> = {
+  user: "founders",
+  yc_company: "companies",
+  non_yc_company: null,
+  school: "alumni_groups",
+  post: "forum",
+  deal: "deals",
+  employer: "staff",
+  startup_library: null,
+  knowledge_base: "knowledge_base",
 };
 
 export const SEARCH_TYPE_ICONS: Record<SearchItemType, Icon> = {
@@ -193,6 +249,7 @@ export const SEARCH_TYPE_ICONS: Record<SearchItemType, Icon> = {
   deal: Icon.Cart,
   employer: Icon.Building,
   startup_library: Icon.BlankDocument,
+  knowledge_base: Icon.Book,
 };
 
 export const SEARCH_TYPE_ORDER: SearchItemType[] = [
@@ -202,6 +259,7 @@ export const SEARCH_TYPE_ORDER: SearchItemType[] = [
   "deal",
   "non_yc_company",
   "startup_library",
+  "knowledge_base",
   "school",
   "employer",
 ];

--- a/extensions/bookface/src/lib/yc.ts
+++ b/extensions/bookface/src/lib/yc.ts
@@ -1,11 +1,62 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { existsSync } from "node:fs";
-import { homedir } from "node:os";
+import { readFile, unlink } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { getPreferenceValues } from "@raycast/api";
+import { logger } from "@chrismessina/raycast-logger";
 
 const execFileAsync = promisify(execFile);
+const log = logger.child("[yc]");
+
+// Capture `yc … --json` via a temp FILE rather than a stdout pipe. `yc` exits
+// before its stdout pipe fully drains, so a piped capture (execFile/useExec)
+// receives only what cleared the OS pipe buffer — truncating large payloads at
+// 64KB/128KB boundaries (a 141KB result arrived cut to 65479/131003 bytes,
+// breaking JSON.parse). Redirecting to a file lets the OS complete the write
+// regardless of the child's flush timing; we then read the whole file.
+//
+// The redirect needs a shell, so we use `sh -c` with the binary, args, and temp
+// path passed as POSITIONAL parameters ($0/$1/$2/…) — never interpolated into
+// the command string — so a query containing shell metacharacters can't inject.
+async function runYcToFile(
+  binary: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string }> {
+  const tmp = join(
+    tmpdir(),
+    `yc-${process.pid}-${Date.now()}-${Math.round(Math.random() * 1e9)}.json`,
+  );
+  // $0 = binary, $1..$n = args, last positional = temp path.
+  const script = `"$0" ${args.map((_, i) => `"$${i + 1}"`).join(" ")} > "$${args.length + 1}"`;
+  try {
+    const { stderr } = await execFileAsync(
+      "/bin/sh",
+      ["-c", script, binary, ...args, tmp],
+      { timeout: 60_000, maxBuffer: 1024 * 1024 },
+    );
+    const stdout = await readFile(tmp, "utf8");
+    return { stdout, stderr };
+  } catch (raw) {
+    // Because stdout is redirected to the file, a non-zero exit leaves the
+    // child's diagnostic in the temp file, NOT on err.stdout (which is empty).
+    // Read it back and attach it so runYc can still classify update-required /
+    // not-authed / 429 — otherwise every CLI error degrades to a generic shell
+    // failure. Then rethrow for runYc's catch to handle.
+    const err = raw as ExecError;
+    if (!err.stdout) {
+      err.stdout = await readFile(tmp, "utf8").catch(() => "");
+    }
+    throw err;
+  } finally {
+    await unlink(tmp).catch(() => {});
+  }
+}
+
+// Version context parsed out of the CLI's version-gate message, when present.
+// Surfaced on the update-required screen so the user sees what changed.
+export type VersionGate = { current?: string; minimum?: string };
 
 export type YcResult<T> =
   | { ok: true; data: T }
@@ -13,6 +64,12 @@ export type YcResult<T> =
       ok: false;
       kind: "missing-cli" | "not-authed" | "error";
       message: string;
+    }
+  | {
+      ok: false;
+      kind: "update-required";
+      message: string;
+      gate: VersionGate;
     };
 
 const BINARY_NAMES = ["yc", "ycp"];
@@ -65,10 +122,68 @@ export function isUnauthedMessage(message: string): boolean {
   return NOT_AUTHED_SENTINELS.some((s) => haystack.includes(s));
 }
 
+// Sentinels for the CLI's version-gate refusal, e.g.:
+//   This version of the YC CLI is no longer supported.
+//   Run `yc update` to continue.
+//   Current version: 0.0.8
+//   Minimum required version: 0.0.14
+const UPDATE_REQUIRED_SENTINELS = [
+  "no longer supported",
+  "yc update",
+  "minimum required version",
+];
+
+export function isUpdateRequiredMessage(message: string): boolean {
+  const haystack = message.toLowerCase();
+  return UPDATE_REQUIRED_SENTINELS.some((s) => haystack.includes(s));
+}
+
+// Pull current/minimum versions out of the gate message so the update screen
+// can show what changed. Tolerant of wording drift — matches on the labels,
+// not on exact phrasing or line order.
+export function parseVersionGate(message: string): VersionGate {
+  const clean = stripAnsi(message);
+  const current = clean.match(/current version:\s*([0-9][0-9.]*)/i)?.[1];
+  const minimum = clean.match(
+    /minimum required version:\s*([0-9][0-9.]*)/i,
+  )?.[1];
+  return { current, minimum };
+}
+
+// `yc` writes raw ANSI control sequences into its human-readable output (e.g.
+// the `\x1b[K` erase-to-end-of-line that rendered as "Ø[K" in the error view).
+// Strip them before any message reaches a Raycast surface. Covers:
+//   - CSI sequences: ESC [ … final-byte  (colors, cursor moves, line erases)
+//   - OSC sequences: ESC ] … BEL or ST   (titles, hyperlinks)
+//   - other two-byte ESC sequences, plus stray C0 control chars (keeps \t \n \r).
+// Built from \x escapes so no raw control bytes live in the source.
+const ANSI_PATTERN = new RegExp(
+  [
+    "\\x1b\\[[0-?]*[ -/]*[@-~]", // CSI
+    "\\x1b\\][^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)", // OSC … BEL | ST
+    "\\x1b[@-Z\\\\-_]", // other two-byte ESC sequences
+    "[\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]", // stray C0 controls (keep \t \n \r)
+  ].join("|"),
+  "g",
+);
+
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_PATTERN, "");
+}
+
 export class NotAuthedError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "NotAuthedError";
+  }
+}
+
+export class UpdateRequiredError extends Error {
+  readonly gate: VersionGate;
+  constructor(message: string) {
+    super(message);
+    this.name = "UpdateRequiredError";
+    this.gate = parseVersionGate(message);
   }
 }
 
@@ -83,15 +198,25 @@ export function truncate(s: string, max: number): string {
 // balanced slice that actually JSON-parses — so a bracketed chatter token like
 // "[notice]" before the real payload is skipped rather than latched onto.
 function tryParseEmbeddedJson<T>(s: string): { value: T } | null {
+  const end = s.trimEnd().length;
   const bracket = /[[{]/g;
   let m: RegExpExecArray | null;
   while ((m = bracket.exec(s)) !== null) {
     const slice = balancedSlice(s, m.index);
     if (slice) {
-      try {
-        return { value: JSON.parse(slice) as T };
-      } catch {
-        // not this bracket — keep scanning from the next one
+      // Only accept a recovered slice that reaches the END of the input. This
+      // recovery exists for leading chatter before an otherwise-complete JSON
+      // document (e.g. a "Token expired, refreshing…" notice line) — the real
+      // payload runs to EOF. A balanced slice that closes well before the end
+      // is an inner fragment of a TRUNCATED/corrupt document; "recovering" it
+      // would silently yield garbage (e.g. items:0), which is worse than
+      // failing. So reject anything that doesn't consume the tail.
+      if (m.index + slice.length >= end) {
+        try {
+          return { value: JSON.parse(slice) as T };
+        } catch {
+          // not valid JSON — keep scanning from the next bracket
+        }
       }
     }
   }
@@ -137,6 +262,25 @@ export function looksLikeJson(s: string): boolean {
   }
 }
 
+// Classify a known-plain-text CLI message (not a JSON data payload) into the
+// specific error it represents, or null when it's just a generic failure.
+// `sentinelText` is what we pattern-match; `message` is what the error carries
+// for display. The version gate is checked before auth because its text also
+// names a command and is the more specific signal. Single source of truth for
+// the classification ladder shared by parseYcJson and runYc.
+function classifyPlainText(
+  sentinelText: string,
+  message: string,
+): UpdateRequiredError | NotAuthedError | null {
+  if (isUpdateRequiredMessage(sentinelText)) {
+    return new UpdateRequiredError(message);
+  }
+  if (isUnauthedMessage(sentinelText)) {
+    return new NotAuthedError(message);
+  }
+  return null;
+}
+
 export function parseYcJson<T>(stdout: string): T {
   if (!stdout || !stdout.trim()) {
     throw new Error("yc returned empty output");
@@ -147,19 +291,33 @@ export function parseYcJson<T>(stdout: string): T {
   // happens to contain "yc login" must NOT be misread as an auth error.
   try {
     return JSON.parse(stdout) as T;
-  } catch {
+  } catch (e) {
     // Not pure JSON. It may be JSON with leading chatter (auto-refresh notice),
     // or a plain-text error. Try to recover an embedded JSON payload.
+    log.debug("Direct JSON.parse failed; attempting recovery", {
+      length: stdout.length,
+      head: stdout.slice(0, 60),
+      tail: stdout.slice(-60),
+      error: e instanceof Error ? e.message : String(e),
+    });
     const recovered = tryParseEmbeddedJson<T>(stdout);
-    if (recovered) return recovered.value;
+    if (recovered) {
+      log.debug("Recovered embedded JSON payload");
+      return recovered.value;
+    }
   }
 
-  // No JSON recoverable: it's a plain-text message. Now sentinel-matching is
-  // safe because we know this is not a data payload.
-  if (isUnauthedMessage(stdout)) {
-    throw new NotAuthedError(truncate(stdout.trim(), 500));
-  }
-  throw new Error(`Failed to parse yc output: ${truncate(stdout.trim(), 500)}`);
+  // No JSON recoverable: it's a plain-text message. Sentinel-matching is safe
+  // now because we know this is not a data payload.
+  const clean = truncate(stripAnsi(stdout).trim(), 500);
+  log.warn("yc output not parseable as JSON", {
+    length: stdout.length,
+    preview: clean.slice(0, 120),
+  });
+  throw (
+    classifyPlainText(clean, clean) ??
+    new Error(`Failed to parse yc output: ${clean}`)
+  );
 }
 
 type ExecError = Error & {
@@ -174,52 +332,118 @@ export async function runYc<T>(args: string[]): Promise<YcResult<T>> {
     return {
       ok: false,
       kind: "missing-cli",
-      message: "yc CLI not found on this system.",
+      message: "YC CLI not found on this system.",
     };
   }
 
+  log.debug("runYc", { args });
   try {
-    const { stdout } = await execFileAsync(binary, args, {
-      timeout: 60_000,
-      maxBuffer: 4 * 1024 * 1024,
-    });
-    return { ok: true, data: parseYcJson<T>(stdout) };
+    const { stdout } = await runYcToFile(binary, args);
+    log.debug("runYc stdout received", { args, bytes: stdout.length });
+    const data = parseYcJson<T>(stdout);
+    return { ok: true, data };
   } catch (raw) {
-    if (raw instanceof NotAuthedError) {
-      return { ok: false, kind: "not-authed", message: raw.message };
-    }
     const err = raw as ExecError;
-    const stderr = err.stderr ?? "";
-    const stdout = err.stdout ?? "";
+    const stderr = stripAnsi(err.stderr ?? "");
+    const stdout = stripAnsi(err.stdout ?? "");
 
-    if (err.code === "ENOENT") {
+    // Binary missing: ENOENT (direct spawn), or `sh` reporting it (exit 127 /
+    // "not found") now that we run via sh -c.
+    if (
+      err.code === "ENOENT" ||
+      err.code === 127 ||
+      /not found|no such file/i.test(stderr)
+    ) {
       cachedPath = null;
-      return { ok: false, kind: "missing-cli", message: "yc CLI not found." };
+      return { ok: false, kind: "missing-cli", message: "YC CLI not found." };
     }
-    // Only sentinel-match against output that is NOT a JSON data payload — same
-    // guard as parseYcJson, so a result/error body that merely mentions "401" or
-    // "yc login" isn't misread as an auth failure. Auth errors are plain text.
-    const authText = [stderr, stdout]
+
+    // A thrown classification from parseYcJson, or a non-zero exit whose
+    // stderr/stdout we classify the same way. Only sentinel-match output that
+    // is NOT a JSON data payload, so a result body that merely mentions "401"
+    // or "yc login" isn't misread.
+    const plainText = [stderr, stdout]
       .filter((s) => s && !looksLikeJson(s))
       .join(" ");
-    if (authText && isUnauthedMessage(authText)) {
+    const message = truncate(
+      stderr || stdout || stripAnsi(err.message ?? "") || "Unknown error",
+      500,
+    );
+
+    // Rate limit (429): give a clear, actionable message instead of the raw
+    // server line. Fired by rapid successive calls (e.g. fast typing).
+    if (/\b429\b|rate limit/i.test(plainText)) {
       return {
         ok: false,
-        kind: "not-authed",
-        message: truncate(stderr || stdout || "Not logged in.", 500),
+        kind: "error",
+        message:
+          "YC CLI rate limit reached. Wait a moment and try again. (The server limits rapid requests.)",
       };
     }
-    return {
-      ok: false,
-      kind: "error",
-      message: truncate(
-        stderr || stdout || err.message || "Unknown error",
-        500,
-      ),
-    };
+
+    const classified =
+      raw instanceof NotAuthedError || raw instanceof UpdateRequiredError
+        ? raw
+        : classifyPlainText(plainText, message);
+
+    if (classified instanceof UpdateRequiredError) {
+      return {
+        ok: false,
+        kind: "update-required",
+        message,
+        gate: classified.gate,
+      };
+    }
+    if (classified instanceof NotAuthedError) {
+      return { ok: false, kind: "not-authed", message };
+    }
+    return { ok: false, kind: "error", message };
   }
+}
+
+export type CsvSearch = { csv: string; count: number; total: number };
+
+// The `yc search <q> --type <X> --json` envelope, distinct from the rich
+// `items[]` shape: { name, result: { csv_results, count, total_count, … } }.
+type CsvEnvelope = {
+  result?: {
+    csv_results?: string;
+    count?: number;
+    total_count?: number;
+  };
+};
+
+// Run a typed search and return its CSV payload (for export). Shares runYc's
+// argument plumbing and error classification — a too-old or unauthed CLI still
+// routes to update-required / not-authed rather than a raw failure.
+export async function runYcCsv(
+  query: string,
+  cliType: string,
+): Promise<YcResult<CsvSearch>> {
+  const result = await runYc<CsvEnvelope>([
+    "search",
+    query,
+    "--type",
+    cliType,
+    "--json",
+  ]);
+  if (!result.ok) return result;
+
+  const csv = result.data.result?.csv_results;
+  if (!csv || !csv.trim()) {
+    return { ok: false, kind: "error", message: "No CSV data returned." };
+  }
+  return {
+    ok: true,
+    data: {
+      csv,
+      count: result.data.result?.count ?? 0,
+      total: result.data.result?.total_count ?? 0,
+    },
+  };
 }
 
 export const INSTALL_COMMAND =
   "curl -fsSL https://bookface.ycombinator.com/cli/install.sh | bash";
 export const LOGIN_COMMAND = "yc login";
+export const UPDATE_COMMAND = "yc update";

--- a/extensions/bookface/src/logout.tsx
+++ b/extensions/bookface/src/logout.tsx
@@ -1,0 +1,72 @@
+import { Alert, Clipboard, Toast, confirmAlert, showToast } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  INSTALL_COMMAND,
+  isUnauthedMessage,
+  resolveYcPath,
+  stripAnsi,
+  truncate,
+} from "./lib/yc";
+
+const execFileAsync = promisify(execFile);
+
+// `yc logout` clears credentials from ~/.yc. It's destructive (you'll need to
+// `yc login` again), so confirm first; runs as a no-view command that reports
+// via toast.
+export default async function Command() {
+  const binary = resolveYcPath();
+  if (!binary) {
+    await showFailureToast(new Error("YC CLI not found."), {
+      title: "YC CLI not found",
+      message: `Install it with: ${INSTALL_COMMAND}`,
+    });
+    return;
+  }
+
+  const confirmed = await confirmAlert({
+    title: "Log out of YC?",
+    message:
+      "This clears your stored YC CLI credentials from ~/.yc. You'll need to run yc login again to use the extension.",
+    primaryAction: { title: "Log Out", style: Alert.ActionStyle.Destructive },
+  });
+  if (!confirmed) return;
+
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: "Logging out…",
+  });
+  try {
+    await execFileAsync(binary, ["logout"], {
+      timeout: 30_000,
+      maxBuffer: 1024 * 1024,
+    });
+    toast.style = Toast.Style.Success;
+    toast.title = "Logged out of YC";
+    toast.message = "Cleared credentials from ~/.yc";
+  } catch (raw) {
+    const err = raw as Error & { stdout?: string; stderr?: string };
+    const message = truncate(
+      stripAnsi(
+        err.stderr || err.stdout || err.message || "Unknown error",
+      ).trim(),
+      300,
+    );
+    // Already logged out reads as a success, not a failure.
+    if (isUnauthedMessage(message)) {
+      toast.style = Toast.Style.Success;
+      toast.title = "Already logged out";
+      return;
+    }
+    // Mutate the existing animated toast rather than spawning a second one,
+    // and attach a Copy Error action per House Style.
+    toast.style = Toast.Style.Failure;
+    toast.title = "Logout failed";
+    toast.message = message;
+    toast.primaryAction = {
+      title: "Copy Error",
+      onAction: () => Clipboard.copy(message),
+    };
+  }
+}

--- a/extensions/bookface/src/search.tsx
+++ b/extensions/bookface/src/search.tsx
@@ -1,16 +1,17 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
-import { useExec } from "@raycast/utils";
+import { usePromise } from "@raycast/utils";
 import { useEffect, useMemo, useState } from "react";
-import { renderItem } from "./lib/items";
+import { SearchContext, renderItem } from "./lib/items";
 import {
-  NotAuthedError,
-  isUnauthedMessage,
-  parseYcJson,
+  runYc,
   resolveYcPath,
+  type VersionGate,
+  type YcResult,
 } from "./lib/yc";
 import {
   MissingCliEmpty,
   NotAuthedEmpty,
+  UpdateRequiredEmpty,
   ErrorEmpty,
 } from "./lib/empty-states";
 import {
@@ -22,6 +23,11 @@ import {
   type SearchResponse,
 } from "./lib/types";
 import { useRecentSearches } from "./hooks/use-recent-searches";
+import { useYcVersionGate } from "./hooks/use-yc-version-gate";
+import { UpdateYcCli } from "./views/updater";
+import { logger } from "@chrismessina/raycast-logger";
+
+const log = logger.child("[search]");
 
 const ALL_FILTER = "all" as const;
 type FilterValue = SearchItemType | typeof ALL_FILTER;
@@ -35,8 +41,11 @@ export default function Command() {
   const toggleDetail = () => setIsShowingDetail((v) => !v);
   const ycPath = resolveYcPath();
 
+  // 500ms debounce: long enough that typing a multi-word query fires one search
+  // at the end rather than one per keystroke, which both cuts latency churn and
+  // keeps us under the YC server's rate limit on rapid successive calls.
   useEffect(() => {
-    const t = setTimeout(() => setDebouncedQuery(query.trim()), 350);
+    const t = setTimeout(() => setDebouncedQuery(query.trim()), 500);
     return () => clearTimeout(t);
   }, [query]);
 
@@ -45,29 +54,60 @@ export default function Command() {
     addRecentSearch,
     removeRecentSearch,
     clearRecentSearches,
-  } = useRecentSearches(RECENT_SEARCHES_KEY);
+    // collapsePrefixes: true — search-as-you-type, so fold "S"/"Stri"/"Stripe".
+  } = useRecentSearches(RECENT_SEARCHES_KEY, 25, true);
+
+  // Probe the CLI version on mount so a too-old binary bounces to the update
+  // screen immediately — before recent searches or any query. Search is broken
+  // until the user updates, so don't let the working-looking empty state show.
+  const versionGate = useYcVersionGate();
 
   const trimmed = query.trim();
-  const shouldRun = debouncedQuery.length > 0 && ycPath !== null;
+  // Hold the search exec until the version probe clears — no point spending a
+  // search call on a binary we're about to send to the update screen.
+  const shouldRun =
+    debouncedQuery.length > 0 &&
+    ycPath !== null &&
+    versionGate.checked &&
+    !versionGate.updateRequired;
 
-  const { isLoading, data, error } = useExec<SearchResponse>(
-    ycPath ?? "yc",
-    ["search", debouncedQuery, "--json"],
+  // Run search through runYc (execFile with a 4MB buffer + 60s timeout) rather
+  // than useExec: useExec's spawn/stream path truncated large payloads (a 141KB
+  // "Stripe" result arrived cut to ~131KB, breaking JSON.parse), so it's unsafe
+  // for results this size.
+  //
+  // usePromise, NOT useCachedPromise: caching persists each query's YcResult, so
+  // a repeated query renders its CACHED result instantly — meaning private
+  // Bookface results could resurface after logout/auth-change before the fresh
+  // call returns. usePromise doesn't persist by query. (It also has no
+  // keepPreviousData — a brief spinner between queries is fine and avoids
+  // showing one query's results under another's text.)
+  //
+  // The fetcher is annotated `: Promise<YcResult<SearchResponse>>` so TS picks
+  // the non-paginated usePromise overload (otherwise it infers data as any[]).
+  const {
+    isLoading,
+    data,
+    revalidate: revalidateSearch,
+  } = usePromise(
+    (q: string): Promise<YcResult<SearchResponse>> =>
+      runYc<SearchResponse>(["search", q, "--json"]),
+    [debouncedQuery],
     {
       execute: shouldRun,
-      parseOutput: ({ stdout }) => {
-        if (!stdout || !stdout.trim()) return { items: [] };
-        return parseYcJson<SearchResponse>(stdout);
-      },
-      keepPreviousData: true,
-      onData: () => {
-        if (debouncedQuery) void addRecentSearch(debouncedQuery);
+      // Persist the query as a recent search only once a search succeeds.
+      onData: (result) => {
+        if (result?.ok && debouncedQuery) {
+          log.debug("search parsed", { items: result.data.items?.length ?? 0 });
+          void addRecentSearch(debouncedQuery);
+        }
       },
     },
   );
 
+  const resultItems = data?.ok ? data.data.items : undefined;
   const items = useMemo(() => {
-    const all = data?.items ?? [];
+    const all = resultItems ?? [];
     const ordered = [...all].sort((a, b) => {
       const ai = SEARCH_TYPE_ORDER.indexOf(a.type);
       const bi = SEARCH_TYPE_ORDER.indexOf(b.type);
@@ -75,48 +115,76 @@ export default function Command() {
     });
     if (filter === ALL_FILTER) return ordered;
     return ordered.filter((i) => i.type === filter);
-  }, [data, filter]);
+  }, [resultItems, filter]);
 
-  const isAuthError =
-    error instanceof NotAuthedError ||
-    (error instanceof Error && isUnauthedMessage(error.message));
+  // runYc already classified the failure into a discriminated kind, so branch on
+  // that rather than sniffing an error. The mount probe is a second source of
+  // the update-required signal (it fires before any query).
+  const searchFailed = data && !data.ok ? data : undefined;
+  const execGate: VersionGate | undefined =
+    searchFailed?.kind === "update-required" ? searchFailed.gate : undefined;
+  const isUpdateError = versionGate.updateRequired || execGate !== undefined;
+  // Prefer the probe's gate, then the search's.
+  const updateGate = versionGate.gate ?? execGate;
+  // After updating, clear BOTH gate signals: the mount probe AND the search.
+  const retryGate = () => {
+    versionGate.revalidate();
+    revalidateSearch();
+  };
+  const isAuthError = !isUpdateError && searchFailed?.kind === "not-authed";
   const errorMessage =
-    error instanceof Error ? error.message : error ? String(error) : null;
+    !isUpdateError && searchFailed?.kind === "error"
+      ? searchFailed.message
+      : null;
 
   const isDebouncing = trimmed !== debouncedQuery;
-  const effectiveLoading = isLoading || isDebouncing;
+  // Show the spinner while the mount probe is still resolving so we don't flash
+  // the recent-searches list and then replace it with the update screen.
+  const probePending = !versionGate.checked && versionGate.isLoading;
+  const effectiveLoading = isLoading || isDebouncing || probePending;
 
   return (
-    <List
-      isLoading={effectiveLoading}
-      isShowingDetail={isShowingDetail && items.length > 0}
-      onSearchTextChange={setQuery}
-      searchBarPlaceholder="Search Bookface for people, companies, posts…"
-      searchBarAccessory={
-        <TypeDropdown
-          value={filter}
-          onChange={setFilter}
-          items={data?.items ?? []}
-        />
-      }
+    <SearchContext.Provider
+      value={{
+        query: debouncedQuery,
+        filterType: filter === ALL_FILTER ? undefined : filter,
+      }}
     >
-      {renderBody({
-        ycPath,
-        errorMessage,
-        isAuthError,
-        trimmed,
-        debouncedQuery,
-        filter,
-        items,
-        effectiveLoading,
-        recentSearches,
-        setQuery,
-        removeRecentSearch,
-        clearRecentSearches,
-        isShowingDetail,
-        toggleDetail,
-      })}
-    </List>
+      <List
+        isLoading={effectiveLoading}
+        isShowingDetail={isShowingDetail && items.length > 0}
+        onSearchTextChange={setQuery}
+        searchBarPlaceholder="Search Bookface for people, companies, posts…"
+        searchBarAccessory={
+          <TypeDropdown
+            value={filter}
+            onChange={setFilter}
+            items={resultItems ?? []}
+          />
+        }
+      >
+        {renderBody({
+          ycPath,
+          errorMessage,
+          isAuthError,
+          isUpdateError,
+          updateGate,
+          revalidateGate: retryGate,
+          probePending,
+          trimmed,
+          debouncedQuery,
+          filter,
+          items,
+          effectiveLoading,
+          recentSearches,
+          setQuery,
+          removeRecentSearch,
+          clearRecentSearches,
+          isShowingDetail,
+          toggleDetail,
+        })}
+      </List>
+    </SearchContext.Provider>
   );
 }
 
@@ -124,6 +192,10 @@ type RenderBodyProps = {
   ycPath: string | null;
   errorMessage: string | null;
   isAuthError: boolean;
+  isUpdateError: boolean;
+  updateGate: VersionGate | undefined;
+  revalidateGate: () => void;
+  probePending: boolean;
   trimmed: string;
   debouncedQuery: string;
   filter: FilterValue;
@@ -139,8 +211,15 @@ type RenderBodyProps = {
 
 function renderBody(p: RenderBodyProps) {
   if (!p.ycPath) return <MissingCliEmpty />;
-  if (p.isAuthError) return <NotAuthedEmpty />;
+  if (p.isUpdateError)
+    return (
+      <UpdateRequiredEmpty gate={p.updateGate} onRetry={p.revalidateGate} />
+    );
+  if (p.isAuthError) return <NotAuthedEmpty onRetry={p.revalidateGate} />;
   if (p.errorMessage) return <ErrorEmpty message={p.errorMessage} />;
+  // Probe still resolving: render nothing (the List spinner covers it) so the
+  // recent-searches list doesn't flash before a possible update-required gate.
+  if (p.probePending && p.trimmed.length === 0) return null;
 
   if (p.trimmed.length === 0) {
     if (p.recentSearches.length === 0) {
@@ -149,6 +228,16 @@ function renderBody(p: RenderBodyProps) {
           icon={Icon.MagnifyingGlass}
           title="Search Bookface"
           description="Type to search across people, companies, posts, deals, and more."
+          actions={
+            <ActionPanel>
+              <Action.Push
+                title="Update YC CLI"
+                icon={Icon.Download}
+                target={<UpdateYcCli />}
+                shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
+              />
+            </ActionPanel>
+          }
         />
       );
     }
@@ -180,6 +269,12 @@ function renderBody(p: RenderBodyProps) {
                   style={Action.Style.Destructive}
                   shortcut={{ modifiers: ["ctrl", "shift"], key: "x" }}
                   onAction={p.clearRecentSearches}
+                />
+                <Action.Push
+                  title="Update YC CLI"
+                  icon={Icon.Download}
+                  target={<UpdateYcCli />}
+                  shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
                 />
               </ActionPanel>
             }

--- a/extensions/bookface/src/views/updater.tsx
+++ b/extensions/bookface/src/views/updater.tsx
@@ -4,13 +4,19 @@ import {
   Clipboard,
   Detail,
   Icon,
+  Keyboard,
   Toast,
   showToast,
 } from "@raycast/api";
 import { useExec } from "@raycast/utils";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { MissingCliDetail } from "../lib/empty-states";
-import { resolveYcPath, truncate } from "../lib/yc";
+import {
+  resolveYcPath,
+  stripAnsi,
+  truncate,
+  type VersionGate,
+} from "../lib/yc";
 
 // `yc -v` prints just the bare version, e.g. "0.0.8".
 function parseVersion(stdout: string): string | null {
@@ -37,7 +43,16 @@ async function readYcVersion(binary: string): Promise<string | null> {
   return parseVersion(stdout);
 }
 
-export function UpdateYcCli() {
+// `gate` is passed when this screen is reached because the CLI refused to run
+// on a too-old version — it lets us explain *why* the user landed here and show
+// the minimum required version, rather than a bare "update available" prompt.
+// `onRetry` is passed when rendered directly as a command's gate landing (vs.
+// pushed): it re-runs the command's own fetch so a successful update drops the
+// user back into working state.
+export function UpdateYcCli({
+  gate,
+  onRetry,
+}: { gate?: VersionGate; onRetry?: () => void } = {}) {
   const ycPath = resolveYcPath();
   const [updating, setUpdating] = useState(false);
   const [result, setResult] = useState<string | null>(null);
@@ -74,28 +89,49 @@ export function UpdateYcCli() {
       const before = await readYcVersion(ycPath);
       await execYc(ycPath, ["update"]);
       const after = await readYcVersion(ycPath);
-      recheckVersion();
 
+      // Set our success toast + on-screen result BEFORE revalidating the `yc -v`
+      // useExec — that revalidation runs useExec's own toast machinery, which
+      // would otherwise clobber this success toast (the bug: no toast appeared).
       const upgraded = before !== null && after !== null && before !== after;
       toast.style = Toast.Style.Success;
       if (upgraded) {
         toast.title = `Updated to ${after}`;
-        setResult(`Updated YC CLI from \`${before}\` to \`${after}\`.`);
+        toast.message = `from ${before}`;
+        setResult(
+          `# YC CLI Updated\n\nUpdated from \`${before}\` to \`${after}\`.`,
+        );
       } else {
         toast.title = "Already up to date";
+        toast.message = after ?? undefined;
         setResult(
-          after
-            ? `YC CLI is already up to date (\`${after}\`).`
-            : "YC CLI is already up to date.",
+          [
+            "# YC CLI Up to Date",
+            "",
+            after
+              ? `You're on the latest version (\`${after}\`).`
+              : "You're on the latest version.",
+          ].join("\n"),
         );
       }
+      // When this screen is a command's gate landing, offer a one-tap jump back
+      // to working state now that the CLI is current.
+      if (onRetry) {
+        toast.primaryAction = { title: "Reload Command", onAction: onRetry };
+      }
+
+      // Refresh the displayed version last, so useExec's toast lifecycle can't
+      // race the success toast above.
+      recheckVersion();
     } catch (raw) {
       const err = raw as Error & { stdout?: string; stderr?: string };
       const message = truncate(
-        (err.stderr || err.stdout || err.message || "Unknown error").trim(),
+        stripAnsi(
+          err.stderr || err.stdout || err.message || "Unknown error",
+        ).trim(),
         500,
       );
-      setResult(`Update failed:\n\n\`\`\`\n${message}\n\`\`\``);
+      setResult(`# Update Failed\n\n\`\`\`\n${message}\n\`\`\``);
       toast.style = Toast.Style.Failure;
       toast.title = "Update failed";
       toast.message = message;
@@ -107,29 +143,49 @@ export function UpdateYcCli() {
       inFlight.current = false;
       setUpdating(false);
     }
-  }, [ycPath, recheckVersion]);
+  }, [ycPath, recheckVersion, onRetry]);
 
   if (!ycPath) {
     return <MissingCliDetail />;
   }
 
-  const markdown = [
-    "# Update YC CLI",
-    "",
-    currentVersion
-      ? `**Current version:** \`${currentVersion}\``
-      : checkingVersion
-        ? "Checking the installed version…"
-        : "Could not read the installed version.",
-    "",
-    "Run an update to fetch the latest `yc` release. The CLI updates itself in place.",
-    result ? `\n---\n\n${result}` : "",
-  ].join("\n");
+  // When reached via the version gate, lead with why and show the minimum the
+  // CLI demands. Otherwise it's the ordinary "check / update" screen.
+  const installed = currentVersion ?? gate?.current ?? null;
+  const versionLine = installed
+    ? `**Current version:** \`${installed}\``
+    : checkingVersion
+      ? "Checking the installed version…"
+      : "Could not read the installed version.";
+
+  // `yc update` can finish in <200ms when already current, so the toast may
+  // flash by. Once a run completes, lead the body with a persistent, prominent
+  // result so success/failure is unmissable on-screen — not just a toast.
+  let markdown: string;
+  if (updating) {
+    markdown = ["# Updating YC CLI…", "", "Fetching the latest release."].join(
+      "\n",
+    );
+  } else if (result) {
+    markdown = result;
+  } else {
+    const lines = [
+      gate ? "# Update Required" : "# Update YC CLI",
+      "",
+      gate
+        ? "This version of the YC CLI is no longer supported. Update it to keep using the extension."
+        : "Run an update to fetch the latest `yc` release. The YC CLI updates itself in place.",
+      "",
+      versionLine,
+    ];
+    if (gate?.minimum) lines.push(`**Minimum required:** \`${gate.minimum}\``);
+    markdown = lines.join("\n");
+  }
 
   return (
     <Detail
       isLoading={checkingVersion || updating}
-      navigationTitle="Update YC CLI"
+      navigationTitle={gate ? "Update Required" : "Update YC CLI"}
       markdown={markdown}
       actions={
         <ActionPanel>
@@ -141,9 +197,17 @@ export function UpdateYcCli() {
           <Action
             title="Recheck Version"
             icon={Icon.ArrowClockwise}
-            shortcut={{ modifiers: ["cmd"], key: "r" }}
+            shortcut={Keyboard.Shortcut.Common.Refresh}
             onAction={recheckVersion}
           />
+          {onRetry ? (
+            <Action
+              title="Reload Command"
+              icon={Icon.Repeat}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "r" }}
+              onAction={onRetry}
+            />
+          ) : null}
         </ActionPanel>
       }
     />


### PR DESCRIPTION
## Description

Update to the published **Bookface** extension, adding new commands and bringing it up to date with YC CLI 0.0.14.

- Added new dropdown filters for additional types exposed in YC CLI 0.0.14
- **Log out of YC** — new command that clears stored YC CLI credentials, with a confirmation prompt.
- **Update Required gate** — when the installed YC CLI is too old to run, the extension now detects the version-gate refusal and routes to an in-app screen that runs `yc update` for you, instead of surfacing a raw parse error.
- **Knowledge Base results** — YC Knowledge Base articles now render in Search (they were silently dropped before, as the type was unhandled).
- **Agent transparency** — Ask answers now show "What the agent did" (the searches the YC agent ran to ground its response), using the `tool_calls` the CLI returns.
- **CSV export** — with a type filter selected in Search, `⌘⇧E` exports that type's full matching set as CSV (`⌘⇧C` copies it), reaching every match rather than just the displayed page.
- **Reliability fix** — large searches (e.g. "stripe") previously returned no results because the CLI's stdout pipe was truncated at OS pipe-buffer boundaries when its process exited before draining. Output is now captured via a temp file so the full payload is read regardless of size.
- **Polish** — a "Check Again" action on signed-out screens (Raycast has no window-focus hook, so this is a one-keystroke re-check after authenticating), and an opt-in Verbose Logging preference for diagnostics (sensitive values redacted).

### Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I ran `npm run lint` (and `npx tsc --noEmit`) — all pass
- [x] I checked that this update does not break existing commands or remove functionality
- [x] I updated the `CHANGELOG.md` following the [changelog conventions](https://developers.raycast.com/basics/prepare-an-extension-for-store#changelog)
