### PR TITLE
fix: Todoist revert Quick Add Task fallback change

### DIFF
--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Todoist Changelog
 
+## [Revert Quick Add Task fallback command fix] - 2026-06-24
+
+- Reverted the Quick Add Task fallback command fix because making the `text` argument optional broke the hotkey workflow (command launched immediately with empty text instead of prompting for input).
+
 ## [Fix Quick Add Task fallback command] - 2026-06-24
 
 - Quick Add Task now works as a Raycast fallback command on Raycast 2.0+. Previously it failed with "Value is missing in argument" because the text argument was required.

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Todoist Changelog
 
-## [Revert Quick Add Task fallback command fix] - 2026-06-24
+## [Revert Quick Add Task fallback command fix] - {PR_MERGE_DATE}
 
 - Reverted the Quick Add Task fallback command fix because making the `text` argument optional broke the hotkey workflow (command launched immediately with empty text instead of prompting for input).
 

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Todoist Changelog
 
-## [Revert Quick Add Task fallback command fix] - {PR_MERGE_DATE}
+## [Revert Quick Add Task fallback command fix] - 2026-06-24
 
 - Reverted the Quick Add Task fallback command fix because making the `text` argument optional broke the hotkey workflow (command launched immediately with empty text instead of prompting for input).
 

--- a/extensions/todoist/package.json
+++ b/extensions/todoist/package.json
@@ -138,7 +138,7 @@
           "name": "text",
           "placeholder": "Text (today 5pm p2)",
           "type": "text",
-          "required": false
+          "required": true
         },
         {
           "name": "description",

--- a/extensions/todoist/src/quick-add-task.tsx
+++ b/extensions/todoist/src/quick-add-task.tsx
@@ -21,14 +21,8 @@ async function QuickAddTask(props: QuickAddTaskProps) {
       popToRoot({ clearSearchBar: true });
     }
 
-    let text = props.arguments.text || props.fallbackText;
-
-    if (!text) {
-      throw new Error("No text provided. Please provide a task text.");
-    }
-
-    if (preferences.autoCreateLabels) {
-      const labelsToCreate = extractLabels(text);
+    if (preferences.autoCreateLabels && props.arguments.text) {
+      const labelsToCreate = extractLabels(props.arguments.text);
       if (labelsToCreate.length > 0) {
         await Promise.all(
           labelsToCreate.map(async (label) => addLabel({ name: label }, { data: undefined, setData: () => {} })),
@@ -36,6 +30,7 @@ async function QuickAddTask(props: QuickAddTaskProps) {
       }
     }
 
+    let text = props.arguments.text ?? props.fallbackText;
     if (props.arguments.description) {
       text = `${text} // ${props.arguments.description}`;
     }


### PR DESCRIPTION
_beep boop :robot:, message from your friendly AI_:

## Description

Reverts the Quick Add Task fallback command fix and restores the original hotkey workflow.

### Background

A previous change made the `text` argument optional to fix fallback command support ([#6586](https://github.com/raycast/extensions/issues/6586)), but this broke the hotkey workflow: since `text` was no longer `required`, Raycast stopped prompting for input on hotkey launch and fired the command immediately with empty text.

This is a fundamental conflict in how Raycast 2.0 handles the `required` flag:
- **`required: true`** — Raycast shows inline argument fields and waits for input (hotkey works), but rejects fallback launches with "Value is missing in argument".
- **`required: false`** — Raycast runs the no-view command immediately without prompting (hotkey breaks), but fallback launches work via `props.fallbackText`.

Since the hotkey workflow is the primary use case, this reverts to `required: true`. A separate issue has been filed with the Raycast team about the 2.0 regression: [#28986](https://github.com/raycast/extensions/issues/28986).

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
