### PR TITLE
[Skills] Use skills audit api

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Skills Changelog
 
+## [Use Security Audit API] - {PR_MERGE_DATE}
+
+- Use the Skills security audit API instead of parsing audit data from the skills.sh HTML page
+
 ## [Sync Skills Agent IDs] - 2026-06-26
 
 - Sync the local Skills CLI agent ID fallback map with the upstream supported agents list

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Use Security Audit API] - {PR_MERGE_DATE}
+## [Use Security Audit API] - 2026-06-26
 
 - Use the Skills security audit API instead of parsing audit data from the skills.sh HTML page
 

--- a/extensions/skills/src/components/InstalledSkillListItem.tsx
+++ b/extensions/skills/src/components/InstalledSkillListItem.tsx
@@ -6,8 +6,8 @@ import { useSkillAudits } from "../hooks/useSkillAudits";
 import {
   type InstalledSkill,
   type Skill,
-  AUDIT_PROVIDER_LABELS,
   buildSkillUrl,
+  formatAuditProviderLabel,
   isGithubBackedInstalledSkill,
   parseFrontmatter,
 } from "../shared";
@@ -135,14 +135,14 @@ function InlineDetail({ skill, isSelected, skillDetailPageUrl, audits }: InlineD
           audit.url ? (
             <List.Item.Detail.Metadata.Link
               key={`agent-audits-${audit.provider}`}
-              title={`${AUDIT_PROVIDER_LABELS[audit.provider]} Audit`}
+              title={`${formatAuditProviderLabel(audit)} Audit`}
               text={formatAuditStatus(audit.status)}
               target={audit.url}
             />
           ) : (
             <List.Item.Detail.Metadata.Label
               key={`agent-audits-${audit.provider}`}
-              title={`${AUDIT_PROVIDER_LABELS[audit.provider]} Audit`}
+              title={`${formatAuditProviderLabel(audit)} Audit`}
               text={formatAuditStatus(audit.status)}
             />
           ),

--- a/extensions/skills/src/components/SkillDetailView.tsx
+++ b/extensions/skills/src/components/SkillDetailView.tsx
@@ -1,9 +1,9 @@
 import { Action, ActionPanel, Color, Detail, Icon, Keyboard } from "@raycast/api";
 import { useCallback, useEffect, useRef } from "react";
 import {
-  AUDIT_PROVIDER_LABELS,
   buildInstallCommand,
   buildSkillUrl,
+  formatAuditProviderLabel,
   formatInstalls,
   formatRelativeDate,
   normalizeAllowedTools,
@@ -184,14 +184,14 @@ ${installCommand}
         audit.url ? (
           <Detail.Metadata.Link
             key={audit.provider}
-            title={`${AUDIT_PROVIDER_LABELS[audit.provider]} Audit`}
+            title={`${formatAuditProviderLabel(audit)} Audit`}
             text={formatAuditStatus(audit.status)}
             target={audit.url}
           />
         ) : (
           <Detail.Metadata.Label
             key={audit.provider}
-            title={`${AUDIT_PROVIDER_LABELS[audit.provider]} Audit`}
+            title={`${formatAuditProviderLabel(audit)} Audit`}
             text={formatAuditStatus(audit.status)}
           />
         ),

--- a/extensions/skills/src/components/actions/InstallSkillAction.tsx
+++ b/extensions/skills/src/components/actions/InstallSkillAction.tsx
@@ -11,7 +11,7 @@ import {
   useNavigation,
 } from "@raycast/api";
 import { useCallback, useState } from "react";
-import { AUDIT_PROVIDER_LABELS, type Skill } from "../../shared";
+import { formatAuditProviderLabel, type Skill } from "../../shared";
 import { useSkillAudits } from "../../hooks/useSkillAudits";
 import { useAvailableAgents } from "../../hooks/useAvailableAgents";
 import { type InstalledSkillMatch } from "../../hooks/useInstalledSkillMatches";
@@ -75,9 +75,7 @@ function getConfirmationMessage({
 
   if (auditRisk === "failed") {
     const failedProviders = joinWithAnd(
-      auditResult.audits
-        .filter((audit) => audit.status === "fail")
-        .map((audit) => AUDIT_PROVIDER_LABELS[audit.provider]),
+      auditResult.audits.filter((audit) => audit.status === "fail").map((audit) => formatAuditProviderLabel(audit)),
     );
     return `Security audits by ${failedProviders} failed for this skill. ${reviewMessage}`;
   }

--- a/extensions/skills/src/components/actions/OpenSecurityAuditActions.tsx
+++ b/extensions/skills/src/components/actions/OpenSecurityAuditActions.tsx
@@ -1,5 +1,5 @@
 import { Action, ActionPanel, Icon } from "@raycast/api";
-import { AUDIT_PROVIDER_LABELS, type SkillAudit } from "../../shared";
+import { formatAuditProviderLabel, type SkillAudit } from "../../shared";
 
 interface OpenSecurityAuditActionsProps {
   audits: SkillAudit[];
@@ -17,7 +17,7 @@ export function OpenSecurityAuditActions({ audits }: OpenSecurityAuditActionsPro
       {openableAudits.map((audit) => (
         <Action.OpenInBrowser
           key={audit.provider}
-          title={`Open ${AUDIT_PROVIDER_LABELS[audit.provider]} Audit`}
+          title={`Open ${formatAuditProviderLabel(audit)} Audit`}
           url={audit.url}
           icon={Icon.Shield}
         />

--- a/extensions/skills/src/shared.ts
+++ b/extensions/skills/src/shared.ts
@@ -9,21 +9,32 @@ export type Skill = {
   source: string;
 };
 
-export type AuditProvider = "agent-trust-hub" | "socket" | "snyk";
-
 export type AuditStatus = "pass" | "warn" | "fail" | "unknown";
 
 export type SkillAudit = {
-  provider: AuditProvider;
+  provider: string;
+  providerLabel?: string;
   status: AuditStatus;
   url?: string;
 };
 
-export const AUDIT_PROVIDER_LABELS: Record<AuditProvider, string> = {
+export const AUDIT_PROVIDER_LABELS: Record<string, string> = {
   "agent-trust-hub": "Gen Agent Trust Hub",
   socket: "Socket",
   snyk: "Snyk",
 };
+
+function formatSlugLabel(slug: string): string {
+  return slug
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`)
+    .join(" ");
+}
+
+export function formatAuditProviderLabel(audit: Pick<SkillAudit, "provider" | "providerLabel">): string {
+  return audit.providerLabel ?? AUDIT_PROVIDER_LABELS[audit.provider] ?? formatSlugLabel(audit.provider);
+}
 
 export type SearchResponse = {
   query: string;

--- a/extensions/skills/src/utils/skill-audits.ts
+++ b/extensions/skills/src/utils/skill-audits.ts
@@ -1,5 +1,6 @@
 import {
   API_BASE_URL,
+  SKILLS_BASE_URL,
   buildSkillUrl,
   buildGithubIssueUrl,
   type AuditStatus,
@@ -128,6 +129,13 @@ function buildSecurityAuditUrl(skill: Skill, provider: string): string {
   return `${buildSkillUrl(skill)}/security/${encodeURIComponent(provider)}`;
 }
 
+function normalizeSecurityAuditUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  if (value.startsWith("https://") || value.startsWith("http://")) return value;
+  if (value.startsWith("/")) return `${SKILLS_BASE_URL}${value}`;
+  return undefined;
+}
+
 function slugifyProviderLabel(label: string): string {
   return label
     .trim()
@@ -137,9 +145,12 @@ function slugifyProviderLabel(label: string): string {
 }
 
 type SkillAuditApiEntry = {
+  auditUrl?: unknown;
+  href?: unknown;
   provider?: unknown;
   slug?: unknown;
   status?: unknown;
+  url?: unknown;
 };
 
 type SkillAuditApiResponse = {
@@ -159,7 +170,11 @@ function parseSkillAuditApiEntry(skill: Skill, entry: SkillAuditApiEntry): Skill
     provider,
     providerLabel,
     status: parseAuditStatus(entry.status),
-    url: buildSecurityAuditUrl(skill, provider),
+    url:
+      normalizeSecurityAuditUrl(entry.url) ??
+      normalizeSecurityAuditUrl(entry.href) ??
+      normalizeSecurityAuditUrl(entry.auditUrl) ??
+      buildSecurityAuditUrl(skill, provider),
   };
 }
 

--- a/extensions/skills/src/utils/skill-audits.ts
+++ b/extensions/skills/src/utils/skill-audits.ts
@@ -1,8 +1,7 @@
 import {
+  API_BASE_URL,
   buildSkillUrl,
   buildGithubIssueUrl,
-  SKILLS_BASE_URL,
-  type AuditProvider,
   type AuditStatus,
   type Skill,
   type SkillAudit,
@@ -27,14 +26,6 @@ export type SkillAuditsResult = {
   availabilityState: SkillAuditsAvailabilityState;
   errorDetails?: SkillAuditErrorDetails;
 };
-
-const KNOWN_PROVIDERS = new Set<AuditProvider>(["agent-trust-hub", "socket", "snyk"]);
-
-function isKnownProvider(slug: string): slug is AuditProvider {
-  return KNOWN_PROVIDERS.has(slug as AuditProvider);
-}
-
-const PROVIDER_ORDER: AuditProvider[] = ["agent-trust-hub", "socket", "snyk"];
 
 function buildAuditErrorResult({
   skill,
@@ -117,117 +108,81 @@ export function buildSecurityAuditGitHubIssueUrl({
   });
 }
 
-/**
- * Normalizes the URL of an audit entry.
- *
- * @param href - The URL of an audit entry.
- * @returns The normalized URL of the audit entry.
- */
-function normalizeSecurityAuditUrl(href: string): string | undefined {
-  if (href.startsWith("https://") || href.startsWith("http://")) {
-    return href;
-  }
-  if (href.startsWith("/")) {
-    return `${SKILLS_BASE_URL}${href}`;
-  }
-  return undefined;
-}
-
-/**
- * Parses the status of a security audit from the HTML of an audit entry.
- *
- * @param entryHtml - The HTML of an audit entry.
- * @returns The status of the security audit.
- */
-function parseAuditStatusFromEntryHtml(entryHtml: string): AuditStatus {
-  const auditStatus = entryHtml.match(/\b(Pass|Warn|Fail)\b/i)?.[1]?.toLowerCase();
+function parseAuditStatus(value: unknown): AuditStatus {
+  const auditStatus = typeof value === "string" ? value.toLowerCase() : undefined;
   if (auditStatus === "pass") return "pass";
   if (auditStatus === "warn") return "warn";
   if (auditStatus === "fail") return "fail";
   return "unknown";
 }
 
-/**
- * Extracts the main content from the HTML content of a page.
- *
- * @param html - The HTML to extract the main content from.
- * @returns The main content of the HTML.
- */
-function extractMainContentFromHtml(html: string): string | undefined {
-  const lower = html.toLowerCase();
-  const mainStartIndex = lower.indexOf("<main");
-  if (mainStartIndex < 0) return undefined;
+function encodePath(value: string): string {
+  return value.split("/").map(encodeURIComponent).join("/");
+}
 
-  const contentStartIndex = lower.indexOf(">", mainStartIndex);
-  if (contentStartIndex < 0) return undefined;
+function buildSkillAuditApiUrl(skill: Skill): string {
+  return `${API_BASE_URL}/v1/skills/audit/${encodePath(skill.source)}/${encodeURIComponent(skill.skillId)}`;
+}
 
-  const mainEndIndex = lower.indexOf("</main>", contentStartIndex);
-  if (mainEndIndex < 0) return undefined;
+function buildSecurityAuditUrl(skill: Skill, provider: string): string {
+  return `${buildSkillUrl(skill)}/security/${encodeURIComponent(provider)}`;
+}
 
-  return html.slice(contentStartIndex + 1, mainEndIndex);
+function slugifyProviderLabel(label: string): string {
+  return label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+type SkillAuditApiEntry = {
+  provider?: unknown;
+  slug?: unknown;
+  status?: unknown;
+};
+
+type SkillAuditApiResponse = {
+  audits?: unknown;
+};
+
+function parseSkillAuditApiEntry(skill: Skill, entry: SkillAuditApiEntry): SkillAudit | undefined {
+  const providerLabelValue = typeof entry.provider === "string" ? entry.provider.trim() : "";
+  const providerLabel = providerLabelValue || undefined;
+  const slugValue = typeof entry.slug === "string" ? entry.slug.trim().toLowerCase() : "";
+  const slug = slugValue || undefined;
+  const provider = slug || (providerLabel ? slugifyProviderLabel(providerLabel) : undefined);
+
+  if (!provider) return undefined;
+
+  return {
+    provider,
+    providerLabel,
+    status: parseAuditStatus(entry.status),
+    url: buildSecurityAuditUrl(skill, provider),
+  };
 }
 
 /**
- * Extracts the security audit section from the HTML content of the skill's details page.
+ * Parses the security audits from the Skills audit API.
  *
- * @param mainHtml - The HTML of the skill's details page.
- * @returns The security audit section of the HTML of the skill's details page.
+ * @param body - The JSON body from the Skills audit API.
+ * @returns The security audits from the Skills audit API.
  */
-function extractSecurityAuditSection(mainHtml: string): string | undefined {
-  const lower = mainHtml.toLowerCase();
-  const sectionStartIndex = lower.indexOf("security audits");
-  if (sectionStartIndex < 0) return undefined;
-
-  const sectionHtml = mainHtml.slice(sectionStartIndex);
-  const sectionLower = sectionHtml.toLowerCase();
-
-  // NOTE: "installed on" marks the start of the installs section that follows security audits on skills.sh
-  // and marks the end of the security audits section. This is a heuristic boundary — update if the page structure changes.
-  const sectionBoundaryIndex = sectionLower.indexOf("installed on");
-  return sectionBoundaryIndex >= 0 ? sectionHtml.slice(0, sectionBoundaryIndex) : sectionHtml;
-}
-
-/**
- * Parses the security audits from the HTML of the skill's details page.
- *
- * @param html - The HTML of the skill's details page.
- * @returns The security audits from the HTML of the skill's details page.
- */
-function parseSecurityAuditsFromHtml(skill: Skill, html: string): SkillAuditsResult {
-  if (!html.trim()) {
-    return buildAuditParseErrorResult(skill, "Invalid HTML");
+function parseSecurityAuditsFromApi(skill: Skill, body: SkillAuditApiResponse): SkillAuditsResult {
+  if (!Array.isArray(body.audits)) {
+    return buildAuditParseErrorResult(skill, "The security audit API response did not include an audits array.");
   }
 
   try {
-    const mainContent = extractMainContentFromHtml(html);
-    if (!mainContent) {
-      return buildAuditParseErrorResult(skill, "The skill page content could not be parsed.");
-    }
-
-    const sectionHtml = extractSecurityAuditSection(mainContent);
-    if (!sectionHtml?.trim()) {
-      return { audits: [], availabilityState: "not-available", errorDetails: undefined };
-    }
-
     const parsedAudits: SkillAudit[] = [];
-    const auditEntryAnchorRegExp =
-      /<a[^>]*href="(?<href>[^"]*\/security\/(?<slug>[^"/?#]+)[^"]*)"[^>]*>(?<entryHtml>[\s\S]*?)<\/a>/gi;
-    for (const match of sectionHtml.matchAll(auditEntryAnchorRegExp)) {
-      const href = match.groups?.href;
-      const slug = match.groups?.slug?.toLowerCase();
-      const entryHtml = match.groups?.entryHtml;
+    for (const entry of body.audits) {
+      if (!entry || typeof entry !== "object") continue;
 
-      if (!href || !slug || !entryHtml) continue;
-      if (!isKnownProvider(slug)) continue;
-      const provider = slug;
+      const audit = parseSkillAuditApiEntry(skill, entry as SkillAuditApiEntry);
+      if (!audit) continue;
 
-      const audit: SkillAudit = {
-        provider,
-        status: parseAuditStatusFromEntryHtml(entryHtml),
-        url: normalizeSecurityAuditUrl(href),
-      };
-
-      const existingAuditIndex = parsedAudits.findIndex((existingAudit) => existingAudit.provider === provider);
+      const existingAuditIndex = parsedAudits.findIndex((existingAudit) => existingAudit.provider === audit.provider);
       if (existingAuditIndex >= 0) {
         parsedAudits[existingAuditIndex] = audit;
       } else {
@@ -235,22 +190,9 @@ function parseSecurityAuditsFromHtml(skill: Skill, html: string): SkillAuditsRes
       }
     }
 
-    const audits = PROVIDER_ORDER.map((provider) => parsedAudits.find((audit) => audit.provider === provider)).filter(
-      (audit): audit is SkillAudit => Boolean(audit),
-    );
-
-    if (audits.length > 0) {
-      return { audits, availabilityState: "available", errorDetails: undefined };
-    }
-
-    const hasSecurityLinkRegExp = /<a[^>]*href="[^"]*\/security\/[^"]*"[^>]*>/i;
-    if (hasSecurityLinkRegExp.test(sectionHtml)) {
-      return buildAuditParseErrorResult(skill, "The security audit data could not be parsed reliably.");
-    }
-
     return {
-      audits: [],
-      availabilityState: "not-available",
+      audits: parsedAudits,
+      availabilityState: parsedAudits.length > 0 ? "available" : "not-available",
       errorDetails: undefined,
     };
   } catch (error) {
@@ -260,18 +202,18 @@ function parseSecurityAuditsFromHtml(skill: Skill, html: string): SkillAuditsRes
 }
 
 /**
- * Fetches the security audits for a skill from the Skills website.
+ * Fetches the security audits for a skill from the Skills audit API.
  *
  * @param skill - The skill to fetch the security audits for.
  * @returns The security audits for the skill.
  */
 export async function fetchSkillAudits(skill: Skill): Promise<SkillAuditsResult> {
-  const detailUrl = buildSkillUrl(skill);
+  const auditApiUrl = buildSkillAuditApiUrl(skill);
   const timeoutSignal = typeof AbortSignal.timeout === "function" ? AbortSignal.timeout(10_000) : undefined;
 
   let response: Response;
   try {
-    response = await fetch(detailUrl, { signal: timeoutSignal });
+    response = await fetch(auditApiUrl, { signal: timeoutSignal });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return buildAuditFetchErrorResult({
@@ -289,9 +231,9 @@ export async function fetchSkillAudits(skill: Skill): Promise<SkillAuditsResult>
     });
   }
 
-  let body: string;
+  let body: SkillAuditApiResponse;
   try {
-    body = await response.text();
+    body = (await response.json()) as SkillAuditApiResponse;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return buildAuditFetchErrorResult({
@@ -301,5 +243,5 @@ export async function fetchSkillAudits(skill: Skill): Promise<SkillAuditsResult>
     });
   }
 
-  return parseSecurityAuditsFromHtml(skill, body);
+  return parseSecurityAuditsFromApi(skill, body);
 }


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

This replaces the Skills extension's security audit HTML scraping with the JSON audit API exposed by skills.sh. The previous parser depended on page structure and a fixed provider list, while the API returns structured audit entries and can include newer providers such as Runlayer and ZeroLeaks. The UI now formats provider labels from the API response when available and falls back gracefully for unknown provider slugs.

## Screencast

Before

<img width="1504" height="946" alt="2026-06-26 at 10 16 59" src="https://github.com/user-attachments/assets/e1185aa2-d44c-4831-a6fd-f33e9b4bb59f" />

After

<img width="1504" height="950" alt="2026-06-26 at 10 17 47" src="https://github.com/user-attachments/assets/2a2c725a-45f3-4393-8e4d-907dfd331ffa" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
