### PR TITLE
Update jira extension

### DIFF
--- a/extensions/jira/.gitignore
+++ b/extensions/jira/.gitignore
@@ -12,20 +12,3 @@ compiled_raycast_rust
 
 # misc
 .DS_Store
-
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-
-# dependencies
-/node_modules
-
-
-# Raycast specific files
-.raycast-swift-build
-.swiftpm
-compiled_raycast_swift
-compiled_raycast_rust
-# misc
-.DS_Store
-raycast-env.d.ts
-#idea
-.idea

--- a/extensions/jira/CHANGELOG.md
+++ b/extensions/jira/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Jira Changelog
 
-## [Fix Jira HTML response errors] - {PR_MERGE_DATE}
+## [Fix Jira HTML response errors] - 2026-06-29
 
 - Fixed Jira requests crashing with `Unexpected token '<'` when Jira returns an HTML login, redirect, or SSO page instead of JSON (#23569, #23474, #23413, #23367).
 - Show clearer Jira authentication/API errors instead of raw JSON parsing stack traces.

--- a/extensions/jira/CHANGELOG.md
+++ b/extensions/jira/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Jira Changelog
 
+## [Fix Jira HTML response errors] - {PR_MERGE_DATE}
+
+- Fixed Jira requests crashing with `Unexpected token '<'` when Jira returns an HTML login, redirect, or SSO page instead of JSON (#23569, #23474, #23413, #23367).
+- Show clearer Jira authentication/API errors instead of raw JSON parsing stack traces.
+
 ## [Bug Fix] - 2026-05-18
 
 - Kept Jira issue lists open when Jira returns an HTML error page while loading issue type icons.

--- a/extensions/jira/README.md
+++ b/extensions/jira/README.md
@@ -13,8 +13,8 @@ The Jira extension supports OAuth authentication by default. But if you want, yo
 
 You can change the default `Git branch name` in preferences; the following keys are available:
 
-* {issueKey}
-* {issueSummary}
-* {issueSummaryShort}
-* {issueType}
-* {projectKey}
+- {issueKey}
+- {issueSummary}
+- {issueSummaryShort}
+- {issueType}
+- {projectKey}

--- a/extensions/jira/src/api/jiraCredentials.ts
+++ b/extensions/jira/src/api/jiraCredentials.ts
@@ -3,6 +3,7 @@ import { OAuthService } from "@raycast/utils";
 import fetch from "node-fetch";
 
 import { User } from "./users";
+import { parseJiraResponse } from "./response";
 
 type JiraCredentials = {
   cloudId?: string;
@@ -32,7 +33,11 @@ export const jiraWithApiToken = {
     });
 
     try {
-      const myself = (await myselfResponse.json()) as User;
+      const myself = await parseJiraResponse<User>(myselfResponse);
+      if (!myself) {
+        throw new Error("Jira returned an empty user response.");
+      }
+
       jiraCredentials = {
         siteUrl: hostname,
         authorizationHeader: authorizationHeader,
@@ -61,7 +66,7 @@ export const jira = OAuthService.jira({
       },
     });
 
-    const sites = (await sitesResponse.json()) as { id: string; url: string }[];
+    const sites = await parseJiraResponse<{ id: string; url: string }[]>(sitesResponse);
 
     if (sites && sites.length > 0) {
       const site = sites[0];
@@ -74,7 +79,10 @@ export const jira = OAuthService.jira({
         },
       });
 
-      const myself = (await myselfResponse.json()) as User;
+      const myself = await parseJiraResponse<User>(myselfResponse);
+      if (!myself) {
+        throw new Error("Jira returned an empty user response.");
+      }
 
       jiraCredentials = {
         cloudId: site.id,

--- a/extensions/jira/src/api/request.ts
+++ b/extensions/jira/src/api/request.ts
@@ -1,6 +1,8 @@
-import fetch, { RequestInit } from "node-fetch";
+import fetch, { type RequestInit } from "node-fetch";
 
 import { getJiraCredentials } from "../api/jiraCredentials";
+
+import { parseJiraResponse } from "./response";
 
 type Method = "GET" | "POST" | "PUT" | "DELETE";
 
@@ -41,16 +43,7 @@ export async function request<T>(path: string, options: RequestOptions = { metho
     },
   );
 
-  if (response.ok) {
-    if (response.status === 204) {
-      return null;
-    }
-
-    return response.json() as T;
-  } else {
-    const result = await response.json();
-    throw new Error(JSON.stringify(result));
-  }
+  return parseJiraResponse<T>(response);
 }
 
 export const getAuthenticatedUri = async (uri: string, contentType: string) => {
@@ -65,8 +58,8 @@ export const getAuthenticatedUri = async (uri: string, contentType: string) => {
     const dataUri = `data:${contentType};base64,${Buffer.from(await response.arrayBuffer()).toString("base64")}`;
     return dataUri;
   } else {
-    const result = await response.json();
-    throw new Error(JSON.stringify(result));
+    await parseJiraResponse(response);
+    throw new Error(`Jira request failed with status ${response.status}.`);
   }
 };
 
@@ -87,10 +80,5 @@ export async function autocomplete<T>(url: string, queryParams: Record<string, s
     },
   });
 
-  if (response.ok) {
-    return response.json() as T;
-  } else {
-    const result = await response.json();
-    throw new Error(JSON.stringify(result));
-  }
+  return parseJiraResponse<T>(response);
 }

