### PR TITLE
Update trakt-manager extension

### DIFF
--- a/extensions/trakt-manager/.prettierrc
+++ b/extensions/trakt-manager/.prettierrc
@@ -1,5 +1,4 @@
 {
   "printWidth": 120,
-  "singleQuote": false,
-  "plugins": ["prettier-plugin-organize-imports"]
+  "singleQuote": false
 }

--- a/extensions/trakt-manager/CHANGELOG.md
+++ b/extensions/trakt-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Trakt Manager Changelog
 
-## [Update] - 2026-06-28
+## [Update] - {PR_MERGE_DATE}
 
 ### Added
 

--- a/extensions/trakt-manager/CHANGELOG.md
+++ b/extensions/trakt-manager/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Trakt Manager Changelog
 
+## [Update] - 2026-06-28
+
+### Added
+
+- **Search Media** command — search movies and TV shows in a single query, with results from both Trakt search endpoints merged into one grid. Reduces friction for users who previously had to run separate Search Movies and Search Shows commands to find what they want.
+- **All** filter for **History** — view movie and episode history together in one timeline, sorted by watch date (newest first). Matches how Trakt.tv presents history and avoids switching filters to see recent activity across both media types.
+- **All** filter for **Watchlist** — view movies and shows together, sorted by date added (newest first). The default view now shows the full watchlist at a glance; Movies and Shows filters remain available.
+
+### Changed
+
+- History and Watchlist use a unified grid implementation when browsing combined results, with per-type actions preserved (e.g. View Details for movies, Browse Seasons for shows).
+
+### Breaking Changes
+
+- None. Existing commands (Search Movies, Search Shows, etc.) are unchanged and remain available.
+
 ## [Update] - 2026-03-25
 
 - Fixed episode check-in sending the show's Trakt ID instead of the episode's Trakt ID (#23638)

--- a/extensions/trakt-manager/CHANGELOG.md
+++ b/extensions/trakt-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Trakt Manager Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-06-29
 
 ### Added
 

--- a/extensions/trakt-manager/eslint.config.js
+++ b/extensions/trakt-manager/eslint.config.js
@@ -1,4 +1,0 @@
-const { defineConfig } = require("eslint/config");
-const raycastConfig = require("@raycast/eslint-config");
-
-module.exports = defineConfig([...raycastConfig]);

--- a/extensions/trakt-manager/eslint.config.mjs
+++ b/extensions/trakt-manager/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { defineConfig } from "eslint/config";
+import raycastConfig from "@raycast/eslint-config";
+
+export default defineConfig([...raycastConfig]);

--- a/extensions/trakt-manager/package-lock.json
+++ b/extensions/trakt-manager/package-lock.json
@@ -8,25 +8,24 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.20",
-        "@raycast/utils": "^1.18.1",
-        "@ts-rest/core": "^3.51.0",
+        "@raycast/utils": "^2.2.7",
+        "@ts-rest/core": "^3.53.0-rc.1",
         "node-fetch": "^3.3.2",
-        "zod": "^3.24.1"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@raycast/eslint-config": "^2.1.1",
-        "@types/node": "20.8.10",
-        "@types/react": "19.0.10",
-        "eslint": "^10.1.0",
-        "prettier-plugin-organize-imports": "^4.1.0",
-        "syncpack": "^14.2.0",
-        "typescript": "^5.7.3"
+        "@raycast/eslint-config": "^2.2.0",
+        "@types/node": "26.0.1",
+        "@types/react": "19.2.17",
+        "eslint": "^10.6.0",
+        "syncpack": "^15.3.2",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -40,9 +39,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -56,9 +55,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -72,9 +71,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -88,9 +87,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +103,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -120,9 +119,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -136,9 +135,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -152,9 +151,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -168,9 +167,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -184,9 +183,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -200,9 +199,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -216,9 +215,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -232,9 +231,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -248,9 +247,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -264,9 +263,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -280,9 +279,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -296,9 +295,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -312,9 +311,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -328,9 +327,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -344,9 +343,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -360,9 +359,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -376,9 +375,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -392,9 +391,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -408,9 +407,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -424,9 +423,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -469,13 +468,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.3",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
         "minimatch": "^10.2.4"
       },
@@ -484,22 +483,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -509,10 +508,23 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -520,13 +532,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -534,25 +546,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -562,6 +588,7 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
       },
@@ -663,26 +690,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/@inquirer/core/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@inquirer/core/node_modules/wrap-ansi": {
@@ -953,9 +960,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.10.2.tgz",
-      "integrity": "sha512-3GvDh5nqpIE8566qUF5cBHKog9DFV9XgBeuR0nUrz0OMuz2FPYHat1AZHOwyQbvH9OKL4gJNQZHcsDOqDM/FRA==",
+      "version": "4.11.11",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.11.tgz",
+      "integrity": "sha512-LoGzrvkH9I8dwhxuLafcf90MAp+fYfAiAhpyixaVAWaclIgs+vXeMMQwBG90/wqjdygIKcFAqNnNJrfl3s3X8Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -968,11 +975,11 @@
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
-        "minimatch": "^10.2.4",
-        "semver": "^7.7.3",
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
         "string-width": "^4.2.3",
         "supports-color": "^8",
-        "tinyglobby": "^0.2.14",
+        "tinyglobby": "^0.2.17",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -981,45 +988,10 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/@oclif/plugin-autocomplete": {
-      "version": "3.2.42",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.42.tgz",
-      "integrity": "sha512-VPL/XJDKhtDxZLTGdtbrAW3FQyCvTaFldBFs+u6XdeSN8PazmU+K8oPiVUsrm1jUYUx3HeVTopce7ap5t+8TFg==",
+      "version": "3.2.53",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.53.tgz",
+      "integrity": "sha512-cGAgN9ujTDxa6C84d6XNVsmoFnDFfHwdiykAnAfym3oBLxoXBNYMZhmfnZ8KBWDy/r/DYf11BrGJwqKl2P0iSA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
@@ -1032,9 +1004,9 @@
       }
     },
     "node_modules/@oclif/plugin-help": {
-      "version": "6.2.39",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.39.tgz",
-      "integrity": "sha512-g/KQ5F68cLZWjm0f/bY2zKjrhYaz941++zp4xeWRtOPeu6U6pEfyBDxaOH5HncWw1qouJGsVQcGdU0ygN8eXTQ==",
+      "version": "6.2.53",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.53.tgz",
+      "integrity": "sha512-njx2nTH87EQEEuz4ShNtL0gzzN981MRkDPqScbu+Tkd7NpIv30OHdTjQK1GzGtkf+V2RvSYIrX+LrLsUVh9DJw==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4"
@@ -1044,27 +1016,18 @@
       }
     },
     "node_modules/@oclif/plugin-not-found": {
-      "version": "3.2.76",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.76.tgz",
-      "integrity": "sha512-YM1S38iHHU4t5zaUuCbOpMXeyYK3uZuqdgRSUFSw29+Rsyw4wXvH9gBvOFm7/RzmqpLNMXwjzO9Dg5mQHNgOWg==",
+      "version": "3.2.88",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.88.tgz",
+      "integrity": "sha512-5YTKSpuV77910/iGnGsj0fr9kOazCy/h1brki1CocbfawdvaVPedcwCH25wMcdRfo8mFD656bG9/kdki/+Wb9A==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",
-        "@oclif/core": "^4.10.2",
+        "@oclif/core": "^4.11.7",
         "ansis": "^3.17.0",
         "fast-levenshtein": "^3.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-not-found/node_modules/fast-levenshtein": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz",
-      "integrity": "sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "fastest-levenshtein": "^1.0.7"
       }
     },
     "node_modules/@raycast/api": {
@@ -1114,6 +1077,15 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@raycast/api/node_modules/@types/react": {
+      "version": "19.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
+      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@raycast/api/node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -1121,94 +1093,65 @@
       "license": "MIT"
     },
     "node_modules/@raycast/eslint-config": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.1.1.tgz",
-      "integrity": "sha512-W0kxF+FJ+BYQn0EKIV739j2ZrHEtjo/LclsoZgUWg3t364Dq75XKcjqYFYx+59/DBaamY0amdajlfuDAf6veAg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.2.0.tgz",
+      "integrity": "sha512-uS/UDvM+3HfABgYhLYnIv0y+IVu+rGiZZIMwQsO5EGrcf2/TX/yioTzfezAQqhdszW4ViCuHbv8BddIagDKZvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint/js": "^9.36.0",
-        "@raycast/eslint-plugin": "^2.1.1",
+        "@eslint/js": "^9.39.4",
+        "@raycast/eslint-plugin": "^2.2.0",
         "eslint-config-prettier": "^10.1.8",
-        "globals": "^16.4.0",
-        "typescript-eslint": "^8.45.0"
+        "globals": "^17.7.0",
+        "typescript-eslint": "^8.62.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.23.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "prettier": ">=2",
-        "typescript": ">=4"
-      }
-    },
-    "node_modules/@raycast/eslint-config/node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
-    "node_modules/@raycast/eslint-config/node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@raycast/eslint-plugin": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-2.1.1.tgz",
-      "integrity": "sha512-r2gs8uIlNp6I2mLOyN/kReGlvigzEeuyQPl4yw7nwLy8Zxjfjhg8txMViaBux8juBWBxbSWq/IfW6ZA50oeOHQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-2.2.0.tgz",
+      "integrity": "sha512-ixO3PoRAEAZZcSQeRPvvDS/vs09D47tXdyXrs7hctoxxPtweXgJ6I24kjCD5GuuuQS5hGTiuL+Uy6hIg6a/a4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.26.1"
+        "@typescript-eslint/utils": "^8.62.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.23.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-1.18.1.tgz",
-      "integrity": "sha512-fNrybWovB5WSiotqrExMNVWtODH5DATFMvqJboIjwM2X8Ddvgt7tkf2Ol0vA0UBDVaGwDV+jpX/ZBhMnjz5TzQ==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.7.tgz",
+      "integrity": "sha512-1jV9tKLluP0Av/ICcl/yvVzCj7mY6F3wnKsh8SJpy/Fsqq/LCFXcI6TgMabIJ45AaDVhEV+JH9jS1lJSwBgiMw==",
       "license": "MIT",
       "dependencies": {
-        "cross-fetch": "^3.1.6",
-        "dequal": "^2.0.3",
-        "object-hash": "^3.0.0",
-        "signal-exit": "^4.0.2",
-        "stream-chain": "^2.2.5",
-        "stream-json": "^1.8.0"
+        "dequal": "^2.0.3"
       },
       "peerDependencies": {
-        "@raycast/api": ">=1.69.0"
+        "@raycast/api": ">=1.99.4",
+        "react": ">=19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ts-rest/core": {
-      "version": "3.51.0",
-      "resolved": "https://registry.npmjs.org/@ts-rest/core/-/core-3.51.0.tgz",
-      "integrity": "sha512-v6lnWEcpZj1UgN9wb84XQ+EORP1QEtncFumoXMJjno5ZUV6vdjKze3MYcQN0C6vjBpIJPQEaI/gab2jr4/0KzQ==",
+      "version": "3.53.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ts-rest/core/-/core-3.53.0-rc.1.tgz",
+      "integrity": "sha512-hDMXqKHSys6w+kXFW1Q6EvN8QgRvtXKXJ2TpYByKI4TquaPjiTOv99aLD26X4LNRzdna8Ci1PVyzr0jYZv0oNQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@types/node": "^18.18.7 || >=20.8.4",
-        "zod": "^3.22.3"
+        "@types/node": "^18.18.7 || >=20.8.4"
       },
       "peerDependenciesMeta": {
         "@types/node": {
-          "optional": true
-        },
-        "zod": {
           "optional": true
         }
       }
@@ -1221,9 +1164,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1235,39 +1178,41 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.8.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
-      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
-      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
-      "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.57.1",
-        "@typescript-eslint/type-utils": "8.57.1",
-        "@typescript-eslint/utils": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1277,9 +1222,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.57.1",
+        "@typescript-eslint/parser": "^8.62.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -1293,16 +1238,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
-      "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.57.1",
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/typescript-estree": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1314,18 +1260,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
-      "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.57.1",
-        "@typescript-eslint/types": "^8.57.1",
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1336,18 +1282,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
-      "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1"
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1358,9 +1304,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
-      "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1371,21 +1317,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
-      "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/typescript-estree": "8.57.1",
-        "@typescript-eslint/utils": "8.57.1",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1396,13 +1342,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
-      "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1414,21 +1360,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
-      "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.57.1",
-        "@typescript-eslint/tsconfig-utils": "8.57.1",
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1",
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1438,20 +1384,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
-      "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.57.1",
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/typescript-estree": "8.57.1"
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1462,17 +1408,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
-      "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/types": "8.62.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1497,11 +1443,12 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1520,9 +1467,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1555,6 +1502,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1563,6 +1511,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1589,23 +1538,30 @@
       "license": "MIT"
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "license": "MIT"
     },
     "node_modules/clean-stack": {
@@ -1627,6 +1583,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -1647,6 +1604,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1657,36 +1615,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
-    "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1704,14 +1634,16 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -1737,7 +1669,8 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -1763,10 +1696,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1776,38 +1715,39 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1816,18 +1756,22 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
-      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.3",
-        "@eslint/config-helpers": "^0.5.3",
-        "@eslint/core": "^1.1.1",
-        "@eslint/plugin-kit": "^0.6.1",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -1911,6 +1855,7 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2023,10 +1968,13 @@
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz",
+      "integrity": "sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fastest-levenshtein": "^1.0.7"
+      }
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -2035,6 +1983,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fetch-blob": {
@@ -2051,6 +2016,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -2081,6 +2047,21 @@
         "minimatch": "^5.0.1"
       }
     },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -2098,6 +2079,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -2134,6 +2116,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -2155,6 +2138,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -2162,10 +2146,24 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2201,6 +2199,7 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
@@ -2234,6 +2233,7 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2252,6 +2252,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2313,7 +2314,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -2330,6 +2332,7 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -2355,6 +2358,7 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -2366,39 +2370,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/ms": {
@@ -2420,12 +2403,14 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
       "funding": [
         {
           "type": "github",
@@ -2436,6 +2421,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
@@ -2444,6 +2430,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -2457,20 +2444,12 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
-    "node_modules/object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -2483,11 +2462,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/optionator/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -2503,6 +2490,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -2518,6 +2506,7 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2543,6 +2532,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2555,15 +2545,17 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.1.tgz",
+      "integrity": "sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -2573,23 +2565,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-plugin-organize-imports": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.1.0.tgz",
-      "integrity": "sha512-5aWRdCgv645xaa58X8lOxzZoiHAldAPChljr/MT0crXVOWTZ+Svl4hIWlz+niYSlO6ikE5UXkN1JrRvIP2ut0A==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "prettier": ">=2.0",
-        "typescript": ">=2.9",
-        "vue-tsc": "^2.1.0"
-      },
-      "peerDependenciesMeta": {
-        "vue-tsc": {
-          "optional": true
-        }
       }
     },
     "node_modules/punycode": {
@@ -2618,9 +2593,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2664,25 +2639,25 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/stream-chain": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
-      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/stream-json": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.8.0.tgz",
-      "integrity": "sha512-HZfXngYHUAr1exT4fxlbc1IOce1RYxp2ldeaf97LYCOPSoOqY/1Psp7iGvpb+6JIOgkra9zDYnPX01hGAHzEPw==",
-      "license": "BSD-3-Clause",
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
-        "stream-chain": "^2.2.5"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2690,10 +2665,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/syncpack": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/syncpack/-/syncpack-14.2.0.tgz",
-      "integrity": "sha512-ZQFEYD6Tq5lwbFkeDM+8ZhNxQlZ6MZcc1TM0KjwI3DpDAm8dWJE5FPlXPGAKtPNvX66MJVueTZPtYwAvBrSQWQ==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/syncpack/-/syncpack-15.3.2.tgz",
+      "integrity": "sha512-RKYfXFQlrIWosTheNbyJg3xHNjTDrW2mOvwxAz3XGghrUDN4hDjhKPCTAQrUtGZw9hNeIr37qRO3/+EP927Vtg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2706,20 +2696,20 @@
         "url": "https://github.com/sponsors/JamieMason"
       },
       "optionalDependencies": {
-        "syncpack-darwin-arm64": "14.2.0",
-        "syncpack-darwin-x64": "14.2.0",
-        "syncpack-linux-arm64": "14.2.0",
-        "syncpack-linux-arm64-musl": "14.2.0",
-        "syncpack-linux-x64": "14.2.0",
-        "syncpack-linux-x64-musl": "14.2.0",
-        "syncpack-windows-arm64": "14.2.0",
-        "syncpack-windows-x64": "14.2.0"
+        "syncpack-darwin-arm64": "15.3.2",
+        "syncpack-darwin-x64": "15.3.2",
+        "syncpack-linux-arm64": "15.3.2",
+        "syncpack-linux-arm64-musl": "15.3.2",
+        "syncpack-linux-x64": "15.3.2",
+        "syncpack-linux-x64-musl": "15.3.2",
+        "syncpack-windows-arm64": "15.3.2",
+        "syncpack-windows-x64": "15.3.2"
       }
     },
     "node_modules/syncpack-darwin-arm64": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/syncpack-darwin-arm64/-/syncpack-darwin-arm64-14.2.0.tgz",
-      "integrity": "sha512-+oOucezHzqvUfdRowva3KS4d08H2QSxiPAGrSS3j3zrJJSoscelM5j6fbtXiv9lghNxwAJVPdgXdBO5xGGKA+A==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/syncpack-darwin-arm64/-/syncpack-darwin-arm64-15.3.2.tgz",
+      "integrity": "sha512-rQwZOvWJbvUzhBySbKnvs+F5khmdkH2W/kTZo+zz6UfH651K9z2fiOYlcpDPX0L97m566gRxVmOr930ygB97ZQ==",
       "cpu": [
         "arm64"
       ],
@@ -2734,9 +2724,9 @@
       }
     },
     "node_modules/syncpack-darwin-x64": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/syncpack-darwin-x64/-/syncpack-darwin-x64-14.2.0.tgz",
-      "integrity": "sha512-l+kR78DeuLWPyHNJvs/Q8W8OgF4PGGqTtYbmCTDoim4v46J8C+moDBsd+7OmHsLC6lMxOetvGz3EYgNpyFGIIg==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/syncpack-darwin-x64/-/syncpack-darwin-x64-15.3.2.tgz",
+      "integrity": "sha512-91CWe9Pamfmlm2nY8bCL5z8GYOafGJUm/nQqtvaQDZ9SS25c6Gn8LDfRu6JSKV0dcI1zOH3EiRCM0K/kn9Mpiw==",
       "cpu": [
         "x64"
       ],
@@ -2751,9 +2741,9 @@
       }
     },
     "node_modules/syncpack-linux-arm64": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/syncpack-linux-arm64/-/syncpack-linux-arm64-14.2.0.tgz",
-      "integrity": "sha512-SCR+HT8SHU3vvjSWZi8ViSZjGZv2PaI1ak/EqQsH/oz7h6UzR8DITmOUEy+O++r6Ka8zrxloV9FL1HzuZnxFYQ==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/syncpack-linux-arm64/-/syncpack-linux-arm64-15.3.2.tgz",
+      "integrity": "sha512-eApeUFLb8yFHAFnCyHicDieTBW0eR3HsaKSWPMmz+VOQOpZYl0cmqbRLtunsYN6OykRi9Sl1faYjKmyETow7Gg==",
       "cpu": [
         "arm64"
       ],
@@ -2768,9 +2758,9 @@
       }
     },
     "node_modules/syncpack-linux-arm64-musl": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/syncpack-linux-arm64-musl/-/syncpack-linux-arm64-musl-14.2.0.tgz",
-      "integrity": "sha512-xfoTKDl8QoQiHdg393ua50SdayWq/kyrolEylXcoz0FI0mxc76UYmBUKrr/u6XzNRXfb0cgR8s7LrOjwHyHgVA==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/syncpack-linux-arm64-musl/-/syncpack-linux-arm64-musl-15.3.2.tgz",
+      "integrity": "sha512-IzI4Sr1rFDuF7FFbZ+ti+qA2/0Rp/aGNgzoUzNH28wYJkJMv9KBBr3Nygc1jsoO1+XE1JkYsXkJHuSFrwiwtgA==",
       "cpu": [
         "arm64"
       ],
@@ -2785,9 +2775,9 @@
       }
     },
     "node_modules/syncpack-linux-x64": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/syncpack-linux-x64/-/syncpack-linux-x64-14.2.0.tgz",
-      "integrity": "sha512-8GG7OogvlILG+kFcQwS1tGTimK5feqFlxbeh96xNfNsUgX+SDHMyut6UsA4ca16QLl8ru6iqJmBZYur6EISQRg==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/syncpack-linux-x64/-/syncpack-linux-x64-15.3.2.tgz",
+      "integrity": "sha512-xrzBZx3DjKoece2h3Olv/Y/U7b1eNorWTMiF407m0tO5KJp5u926TMeHlldaA5GRCkVJBe5VaI33WYTJF753oQ==",
       "cpu": [
         "x64"
       ],
@@ -2802,9 +2792,9 @@
       }
     },
     "node_modules/syncpack-linux-x64-musl": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/syncpack-linux-x64-musl/-/syncpack-linux-x64-musl-14.2.0.tgz",
-      "integrity": "sha512-mC+XuYZ7o4A73Npr3xQ2gByOhKkSEFIDR9tMZ3RP1ShVEosnLYllqHIyRjShPPN777pKMAiDKl3frvAmvOGTbw==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/syncpack-linux-x64-musl/-/syncpack-linux-x64-musl-15.3.2.tgz",
+      "integrity": "sha512-dohyuYgUVHdSFz1KYW/XngyYSiSV3tarroYRsloYsT8bcSStkh2vJVBht0eMl1OFTh3Hb6lNEC12Pgtw4gWTcg==",
       "cpu": [
         "x64"
       ],
@@ -2819,9 +2809,9 @@
       }
     },
     "node_modules/syncpack-windows-arm64": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/syncpack-windows-arm64/-/syncpack-windows-arm64-14.2.0.tgz",
-      "integrity": "sha512-BsN0jZ7wlVi79SA37H5ynXYlwgpIQzQjEMO6e6ra80V/X5myC4Js4MiudHavtsrCxtuoUq7bDY86rRzyKRoD1g==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/syncpack-windows-arm64/-/syncpack-windows-arm64-15.3.2.tgz",
+      "integrity": "sha512-ZGjVpyS8PW6Y69HyXOb8RYVWRQ+hlRklqdgOp+x+eqrCRidGho8z2nN5tleMGzcaMC7hg+qSPFh5u6Fy/BXr4w==",
       "cpu": [
         "arm64"
       ],
