### PR TITLE
Fix TinyPNG multiple compression command

### DIFF
--- a/extensions/tinypng/CHANGELOG.md
+++ b/extensions/tinypng/CHANGELOG.md
@@ -1,6 +1,6 @@
 # TinyPNG Changelog
 
-## [New Command] - 2026-06-29
+## [New Command] - {PR_MERGE_DATE}
 
 - Added `Compress Images Multiple Times` to run TinyPNG compression multiple times in one command.
 

--- a/extensions/tinypng/CHANGELOG.md
+++ b/extensions/tinypng/CHANGELOG.md
@@ -1,6 +1,6 @@
 # TinyPNG Changelog
 
-## [New Command] - {PR_MERGE_DATE}
+## [New Command] - 2026-06-29
 
 - Added `Compress Images Multiple Times` to run TinyPNG compression multiple times in one command.
 

--- a/extensions/tinypng/package-lock.json
+++ b/extensions/tinypng/package-lock.json
@@ -28,7 +28,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -41,7 +40,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1522,7 +1520,6 @@
       "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1582,7 +1579,6 @@
       "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.0",
         "@typescript-eslint/types": "8.62.0",
@@ -1900,7 +1896,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2248,7 +2243,6 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3365,7 +3359,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3418,7 +3411,6 @@
       "integrity": "sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3702,7 +3694,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3758,7 +3749,6 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/extensions/tinypng/package.json
+++ b/extensions/tinypng/package.json
@@ -6,7 +6,8 @@
   "icon": "tinypng-icon.png",
   "author": "kawamataryo",
   "contributors": [
-    "j3lte"
+    "j3lte",
+    "thuggyduck"
   ],
   "categories": [
     "Developer Tools"

--- a/extensions/tinypng/src/compressImagesMultipleTimes.ts
+++ b/extensions/tinypng/src/compressImagesMultipleTimes.ts
@@ -2,6 +2,7 @@ import { existsSync } from "fs";
 import { mkdirSync } from "fs";
 import { showToast, Toast, getSelectedFinderItems, getPreferenceValues, showHUD, LaunchProps } from "@raycast/api";
 import { statSync, createReadStream, createWriteStream } from "fs";
+import fetch from "node-fetch";
 import { dirname, basename, join, extname } from "path";
 import { compressImageResponseScheme } from "./lib/zodSchema";
 import { resolveOutputPath } from "./lib/utils";


### PR DESCRIPTION
## Description

Fixes the TinyPNG `Compress Images Multiple Times` command by restoring the missing `node-fetch` import used for TinyPNG API requests.

Also adds `thuggyduck` to the extension contributors list and refreshes the npm lockfile metadata generated by the current npm version.

## Screencast

Not included because this is a small bugfix to an existing no-view command.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder

### Verification

- `npm run build`
- `npm run lint`
- `npm test`