--- a/extensions/jira/src/api/response.ts
+++ b/extensions/jira/src/api/response.ts
@@ -1,0 +1,89 @@
+import { type Response } from "node-fetch";
+
+import { getRateLimitErrorMessage } from "../helpers/errors";
+
+const HTML_RESPONSE_ERROR_MESSAGE = "Jira returned an HTML page instead of JSON. Please reconnect Jira and try again.";
+const AUTH_ERROR_MESSAGE =
+  "Your Jira session has expired or was revoked. Please reconnect Jira in Raycast extension preferences and try again.";
+
+export class JiraApiError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "JiraApiError";
+  }
+}
+
+export class JiraAuthError extends JiraApiError {
+  constructor(message = AUTH_ERROR_MESSAGE, status?: number) {
+    super(message, status);
+    this.name = "JiraAuthError";
+  }
+}
+
+export async function parseJiraResponse<T>(response: Response): Promise<T | null> {
+  if (response.status === 204) {
+    return null;
+  }
+
+  if (!response.ok) {
+    await throwOnErrorResponse(response);
+  }
+
+  return parseJiraJsonResponse<T>(response);
+}
+
+export async function parseJiraJsonResponse<T>(response: Response): Promise<T> {
+  const body = await response.text();
+  const contentType = response.headers.get("content-type");
+
+  if (isHtmlResponse(contentType, body)) {
+    throw response.status === 401 || response.status === 403
+      ? new JiraAuthError(undefined, response.status)
+      : new JiraApiError(HTML_RESPONSE_ERROR_MESSAGE, response.status);
+  }
+
+  if (body.trim().length === 0) {
+    throw new JiraApiError(`Jira returned an empty response with status ${response.status}.`, response.status);
+  }
+
+  try {
+    return JSON.parse(body) as T;
+  } catch {
+    throw new JiraApiError(`Jira returned an invalid JSON response with status ${response.status}.`, response.status);
+  }
+}
+
+async function throwOnErrorResponse(response: Response): Promise<never> {
+  if (response.status === 429) {
+    throw new JiraApiError(getRateLimitErrorMessage(response.headers.get("Retry-After")), response.status);
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new JiraAuthError(undefined, response.status);
+  }
+
+  try {
+    const result = await parseJiraJsonResponse<unknown>(response);
+    throw new JiraApiError(JSON.stringify(result), response.status);
+  } catch (error) {
+    if (error instanceof JiraApiError) {
+      throw error;
+    }
+
+    throw new JiraApiError(`Jira request failed with status ${response.status}.`, response.status);
+  }
+}
+
+function isHtmlResponse(contentType: string | null, body: string): boolean {
+  const normalizedContentType = contentType?.toLowerCase() ?? "";
+  const trimmedBody = body.trimStart().toLowerCase();
+
+  return (
+    normalizedContentType.includes("text/html") ||
+    trimmedBody.startsWith("<!doctype html") ||
+    trimmedBody.startsWith("<html")
+  );
+}

