### PR TITLE
Update web-converter extension - Space-separated `hsl()` values

### DIFF
--- a/extensions/convert/CHANGELOG.md
+++ b/extensions/convert/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Convert Changelog
 
+## [Update] - {PR_MERGE_DATE}
+
+- Added support for modern space-separated hsl() color syntax
+
 ## [Update] - 2026-01-13
 
 - Added OKLCH color conversion

--- a/extensions/convert/CHANGELOG.md
+++ b/extensions/convert/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Convert Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-06-25
 
 - Added support for modern space-separated hsl() color syntax
 

--- a/extensions/convert/package.json
+++ b/extensions/convert/package.json
@@ -7,7 +7,8 @@
   "author": "nielsvanrijn",
   "contributors": [
     "yusifaliyevpro",
-    "ridemountainpig"
+    "ridemountainpig",
+    "cedric25"
   ],
   "categories": [
     "Developer Tools",

--- a/extensions/convert/src/convert.tsx
+++ b/extensions/convert/src/convert.tsx
@@ -130,22 +130,23 @@ export default function Command() {
       }
     }
 
-    // check if input is hsl color
+    // check if input is hsl color (comma-separated or space-separated)
     const hslMatch = value.match(
-      /^hsl(a)?\((\d{1,3}),(\s)?(\d{1,3})(%)?,(\s)?(\d{1,3})(%)?(,(\s)?(?<alpha>\d+\.\d+|\.\d+))?\)$/i,
+      /^hsla?\(\s*(?<h>\d{1,3})\s*(?:,\s*|\s+)(?<s>\d{1,3})%?\s*(?:,\s*|\s+)(?<l>\d{1,3})%?\s*(?:[,/]\s*(?<alpha>\d+\.?\d*|\.?\d+))?\s*\)$/i,
     );
-    if (hslMatch) {
+    if (hslMatch && hslMatch.groups) {
       console.log("its a hsl");
+      const { h, s, l, alpha } = hslMatch.groups;
       // if hsl color has alpha
-      if (hslMatch.groups && hslMatch.groups.alpha) {
-        setHEX(HSLtoHEX([+hslMatch[2], +hslMatch[4], +hslMatch[7]]));
-        setHEXA(HSLtoHEXA([+hslMatch[2], +hslMatch[4], +hslMatch[7], +hslMatch.groups.alpha]));
-        setRGB(HSLtoRGB([+hslMatch[2], +hslMatch[4], +hslMatch[7]]));
-        setRGBA(HSLtoRGBA([+hslMatch[2], +hslMatch[4], +hslMatch[7], +hslMatch.groups.alpha]));
+      if (alpha) {
+        setHEX(HSLtoHEX([+h, +s, +l]));
+        setHEXA(HSLtoHEXA([+h, +s, +l, +alpha]));
+        setRGB(HSLtoRGB([+h, +s, +l]));
+        setRGBA(HSLtoRGBA([+h, +s, +l, +alpha]));
       } else {
-        const hslToRgbResult = HSLtoRGB([+hslMatch[2], +hslMatch[4], +hslMatch[7]]);
-        setHEX(HSLtoHEX([+hslMatch[2], +hslMatch[4], +hslMatch[7]]));
-        setHSL([+hslMatch[2], +hslMatch[4], +hslMatch[7]]);
+        const hslToRgbResult = HSLtoRGB([+h, +s, +l]);
+        setHEX(HSLtoHEX([+h, +s, +l]));
+        setHSL([+h, +s, +l]);
         setRGB(hslToRgbResult);
         setOKLCH(RGBtoOKLCH(hslToRgbResult));
         setClosestColor(findClosestColor(hslToRgbResult[0], hslToRgbResult[1], hslToRgbResult[2]));


### PR DESCRIPTION
## Description

With a space-separated hsl value:

Before:
<img width="752" height="478" alt="Screenshot 2026-06-24 at 16 39 38" src="https://github.com/user-attachments/assets/b730fd48-fd81-478d-a2db-99cb0b8e44a7" /><br>

After:
<img width="752" height="478" alt="Screenshot 2026-06-24 at 16 39 48" src="https://github.com/user-attachments/assets/aaaadc97-6249-495f-b31c-a866095948a1" />

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
