### PR TITLE
Show Codex reset credit expiration times

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Agent Usage Changelog
 
+## [Show Codex Reset Credits] - 2026-06-28
+
+- Show Codex reset credits and their expiration times in Codex usage details
+
 ## [Support Claude Config Directory] - 2026-06-16
 
 - Respect `CLAUDE_CONFIG_DIR` when reading Claude credentials

--- a/extensions/agent-usage/src/codex/fetcher.test.ts
+++ b/extensions/agent-usage/src/codex/fetcher.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("parseCodexResetCreditsResponse returns available credits sorted by expiration", async () => {
+  const { parseCodexResetCreditsResponse } = await import("./fetcher");
+
+  const result = parseCodexResetCreditsResponse({
+    available_count: 2,
+    credits: [
+      {
+        id: "later",
+        status: "available",
+        expires_at: "2026-07-27T00:05:33.936875Z",
+      },
+      {
+        id: "used",
+        status: "consumed",
+        expires_at: "2026-07-20T00:05:33.936875Z",
+      },
+      {
+        id: "earlier",
+        status: "available",
+        expires_at: "2026-07-18T00:44:44.314142Z",
+      },
+    ],
+  });
+
+  assert.deepEqual(result, {
+    availableCount: 2,
+    credits: [
+      {
+        id: "earlier",
+        expiresAt: "2026-07-18T00:44:44.314142Z",
+      },
+      {
+        id: "later",
+        expiresAt: "2026-07-27T00:05:33.936875Z",
+      },
+    ],
+  });
+});
+
+test("parseCodexResetCreditsResponse falls back to listed credits count", async () => {
+  const { parseCodexResetCreditsResponse } = await import("./fetcher");
+
+  const result = parseCodexResetCreditsResponse({
+    credits: [
+      {
+        expires_at: "2026-07-18T00:44:44.314142Z",
+      },
+    ],
+  });
+
+  assert.equal(result?.availableCount, 1);
+  assert.equal(result?.credits.length, 1);
+});

--- a/extensions/agent-usage/src/codex/fetcher.ts
+++ b/extensions/agent-usage/src/codex/fetcher.ts
@@ -6,6 +6,7 @@ import { loadAccounts } from "../accounts/storage";
 import type { AccountUsageState } from "../accounts/types";
 
 const CODEX_USAGE_API = "https://chatgpt.com/backend-api/wham/usage";