--- a/extensions/jira/src/helpers/errors.ts
+++ b/extensions/jira/src/helpers/errors.ts
@@ -1,3 +1,41 @@
+export function getRateLimitErrorMessage(retryAfter: string | null): string {
+  const baseMessage = "Jira rate limit reached. Please wait a bit and try again.";
+  if (!retryAfter) {
+    return baseMessage;
+  }
+
+  const retryAfterSeconds = parseRetryAfter(retryAfter);
+  if (retryAfterSeconds === null) {
+    return baseMessage;
+  }
+
+  return `Jira rate limit reached. Please try again in ${formatRetryAfterDuration(retryAfterSeconds)}.`;
+}
+
+function parseRetryAfter(retryAfter: string): number | null {
+  const seconds = Number(retryAfter);
+  if (!Number.isNaN(seconds) && seconds >= 0) {
+    return Math.ceil(seconds);
+  }
+
+  const retryDate = Date.parse(retryAfter);
+  if (!Number.isNaN(retryDate)) {
+    const deltaSeconds = Math.ceil((retryDate - Date.now()) / 1000);
+    return deltaSeconds > 0 ? deltaSeconds : null;
+  }
+
+  return null;
+}
+
+function formatRetryAfterDuration(seconds: number): string {
+  if (seconds < 60) {
+    return seconds === 1 ? "1 second" : `${seconds} seconds`;
+  }
+
+  const minutes = Math.ceil(seconds / 60);
+  return minutes === 1 ? "1 minute" : `${minutes} minutes`;
+}
+
 export function getErrorMessage(error: unknown) {
   if (error instanceof Error) {
     try {

--- a/extensions/jira/src/helpers/errors.ts
+++ b/extensions/jira/src/helpers/errors.ts
@@ -13,12 +13,17 @@ export function getRateLimitErrorMessage(retryAfter: string | null): string {
 }
 
 function parseRetryAfter(retryAfter: string): number | null {
-  const seconds = Number(retryAfter);
+  const normalizedRetryAfter = retryAfter.trim();
+  if (!normalizedRetryAfter) {
+    return null;
+  }
+
+  const seconds = Number(normalizedRetryAfter);
   if (!Number.isNaN(seconds) && seconds >= 0) {
     return Math.ceil(seconds);
   }
 
-  const retryDate = Date.parse(retryAfter);
+  const retryDate = Date.parse(normalizedRetryAfter);
   if (!Number.isNaN(retryDate)) {
     const deltaSeconds = Math.ceil((retryDate - Date.now()) / 1000);
     return deltaSeconds > 0 ? deltaSeconds : null;

--- a/extensions/jira/test/request.test.ts
+++ b/extensions/jira/test/request.test.ts
@@ -1,0 +1,19 @@
+import { rejects } from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { Response } from "node-fetch";
+
+import { parseJiraJsonResponse } from "../src/api/response";
+
+describe("parseJiraJsonResponse", () => {
+  it("throws a clear Jira error when a successful response contains HTML", async () => {
+    const response = new Response("<!DOCTYPE html><html><body>Sign in to Jira</body></html>", {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+      status: 200,
+    });
+
+    await rejects(() => parseJiraJsonResponse(response), {
+      message: "Jira returned an HTML page instead of JSON. Please reconnect Jira and try again.",
+    });
+  });
+});


### PR DESCRIPTION
## Description

- Fixes #23569
- Fixes #23474
- Fixes #23413
- Fixes #23367
- Prevents Jira commands from crashing with `Unexpected token '<'` when Jira returns an HTML login, redirect, or SSO page instead of JSON.
- Adds shared Jira response validation for API requests and credential bootstrap calls.
- Shows clearer Jira authentication/API errors instead of raw JSON parsing stack traces.

## Screencast

N/A. This is an API error-handling fix with no UI changes.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder