### PR TITLE
[Google Calendar]: add event color support

### DIFF
--- a/extensions/google-calendar/CHANGELOG.md
+++ b/extensions/google-calendar/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Calendar Changelog
 
-## [1.4.4] - {PR_MERGE_DATE}
+## [1.4.4] - 2026-06-26
 
 - Add a `color` parameter to the `create-event` and `edit-event` AI tools so events can be created and recolored with a specific Google Calendar color (named color, `colorId` 1–11, or a hex code that snaps to the nearest supported event color)
 

--- a/extensions/google-calendar/CHANGELOG.md
+++ b/extensions/google-calendar/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Calendar Changelog
 
-## [Add per-event color support] - {PR_MERGE_DATE}
+## [1.4.4] - {PR_MERGE_DATE}
 
 - Add a `color` parameter to the `create-event` and `edit-event` AI tools so events can be created and recolored with a specific Google Calendar color (named color, `colorId` 1–11, or a hex code that snaps to the nearest supported event color)
 

--- a/extensions/google-calendar/CHANGELOG.md
+++ b/extensions/google-calendar/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Calendar Changelog
 
+## [Add per-event color support] - {PR_MERGE_DATE}
+
+- Add a `color` parameter to the `create-event` and `edit-event` AI tools so events can be created and recolored with a specific Google Calendar color (named color, `colorId` 1–11, or a hex code that snaps to the nearest supported event color)
+
 ## [1.4.3] - 2026-05-12
 
 - Fix Google OAuth authentication by using Raycast's built-in Google OAuth flow ([#26572](https://github.com/raycast/extensions/issues/26572))

