### PR TITLE
Update GitHub Copilot extension to not open PRs by default for new agent tasks

### DIFF
--- a/extensions/github-copilot/CHANGELOG.md
+++ b/extensions/github-copilot/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitHub Copilot Changelog
 
+## [Group models by category in the model picker] - {PR_MERGE_DATE}
+
+- Group models in the model picker by their category, with humanized section titles
+
 ## [Fix tasks without an associated pull request] - 2026-05-13
 
 - Handle tasks returned by the Copilot API that don't have an associated pull request

--- a/extensions/github-copilot/CHANGELOG.md
+++ b/extensions/github-copilot/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Changelog
 
-## [Create tasks without auto-opening a pull request] - {PR_MERGE_DATE}
+## [Create tasks without auto-opening a pull request] - 2026-06-26
 
 - Create tasks without auto-opening a pull request, with a prompt placeholder explaining that users can ask Copilot to open a PR
 - Group models in the model picker by their category, with humanized section titles

--- a/extensions/github-copilot/CHANGELOG.md
+++ b/extensions/github-copilot/CHANGELOG.md
@@ -1,8 +1,11 @@
 # GitHub Copilot Changelog
 
-## [Group models by category in the model picker] - {PR_MERGE_DATE}
+## [Create tasks without auto-opening a pull request] - {PR_MERGE_DATE}
 
+- Create tasks without auto-opening a pull request, with a prompt placeholder explaining that users can ask Copilot to open a PR
 - Group models in the model picker by their category, with humanized section titles
+- Relabel "Premium requests" as "AI credits" in the usage view, including the additional paid credits indicator
+- Remove the premium request count from the "View Tasks" command because the global sessions API does not expose the same usage data as the GitHub UI
 
 ## [Fix tasks without an associated pull request] - 2026-05-13
 

--- a/extensions/github-copilot/src/components/ModelDropdown.tsx
+++ b/extensions/github-copilot/src/components/ModelDropdown.tsx
@@ -3,11 +3,7 @@ import { useMemo, useEffect } from "react";
 import { useModels } from "../hooks/useModels";
 import { Model } from "../services/models";
 
-const getTitle = (name: string) => name;
-
-// Models whose name starts with "Auto" should be rendered outside of any
-// category section, at the very top of the dropdown.
-const isAutoModel = (model: Model) => model.name.toLowerCase().startsWith("auto");
+const isAutoModel = (model: Model) => model.id === "auto";
 
 // Convert a raw model_picker_category value (e.g. "lightweight_models") into a
 // human-friendly section title (e.g. "Lightweight Models").
