### PR TITLE
Update quick-latex extension

### DIFF
--- a/extensions/quick-latex/CHANGELOG.md
+++ b/extensions/quick-latex/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Quick LaTeX Changelog
 
+## [Improve preview sizing] - 2026-06-24
+
+- Automatically scale LaTeX previews to fit within the Raycast window
+- Keep previews centered without borders or vertical scrolling
+
 ## [Support for background color] - 2024-06-04
 
- - Add support for background color change
+- Add support for background color change
 
 ## [Support for more formats] - 2023-09-14
 

--- a/extensions/quick-latex/package.json
+++ b/extensions/quick-latex/package.json
@@ -88,5 +88,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/quick-latex/package.json
+++ b/extensions/quick-latex/package.json
@@ -48,7 +48,7 @@
           "type": "textfield",
           "default": "500",
           "required": false
-        }, 
+        },
         {
           "name": "svgViewbox",
           "title": "SVG Viewbox",
@@ -57,7 +57,6 @@
           "default": "0 0 50 50",
           "required": false
         }
-          
       ],
       "arguments": [
         {

--- a/extensions/quick-latex/src/api.tsx
+++ b/extensions/quick-latex/src/api.tsx
@@ -1,8 +1,10 @@
 import { getPreferenceValues, showHUD } from "@raycast/api";
 import { BASE_URL, DISPLAY_LATEX_URL, DOWNLOAD_DIR, ExportType, QuickLatexPreferences } from "./utils";
 import { parse, stringify } from "svgson";
-import fetch from "node-fetch";
+import fetch, { RequestInit } from "node-fetch";
 import fs from "fs";
+
+export type PreviewAbortSignal = NonNullable<RequestInit["signal"]>;
 
 async function editSVG(text: string) {
   const preferences = getPreferenceValues<QuickLatexPreferences>();
@@ -56,16 +58,19 @@ export function getDisplayLatex(searchText: string) {
   };
 }
 
-export async function getPreviewImage(searchText: string) {
-  const latex = searchText == "" ? "LaTeX" : searchText;
-  const res = await fetch(getPreviewUrl(latex));
+export async function getPreviewImage(searchText: string, signal?: PreviewAbortSignal) {
+  const latex = searchText === "" ? "LaTeX" : searchText;
+  const res = await fetch(getPreviewUrl(latex), { signal });
 
   if (!res.ok) {
     throw new Error("Failed to fetch preview SVG");
   }
 
   const lightSvg = await res.text();
-  const darkSvg = lightSvg.replace("<svg ", '<svg fill="white" ');
+  const darkSvgNode = await parse(lightSvg);
+  darkSvgNode.attributes.fill = "white";
+  darkSvgNode.attributes.style = [darkSvgNode.attributes.style, "color:white;fill:white"].filter(Boolean).join(";");
+  const darkSvg = stringify(darkSvgNode);
 
   return {
     source: {

--- a/extensions/quick-latex/src/api.tsx
+++ b/extensions/quick-latex/src/api.tsx
@@ -55,3 +55,35 @@ export function getDisplayLatex(searchText: string) {
     },
   };
 }
+
+export async function getPreviewImage(searchText: string) {
+  const latex = searchText == "" ? "LaTeX" : searchText;
+  const res = await fetch(getPreviewUrl(latex));
+
+  if (!res.ok) {
+    throw new Error("Failed to fetch preview SVG");
+  }
+
+  const lightSvg = await res.text();
+  const darkSvg = lightSvg.replace("<svg ", '<svg fill="white" ');
+
+  return {
+    source: {
+      light: createPreviewCanvas(lightSvg),
+      dark: createPreviewCanvas(darkSvg),
+    },
+  };
+}
+
+function getPreviewUrl(latex: string) {
+  return BASE_URL + "svg.image?" + encodeURIComponent(latex);
+}
+
+function createPreviewCanvas(svg: string) {
+  const embeddedSvg = Buffer.from(svg).toString("base64");
+  const canvas = `<svg xmlns="http://www.w3.org/2000/svg" width="640px" height="280px" viewBox="0 0 640 280">
+    <image x="32" y="24" width="576" height="232" preserveAspectRatio="xMidYMid meet" href="data:image/svg+xml;base64,${embeddedSvg}" />
+  </svg>`;
+
+  return `data:image/svg+xml;utf8,${encodeURIComponent(canvas)}`;
+}

--- a/extensions/quick-latex/src/quick-latex.tsx
+++ b/extensions/quick-latex/src/quick-latex.tsx
@@ -28,6 +28,7 @@ export default function CommandWithCustoEmptyView(props: LaunchProps<{ arguments
         })
         .catch((error: unknown) => {
           if (isCurrent && !(error instanceof Error && error.name === "AbortError")) {
+            setPreviewImage(undefined);
             setIsLoading(false);
           }
         });

--- a/extensions/quick-latex/src/quick-latex.tsx
+++ b/extensions/quick-latex/src/quick-latex.tsx
@@ -1,22 +1,39 @@
-import { Action, ActionPanel, LaunchProps, List, popToRoot, showHUD } from "@raycast/api";
+import { Action, ActionPanel, Image, LaunchProps, List, popToRoot, showHUD } from "@raycast/api";
 import { useEffect, useState } from "react";
 
-import { downloadLatex, getDisplayLatex } from "./api";
-import { DEFAULT_ICON, ExportType, QuickLatexArguments, makeDonwloadDir, toClipboard } from "./utils";
+import { downloadLatex, getPreviewImage } from "./api";
+import { ExportType, QuickLatexArguments, makeDonwloadDir, toClipboard } from "./utils";
 
 export default function CommandWithCustoEmptyView(props: LaunchProps<{ arguments: QuickLatexArguments }>) {
   const [searchText, setSearchText] = useState(props.arguments.latex ?? "");
+  const [previewImage, setPreviewImage] = useState<Image.ImageLike>();
 
   useEffect(() => {
     makeDonwloadDir();
   }, []);
 
-  const icon = searchText == "" ? DEFAULT_ICON : getDisplayLatex(searchText);
+  useEffect(() => {
+    let isCurrent = true;
+    const timeout = setTimeout(() => {
+      getPreviewImage(searchText)
+        .then((image) => {
+          if (isCurrent) {
+            setPreviewImage(image);
+          }
+        })
+        .catch(() => undefined);
+    }, 200);
+
+    return () => {
+      isCurrent = false;
+      clearTimeout(timeout);
+    };
+  }, [searchText]);
 
   return (
-    <List onSearchTextChange={setSearchText} searchText={searchText}>
+    <List isLoading={previewImage == undefined} onSearchTextChange={setSearchText} searchText={searchText}>
       <List.EmptyView
-        icon={icon}
+        icon={previewImage}
         actions={
           <ActionPanel>
             {Object.values(ExportType).map((exportType) => (

--- a/extensions/quick-latex/src/quick-latex.tsx
+++ b/extensions/quick-latex/src/quick-latex.tsx
@@ -1,12 +1,13 @@
 import { Action, ActionPanel, Image, LaunchProps, List, popToRoot, showHUD } from "@raycast/api";
 import { useEffect, useState } from "react";
 
-import { downloadLatex, getPreviewImage } from "./api";
+import { downloadLatex, getPreviewImage, PreviewAbortSignal } from "./api";
 import { ExportType, QuickLatexArguments, makeDonwloadDir, toClipboard } from "./utils";
 
 export default function CommandWithCustoEmptyView(props: LaunchProps<{ arguments: QuickLatexArguments }>) {
   const [searchText, setSearchText] = useState(props.arguments.latex ?? "");
   const [previewImage, setPreviewImage] = useState<Image.ImageLike>();
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     makeDonwloadDir();
@@ -14,24 +15,33 @@ export default function CommandWithCustoEmptyView(props: LaunchProps<{ arguments
 
   useEffect(() => {
     let isCurrent = true;
+    const abortController = new AbortController();
+    setIsLoading(true);
+
     const timeout = setTimeout(() => {
-      getPreviewImage(searchText)
+      getPreviewImage(searchText, abortController.signal as PreviewAbortSignal)
         .then((image) => {
           if (isCurrent) {
             setPreviewImage(image);
+            setIsLoading(false);
           }
         })
-        .catch(() => undefined);
+        .catch((error: unknown) => {
+          if (isCurrent && !(error instanceof Error && error.name === "AbortError")) {
+            setIsLoading(false);
+          }
+        });
     }, 200);
 
     return () => {
       isCurrent = false;
       clearTimeout(timeout);
+      abortController.abort();
     };
   }, [searchText]);
 
   return (
-    <List isLoading={previewImage == undefined} onSearchTextChange={setSearchText} searchText={searchText}>
+    <List isLoading={isLoading} onSearchTextChange={setSearchText} searchText={searchText}>
       <List.EmptyView
         icon={previewImage}
         actions={


### PR DESCRIPTION
## Description

Fixes #28347.

- Automatically scales long LaTeX previews to fit within the Raycast window.
- Keeps previews centered and borderless without vertical scrolling.
- Preserves the existing high-resolution export behavior for PNG, GIF, SVG, PDF, and EMF.
- Cancels superseded preview requests and exits the loading state cleanly when preview generation fails.
- Generates dark-mode previews through parsed SVG attributes instead of brittle string replacement.

## Screenshots
### Old
<img width="2000" height="1250" alt="old" src="https://github.com/user-attachments/assets/846a40a8-4de8-4abc-937b-1bc93af5ca7c" />

### New
<img width="2000" height="1250" alt="new" src="https://github.com/user-attachments/assets/aea48e0b-ae52-43eb-80f6-9dae6f7b5ccd" />

## Testing

- Ran `npm run lint`.
- Ran `npm run build`.
- Manually verified empty, short, and long expressions in Raycast Beta.
- Confirmed the reported long expression fits without cropping or scrolling in light/dark preview handling.
- Confirmed export actions remain unchanged.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store).
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension).
- [x] I ran `npm run build` and tested the distribution build in Raycast.
- [x] I checked that files in the `assets` folder are used by the extension itself.
- [x] I checked that assets used by the README are placed outside of the `metadata` folder.