### PR TITLE
Update obsidian extension

### DIFF
--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Obsidian Changelog
 
-## [Add] - {PR_MERGE_DATE}
+## [Add] - 2026-06-28
 
 - Added vault path display to the Open Vault command
 

--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Obsidian Changelog
 
+## [Add] - {PR_MERGE_DATE}
+
+- Added vault path display to the Open Vault command
+
 ## [Fix] - 2026-05-05
 
 - Fix vault auto-discovery on Windows and Linux by reading `obsidian.json` from the per-platform Obsidian config dir

--- a/extensions/obsidian/package-lock.json
+++ b/extensions/obsidian/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.94.0",
@@ -1777,7 +1777,6 @@
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1879,7 +1878,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2319,7 +2317,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2795,7 +2792,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4143,7 +4139,6 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -4587,7 +4582,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4705,7 +4699,6 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4746,7 +4739,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5347,7 +5339,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5361,7 +5352,6 @@
       "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.6",
@@ -5551,7 +5541,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/extensions/obsidian/package.json
+++ b/extensions/obsidian/package.json
@@ -22,7 +22,8 @@
     "chris_van_es",
     "vicampuzano",
     "ErBlack",
-    "byheaven"
+    "byheaven",
+    "tofrankie"
   ],
   "license": "MIT",
   "preferences": [
@@ -715,5 +716,5 @@
     "macOS",
     "Windows"
   ],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/extensions/obsidian/src/openVaultCommand.tsx
+++ b/extensions/obsidian/src/openVaultCommand.tsx
@@ -4,6 +4,7 @@ import { NoVaultFoundMessage } from "./components/Notifications/NoVaultFoundMess
 import { Obsidian, ObsidianTargetType } from "@/obsidian";
 import { ShowVaultInFinderAction, CopyVaultPathAction } from "./utils/actions";
 import { useObsidianVaults } from "./utils/hooks";
+import { simplifyHomePath } from "./utils/utils";
 
 export default function Command() {
   const { ready, vaults } = useObsidianVaults();
@@ -30,6 +31,7 @@ export default function Command() {
           <List.Item
             title={vault.name}
             key={vault.key}
+            accessories={[{ text: simplifyHomePath(vault.path) }]}
             actions={
               <ActionPanel>
                 <Action.Open

--- a/extensions/obsidian/src/runActionCommand.tsx
+++ b/extensions/obsidian/src/runActionCommand.tsx
@@ -221,7 +221,9 @@ export default function RunActionCommand(props: LaunchProps<{ launchContext?: { 
               <Action.Push title="Run Action" target={<ActionInput action={a} />} icon={Icon.Play} />
               <Action.CopyToClipboard
                 title="Copy Quicklink URL"
-                content={`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/marcjulian/obsidian/runActionCommand?launchContext=${encodeURIComponent(
+                content={`${
+                  process.env.RAYCAST_SCHEME ?? "raycast"
+                }://extensions/marcjulian/obsidian/runActionCommand?launchContext=${encodeURIComponent(
                   JSON.stringify({ actionId: a.id })
                 )}`}
                 shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}

--- a/extensions/obsidian/src/utils/utils.ts
+++ b/extensions/obsidian/src/utils/utils.ts
@@ -1,6 +1,7 @@
 import { Note } from "@/obsidian";
 import { getPreferenceValues, getSelectedText, Icon } from "@raycast/api";
 import fs from "fs";
+import { homedir } from "os";
 import path from "path";
 import {
   AUDIO_FILE_EXTENSIONS,
@@ -58,6 +59,25 @@ export function trimPathToMaxLength(path: string, maxLength: number) {
   } else {
     return path.slice(1);
   }
+}
+
+export function simplifyHomePath(filePath: string) {
+  const userHome = homedir();
+
+  // I'm not sure which symbol Windows users expect for their home directory, so we leave it untouched for now.
+  if (process.platform === "win32") {
+    return filePath;
+  }
+
+  if (filePath === userHome) {
+    return "~";
+  }
+
+  if (filePath.startsWith(`${userHome}${path.sep}`)) {
+    return `~${filePath.slice(userHome.length)}`;
+  }
+
+  return filePath;
 }
 
 /**


### PR DESCRIPTION
## Description

Added vault path display to the Open Vault command

## Screencast

<img width="762" height="486" alt="image" src="https://github.com/user-attachments/assets/17c67a22-9e2c-45ff-b806-00df24b8dbf4" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
