### PR TITLE
[Reclaim] Fix duplicate recurring sync events on calendar view

### DIFF
--- a/extensions/reclaim-ai/CHANGELOG.md
+++ b/extensions/reclaim-ai/CHANGELOG.md
@@ -1,6 +1,6 @@
 # reclaim Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-06-25
 - Fix duplicate recurring events showing on the calendar when synced across multiple calendars
 
 ## [Update] - 2026-05-27

--- a/extensions/reclaim-ai/CHANGELOG.md
+++ b/extensions/reclaim-ai/CHANGELOG.md
@@ -1,5 +1,8 @@
 # reclaim Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+- Fix duplicate recurring events showing on the calendar when synced across multiple calendars
+
 ## [Update] - 2026-05-27
 - Add snooze actions to Search Tasks.
 

--- a/extensions/reclaim-ai/src/utils/events.ts
+++ b/extensions/reclaim-ai/src/utils/events.ts
@@ -66,7 +66,17 @@ export function filterMultipleOutDuplicateEvents<Events extends ApiResponseEvent
 ): Events | undefined {
   if (!events) return events;
 
-  const ids = new Set(events.map((event) => event.recurringEventId ?? event.eventId));
+  // Index by both `eventId` and `recurringEventId`. A sync event's decoded id
+  // always embeds the source event's full instance `eventId` (e.g. with a
+  // `_20260625T200000Z` recurrence suffix), but a recurring source event's
+  // `recurringEventId` is the bare series id without that suffix. Keying only
+  // by `recurringEventId ?? eventId` would therefore miss the match for
+  // recurring events and leak the duplicate sync copy onto the calendar.
+  const ids = new Set<string>();
+  for (const event of events) {
+    ids.add(event.eventId);
+    if (event.recurringEventId) ids.add(event.recurringEventId);
+  }
 
   return events.filter((event) => {
     try {


### PR DESCRIPTION
## Description

Fixes a bug where a recurring event synced across multiple calendars shows up as duplicates in the **My Calendar** view instead of being merged down to a single entry.

`filterMultipleOutDuplicateEvents` builds a lookup `Set` of existing event ids keyed by `recurringEventId ?? eventId`, then for each sync event it decodes the `reclaim-personal-sync:<sourceId>:…` id and checks `ids.has(sourceId)` to drop the duplicate.

The problem: for a **recurring** source event, `recurringEventId` is the bare series id (e.g. `0e9aualupvvi2j0k6mst8cc8cq`), so that's what lands in the Set. But the sync copy's decoded id embeds the source's **full instance id** including the recurrence suffix (e.g. `0e9aualupvvi2j0k6mst8cc8cq_20260625T200000Z`). The lookup therefore misses and the duplicate sync event leaks onto the calendar. Non-recurring events are unaffected because they fall back to `eventId` (the full id), which is why this only reproduces on recurring events.

The fix indexes the `Set` by **both** `eventId` and `recurringEventId`, so the embedded full-instance id always matches.

## Screencast / Testing

Verified against three cases:
- recurring source + sync copy → 1 event kept (was 2 — the bug)
- non-recurring source + sync copy → 1 event kept (unchanged)
- orphan sync event with no source present → 1 event kept (not incorrectly dropped)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I added a `CHANGELOG.md` entry
- [x] I ran the change locally and verified the behavior