### PR TITLE
Update Agent Usage Codex reset credit display

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Agent Usage Changelog
 
+## [Improve Codex Usage Details] - 2026-06-28
+
+- Show Codex manual limit reset credits and their next expiration time when available
+- Support proxy environment variables for agent usage requests
+
 ## [Support Claude Config Directory] - 2026-06-16
 
 - Respect `CLAUDE_CONFIG_DIR` when reading Claude credentials

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Improve Codex Usage Details] - 2026-06-28
+## [Improve Codex Usage Details] - {PR_MERGE_DATE}
 
 - Show Codex manual limit reset credits and their next expiration time when available
 - Support proxy environment variables for agent usage requests

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Improve Codex Usage Details] - {PR_MERGE_DATE}
+## [Improve Codex Usage Details] - 2026-06-29
 
 - Show Codex manual limit reset credits and their next expiration time when available
 - Support proxy environment variables for agent usage requests

--- a/extensions/agent-usage/package-lock.json
+++ b/extensions/agent-usage/package-lock.json
@@ -8,7 +8,8 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.3",
-        "@raycast/utils": "^1.17.0"
+        "@raycast/utils": "^1.17.0",
+        "undici": "^6.27.0"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.0.4",
@@ -2890,6 +2891,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/extensions/agent-usage/package.json
+++ b/extensions/agent-usage/package.json
@@ -203,7 +203,8 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.104.3",
-    "@raycast/utils": "^1.17.0"
+    "@raycast/utils": "^1.17.0",
+    "undici": "^6.27.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.0.4",