@@ -2836,9 +2826,9 @@
       }
     },
     "node_modules/syncpack-windows-x64": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/syncpack-windows-x64/-/syncpack-windows-x64-14.2.0.tgz",
-      "integrity": "sha512-swrwXueQ438vyB1uJWt3mfho0jUiDT6wJDl3fKfk3BwLPsAARidNnHo4V+uweJ/89aQSGuNN0Xp41klU2N9/jg==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/syncpack-windows-x64/-/syncpack-windows-x64-15.3.2.tgz",
+      "integrity": "sha512-9zKWNXGhd3rryQjcpBjs02pKgvIzuz3PUS+vKL4vWnDu5VoHad4e6TzL4pvn+VfAm4wXzcuS9fZkxLBEMPLerw==",
       "cpu": [
         "x64"
       ],
@@ -2853,13 +2843,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2867,29 +2857,6 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
-    },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -2909,6 +2876,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -2929,11 +2897,12 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2943,16 +2912,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
-      "integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.57.1",
-        "@typescript-eslint/parser": "8.57.1",
-        "@typescript-eslint/typescript-estree": "8.57.1",
-        "@typescript-eslint/utils": "8.57.1"
+        "@typescript-eslint/eslint-plugin": "8.62.0",
+        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2963,13 +2932,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -2987,24 +2956,9 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -3035,31 +2989,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/widest-line/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/widest-line/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3087,31 +3022,12 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3132,9 +3048,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/extensions/trakt-manager/package-lock.json
+++ b/extensions/trakt-manager/package-lock.json
@@ -7,7 +7,7 @@
       "name": "trakt-manager",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.10",
+        "@raycast/api": "^1.104.20",
         "@raycast/utils": "^1.18.1",
         "@ts-rest/core": "^3.51.0",
         "node-fetch": "^3.3.2",
@@ -1068,16 +1068,16 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.10",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.10.tgz",
-      "integrity": "sha512-pSbqV0aUZKAoG760DB7mMoNAFfjuyw7ok0kLHKiu6T6mkKbRZwsH2rOgVFCpl5QmvVtjOX7V5ieETZGLOHuB+A==",
+      "version": "1.104.20",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.20.tgz",
+      "integrity": "sha512-Hcvt0OVjdjBFLtb9rNQjRBL7FAZBF3mlU17y2TgCdNolkeGixfJdMb7idfiILfgoNa94gj4C+M/MZn1tf/q4Dg==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
         "@oclif/plugin-autocomplete": "^3.2.40",
         "@oclif/plugin-help": "^6.2.37",
         "@oclif/plugin-not-found": "^3.2.74",
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "esbuild": "^0.27.3",
         "react": "19.0.0"
@@ -1086,10 +1086,10 @@
         "ray": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.14.0"
+        "node": ">=22.22.2"
       },
       "peerDependencies": {
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "react-devtools": "6.1.1"
       },
@@ -1106,18 +1106,18 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@raycast/api/node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/@raycast/eslint-config": {

--- a/extensions/trakt-manager/package.json
+++ b/extensions/trakt-manager/package.json
@@ -13,7 +13,12 @@
       "title": "Search Media",
       "subtitle": "Trakt Manager",
       "description": "Search for movies and shows by title",
-      "keywords": ["movies", "shows", "trakt", "search"],
+      "keywords": [
+        "movies",
+        "shows",
+        "trakt",
+        "search"
+      ],
       "mode": "view"
     },
     {
@@ -72,19 +77,18 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.104.20",
-    "@raycast/utils": "^1.18.1",
-    "@ts-rest/core": "^3.51.0",
+    "@raycast/utils": "^2.2.7",
+    "@ts-rest/core": "^3.53.0-rc.1",
     "node-fetch": "^3.3.2",
-    "zod": "^3.24.1"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@raycast/eslint-config": "^2.1.1",
-    "@types/node": "20.8.10",
-    "@types/react": "19.0.10",
-    "eslint": "^10.1.0",
-    "prettier-plugin-organize-imports": "^4.1.0",
-    "syncpack": "^14.2.0",
-    "typescript": "^5.7.3"
+    "@raycast/eslint-config": "^2.2.0",
+    "@types/node": "26.0.1",
+    "@types/react": "19.2.17",
+    "eslint": "^10.6.0",
+    "syncpack": "^15.3.2",
+    "typescript": "^6.0.3"
   },
   "icon": "trakt.png",
   "license": "MIT",

