### PR TITLE
[sesh] Force UTF-8 locale

### DIFF
--- a/extensions/sesh/CHANGELOG.md
+++ b/extensions/sesh/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Sesh Changelog
 
+## [Force LANG / LC_ALL to UTF-8 Locale] - 2026-06-26
+- Force LANG and LC_ALL to UTF-8 to allow emoji and other multibyte names to be rendered correctly
+
 ## [Make PATH configurable] - 2025-10-09
 - Add a user-setting for the PATH variable
 

--- a/extensions/sesh/CHANGELOG.md
+++ b/extensions/sesh/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Sesh Changelog
 
-## [Force LANG / LC_ALL to UTF-8 Locale] - {PR_MERGE_DATE}
+## [Force LANG / LC_ALL to UTF-8 Locale] - 2026-06-26
 - Force LANG and LC_ALL to UTF-8 to allow emoji and other multibyte names to be rendered correctly
 
 ## [Make PATH configurable] - 2025-10-09

--- a/extensions/sesh/CHANGELOG.md
+++ b/extensions/sesh/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Sesh Changelog
 
-## [Force LANG / LC_ALL to UTF-8 Locale] - 2026-06-26
+## [Force LANG / LC_ALL to UTF-8 Locale] - {PR_MERGE_DATE}
 - Force LANG and LC_ALL to UTF-8 to allow emoji and other multibyte names to be rendered correctly
 
 ## [Make PATH configurable] - 2025-10-09

--- a/extensions/sesh/src/env.ts
+++ b/extensions/sesh/src/env.ts
@@ -12,6 +12,8 @@ export function getEnv() {
 
   const env = Object.assign({}, process.env, {
     PATH: pathString,
+    LANG: "en_US.UTF-8",
+    LC_ALL: "en_US.UTF-8",
   });
 
   return env;


### PR DESCRIPTION
Forcing LANG/LC_ALL to UTF-8 locale so emoji and other multibyte names render correctly (currently are replaced with "_").