--- a/extensions/agent-usage/src/accounts/ManageAccountsForm.tsx
+++ b/extensions/agent-usage/src/accounts/ManageAccountsForm.tsx
@@ -26,7 +26,9 @@ export function ManageAccountsForm({ provider, providerName, onSave }: ManageAcc
   const [accounts, setAccounts] = useState<AccountEntry[]>([]);
   const [newLabel, setNewLabel] = useState("");
   const [newToken, setNewToken] = useState("");
+  const [newAccountId, setNewAccountId] = useState("");
   const [isLoading, setIsLoading] = useState(true);
+  const supportsAccountId = provider === "codex";
 
   const refresh = useCallback(async () => {
     setIsLoading(true);
@@ -42,6 +44,7 @@ export function ManageAccountsForm({ provider, providerName, onSave }: ManageAcc
   const handleAdd = async () => {
     const labelTrimmed = newLabel.trim();
     const tokenTrimmed = newToken.trim();
+    const accountIdTrimmed = newAccountId.trim();
 
     if (!labelTrimmed) {
       await showToast({ style: Toast.Style.Failure, title: "Label is required" });
@@ -59,10 +62,11 @@ export function ManageAccountsForm({ provider, providerName, onSave }: ManageAcc
     }
 
     try {
-      await addAccount(provider, labelTrimmed, tokenTrimmed);
+      await addAccount(provider, labelTrimmed, tokenTrimmed, supportsAccountId ? accountIdTrimmed : undefined);
       onSave();
       setNewLabel("");
       setNewToken("");
+      setNewAccountId("");
       await refresh();
       await showToast({ style: Toast.Style.Success, title: `Added "${labelTrimmed}"` });
     } catch (error) {
@@ -102,9 +106,13 @@ export function ManageAccountsForm({ provider, providerName, onSave }: ManageAcc
   };
 
   const [editingLabel, setEditingLabel] = useState<Record<string, string>>({});
+  const [editingAccountId, setEditingAccountId] = useState<Record<string, string>>({});
 
-  const handleSaveLabel = async (account: AccountEntry) => {
+  const handleSaveAccount = async (account: AccountEntry) => {
     const newLabelValue = editingLabel[account.id]?.trim() ?? account.label;
+    const newAccountIdValue = supportsAccountId
+      ? (editingAccountId[account.id]?.trim() ?? account.accountId ?? "")
+      : undefined;
     if (!newLabelValue) {
       await showToast({ style: Toast.Style.Failure, title: "Label cannot be empty" });
       return;
@@ -118,10 +126,10 @@ export function ManageAccountsForm({ provider, providerName, onSave }: ManageAcc
     }
 
     try {
-      await updateAccount(provider, account.id, { label: newLabelValue });
+      await updateAccount(provider, account.id, { label: newLabelValue, accountId: newAccountIdValue || undefined });
       onSave();
       await refresh();
-      await showToast({ style: Toast.Style.Success, title: `Updated label to "${newLabelValue}"` });
+      await showToast({ style: Toast.Style.Success, title: `Updated "${newLabelValue}"` });
     } catch (error) {
       await showToast({
         style: Toast.Style.Failure,
@@ -154,7 +162,7 @@ export function ManageAccountsForm({ provider, providerName, onSave }: ManageAcc
                 key={`save-${account.id}`}
                 title={`Save "${account.label}"`}
                 icon={Icon.CheckCircle}
-                onAction={() => void handleSaveLabel(account)}
+                onAction={() => void handleSaveAccount(account)}
               />
             ))}
           </ActionPanel.Section>
@@ -174,7 +182,14 @@ export function ManageAccountsForm({ provider, providerName, onSave }: ManageAcc
       }
     >
       {/* Add New Account section at the TOP to prevent jitter */}
-      <Form.Description title="Add New Account" text="Enter a label and paste the API token for the new account." />
+      <Form.Description
+        title="Add New Account"
+        text={
+          supportsAccountId
+            ? "Enter a label, API token, and optional ChatGPT account ID for multi-account setups."
+            : "Enter a label and paste the API token for the new account."
+        }
+      />
       <Form.TextField
         id="new-label"
         title="Label"
@@ -189,6 +204,15 @@ export function ManageAccountsForm({ provider, providerName, onSave }: ManageAcc
         value={newToken}
         onChange={setNewToken}
       />
+      {supportsAccountId && (
+        <Form.TextField
+          id="new-account-id"
+          title="ChatGPT Account ID"
+          placeholder="Optional, e.g. acct_..."
+          value={newAccountId}
+          onChange={setNewAccountId}
+        />
+      )}
 
       {accounts.length > 0 && <Form.Separator />}
 
@@ -199,7 +223,7 @@ export function ManageAccountsForm({ provider, providerName, onSave }: ManageAcc
 
       {accounts.map((account) => (
         <Form.TextField
-          key={account.id}
+          key={`label-${account.id}`}
           id={`label-${account.id}`}
           title={account.label}
           placeholder="Account label"
@@ -207,6 +231,17 @@ export function ManageAccountsForm({ provider, providerName, onSave }: ManageAcc
           onChange={(val) => setEditingLabel((prev) => ({ ...prev, [account.id]: val }))}
         />
       ))}
+      {supportsAccountId &&
+        accounts.map((account) => (
+          <Form.TextField
+            key={`account-id-${account.id}`}
+            id={`account-id-${account.id}`}
+            title={`${account.label} Account ID`}
+            placeholder="Optional ChatGPT account ID"
+            defaultValue={account.accountId ?? ""}
+            onChange={(val) => setEditingAccountId((prev) => ({ ...prev, [account.id]: val }))}
+          />
+        ))}
     </Form>
   );
 }

--- a/extensions/agent-usage/src/accounts/storage.test.ts
+++ b/extensions/agent-usage/src/accounts/storage.test.ts
@@ -75,6 +75,7 @@ test("loadAccounts filters malformed entries", async () => {
     { id: "missing-token", label: "No Token" },
     { id: "empty-token", label: "Empty Token", token: "" },
     { id: "whitespace-token", label: "Whitespace Token", token: "   " },
+    { id: "invalid-account-id", label: "Invalid Account ID", token: "token456", accountId: 123 },
     null,
     "not an object",
     { label: "No ID", token: "token789" },
@@ -122,6 +123,28 @@ test("addAccount trims whitespace from label and token", async () => {
   const accounts = await loadAccounts("kimi");
   assert.equal(accounts[0].label, "Test Account");
   assert.equal(accounts[0].token, "test-token");
+});
+
+test("addAccount trims and stores account ID when provided", async () => {
+  const { addAccount, loadAccounts } = await loadStorageModule();
+
+  const entry = await addAccount("codex", "Codex Account", "codex-token", "  acct_123  ");
+
+  assert.equal(entry.accountId, "acct_123");
+
+  const accounts = await loadAccounts("codex");
+  assert.equal(accounts[0].accountId, "acct_123");
+});
+
+test("addAccount omits blank account ID", async () => {
+  const { addAccount, loadAccounts } = await loadStorageModule();
+
+  const entry = await addAccount("codex", "Codex Account", "codex-token", "   ");
+
+  assert.equal(entry.accountId, undefined);
+
+  const accounts = await loadAccounts("codex");
+  assert.equal(accounts[0].accountId, undefined);
 });
 
 test("addAccount uses separate storage per provider", async () => {
@@ -173,6 +196,16 @@ test("updateAccount updates token only", async () => {
   const accounts = await loadAccounts("kimi");
   assert.equal(accounts[0].label, "Test");
   assert.equal(accounts[0].token, "new-token");
+});
+
+test("updateAccount updates account ID", async () => {
+  const { addAccount, updateAccount, loadAccounts } = await loadStorageModule();
+
+  const entry = await addAccount("codex", "Test", "token123");
+  await updateAccount("codex", entry.id, { accountId: "acct_456" });
+
+  const accounts = await loadAccounts("codex");
+  assert.equal(accounts[0].accountId, "acct_456");
 });
 
 test("deleteAccount returns true and removes existing account", async () => {

--- a/extensions/agent-usage/src/accounts/storage.ts
+++ b/extensions/agent-usage/src/accounts/storage.ts
@@ -21,6 +21,7 @@ export async function loadAccounts(provider: AccountsProvider): Promise<AccountE
         e !== null &&
         typeof e.id === "string" &&
         typeof e.label === "string" &&
+        (typeof e.accountId === "undefined" || typeof e.accountId === "string") &&
         typeof e.token === "string" &&
         e.token.trim().length > 0,
     );
@@ -34,9 +35,20 @@ export async function saveAccounts(provider: AccountsProvider, accounts: Account
   await LocalStorage.setItem(storageKey(provider), JSON.stringify(accounts));
 }
 
-export async function addAccount(provider: AccountsProvider, label: string, token: string): Promise<AccountEntry> {
+export async function addAccount(
+  provider: AccountsProvider,
+  label: string,
+  token: string,
+  accountId?: string,
+): Promise<AccountEntry> {
   const accounts = await loadAccounts(provider);
-  const entry: AccountEntry = { id: randomUUID(), label: label.trim(), token: token.trim() };
+  const trimmedAccountId = accountId?.trim();
+  const entry: AccountEntry = {
+    id: randomUUID(),
+    label: label.trim(),
+    token: token.trim(),
+    ...(trimmedAccountId ? { accountId: trimmedAccountId } : {}),
+  };
   await saveAccounts(provider, [...accounts, entry]);
   return entry;
 }
@@ -44,7 +56,7 @@ export async function addAccount(provider: AccountsProvider, label: string, toke
 export async function updateAccount(
   provider: AccountsProvider,
   id: string,
-  patch: Partial<Pick<AccountEntry, "label" | "token">>,
+  patch: Partial<Pick<AccountEntry, "label" | "token" | "accountId">>,
 ): Promise<boolean> {
   const accounts = await loadAccounts(provider);
   const found = accounts.some((a) => a.id === id);

--- a/extensions/agent-usage/src/accounts/types.ts
+++ b/extensions/agent-usage/src/accounts/types.ts
@@ -10,6 +10,8 @@ export interface AccountEntry {
   label: string;
   /** Raw API token — stored as plaintext in LocalStorage (same as Raycast password prefs) */
   token: string;
+  /** Optional provider-specific account scope, e.g. ChatGPT account ID for Codex */
+  accountId?: string;
 }
 
 /** The per-provider storage key constants. */

--- a/extensions/agent-usage/src/agents/http.ts
+++ b/extensions/agent-usage/src/agents/http.ts
@@ -34,7 +34,7 @@ function getProxyUrl(url: string): string | null {
     return null;
   }
 
-  if (isNoProxyHost(parsedUrl.hostname)) {
+  if (isNoProxyHost(parsedUrl.hostname, parsedUrl.port || getDefaultPort(parsedUrl.protocol))) {
     return null;
   }
 
@@ -50,7 +50,31 @@ function getProxyUrl(url: string): string | null {
   return trimmedProxyUrl;
 }
 
-function isNoProxyHost(hostname: string): boolean {
+function getDefaultPort(protocol: string): string | undefined {
+  if (protocol === "https:") {
+    return "443";
+  }
+  if (protocol === "http:") {
+    return "80";
+  }
+  return undefined;
+}
+
+function parseNoProxyEntry(entry: string): { hostname: string; port?: string } {
+  if (entry.startsWith("[")) {
+    const hostEnd = entry.indexOf("]");
+    if (hostEnd !== -1) {
+      const port = entry.slice(hostEnd + 1).startsWith(":") ? entry.slice(hostEnd + 2) : undefined;
+      return { hostname: entry.slice(1, hostEnd), port };
+    }
+  }
+
+  const colonIndex = entry.lastIndexOf(":");
+  const hasPort = colonIndex > -1 && entry.indexOf(":") === colonIndex;
+  return hasPort ? { hostname: entry.slice(0, colonIndex), port: entry.slice(colonIndex + 1) } : { hostname: entry };
+}
+
+function isNoProxyHost(hostname: string, port?: string): boolean {
   const noProxy = process.env.NO_PROXY || process.env.no_proxy;
   if (!noProxy) {
     return false;
@@ -65,7 +89,11 @@ function isNoProxyHost(hostname: string): boolean {
       if (entry === "*") {
         return true;
       }
-      const normalizedEntry = entry.startsWith(".") ? entry.slice(1) : entry;
+      const { hostname: entryHostname, port: entryPort } = parseNoProxyEntry(entry);
+      const normalizedEntry = entryHostname.startsWith(".") ? entryHostname.slice(1) : entryHostname;
+      if (entryPort && entryPort !== port) {
+        return false;
+      }
       return normalizedHostname === normalizedEntry || normalizedHostname.endsWith(`.${normalizedEntry}`);
     });
 }

--- a/extensions/agent-usage/src/agents/http.ts
+++ b/extensions/agent-usage/src/agents/http.ts
@@ -1,3 +1,7 @@
+import { ProxyAgent, fetch as undiciFetch } from "undici";
+
+const proxyAgents = new Map<string, ProxyAgent>();
+
 export function normalizeBearerToken(token: string): string {
   return token.startsWith("Bearer ") ? token : `Bearer ${token}`;
 }
@@ -22,6 +26,61 @@ export interface HttpFetchResult {
   error: HttpFetchError | null;
 }
 
+function getProxyUrl(url: string): string | null {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (isNoProxyHost(parsedUrl.hostname)) {
+    return null;
+  }
+
+  const proxyUrl =
+    parsedUrl.protocol === "https:"
+      ? process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy
+      : process.env.HTTP_PROXY || process.env.http_proxy;
+  const trimmedProxyUrl = proxyUrl?.trim();
+  if (!trimmedProxyUrl || !/^https?:\/\//i.test(trimmedProxyUrl)) {
+    return null;
+  }
+
+  return trimmedProxyUrl;
+}
+
+function isNoProxyHost(hostname: string): boolean {
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy;
+  if (!noProxy) {
+    return false;
+  }
+
+  const normalizedHostname = hostname.toLowerCase();
+  return noProxy
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean)
+    .some((entry) => {
+      if (entry === "*") {
+        return true;
+      }
+      const normalizedEntry = entry.startsWith(".") ? entry.slice(1) : entry;
+      return normalizedHostname === normalizedEntry || normalizedHostname.endsWith(`.${normalizedEntry}`);
+    });
+}
+
+function getProxyAgent(proxyUrl: string): ProxyAgent {
+  const cachedAgent = proxyAgents.get(proxyUrl);
+  if (cachedAgent) {
+    return cachedAgent;
+  }
+
+  const agent = new ProxyAgent(proxyUrl);
+  proxyAgents.set(proxyUrl, agent);
+  return agent;
+}
+
 export async function httpFetch(options: HttpFetchOptions): Promise<HttpFetchResult> {
   const {
     url,
@@ -42,7 +101,16 @@ export async function httpFetch(options: HttpFetchOptions): Promise<HttpFetchRes
   }
 
   try {
-    const response = await fetch(url, { method, headers: allHeaders, body, signal: controller.signal });
+    const proxyUrl = getProxyUrl(url);
+    const response = proxyUrl
+      ? await undiciFetch(url, {
+          method,
+          headers: allHeaders,
+          body,
+          signal: controller.signal,
+          dispatcher: getProxyAgent(proxyUrl),
+        })
+      : await fetch(url, { method, headers: allHeaders, body, signal: controller.signal });
     clearTimeout(timeoutId);
 
     if (response.status === 401) {

--- a/extensions/agent-usage/src/codex/auth.test.ts
+++ b/extensions/agent-usage/src/codex/auth.test.ts
@@ -13,7 +13,9 @@ function makeTempFile(content: string): { dir: string; filePath: string } {
 
 test("resolveCodexAuthToken prefers local Codex login token over preference token", async () => {
   const { resolveCodexAuthToken } = await import("./auth");
-  const { dir, filePath } = makeTempFile(JSON.stringify({ tokens: { access_token: "local-token" } }));
+  const { dir, filePath } = makeTempFile(
+    JSON.stringify({ tokens: { access_token: "local-token", account_id: "account-id" } }),
+  );
 
   try {
     const token = resolveCodexAuthToken({
@@ -58,7 +60,9 @@ test("normalizeCodexAuthorizationHeader adds Bearer prefix when missing", async 
 
 test("resolveCodexAuthTokens exposes primary/local/preference tokens", async () => {
   const { resolveCodexAuthTokens } = await import("./auth");
-  const { dir, filePath } = makeTempFile(JSON.stringify({ tokens: { access_token: "local-token" } }));
+  const { dir, filePath } = makeTempFile(
+    JSON.stringify({ tokens: { access_token: "local-token", account_id: "account-id" } }),
+  );
 
   try {
     const tokens = resolveCodexAuthTokens({
@@ -68,7 +72,9 @@ test("resolveCodexAuthTokens exposes primary/local/preference tokens", async () 
 
     assert.deepEqual(tokens, {
       primaryToken: "local-token",
+      primaryAccountId: "account-id",
       localToken: "local-token",
+      localAccountId: "account-id",
       preferenceToken: "pref-token",
     });
   } finally {

--- a/extensions/agent-usage/src/codex/auth.ts
+++ b/extensions/agent-usage/src/codex/auth.ts
@@ -7,6 +7,8 @@ const DEFAULT_CODEX_AUTH_FILE = path.join(os.homedir(), ".codex", "auth.json");
 interface CodexAuthFile {
   tokens?: {
     access_token?: string;
+    account_id?: string;
+    accountId?: string;
   };
 }
 
@@ -17,7 +19,9 @@ interface ResolveCodexAuthTokenOptions {
 
 interface ResolveCodexAuthTokensResult {
   primaryToken: string | null;
+  primaryAccountId: string | null;
   localToken: string | null;
+  localAccountId: string | null;
   preferenceToken: string | null;
 }
 
@@ -32,27 +36,33 @@ function cleanToken(token: string | undefined): string | null {
   return trimmedToken ? trimmedToken : null;
 }
 
-function readCodexLoginToken(authFilePath: string): string | null {
+function readCodexLoginAuth(authFilePath: string): { token: string | null; accountId: string | null } {
   try {
     if (!fs.existsSync(authFilePath)) {
-      return null;
+      return { token: null, accountId: null };
     }
 
     const raw = fs.readFileSync(authFilePath, "utf-8");
     const parsed = JSON.parse(raw) as CodexAuthFile;
-    return cleanToken(parsed.tokens?.access_token);
+    return {
+      token: cleanToken(parsed.tokens?.access_token),
+      accountId: cleanToken(parsed.tokens?.account_id ?? parsed.tokens?.accountId),
+    };
   } catch {
-    return null;
+    return { token: null, accountId: null };
   }
 }
 
 export function resolveCodexAuthTokens(options: ResolveCodexAuthTokenOptions = {}): ResolveCodexAuthTokensResult {
-  const localToken = readCodexLoginToken(options.authFilePath ?? DEFAULT_CODEX_AUTH_FILE);
+  const localAuth = readCodexLoginAuth(options.authFilePath ?? DEFAULT_CODEX_AUTH_FILE);
+  const localToken = localAuth.token;
   const preferenceToken = cleanToken(options.preferenceToken);
 
   return {
     primaryToken: localToken ?? preferenceToken,
+    primaryAccountId: localToken ? localAuth.accountId : null,
     localToken,
+    localAccountId: localAuth.accountId,
     preferenceToken,
   };
 }

--- a/extensions/agent-usage/src/codex/fetcher.ts
+++ b/extensions/agent-usage/src/codex/fetcher.ts
@@ -309,6 +309,7 @@ export function useCodexAccounts(enabled = true): AccountUsageState<CodexUsage, 
         id: "codex-auto",
         label: "Auto-detected",
         token: localToken,
+        ...(localAccountId ? { accountId: localAccountId } : {}),
       });
     }
 
@@ -337,7 +338,20 @@ export function useCodexAccounts(enabled = true): AccountUsageState<CodexUsage, 
     // Kick off all fetches in parallel
     const results = await Promise.all(
       accounts.map(async (account) => {
-        const accountId = account.token === localToken ? localAccountId : null;
+        const accountId = account.accountId ?? (account.token === localToken ? localAccountId : null);
+        if (!accountId && account.token !== localToken) {
+          return {
+            account,
+            result: {
+              usage: null,
+              error: {
+                type: "not_configured" as const,
+                message:
+                  "Add the ChatGPT account ID for this Codex account to avoid showing the token's default account.",
+              },
+            },
+          };
+        }
         const result = await fetchCodexUsage(account.token, accountId);
         return { account, result };
       }),

--- a/extensions/agent-usage/src/codex/fetcher.ts
+++ b/extensions/agent-usage/src/codex/fetcher.ts
@@ -15,6 +15,11 @@ const CODEX_HEADERS = {
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
 };
 
+interface CodexResetCreditsResult {
+  resetCredits: CodexUsage["resetCredits"] | null;
+  error: CodexError | null;
+}
+
 export async function fetchCodexUsage(
   token: string,
   accountId?: string | null,
@@ -28,14 +33,11 @@ export async function fetchCodexUsage(
   });
   if (error) return { usage: null, error };
 
-  const resetCredits = await fetchCodexResetCredits(token, accountId);
-  return parseCodexApiResponse(data, resetCredits ?? { availableCount: null, nextExpiresAt: null });
+  const { resetCredits, error: resetCreditsError } = await fetchCodexResetCredits(token, accountId);
+  return parseCodexApiResponse(data, resetCredits ?? { availableCount: null, nextExpiresAt: null }, resetCreditsError);
 }
 
-async function fetchCodexResetCredits(
-  token: string,
-  accountId?: string | null,
-): Promise<{ availableCount: number; nextExpiresAt: string | null } | null> {
+async function fetchCodexResetCredits(token: string, accountId?: string | null): Promise<CodexResetCreditsResult> {
   const { data, error } = await httpFetch({
     url: CODEX_RESET_CREDITS_API,
     token,
@@ -49,8 +51,15 @@ async function fetchCodexResetCredits(
     unauthorizedMessage: "Authorization token expired or invalid. Run 'codex login' to refresh credentials.",
   });
 
-  if (error || !data || typeof data !== "object") {
-    return null;
+  if (error) {
+    return { resetCredits: null, error };
+  }
+
+  if (!data || typeof data !== "object") {
+    return {
+      resetCredits: null,
+      error: { type: "parse_error", message: "Invalid reset-credit response format" },
+    };
   }
 
   const response = data as {
@@ -63,7 +72,10 @@ async function fetchCodexResetCredits(
 
   const availableCount = typeof response.available_count === "number" ? response.available_count : null;
   if (availableCount === null || availableCount < 0) {
-    return null;
+    return {
+      resetCredits: null,
+      error: { type: "parse_error", message: "Invalid reset-credit response format" },
+    };
   }
 
   const now = Date.now();
@@ -76,7 +88,7 @@ async function fetchCodexResetCredits(
     })
     .sort((a, b) => Date.parse(a) - Date.parse(b))[0];
 
-  return { availableCount, nextExpiresAt: nextExpiresAt ?? null };
+  return { resetCredits: { availableCount, nextExpiresAt: nextExpiresAt ?? null }, error: null };
 }
 
 function getCodexAccountHeaders(accountId?: string | null): Record<string, string> {
@@ -87,6 +99,7 @@ function getCodexAccountHeaders(accountId?: string | null): Record<string, strin
 function parseCodexApiResponse(
   data: unknown,
   resetCredits: CodexUsage["resetCredits"] | null = null,
+  resetCreditsError: CodexError | null = null,
 ): { usage: CodexUsage | null; error: CodexError | null } {
   try {
     if (!data || typeof data !== "object") {
@@ -161,6 +174,7 @@ function parseCodexApiResponse(
         balance: response.credits?.balance || "0",
       },
       resetCredits: resetCredits ?? undefined,
+      resetCreditsError: resetCreditsError?.message,
     };
 
     if (response.code_review_rate_limit?.primary_window) {

--- a/extensions/agent-usage/src/codex/fetcher.ts
+++ b/extensions/agent-usage/src/codex/fetcher.ts
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { CodexUsage, CodexError } from "./types";
-import { resolveCodexAuthToken, resolveCodexAuthTokens } from "./auth";
-import { httpFetch, normalizeBearerToken } from "../agents/http";
+import { resolveCodexAuthTokens } from "./auth";
+import { httpFetch } from "../agents/http";
+import { parseDate } from "../agents/format";
 import { loadAccounts } from "../accounts/storage";
 import type { AccountUsageState } from "../accounts/types";
 
 const CODEX_USAGE_API = "https://chatgpt.com/backend-api/wham/usage";
+const CODEX_RESET_CREDITS_API = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
 
 const CODEX_HEADERS = {
   Accept: "application/json",
@@ -13,17 +15,79 @@ const CODEX_HEADERS = {
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
 };
 
-export async function fetchCodexUsage(token: string): Promise<{ usage: CodexUsage | null; error: CodexError | null }> {
+export async function fetchCodexUsage(
+  token: string,
+  accountId?: string | null,
+): Promise<{ usage: CodexUsage | null; error: CodexError | null }> {
+  const accountHeaders = getCodexAccountHeaders(accountId);
   const { data, error } = await httpFetch({
     url: CODEX_USAGE_API,
-    headers: { ...CODEX_HEADERS, Authorization: normalizeBearerToken(token) },
+    token,
+    headers: { ...CODEX_HEADERS, ...accountHeaders },
     unauthorizedMessage: "Authorization token expired or invalid. Run 'codex login' to refresh credentials.",
   });
   if (error) return { usage: null, error };
-  return parseCodexApiResponse(data);
+
+  const resetCredits = await fetchCodexResetCredits(token, accountId);
+  return parseCodexApiResponse(data, resetCredits ?? { availableCount: null, nextExpiresAt: null });
 }
 
-function parseCodexApiResponse(data: unknown): { usage: CodexUsage | null; error: CodexError | null } {
+async function fetchCodexResetCredits(
+  token: string,
+  accountId?: string | null,
+): Promise<{ availableCount: number; nextExpiresAt: string | null } | null> {
+  const { data, error } = await httpFetch({
+    url: CODEX_RESET_CREDITS_API,
+    token,
+    headers: {
+      ...CODEX_HEADERS,
+      ...getCodexAccountHeaders(accountId),
+      "OpenAI-Beta": "codex-1",
+      originator: "Codex Desktop",
+    },
+    timeoutMs: 4000,
+    unauthorizedMessage: "Authorization token expired or invalid. Run 'codex login' to refresh credentials.",
+  });
+
+  if (error || !data || typeof data !== "object") {
+    return null;
+  }
+
+  const response = data as {
+    available_count?: number;
+    credits?: Array<{
+      status?: string;
+      expires_at?: string | null;
+    }>;
+  };
+
+  const availableCount = typeof response.available_count === "number" ? response.available_count : null;
+  if (availableCount === null || availableCount < 0) {
+    return null;
+  }
+
+  const now = Date.now();
+  const nextExpiresAt = (response.credits ?? [])
+    .filter((credit) => credit.status === "available" && typeof credit.expires_at === "string")
+    .map((credit) => credit.expires_at as string)
+    .filter((expiresAt) => {
+      const timestamp = Date.parse(expiresAt);
+      return Number.isFinite(timestamp) && timestamp > now;
+    })
+    .sort((a, b) => Date.parse(a) - Date.parse(b))[0];
+
+  return { availableCount, nextExpiresAt: nextExpiresAt ?? null };
+}
+
+function getCodexAccountHeaders(accountId?: string | null): Record<string, string> {
+  const trimmedAccountId = accountId?.trim();
+  return trimmedAccountId ? { "ChatGPT-Account-ID": trimmedAccountId } : {};
+}
+
+function parseCodexApiResponse(
+  data: unknown,
+  resetCredits: CodexUsage["resetCredits"] | null = null,
+): { usage: CodexUsage | null; error: CodexError | null } {
   try {
     if (!data || typeof data !== "object") {
       return {
@@ -41,19 +105,22 @@ function parseCodexApiResponse(data: unknown): { usage: CodexUsage | null; error
         primary_window?: {
           used_percent: number;
           limit_window_seconds: number;
-          reset_after_seconds: number;
+          reset_after_seconds?: number;
+          reset_at?: number;
         };
         secondary_window?: {
           used_percent: number;
           limit_window_seconds: number;
-          reset_after_seconds: number;
+          reset_after_seconds?: number;
+          reset_at?: number;
         };
       };
       code_review_rate_limit?: {
         primary_window?: {
           used_percent: number;
           limit_window_seconds: number;
-          reset_after_seconds: number;
+          reset_after_seconds?: number;
+          reset_at?: number;
         };
       };
       credits?: {
@@ -80,12 +147,12 @@ function parseCodexApiResponse(data: unknown): { usage: CodexUsage | null; error
       account: response.plan_type || "Unknown",
       fiveHourLimit: {
         percentageRemaining: 100 - primaryWindow.used_percent,
-        resetsInSeconds: primaryWindow.reset_after_seconds,
+        resetsInSeconds: getResetsInSeconds(primaryWindow),
         limitWindowSeconds: primaryWindow.limit_window_seconds,
       },
       weeklyLimit: {
         percentageRemaining: 100 - secondaryWindow.used_percent,
-        resetsInSeconds: secondaryWindow.reset_after_seconds,
+        resetsInSeconds: getResetsInSeconds(secondaryWindow),
         limitWindowSeconds: secondaryWindow.limit_window_seconds,
       },
       credits: {
@@ -93,13 +160,14 @@ function parseCodexApiResponse(data: unknown): { usage: CodexUsage | null; error
         unlimited: response.credits?.unlimited || false,
         balance: response.credits?.balance || "0",
       },
+      resetCredits: resetCredits ?? undefined,
     };
 
     if (response.code_review_rate_limit?.primary_window) {
       const reviewWindow = response.code_review_rate_limit.primary_window;
       usage.codeReviewLimit = {
         percentageRemaining: 100 - reviewWindow.used_percent,
-        resetsInSeconds: reviewWindow.reset_after_seconds,
+        resetsInSeconds: getResetsInSeconds(reviewWindow),
         limitWindowSeconds: reviewWindow.limit_window_seconds,
       };
     }
@@ -114,6 +182,19 @@ function parseCodexApiResponse(data: unknown): { usage: CodexUsage | null; error
       },
     };
   }
+}
+
+function getResetsInSeconds(window: { reset_after_seconds?: number; reset_at?: number }): number {
+  if (typeof window.reset_after_seconds === "number") {
+    return Math.max(0, Math.floor(window.reset_after_seconds));
+  }
+
+  if (typeof window.reset_at !== "number") {
+    return 0;
+  }
+
+  const resetAt = parseDate(String(window.reset_at));
+  return resetAt ? Math.max(0, Math.floor((resetAt.getTime() - Date.now()) / 1000)) : 0;
 }
 
 export { formatDuration } from "../agents/format";
@@ -131,7 +212,7 @@ export function useCodexUsage(enabled = true) {
     setIsLoading(true);
     setError(null);
 
-    const token = resolveCodexAuthToken();
+    const { primaryToken: token, primaryAccountId } = resolveCodexAuthTokens();
 
     if (!token) {
       setUsage(null);
@@ -144,7 +225,7 @@ export function useCodexUsage(enabled = true) {
       return;
     }
 
-    const result = await fetchCodexUsage(token);
+    const result = await fetchCodexUsage(token, primaryAccountId);
     if (requestId !== requestIdRef.current) {
       return;
     }
@@ -203,7 +284,7 @@ export function useCodexAccounts(enabled = true): AccountUsageState<CodexUsage, 
     const manualAccounts = await loadAccounts("codex");
 
     // Get auto-detected token from codex auth file
-    const { localToken } = resolveCodexAuthTokens();
+    const { localToken, localAccountId } = resolveCodexAuthTokens();
 
     // Build list of all accounts: manual + auto-detected (if not duplicate)
     const accounts = [...manualAccounts];
@@ -242,7 +323,8 @@ export function useCodexAccounts(enabled = true): AccountUsageState<CodexUsage, 
     // Kick off all fetches in parallel
     const results = await Promise.all(
       accounts.map(async (account) => {
-        const result = await fetchCodexUsage(account.token);
+        const accountId = account.token === localToken ? localAccountId : null;
+        const result = await fetchCodexUsage(account.token, accountId);
         return { account, result };
       }),
     );

--- a/extensions/agent-usage/src/codex/renderer.tsx
+++ b/extensions/agent-usage/src/codex/renderer.tsx
@@ -36,6 +36,9 @@ export function formatCodexUsageText(usage: CodexUsage | null, error: CodexError
     if (u.resetCredits.nextExpiresAt) {
       text += `\nNext Expires In: ${formatResetTime(u.resetCredits.nextExpiresAt)}`;
     }
+    if (u.resetCreditsError) {
+      text += `\nReset Credits Error: ${u.resetCreditsError}`;
+    }
   }
 
   return text;
@@ -92,6 +95,9 @@ export function renderCodexDetail(usage: CodexUsage | null, error: CodexError | 
               title="Next Expires In"
               text={formatResetTime(u.resetCredits.nextExpiresAt)}
             />
+          )}
+          {u.resetCreditsError && (
+            <List.Item.Detail.Metadata.Label title="Reset Credits Error" text={u.resetCreditsError} />
           )}
         </>
       )}

--- a/extensions/agent-usage/src/codex/renderer.tsx
+++ b/extensions/agent-usage/src/codex/renderer.tsx
@@ -1,7 +1,7 @@
 import { List } from "@raycast/api";
 import { CodexUsage, CodexError } from "./types";
 import type { Accessory } from "../agents/types";
-import { formatDuration } from "../agents/format";
+import { formatDuration, formatResetTime } from "../agents/format";
 import {
   renderErrorOrNoData,
   formatErrorOrNoData,
@@ -30,6 +30,13 @@ export function formatCodexUsageText(usage: CodexUsage | null, error: CodexError
   }
 
   text += `\n\nCredits: ${u.credits.unlimited ? "Unlimited" : u.credits.balance}`;
+
+  if (u.resetCredits) {
+    text += `\nLimit Reset Credits: ${formatResetCredits(u.resetCredits.availableCount)}`;
+    if (u.resetCredits.nextExpiresAt) {
+      text += `\nNext Expires In: ${formatResetTime(u.resetCredits.nextExpiresAt)}`;
+    }
+  }
 
   return text;
 }
@@ -72,8 +79,30 @@ export function renderCodexDetail(usage: CodexUsage | null, error: CodexError | 
       <List.Item.Detail.Metadata.Separator />
 
       <List.Item.Detail.Metadata.Label title="Credits" text={u.credits.unlimited ? "Unlimited" : u.credits.balance} />
+
+      {u.resetCredits && (
+        <>
+          <List.Item.Detail.Metadata.Separator />
+          <List.Item.Detail.Metadata.Label
+            title="Limit Reset Credits"
+            text={formatResetCredits(u.resetCredits.availableCount)}
+          />
+          {u.resetCredits.nextExpiresAt && (
+            <List.Item.Detail.Metadata.Label
+              title="Next Expires In"
+              text={formatResetTime(u.resetCredits.nextExpiresAt)}
+            />
+          )}
+        </>
+      )}
     </List.Item.Detail.Metadata>
   );
+}
+
+function formatResetCredits(availableCount: number | null): string {
+  return availableCount === null
+    ? "Unavailable"
+    : `${availableCount} manual reset${availableCount === 1 ? "" : "s"} available`;
 }
 
 export function getCodexAccessory(usage: CodexUsage | null, error: CodexError | null, isLoading: boolean): Accessory {

--- a/extensions/agent-usage/src/codex/types.ts
+++ b/extensions/agent-usage/src/codex/types.ts
@@ -24,6 +24,7 @@ export interface CodexUsage {
     availableCount: number | null;
     nextExpiresAt: string | null;
   };
+  resetCreditsError?: string;
 }
 
 export interface CodexError {

--- a/extensions/agent-usage/src/codex/types.ts
+++ b/extensions/agent-usage/src/codex/types.ts
@@ -20,6 +20,10 @@ export interface CodexUsage {
     unlimited: boolean;
     balance: string;
   };
+  resetCredits?: {
+    availableCount: number | null;
+    nextExpiresAt: string | null;
+  };
 }
 
 export interface CodexError {


### PR DESCRIPTION
## Description
- Add Codex manual limit reset credit fetching and display
- Pass ChatGPT account ID from local Codex auth when available
- Respect HTTP(S)_PROXY/NO_PROXY for shared agent HTTP fetches

## Screencast
N/A

## Checklist
- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I ran `npm run build` and `npm run lint` locally
