### PR TITLE
Update picgo extension

### DIFF
--- a/extensions/picgo/CHANGELOG.md
+++ b/extensions/picgo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Picgo Changelog
 
+## [Bugfix: Upload Result Copy Actions] - {PR_MERGE_DATE}
+
+- Fix automatic URL copying to run only once after a successful upload instead of running again when switching result views.
+- Align copy action titles across result views and clarify when all uploaded image URLs are copied.
+
 ## [Bugfix: Image Grid Format Selection] - 2026-06-24
 
 - Fix a crash when switching to the Image Grid view caused by an empty image format selection in newer Raycast versions.

--- a/extensions/picgo/CHANGELOG.md
+++ b/extensions/picgo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Picgo Changelog
 
-## [Bugfix: Upload Result Copy Actions] - {PR_MERGE_DATE}
+## [Bugfix: Upload Result Copy Actions] - 2026-06-29
 
 - Fix automatic URL copying to run only once after a successful upload instead of running again when switching result views.
 - Align copy action titles across result views and clarify when all uploaded image URLs are copied.

--- a/extensions/picgo/src/components/FormatListPage.tsx
+++ b/extensions/picgo/src/components/FormatListPage.tsx
@@ -1,25 +1,16 @@
 import { type IImgInfo } from "picgo";
 
-import { Action, ActionPanel, Icon, List, getPreferenceValues, Clipboard, showToast, Toast } from "@raycast/api";
+import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { exportFormats } from "../util/format";
 import ImagesMetadataPanel from "./ImagesMetadataPanel";
 import ImagesPreviewPage from "./ImagesPreviewPage";
-import { useEffect } from "react";
 
 interface Props {
     result: IImgInfo[];
 }
 
 export default function FormatListPage({ result }: Props) {
-    const { autoCopyAfterUpload } = getPreferenceValues<Preferences.UploadImages>();
     const imgs = result.filter((r) => r.imgUrl);
-
-    useEffect(() => {
-        if (autoCopyAfterUpload) {
-            Clipboard.copy(exportFormats.url.generate(imgs));
-            showToast({ style: Toast.Style.Success, title: "URL Copied!" });
-        }
-    }, []);
 
     if (imgs.length === 0)
         return (
@@ -39,7 +30,7 @@ export default function FormatListPage({ result }: Props) {
                         actions={
                             <ActionPanel>
                                 <Action.CopyToClipboard
-                                    title={`Copy ${f.label} to Clipboard`}
+                                    title={`Copy All ${f.label} to Clipboard`}
                                     content={f.generate(imgs)}
                                     shortcut={{ modifiers: ["cmd"], key: "c" }}
                                 ></Action.CopyToClipboard>

--- a/extensions/picgo/src/components/ImagesPreviewPage.tsx
+++ b/extensions/picgo/src/components/ImagesPreviewPage.tsx
@@ -1,7 +1,7 @@
-import { ActionPanel, Action, Grid, Icon, getPreferenceValues, Clipboard, showToast, Toast } from "@raycast/api";
+import { ActionPanel, Action, Grid, Icon } from "@raycast/api";
 import { IImgInfo } from "picgo";
 import { exportFormats, type ExportFormatKey } from "../util/format";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import FormatListPage from "./FormatListPage";
 
 interface Props {
@@ -11,15 +11,7 @@ interface Props {
 export default function ImagesPreviewPage({ imgs }: Props) {
     const [formatKey, setFormatKey] = useState<ExportFormatKey>("url");
     const format = exportFormats[formatKey];
-    const { autoCopyAfterUpload } = getPreferenceValues<Preferences.UploadImages>();
     const validImgs = imgs.filter((i) => i.imgUrl);
-
-    useEffect(() => {
-        if (autoCopyAfterUpload) {
-            Clipboard.copy(exportFormats.url.generate(validImgs));
-            showToast({ style: Toast.Style.Success, title: "URL Copied!" });
-        }
-    }, []);
 
     if (validImgs.length === 0) {
         return (
@@ -57,11 +49,11 @@ export default function ImagesPreviewPage({ imgs }: Props) {
                     actions={
                         <ActionPanel>
                             <Action.CopyToClipboard
-                                title={`Copy as ${format.label} Format`}
+                                title={`Copy ${format.label} to Clipboard`}
                                 content={format.generate([img])}
                             />
                             <Action.CopyToClipboard
-                                title={`Copy All as ${format.label} Format`}
+                                title={`Copy All ${format.label} to Clipboard`}
                                 content={format.generate(validImgs)}
                             />
                             <Action.Push

--- a/extensions/picgo/src/upload-images.tsx
+++ b/extensions/picgo/src/upload-images.tsx
@@ -22,7 +22,6 @@ import { useLocalStorage } from "@raycast/utils";
 import { useEffect, useMemo, useState } from "react";
 import UploaderManagement from "./uploader-management";
 import ImagesPreviewPage from "./components/ImagesPreviewPage";
-import { exportFormats } from "./util/format";
 
 const UPLOADER_CONFIG_KEY = "picgo:user_uploader_config";
 
@@ -100,8 +99,14 @@ export default function Command() {
             toast.title = "Success";
 
             if (autoCopyAfterUpload) {
-                await Clipboard.copy(exportFormats.url.generate(res));
-                toast.title = "URLs Copied!";
+                try {
+                    await Clipboard.copy(urls.join("\n"));
+                    toast.title = "URLs Copied!";
+                } catch (err) {
+                    console.warn("Failed to copy URLs:", err);
+                    toast.title = "Upload Succeeded";
+                    toast.message = "Failed to copy URLs to clipboard.";
+                }
             }
 
             if (uploadResultView === "format_list") push(<FormatListPage result={res} />);

--- a/extensions/picgo/src/upload-images.tsx
+++ b/extensions/picgo/src/upload-images.tsx
@@ -22,11 +22,12 @@ import { useLocalStorage } from "@raycast/utils";
 import { useEffect, useMemo, useState } from "react";
 import UploaderManagement from "./uploader-management";
 import ImagesPreviewPage from "./components/ImagesPreviewPage";
+import { exportFormats } from "./util/format";
 
 const UPLOADER_CONFIG_KEY = "picgo:user_uploader_config";
 
 export default function Command() {
-    const { uploadResultView } = getPreferenceValues<Preferences.UploadImages>();
+    const { uploadResultView, autoCopyAfterUpload } = getPreferenceValues<Preferences.UploadImages>();
     const {
         upload,
         getActiveUploaderType,
@@ -97,6 +98,11 @@ export default function Command() {
 
             toast.style = Toast.Style.Success;
             toast.title = "Success";
+
+            if (autoCopyAfterUpload) {
+                await Clipboard.copy(exportFormats.url.generate(res));
+                toast.title = "URLs Copied!";
+            }
 
             if (uploadResultView === "format_list") push(<FormatListPage result={res} />);
             else push(<ImagesPreviewPage imgs={res} />);


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

- Fix automatic URL copying to run only once after a successful upload instead of running again when switching result views.
- Align copy action titles across result views and clarify when all uploaded image URLs are copied.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