--- a/extensions/trakt-manager/package.json
+++ b/extensions/trakt-manager/package.json
@@ -9,6 +9,14 @@
   ],
   "commands": [
     {
+      "name": "search-media",
+      "title": "Search Media",
+      "subtitle": "Trakt Manager",
+      "description": "Search for movies and shows by title",
+      "keywords": ["movies", "shows", "trakt", "search"],
+      "mode": "view"
+    },
+    {
       "name": "movies",
       "title": "Search Movies",
       "subtitle": "Trakt Manager",
@@ -59,10 +67,11 @@
     }
   ],
   "contributors": [
-    "vishalbalaji3"
+    "vishalbalaji3",
+    "Berenger"
   ],
   "dependencies": {
-    "@raycast/api": "^1.104.10",
+    "@raycast/api": "^1.104.20",
     "@raycast/utils": "^1.18.1",
     "@ts-rest/core": "^3.51.0",
     "node-fetch": "^3.3.2",
@@ -87,6 +96,7 @@
     "build": "ray build -e dist",
     "check": "tsc --noEmit",
     "dev": "ray develop",
+    "dev:x": "RAY_Target=x ray develop",
     "fix-lint": "ray lint --fix",
     "fmt": "prettier '**/*' -wu && syncpack-format",
     "lint": "ray lint",

--- a/extensions/trakt-manager/src/components/episode-actions.tsx
+++ b/extensions/trakt-manager/src/components/episode-actions.tsx
@@ -1,0 +1,98 @@
+import { Action, ActionPanel, Detail, Icon, Keyboard } from "@raycast/api";
+import { getFavicon } from "@raycast/utils";
+import { IMDB_APP_URL, IMDB_SHORTCUT, TRAKT_APP_URL } from "../lib/constants";
+import { getIMDbUrl, getTraktUrl } from "../lib/helper";
+import { GenericDetail } from "./generic-detail";
+
+type EpisodeAction<T> = {
+  title: string;
+  icon: Icon;
+  shortcut?: Keyboard.Shortcut;
+  onAction: (item: T) => void;
+};
+
+type EpisodeActionPanelProps<T> = {
+  item: T;
+  actions: EpisodeAction<T>[];
+  markdown: (item: T) => string;
+  metadata: (item: T) => Detail.Props["metadata"];
+  navigationTitle: (item: T) => string;
+  traktUrl: (item: T) => string;
+  imdbId: (item: T) => string;
+};
+
+const EpisodeActionList = <T,>({ item, actions }: { item: T; actions: EpisodeAction<T>[] }) => (
+  <>
+    {actions.map((action) => (
+      <Action
+        key={action.title}
+        title={action.title}
+        icon={action.icon}
+        shortcut={action.shortcut}
+        onAction={() => action.onAction(item)}
+      />
+    ))}
+  </>
+);
+
+const EpisodeBrowserActions = <T,>({
+  item,
+  traktUrl,
+  imdbId,
+}: Pick<EpisodeActionPanelProps<T>, "item" | "traktUrl" | "imdbId">) => (
+  <ActionPanel.Section>
+    <Action.OpenInBrowser
+      icon={getFavicon(TRAKT_APP_URL)}
+      title="Open in Trakt"
+      shortcut={Keyboard.Shortcut.Common.Open}
+      url={traktUrl(item)}
+    />
+    <Action.OpenInBrowser
+      icon={getFavicon(IMDB_APP_URL)}
+      title="Open in Imdb"
+      shortcut={IMDB_SHORTCUT}
+      url={getIMDbUrl(imdbId(item))}
+    />
+  </ActionPanel.Section>
+);
+
+export const episodeTraktUrl = (slug: string | undefined, season: number, episode: number) =>
+  getTraktUrl("episode", slug, season, episode);
+
+export const EpisodeActionPanel = <T,>({
+  item,
+  actions,
+  markdown,
+  metadata,
+  navigationTitle,
+  traktUrl,
+  imdbId,
+}: EpisodeActionPanelProps<T>) => (
+  <ActionPanel>
+    <ActionPanel.Section>
+      <Action.Push
+        icon={Icon.Eye}
+        title="View Details"
+        target={
+          <GenericDetail
+            item={item}
+            isLoading={false}
+            markdown={markdown}
+            metadata={metadata}
+            navigationTitle={navigationTitle}
+            actions={(detailItem) => (
+              <ActionPanel>
+                <ActionPanel.Section>
+                  <EpisodeActionList item={detailItem} actions={actions} />
+                </ActionPanel.Section>
+                <EpisodeBrowserActions item={detailItem} traktUrl={traktUrl} imdbId={imdbId} />
+              </ActionPanel>
+            )}
+          />
+        }
+      />
+      <EpisodeActionList item={item} actions={actions} />
+    </ActionPanel.Section>
+    <EpisodeBrowserActions item={item} traktUrl={traktUrl} imdbId={imdbId} />
+  </ActionPanel>
+);

--- a/extensions/trakt-manager/src/components/episode-grid.tsx
+++ b/extensions/trakt-manager/src/components/episode-grid.tsx
@@ -1,13 +1,14 @@
-import { Action, ActionPanel, Grid, Icon, Keyboard, Toast, showToast } from "@raycast/api";
-import { getFavicon, useCachedPromise } from "@raycast/utils";
+import { Grid, Icon, Keyboard, Toast, showToast } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
 import { setMaxListeners } from "node:events";
 import { useCallback, useRef, useState } from "react";
+import { useActionRunner } from "../lib/action-runner";
 import { initTraktClient } from "../lib/client";
-import { APP_MAX_LISTENERS, IMDB_APP_URL, TRAKT_APP_URL } from "../lib/constants";
+import { APP_MAX_LISTENERS } from "../lib/constants";
 import { createEpisodeMarkdown, createEpisodeMetadata } from "../lib/detail-helpers";
-import { getIMDbUrl, getScreenshotUrl, getTraktUrl } from "../lib/helper";
+import { getScreenshotUrl } from "../lib/helper";
 import { TraktEpisodeListItem, TraktShowBaseItem } from "../lib/schema";
-import { GenericDetail } from "./generic-detail";
+import { EpisodeActionPanel, episodeTraktUrl } from "./episode-actions";
 import { GenericGrid } from "./generic-grid";
 
 export const EpisodeGrid = ({
@@ -87,30 +88,7 @@ export const EpisodeGrid = ({
     });
   }, []);
 
-  const handleAction = useCallback(
-    async (
-      episode: TraktEpisodeListItem,
-      action: (episode: TraktEpisodeListItem) => Promise<void>,
-      message: string,
-    ) => {
-      setActionLoading(true);
-      try {
-        await action(episode);
-        showToast({
-          title: message,
-          style: Toast.Style.Success,
-        });
-      } catch (e) {
-        showToast({
-          title: (e as Error).message,
-          style: Toast.Style.Failure,
-        });
-      } finally {
-        setActionLoading(false);
-      }
-    },
-    [],
-  );
+  const handleAction = useActionRunner<TraktEpisodeListItem>({ setActionLoading });
 
   const episodeMarkdown = useCallback(
     (episode: TraktEpisodeListItem) =>
@@ -137,68 +115,28 @@ export const EpisodeGrid = ({
       poster={(item) => getScreenshotUrl(item.images, "episode.png")}
       keyFn={(item, index) => `${item.ids.trakt}-${index}`}
       actions={(item) => (
-        <ActionPanel>
-          <ActionPanel.Section>
-            <Action.Push
-              icon={Icon.Eye}
-              title="View Details"
-              target={
-                <GenericDetail
-                  item={item}
-                  isLoading={false}
-                  markdown={episodeMarkdown}
-                  metadata={episodeMetadata}
-                  navigationTitle={(episode) => `${episode.title} • S${episode.season}E${episode.number}`}
-                  actions={(episode) => (
-                    <ActionPanel>
-                      <ActionPanel.Section>
-                        <Action
-                          title="Check-In"
-                          icon={Icon.Checkmark}
-                          onAction={() => handleAction(episode, checkInEpisode, "Episode checked-in")}
-                        />
-                        <Action
-                          title="Add to History"
-                          icon={Icon.Clock}
-                          shortcut={Keyboard.Shortcut.Common.Duplicate}
-                          onAction={() => handleAction(episode, addEpisodeToHistory, "Episode added to history")}
-                        />
-                      </ActionPanel.Section>
-                      <ActionPanel.Section>
-                        <Action.OpenInBrowser
-                          icon={getFavicon(TRAKT_APP_URL)}
-                          title="Open in Trakt"
-                          shortcut={Keyboard.Shortcut.Common.Open}
-                          url={getTraktUrl("episode", slug, episode.season, episode.number)}
-                        />
-                        <Action.OpenInBrowser
-                          icon={getFavicon(IMDB_APP_URL)}
-                          title="Open in Imdb"
-                          shortcut={{ modifiers: ["cmd"], key: "i" }}
-                          url={getIMDbUrl(episode.ids.imdb)}
-                        />
-                      </ActionPanel.Section>
-                    </ActionPanel>
-                  )}
-                />
-              }
-            />
-          </ActionPanel.Section>
-          <ActionPanel.Section>
-            <Action
-              title="Check-In"
-              icon={Icon.Checkmark}
-              shortcut={Keyboard.Shortcut.Common.Edit}
-              onAction={() => handleAction(item, checkInEpisode, "Episode checked-in")}
-            />
-            <Action
-              title="Add to History"
-              icon={Icon.Clock}
-              shortcut={Keyboard.Shortcut.Common.Duplicate}
-              onAction={() => handleAction(item, addEpisodeToHistory, "Episode added to history")}
-            />
-          </ActionPanel.Section>
-        </ActionPanel>
+        <EpisodeActionPanel
+          item={item}
+          markdown={episodeMarkdown}
+          metadata={episodeMetadata}
+          navigationTitle={(episode) => `${episode.title} • S${episode.season}E${episode.number}`}
+          traktUrl={(episode) => episodeTraktUrl(slug, episode.season, episode.number)}
+          imdbId={(episode) => episode.ids.imdb}
+          actions={[
+            {
+              title: "Check-In",
+              icon: Icon.Checkmark,
+              shortcut: Keyboard.Shortcut.Common.Edit,
+              onAction: (episode) => handleAction(episode, checkInEpisode, "Episode checked-in"),
+            },
+            {
+              title: "Add to History",
+              icon: Icon.Clock,
+              shortcut: Keyboard.Shortcut.Common.Duplicate,
+              onAction: (episode) => handleAction(episode, addEpisodeToHistory, "Episode added to history"),
+            },
+          ]}
+        />
       )}
     />
   );

--- a/extensions/trakt-manager/src/components/episode-grid.tsx
+++ b/extensions/trakt-manager/src/components/episode-grid.tsx
@@ -153,7 +153,7 @@ export const EpisodeGrid = ({
                     <ActionPanel>
                       <ActionPanel.Section>
                         <Action
-                          title="Check-in"
+                          title="Check-In"
                           icon={Icon.Checkmark}
                           onAction={() => handleAction(episode, checkInEpisode, "Episode checked-in")}
                         />
@@ -186,7 +186,7 @@ export const EpisodeGrid = ({
           </ActionPanel.Section>
           <ActionPanel.Section>
             <Action
-              title="Check-in"
+              title="Check-In"
               icon={Icon.Checkmark}
               shortcut={Keyboard.Shortcut.Common.Edit}
               onAction={() => handleAction(item, checkInEpisode, "Episode checked-in")}

--- a/extensions/trakt-manager/src/components/media-actions.tsx
+++ b/extensions/trakt-manager/src/components/media-actions.tsx
@@ -1,0 +1,118 @@
+import { Action, ActionPanel, Icon, Keyboard } from "@raycast/api";
+import { getFavicon } from "@raycast/utils";
+import { GenericDetail } from "./generic-detail";
+import { SeasonGrid } from "./season-grid";
+import { IMDB_APP_URL, IMDB_SHORTCUT, TRAKT_APP_URL } from "../lib/constants";
+import { createMovieMarkdown, createMovieMetadata } from "../lib/detail-helpers";
+import { getIMDbUrl, getTraktUrl } from "../lib/helper";
+import { TraktMovieHistoryListItem, TraktMovieListItem, TraktShowListItem } from "../lib/schema";
+
+type MediaAction<T> = {
+  title: string;
+  icon: Icon;
+  shortcut?: Keyboard.Shortcut;
+  onAction: (item: T) => void;
+};
+
+type MovieActionItem = TraktMovieListItem | TraktMovieHistoryListItem;
+
+type MovieActionPanelProps<M extends MovieActionItem> = {
+  item: M;
+  actions: MediaAction<M>[];
+};
+
+type ShowActionPanelProps = {
+  item: TraktShowListItem;
+  actions: MediaAction<TraktShowListItem>[];
+  onCheckInFirstEpisode: (item: TraktShowListItem) => void;
+};
+
+const MovieBrowserActions = <M extends MovieActionItem>({ item }: { item: M }) => (
+  <ActionPanel.Section>
+    <Action.OpenInBrowser
+      icon={getFavicon(TRAKT_APP_URL)}
+      title="Open in Trakt"
+      shortcut={Keyboard.Shortcut.Common.Open}
+      url={getTraktUrl("movies", item.movie.ids.slug)}
+    />
+    <Action.OpenInBrowser
+      icon={getFavicon(IMDB_APP_URL)}
+      title="Open in Imdb"
+      shortcut={IMDB_SHORTCUT}
+      url={getIMDbUrl(item.movie.ids.imdb)}
+    />
+  </ActionPanel.Section>
+);
+
+const MediaActionList = <T,>({ item, actions }: { item: T; actions: MediaAction<T>[] }) => (
+  <>
+    {actions.map((action) => (
+      <Action
+        key={action.title}
+        title={action.title}
+        icon={action.icon}
+        shortcut={action.shortcut}
+        onAction={() => action.onAction(item)}
+      />
+    ))}
+  </>
+);
+
+export const MovieActionPanel = <M extends MovieActionItem>({ item, actions }: MovieActionPanelProps<M>) => (
+  <ActionPanel>
+    <ActionPanel.Section>
+      <Action.Push
+        icon={Icon.Eye}
+        title="View Details"
+        target={
+          <GenericDetail
+            item={item}
+            isLoading={false}
+            markdown={(movie) => createMovieMarkdown(movie.movie)}
+            metadata={createMovieMetadata}
+            navigationTitle={(movie) => movie.movie.title}
+            actions={(movie) => (
+              <ActionPanel>
+                <ActionPanel.Section>
+                  <MediaActionList item={movie} actions={actions} />
+                </ActionPanel.Section>
+                <MovieBrowserActions item={movie} />
+              </ActionPanel>
+            )}
+          />
+        }
+      />
+      <MediaActionList item={item} actions={actions} />
+    </ActionPanel.Section>
+    <MovieBrowserActions item={item} />
+  </ActionPanel>
+);
+
+export const ShowActionPanel = ({ item, actions, onCheckInFirstEpisode }: ShowActionPanelProps) => (
+  <ActionPanel>
+    <ActionPanel.Section>
+      <Action.Push
+        icon={Icon.Switch}
+        title="Browse Seasons"
+        target={<SeasonGrid showId={item.show.ids.trakt} slug={item.show.ids.slug} imdbId={item.show.ids.imdb} />}
+      />
+      <Action
+        title="Check-In"
+        icon={Icon.Checkmark}
+        shortcut={Keyboard.Shortcut.Common.ToggleQuickLook}
+        onAction={() => onCheckInFirstEpisode(item)}
+      />
+    </ActionPanel.Section>
+    <ActionPanel.Section>
+      <Action.OpenInBrowser
+        icon={getFavicon(TRAKT_APP_URL)}
+        title="Open in Trakt"
+        url={getTraktUrl("shows", item.show.ids.slug)}
+      />
+      <Action.OpenInBrowser icon={getFavicon(IMDB_APP_URL)} title="Open in Imdb" url={getIMDbUrl(item.show.ids.imdb)} />
+    </ActionPanel.Section>
+    <ActionPanel.Section>
+      <MediaActionList item={item} actions={actions} />
+    </ActionPanel.Section>
+  </ActionPanel>
+);

--- a/extensions/trakt-manager/src/components/season-grid.tsx
+++ b/extensions/trakt-manager/src/components/season-grid.tsx
@@ -2,6 +2,7 @@ import { Action, ActionPanel, Grid, Icon, Keyboard, showToast, Toast } from "@ra
 import { getFavicon, useCachedPromise } from "@raycast/utils";
 import { setMaxListeners } from "node:events";
 import { useCallback, useRef, useState } from "react";
+import { useActionRunner } from "../lib/action-runner";
 import { initTraktClient } from "../lib/client";
 import { APP_MAX_LISTENERS, IMDB_APP_URL, TRAKT_APP_URL } from "../lib/constants";
 import { getIMDbUrl, getPosterUrl, getTraktUrl } from "../lib/helper";
@@ -47,26 +48,7 @@ export const SeasonGrid = ({ showId, slug, imdbId }: { showId: number; slug?: st
     },
   );
 
-  const handleAction = useCallback(
-    async (show: TraktSeasonListItem, action: (show: TraktSeasonListItem) => Promise<void>, message: string) => {
-      setActionLoading(true);
-      try {
-        await action(show);
-        showToast({
-          title: message,
-          style: Toast.Style.Success,
-        });
-      } catch (e) {
-        showToast({
-          title: (e as Error).message,
-          style: Toast.Style.Failure,
-        });
-      } finally {
-        setActionLoading(false);
-      }
-    },
-    [],
-  );
+  const handleAction = useActionRunner<TraktSeasonListItem>({ setActionLoading });
 
   const addSeasonToHistory = useCallback(async (season: TraktSeasonListItem) => {
     await traktClient.shows.addSeasonToHistory({

--- a/extensions/trakt-manager/src/episodes.tsx
+++ b/extensions/trakt-manager/src/episodes.tsx
@@ -169,7 +169,7 @@ export default function Command() {
                     <ActionPanel>
                       <ActionPanel.Section>
                         <Action
-                          title="Check-in"
+                          title="Check-In"
                           icon={Icon.Checkmark}
                           shortcut={Keyboard.Shortcut.Common.ToggleQuickLook}
                           onAction={() => handleAction(episode, checkInEpisode, "Episode checked-in")}
@@ -206,7 +206,7 @@ export default function Command() {
               }
             />
             <Action
-              title="Check-in"
+              title="Check-In"
               icon={Icon.Checkmark}
               onAction={() => handleAction(item, checkInEpisode, "Episode checked-in")}
             />

--- a/extensions/trakt-manager/src/episodes.tsx
+++ b/extensions/trakt-manager/src/episodes.tsx
@@ -1,16 +1,14 @@
-import { Action, ActionPanel, Grid, Icon, Keyboard, showToast, Toast } from "@raycast/api";
-import { getFavicon, useCachedPromise } from "@raycast/utils";
-import { PaginationOptions } from "@raycast/utils/dist/types";
-import { setMaxListeners } from "node:events";
-import { setTimeout } from "node:timers/promises";
+import { Grid, Icon, Keyboard, showToast, Toast } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
 import { useCallback, useRef, useState } from "react";
-import { GenericDetail } from "./components/generic-detail";
+import { EpisodeActionPanel, episodeTraktUrl } from "./components/episode-actions";
 import { GenericGrid } from "./components/generic-grid";
+import { useActionRunner } from "./lib/action-runner";
 import { initTraktClient } from "./lib/client";
-import { APP_MAX_LISTENERS, IMDB_APP_URL, TRAKT_APP_URL } from "./lib/constants";
 import { createEpisodeMarkdown, createEpisodeMetadata } from "./lib/detail-helpers";
-import { getIMDbUrl, getPosterUrl, getTraktUrl } from "./lib/helper";
-import { TraktShowHistoryListItem, withPagination } from "./lib/schema";
+import { getPosterUrl } from "./lib/helper";
+import { TraktShowHistoryListItem } from "./lib/schema";
+import { abortSearch, createSearchFetcher } from "./lib/search";
 
 export default function Command() {
   const abortable = useRef<AbortController | undefined>(undefined);
@@ -22,35 +20,10 @@ export default function Command() {
     data: episodes,
     pagination,
   } = useCachedPromise(
-    (searchText: string) => async (options: PaginationOptions) => {
-      if (!searchText) return { data: [], hasMore: false };
-      await setTimeout(100);
-
-      abortable.current = new AbortController();
-      setMaxListeners(APP_MAX_LISTENERS, abortable.current?.signal);
-
-      const response = await traktClient.shows.searchEpisodes({
-        query: {
-          query: searchText,
-          page: options.page + 1,
-          limit: 10,
-          fields: "title",
-          extended: "full,cloud9",
-        },
-        fetchOptions: {
-          signal: abortable.current.signal,
-        },
-      });
-
-      if (response.status !== 200) return { data: [], hasMore: false };
-      const paginatedResponse = withPagination(response);
-
-      return {
-        data: paginatedResponse.data,
-        hasMore:
-          paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
-      };
-    },
+    createSearchFetcher({
+      abortable,
+      search: traktClient.shows.searchEpisodes,
+    }),
     [searchText],
     {
       initialData: undefined,
@@ -96,39 +69,8 @@ export default function Command() {
     });
   }, []);
 
-  const handleSearchTextChange = useCallback(
-    (text: string): void => {
-      abortable.current?.abort();
-      abortable.current = new AbortController();
-      setSearchText(text);
-    },
-    [abortable],
-  );
-
-  const handleAction = useCallback(
-    async (
-      episode: TraktShowHistoryListItem,
-      action: (episode: TraktShowHistoryListItem) => Promise<void>,
-      message: string,
-    ) => {
-      setActionLoading(true);
-      try {
-        await action(episode);
-        showToast({
-          title: message,
-          style: Toast.Style.Success,
-        });
-      } catch (e) {
-        showToast({
-          title: (e as Error).message,
-          style: Toast.Style.Failure,
-        });
-      } finally {
-        setActionLoading(false);
-      }
-    },
-    [],
-  );
+  const handleSearchTextChange = useCallback(abortSearch(abortable, setSearchText), []);
+  const handleAction = useActionRunner<TraktShowHistoryListItem>({ setActionLoading });
 
   const episodeMarkdown = useCallback((episode: TraktShowHistoryListItem) => {
     return createEpisodeMarkdown(episode.episode, episode.show);
@@ -153,85 +95,27 @@ export default function Command() {
       poster={(item) => getPosterUrl(item.show.images, "poster.png")}
       keyFn={(item, index) => `${item.show.ids.trakt}-${item.episode.ids.trakt}-${index}`}
       actions={(item) => (
-        <ActionPanel>
-          <ActionPanel.Section>
-            <Action.Push
-              icon={Icon.Eye}
-              title="View Details"
-              target={
-                <GenericDetail
-                  item={item}
-                  isLoading={false}
-                  markdown={episodeMarkdown}
-                  metadata={episodeMetadata}
-                  navigationTitle={(episode) => episode.episode.title}
-                  actions={(episode) => (
-                    <ActionPanel>
-                      <ActionPanel.Section>
-                        <Action
-                          title="Check-In"
-                          icon={Icon.Checkmark}
-                          shortcut={Keyboard.Shortcut.Common.ToggleQuickLook}
-                          onAction={() => handleAction(episode, checkInEpisode, "Episode checked-in")}
-                        />
-                        <Action
-                          title="Add to History"
-                          icon={Icon.Clock}
-                          shortcut={Keyboard.Shortcut.Common.Duplicate}
-                          onAction={() => handleAction(episode, addEpisodeToHistory, "Episode added to history")}
-                        />
-                      </ActionPanel.Section>
-                      <ActionPanel.Section>
-                        <Action.OpenInBrowser
-                          icon={getFavicon(TRAKT_APP_URL)}
-                          title="Open in Trakt"
-                          shortcut={Keyboard.Shortcut.Common.Open}
-                          url={getTraktUrl(
-                            "episode",
-                            episode.show.ids.slug,
-                            episode.episode.season,
-                            episode.episode.number,
-                          )}
-                        />
-                        <Action.OpenInBrowser
-                          icon={getFavicon(IMDB_APP_URL)}
-                          title="Open in Imdb"
-                          shortcut={{ modifiers: ["cmd"], key: "i" }}
-                          url={getIMDbUrl(episode.episode.ids.imdb)}
-                        />
-                      </ActionPanel.Section>
-                    </ActionPanel>
-                  )}
-                />
-              }
-            />
-            <Action
-              title="Check-In"
-              icon={Icon.Checkmark}
-              onAction={() => handleAction(item, checkInEpisode, "Episode checked-in")}
-            />
-            <Action
-              title="Add to History"
-              icon={Icon.Clock}
-              shortcut={Keyboard.Shortcut.Common.Duplicate}
-              onAction={() => handleAction(item, addEpisodeToHistory, "Episode added to history")}
-            />
-          </ActionPanel.Section>
-          <ActionPanel.Section>
-            <Action.OpenInBrowser
-              icon={getFavicon(TRAKT_APP_URL)}
-              title="Open in Trakt"
-              shortcut={Keyboard.Shortcut.Common.Open}
-              url={getTraktUrl("episode", item.show.ids.slug, item.episode.season, item.episode.number)}
-            />
-            <Action.OpenInBrowser
-              icon={getFavicon(IMDB_APP_URL)}
-              title="Open in Imdb"
-              shortcut={{ modifiers: ["cmd"], key: "i" }}
-              url={getIMDbUrl(item.episode.ids.imdb)}
-            />
-          </ActionPanel.Section>
-        </ActionPanel>
+        <EpisodeActionPanel
+          item={item}
+          markdown={episodeMarkdown}
+          metadata={episodeMetadata}
+          navigationTitle={(episode) => episode.episode.title}
+          traktUrl={(episode) => episodeTraktUrl(episode.show.ids.slug, episode.episode.season, episode.episode.number)}
+          imdbId={(episode) => episode.episode.ids.imdb}
+          actions={[
+            {
+              title: "Check-In",
+              icon: Icon.Checkmark,
+              onAction: (episode) => handleAction(episode, checkInEpisode, "Episode checked-in"),
+            },
+            {
+              title: "Add to History",
+              icon: Icon.Clock,
+              shortcut: Keyboard.Shortcut.Common.Duplicate,
+              onAction: (episode) => handleAction(episode, addEpisodeToHistory, "Episode added to history"),
+            },
+          ]}
+        />
       )}
     />
   );

--- a/extensions/trakt-manager/src/history.tsx
+++ b/extensions/trakt-manager/src/history.tsx
@@ -26,8 +26,6 @@ const formatter = new Intl.DateTimeFormat(undefined, { year: "numeric", month: "
 const historyQuery = {
   limit: 10,
   extended: "full,cloud9" as const,
-  sort_by: "added" as const,
-  sort_how: "desc" as const,
 };
 const combinedHistoryPageLimit = historyQuery.limit * 2;
 

--- a/extensions/trakt-manager/src/history.tsx
+++ b/extensions/trakt-manager/src/history.tsx
@@ -1,27 +1,25 @@
-import { Action, ActionPanel, Grid, Icon, Keyboard, Toast, showToast } from "@raycast/api";
+import { Action, ActionPanel, Grid, Icon, Keyboard } from "@raycast/api";
 import { getFavicon, useCachedPromise } from "@raycast/utils";
-import { PaginationOptions } from "@raycast/utils/dist/types";
+import { type PaginationOptions } from "./lib/pagination";
 import { setMaxListeners } from "node:events";
 import { setTimeout } from "node:timers/promises";
 import { useCallback, useRef, useState } from "react";
 import { GenericDetail } from "./components/generic-detail";
 import { GenericGrid } from "./components/generic-grid";
+import { MovieActionPanel } from "./components/media-actions";
+import { useActionRunner } from "./lib/action-runner";
 import { initTraktClient } from "./lib/client";
 import { APP_MAX_LISTENERS, IMDB_APP_URL, TRAKT_APP_URL } from "./lib/constants";
-import {
-  createEpisodeMarkdown,
-  createEpisodeMetadata,
-  createMovieMarkdown,
-  createMovieMetadata,
-} from "./lib/detail-helpers";
+import { createEpisodeMarkdown, createEpisodeMetadata } from "./lib/detail-helpers";
 import { getIMDbUrl, getPosterUrl, getTraktUrl } from "./lib/helper";
-import { TraktMovieHistoryListItem, TraktShowHistoryListItem, withPagination } from "./lib/schema";
+import { fetchCombinedMediaPage, fetchMediaPage, mediaListCacheOptions } from "./lib/media-pagination";
+import { removeEpisodeFromHistory, removeMovieFromHistory } from "./lib/media-mutations";
+import { TraktMovieHistoryListItem, TraktShowHistoryListItem } from "./lib/schema";
 
 type HistoryFilterType = "all" | "movie" | "show";
 
 type HistoryItem =
-  | { mediaType: "movie"; item: TraktMovieHistoryListItem }
-  | { mediaType: "show"; item: TraktShowHistoryListItem };
+  { mediaType: "movie"; item: TraktMovieHistoryListItem } | { mediaType: "show"; item: TraktShowHistoryListItem };
 
 const formatter = new Intl.DateTimeFormat(undefined, { year: "numeric", month: "short", day: "2-digit" });
 
@@ -31,6 +29,7 @@ const historyQuery = {
   sort_by: "added" as const,
   sort_how: "desc" as const,
 };
+const combinedHistoryPageLimit = historyQuery.limit * 2;
 
 const sortByWatchedAt = (items: HistoryItem[]) =>
   [...items].sort((a, b) => {
@@ -60,115 +59,44 @@ export default function Command() {
       const page = options.page + 1;
 
       if (mediaType === "movie") {
-        const response = await traktClient.movies.getMovieHistory({
-          query: { ...historyQuery, page },
-          fetchOptions,
-        });
-
-        if (response.status !== 200) return { data: [], hasMore: false };
-        const paginatedResponse = withPagination(response);
-
-        return {
-          data: paginatedResponse.data.map((item) => ({ mediaType: "movie" as const, item })),
-          hasMore:
-            paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
-        };
+        return fetchMediaPage<"movie", TraktMovieHistoryListItem>("movie", () =>
+          traktClient.movies.getMovieHistory({ query: { ...historyQuery, page }, fetchOptions }),
+        );
       }
 
       if (mediaType === "show") {
-        const response = await traktClient.shows.getShowHistory({
-          query: { ...historyQuery, page },
-          fetchOptions,
-        });
-
-        if (response.status !== 200) return { data: [], hasMore: false };
-        const paginatedResponse = withPagination(response);
-
-        return {
-          data: paginatedResponse.data.map((item) => ({ mediaType: "show" as const, item })),
-          hasMore:
-            paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
-        };
+        return fetchMediaPage<"show", TraktShowHistoryListItem>("show", () =>
+          traktClient.shows.getShowHistory({ query: { ...historyQuery, page }, fetchOptions }),
+        );
       }
 
-      const [moviesResponse, showsResponse] = await Promise.all([
-        traktClient.movies.getMovieHistory({ query: { ...historyQuery, page }, fetchOptions }),
-        traktClient.shows.getShowHistory({ query: { ...historyQuery, page }, fetchOptions }),
-      ]);
-
-      const movies =
-        moviesResponse.status === 200
-          ? withPagination(moviesResponse)
-          : { data: [] as TraktMovieHistoryListItem[], pagination: null };
-      const shows =
-        showsResponse.status === 200
-          ? withPagination(showsResponse)
-          : { data: [] as TraktShowHistoryListItem[], pagination: null };
-
-      const merged = sortByWatchedAt([
-        ...movies.data.map((item) => ({ mediaType: "movie" as const, item })),
-        ...shows.data.map((item) => ({ mediaType: "show" as const, item })),
-      ]);
-
-      const moviesHasMore =
-        movies.pagination !== null &&
-        movies.pagination["x-pagination-page"] < movies.pagination["x-pagination-page-count"];
-      const showsHasMore =
-        shows.pagination !== null &&
-        shows.pagination["x-pagination-page"] < shows.pagination["x-pagination-page-count"];
-
-      return {
-        data: merged,
-        hasMore: moviesHasMore || showsHasMore,
-      };
+      return fetchCombinedMediaPage<TraktMovieHistoryListItem, TraktShowHistoryListItem>({
+        page: options.page,
+        perPageLimit: historyQuery.limit,
+        combinedPageLimit: combinedHistoryPageLimit,
+        requestMoviePage: (page) =>
+          traktClient.movies.getMovieHistory({ query: { ...historyQuery, page }, fetchOptions }),
+        requestShowPage: (page) => traktClient.shows.getShowHistory({ query: { ...historyQuery, page }, fetchOptions }),
+        sort: sortByWatchedAt,
+      });
     },
     [mediaType],
-    {
-      initialData: undefined,
-      keepPreviousData: true,
-      abortable,
-      onError(error) {
-        showToast({
-          title: error.message,
-          style: Toast.Style.Failure,
-        });
-      },
-    },
+    mediaListCacheOptions(abortable),
   );
 
-  const removeMovieFromHistory = useCallback(async (movie: TraktMovieHistoryListItem) => {
-    await traktClient.movies.removeMovieFromHistory({
-      body: {
-        movies: [
-          {
-            ids: {
-              trakt: movie.movie.ids.trakt,
-            },
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
+  const removeMovieFromHistoryAction = useCallback(
+    async (movie: TraktMovieHistoryListItem) => {
+      await removeMovieFromHistory(traktClient, movie, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
 
-  const removeEpisodeFromHistory = useCallback(async (episode: TraktShowHistoryListItem) => {
-    await traktClient.shows.removeEpisodeFromHistory({
-      body: {
-        episodes: [
-          {
-            ids: {
-              trakt: episode.episode.ids.trakt,
-            },
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
+  const removeEpisodeFromHistoryAction = useCallback(
+    async (episode: TraktShowHistoryListItem) => {
+      await removeEpisodeFromHistory(traktClient, episode, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
 
   const onMediaTypeChange = useCallback((newValue: string) => {
     abortable.current?.abort();
@@ -176,127 +104,24 @@ export default function Command() {
     setMediaType(newValue as HistoryFilterType);
   }, []);
 
-  const handleMovieAction = useCallback(
-    async (
-      movie: TraktMovieHistoryListItem,
-      action: (movie: TraktMovieHistoryListItem) => Promise<void>,
-      message: string,
-    ) => {
-      setActionLoading(true);
-      try {
-        await action(movie);
-        revalidate();
-        showToast({
-          title: message,
-          style: Toast.Style.Success,
-        });
-      } catch (error) {
-        showToast({
-          title: (error as Error).message,
-          style: Toast.Style.Failure,
-        });
-      } finally {
-        setActionLoading(false);
-      }
-    },
-    [revalidate],
-  );
-
-  const handleShowAction = useCallback(
-    async (
-      episode: TraktShowHistoryListItem,
-      action: (episode: TraktShowHistoryListItem) => Promise<void>,
-      message: string,
-    ) => {
-      setActionLoading(true);
-      try {
-        await action(episode);
-        revalidate();
-        showToast({
-          title: message,
-          style: Toast.Style.Success,
-        });
-      } catch (error) {
-        showToast({
-          title: (error as Error).message,
-          style: Toast.Style.Failure,
-        });
-      } finally {
-        setActionLoading(false);
-      }
-    },
-    [revalidate],
-  );
-
-  const movieMarkdown = useCallback((movie: TraktMovieHistoryListItem) => {
-    return createMovieMarkdown(movie.movie);
-  }, []);
-
-  const movieMetadata = useCallback((movie: TraktMovieHistoryListItem) => {
-    return createMovieMetadata(movie);
-  }, []);
+  const handleMovieAction = useActionRunner<TraktMovieHistoryListItem>({ setActionLoading, onSuccess: revalidate });
+  const handleShowAction = useActionRunner<TraktShowHistoryListItem>({ setActionLoading, onSuccess: revalidate });
 
   const movieActions = useCallback(
     (item: TraktMovieHistoryListItem) => (
-      <ActionPanel>
-        <ActionPanel.Section>
-          <Action.Push
-            icon={Icon.Eye}
-            title="View Details"
-            target={
-              <GenericDetail
-                item={item}
-                isLoading={false}
-                markdown={movieMarkdown}
-                metadata={movieMetadata}
-                navigationTitle={(movie) => movie.movie.title}
-                actions={(movie) => (
-                  <ActionPanel>
-                    <ActionPanel.Section>
-                      <Action.OpenInBrowser
-                        icon={getFavicon(TRAKT_APP_URL)}
-                        title="Open in Trakt"
-                        shortcut={Keyboard.Shortcut.Common.Open}
-                        url={getTraktUrl("movies", movie.movie.ids.slug)}
-                      />
-                      <Action.OpenInBrowser
-                        icon={getFavicon(IMDB_APP_URL)}
-                        title="Open in Imdb"
-                        shortcut={{ modifiers: ["cmd"], key: "i" }}
-                        url={getIMDbUrl(movie.movie.ids.imdb)}
-                      />
-                    </ActionPanel.Section>
-                  </ActionPanel>
-                )}
-              />
-            }
-          />
-        </ActionPanel.Section>
-        <ActionPanel.Section>
-          <Action.OpenInBrowser
-            icon={getFavicon(TRAKT_APP_URL)}
-            title="Open in Trakt"
-            shortcut={Keyboard.Shortcut.Common.Open}
-            url={getTraktUrl("movies", item.movie.ids.slug)}
-          />
-          <Action.OpenInBrowser
-            icon={getFavicon(IMDB_APP_URL)}
-            title="Open in Imdb"
-            shortcut={{ modifiers: ["cmd"], key: "i" }}
-            url={getIMDbUrl(item.movie.ids.imdb)}
-          />
-        </ActionPanel.Section>
-        <ActionPanel.Section>
-          <Action
-            title="Remove from History"
-            icon={Icon.Trash}
-            shortcut={Keyboard.Shortcut.Common.Remove}
-            onAction={() => handleMovieAction(item, removeMovieFromHistory, "Movie removed from history")}
-          />
-        </ActionPanel.Section>
-      </ActionPanel>
+      <MovieActionPanel
+        item={item}
+        actions={[
+          {
+            title: "Remove from History",
+            icon: Icon.Trash,
+            shortcut: Keyboard.Shortcut.Common.Remove,
+            onAction: (movie) => handleMovieAction(movie, removeMovieFromHistoryAction, "Movie removed from history"),
+          },
+        ]}
+      />
     ),
-    [handleMovieAction, movieMarkdown, movieMetadata, removeMovieFromHistory],
+    [handleMovieAction, removeMovieFromHistoryAction],
   );
 
   const showActions = useCallback(
@@ -321,7 +146,9 @@ export default function Command() {
                       title="Remove from History"
                       icon={Icon.Trash}
                       shortcut={Keyboard.Shortcut.Common.Remove}
-                      onAction={() => handleShowAction(item, removeEpisodeFromHistory, "Episode removed from history")}
+                      onAction={() =>
+                        handleShowAction(item, removeEpisodeFromHistoryAction, "Episode removed from history")
+                      }
                     />
                     <Action.OpenInBrowser
                       icon={getFavicon(TRAKT_APP_URL)}
@@ -342,7 +169,7 @@ export default function Command() {
             title="Remove from History"
             icon={Icon.Trash}
             shortcut={Keyboard.Shortcut.Common.Remove}
-            onAction={() => handleShowAction(item, removeEpisodeFromHistory, "Episode removed from history")}
+            onAction={() => handleShowAction(item, removeEpisodeFromHistoryAction, "Episode removed from history")}
           />
         </ActionPanel.Section>
         <ActionPanel.Section>
@@ -359,7 +186,7 @@ export default function Command() {
         </ActionPanel.Section>
       </ActionPanel>
     ),
-    [handleShowAction, removeEpisodeFromHistory],
+    [handleShowAction, removeEpisodeFromHistoryAction],
   );
 
   const searchBarAccessory = (

--- a/extensions/trakt-manager/src/history.tsx
+++ b/extensions/trakt-manager/src/history.tsx
@@ -15,96 +15,111 @@ import {
   createMovieMetadata,
 } from "./lib/detail-helpers";
 import { getIMDbUrl, getPosterUrl, getTraktUrl } from "./lib/helper";
-import { TraktMediaType, TraktMovieHistoryListItem, TraktShowHistoryListItem, withPagination } from "./lib/schema";
+import { TraktMovieHistoryListItem, TraktShowHistoryListItem, withPagination } from "./lib/schema";
+
+type HistoryFilterType = "all" | "movie" | "show";
+
+type HistoryItem =
+  | { mediaType: "movie"; item: TraktMovieHistoryListItem }
+  | { mediaType: "show"; item: TraktShowHistoryListItem };
 
 const formatter = new Intl.DateTimeFormat(undefined, { year: "numeric", month: "short", day: "2-digit" });
 
+const historyQuery = {
+  limit: 10,
+  extended: "full,cloud9" as const,
+  sort_by: "added" as const,
+  sort_how: "desc" as const,
+};
+
+const sortByWatchedAt = (items: HistoryItem[]) =>
+  [...items].sort((a, b) => {
+    const aTime = a.item.watched_at ? new Date(a.item.watched_at).getTime() : 0;
+    const bTime = b.item.watched_at ? new Date(b.item.watched_at).getTime() : 0;
+    return bTime - aTime;
+  });
+
 export default function Command() {
   const abortable = useRef<AbortController | undefined>(undefined);
-  const [mediaType, setMediaType] = useState<TraktMediaType>("movie");
+  const [mediaType, setMediaType] = useState<HistoryFilterType>("all");
   const [actionLoading, setActionLoading] = useState(false);
   const traktClient = initTraktClient();
   const {
-    isLoading: isMovieLoading,
-    data: movies,
-    pagination: moviePagination,
-    revalidate: revalidateMovie,
+    isLoading,
+    data: history,
+    pagination,
+    revalidate,
   } = useCachedPromise(
-    (mediaType: TraktMediaType) => async (options: PaginationOptions) => {
+    (mediaType: HistoryFilterType) => async (options: PaginationOptions) => {
       await setTimeout(100);
-      if (mediaType === "show") return { data: [], hasMore: false };
 
       abortable.current = new AbortController();
       setMaxListeners(APP_MAX_LISTENERS, abortable.current?.signal);
 
-      const response = await traktClient.movies.getMovieHistory({
-        query: {
-          page: options.page + 1,
-          limit: 10,
-          extended: "full,cloud9",
-          sort_by: "added",
-          sort_how: "desc",
-        },
-        fetchOptions: {
-          signal: abortable.current.signal,
-        },
-      });
+      const fetchOptions = { signal: abortable.current.signal };
+      const page = options.page + 1;
 
-      if (response.status !== 200) return { data: [], hasMore: false };
-      const paginatedResponse = withPagination(response);
-
-      return {
-        data: paginatedResponse.data,
-        hasMore:
-          paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
-      };
-    },
-    [mediaType],
-    {
-      initialData: undefined,
-      keepPreviousData: true,
-      abortable,
-      onError(error) {
-        showToast({
-          title: error.message,
-          style: Toast.Style.Failure,
+      if (mediaType === "movie") {
+        const response = await traktClient.movies.getMovieHistory({
+          query: { ...historyQuery, page },
+          fetchOptions,
         });
-      },
-    },
-  );
-  const {
-    isLoading: isShowsLoading,
-    data: shows,
-    pagination: showPagination,
-    revalidate: revalidateShow,
-  } = useCachedPromise(
-    (mediaType: TraktMediaType) => async (options: PaginationOptions) => {
-      await setTimeout(100);
-      if (mediaType === "movie") return { data: [], hasMore: false };
 
-      abortable.current = new AbortController();
-      setMaxListeners(APP_MAX_LISTENERS, abortable.current?.signal);
+        if (response.status !== 200) return { data: [], hasMore: false };
+        const paginatedResponse = withPagination(response);
 
-      const response = await traktClient.shows.getShowHistory({
-        query: {
-          page: options.page + 1,
-          limit: 10,
-          extended: "full,cloud9",
-          sort_by: "added",
-          sort_how: "desc",
-        },
-        fetchOptions: {
-          signal: abortable.current.signal,
-        },
-      });
+        return {
+          data: paginatedResponse.data.map((item) => ({ mediaType: "movie" as const, item })),
+          hasMore:
+            paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
+        };
+      }
 
-      if (response.status !== 200) return { data: [], hasMore: false };
-      const paginatedResponse = withPagination(response);
+      if (mediaType === "show") {
+        const response = await traktClient.shows.getShowHistory({
+          query: { ...historyQuery, page },
+          fetchOptions,
+        });
+
+        if (response.status !== 200) return { data: [], hasMore: false };
+        const paginatedResponse = withPagination(response);
+
+        return {
+          data: paginatedResponse.data.map((item) => ({ mediaType: "show" as const, item })),
+          hasMore:
+            paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
+        };
+      }
+
+      const [moviesResponse, showsResponse] = await Promise.all([
+        traktClient.movies.getMovieHistory({ query: { ...historyQuery, page }, fetchOptions }),
+        traktClient.shows.getShowHistory({ query: { ...historyQuery, page }, fetchOptions }),
+      ]);
+
+      const movies =
+        moviesResponse.status === 200
+          ? withPagination(moviesResponse)
+          : { data: [] as TraktMovieHistoryListItem[], pagination: null };
+      const shows =
+        showsResponse.status === 200
+          ? withPagination(showsResponse)
+          : { data: [] as TraktShowHistoryListItem[], pagination: null };
+
+      const merged = sortByWatchedAt([
+        ...movies.data.map((item) => ({ mediaType: "movie" as const, item })),
+        ...shows.data.map((item) => ({ mediaType: "show" as const, item })),
+      ]);
+
+      const moviesHasMore =
+        movies.pagination !== null &&
+        movies.pagination["x-pagination-page"] < movies.pagination["x-pagination-page-count"];
+      const showsHasMore =
+        shows.pagination !== null &&
+        shows.pagination["x-pagination-page"] < shows.pagination["x-pagination-page-count"];
 
       return {
-        data: paginatedResponse.data,
-        hasMore:
-          paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
+        data: merged,
+        hasMore: moviesHasMore || showsHasMore,
       };
     },
     [mediaType],
@@ -158,7 +173,7 @@ export default function Command() {
   const onMediaTypeChange = useCallback((newValue: string) => {
     abortable.current?.abort();
     abortable.current = new AbortController();
-    setMediaType(newValue as TraktMediaType);
+    setMediaType(newValue as HistoryFilterType);
   }, []);
 
   const handleMovieAction = useCallback(
@@ -170,7 +185,7 @@ export default function Command() {
       setActionLoading(true);
       try {
         await action(movie);
-        revalidateMovie();
+        revalidate();
         showToast({
           title: message,
           style: Toast.Style.Success,
@@ -184,7 +199,7 @@ export default function Command() {
         setActionLoading(false);
       }
     },
-    [],
+    [revalidate],
   );
 
   const handleShowAction = useCallback(
@@ -196,7 +211,7 @@ export default function Command() {
       setActionLoading(true);
       try {
         await action(episode);
-        revalidateShow();
+        revalidate();
         showToast({
           title: message,
           style: Toast.Style.Success,
@@ -210,7 +225,7 @@ export default function Command() {
         setActionLoading(false);
       }
     },
-    [],
+    [revalidate],
   );
 
   const movieMarkdown = useCallback((movie: TraktMovieHistoryListItem) => {
@@ -221,172 +236,170 @@ export default function Command() {
     return createMovieMetadata(movie);
   }, []);
 
-  return mediaType === "movie" ? (
-    <GenericGrid
-      isLoading={isMovieLoading || actionLoading}
-      emptyViewTitle="No history available"
-      searchBarPlaceholder="Search history"
-      searchBarAccessory={
-        <Grid.Dropdown onChange={onMediaTypeChange} tooltip="Media Type">
-          <Grid.Dropdown.Item value="movie" title="Movies" />
-          <Grid.Dropdown.Item value="show" title="Shows" />
-        </Grid.Dropdown>
-      }
-      pagination={moviePagination}
-      items={movies}
-      aspectRatio="9/16"
-      fit={Grid.Fit.Fill}
-      poster={(item) => getPosterUrl(item.movie.images, "poster.png")}
-      title={(item) => item.movie.title}
-      subtitle={(item) => (item.watched_at ? `${formatter.format(new Date(item.watched_at))}` : "")}
-      keyFn={(item, index) => `${item.movie.ids.trakt}-${index}`}
-      actions={(item) => (
-        <ActionPanel>
-          <ActionPanel.Section>
-            <Action.Push
-              icon={Icon.Eye}
-              title="View Details"
-              target={
-                <GenericDetail
-                  item={item}
-                  isLoading={false}
-                  markdown={movieMarkdown}
-                  metadata={movieMetadata}
-                  navigationTitle={(movie) => movie.movie.title}
-                  actions={(movie) => (
-                    <ActionPanel>
-                      <ActionPanel.Section>
-                        <Action.OpenInBrowser
-                          icon={getFavicon(TRAKT_APP_URL)}
-                          title="Open in Trakt"
-                          shortcut={Keyboard.Shortcut.Common.Open}
-                          url={getTraktUrl("movies", movie.movie.ids.slug)}
-                        />
-                        <Action.OpenInBrowser
-                          icon={getFavicon(IMDB_APP_URL)}
-                          title="Open in Imdb"
-                          shortcut={{ modifiers: ["cmd"], key: "i" }}
-                          url={getIMDbUrl(movie.movie.ids.imdb)}
-                        />
-                      </ActionPanel.Section>
-                    </ActionPanel>
-                  )}
-                />
-              }
-            />
-          </ActionPanel.Section>
-          <ActionPanel.Section>
-            <Action.OpenInBrowser
-              icon={getFavicon(TRAKT_APP_URL)}
-              title="Open in Trakt"
-              shortcut={Keyboard.Shortcut.Common.Open}
-              url={getTraktUrl("movies", item.movie.ids.slug)}
-            />
-            <Action.OpenInBrowser
-              icon={getFavicon(IMDB_APP_URL)}
-              title="Open in Imdb"
-              shortcut={{ modifiers: ["cmd"], key: "i" }}
-              url={getIMDbUrl(item.movie.ids.imdb)}
-            />
-          </ActionPanel.Section>
-          <ActionPanel.Section>
-            <Action
-              title="Remove from History"
-              icon={Icon.Trash}
-              shortcut={Keyboard.Shortcut.Common.Remove}
-              onAction={() => handleMovieAction(item, removeMovieFromHistory, "Movie removed from history")}
-            />
-          </ActionPanel.Section>
-        </ActionPanel>
-      )}
-    />
-  ) : (
-    <GenericGrid
-      isLoading={isShowsLoading || actionLoading}
-      emptyViewTitle="No history available"
-      searchBarPlaceholder="Search history"
-      searchBarAccessory={
-        <Grid.Dropdown onChange={onMediaTypeChange} tooltip="Media Type">
-          <Grid.Dropdown.Item value="movie" title="Movies" />
-          <Grid.Dropdown.Item value="show" title="Shows" />
-        </Grid.Dropdown>
-      }
-      pagination={showPagination}
-      items={shows}
-      aspectRatio="9/16"
-      fit={Grid.Fit.Fill}
-      poster={(item) => getPosterUrl(item.show.images, "poster.png")}
-      title={(item) => `${item.show.title} - ${item.episode.title}`}
-      subtitle={(item) =>
-        `${item.episode.season}x${item.episode.number.toString().padStart(2, "0")}${
-          item.watched_at ? ` - ${formatter.format(new Date(item.watched_at))}` : ""
-        }`
-      }
-      keyFn={(item, index) => `${item.show.ids.trakt}-${item.episode.ids.trakt}-${index}`}
-      actions={(item) => (
-        <ActionPanel>
-          <ActionPanel.Section>
-            <Action.Push
-              icon={Icon.Eye}
-              title="View Details"
-              target={
-                <GenericDetail
-                  item={item}
-                  isLoading={false}
-                  markdown={(item) =>
-                    // Use the episode and show objects for markdown
-                    createEpisodeMarkdown(item.episode, item.show)
-                  }
-                  metadata={(item) => createEpisodeMetadata(item.episode, item.show)}
-                  navigationTitle={(item) =>
-                    `${item.show.title} - S${item.episode.season}E${item.episode.number.toString().padStart(2, "0")}`
-                  }
-                  actions={(item) => (
-                    <ActionPanel>
-                      <Action
-                        title="Remove from History"
-                        icon={Icon.Trash}
-                        shortcut={Keyboard.Shortcut.Common.Remove}
-                        onAction={() =>
-                          handleShowAction(item, removeEpisodeFromHistory, "Episode removed from history")
-                        }
-                      />
+  const movieActions = useCallback(
+    (item: TraktMovieHistoryListItem) => (
+      <ActionPanel>
+        <ActionPanel.Section>
+          <Action.Push
+            icon={Icon.Eye}
+            title="View Details"
+            target={
+              <GenericDetail
+                item={item}
+                isLoading={false}
+                markdown={movieMarkdown}
+                metadata={movieMetadata}
+                navigationTitle={(movie) => movie.movie.title}
+                actions={(movie) => (
+                  <ActionPanel>
+                    <ActionPanel.Section>
                       <Action.OpenInBrowser
                         icon={getFavicon(TRAKT_APP_URL)}
                         title="Open in Trakt"
-                        url={getTraktUrl("episode", item.show.ids.slug, item.episode.season, item.episode.number)}
+                        shortcut={Keyboard.Shortcut.Common.Open}
+                        url={getTraktUrl("movies", movie.movie.ids.slug)}
                       />
                       <Action.OpenInBrowser
                         icon={getFavicon(IMDB_APP_URL)}
                         title="Open in Imdb"
-                        url={getIMDbUrl(item.episode.ids.imdb)}
+                        shortcut={{ modifiers: ["cmd"], key: "i" }}
+                        url={getIMDbUrl(movie.movie.ids.imdb)}
                       />
-                    </ActionPanel>
-                  )}
-                />
-              }
-            />
-            <Action
-              title="Remove from History"
-              icon={Icon.Trash}
-              shortcut={Keyboard.Shortcut.Common.Remove}
-              onAction={() => handleShowAction(item, removeEpisodeFromHistory, "Episode removed from history")}
-            />
-          </ActionPanel.Section>
-          <ActionPanel.Section>
-            <Action.OpenInBrowser
-              icon={getFavicon(TRAKT_APP_URL)}
-              title="Open in Trakt"
-              url={getTraktUrl("episode", item.show.ids.slug, item.episode.season, item.episode.number)}
-            />
-            <Action.OpenInBrowser
-              icon={getFavicon(IMDB_APP_URL)}
-              title="Open in Imdb"
-              url={getIMDbUrl(item.episode.ids.imdb)}
-            />
-          </ActionPanel.Section>
-        </ActionPanel>
-      )}
+                    </ActionPanel.Section>
+                  </ActionPanel>
+                )}
+              />
+            }
+          />
+        </ActionPanel.Section>
+        <ActionPanel.Section>
+          <Action.OpenInBrowser
+            icon={getFavicon(TRAKT_APP_URL)}
+            title="Open in Trakt"
+            shortcut={Keyboard.Shortcut.Common.Open}
+            url={getTraktUrl("movies", item.movie.ids.slug)}
+          />
+          <Action.OpenInBrowser
+            icon={getFavicon(IMDB_APP_URL)}
+            title="Open in Imdb"
+            shortcut={{ modifiers: ["cmd"], key: "i" }}
+            url={getIMDbUrl(item.movie.ids.imdb)}
+          />
+        </ActionPanel.Section>
+        <ActionPanel.Section>
+          <Action
+            title="Remove from History"
+            icon={Icon.Trash}
+            shortcut={Keyboard.Shortcut.Common.Remove}
+            onAction={() => handleMovieAction(item, removeMovieFromHistory, "Movie removed from history")}
+          />
+        </ActionPanel.Section>
+      </ActionPanel>
+    ),
+    [handleMovieAction, movieMarkdown, movieMetadata, removeMovieFromHistory],
+  );
+
+  const showActions = useCallback(
+    (item: TraktShowHistoryListItem) => (
+      <ActionPanel>
+        <ActionPanel.Section>
+          <Action.Push
+            icon={Icon.Eye}
+            title="View Details"
+            target={
+              <GenericDetail
+                item={item}
+                isLoading={false}
+                markdown={(item) => createEpisodeMarkdown(item.episode, item.show)}
+                metadata={(item) => createEpisodeMetadata(item.episode, item.show)}
+                navigationTitle={(item) =>
+                  `${item.show.title} - S${item.episode.season}E${item.episode.number.toString().padStart(2, "0")}`
+                }
+                actions={(item) => (
+                  <ActionPanel>
+                    <Action
+                      title="Remove from History"
+                      icon={Icon.Trash}
+                      shortcut={Keyboard.Shortcut.Common.Remove}
+                      onAction={() => handleShowAction(item, removeEpisodeFromHistory, "Episode removed from history")}
+                    />
+                    <Action.OpenInBrowser
+                      icon={getFavicon(TRAKT_APP_URL)}
+                      title="Open in Trakt"
+                      url={getTraktUrl("episode", item.show.ids.slug, item.episode.season, item.episode.number)}
+                    />
+                    <Action.OpenInBrowser
+                      icon={getFavicon(IMDB_APP_URL)}
+                      title="Open in Imdb"
+                      url={getIMDbUrl(item.episode.ids.imdb)}
+                    />
+                  </ActionPanel>
+                )}
+              />
+            }
+          />
+          <Action
+            title="Remove from History"
+            icon={Icon.Trash}
+            shortcut={Keyboard.Shortcut.Common.Remove}
+            onAction={() => handleShowAction(item, removeEpisodeFromHistory, "Episode removed from history")}
+          />
+        </ActionPanel.Section>
+        <ActionPanel.Section>
+          <Action.OpenInBrowser
+            icon={getFavicon(TRAKT_APP_URL)}
+            title="Open in Trakt"
+            url={getTraktUrl("episode", item.show.ids.slug, item.episode.season, item.episode.number)}
+          />
+          <Action.OpenInBrowser
+            icon={getFavicon(IMDB_APP_URL)}
+            title="Open in Imdb"
+            url={getIMDbUrl(item.episode.ids.imdb)}
+          />
+        </ActionPanel.Section>
+      </ActionPanel>
+    ),
+    [handleShowAction, removeEpisodeFromHistory],
+  );
+
+  const searchBarAccessory = (
+    <Grid.Dropdown onChange={onMediaTypeChange} tooltip="Media Type">
+      <Grid.Dropdown.Item value="all" title="All" />
+      <Grid.Dropdown.Item value="movie" title="Movies" />
+      <Grid.Dropdown.Item value="show" title="Shows" />
+    </Grid.Dropdown>
+  );
+
+  return (
+    <GenericGrid
+      isLoading={isLoading || actionLoading}
+      emptyViewTitle="No history available"
+      searchBarPlaceholder="Search history"
+      searchBarAccessory={searchBarAccessory}
+      pagination={pagination}
+      items={history}
+      aspectRatio="9/16"
+      fit={Grid.Fit.Fill}
+      title={(item) =>
+        item.mediaType === "movie" ? item.item.movie.title : `${item.item.show.title} - ${item.item.episode.title}`
+      }
+      subtitle={(item) => {
+        const watchedAt = item.item.watched_at ? formatter.format(new Date(item.item.watched_at)) : "";
+        if (item.mediaType === "movie") {
+          return watchedAt;
+        }
+        const episodeLabel = `${item.item.episode.season}x${item.item.episode.number.toString().padStart(2, "0")}`;
+        return watchedAt ? `${episodeLabel} - ${watchedAt}` : episodeLabel;
+      }}
+      poster={(item) =>
+        getPosterUrl(item.mediaType === "movie" ? item.item.movie.images : item.item.show.images, "poster.png")
+      }
+      keyFn={(item, index) =>
+        item.mediaType === "movie"
+          ? `${item.item.movie.ids.trakt}-${index}`
+          : `${item.item.show.ids.trakt}-${item.item.episode.ids.trakt}-${index}`
+      }
+      actions={(item) => (item.mediaType === "movie" ? movieActions(item.item) : showActions(item.item))}
     />
   );
 }

--- a/extensions/trakt-manager/src/lib/action-runner.ts
+++ b/extensions/trakt-manager/src/lib/action-runner.ts
@@ -1,0 +1,31 @@
+import { Toast, showToast } from "@raycast/api";
+import { Dispatch, SetStateAction, useCallback } from "react";
+
+type RunActionOptions = {
+  setActionLoading: Dispatch<SetStateAction<boolean>>;
+  onSuccess?: () => void;
+};
+
+export function useActionRunner<T>({ setActionLoading, onSuccess }: RunActionOptions) {
+  return useCallback(
+    async (item: T, action: (item: T) => Promise<void>, message: string) => {
+      setActionLoading(true);
+      try {
+        await action(item);
+        onSuccess?.();
+        showToast({
+          title: message,
+          style: Toast.Style.Success,
+        });
+      } catch (error) {
+        showToast({
+          title: (error as Error).message,
+          style: Toast.Style.Failure,
+        });
+      } finally {
+        setActionLoading(false);
+      }
+    },
+    [onSuccess, setActionLoading],
+  );
+}

--- a/extensions/trakt-manager/src/lib/constants.ts
+++ b/extensions/trakt-manager/src/lib/constants.ts
@@ -1,6 +1,12 @@
+import { Keyboard } from "@raycast/api";
+
 export const TRAKT_API_URL = "https://api.trakt.tv";
 export const TRAKT_APP_URL = "https://trakt.tv";
 export const TRAKT_CLIENT_ID = "f7525a53be3842c4ff7570cfd33ca792c7f9717ab8f74af34337d6595f40af46";
 export const IMDB_APP_URL = "https://www.imdb.com";
 export const APP_MAX_LISTENERS = 100;
 export const USER_AGENT = "trakt-manager-raycast/1.0";
+export const IMDB_SHORTCUT = {
+  macOS: { modifiers: ["cmd"], key: "i" },
+  Windows: { modifiers: ["ctrl"], key: "i" },
+} satisfies Keyboard.Shortcut;

--- a/extensions/trakt-manager/src/lib/contract.ts
+++ b/extensions/trakt-manager/src/lib/contract.ts
@@ -9,6 +9,7 @@ import {
   TraktMovieHistoryList,
   TraktMovieList,
   TraktMovieRecommendationList,
+  TraktHistoryQuerySchema,
   TraktPaginationWithSortingSchema,
   TraktRecommendationRequestSchema,
   TraktSearchSchema,
@@ -101,7 +102,7 @@ const TraktMovieContract = c.router({
     responses: {
       200: TraktMovieHistoryList,
     },
-    query: TraktPaginationWithSortingSchema,
+    query: TraktHistoryQuerySchema,
     summary: "Get movie history",
   },
   removeMovieFromHistory: {
@@ -217,7 +218,7 @@ const TraktShowContract = c.router({
     responses: {
       200: TraktShowHistoryList,
     },
-    query: TraktPaginationWithSortingSchema,
+    query: TraktHistoryQuerySchema,
     summary: "Get show history",
   },
   removeShowFromHistory: {

--- a/extensions/trakt-manager/src/lib/detail-helpers.tsx
+++ b/extensions/trakt-manager/src/lib/detail-helpers.tsx
@@ -1,5 +1,4 @@
 import { Detail } from "@raycast/api";
-import { type ReactElement } from "react";
 import { getBannerUrl, getIMDbUrl, getScreenshotUrl, getTraktUrl } from "./helper";
 import {
   TraktEpisodeListItem,
@@ -74,7 +73,7 @@ export const createEpisodeMarkdown = (episode: TraktEpisodeListItem, show?: Trak
 
 export const createMovieMetadata = (
   movie: TraktMovieBaseItem | TraktMovieListItem | TraktMovieHistoryListItem,
-): ReactElement => {
+): Detail.Props["metadata"] => {
   const movieData = "movie" in movie ? movie.movie : movie;
   const baseFields = getMovieMetadataFields(movieData);
   return (
@@ -121,7 +120,10 @@ export const createMovieMetadata = (
   );
 };
 
-export const createEpisodeMetadata = (episode: TraktEpisodeListItem, show: TraktShowBaseItem): ReactElement => {
+export const createEpisodeMetadata = (
+  episode: TraktEpisodeListItem,
+  show: TraktShowBaseItem,
+): Detail.Props["metadata"] => {
   const episodeFields = getEpisodeMetadataFields(episode);
   const showFields = getShowMetadataFields(show);
   return (

--- a/extensions/trakt-manager/src/lib/media-mutations.ts
+++ b/extensions/trakt-manager/src/lib/media-mutations.ts
@@ -1,0 +1,207 @@
+import { initTraktClient } from "./client";
+import { TraktMovieHistoryListItem, TraktMovieListItem, TraktShowHistoryListItem, TraktShowListItem } from "./schema";
+
+type TraktClient = ReturnType<typeof initTraktClient>;
+
+type MutationOptions = {
+  signal?: AbortSignal;
+};
+
+export async function addMovieToWatchlist(
+  traktClient: TraktClient,
+  movie: TraktMovieListItem,
+  { signal }: MutationOptions,
+) {
+  await traktClient.movies.addMovieToWatchlist({
+    body: {
+      movies: [
+        {
+          ids: { trakt: movie.movie.ids.trakt },
+        },
+      ],
+    },
+    fetchOptions: {
+      signal,
+    },
+  });
+}
+
+export async function removeMovieFromWatchlist(
+  traktClient: TraktClient,
+  movie: TraktMovieListItem,
+  { signal }: MutationOptions,
+) {
+  await traktClient.movies.removeMovieFromWatchlist({
+    body: {
+      movies: [
+        {
+          ids: { trakt: movie.movie.ids.trakt },
+        },
+      ],
+    },
+    fetchOptions: {
+      signal,
+    },
+  });
+}
+
+export async function addMovieToHistory(
+  traktClient: TraktClient,
+  movie: TraktMovieListItem,
+  { signal }: MutationOptions,
+) {
+  await traktClient.movies.addMovieToHistory({
+    body: {
+      movies: [
+        {
+          ids: { trakt: movie.movie.ids.trakt },
+          watched_at: new Date().toISOString(),
+        },
+      ],
+    },
+    fetchOptions: {
+      signal,
+    },
+  });
+}
+
+export async function removeMovieFromHistory(
+  traktClient: TraktClient,
+  movie: TraktMovieHistoryListItem,
+  { signal }: MutationOptions,
+) {
+  await traktClient.movies.removeMovieFromHistory({
+    body: {
+      movies: [
+        {
+          ids: {
+            trakt: movie.movie.ids.trakt,
+          },
+        },
+      ],
+    },
+    fetchOptions: {
+      signal,
+    },
+  });
+}
+
+export async function addShowToWatchlist(
+  traktClient: TraktClient,
+  show: TraktShowListItem,
+  { signal }: MutationOptions,
+) {
+  await traktClient.shows.addShowToWatchlist({
+    body: {
+      shows: [
+        {
+          ids: {
+            trakt: show.show.ids.trakt,
+          },
+        },
+      ],
+    },
+    fetchOptions: {
+      signal,
+    },
+  });
+}
+
+export async function removeShowFromWatchlist(
+  traktClient: TraktClient,
+  show: TraktShowListItem,
+  { signal }: MutationOptions,
+) {
+  await traktClient.shows.removeShowFromWatchlist({
+    body: {
+      shows: [
+        {
+          ids: {
+            trakt: show.show.ids.trakt,
+          },
+        },
+      ],
+    },
+    fetchOptions: {
+      signal,
+    },
+  });
+}
+
+export async function addShowToHistory(traktClient: TraktClient, show: TraktShowListItem, { signal }: MutationOptions) {
+  await traktClient.shows.addShowToHistory({
+    body: {
+      shows: [
+        {
+          ids: {
+            trakt: show.show.ids.trakt,
+          },
+          watched_at: new Date().toISOString(),
+        },
+      ],
+    },
+    fetchOptions: {
+      signal,
+    },
+  });
+}
+
+export async function checkInFirstEpisodeToHistory(
+  traktClient: TraktClient,
+  show: TraktShowListItem,
+  { signal }: MutationOptions,
+) {
+  const response = await traktClient.shows.getEpisode({
+    params: {
+      showid: show.show.ids.trakt,
+      seasonNumber: 1,
+      episodeNumber: 1,
+    },
+    query: {
+      extended: "full",
+    },
+    fetchOptions: {
+      signal,
+    },
+  });
+
+  if (response.status !== 200) throw new Error("Failed to get first episode");
+  const firstEpisode = response.body;
+
+  await traktClient.shows.checkInEpisode({
+    body: {
+      episodes: [
+        {
+          ids: {
+            trakt: firstEpisode.ids.trakt,
+          },
+          watched_at: new Date().toISOString(),
+        },
+      ],
+    },
+    fetchOptions: {
+      signal,
+    },
+  });
+}
+
+export async function removeEpisodeFromHistory(
+  traktClient: TraktClient,
+  episode: TraktShowHistoryListItem,
+  { signal }: MutationOptions,
+) {
+  await traktClient.shows.removeEpisodeFromHistory({
+    body: {
+      episodes: [
+        {
+          ids: {
+            trakt: episode.episode.ids.trakt,
+          },
+        },
+      ],
+    },
+    fetchOptions: {
+      signal,
+    },
+  });
+}

--- a/extensions/trakt-manager/src/lib/media-pagination.ts
+++ b/extensions/trakt-manager/src/lib/media-pagination.ts
@@ -1,0 +1,100 @@
+import { Toast, showToast } from "@raycast/api";
+import { type MutableRefObject } from "react";
+import { withPagination } from "./schema";
+
+type TraktApiResponse = { status: number; headers: Headers; body: unknown };
+
+type PaginationHeaders = { "x-pagination-page": number; "x-pagination-page-count": number };
+
+type PaginatedResult<T> = { data: T[]; hasMore: boolean };
+
+export type CombinedMediaItem<MovieItem, ShowItem> =
+  { mediaType: "movie"; item: MovieItem } | { mediaType: "show"; item: ShowItem };
+
+const hasMorePages = (pagination?: PaginationHeaders) =>
+  (pagination?.["x-pagination-page"] ?? 0) < (pagination?.["x-pagination-page-count"] ?? 0);
+
+/**
+ * Fetches a single page of a single media type and tags each item with its `mediaType`.
+ * The `Item` type is supplied by the caller because the ts-rest response body is a
+ * status-discriminated union that can't be narrowed generically here.
+ */
+export async function fetchMediaPage<MediaType extends "movie" | "show", Item>(
+  mediaType: MediaType,
+  request: () => Promise<TraktApiResponse>,
+): Promise<PaginatedResult<{ mediaType: MediaType; item: Item }>> {
+  const response = await request();
+  if (response.status !== 200) return { data: [], hasMore: false };
+
+  const paginated = withPagination(response);
+  const items = paginated.data as Item[];
+
+  return {
+    data: items.map((item) => ({ mediaType, item })),
+    hasMore: hasMorePages(paginated.pagination),
+  };
+}
+
+/**
+ * Fetches movies and shows in parallel up to the page needed to fill a combined window,
+ * merges them via `sort`, then slices the requested window. Used by the "all" filter where
+ * two paginated sources are interleaved into a single grid.
+ */
+export async function fetchCombinedMediaPage<MovieItem, ShowItem>(options: {
+  page: number;
+  perPageLimit: number;
+  combinedPageLimit: number;
+  requestMoviePage: (page: number) => Promise<TraktApiResponse>;
+  requestShowPage: (page: number) => Promise<TraktApiResponse>;
+  sort: (items: CombinedMediaItem<MovieItem, ShowItem>[]) => CombinedMediaItem<MovieItem, ShowItem>[];
+}): Promise<PaginatedResult<CombinedMediaItem<MovieItem, ShowItem>>> {
+  const { page, perPageLimit, combinedPageLimit, requestMoviePage, requestShowPage, sort } = options;
+
+  const pageCount = Math.ceil(((page + 1) * combinedPageLimit) / perPageLimit);
+  const pages = Array.from({ length: pageCount }, (_, index) => index + 1);
+
+  const [movieResponses, showResponses] = await Promise.all([
+    Promise.all(pages.map(requestMoviePage)),
+    Promise.all(pages.map(requestShowPage)),
+  ]);
+
+  const moviePages = movieResponses
+    .filter((response) => response.status === 200)
+    .map((response) => withPagination(response));
+  const showPages = showResponses
+    .filter((response) => response.status === 200)
+    .map((response) => withPagination(response));
+
+  const merged = sort([
+    ...moviePages.flatMap((moviePage) =>
+      (moviePage.data as MovieItem[]).map((item) => ({ mediaType: "movie" as const, item })),
+    ),
+    ...showPages.flatMap((showPage) =>
+      (showPage.data as ShowItem[]).map((item) => ({ mediaType: "show" as const, item })),
+    ),
+  ]);
+
+  const sliceStart = page * combinedPageLimit;
+  const sliceEnd = sliceStart + combinedPageLimit;
+  const moviesHasMore = hasMorePages(moviePages.at(-1)?.pagination);
+  const showsHasMore = hasMorePages(showPages.at(-1)?.pagination);
+
+  return {
+    data: merged.slice(sliceStart, sliceEnd),
+    hasMore: merged.length > sliceEnd || moviesHasMore || showsHasMore,
+  };
+}
+
+export function mediaListCacheOptions(abortable: MutableRefObject<AbortController | undefined>) {
+  return {
+    initialData: undefined,
+    keepPreviousData: true,
+    abortable,
+    onError(error: Error) {
+      showToast({
+        title: error.message,
+        style: Toast.Style.Failure,
+      });
+    },
+  };
+}

--- a/extensions/trakt-manager/src/lib/pagination.ts
+++ b/extensions/trakt-manager/src/lib/pagination.ts
@@ -1,0 +1,7 @@
+type Flatten<T> = T extends Array<infer U> ? U : T;
+
+export type PaginationOptions<T = unknown> = {
+  page: number;
+  lastItem?: Flatten<T>;
+  cursor?: unknown;
+};

--- a/extensions/trakt-manager/src/lib/schema.ts
+++ b/extensions/trakt-manager/src/lib/schema.ts
@@ -36,6 +36,8 @@ export const TraktSearchSchema = TraktPaginationSchema.merge(TraktExtendedSchema
 
 export const TraktPaginationWithSortingSchema = TraktPaginationSchema.merge(TraktSortingSchema);
 
+export const TraktHistoryQuerySchema = TraktPaginationSchema.merge(TraktExtendedSchema);
+
 export const TraktUpNextQuerySchema = TraktPaginationWithSortingSchema.extend({
   include_stats: z.coerce.boolean(),
 });
@@ -91,6 +93,7 @@ export const TraktMovieListItem = z.object({
   type: z.string(),
   score: z.number(),
   plays: z.number().optional(),
+  listed_at: z.string().optional(),
   last_watched_at: z.string().optional(),
   last_updated_at: z.string().optional(),
   movie: TraktMovieBaseItem,
@@ -152,6 +155,7 @@ export const TraktShowListItem = z.object({
   type: z.string(),
   score: z.number(),
   plays: z.number().optional(),
+  listed_at: z.string().optional(),
   last_watched_at: z.string().optional(),
   last_updated_at: z.string().optional(),
   show: TraktShowBaseItem,

--- a/extensions/trakt-manager/src/lib/search.ts
+++ b/extensions/trakt-manager/src/lib/search.ts
@@ -1,0 +1,74 @@
+import { setMaxListeners } from "node:events";
+import { setTimeout } from "node:timers/promises";
+import { MutableRefObject } from "react";
+import { APP_MAX_LISTENERS } from "./constants";
+import { PaginationOptions } from "./pagination";
+import { withPagination } from "./schema";
+
+type SearchResponse<T> = {
+  status: number;
+  body: T[];
+  headers: Headers;
+};
+
+type SearchQuery = {
+  query: string;
+  page: number;
+  limit: 10;
+  fields: "title";
+  extended: "full,cloud9";
+};
+
+type SearchEndpoint<T> = (args: {
+  query: SearchQuery;
+  fetchOptions: { signal: AbortSignal };
+}) => Promise<SearchResponse<T>>;
+
+type CreateSearchFetcherOptions<T> = {
+  abortable: MutableRefObject<AbortController | undefined>;
+  delay?: number;
+  search: SearchEndpoint<T>;
+};
+
+export function createSearchFetcher<T>({ abortable, delay = 100, search }: CreateSearchFetcherOptions<T>) {
+  return (searchText: string) => async (options: PaginationOptions) => {
+    if (!searchText) return { data: [], hasMore: false };
+    await setTimeout(delay);
+
+    abortable.current = new AbortController();
+    setMaxListeners(APP_MAX_LISTENERS, abortable.current?.signal);
+
+    const response = await search({
+      query: {
+        query: searchText,
+        page: options.page + 1,
+        limit: 10,
+        fields: "title",
+        extended: "full,cloud9",
+      },
+      fetchOptions: {
+        signal: abortable.current.signal,
+      },
+    });
+
+    if (response.status !== 200) return { data: [], hasMore: false };
+    const paginatedResponse = withPagination(response);
+
+    return {
+      data: paginatedResponse.data,
+      hasMore:
+        paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
+    };
+  };
+}
+
+export function abortSearch(
+  abortable: MutableRefObject<AbortController | undefined>,
+  setSearchText: (text: string) => void,
+) {
+  return (text: string): void => {
+    abortable.current?.abort();
+    abortable.current = new AbortController();
+    setSearchText(text);
+  };
+}

--- a/extensions/trakt-manager/src/movies.tsx
+++ b/extensions/trakt-manager/src/movies.tsx
@@ -1,16 +1,14 @@
-import { Action, ActionPanel, Grid, Icon, Keyboard, Toast, showToast } from "@raycast/api";
-import { getFavicon, useCachedPromise } from "@raycast/utils";
-import { PaginationOptions } from "@raycast/utils/dist/types";
-import { setMaxListeners } from "node:events";
-import { setTimeout } from "node:timers/promises";
+import { Grid, Icon, Keyboard, Toast, showToast } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
 import { useCallback, useRef, useState } from "react";
-import { GenericDetail } from "./components/generic-detail";
 import { GenericGrid } from "./components/generic-grid";
+import { MovieActionPanel } from "./components/media-actions";
+import { useActionRunner } from "./lib/action-runner";
 import { initTraktClient } from "./lib/client";
-import { APP_MAX_LISTENERS, IMDB_APP_URL, TRAKT_APP_URL } from "./lib/constants";
-import { createMovieMarkdown, createMovieMetadata } from "./lib/detail-helpers";
-import { getIMDbUrl, getPosterUrl, getTraktUrl } from "./lib/helper";
-import { TraktMovieListItem, withPagination } from "./lib/schema";
+import { getPosterUrl } from "./lib/helper";
+import { addMovieToHistory, addMovieToWatchlist } from "./lib/media-mutations";
+import { TraktMovieListItem } from "./lib/schema";
+import { abortSearch, createSearchFetcher } from "./lib/search";
 
 export default function Command() {
   const abortable = useRef<AbortController | undefined>(undefined);
@@ -22,35 +20,10 @@ export default function Command() {
     data: movies,
     pagination,
   } = useCachedPromise(
-    (searchText: string) => async (options: PaginationOptions) => {
-      if (!searchText) return { data: [], hasMore: false };
-      await setTimeout(100);
-
-      abortable.current = new AbortController();
-      setMaxListeners(APP_MAX_LISTENERS, abortable.current?.signal);
-
-      const response = await traktClient.movies.searchMovies({
-        query: {
-          query: searchText,
-          page: options.page + 1,
-          limit: 10,
-          fields: "title",
-          extended: "full,cloud9",
-        },
-        fetchOptions: {
-          signal: abortable.current.signal,
-        },
-      });
-
-      if (response.status !== 200) return { data: [], hasMore: false };
-      const paginatedResponse = withPagination(response);
-
-      return {
-        data: paginatedResponse.data,
-        hasMore:
-          paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
-      };
-    },
+    createSearchFetcher({
+      abortable,
+      search: traktClient.movies.searchMovies,
+    }),
     [searchText],
     {
       initialData: undefined,
@@ -65,74 +38,23 @@ export default function Command() {
     },
   );
 
-  const addMovieToWatchlist = useCallback(async (movie: TraktMovieListItem) => {
-    await traktClient.movies.addMovieToWatchlist({
-      body: {
-        movies: [
-          {
-            ids: { trakt: movie.movie.ids.trakt },
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
-
-  const addMovieToHistory = useCallback(async (movie: TraktMovieListItem) => {
-    await traktClient.movies.addMovieToHistory({
-      body: {
-        movies: [
-          {
-            ids: { trakt: movie.movie.ids.trakt },
-            watched_at: new Date().toISOString(),
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
-
-  const handleSearchTextChange = useCallback(
-    (text: string): void => {
-      abortable.current?.abort();
-      abortable.current = new AbortController();
-      setSearchText(text);
+  const addMovieToWatchlistAction = useCallback(
+    async (movie: TraktMovieListItem) => {
+      await addMovieToWatchlist(traktClient, movie, { signal: abortable.current?.signal });
     },
-    [abortable],
+    [traktClient],
   );
 
-  const handleAction = useCallback(
-    async (movie: TraktMovieListItem, action: (movie: TraktMovieListItem) => Promise<void>, message: string) => {
-      setActionLoading(true);
-      try {
-        await action(movie);
-        showToast({
-          title: message,
-          style: Toast.Style.Success,
-        });
-      } catch (e) {
-        showToast({
-          title: (e as Error).message,
-          style: Toast.Style.Failure,
-        });
-      } finally {
-        setActionLoading(false);
-      }
+  const addMovieToHistoryAction = useCallback(
+    async (movie: TraktMovieListItem) => {
+      await addMovieToHistory(traktClient, movie, { signal: abortable.current?.signal });
     },
-    [],
+    [traktClient],
   );
 
-  const movieMarkdown = useCallback((movie: TraktMovieListItem) => {
-    return createMovieMarkdown(movie.movie);
-  }, []);
+  const handleSearchTextChange = useCallback(abortSearch(abortable, setSearchText), []);
 
-  const movieMetadata = useCallback((movie: TraktMovieListItem) => {
-    return createMovieMetadata(movie);
-  }, []);
+  const runMovieAction = useActionRunner<TraktMovieListItem>({ setActionLoading });
 
   return (
     <GenericGrid
@@ -149,67 +71,23 @@ export default function Command() {
       poster={(item) => getPosterUrl(item.movie.images, "poster.png")}
       keyFn={(item, index) => `${item.movie.ids.trakt}-${index}`}
       actions={(item) => (
-        <ActionPanel>
-          <ActionPanel.Section>
-            <Action.Push
-              icon={Icon.Eye}
-              title="View Details"
-              target={
-                <GenericDetail
-                  item={item}
-                  isLoading={false}
-                  markdown={movieMarkdown}
-                  metadata={movieMetadata}
-                  navigationTitle={(movie) => movie.movie.title}
-                  actions={(movie) => (
-                    <ActionPanel>
-                      <ActionPanel.Section>
-                        <Action.OpenInBrowser
-                          icon={getFavicon(TRAKT_APP_URL)}
-                          title="Open in Trakt"
-                          shortcut={Keyboard.Shortcut.Common.Open}
-                          url={getTraktUrl("movies", movie.movie.ids.slug)}
-                        />
-                        <Action.OpenInBrowser
-                          icon={getFavicon(IMDB_APP_URL)}
-                          title="Open in Imdb"
-                          shortcut={{ modifiers: ["cmd"], key: "i" }}
-                          url={getIMDbUrl(movie.movie.ids.imdb)}
-                        />
-                      </ActionPanel.Section>
-                    </ActionPanel>
-                  )}
-                />
-              }
-            />
-            <Action
-              title="Add to Watchlist"
-              icon={Icon.Bookmark}
-              shortcut={Keyboard.Shortcut.Common.Edit}
-              onAction={() => handleAction(item, addMovieToWatchlist, "Movie added to watchlist")}
-            />
-            <Action
-              title="Add to History"
-              icon={Icon.Clock}
-              shortcut={Keyboard.Shortcut.Common.Duplicate}
-              onAction={() => handleAction(item, addMovieToHistory, "Movie added to history")}
-            />
-          </ActionPanel.Section>
-          <ActionPanel.Section>
-            <Action.OpenInBrowser
-              icon={getFavicon(TRAKT_APP_URL)}
-              title="Open in Trakt"
-              shortcut={Keyboard.Shortcut.Common.Open}
-              url={getTraktUrl("movies", item.movie.ids.slug)}
-            />
-            <Action.OpenInBrowser
-              icon={getFavicon(IMDB_APP_URL)}
-              title="Open in Imdb"
-              shortcut={{ modifiers: ["cmd"], key: "i" }}
-              url={getIMDbUrl(item.movie.ids.imdb)}
-            />
-          </ActionPanel.Section>
-        </ActionPanel>
+        <MovieActionPanel
+          item={item}
+          actions={[
+            {
+              title: "Add to Watchlist",
+              icon: Icon.Bookmark,
+              shortcut: Keyboard.Shortcut.Common.Edit,
+              onAction: (movie) => runMovieAction(movie, addMovieToWatchlistAction, "Movie added to watchlist"),
+            },
+            {
+              title: "Add to History",
+              icon: Icon.Clock,
+              shortcut: Keyboard.Shortcut.Common.Duplicate,
+              onAction: (movie) => runMovieAction(movie, addMovieToHistoryAction, "Movie added to history"),
+            },
+          ]}
+        />
       )}
     />
   );

--- a/extensions/trakt-manager/src/recommendations.tsx
+++ b/extensions/trakt-manager/src/recommendations.tsx
@@ -1,6 +1,6 @@
 import { Action, ActionPanel, Grid, Icon, Keyboard, Toast, showToast } from "@raycast/api";
 import { getFavicon, useCachedPromise } from "@raycast/utils";
-import { PaginationOptions } from "@raycast/utils/dist/types";
+import { type PaginationOptions } from "./lib/pagination";
 import { setMaxListeners } from "node:events";
 import { setTimeout } from "node:timers/promises";
 import { useCallback, useRef, useState } from "react";
@@ -8,7 +8,7 @@ import { GenericDetail } from "./components/generic-detail";
 import { GenericGrid } from "./components/generic-grid";
 import { SeasonGrid } from "./components/season-grid";
 import { initTraktClient } from "./lib/client";
-import { APP_MAX_LISTENERS, IMDB_APP_URL, TRAKT_APP_URL } from "./lib/constants";
+import { APP_MAX_LISTENERS, IMDB_APP_URL, IMDB_SHORTCUT, TRAKT_APP_URL } from "./lib/constants";
 import { createMovieMarkdown, createMovieMetadata } from "./lib/detail-helpers";
 import { getIMDbUrl, getPosterUrl, getTraktUrl } from "./lib/helper";
 import { TraktMediaType, TraktMovieBaseItem, TraktShowBaseItem, withPagination } from "./lib/schema";
@@ -335,7 +335,7 @@ export default function Command() {
                         <Action.OpenInBrowser
                           icon={getFavicon(IMDB_APP_URL)}
                           title="Open in Imdb"
-                          shortcut={{ modifiers: ["cmd"], key: "i" }}
+                          shortcut={IMDB_SHORTCUT}
                           url={getIMDbUrl(movie.ids.imdb)}
                         />
                       </ActionPanel.Section>
@@ -355,7 +355,7 @@ export default function Command() {
             <Action.OpenInBrowser
               icon={getFavicon(IMDB_APP_URL)}
               title="Open in Imdb"
-              shortcut={{ modifiers: ["cmd"], key: "i" }}
+              shortcut={IMDB_SHORTCUT}
               url={getIMDbUrl(item.ids.imdb)}
             />
           </ActionPanel.Section>

--- a/extensions/trakt-manager/src/recommendations.tsx
+++ b/extensions/trakt-manager/src/recommendations.tsx
@@ -403,7 +403,7 @@ export default function Command() {
               target={<SeasonGrid showId={item.ids.trakt} slug={item.ids.slug} imdbId={item.ids.imdb} />}
             />
             <Action
-              title="Check-in"
+              title="Check-In"
               icon={Icon.Checkmark}
               shortcut={Keyboard.Shortcut.Common.ToggleQuickLook}
               onAction={() => handleShowAction(item, checkInFirstEpisodeToHistory, "First episode checked-in")}

--- a/extensions/trakt-manager/src/search-media.tsx
+++ b/extensions/trakt-manager/src/search-media.tsx
@@ -13,74 +13,39 @@ import { createMovieMarkdown, createMovieMetadata } from "./lib/detail-helpers";
 import { getIMDbUrl, getPosterUrl, getTraktUrl } from "./lib/helper";
 import { TraktMovieListItem, TraktShowListItem, withPagination } from "./lib/schema";
 
-type WatchlistFilterType = "all" | "movie" | "show";
-
-type WatchlistItem = { mediaType: "movie"; item: TraktMovieListItem } | { mediaType: "show"; item: TraktShowListItem };
-
-const watchlistQuery = {
-  limit: 10,
-  extended: "full,cloud9" as const,
-  sort_by: "added" as const,
-};
-
-const sortByAddedAt = (items: WatchlistItem[]) =>
-  [...items].sort((a, b) => {
-    const aTime = a.item.last_updated_at ? new Date(a.item.last_updated_at).getTime() : 0;
-    const bTime = b.item.last_updated_at ? new Date(b.item.last_updated_at).getTime() : 0;
-    return bTime - aTime;
-  });
+type SearchMediaItem =
+  | { mediaType: "movie"; item: TraktMovieListItem }
+  | { mediaType: "show"; item: TraktShowListItem };
 
 export default function Command() {
   const abortable = useRef<AbortController | undefined>(undefined);
-  const [mediaType, setMediaType] = useState<WatchlistFilterType>("all");
+  const [searchText, setSearchText] = useState<string>("");
   const [actionLoading, setActionLoading] = useState(false);
   const traktClient = initTraktClient();
   const {
     isLoading,
-    data: watchlist,
+    data: media,
     pagination,
-    revalidate,
   } = useCachedPromise(
-    (mediaType: WatchlistFilterType) => async (options: PaginationOptions) => {
-      await setTimeout(100);
+    (searchText: string) => async (options: PaginationOptions) => {
+      if (!searchText) return { data: [], hasMore: false };
+      await setTimeout(200);
 
       abortable.current = new AbortController();
       setMaxListeners(APP_MAX_LISTENERS, abortable.current?.signal);
 
       const fetchOptions = { signal: abortable.current.signal };
-      const page = options.page + 1;
-      const sortHow = mediaType === "all" ? ("desc" as const) : ("asc" as const);
-      const query = { ...watchlistQuery, page, sort_how: sortHow };
-
-      if (mediaType === "movie") {
-        const response = await traktClient.movies.getWatchlistMovies({ query, fetchOptions });
-
-        if (response.status !== 200) return { data: [], hasMore: false };
-        const paginatedResponse = withPagination(response);
-
-        return {
-          data: paginatedResponse.data.map((item) => ({ mediaType: "movie" as const, item })),
-          hasMore:
-            paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
-        };
-      }
-
-      if (mediaType === "show") {
-        const response = await traktClient.shows.getWatchlistShows({ query, fetchOptions });
-
-        if (response.status !== 200) return { data: [], hasMore: false };
-        const paginatedResponse = withPagination(response);
-
-        return {
-          data: paginatedResponse.data.map((item) => ({ mediaType: "show" as const, item })),
-          hasMore:
-            paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
-        };
-      }
+      const query = {
+        query: searchText,
+        page: options.page + 1,
+        limit: 10,
+        fields: "title" as const,
+        extended: "full,cloud9" as const,
+      };
 
       const [moviesResponse, showsResponse] = await Promise.all([
-        traktClient.movies.getWatchlistMovies({ query, fetchOptions }),
-        traktClient.shows.getWatchlistShows({ query, fetchOptions }),
+        traktClient.movies.searchMovies({ query, fetchOptions }),
+        traktClient.shows.searchShows({ query, fetchOptions }),
       ]);
 
       const movies =
@@ -92,10 +57,10 @@ export default function Command() {
           ? withPagination(showsResponse)
           : { data: [] as TraktShowListItem[], pagination: null };
 
-      const merged = sortByAddedAt([
+      const merged: SearchMediaItem[] = [
         ...movies.data.map((item) => ({ mediaType: "movie" as const, item })),
         ...shows.data.map((item) => ({ mediaType: "show" as const, item })),
-      ]);
+      ];
 
       const moviesHasMore =
         movies.pagination !== null &&
@@ -109,7 +74,7 @@ export default function Command() {
         hasMore: moviesHasMore || showsHasMore,
       };
     },
-    [mediaType],
+    [searchText],
     {
       initialData: undefined,
       keepPreviousData: true,
@@ -123,31 +88,12 @@ export default function Command() {
     },
   );
 
-  const removeShowFromWatchlist = useCallback(async (show: TraktShowListItem) => {
-    await traktClient.shows.removeShowFromWatchlist({
-      body: {
-        shows: [
-          {
-            ids: {
-              trakt: show.show.ids.trakt,
-            },
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
-
-  const removeMovieFromWatchlist = useCallback(async (movie: TraktMovieListItem) => {
-    await traktClient.movies.removeMovieFromWatchlist({
+  const addMovieToWatchlist = useCallback(async (movie: TraktMovieListItem) => {
+    await traktClient.movies.addMovieToWatchlist({
       body: {
         movies: [
           {
-            ids: {
-              trakt: movie.movie.ids.trakt,
-            },
+            ids: { trakt: movie.movie.ids.trakt },
           },
         ],
       },
@@ -162,10 +108,25 @@ export default function Command() {
       body: {
         movies: [
           {
-            ids: {
-              trakt: movie.movie.ids.trakt,
-            },
+            ids: { trakt: movie.movie.ids.trakt },
             watched_at: new Date().toISOString(),
+          },
+        ],
+      },
+      fetchOptions: {
+        signal: abortable.current?.signal,
+      },
+    });
+  }, []);
+
+  const addShowToWatchlist = useCallback(async (show: TraktShowListItem) => {
+    await traktClient.shows.addShowToWatchlist({
+      body: {
+        shows: [
+          {
+            ids: {
+              trakt: show.show.ids.trakt,
+            },
           },
         ],
       },
@@ -228,10 +189,10 @@ export default function Command() {
     });
   }, []);
 
-  const onMediaTypeChange = useCallback((newValue: string) => {
+  const handleSearchTextChange = useCallback((text: string): void => {
     abortable.current?.abort();
     abortable.current = new AbortController();
-    setMediaType(newValue as WatchlistFilterType);
+    setSearchText(text);
   }, []);
 
   const handleMovieAction = useCallback(
@@ -239,21 +200,20 @@ export default function Command() {
       setActionLoading(true);
       try {
         await action(movie);
-        revalidate();
         showToast({
           title: message,
           style: Toast.Style.Success,
         });
-      } catch (error) {
+      } catch (e) {
         showToast({
-          title: (error as Error).message,
+          title: (e as Error).message,
           style: Toast.Style.Failure,
         });
       } finally {
         setActionLoading(false);
       }
     },
-    [revalidate],
+    [],
   );
 
   const handleShowAction = useCallback(
@@ -261,21 +221,20 @@ export default function Command() {
       setActionLoading(true);
       try {
         await action(show);
-        revalidate();
         showToast({
           title: message,
           style: Toast.Style.Success,
         });
-      } catch (error) {
+      } catch (e) {
         showToast({
-          title: (error as Error).message,
+          title: (e as Error).message,
           style: Toast.Style.Failure,
         });
       } finally {
         setActionLoading(false);
       }
     },
-    [revalidate],
+    [],
   );
 
   const movieMarkdown = useCallback((movie: TraktMovieListItem) => {
@@ -303,22 +262,6 @@ export default function Command() {
                 actions={(movie) => (
                   <ActionPanel>
                     <ActionPanel.Section>
-                      <Action
-                        title="Add to History"
-                        icon={Icon.Clock}
-                        shortcut={Keyboard.Shortcut.Common.Duplicate}
-                        onAction={() => handleMovieAction(movie, addMovieToHistory, "Movie added to history")}
-                      />
-                      <Action
-                        title="Remove from Watchlist"
-                        icon={Icon.Trash}
-                        shortcut={Keyboard.Shortcut.Common.Remove}
-                        onAction={() =>
-                          handleMovieAction(movie, removeMovieFromWatchlist, "Movie removed from watchlist")
-                        }
-                      />
-                    </ActionPanel.Section>
-                    <ActionPanel.Section>
                       <Action.OpenInBrowser
                         icon={getFavicon(TRAKT_APP_URL)}
                         title="Open in Trakt"
@@ -338,16 +281,16 @@ export default function Command() {
             }
           />
           <Action
+            title="Add to Watchlist"
+            icon={Icon.Bookmark}
+            shortcut={Keyboard.Shortcut.Common.Edit}
+            onAction={() => handleMovieAction(item, addMovieToWatchlist, "Movie added to watchlist")}
+          />
+          <Action
             title="Add to History"
             icon={Icon.Clock}
             shortcut={Keyboard.Shortcut.Common.Duplicate}
             onAction={() => handleMovieAction(item, addMovieToHistory, "Movie added to history")}
-          />
-          <Action
-            title="Remove from Watchlist"
-            icon={Icon.Trash}
-            shortcut={Keyboard.Shortcut.Common.Remove}
-            onAction={() => handleMovieAction(item, removeMovieFromWatchlist, "Movie removed from watchlist")}
           />
         </ActionPanel.Section>
         <ActionPanel.Section>
@@ -366,7 +309,7 @@ export default function Command() {
         </ActionPanel.Section>
       </ActionPanel>
     ),
-    [addMovieToHistory, handleMovieAction, movieMarkdown, movieMetadata, removeMovieFromWatchlist],
+    [addMovieToHistory, addMovieToWatchlist, handleMovieAction, movieMarkdown, movieMetadata],
   );
 
   const showActions = useCallback(
@@ -399,50 +342,41 @@ export default function Command() {
         </ActionPanel.Section>
         <ActionPanel.Section>
           <Action
+            title="Add to Watchlist"
+            icon={Icon.Bookmark}
+            shortcut={Keyboard.Shortcut.Common.Edit}
+            onAction={() => handleShowAction(item, addShowToWatchlist, "Show added to watchlist")}
+          />
+          <Action
             title="Add to History"
             icon={Icon.Clock}
             shortcut={Keyboard.Shortcut.Common.Duplicate}
             onAction={() => handleShowAction(item, addShowToHistory, "Show added to history")}
           />
-          <Action
-            title="Remove from Watchlist"
-            icon={Icon.Trash}
-            shortcut={Keyboard.Shortcut.Common.Remove}
-            onAction={() => handleShowAction(item, removeShowFromWatchlist, "Show removed from watchlist")}
-          />
         </ActionPanel.Section>
       </ActionPanel>
     ),
-    [addShowToHistory, checkInFirstEpisodeToHistory, handleShowAction, removeShowFromWatchlist],
-  );
-
-  const searchBarAccessory = (
-    <Grid.Dropdown onChange={onMediaTypeChange} tooltip="Media Type">
-      <Grid.Dropdown.Item value="all" title="All" />
-      <Grid.Dropdown.Item value="movie" title="Movies" />
-      <Grid.Dropdown.Item value="show" title="Shows" />
-    </Grid.Dropdown>
+    [addShowToHistory, addShowToWatchlist, checkInFirstEpisodeToHistory, handleShowAction],
   );
 
   return (
     <GenericGrid
       isLoading={isLoading || actionLoading}
-      emptyViewTitle="No watchlist available"
-      searchBarPlaceholder="Search watchlist"
-      searchBarAccessory={searchBarAccessory}
+      emptyViewTitle="Search for movies and shows"
+      searchBarPlaceholder="Search for movies and shows"
+      onSearchTextChange={handleSearchTextChange}
+      throttle={true}
       pagination={pagination}
-      items={watchlist}
+      items={media}
       aspectRatio="9/16"
       fit={Grid.Fit.Fill}
       title={(item) => (item.mediaType === "movie" ? item.item.movie.title : item.item.show.title)}
-      subtitle={(item) =>
-        item.mediaType === "movie" ? item.item.movie.year?.toString() || "" : item.item.show.year?.toString() || ""
-      }
+      subtitle={(item) => (item.mediaType === "show" ? item.item.show.year?.toString() || "" : "")}
       poster={(item) =>
         getPosterUrl(item.mediaType === "movie" ? item.item.movie.images : item.item.show.images, "poster.png")
       }
       keyFn={(item, index) =>
-        item.mediaType === "movie" ? `${item.item.movie.ids.trakt}-${index}` : `${item.item.show.ids.trakt}-${index}`
+        `${item.mediaType}-${item.mediaType === "movie" ? item.item.movie.ids.trakt : item.item.show.ids.trakt}-${index}`
       }
       actions={(item) => (item.mediaType === "movie" ? movieActions(item.item) : showActions(item.item))}
     />

--- a/extensions/trakt-manager/src/search-media.tsx
+++ b/extensions/trakt-manager/src/search-media.tsx
@@ -1,21 +1,26 @@
-import { Action, ActionPanel, Grid, Icon, Keyboard, Toast, showToast } from "@raycast/api";
-import { getFavicon, useCachedPromise } from "@raycast/utils";
-import { PaginationOptions } from "@raycast/utils/dist/types";
+import { Grid, Icon, Keyboard, Toast, showToast } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { type PaginationOptions } from "./lib/pagination";
 import { setMaxListeners } from "node:events";
 import { setTimeout } from "node:timers/promises";
 import { useCallback, useRef, useState } from "react";
-import { GenericDetail } from "./components/generic-detail";
 import { GenericGrid } from "./components/generic-grid";
-import { SeasonGrid } from "./components/season-grid";
+import { MovieActionPanel, ShowActionPanel } from "./components/media-actions";
+import { useActionRunner } from "./lib/action-runner";
 import { initTraktClient } from "./lib/client";
-import { APP_MAX_LISTENERS, IMDB_APP_URL, TRAKT_APP_URL } from "./lib/constants";
-import { createMovieMarkdown, createMovieMetadata } from "./lib/detail-helpers";
-import { getIMDbUrl, getPosterUrl, getTraktUrl } from "./lib/helper";
+import { APP_MAX_LISTENERS } from "./lib/constants";
+import { getPosterUrl } from "./lib/helper";
+import {
+  addMovieToHistory,
+  addMovieToWatchlist,
+  addShowToHistory,
+  addShowToWatchlist,
+  checkInFirstEpisodeToHistory,
+} from "./lib/media-mutations";
 import { TraktMovieListItem, TraktShowListItem, withPagination } from "./lib/schema";
 
 type SearchMediaItem =
-  | { mediaType: "movie"; item: TraktMovieListItem }
-  | { mediaType: "show"; item: TraktShowListItem };
+  { mediaType: "movie"; item: TraktMovieListItem } | { mediaType: "show"; item: TraktShowListItem };
 
 export default function Command() {
   const abortable = useRef<AbortController | undefined>(undefined);
@@ -88,106 +93,40 @@ export default function Command() {
     },
   );
 
-  const addMovieToWatchlist = useCallback(async (movie: TraktMovieListItem) => {
-    await traktClient.movies.addMovieToWatchlist({
-      body: {
-        movies: [
-          {
-            ids: { trakt: movie.movie.ids.trakt },
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
+  const addMovieToWatchlistAction = useCallback(
+    async (movie: TraktMovieListItem) => {
+      await addMovieToWatchlist(traktClient, movie, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
 
-  const addMovieToHistory = useCallback(async (movie: TraktMovieListItem) => {
-    await traktClient.movies.addMovieToHistory({
-      body: {
-        movies: [
-          {
-            ids: { trakt: movie.movie.ids.trakt },
-            watched_at: new Date().toISOString(),
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
+  const addMovieToHistoryAction = useCallback(
+    async (movie: TraktMovieListItem) => {
+      await addMovieToHistory(traktClient, movie, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
 
-  const addShowToWatchlist = useCallback(async (show: TraktShowListItem) => {
-    await traktClient.shows.addShowToWatchlist({
-      body: {
-        shows: [
-          {
-            ids: {
-              trakt: show.show.ids.trakt,
-            },
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
+  const addShowToWatchlistAction = useCallback(
+    async (show: TraktShowListItem) => {
+      await addShowToWatchlist(traktClient, show, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
 
-  const addShowToHistory = useCallback(async (show: TraktShowListItem) => {
-    await traktClient.shows.addShowToHistory({
-      body: {
-        shows: [
-          {
-            ids: {
-              trakt: show.show.ids.trakt,
-            },
-            watched_at: new Date().toISOString(),
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
+  const addShowToHistoryAction = useCallback(
+    async (show: TraktShowListItem) => {
+      await addShowToHistory(traktClient, show, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
 
-  const checkInFirstEpisodeToHistory = useCallback(async (show: TraktShowListItem) => {
-    const response = await traktClient.shows.getEpisode({
-      params: {
-        showid: show.show.ids.trakt,
-        seasonNumber: 1,
-        episodeNumber: 1,
-      },
-      query: {
-        extended: "full",
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-
-    if (response.status !== 200) throw new Error("Failed to get first episode");
-    const firstEpisode = response.body;
-
-    await traktClient.shows.checkInEpisode({
-      body: {
-        episodes: [
-          {
-            ids: {
-              trakt: firstEpisode.ids.trakt,
-            },
-            watched_at: new Date().toISOString(),
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
+  const checkInFirstEpisodeToHistoryAction = useCallback(
+    async (show: TraktShowListItem) => {
+      await checkInFirstEpisodeToHistory(traktClient, show, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
 
   const handleSearchTextChange = useCallback((text: string): void => {
     abortable.current?.abort();
@@ -195,168 +134,56 @@ export default function Command() {
     setSearchText(text);
   }, []);
 
-  const handleMovieAction = useCallback(
-    async (movie: TraktMovieListItem, action: (movie: TraktMovieListItem) => Promise<void>, message: string) => {
-      setActionLoading(true);
-      try {
-        await action(movie);
-        showToast({
-          title: message,
-          style: Toast.Style.Success,
-        });
-      } catch (e) {
-        showToast({
-          title: (e as Error).message,
-          style: Toast.Style.Failure,
-        });
-      } finally {
-        setActionLoading(false);
-      }
-    },
-    [],
-  );
-
-  const handleShowAction = useCallback(
-    async (show: TraktShowListItem, action: (show: TraktShowListItem) => Promise<void>, message: string) => {
-      setActionLoading(true);
-      try {
-        await action(show);
-        showToast({
-          title: message,
-          style: Toast.Style.Success,
-        });
-      } catch (e) {
-        showToast({
-          title: (e as Error).message,
-          style: Toast.Style.Failure,
-        });
-      } finally {
-        setActionLoading(false);
-      }
-    },
-    [],
-  );
-
-  const movieMarkdown = useCallback((movie: TraktMovieListItem) => {
-    return createMovieMarkdown(movie.movie);
-  }, []);
-
-  const movieMetadata = useCallback((movie: TraktMovieListItem) => {
-    return createMovieMetadata(movie);
-  }, []);
+  const runMovieAction = useActionRunner<TraktMovieListItem>({ setActionLoading });
+  const runShowAction = useActionRunner<TraktShowListItem>({ setActionLoading });
 
   const movieActions = useCallback(
     (item: TraktMovieListItem) => (
-      <ActionPanel>
-        <ActionPanel.Section>
-          <Action.Push
-            icon={Icon.Eye}
-            title="View Details"
-            target={
-              <GenericDetail
-                item={item}
-                isLoading={false}
-                markdown={movieMarkdown}
-                metadata={movieMetadata}
-                navigationTitle={(movie) => movie.movie.title}
-                actions={(movie) => (
-                  <ActionPanel>
-                    <ActionPanel.Section>
-                      <Action.OpenInBrowser
-                        icon={getFavicon(TRAKT_APP_URL)}
-                        title="Open in Trakt"
-                        shortcut={Keyboard.Shortcut.Common.Open}
-                        url={getTraktUrl("movies", movie.movie.ids.slug)}
-                      />
-                      <Action.OpenInBrowser
-                        icon={getFavicon(IMDB_APP_URL)}
-                        title="Open in Imdb"
-                        shortcut={{ modifiers: ["cmd"], key: "i" }}
-                        url={getIMDbUrl(movie.movie.ids.imdb)}
-                      />
-                    </ActionPanel.Section>
-                  </ActionPanel>
-                )}
-              />
-            }
-          />
-          <Action
-            title="Add to Watchlist"
-            icon={Icon.Bookmark}
-            shortcut={Keyboard.Shortcut.Common.Edit}
-            onAction={() => handleMovieAction(item, addMovieToWatchlist, "Movie added to watchlist")}
-          />
-          <Action
-            title="Add to History"
-            icon={Icon.Clock}
-            shortcut={Keyboard.Shortcut.Common.Duplicate}
-            onAction={() => handleMovieAction(item, addMovieToHistory, "Movie added to history")}
-          />
-        </ActionPanel.Section>
-        <ActionPanel.Section>
-          <Action.OpenInBrowser
-            icon={getFavicon(TRAKT_APP_URL)}
-            title="Open in Trakt"
-            shortcut={Keyboard.Shortcut.Common.Open}
-            url={getTraktUrl("movies", item.movie.ids.slug)}
-          />
-          <Action.OpenInBrowser
-            icon={getFavicon(IMDB_APP_URL)}
-            title="Open in Imdb"
-            shortcut={{ modifiers: ["cmd"], key: "i" }}
-            url={getIMDbUrl(item.movie.ids.imdb)}
-          />
-        </ActionPanel.Section>
-      </ActionPanel>
+      <MovieActionPanel
+        item={item}
+        actions={[
+          {
+            title: "Add to Watchlist",
+            icon: Icon.Bookmark,
+            shortcut: Keyboard.Shortcut.Common.Edit,
+            onAction: (movie) => runMovieAction(movie, addMovieToWatchlistAction, "Movie added to watchlist"),
+          },
+          {
+            title: "Add to History",
+            icon: Icon.Clock,
+            shortcut: Keyboard.Shortcut.Common.Duplicate,
+            onAction: (movie) => runMovieAction(movie, addMovieToHistoryAction, "Movie added to history"),
+          },
+        ]}
+      />
     ),
-    [addMovieToHistory, addMovieToWatchlist, handleMovieAction, movieMarkdown, movieMetadata],
+    [addMovieToHistoryAction, addMovieToWatchlistAction, runMovieAction],
   );
 
   const showActions = useCallback(
     (item: TraktShowListItem) => (
-      <ActionPanel>
-        <ActionPanel.Section>
-          <Action.Push
-            icon={Icon.Switch}
-            title="Browse Seasons"
-            target={<SeasonGrid showId={item.show.ids.trakt} slug={item.show.ids.slug} imdbId={item.show.ids.imdb} />}
-          />
-          <Action
-            title="Check-In"
-            icon={Icon.Checkmark}
-            shortcut={Keyboard.Shortcut.Common.ToggleQuickLook}
-            onAction={() => handleShowAction(item, checkInFirstEpisodeToHistory, "First episode checked-in")}
-          />
-        </ActionPanel.Section>
-        <ActionPanel.Section>
-          <Action.OpenInBrowser
-            icon={getFavicon(TRAKT_APP_URL)}
-            title="Open in Trakt"
-            url={getTraktUrl("shows", item.show.ids.slug)}
-          />
-          <Action.OpenInBrowser
-            icon={getFavicon(IMDB_APP_URL)}
-            title="Open in Imdb"
-            url={getIMDbUrl(item.show.ids.imdb)}
-          />
-        </ActionPanel.Section>
-        <ActionPanel.Section>
-          <Action
-            title="Add to Watchlist"
-            icon={Icon.Bookmark}
-            shortcut={Keyboard.Shortcut.Common.Edit}
-            onAction={() => handleShowAction(item, addShowToWatchlist, "Show added to watchlist")}
-          />
-          <Action
-            title="Add to History"
-            icon={Icon.Clock}
-            shortcut={Keyboard.Shortcut.Common.Duplicate}
-            onAction={() => handleShowAction(item, addShowToHistory, "Show added to history")}
-          />
-        </ActionPanel.Section>
-      </ActionPanel>
+      <ShowActionPanel
+        item={item}
+        onCheckInFirstEpisode={(show) =>
+          runShowAction(show, checkInFirstEpisodeToHistoryAction, "First episode checked-in")
+        }
+        actions={[
+          {
+            title: "Add to Watchlist",
+            icon: Icon.Bookmark,
+            shortcut: Keyboard.Shortcut.Common.Edit,
+            onAction: (show) => runShowAction(show, addShowToWatchlistAction, "Show added to watchlist"),
+          },
+          {
+            title: "Add to History",
+            icon: Icon.Clock,
+            shortcut: Keyboard.Shortcut.Common.Duplicate,
+            onAction: (show) => runShowAction(show, addShowToHistoryAction, "Show added to history"),
+          },
+        ]}
+      />
     ),
-    [addShowToHistory, addShowToWatchlist, checkInFirstEpisodeToHistory, handleShowAction],
+    [addShowToHistoryAction, addShowToWatchlistAction, checkInFirstEpisodeToHistoryAction, runShowAction],
   );
 
   return (

--- a/extensions/trakt-manager/src/shows.tsx
+++ b/extensions/trakt-manager/src/shows.tsx
@@ -1,15 +1,14 @@
-import { Action, ActionPanel, Grid, Icon, Keyboard, Toast, showToast } from "@raycast/api";
-import { getFavicon, useCachedPromise } from "@raycast/utils";
-import { PaginationOptions } from "@raycast/utils/dist/types";
-import { setMaxListeners } from "node:events";
-import { setTimeout } from "node:timers/promises";
+import { Grid, Icon, Keyboard, Toast, showToast } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
 import { useCallback, useRef, useState } from "react";
 import { GenericGrid } from "./components/generic-grid";
-import { SeasonGrid } from "./components/season-grid";
+import { ShowActionPanel } from "./components/media-actions";
+import { useActionRunner } from "./lib/action-runner";
 import { initTraktClient } from "./lib/client";
-import { APP_MAX_LISTENERS, IMDB_APP_URL, TRAKT_APP_URL } from "./lib/constants";
-import { getIMDbUrl, getPosterUrl, getTraktUrl } from "./lib/helper";
-import { TraktShowListItem, withPagination } from "./lib/schema";
+import { getPosterUrl } from "./lib/helper";
+import { addShowToHistory, addShowToWatchlist, checkInFirstEpisodeToHistory } from "./lib/media-mutations";
+import { TraktShowListItem } from "./lib/schema";
+import { abortSearch, createSearchFetcher } from "./lib/search";
 
 export default function Command() {
   const abortable = useRef<AbortController | undefined>(undefined);
@@ -21,35 +20,11 @@ export default function Command() {
     data: shows,
     pagination,
   } = useCachedPromise(
-    (searchText: string) => async (options: PaginationOptions) => {
-      if (!searchText) return { data: [], hasMore: false };
-      await setTimeout(200);
-
-      abortable.current = new AbortController();
-      setMaxListeners(APP_MAX_LISTENERS, abortable.current?.signal);
-
-      const response = await traktClient.shows.searchShows({
-        query: {
-          query: searchText,
-          page: options.page + 1,
-          limit: 10,
-          fields: "title",
-          extended: "full,cloud9",
-        },
-        fetchOptions: {
-          signal: abortable.current.signal,
-        },
-      });
-
-      if (response.status !== 200) return { data: [], hasMore: false };
-      const paginatedResponse = withPagination(response);
-
-      return {
-        data: paginatedResponse.data,
-        hasMore:
-          paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
-      };
-    },
+    createSearchFetcher({
+      abortable,
+      delay: 200,
+      search: traktClient.shows.searchShows,
+    }),
     [searchText],
     {
       initialData: undefined,
@@ -64,102 +39,30 @@ export default function Command() {
     },
   );
 
-  const addShowToWatchlist = useCallback(async (show: TraktShowListItem) => {
-    await traktClient.shows.addShowToWatchlist({
-      body: {
-        shows: [
-          {
-            ids: {
-              trakt: show.show.ids.trakt,
-            },
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
-
-  const addShowToHistory = useCallback(async (show: TraktShowListItem) => {
-    await traktClient.shows.addShowToHistory({
-      body: {
-        shows: [
-          {
-            ids: {
-              trakt: show.show.ids.trakt,
-            },
-            watched_at: new Date().toISOString(),
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
-
-  const checkInFirstEpisodeToHistory = useCallback(async (show: TraktShowListItem) => {
-    const response = await traktClient.shows.getEpisode({
-      params: {
-        showid: show.show.ids.trakt,
-        seasonNumber: 1,
-        episodeNumber: 1,
-      },
-      query: {
-        extended: "full",
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-
-    if (response.status !== 200) throw new Error("Failed to get first episode");
-    const firstEpisode = response.body;
-
-    await traktClient.shows.checkInEpisode({
-      body: {
-        episodes: [
-          {
-            ids: {
-              trakt: firstEpisode.ids.trakt,
-            },
-            watched_at: new Date().toISOString(),
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
-
-  const handleSearchTextChange = useCallback((text: string): void => {
-    abortable.current?.abort();
-    abortable.current = new AbortController();
-    setSearchText(text);
-  }, []);
-
-  const handleAction = useCallback(
-    async (show: TraktShowListItem, action: (show: TraktShowListItem) => Promise<void>, message: string) => {
-      setActionLoading(true);
-      try {
-        await action(show);
-        showToast({
-          title: message,
-          style: Toast.Style.Success,
-        });
-      } catch (e) {
-        showToast({
-          title: (e as Error).message,
-          style: Toast.Style.Failure,
-        });
-      } finally {
-        setActionLoading(false);
-      }
+  const addShowToWatchlistAction = useCallback(
+    async (show: TraktShowListItem) => {
+      await addShowToWatchlist(traktClient, show, { signal: abortable.current?.signal });
     },
-    [],
+    [traktClient],
   );
+
+  const addShowToHistoryAction = useCallback(
+    async (show: TraktShowListItem) => {
+      await addShowToHistory(traktClient, show, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
+
+  const checkInFirstEpisodeToHistoryAction = useCallback(
+    async (show: TraktShowListItem) => {
+      await checkInFirstEpisodeToHistory(traktClient, show, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
+
+  const handleSearchTextChange = useCallback(abortSearch(abortable, setSearchText), []);
+
+  const runShowAction = useActionRunner<TraktShowListItem>({ setActionLoading });
 
   return (
     <GenericGrid
@@ -177,47 +80,26 @@ export default function Command() {
       poster={(item) => getPosterUrl(item.show.images, "poster.png")}
       keyFn={(item, index) => `${item.show.ids.trakt}-${index}`}
       actions={(item) => (
-        <ActionPanel>
-          <ActionPanel.Section>
-            <Action.Push
-              icon={Icon.Switch}
-              title="Browse Seasons"
-              target={<SeasonGrid showId={item.show.ids.trakt} slug={item.show.ids.slug} imdbId={item.show.ids.imdb} />}
-            />
-            <Action
-              title="Check-In"
-              icon={Icon.Checkmark}
-              shortcut={Keyboard.Shortcut.Common.ToggleQuickLook}
-              onAction={() => handleAction(item, checkInFirstEpisodeToHistory, "First episode checked-in")}
-            />
-          </ActionPanel.Section>
-          <ActionPanel.Section>
-            <Action.OpenInBrowser
-              icon={getFavicon(TRAKT_APP_URL)}
-              title="Open in Trakt"
-              url={getTraktUrl("shows", item.show.ids.slug)}
-            />
-            <Action.OpenInBrowser
-              icon={getFavicon(IMDB_APP_URL)}
-              title="Open in Imdb"
-              url={getIMDbUrl(item.show.ids.imdb)}
-            />
-          </ActionPanel.Section>
-          <ActionPanel.Section>
-            <Action
-              title="Add to Watchlist"
-              icon={Icon.Bookmark}
-              shortcut={Keyboard.Shortcut.Common.Edit}
-              onAction={() => handleAction(item, addShowToWatchlist, "Show added to watchlist")}
-            />
-            <Action
-              title="Add to History"
-              icon={Icon.Clock}
-              shortcut={Keyboard.Shortcut.Common.Duplicate}
-              onAction={() => handleAction(item, addShowToHistory, "Show added to history")}
-            />
-          </ActionPanel.Section>
-        </ActionPanel>
+        <ShowActionPanel
+          item={item}
+          onCheckInFirstEpisode={(show) =>
+            runShowAction(show, checkInFirstEpisodeToHistoryAction, "First episode checked-in")
+          }
+          actions={[
+            {
+              title: "Add to Watchlist",
+              icon: Icon.Bookmark,
+              shortcut: Keyboard.Shortcut.Common.Edit,
+              onAction: (show) => runShowAction(show, addShowToWatchlistAction, "Show added to watchlist"),
+            },
+            {
+              title: "Add to History",
+              icon: Icon.Clock,
+              shortcut: Keyboard.Shortcut.Common.Duplicate,
+              onAction: (show) => runShowAction(show, addShowToHistoryAction, "Show added to history"),
+            },
+          ]}
+        />
       )}
     />
   );

--- a/extensions/trakt-manager/src/shows.tsx
+++ b/extensions/trakt-manager/src/shows.tsx
@@ -185,7 +185,7 @@ export default function Command() {
               target={<SeasonGrid showId={item.show.ids.trakt} slug={item.show.ids.slug} imdbId={item.show.ids.imdb} />}
             />
             <Action
-              title="Check-in"
+              title="Check-In"
               icon={Icon.Checkmark}
               shortcut={Keyboard.Shortcut.Common.ToggleQuickLook}
               onAction={() => handleAction(item, checkInFirstEpisodeToHistory, "First episode checked-in")}

--- a/extensions/trakt-manager/src/tools/movies.ts
+++ b/extensions/trakt-manager/src/tools/movies.ts
@@ -1,7 +1,5 @@
-import { initTraktClient } from "../lib/client";
-import { withPagination } from "../lib/schema";
-
-const traktClient = initTraktClient();
+import { TraktMovieListItem } from "../lib/schema";
+import { createSearchTool, toolTraktClient } from "./search-tool";
 
 type Input = {
   /**
@@ -40,29 +38,6 @@ type Input = {
  * data: List of movies with title, year, overview, rating, genres
  * hasMore: True if more pages are available
  */
-const tool = async (input: Input) => {
-  const { title, page } = input;
-  const response = await traktClient.movies.searchMovies({
-    query: {
-      query: title,
-      page: page,
-      limit: 10,
-      fields: "title",
-      extended: "full,cloud9",
-    },
-    fetchOptions: {
-      signal: AbortSignal.timeout(3600),
-    },
-  });
-
-  if (response.status !== 200) return { data: [], hasMore: false };
-  const paginatedResponse = withPagination(response);
-
-  return {
-    data: paginatedResponse.data,
-    hasMore:
-      paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
-  };
-};
+const tool = createSearchTool<TraktMovieListItem, Input>(toolTraktClient.movies.searchMovies);
 
 export default tool;

--- a/extensions/trakt-manager/src/tools/search-tool.ts
+++ b/extensions/trakt-manager/src/tools/search-tool.ts
@@ -1,0 +1,55 @@
+import { initTraktClient } from "../lib/client";
+import { withPagination } from "../lib/schema";
+
+type ToolInput = {
+  title: string;
+  page: number;
+};
+
+type ToolSearchResponse<T> = {
+  status: number;
+  body: T[];
+  headers: Headers;
+};
+
+type ToolSearchEndpoint<T> = (args: {
+  query: {
+    query: string;
+    page: number;
+    limit: 10;
+    fields: "title";
+    extended: "full,cloud9";
+  };
+  fetchOptions: { signal: AbortSignal };
+}) => Promise<ToolSearchResponse<T>>;
+
+const traktClient = initTraktClient();
+
+export function createSearchTool<T, TInput extends ToolInput = ToolInput>(search: ToolSearchEndpoint<T>) {
+  return async (input: TInput) => {
+    const { title, page } = input;
+    const response = await search({
+      query: {
+        query: title,
+        page,
+        limit: 10,
+        fields: "title",
+        extended: "full,cloud9",
+      },
+      fetchOptions: {
+        signal: AbortSignal.timeout(3600),
+      },
+    });
+
+    if (response.status !== 200) return { data: [], hasMore: false };
+    const paginatedResponse = withPagination(response);
+
+    return {
+      data: paginatedResponse.data,
+      hasMore:
+        paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
+    };
+  };
+}
+
+export const toolTraktClient = traktClient;

--- a/extensions/trakt-manager/src/tools/shows.ts
+++ b/extensions/trakt-manager/src/tools/shows.ts
@@ -1,7 +1,5 @@
-import { initTraktClient } from "../lib/client";
-import { withPagination } from "../lib/schema";
-
-const traktClient = initTraktClient();
+import { TraktShowListItem } from "../lib/schema";
+import { createSearchTool, toolTraktClient } from "./search-tool";
 
 type Input = {
   /**
@@ -40,29 +38,6 @@ type Input = {
  * data: List of TV shows with title, year, status, episodes, rating
  * hasMore: True if more pages are available
  */
-const tool = async (input: Input) => {
-  const { title, page } = input;
-  const response = await traktClient.shows.searchShows({
-    query: {
-      query: title,
-      page: page,
-      limit: 10,
-      fields: "title",
-      extended: "full,cloud9",
-    },
-    fetchOptions: {
-      signal: AbortSignal.timeout(3600),
-    },
-  });
-
-  if (response.status !== 200) return { data: [], hasMore: false };
-  const paginatedResponse = withPagination(response);
-
-  return {
-    data: paginatedResponse.data,
-    hasMore:
-      paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
-  };
-};
+const tool = createSearchTool<TraktShowListItem, Input>(toolTraktClient.shows.searchShows);
 
 export default tool;

--- a/extensions/trakt-manager/src/up-next.tsx
+++ b/extensions/trakt-manager/src/up-next.tsx
@@ -1,13 +1,14 @@
 import { Action, ActionPanel, Grid, Icon, Keyboard, Toast, showToast } from "@raycast/api";
 import { getFavicon, useCachedPromise } from "@raycast/utils";
-import { PaginationOptions } from "@raycast/utils/dist/types";
+import { type PaginationOptions } from "./lib/pagination";
 import { setMaxListeners } from "node:events";
 import { setTimeout } from "node:timers/promises";
 import { useCallback, useRef, useState } from "react";
 import { GenericDetail } from "./components/generic-detail";
 import { GenericGrid } from "./components/generic-grid";
+import { useActionRunner } from "./lib/action-runner";
 import { initTraktClient } from "./lib/client";
-import { APP_MAX_LISTENERS, IMDB_APP_URL, TRAKT_APP_URL } from "./lib/constants";
+import { APP_MAX_LISTENERS, IMDB_APP_URL, IMDB_SHORTCUT, TRAKT_APP_URL } from "./lib/constants";
 import { createEpisodeMarkdown, createEpisodeMetadata } from "./lib/detail-helpers";
 import { getIMDbUrl, getPosterUrl, getTraktUrl } from "./lib/helper";
 import { TraktShowListItem, withPagination } from "./lib/schema";
@@ -101,27 +102,7 @@ export default function Command() {
     });
   }, []);
 
-  const handleAction = useCallback(
-    async (show: TraktShowListItem, action: (show: TraktShowListItem) => Promise<void>, message: string) => {
-      setActionLoading(true);
-      try {
-        await action(show);
-        revalidate();
-        showToast({
-          title: message,
-          style: Toast.Style.Success,
-        });
-      } catch (error) {
-        showToast({
-          title: (error as Error).message,
-          style: Toast.Style.Failure,
-        });
-      } finally {
-        setActionLoading(false);
-      }
-    },
-    [],
-  );
+  const handleAction = useActionRunner<TraktShowListItem>({ setActionLoading, onSuccess: revalidate });
 
   const upNextMarkdown = useCallback((show: TraktShowListItem) => {
     return createEpisodeMarkdown(show.progress.next_episode, show.show);
@@ -185,7 +166,7 @@ export default function Command() {
                         <Action.OpenInBrowser
                           icon={getFavicon(IMDB_APP_URL)}
                           title="Open Show in Imdb"
-                          shortcut={{ modifiers: ["cmd"], key: "i" }}
+                          shortcut={IMDB_SHORTCUT}
                           url={getIMDbUrl(show.show.ids.imdb)}
                         />
                       </ActionPanel.Section>
@@ -216,7 +197,7 @@ export default function Command() {
             <Action.OpenInBrowser
               icon={getFavicon(IMDB_APP_URL)}
               title="Open in Imdb"
-              shortcut={{ modifiers: ["cmd"], key: "i" }}
+              shortcut={IMDB_SHORTCUT}
               url={getIMDbUrl(item.show.ids.imdb)}
             />
           </ActionPanel.Section>

--- a/extensions/trakt-manager/src/up-next.tsx
+++ b/extensions/trakt-manager/src/up-next.tsx
@@ -163,7 +163,7 @@ export default function Command() {
                     <ActionPanel>
                       <ActionPanel.Section>
                         <Action
-                          title="Check-in"
+                          title="Check-In"
                           icon={Icon.Checkmark}
                           shortcut={Keyboard.Shortcut.Common.ToggleQuickLook}
                           onAction={() => handleAction(show, checkInEpisode, "Episode checked-in")}
@@ -195,7 +195,7 @@ export default function Command() {
               }
             />
             <Action
-              title="Check-in"
+              title="Check-In"
               icon={Icon.Checkmark}
               onAction={() => handleAction(item, checkInEpisode, "Episode checked-in")}
             />

--- a/extensions/trakt-manager/src/watchlist.tsx
+++ b/extensions/trakt-manager/src/watchlist.tsx
@@ -1,17 +1,24 @@
-import { Action, ActionPanel, Grid, Icon, Keyboard, Toast, showToast } from "@raycast/api";
-import { getFavicon, useCachedPromise } from "@raycast/utils";
-import { PaginationOptions } from "@raycast/utils/dist/types";
+import { Grid, Icon, Keyboard } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { type PaginationOptions } from "./lib/pagination";
 import { setMaxListeners } from "node:events";
 import { setTimeout } from "node:timers/promises";
 import { useCallback, useRef, useState } from "react";
-import { GenericDetail } from "./components/generic-detail";
 import { GenericGrid } from "./components/generic-grid";
-import { SeasonGrid } from "./components/season-grid";
+import { MovieActionPanel, ShowActionPanel } from "./components/media-actions";
+import { useActionRunner } from "./lib/action-runner";
 import { initTraktClient } from "./lib/client";
-import { APP_MAX_LISTENERS, IMDB_APP_URL, TRAKT_APP_URL } from "./lib/constants";
-import { createMovieMarkdown, createMovieMetadata } from "./lib/detail-helpers";
-import { getIMDbUrl, getPosterUrl, getTraktUrl } from "./lib/helper";
-import { TraktMovieListItem, TraktShowListItem, withPagination } from "./lib/schema";
+import { APP_MAX_LISTENERS } from "./lib/constants";
+import { getPosterUrl } from "./lib/helper";
+import { fetchCombinedMediaPage, fetchMediaPage, mediaListCacheOptions } from "./lib/media-pagination";
+import {
+  addMovieToHistory,
+  addShowToHistory,
+  checkInFirstEpisodeToHistory,
+  removeMovieFromWatchlist,
+  removeShowFromWatchlist,
+} from "./lib/media-mutations";
+import { TraktMovieListItem, TraktShowListItem } from "./lib/schema";
 
 type WatchlistFilterType = "all" | "movie" | "show";
 
@@ -22,6 +29,7 @@ const watchlistQuery = {
   extended: "full,cloud9" as const,
   sort_by: "added" as const,
 };
+const combinedWatchlistPageLimit = watchlistQuery.limit * 2;
 
 const sortByAddedAt = (items: WatchlistItem[]) =>
   [...items].sort((a, b) => {
@@ -53,180 +61,64 @@ export default function Command() {
       const query = { ...watchlistQuery, page, sort_how: sortHow };
 
       if (mediaType === "movie") {
-        const response = await traktClient.movies.getWatchlistMovies({ query, fetchOptions });
-
-        if (response.status !== 200) return { data: [], hasMore: false };
-        const paginatedResponse = withPagination(response);
-
-        return {
-          data: paginatedResponse.data.map((item) => ({ mediaType: "movie" as const, item })),
-          hasMore:
-            paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
-        };
+        return fetchMediaPage<"movie", TraktMovieListItem>("movie", () =>
+          traktClient.movies.getWatchlistMovies({ query, fetchOptions }),
+        );
       }
 
       if (mediaType === "show") {
-        const response = await traktClient.shows.getWatchlistShows({ query, fetchOptions });
-
-        if (response.status !== 200) return { data: [], hasMore: false };
-        const paginatedResponse = withPagination(response);
-
-        return {
-          data: paginatedResponse.data.map((item) => ({ mediaType: "show" as const, item })),
-          hasMore:
-            paginatedResponse.pagination["x-pagination-page"] < paginatedResponse.pagination["x-pagination-page-count"],
-        };
+        return fetchMediaPage<"show", TraktShowListItem>("show", () =>
+          traktClient.shows.getWatchlistShows({ query, fetchOptions }),
+        );
       }
 
-      const [moviesResponse, showsResponse] = await Promise.all([
-        traktClient.movies.getWatchlistMovies({ query, fetchOptions }),
-        traktClient.shows.getWatchlistShows({ query, fetchOptions }),
-      ]);
-
-      const movies =
-        moviesResponse.status === 200
-          ? withPagination(moviesResponse)
-          : { data: [] as TraktMovieListItem[], pagination: null };
-      const shows =
-        showsResponse.status === 200
-          ? withPagination(showsResponse)
-          : { data: [] as TraktShowListItem[], pagination: null };
-
-      const merged = sortByAddedAt([
-        ...movies.data.map((item) => ({ mediaType: "movie" as const, item })),
-        ...shows.data.map((item) => ({ mediaType: "show" as const, item })),
-      ]);
-
-      const moviesHasMore =
-        movies.pagination !== null &&
-        movies.pagination["x-pagination-page"] < movies.pagination["x-pagination-page-count"];
-      const showsHasMore =
-        shows.pagination !== null &&
-        shows.pagination["x-pagination-page"] < shows.pagination["x-pagination-page-count"];
-
-      return {
-        data: merged,
-        hasMore: moviesHasMore || showsHasMore,
-      };
+      return fetchCombinedMediaPage<TraktMovieListItem, TraktShowListItem>({
+        page: options.page,
+        perPageLimit: watchlistQuery.limit,
+        combinedPageLimit: combinedWatchlistPageLimit,
+        requestMoviePage: (page) => traktClient.movies.getWatchlistMovies({ query: { ...query, page }, fetchOptions }),
+        requestShowPage: (page) => traktClient.shows.getWatchlistShows({ query: { ...query, page }, fetchOptions }),
+        sort: sortByAddedAt,
+      });
     },
     [mediaType],
-    {
-      initialData: undefined,
-      keepPreviousData: true,
-      abortable,
-      onError(error) {
-        showToast({
-          title: error.message,
-          style: Toast.Style.Failure,
-        });
-      },
-    },
+    mediaListCacheOptions(abortable),
   );
 
-  const removeShowFromWatchlist = useCallback(async (show: TraktShowListItem) => {
-    await traktClient.shows.removeShowFromWatchlist({
-      body: {
-        shows: [
-          {
-            ids: {
-              trakt: show.show.ids.trakt,
-            },
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
+  const removeShowFromWatchlistAction = useCallback(
+    async (show: TraktShowListItem) => {
+      await removeShowFromWatchlist(traktClient, show, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
 
-  const removeMovieFromWatchlist = useCallback(async (movie: TraktMovieListItem) => {
-    await traktClient.movies.removeMovieFromWatchlist({
-      body: {
-        movies: [
-          {
-            ids: {
-              trakt: movie.movie.ids.trakt,
-            },
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
+  const removeMovieFromWatchlistAction = useCallback(
+    async (movie: TraktMovieListItem) => {
+      await removeMovieFromWatchlist(traktClient, movie, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
 
-  const addMovieToHistory = useCallback(async (movie: TraktMovieListItem) => {
-    await traktClient.movies.addMovieToHistory({
-      body: {
-        movies: [
-          {
-            ids: {
-              trakt: movie.movie.ids.trakt,
-            },
-            watched_at: new Date().toISOString(),
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
+  const addMovieToHistoryAction = useCallback(
+    async (movie: TraktMovieListItem) => {
+      await addMovieToHistory(traktClient, movie, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
 
-  const addShowToHistory = useCallback(async (show: TraktShowListItem) => {
-    await traktClient.shows.addShowToHistory({
-      body: {
-        shows: [
-          {
-            ids: {
-              trakt: show.show.ids.trakt,
-            },
-            watched_at: new Date().toISOString(),
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
+  const addShowToHistoryAction = useCallback(
+    async (show: TraktShowListItem) => {
+      await addShowToHistory(traktClient, show, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
 
-  const checkInFirstEpisodeToHistory = useCallback(async (show: TraktShowListItem) => {
-    const response = await traktClient.shows.getEpisode({
-      params: {
-        showid: show.show.ids.trakt,
-        seasonNumber: 1,
-        episodeNumber: 1,
-      },
-      query: {
-        extended: "full",
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-
-    if (response.status !== 200) throw new Error("Failed to get first episode");
-    const firstEpisode = response.body;
-
-    await traktClient.shows.checkInEpisode({
-      body: {
-        episodes: [
-          {
-            ids: {
-              trakt: firstEpisode.ids.trakt,
-            },
-            watched_at: new Date().toISOString(),
-          },
-        ],
-      },
-      fetchOptions: {
-        signal: abortable.current?.signal,
-      },
-    });
-  }, []);
+  const checkInFirstEpisodeToHistoryAction = useCallback(
+    async (show: TraktShowListItem) => {
+      await checkInFirstEpisodeToHistory(traktClient, show, { signal: abortable.current?.signal });
+    },
+    [traktClient],
+  );
 
   const onMediaTypeChange = useCallback((newValue: string) => {
     abortable.current?.abort();
@@ -234,186 +126,56 @@ export default function Command() {
     setMediaType(newValue as WatchlistFilterType);
   }, []);
 
-  const handleMovieAction = useCallback(
-    async (movie: TraktMovieListItem, action: (movie: TraktMovieListItem) => Promise<void>, message: string) => {
-      setActionLoading(true);
-      try {
-        await action(movie);
-        revalidate();
-        showToast({
-          title: message,
-          style: Toast.Style.Success,
-        });
-      } catch (error) {
-        showToast({
-          title: (error as Error).message,
-          style: Toast.Style.Failure,
-        });
-      } finally {
-        setActionLoading(false);
-      }
-    },
-    [revalidate],
-  );
-
-  const handleShowAction = useCallback(
-    async (show: TraktShowListItem, action: (show: TraktShowListItem) => Promise<void>, message: string) => {
-      setActionLoading(true);
-      try {
-        await action(show);
-        revalidate();
-        showToast({
-          title: message,
-          style: Toast.Style.Success,
-        });
-      } catch (error) {
-        showToast({
-          title: (error as Error).message,
-          style: Toast.Style.Failure,
-        });
-      } finally {
-        setActionLoading(false);
-      }
-    },
-    [revalidate],
-  );
-
-  const movieMarkdown = useCallback((movie: TraktMovieListItem) => {
-    return createMovieMarkdown(movie.movie);
-  }, []);
-
-  const movieMetadata = useCallback((movie: TraktMovieListItem) => {
-    return createMovieMetadata(movie);
-  }, []);
+  const runMovieAction = useActionRunner<TraktMovieListItem>({ setActionLoading, onSuccess: revalidate });
+  const runShowAction = useActionRunner<TraktShowListItem>({ setActionLoading, onSuccess: revalidate });
 
   const movieActions = useCallback(
     (item: TraktMovieListItem) => (
-      <ActionPanel>
-        <ActionPanel.Section>
-          <Action.Push
-            icon={Icon.Eye}
-            title="View Details"
-            target={
-              <GenericDetail
-                item={item}
-                isLoading={false}
-                markdown={movieMarkdown}
-                metadata={movieMetadata}
-                navigationTitle={(movie) => movie.movie.title}
-                actions={(movie) => (
-                  <ActionPanel>
-                    <ActionPanel.Section>
-                      <Action
-                        title="Add to History"
-                        icon={Icon.Clock}
-                        shortcut={Keyboard.Shortcut.Common.Duplicate}
-                        onAction={() => handleMovieAction(movie, addMovieToHistory, "Movie added to history")}
-                      />
-                      <Action
-                        title="Remove from Watchlist"
-                        icon={Icon.Trash}
-                        shortcut={Keyboard.Shortcut.Common.Remove}
-                        onAction={() =>
-                          handleMovieAction(movie, removeMovieFromWatchlist, "Movie removed from watchlist")
-                        }
-                      />
-                    </ActionPanel.Section>
-                    <ActionPanel.Section>
-                      <Action.OpenInBrowser
-                        icon={getFavicon(TRAKT_APP_URL)}
-                        title="Open in Trakt"
-                        shortcut={Keyboard.Shortcut.Common.Open}
-                        url={getTraktUrl("movies", movie.movie.ids.slug)}
-                      />
-                      <Action.OpenInBrowser
-                        icon={getFavicon(IMDB_APP_URL)}
-                        title="Open in Imdb"
-                        shortcut={{ modifiers: ["cmd"], key: "i" }}
-                        url={getIMDbUrl(movie.movie.ids.imdb)}
-                      />
-                    </ActionPanel.Section>
-                  </ActionPanel>
-                )}
-              />
-            }
-          />
-          <Action
-            title="Add to History"
-            icon={Icon.Clock}
-            shortcut={Keyboard.Shortcut.Common.Duplicate}
-            onAction={() => handleMovieAction(item, addMovieToHistory, "Movie added to history")}
-          />
-          <Action
-            title="Remove from Watchlist"
-            icon={Icon.Trash}
-            shortcut={Keyboard.Shortcut.Common.Remove}
-            onAction={() => handleMovieAction(item, removeMovieFromWatchlist, "Movie removed from watchlist")}
-          />
-        </ActionPanel.Section>
-        <ActionPanel.Section>
-          <Action.OpenInBrowser
-            icon={getFavicon(TRAKT_APP_URL)}
-            title="Open in Trakt"
-            shortcut={Keyboard.Shortcut.Common.Open}
-            url={getTraktUrl("movies", item.movie.ids.slug)}
-          />
-          <Action.OpenInBrowser
-            icon={getFavicon(IMDB_APP_URL)}
-            title="Open in Imdb"
-            shortcut={{ modifiers: ["cmd"], key: "i" }}
-            url={getIMDbUrl(item.movie.ids.imdb)}
-          />
-        </ActionPanel.Section>
-      </ActionPanel>
+      <MovieActionPanel
+        item={item}
+        actions={[
+          {
+            title: "Add to History",
+            icon: Icon.Clock,
+            shortcut: Keyboard.Shortcut.Common.Duplicate,
+            onAction: (movie) => runMovieAction(movie, addMovieToHistoryAction, "Movie added to history"),
+          },
+          {
+            title: "Remove from Watchlist",
+            icon: Icon.Trash,
+            shortcut: Keyboard.Shortcut.Common.Remove,
+            onAction: (movie) => runMovieAction(movie, removeMovieFromWatchlistAction, "Movie removed from watchlist"),
+          },
+        ]}
+      />
     ),
-    [addMovieToHistory, handleMovieAction, movieMarkdown, movieMetadata, removeMovieFromWatchlist],
+    [addMovieToHistoryAction, removeMovieFromWatchlistAction, runMovieAction],
   );
 
   const showActions = useCallback(
     (item: TraktShowListItem) => (
-      <ActionPanel>
-        <ActionPanel.Section>
-          <Action.Push
-            icon={Icon.Switch}
-            title="Browse Seasons"
-            target={<SeasonGrid showId={item.show.ids.trakt} slug={item.show.ids.slug} imdbId={item.show.ids.imdb} />}
-          />
-          <Action
-            title="Check-In"
-            icon={Icon.Checkmark}
-            shortcut={Keyboard.Shortcut.Common.ToggleQuickLook}
-            onAction={() => handleShowAction(item, checkInFirstEpisodeToHistory, "First episode checked-in")}
-          />
-        </ActionPanel.Section>
-        <ActionPanel.Section>
-          <Action.OpenInBrowser
-            icon={getFavicon(TRAKT_APP_URL)}
-            title="Open in Trakt"
-            url={getTraktUrl("shows", item.show.ids.slug)}
-          />
-          <Action.OpenInBrowser
-            icon={getFavicon(IMDB_APP_URL)}
-            title="Open in Imdb"
-            url={getIMDbUrl(item.show.ids.imdb)}
-          />
-        </ActionPanel.Section>
-        <ActionPanel.Section>
-          <Action
-            title="Add to History"
-            icon={Icon.Clock}
-            shortcut={Keyboard.Shortcut.Common.Duplicate}
-            onAction={() => handleShowAction(item, addShowToHistory, "Show added to history")}
-          />
-          <Action
-            title="Remove from Watchlist"
-            icon={Icon.Trash}
-            shortcut={Keyboard.Shortcut.Common.Remove}
-            onAction={() => handleShowAction(item, removeShowFromWatchlist, "Show removed from watchlist")}
-          />
-        </ActionPanel.Section>
-      </ActionPanel>
+      <ShowActionPanel
+        item={item}
+        onCheckInFirstEpisode={(show) =>
+          runShowAction(show, checkInFirstEpisodeToHistoryAction, "First episode checked-in")
+        }
+        actions={[
+          {
+            title: "Add to History",
+            icon: Icon.Clock,
+            shortcut: Keyboard.Shortcut.Common.Duplicate,
+            onAction: (show) => runShowAction(show, addShowToHistoryAction, "Show added to history"),
+          },
+          {
+            title: "Remove from Watchlist",
+            icon: Icon.Trash,
+            shortcut: Keyboard.Shortcut.Common.Remove,
+            onAction: (show) => runShowAction(show, removeShowFromWatchlistAction, "Show removed from watchlist"),
+          },
+        ]}
+      />
     ),
-    [addShowToHistory, checkInFirstEpisodeToHistory, handleShowAction, removeShowFromWatchlist],
+    [addShowToHistoryAction, checkInFirstEpisodeToHistoryAction, removeShowFromWatchlistAction, runShowAction],
   );
 
   const searchBarAccessory = (

--- a/extensions/trakt-manager/src/watchlist.tsx
+++ b/extensions/trakt-manager/src/watchlist.tsx
@@ -31,10 +31,10 @@ const watchlistQuery = {
 };
 const combinedWatchlistPageLimit = watchlistQuery.limit * 2;
 
-const sortByAddedAt = (items: WatchlistItem[]) =>
+const sortByListedAt = (items: WatchlistItem[]) =>
   [...items].sort((a, b) => {
-    const aTime = a.item.last_updated_at ? new Date(a.item.last_updated_at).getTime() : 0;
-    const bTime = b.item.last_updated_at ? new Date(b.item.last_updated_at).getTime() : 0;
+    const aTime = a.item.listed_at ? new Date(a.item.listed_at).getTime() : 0;
+    const bTime = b.item.listed_at ? new Date(b.item.listed_at).getTime() : 0;
     return bTime - aTime;
   });
 
@@ -78,7 +78,7 @@ export default function Command() {
         combinedPageLimit: combinedWatchlistPageLimit,
         requestMoviePage: (page) => traktClient.movies.getWatchlistMovies({ query: { ...query, page }, fetchOptions }),
         requestShowPage: (page) => traktClient.shows.getWatchlistShows({ query: { ...query, page }, fetchOptions }),
-        sort: sortByAddedAt,
+        sort: sortByListedAt,
       });
     },
     [mediaType],


### PR DESCRIPTION
## Description

This update improves how Trakt Manager handles cross-media browsing by aligning key commands with how [Trakt.tv](https://trakt.tv) presents content: one unified search, and combined History/Watchlist views instead of forcing users to switch between movies and shows.

### What was added

- **Search Media** — A new command that searches movies and TV shows in a single query. Results from both Trakt search endpoints are fetched in parallel and merged into one grid (movies first, then shows per page). Users no longer need to guess whether something is a movie or a show before opening the right search command.

- **All filter for History** — History now defaults to an **All** view that combines movie and episode history into a single timeline, sorted by watch date (newest first). The existing **Movies** and **Shows** filters remain unchanged for users who prefer type-specific lists.

- **All filter for Watchlist** — Watchlist now defaults to an **All** view that combines movies and shows, sorted by date added (newest first). **Movies** and **Shows** filters are still available and keep their existing sort behavior.

### Why these changes

On Trakt.tv, History and Watchlist are naturally cross-media — you see everything you've watched or saved in one place. Previously, the Raycast extension required switching commands or filters to get the same picture. These changes reduce friction for the most common workflows: "find this title" and "see what I recently watched or saved."

### Implementation notes for reviewers

- **Search Media** (`src/search-media.tsx`): Uses `Promise.all` to call `searchMovies` and `searchShows` with shared pagination/abort handling. Each result is tagged with a `mediaType` discriminator so the correct action panel (movie vs. show) is rendered.
- **History** (`src/history.tsx`): Refactored to a single `useCachedPromise` + `GenericGrid`. In **All** mode, movie and show history are fetched in parallel, merged, and sorted client-side by `watched_at` (desc). Type-specific filters still use the dedicated Trakt endpoints with server-side sorting.
- **Watchlist** (`src/watchlist.tsx`): Same unified pattern. **All** mode merges by `last_updated_at` (desc). Per-item actions are preserved (e.g. View Details for movies, Browse Seasons for shows).
- **No breaking changes.** Existing commands — Search Movies, Search Shows, Search Episodes, etc. — are unchanged and remain available. Search Media is additive.
- **Minor lint fix:** "Check-In" action titles updated to title case across a few commands (`shows.tsx`, `episodes.tsx`, `up-next.tsx`, `recommendations.tsx`, `episode-grid.tsx`) to satisfy Raycast ESLint rules.
- **Dependencies:** `@raycast/api` bumped to `^1.104.20`. Contributor credit added in `package.json`.

### Files changed

| File | Change |
|------|--------|
| `src/search-media.tsx` | **New** — unified movie + show search command |
| `src/history.tsx` | Refactored — added **All** filter with merged timeline |
| `src/watchlist.tsx` | Refactored — added **All** filter with merged list |
| `package.json` | Registered Search Media command, contributor, `@raycast/api` bump |
| `package-lock.json` | Lockfile update for dependency bump |
| `CHANGELOG.md` | Documented all changes |
| `src/shows.tsx` | Lint: Check-In title case |
| `src/episodes.tsx` | Lint: Check-In title case |
| `src/up-next.tsx` | Lint: Check-In title case |
| `src/recommendations.tsx` | Lint: Check-In title case |
| `src/components/episode-grid.tsx` | Lint: Check-In title case |

## Screencast

### Search Media
<!-- Drag screenshot here: Search Media results showing both movies and shows -->
<img width="2000" height="1250" alt="Raycast 2026-06-28 18 21 51" src="https://github.com/user-attachments/assets/a0a1ade3-4f36-46c6-87a4-027f26867cda" />

### History — All filter
<!-- Drag screenshot here: History with All filter selected, mixed movie/episode timeline -->
<img width="2000" height="1250" alt="Raycast 2026-06-28 18 22 39" src="https://github.com/user-attachments/assets/976eda86-7afc-4899-9686-dcb0d072e6ca" />

### Watchlist — All filter
<!-- Drag screenshot here: Watchlist with All filter selected, mixed movies and shows -->
<img width="2000" height="1250" alt="Raycast 2026-06-28 18 22 58" src="https://github.com/user-attachments/assets/6a1e5bac-1a82-412a-8536-039130332071" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