--- a/extensions/google-calendar/package.json
+++ b/extensions/google-calendar/package.json
@@ -5,7 +5,7 @@
   "description": "Manage your Google calendar easily. Create events, search contacts, and check out your upcoming schedule.",
   "icon": "icon.png",
   "author": "thomas",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "contributors": [
     "j3lte",
     "markusjura",

--- a/extensions/google-calendar/package.json
+++ b/extensions/google-calendar/package.json
@@ -12,7 +12,8 @@
     "fabitosh",
     "geekyed",
     "dangkhoipro",
-    "0xdhrv"
+    "0xdhrv",
+    "peduarte"
   ],
   "categories": [
     "Productivity",

--- a/extensions/google-calendar/src/lib/utils.ts
+++ b/extensions/google-calendar/src/lib/utils.ts
@@ -220,6 +220,29 @@ export const EVENT_COLORS = {
 
 export type EventColorName = keyof typeof EVENT_COLORS;
 
+const COLOR_ID_TO_NAME: Record<string, EventColorName> = Object.fromEntries(
+  Object.entries(EVENT_COLORS).map(([name, id]) => [id, name as EventColorName]),
+);
+
+/**
+ * Returns a human-readable, capitalized color name for a Google Calendar `colorId`
+ * (e.g. "2" → "Sage"). Falls back to "default" when no color is set, or to the raw
+ * id if it isn't part of the known palette.
+ */
+export function colorIdToName(colorId?: string | number | null): string {
+  if (colorId === undefined || colorId === null || String(colorId).trim().length === 0) {
+    return "default";
+  }
+
+  const id = String(colorId).trim();
+  const name = COLOR_ID_TO_NAME[id];
+  if (!name) {
+    return id;
+  }
+
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
 /**
  * The official background hex value for each event `colorId`, as returned by the
  * Google Calendar `colors.get` endpoint. Used to snap an arbitrary hex code to

--- a/extensions/google-calendar/src/lib/utils.ts
+++ b/extensions/google-calendar/src/lib/utils.ts
@@ -199,6 +199,163 @@ export function parseAttendeeEmails(attendees?: string | string[] | null): {
   return { emails, invalidEntries };
 }
 
+/**
+ * Google Calendar's named event colors mapped to their API `colorId` values (1–11).
+ * These are the colors exposed in the event color picker in Google Calendar.
+ * @see https://developers.google.com/calendar/api/v3/reference/colors
+ */
+export const EVENT_COLORS = {
+  lavender: "1",
+  sage: "2",
+  grape: "3",
+  flamingo: "4",
+  banana: "5",
+  tangerine: "6",
+  peacock: "7",
+  graphite: "8",
+  blueberry: "9",
+  basil: "10",
+  tomato: "11",
+} as const;
+
+export type EventColorName = keyof typeof EVENT_COLORS;
+
+/**
+ * The official background hex value for each event `colorId`, as returned by the
+ * Google Calendar `colors.get` endpoint. Used to snap an arbitrary hex code to
+ * the nearest supported event color (the API only allows colorId 1–11, not
+ * arbitrary per-event colors).
+ * @see https://developers.google.com/calendar/api/v3/reference/colors
+ */
+export const EVENT_COLOR_HEX: Record<string, string> = {
+  "1": "#a4bdfc", // lavender
+  "2": "#7ae7bf", // sage
+  "3": "#dbadff", // grape
+  "4": "#ff887c", // flamingo
+  "5": "#fbd75b", // banana
+  "6": "#ffb878", // tangerine
+  "7": "#46d6db", // peacock
+  "8": "#e1e1e1", // graphite
+  "9": "#5484ed", // blueberry
+  "10": "#51b749", // basil
+  "11": "#dc2127", // tomato
+};
+
+function hexToRgb(hex: string): [number, number, number] | undefined {
+  const cleaned = hex.trim().replace(/^#/, "");
+  const normalized =
+    cleaned.length === 3
+      ? cleaned
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : cleaned;
+
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    return undefined;
+  }
+
+  const int = parseInt(normalized, 16);
+  return [(int >> 16) & 255, (int >> 8) & 255, int & 255];
+}
+
+/**
+ * Finds the supported event `colorId` whose palette color is closest to the
+ * given hex code, using squared Euclidean distance in RGB space.
+ */
+function nearestColorId(hex: string): string | undefined {
+  const rgb = hexToRgb(hex);
+  if (!rgb) {
+    return undefined;
+  }
+
+  let bestId: string | undefined;
+  let bestDistance = Infinity;
+
+  for (const [id, paletteHex] of Object.entries(EVENT_COLOR_HEX)) {
+    const target = hexToRgb(paletteHex);
+    if (!target) {
+      continue;
+    }
+
+    const distance = (rgb[0] - target[0]) ** 2 + (rgb[1] - target[1]) ** 2 + (rgb[2] - target[2]) ** 2;
+
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestId = id;
+    }
+  }
+
+  return bestId;
+}
+
+/**
+ * Resolves a user-provided color into a Google Calendar `colorId` (1–11).
+ *
+ * Accepts:
+ * - a named color (e.g. "green", "sage", "purple", "grape");
+ * - a raw numeric `colorId` as a string or number (e.g. "2", 3);
+ * - a hex code (e.g. "#FF6363" or "#f63"), which is snapped to the nearest
+ *   supported event color since Google Calendar does not allow arbitrary
+ *   per-event hex colors.
+ *
+ * @throws Error if the value cannot be resolved to a valid colorId.
+ */
+export function resolveColorId(color?: string | number | null): string | undefined {
+  if (color === undefined || color === null) {
+    return undefined;
+  }
+
+  const value = String(color).trim().toLowerCase();
+  if (value.length === 0) {
+    return undefined;
+  }
+
+  // Hex code (e.g. "#FF6363", "f63") — snap to the nearest supported color.
+  if (/^#?[0-9a-f]{3}$/.test(value) || /^#?[0-9a-f]{6}$/.test(value)) {
+    const nearest = nearestColorId(value);
+    if (nearest) {
+      return nearest;
+    }
+    throw new Error(`Invalid hex color "${color}".`);
+  }
+
+  // Raw numeric colorId (1–11).
+  if (/^\d+$/.test(value)) {
+    const id = Number(value);
+    if (id >= 1 && id <= 11) {
+      return value;
+    }
+    throw new Error(`Invalid colorId "${color}". Expected a value between 1 and 11.`);
+  }
+
+  // Named color, including a few common aliases.
+  const aliases: Record<string, EventColorName> = {
+    green: "sage",
+    purple: "grape",
+    violet: "grape",
+    red: "tomato",
+    orange: "tangerine",
+    yellow: "banana",
+    blue: "blueberry",
+    teal: "peacock",
+    cyan: "peacock",
+    gray: "graphite",
+    grey: "graphite",
+    pink: "flamingo",
+  };
+
+  const name = (aliases[value] ?? value) as EventColorName;
+  const colorId = EVENT_COLORS[name];
+  if (!colorId) {
+    throw new Error(
+      `Invalid color "${color}". Expected a colorId (1–11) or one of: ${Object.keys(EVENT_COLORS).join(", ")}.`,
+    );
+  }
+
+  return colorId;
+}
+
 const DURATION_SEGMENT_REGEX =
   /(\d+(?:\.\d+)?)\s*(milliseconds?|ms|seconds?|secs?|sec|s|minutes?|mins?|min|m|hours?|hrs?|hr|h|days?|d|weeks?|w)/gi;
 

--- a/extensions/google-calendar/src/tools/create-event.ts
+++ b/extensions/google-calendar/src/tools/create-event.ts
@@ -1,7 +1,7 @@
 import { getPreferenceValues, Tool } from "@raycast/api";
 import humanizeDuration from "humanize-duration";
 import { withGoogleAPIs, getCalendarClient } from "../lib/google";
-import { addSignature, parseAttendeeEmails, toISO8601WithTimezoneOffset } from "../lib/utils";
+import { addSignature, parseAttendeeEmails, resolveColorId, toISO8601WithTimezoneOffset } from "../lib/utils";
 import { parseISO, addMinutes } from "date-fns";
 import { calendar_v3 } from "@googleapis/calendar";
 import { randomUUID } from "node:crypto";
@@ -49,6 +49,12 @@ type Input = {
    * @remarks If not provided, the event will be created in the user's primary calendar. The calendar ID can be found using the `list-calendars` tool.
    */
   calendarId?: string;
+  /**
+   * The color of the event. Accepts a Google Calendar named color, a raw colorId (1–11), or a hex code.
+   * @example "sage" or "green" for green, "grape" or "purple" for purple, "#FF6363" for a custom hex
+   * @remarks Supported names: lavender (1), sage (2, green), grape (3, purple), flamingo (4, pink), banana (5, yellow), tangerine (6, orange), peacock (7, teal), graphite (8, gray), blueberry (9, blue), basil (10), tomato (11, red). Google Calendar only supports these 11 fixed event colors, so a hex code is snapped to the nearest one. If not provided, the event inherits the calendar's default color.
+   */
+  color?: string;
 };
 
 const preferences = getPreferenceValues();
@@ -70,6 +76,7 @@ export const confirmation: Tool.Confirmation<Input> = async (input) => {
       { name: "Attendees", value: input.attendees },
       { name: "Description", value: input.description },
       { name: "Add Google Meet Link", value: input.addGoogleMeetLink ? "Yes" : "No" },
+      ...(input.color ? [{ name: "Color", value: input.color }] : []),
     ],
   };
 };
