### PR TITLE
Fix WhatsApp phone parsing crash

### DIFF
--- a/extensions/whatsapp/CHANGELOG.md
+++ b/extensions/whatsapp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # WhatsApp Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-06-25
 - Prevent phone parsing from crashing when the default country preference is missing.
 
 ## [Enhancements] - 2026-05-16

--- a/extensions/whatsapp/CHANGELOG.md
+++ b/extensions/whatsapp/CHANGELOG.md
@@ -1,5 +1,8 @@
 # WhatsApp Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+- Prevent phone parsing from crashing when the default country preference is missing.
+
 ## [Enhancements] - 2026-05-16
 - Type a phone number in Open Chat to open it without saving (also offers to save the contact)
 - Added a `Default Country` preference so local phone numbers (e.g. `0530572910`) are accepted alongside international format

--- a/extensions/whatsapp/src/utils/parsePhone.ts
+++ b/extensions/whatsapp/src/utils/parsePhone.ts
@@ -6,13 +6,13 @@ import { phone as parsePhone } from "phone";
  * If the input already starts with "+" we treat it as international and ignore
  * the preference (so an IL user can still paste a US +1 number).
  */
-export function parseUserPhone(input: string): ReturnType<typeof parsePhone> {
-  const trimmed = input.trim();
+export function parseUserPhone(input?: string): ReturnType<typeof parsePhone> {
+  const trimmed = input?.trim() ?? "";
   if (trimmed.startsWith("+")) {
     return parsePhone(trimmed);
   }
   const { defaultCountry } = getPreferenceValues<Preferences>();
-  const country = defaultCountry.trim().toUpperCase();
+  const country = defaultCountry?.trim().toUpperCase();
   if (country) {
     return parsePhone(trimmed, { country });
   }


### PR DESCRIPTION
## Summary

Fixes a crash in the WhatsApp extension phone parsing helper when the default country preference is missing.

The `parseUserPhone` helper previously called `.trim()` directly on the configured `defaultCountry`. When that preference is unavailable, the Open Chat command can crash while parsing search input.

## Changes

- Allow `parseUserPhone` to safely handle missing input.
- Guard the `defaultCountry` preference before trimming it.
- Keep existing behavior for international numbers and configured default countries.
- Add a changelog entry using `{PR_MERGE_DATE}`.

## Validation

- `npm run lint`
- `npm run build`

Fixes #28921
Fixes #28918