+const CODEX_RESET_CREDITS_API = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
 
 const CODEX_HEADERS = {
   Accept: "application/json",
@@ -14,16 +15,40 @@ const CODEX_HEADERS = {
 };
 
 export async function fetchCodexUsage(token: string): Promise<{ usage: CodexUsage | null; error: CodexError | null }> {
-  const { data, error } = await httpFetch({
-    url: CODEX_USAGE_API,
-    headers: { ...CODEX_HEADERS, Authorization: normalizeBearerToken(token) },
-    unauthorizedMessage: "Authorization token expired or invalid. Run 'codex login' to refresh credentials.",
-  });
+  const [usageResponse, resetCredits] = await Promise.all([
+    httpFetch({
+      url: CODEX_USAGE_API,
+      headers: { ...CODEX_HEADERS, Authorization: normalizeBearerToken(token) },
+      unauthorizedMessage: "Authorization token expired or invalid. Run 'codex login' to refresh credentials.",
+    }),
+    fetchCodexResetCredits(token),
+  ]);
+
+  const { data, error } = usageResponse;
   if (error) return { usage: null, error };
-  return parseCodexApiResponse(data);
+  const result = parseCodexApiResponse(data);
+  if (result.usage && resetCredits) {
+    result.usage.resetCredits = resetCredits;
+  }
+  return result;
 }
 
-function parseCodexApiResponse(data: unknown): { usage: CodexUsage | null; error: CodexError | null } {
+async function fetchCodexResetCredits(token: string): Promise<CodexUsage["resetCredits"] | null> {
+  const { data, error } = await httpFetch({
+    url: CODEX_RESET_CREDITS_API,
+    headers: {
+      ...CODEX_HEADERS,
+      Authorization: normalizeBearerToken(token),
+      "OAI-Product-Sku": "CODEX",
+    },
+    unauthorizedMessage: "Authorization token expired or invalid. Run 'codex login' to refresh credentials.",
+  });
+
+  if (error) return null;
+  return parseCodexResetCreditsResponse(data);
+}
+
+export function parseCodexApiResponse(data: unknown): { usage: CodexUsage | null; error: CodexError | null } {
   try {
     if (!data || typeof data !== "object") {
       return {
@@ -114,6 +139,49 @@ function parseCodexApiResponse(data: unknown): { usage: CodexUsage | null; error
       },
     };
   }
+}
+
+export function parseCodexResetCreditsResponse(data: unknown): CodexUsage["resetCredits"] | null {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+
+  const response = data as {
+    available_count?: number | string;
+    credits?: {
+      id?: string;
+      status?: string;
+      expires_at?: string;
+    }[];
+  };
+
+  const credits = Array.isArray(response.credits)
+    ? response.credits
+        .filter((credit) => {
+          return (
+            typeof credit.expires_at === "string" &&
+            credit.expires_at.length > 0 &&
+            (!credit.status || credit.status === "available")
+          );
+        })
+        .map((credit) => ({
+          id: credit.id ?? null,
+          expiresAt: credit.expires_at as string,
+        }))
+        .sort((a, b) => new Date(a.expiresAt).getTime() - new Date(b.expiresAt).getTime())
+    : [];
+
+  const availableCount =
+    typeof response.available_count === "number"
+      ? response.available_count
+      : typeof response.available_count === "string"
+        ? Number.parseInt(response.available_count, 10)
+        : credits.length;
+
+  return {
+    availableCount: Number.isFinite(availableCount) ? availableCount : credits.length,
+    credits,
+  };
 }
 
 export { formatDuration } from "../agents/format";

--- a/extensions/agent-usage/src/codex/renderer.tsx
+++ b/extensions/agent-usage/src/codex/renderer.tsx
@@ -1,7 +1,7 @@
 import { List } from "@raycast/api";
 import { CodexUsage, CodexError } from "./types";
 import type { Accessory } from "../agents/types";
-import { formatDuration } from "../agents/format";
+import { formatDuration, formatResetTime } from "../agents/format";
 import {
   renderErrorOrNoData,
   formatErrorOrNoData,
@@ -10,6 +10,18 @@ import {
   generatePieIcon,
   generateAsciiBar,
 } from "../agents/ui";
+
+function formatResetCreditExpiry(expiresAt: string): string {
+  const date = new Date(expiresAt);
+  if (Number.isNaN(date.getTime())) return formatResetTime(expiresAt);
+
+  return `${formatResetTime(expiresAt)} (${date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })})`;
+}
 
 export function formatCodexUsageText(usage: CodexUsage | null, error: CodexError | null): string {
   const fallback = formatErrorOrNoData("Codex", usage, error);
@@ -27,6 +39,13 @@ export function formatCodexUsageText(usage: CodexUsage | null, error: CodexError
   if (u.codeReviewLimit) {
     text += `\n\nCode Review Limit: ${u.codeReviewLimit.percentageRemaining}% remaining`;
     text += `\nResets In: ${formatDuration(u.codeReviewLimit.resetsInSeconds)}`;
+  }
+
+  if (u.resetCredits) {
+    text += `\n\nReset Credits: ${u.resetCredits.availableCount} available`;
+    for (const [index, credit] of u.resetCredits.credits.entries()) {
+      text += `\nReset #${index + 1} Expires: ${formatResetCreditExpiry(credit.expiresAt)}`;
+    }
   }
 
   text += `\n\nCredits: ${u.credits.unlimited ? "Unlimited" : u.credits.balance}`;
@@ -70,6 +89,20 @@ export function renderCodexDetail(usage: CodexUsage | null, error: CodexError | 
       )}
 
       <List.Item.Detail.Metadata.Separator />
+
+      {u.resetCredits && (
+        <>
+          <List.Item.Detail.Metadata.Label title="Reset Credits" text={`${u.resetCredits.availableCount} available`} />
+          {u.resetCredits.credits.map((credit, index) => (
+            <List.Item.Detail.Metadata.Label
+              key={`${credit.id ?? "reset-credit"}-${credit.expiresAt}`}
+              title={`Reset #${index + 1} Expires`}
+              text={formatResetCreditExpiry(credit.expiresAt)}
+            />
+          ))}
+          <List.Item.Detail.Metadata.Separator />
+        </>
+      )}
 
       <List.Item.Detail.Metadata.Label title="Credits" text={u.credits.unlimited ? "Unlimited" : u.credits.balance} />
     </List.Item.Detail.Metadata>

--- a/extensions/agent-usage/src/codex/types.ts
+++ b/extensions/agent-usage/src/codex/types.ts
@@ -20,6 +20,13 @@ export interface CodexUsage {
     unlimited: boolean;
     balance: string;
   };
+  resetCredits?: {
+    availableCount: number;
+    credits: {
+      id: string | null;
+      expiresAt: string;
+    }[];
+  };
 }
 
 export interface CodexError {


### PR DESCRIPTION
## Summary
- fetch Codex reset credits from the wham reset-credit endpoint alongside usage data
- show available reset credits and each expiration time in Codex detail metadata and markdown text
- add parser coverage for reset-credit response filtering and expiration ordering

## Validation
- npm run lint
- npm run build
- npm test (fails in this local Node environment because existing extensionless TypeScript imports cannot be resolved by the current node --test ESM loader)