### PR TITLE
Fix Cloudflare Pages crash without latest deployment

### DIFF
--- a/extensions/cloudflare/CHANGELOG.md
+++ b/extensions/cloudflare/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Cloudflare Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-06-25
 
 - Prevent View Pages from crashing when a Pages project has no latest deployment.
 

--- a/extensions/cloudflare/CHANGELOG.md
+++ b/extensions/cloudflare/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Cloudflare Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Prevent View Pages from crashing when a Pages project has no latest deployment.
+
 ## [Improve View Workers Command] - 2026-05-25
 
 - Improve `View Workers` command to show more fields in the detail view

--- a/extensions/cloudflare/src/service.ts
+++ b/extensions/cloudflare/src/service.ts
@@ -98,7 +98,7 @@ interface PageItem {
   subdomain: string;
   domains: string;
   source?: SourceItem;
-  latest_deployment: DeploymentItem;
+  latest_deployment: DeploymentItem | null;
 }
 
 interface Source {
@@ -117,14 +117,14 @@ interface Page {
   status: DeploymentStatus;
 }
 
-type DeploymentStatus = 'active' | 'success' | 'failure';
+type DeploymentStatus = 'active' | 'success' | 'failure' | 'unknown';
 
 interface DeploymentItem {
   id: string;
   url: string;
   latest_stage: {
     status: DeploymentStatus;
-  };
+  } | null;
   deployment_trigger: {
     metadata: {
       commit_hash: string;
@@ -466,7 +466,7 @@ function formatPage(item: PageItem): Page {
           },
         }
       : undefined,
-    status: latest_deployment.latest_stage.status,
+    status: latest_deployment?.latest_stage?.status ?? 'unknown',
   };
 }
 
@@ -479,7 +479,7 @@ function formatDeployment(item: DeploymentItem): Deployment {
       hash: deployment_trigger.metadata.commit_hash,
       message: deployment_trigger.metadata.commit_message,
     },
-    status: latest_stage.status,
+    status: latest_stage?.status ?? 'unknown',
     source: {
       type: source.type,
       config: {

--- a/extensions/cloudflare/src/utils.ts
+++ b/extensions/cloudflare/src/utils.ts
@@ -44,6 +44,8 @@ function getDeploymentStatusIcon(status: DeploymentStatus): Icon {
       return Icon.CheckCircle;
     case 'failure':
       return Icon.XMarkCircle;
+    case 'unknown':
+      return Icon.QuestionMarkCircle;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes a crash in the Cloudflare View Pages command when a Pages project has no latest deployment.

The Cloudflare API can return `latest_deployment` as `null`, but the extension previously accessed `latest_deployment.latest_stage.status` directly.

## Changes

- Allow Pages projects to have a missing latest deployment.
- Allow deployment stages to be missing.
- Add an `unknown` deployment status for Pages/deployments without status data.
- Render unknown deployment status with a neutral icon.
- Add a changelog entry using `{PR_MERGE_DATE}`.

## Validation

- `npm run lint`
- `npm run build`

Fixes #28848