@@ -84,9 +91,12 @@ const tool = async (input: Input) => {
   const startDate = parseISO(input.startDate);
   const endDate = addMinutes(startDate, input.duration ?? parseInt(preferences.defaultEventDuration));
 
+  const colorId = resolveColorId(input.color);
+
   const requestBody: calendar_v3.Schema$Event = {
     summary: input.title,
     description: addSignature(input.description),
+    colorId,
     start: {
       dateTime: toISO8601WithTimezoneOffset(startDate),
     },

--- a/extensions/google-calendar/src/tools/create-event.ts
+++ b/extensions/google-calendar/src/tools/create-event.ts
@@ -1,7 +1,13 @@
 import { getPreferenceValues, Tool } from "@raycast/api";
 import humanizeDuration from "humanize-duration";
 import { withGoogleAPIs, getCalendarClient } from "../lib/google";
-import { addSignature, parseAttendeeEmails, resolveColorId, toISO8601WithTimezoneOffset } from "../lib/utils";
+import {
+  addSignature,
+  colorIdToName,
+  parseAttendeeEmails,
+  resolveColorId,
+  toISO8601WithTimezoneOffset,
+} from "../lib/utils";
 import { parseISO, addMinutes } from "date-fns";
 import { calendar_v3 } from "@googleapis/calendar";
 import { randomUUID } from "node:crypto";
@@ -76,7 +82,7 @@ export const confirmation: Tool.Confirmation<Input> = async (input) => {
       { name: "Attendees", value: input.attendees },
       { name: "Description", value: input.description },
       { name: "Add Google Meet Link", value: input.addGoogleMeetLink ? "Yes" : "No" },
-      ...(input.color ? [{ name: "Color", value: input.color }] : []),
+      ...(input.color ? [{ name: "Color", value: colorIdToName(resolveColorId(input.color)) }] : []),
     ],
   };
 };

