### PR TITLE
Fix ShareX library path handling

### DIFF
--- a/extensions/sharex/CHANGELOG.md
+++ b/extensions/sharex/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ShareX Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-06-25
 - Include media files stored directly in the configured screenshots folder.
 
 ## [Feature] - 2026-05-05

--- a/extensions/sharex/CHANGELOG.md
+++ b/extensions/sharex/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ShareX Changelog
 
+## [Fix] - 2026-06-24
+- Include media files stored directly in the configured screenshots folder.
+
 ## [Feature] - 2026-05-05
 - Add OCR, Screen Color Picker, Image Splitter and Image effects commands.
 

--- a/extensions/sharex/CHANGELOG.md
+++ b/extensions/sharex/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ShareX Changelog
 
-## [Fix] - 2026-06-24
+## [Fix] - {PR_MERGE_DATE}
 - Include media files stored directly in the configured screenshots folder.
 
 ## [Feature] - 2026-05-05

--- a/extensions/sharex/src/browse-library.tsx
+++ b/extensions/sharex/src/browse-library.tsx
@@ -61,30 +61,42 @@ export default function Command() {
       return;
     }
 
-    const basePath = prefs.screenshotsPath || join(homedir(), "Documents", "ShareX", "Screenshots");
+    const screenshotsPath = prefs.screenshotsPath || join(homedir(), "Documents", "ShareX", "Screenshots");
     const limit = parseInt(prefs.folderLimit) || 5;
+    const mediaFileRegex = /\.(png|jpe?g|gif|bmp|tiff?|mp4|webm|avi|webp|apng)$/i;
 
     try {
-      const items = await readdir(basePath);
-      const foldersWithStats = await Promise.all(
+      const items = await readdir(screenshotsPath);
+      const entriesWithStats = await Promise.all(
         items.map(async (item) => {
-          const path = join(basePath, item);
+          const path = join(screenshotsPath, item);
           const s = await stat(path);
           return { name: item, path, stat: s };
         }),
       );
 
-      const targetFolders = foldersWithStats
+      const allScreenshots: Screenshot[] = [];
+
+      for (const { path: filePath, name, stat: fileStat } of entriesWithStats) {
+        if (fileStat.isFile() && mediaFileRegex.test(name)) {
+          allScreenshots.push({
+            path: filePath,
+            name,
+            folder: "Screenshots",
+            created: fileStat.birthtimeMs,
+          });
+        }
+      }
+
+      const targetFolders = entriesWithStats
         .filter((f) => f.stat.isDirectory())
         .sort((a, b) => b.stat.birthtimeMs - a.stat.birthtimeMs)
         .slice(0, limit);
 
-      const allScreenshots: Screenshot[] = [];
-
       for (const { path: folderPath, name: folderName } of targetFolders) {
         const files = await readdir(folderPath);
         for (const file of files) {
-          if (/\.(png|jpe?g|gif|bmp|tiff?|mp4|webm|avi|webp|apng)$/i.test(file)) {
+          if (mediaFileRegex.test(file)) {
             const filePath = join(folderPath, file);
             const fileStat = await stat(filePath);
             allScreenshots.push({


### PR DESCRIPTION
## Summary

Fixes the ShareX Browse Library command so the configured `screenshotsPath` is treated as the final screenshots folder.

Previously, the command only scanned subfolders inside the configured path. This meant files stored directly in a custom ShareX screenshots folder were ignored.

## Changes

- Add support for media files located directly inside the configured screenshots folder.
- Keep the existing behavior that scans recent subfolders, preserving support for organized ShareX folder structures.
- Reuse a shared media-file regex for direct files and subfolder files.
- Rename the resolved path variable from `basePath` to `screenshotsPath` for clarity.

## Validation

- `npm run lint`
- `npm run build`

Fixes #28975
