### PR TITLE
Password Generator: Add Copy Random Password command

### DIFF
--- a/extensions/password-generator/CHANGELOG.md
+++ b/extensions/password-generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Password Generator Changelog
 
+## [Add Copy Random Password command] - 2026-06-26
+
+- Added `Copy Random Password` no-view command that generates a password and copies it directly to the clipboard, with command preferences for number of characters, using numbers, and using special characters.
+
 ## [Remember numbers and characters] - 2026-01-08
 
 - Added `README.md`

--- a/extensions/password-generator/CHANGELOG.md
+++ b/extensions/password-generator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Password Generator Changelog
 
-## [Add Copy Random Password command] - 2026-06-26
+## [Add Copy Random Password command] - {PR_MERGE_DATE}
 
 - Added `Copy Random Password` no-view command that generates a password and copies it directly to the clipboard, with command preferences for number of characters, using numbers, and using special characters.
 

--- a/extensions/password-generator/CHANGELOG.md
+++ b/extensions/password-generator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Password Generator Changelog
 
-## [Add Copy Random Password command] - {PR_MERGE_DATE}
+## [Add Copy Random Password command] - 2026-06-27
 
 - Added `Copy Random Password` no-view command that generates a password and copies it directly to the clipboard, with command preferences for number of characters, using numbers, and using special characters.
 

--- a/extensions/password-generator/package.json
+++ b/extensions/password-generator/package.json
@@ -10,7 +10,8 @@
     "pernielsentikaer",
     "hnsn",
     "yusifaliyevpro",
-    "xmok"
+    "xmok",
+    "peduarte"
   ],
   "categories": [
     "Productivity",
@@ -50,6 +51,39 @@
           "required": false,
           "default": false,
           "label": "Remember numbers and characters"
+        }
+      ]
+    },
+    {
+      "name": "copy-random-password",
+      "title": "Copy Random Password",
+      "description": "Generates a random password and copies it directly to the clipboard.",
+      "mode": "no-view",
+      "preferences": [
+        {
+          "name": "length",
+          "title": "Number of characters",
+          "description": "The number of characters in the generated password (5–64).",
+          "type": "textfield",
+          "required": false,
+          "default": "16"
+        },
+        {
+          "name": "useNumbers",
+          "description": "Include numbers in the generated password.",
+          "type": "checkbox",
+          "required": false,
+          "default": true,
+          "title": "Options",
+          "label": "Use numbers"
+        },
+        {
+          "name": "useChars",
+          "description": "Include special characters in the generated password.",
+          "type": "checkbox",
+          "required": false,
+          "default": true,
+          "label": "Use special characters"
         }
       ]
     },

--- a/extensions/password-generator/src/copy-random-password.tsx
+++ b/extensions/password-generator/src/copy-random-password.tsx
@@ -1,0 +1,33 @@
+import { Clipboard, PopToRootType, Toast, getPreferenceValues, showHUD, showToast } from "@raycast/api";
+
+import { generatePassword } from "@/helpers/helpers";
+
+export default async function Command() {
+  const { hideAfterCopy } = getPreferenceValues<ExtensionPreferences>();
+  const { length: lengthInput, useNumbers, useChars } = getPreferenceValues<Preferences.CopyRandomPassword>();
+
+  const length = parseInt(lengthInput, 10);
+
+  if (!Number.isFinite(length)) {
+    await showToast(Toast.Style.Failure, "Password length must be a number");
+    return;
+  }
+
+  if (length < 5 || length > 64) {
+    await showToast(Toast.Style.Failure, "Password length must be between 5 and 64");
+    return;
+  }
+
+  const generatedPassword = generatePassword(length, useNumbers, useChars);
+
+  await Clipboard.copy(generatedPassword);
+
+  if (hideAfterCopy) {
+    await showHUD(`Copied Password - ${generatedPassword} 🎉`, {
+      clearRootSearch: false,
+      popToRootType: PopToRootType.Suspended,
+    });
+  } else {
+    await showHUD("Copied Password 🎉");
+  }
+}


### PR DESCRIPTION
## Description

Adds a new `Copy Random Password` **no-view** command to the Password Generator extension.

When triggered, it generates a random password and copies it directly to the clipboard (no UI), then shows an HUD confirmation. It reuses the existing `generatePassword` helper so behavior stays consistent with `Generate Random Password` (guaranteed numbers/symbols, shuffling, 5–64 length validation), and respects the extension-wide `Hide Raycast after copy` preference.

The command exposes its own preferences mirroring the options in `Generate Random Password`:

- **Number of characters** (textfield, default `16`, validated to 5–64)
- **Use numbers** (checkbox, default `true`)
- **Use special characters** (checkbox, default `true`)

## Screencast

<!-- Straightforward no-view command; happy to add a screencast if needed. -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

Made with [Cursor](https://cursor.com)