### PR TITLE
Fix Google Tasks create task success handling

### DIFF
--- a/extensions/google-tasks/CHANGELOG.md
+++ b/extensions/google-tasks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Tasks Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-06-26
 
 - Await task creation before showing success and closing the create task form.
 

--- a/extensions/google-tasks/CHANGELOG.md
+++ b/extensions/google-tasks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Tasks Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Await task creation before showing success and closing the create task form.
+
 ## [Fix] - 2026-03-31
 
 - Fix due date timezone shift for UTC+ users

--- a/extensions/google-tasks/src/components/CreateTaskForm.tsx
+++ b/extensions/google-tasks/src/components/CreateTaskForm.tsx
@@ -15,24 +15,43 @@ interface CreateTaskFormValues {
 export default function CreateTaskForm(props: {
   listId?: string;
   title?: string;
-  onCreate: (listId: string, task: TaskForm) => void;
+  onCreate: (listId: string, task: TaskForm) => Promise<void>;
 }) {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [lists, setLists] = useState<{ id: string; title: string }[]>([]);
   const { pop } = useNavigation();
   const { handleSubmit, itemProps } = useForm<CreateTaskFormValues>({
-    onSubmit(values) {
-      props.onCreate(values.listId, {
-        title: values.title,
-        notes: values.notes,
-        due: values.due,
-      });
-      showToast({
-        style: Toast.Style.Success,
-        title: "Task Created!",
-        message: `${values.title} created`,
-      });
-      pop();
+    async onSubmit(values) {
+      const listId = values.listId || props.listId || lists[0]?.id;
+
+      if (!listId) {
+        showToast({
+          style: Toast.Style.Failure,
+          title: "No task list selected",
+        });
+        return;
+      }
+
+      try {
+        await props.onCreate(listId, {
+          title: values.title,
+          notes: values.notes,
+          due: values.due,
+        });
+        showToast({
+          style: Toast.Style.Success,
+          title: "Task Created!",
+          message: `${values.title} created`,
+        });
+        pop();
+      } catch (error) {
+        console.error(error);
+        showToast({
+          style: Toast.Style.Failure,
+          title: "Failed to create task",
+          message: String(error),
+        });
+      }
     },
     initialValues: { title: props.title, listId: props.listId },
     validation: {

--- a/extensions/google-tasks/src/components/EmtpyView.tsx
+++ b/extensions/google-tasks/src/components/EmtpyView.tsx
@@ -7,7 +7,7 @@ export default function EmptyView(props: {
   tasks: Task[];
   filter: Filter;
   searchText: string;
-  onCreate: (listId: string, task: TaskForm) => void;
+  onCreate: (listId: string, task: TaskForm) => Promise<void>;
 }) {
   if (props.tasks.length > 0) {
     return (

--- a/extensions/google-tasks/src/components/ListView.tsx
+++ b/extensions/google-tasks/src/components/ListView.tsx
@@ -43,29 +43,27 @@ export default function ListView(props: { listId: string }) {
   }, [google, state.filter]);
 
   const handleCreate = useCallback(
-    (listId: string, taskToCreate: TaskForm) => {
-      (async () => {
-        try {
-          setState((previous) => ({ ...previous, isLoading: true }));
-          await createTask(props.listId, taskToCreate);
-          const refreshedList = await fetchList(props.listId);
-          setState((previous) => ({
-            ...previous,
-            tasks: refreshedList,
-            isLoading: false,
-          }));
-        } catch (error) {
-          console.error(error);
-          setState((previous) => ({
-            ...previous,
-            tasks: [],
-            isLoading: false,
-          }));
-          showToast({ style: Toast.Style.Failure, title: String(error) });
-        }
-      })();
+    async (listId: string, taskToCreate: TaskForm) => {
+      try {
+        setState((previous) => ({ ...previous, isLoading: true }));
+        await createTask(listId, taskToCreate);
+        const refreshedList = await fetchList(listId);
+        setState((previous) => ({
+          ...previous,
+          tasks: refreshedList,
+          isLoading: false,
+        }));
+      } catch (error) {
+        console.error(error);
+        setState((previous) => ({
+          ...previous,
+          tasks: [],
+          isLoading: false,
+        }));
+        throw error;
+      }
     },
-    [state.tasks, setState],
+    [setState],
   );
   const handleEdit = useCallback(
     (listId: string, taskToEdit: Task) => {

--- a/extensions/google-tasks/src/components/TaskItem.tsx
+++ b/extensions/google-tasks/src/components/TaskItem.tsx
@@ -10,7 +10,7 @@ export default function TaskItem(props: {
   task: Task;
   onToggle: () => void;
   onDelete: () => void;
-  onCreate: (listId: string, task: TaskForm) => void;
+  onCreate: (listId: string, task: TaskForm) => Promise<void>;
   onEdit: (listId: string, task: Task) => void;
 }) {
   return (

--- a/extensions/google-tasks/src/create-task.tsx
+++ b/extensions/google-tasks/src/create-task.tsx
@@ -22,12 +22,7 @@ export default function Command() {
   }, []);
 
   const handleCreate = async (listId: string, task: TaskForm) => {
-    try {
-      await createTask(listId, task);
-    } catch (error) {
-      console.error(error);
-      showToast({ style: Toast.Style.Failure, title: String(error) });
-    }
+    await createTask(listId, task);
   };
 
   if (isLoading) {


### PR DESCRIPTION
## Summary

Fixes the Google Tasks Create Task command so it only shows the success toast and closes the form after the task creation request has completed successfully.

Previously, the form called the async `onCreate` handler without awaiting it, then immediately showed `Task Created!` and navigated back. If the Google Tasks API request failed, users could still see a success message even though the task was not created.

## Changes

- Make the create form `onCreate` contract async.
- Await task creation before showing the success toast.
- Keep the form open and show a failure toast if creation fails.
- Refresh the task list after successful creation from list views.
- Add a changelog entry.

## Validation

- `npm run lint`
- `npm run build`

Fixes #28900