--- a/extensions/google-calendar/src/tools/edit-event.ts
+++ b/extensions/google-calendar/src/tools/edit-event.ts
@@ -1,6 +1,12 @@
 import humanizeDuration from "humanize-duration";
 import { withGoogleAPIs, getCalendarClient } from "../lib/google";
-import { addSignature, parseAttendeeEmails, resolveColorId, toISO8601WithTimezoneOffset } from "../lib/utils";
+import {
+  addSignature,
+  colorIdToName,
+  parseAttendeeEmails,
+  resolveColorId,
+  toISO8601WithTimezoneOffset,
+} from "../lib/utils";
 import { parseISO, addMinutes } from "date-fns";
 import { getPreferenceValues } from "@raycast/api";
 
@@ -97,7 +103,7 @@ export const confirmation = withGoogleAPIs(async (input: Input) => {
   if (input.color !== undefined) {
     changes.push({
       name: "Color",
-      value: `${event.data.colorId || "default"} → ${resolveColorId(input.color) || "default"}`,
+      value: `${colorIdToName(event.data.colorId)} → ${colorIdToName(resolveColorId(input.color))}`,
     });
   }
 

--- a/extensions/google-calendar/src/tools/edit-event.ts
+++ b/extensions/google-calendar/src/tools/edit-event.ts
@@ -1,6 +1,6 @@
 import humanizeDuration from "humanize-duration";
 import { withGoogleAPIs, getCalendarClient } from "../lib/google";
-import { addSignature, parseAttendeeEmails, toISO8601WithTimezoneOffset } from "../lib/utils";
+import { addSignature, parseAttendeeEmails, resolveColorId, toISO8601WithTimezoneOffset } from "../lib/utils";
 import { parseISO, addMinutes } from "date-fns";
 import { getPreferenceValues } from "@raycast/api";
 
@@ -41,6 +41,12 @@ type Input = {
    * @remarks If not provided, the event will be updated in the user's primary calendar. The calendar ID can be found using the `list-calendars` tool.
    */
   calendarId?: string;
+  /**
+   * The color of the event. Accepts a Google Calendar named color, a raw colorId (1–11), or a hex code.
+   * @example "sage" or "green" for green, "grape" or "purple" for purple, "#FF6363" for a custom hex
+   * @remarks Supported names: lavender (1), sage (2, green), grape (3, purple), flamingo (4, pink), banana (5, yellow), tangerine (6, orange), peacock (7, teal), graphite (8, gray), blueberry (9, blue), basil (10), tomato (11, red). Google Calendar only supports these 11 fixed event colors, so a hex code is snapped to the nearest one. If not provided, the event keeps its current color.
+   */
+  color?: string;
 };
 
 export const confirmation = withGoogleAPIs(async (input: Input) => {
@@ -86,6 +92,12 @@ export const confirmation = withGoogleAPIs(async (input: Input) => {
     changes.push({
       name: "Description",
       value: `${event.data.description || "none"} → ${input.description || "none"}`,
+    });
+  }
+  if (input.color !== undefined) {
+    changes.push({
+      name: "Color",
+      value: `${event.data.colorId || "default"} → ${resolveColorId(input.color) || "default"}`,
     });
   }
 
@@ -140,6 +152,7 @@ const tool = async (input: Input) => {
     },
     attendees: attendeeEmails.length > 0 ? attendeeEmails.map((email) => ({ email })) : existingEvent.data.attendees,
     location: input.conferencingProvider ?? existingEvent.data.location ?? "",
+    colorId: input.color !== undefined ? resolveColorId(input.color) : (existingEvent.data.colorId ?? undefined),
   };
 
   await calendar.events.update({


### PR DESCRIPTION
## Description

Add support for per-event color when using it via the AI Extension tool

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