@@ -116,7 +112,7 @@ export function ModelDropdown(
   if (models.length === 0) return null;
 
   const renderItem = (model: Model) => (
-    <Form.Dropdown.Item key={model.id} title={getTitle(model.name)} value={model.id} />
+    <Form.Dropdown.Item key={model.id} title={model.name} value={model.id} />
   );
 
   return (

--- a/extensions/github-copilot/src/components/ModelDropdown.tsx
+++ b/extensions/github-copilot/src/components/ModelDropdown.tsx
@@ -111,9 +111,7 @@ export function ModelDropdown(
 
   if (models.length === 0) return null;
 
-  const renderItem = (model: Model) => (
-    <Form.Dropdown.Item key={model.id} title={model.name} value={model.id} />
-  );
+  const renderItem = (model: Model) => <Form.Dropdown.Item key={model.id} title={model.name} value={model.id} />;
 
   return (
     <Form.Dropdown

--- a/extensions/github-copilot/src/components/ModelDropdown.tsx
+++ b/extensions/github-copilot/src/components/ModelDropdown.tsx
@@ -1,13 +1,82 @@
 import { Form } from "@raycast/api";
 import { useMemo, useEffect } from "react";
 import { useModels } from "../hooks/useModels";
+import { Model } from "../services/models";
 
-const getTitle = (name: string, multiplier: number | undefined) => {
-  if (multiplier === undefined || multiplier === 1) {
-    return name;
-  } else {
-    return `${name} (${multiplier}x)`;
+const getTitle = (name: string) => name;
+
+// Models whose name starts with "Auto" should be rendered outside of any
+// category section, at the very top of the dropdown.
+const isAutoModel = (model: Model) => model.name.toLowerCase().startsWith("auto");
+
+// Convert a raw model_picker_category value (e.g. "lightweight_models") into a
+// human-friendly section title (e.g. "Lightweight Models").
+const humanizeCategory = (category: string) =>
+  category
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ")
+    .split(" ")
+    .map((word) => (word.length > 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word))
+    .join(" ");
+
+// Preferred category order. Any categories not in this list are appended after
+// the known ones in the order they first appear from the API.
+const CATEGORY_ORDER = ["lightweight", "versatile", "powerful"];
+
+const categorySortIndex = (category: string) => {
+  const index = CATEGORY_ORDER.indexOf(category.toLowerCase());
+  return index === -1 ? CATEGORY_ORDER.length : index;
+};
+
+// Group models by their model_picker_category, preserving the order in which
+// models first appear within each category. Models without a category are
+// grouped together at the end under an "Other" section. Auto models are always
+// rendered first, outside of any category section.
+interface ModelGroup {
+  title: string | null;
+  models: Model[];
+  rawCategory: string;
+}
+
+const groupModelsByCategory = (models: Model[]): { autoModels: Model[]; groups: ModelGroup[] } => {
+  const autoModels: Model[] = [];
+  const nonAutoModels: Model[] = [];
+
+  for (const model of models) {
+    if (isAutoModel(model)) {
+      autoModels.push(model);
+    } else {
+      nonAutoModels.push(model);
+    }
   }
+
+  const groups: ModelGroup[] = [];
+  const groupsByKey = new Map<string, ModelGroup>();
+
+  for (const model of nonAutoModels) {
+    const key = model.model_picker_category ?? "";
+    let group = groupsByKey.get(key);
+    if (!group) {
+      group = {
+        title: model.model_picker_category ? humanizeCategory(model.model_picker_category) : null,
+        models: [],
+        rawCategory: key,
+      };
+      groupsByKey.set(key, group);
+      groups.push(group);
+    }
+    group.models.push(model);
+  }
+
+  for (const group of groups) {
+    group.models.sort((a, b) => b.name.localeCompare(a.name));
+  }
+
+  return {
+    autoModels,
+    groups: groups.sort((a, b) => categorySortIndex(a.rawCategory) - categorySortIndex(b.rawCategory)),
+  };
 };
 
 export function ModelDropdown(
@@ -35,6 +104,8 @@ export function ModelDropdown(
     }
   }, [models, value]);
 
+  const { autoModels, groups } = useMemo(() => groupModelsByCategory(models), [models]);
+
   // Update the form value when controlledValue changes
   useEffect(() => {
     if (controlledValue && controlledValue !== value && onChange) {
@@ -43,6 +114,10 @@ export function ModelDropdown(
   }, [controlledValue, value, onChange]);
 
   if (models.length === 0) return null;
+
+  const renderItem = (model: Model) => (
+    <Form.Dropdown.Item key={model.id} title={getTitle(model.name)} value={model.id} />
+  );
 
   return (
     <Form.Dropdown
@@ -55,9 +130,16 @@ export function ModelDropdown(
       value={controlledValue}
       {...restItemProps}
     >
-      {models.map((model) => (
-        <Form.Dropdown.Item key={model.name} title={getTitle(model.name, model.billing?.multiplier)} value={model.id} />
-      ))}
+      {autoModels.map(renderItem)}
+      {groups.map((group) =>
+        group.title ? (
+          <Form.Dropdown.Section key={group.title} title={group.title}>
+            {group.models.map(renderItem)}
+          </Form.Dropdown.Section>
+        ) : (
+          group.models.map(renderItem)
+        ),
+      )}
     </Form.Dropdown>
   );
 }

--- a/extensions/github-copilot/src/components/TaskItem.tsx
+++ b/extensions/github-copilot/src/components/TaskItem.tsx
@@ -10,7 +10,7 @@ export function TaskItem(
     taskWithPullRequest: TaskWithPullRequest;
   }>,
 ) {
-  const { task, pullRequest, premiumRequests, repository } = props.taskWithPullRequest;
+  const { task, pullRequest, repository } = props.taskWithPullRequest;
   const { push } = useNavigation();
   const title = pullRequest?.title ?? task.name ?? `Task ${task.id}`;
   const subtitle = repository ? `${repository.owner.login}/${repository.name}` : undefined;
@@ -22,7 +22,6 @@ export function TaskItem(
 
   const createdAt = useMemo(() => new Date(task.created_at), [task.created_at]);
   const relativeDate = useMemo(() => formatRelativeDate(createdAt), [createdAt]);
-  const premiumRequestsConsumed = useMemo(() => premiumRequests > 0, [premiumRequests]);
 
   return (
     <List.Item
@@ -32,11 +31,8 @@ export function TaskItem(
       icon={getTaskIcon(props.taskWithPullRequest)}
       accessories={[
         {
-          icon: premiumRequestsConsumed ? Icon.Bolt : undefined,
-          text: premiumRequestsConsumed ? `${premiumRequests} · ${relativeDate}` : relativeDate,
-          tooltip: premiumRequestsConsumed
-            ? `${premiumRequests} premium requests · Started at ${createdAt.toLocaleString()}`
-            : `Started at ${createdAt.toLocaleString()}`,
+          text: relativeDate,
+          tooltip: `Started at ${createdAt.toLocaleString()}`,
         },
       ]}
       actions={

--- a/extensions/github-copilot/src/copilot-usage.tsx
+++ b/extensions/github-copilot/src/copilot-usage.tsx
@@ -39,7 +39,8 @@ function Command() {
 
   const UsageActions = (
     <ActionPanel>
-      <Action.OpenInBrowser title="Manage Paid Premium Requests" url="https://github.com/settings/billing/budgets" />
+      {/* eslint-disable-next-line @raycast/prefer-title-case */}
+      <Action.OpenInBrowser title="Manage paid AI credits" url="https://github.com/settings/billing/budgets" />
       <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={revalidate} />
       {/* eslint-disable-next-line @raycast/prefer-title-case */}
       <Action title="Log Out" icon={Icon.Logout} onAction={reauthorize} />
@@ -93,7 +94,7 @@ function Command() {
               actions={UsageActions}
             />
             <List.Item
-              title="Premium requests"
+              title="AI credits"
               accessories={[
                 {
                   text: formatUsage(usage.premiumRequests.percentageUsed, usage.premiumRequests.limit),
@@ -111,7 +112,7 @@ function Command() {
           {usage.allowanceResetAt && (
             <List.Section title="">
               <List.Item
-                title="Additional paid premium requests enabled."
+                title="Additional paid AI credits enabled."
                 icon={{ source: Icon.Info, tintColor: Color.SecondaryText }}
                 actions={UsageActions}
               />

--- a/extensions/github-copilot/src/create-task.tsx
+++ b/extensions/github-copilot/src/create-task.tsx
@@ -118,8 +118,7 @@ function Command() {
     >
       <Form.TextArea
         title="Prompt"
-        placeholder="Describe a coding task to work on"
-        info="You can ask the agent to open a pull request in your prompt if you want one"
+        placeholder={"Give Copilot a background task to work on.\nIf you want Copilot to open a PR, just ask."}
         {...itemProps.prompt}
       />
       <RepositoryDropdown

--- a/extensions/github-copilot/src/create-task.tsx
+++ b/extensions/github-copilot/src/create-task.tsx
@@ -116,7 +116,12 @@ function Command() {
       }
       isLoading={isLoading}
     >
-      <Form.TextArea title="Prompt" placeholder="Describe a coding task to work on" {...itemProps.prompt} />
+      <Form.TextArea
+        title="Prompt"
+        placeholder="Describe a coding task to work on"
+        info="You can ask the agent to open a pull request in your prompt if you want one"
+        {...itemProps.prompt}
+      />
       <RepositoryDropdown
         organizations={data?.organizations.nodes.map((org) => org.login)}
         itemProps={itemProps.repository}

--- a/extensions/github-copilot/src/hooks/useTasks.ts
+++ b/extensions/github-copilot/src/hooks/useTasks.ts
@@ -10,7 +10,6 @@ const minutesAgoISO8601Timestamp = (n: number): string => {
 const DUMMY_TASKS_WITH_PULL_REQUESTS: TaskWithPullRequest[] = [
   {
     key: "1",
-    premiumRequests: 2,
     repository: { name: "bookstore", owner: { login: "contoso" } },
     pullRequest: {
       globalId: "foo",
@@ -44,7 +43,6 @@ const DUMMY_TASKS_WITH_PULL_REQUESTS: TaskWithPullRequest[] = [
   },
   {
     key: "2",
-    premiumRequests: 4,
     repository: { name: "bookstore", owner: { login: "contoso" } },
     pullRequest: {
       globalId: "foo",
@@ -78,7 +76,6 @@ const DUMMY_TASKS_WITH_PULL_REQUESTS: TaskWithPullRequest[] = [
   },
   {
     key: "3",
-    premiumRequests: 2,
     repository: { name: "bookstore", owner: { login: "contoso" } },
     pullRequest: {
       globalId: "foo",
@@ -112,7 +109,6 @@ const DUMMY_TASKS_WITH_PULL_REQUESTS: TaskWithPullRequest[] = [
   },
   {
     key: "3.1",
-    premiumRequests: 2,
     repository: { name: "bookstore", owner: { login: "contoso" } },
     pullRequest: {
       globalId: "foo",
@@ -146,7 +142,6 @@ const DUMMY_TASKS_WITH_PULL_REQUESTS: TaskWithPullRequest[] = [
   },
   {
     key: "4",
-    premiumRequests: 2,
     repository: { name: "bookstore", owner: { login: "contoso" } },
     pullRequest: {
       globalId: "foo",
@@ -180,7 +175,6 @@ const DUMMY_TASKS_WITH_PULL_REQUESTS: TaskWithPullRequest[] = [
   },
   {
     key: "5",
-    premiumRequests: 2,
     repository: { name: "bookstore", owner: { login: "contoso" } },
     pullRequest: {
       globalId: "foo",
@@ -214,7 +208,6 @@ const DUMMY_TASKS_WITH_PULL_REQUESTS: TaskWithPullRequest[] = [
   },
   {
     key: "6",
-    premiumRequests: 4,
     repository: { name: "bookstore", owner: { login: "contoso" } },
     pullRequest: {
       globalId: "foo",
@@ -248,7 +241,6 @@ const DUMMY_TASKS_WITH_PULL_REQUESTS: TaskWithPullRequest[] = [
   },
   {
     key: "7",
-    premiumRequests: 0,
     repository: { name: "bookstore", owner: { login: "contoso" } },
     pullRequest: {
       globalId: "foo",

--- a/extensions/github-copilot/src/services/copilot.ts
+++ b/extensions/github-copilot/src/services/copilot.ts
@@ -82,16 +82,6 @@ type PullRequest = {
   };
 };
 
-// An agent session returned from the sessions API
-type AgentSession = {
-  resource_global_id: string;
-  premium_requests: number;
-};
-
-type ListAgentSessionsResponse = {
-  sessions: AgentSession[];
-};
-
 type Repository = {
   name: string;
   owner: {
@@ -103,7 +93,6 @@ type Repository = {
 type TaskWithPullRequest = {
   task: Task;
   pullRequest: PullRequest | null;
-  premiumRequests: number;
   repository: Repository | null;
   key: string;
 };
@@ -228,10 +217,9 @@ const fetchTasks = async (): Promise<TaskWithPullRequest[]> => {
     "Copilot-Integration-Id": "copilot-raycast",
   };
 
-  const [listTasksResponse, listSessionsResponse] = await Promise.all([
-    fetch("https://api.githubcopilot.com/agents/tasks?sort=updated_at&direction=desc", { headers }),
-    fetch("https://api.githubcopilot.com/agents/sessions", { headers }),
-  ]);
+  const listTasksResponse = await fetch("https://api.githubcopilot.com/agents/tasks?sort=updated_at&direction=desc", {
+    headers,
+  });
 
   if (!listTasksResponse.ok) {
     const responseText = await listTasksResponse.text();
@@ -241,15 +229,6 @@ const fetchTasks = async (): Promise<TaskWithPullRequest[]> => {
   }
 
   const { tasks: retrievedTasks } = (await listTasksResponse.json()) as ListTasksResponse;
-
-  // Build a map of PR global ID -> total premium requests from sessions
-  const sessions = listSessionsResponse.ok
-    ? ((await listSessionsResponse.json()) as ListAgentSessionsResponse).sessions
-    : [];
-  const premiumByGlobalId = sessions.reduce<Record<string, number>>((acc, session) => {
-    const key = session.resource_global_id;
-    return { ...acc, [key]: (acc[key] || 0) + (session.premium_requests || 0) };
-  }, {});
 
   // Extract pull request global IDs from task artifacts
   const pullRequestGlobalIds = Array.from(
@@ -328,14 +307,11 @@ const fetchTasks = async (): Promise<TaskWithPullRequest[]> => {
       ? pullRequests.find((pr) => pr.globalId === pullArtifact.data.global_id) || null
       : null;
 
-    const prGlobalId = pullArtifact?.data.global_id;
-    const premiumRequests = prGlobalId ? premiumByGlobalId[prGlobalId] || 0 : 0;
     const repository = pullRequest?.repository ?? repositories.find((r) => r.repoId === task.repository.id) ?? null;
 
     return {
       task,
       pullRequest,
-      premiumRequests,
       repository,
       key: task.id,
     };

--- a/extensions/github-copilot/src/services/copilot.ts
+++ b/extensions/github-copilot/src/services/copilot.ts
@@ -179,7 +179,7 @@ async function createTask(
   } = {
     event_content: prompt,
     problem_statement: prompt,
-    create_pull_request: true,
+    create_pull_request: false,
     base_ref: branch,
   };
 

--- a/extensions/github-copilot/src/services/models.ts
+++ b/extensions/github-copilot/src/services/models.ts
@@ -3,6 +3,7 @@ import { getAccessToken } from "@raycast/utils";
 export interface Model {
   name: string;
   id: string;
+  model_picker_category?: string;
   billing?: {
     multiplier: number;
   };

--- a/extensions/github-copilot/src/tools/parse-copilot-usage.ts
+++ b/extensions/github-copilot/src/tools/parse-copilot-usage.ts
@@ -33,7 +33,7 @@ export const parseUsageData = (response: CopilotInternalUserResponse): CopilotUs
   const chatMessagesLimit = chatSnapshot?.unlimited ? null : (chatSnapshot?.entitlement ?? 0);
   const chatMessagesCurrent = getConsumedPercentage(chatSnapshot);
 
-  // Extract premium interactions (premium requests)
+  // Extract premium interactions (AI credits)
   const premiumSnapshot = snapshots.premium_interactions;
   const premiumRequestsLimit = premiumSnapshot?.unlimited ? null : (premiumSnapshot?.entitlement ?? 0);
   const premiumRequestsCurrent = getConsumedPercentage(premiumSnapshot);


### PR DESCRIPTION
## Description

- Start Copilot tasks without auto-opening a pull request, with a prompt placeholder explaining that users can ask Copilot to open a PR
- Group models in the model picker by their category, with humanized section titles
- Relabel "Premium requests" as "AI credits" in the usage view, including the additional paid credits indicator
- Remove the premium request count from the "View Tasks" command because the global sessions API does not expose the same usage data as the GitHub UI

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
