### PR TITLE
[Agent Usage] Add support for multiple Codex OAuth accounts

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Agent Usage Changelog
 
+## [Codex OAuth multi-account support] - 2026-06-29
+
+### Improvements
+
+- Auto-detect multiple local Codex OAuth accounts from `CODEX_HOME` / `~/.codex`, using the format from https://github.com/loongphy/codex-auth
+
 ## [Improve Codex Usage Details] - 2026-06-29
 
 - Show Codex manual limit reset credits and their next expiration time when available

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Codex OAuth multi-account support] - {PR_MERGE_DATE}
+## [Codex OAuth multi-account support] - 2026-06-30
 
 ### Improvements
 

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Codex OAuth multi-account support] - 2026-06-29
+## [Codex OAuth multi-account support] - {PR_MERGE_DATE}
 
 ### Improvements
 

--- a/extensions/agent-usage/src/codex/accounts.test.ts
+++ b/extensions/agent-usage/src/codex/accounts.test.ts
@@ -51,9 +51,13 @@ test("buildCodexAccountCandidates prefers file-backed Codex OAuth accounts befor
   );
 });
 
-test("buildCodexAccountCandidates skips manual accounts duplicated by token or account ID", () => {
+test("buildCodexAccountCandidates dedupes manual accounts by account ID while keeping distinct ones", () => {
   const manualAccounts: AccountEntry[] = [
+    // Same token as the discovered account but a distinct account ID — a separate
+    // ChatGPT account reachable by the same login, so it must be kept.
     { id: "same-token", label: "Same Token", token: "active-token", accountId: "acct_other" },
+    // Same account ID as the discovered account via a different token — identical
+    // usage, so it is dropped.
     { id: "same-account", label: "Same Account", token: "other-token", accountId: "acct_active" },
     { id: "unique", label: "Unique", token: "unique-token", accountId: "acct_unique" },
   ];
@@ -62,7 +66,38 @@ test("buildCodexAccountCandidates skips manual accounts duplicated by token or a
 
   assert.deepEqual(
     candidates.map((candidate) => candidate.id),
-    ["codex-active", "unique"],
+    ["codex-active", "same-token", "unique"],
+  );
+});
+
+test("buildCodexAccountCandidates keeps manual accounts that share a token but target different accounts", () => {
+  const manualAccounts: AccountEntry[] = [
+    { id: "manual-personal", label: "Personal", token: "shared-token", accountId: "acct_personal" },
+    { id: "manual-work", label: "Work", token: "shared-token", accountId: "acct_work" },
+  ];
+
+  const candidates = buildCodexAccountCandidates([], manualAccounts);
+
+  assert.deepEqual(
+    candidates.map((candidate) => ({ id: candidate.id, accountId: candidate.accountId })),
+    [
+      { id: "manual-personal", accountId: "acct_personal" },
+      { id: "manual-work", accountId: "acct_work" },
+    ],
+  );
+});
+
+test("buildCodexAccountCandidates dedupes manual accounts that share a token and account ID", () => {
+  const manualAccounts: AccountEntry[] = [
+    { id: "manual-first", label: "First", token: "shared-token", accountId: "acct_shared" },
+    { id: "manual-second", label: "Second", token: "shared-token", accountId: "acct_shared" },
+  ];
+
+  const candidates = buildCodexAccountCandidates([], manualAccounts);
+
+  assert.deepEqual(
+    candidates.map((candidate) => candidate.id),
+    ["manual-first"],
   );
 });
 
@@ -89,9 +124,9 @@ test("buildCodexAccountCandidates backfills a manual account ID onto a token-mat
   assert.equal(candidates[0].needsAccountId, false);
 });
 
-test("buildCodexAccountCandidates keeps a discovered account ID over a token-matched manual one", () => {
+test("buildCodexAccountCandidates drops a manual account that duplicates a discovered token and account ID", () => {
   const manualAccounts: AccountEntry[] = [
-    { id: "manual-work", label: "Manual Work", token: "active-token", accountId: "acct_manual" },
+    { id: "manual-work", label: "Manual Work", token: "active-token", accountId: "acct_active" },
   ];
 
   const candidates = buildCodexAccountCandidates([discoveredAccount], manualAccounts);

--- a/extensions/agent-usage/src/codex/accounts.test.ts
+++ b/extensions/agent-usage/src/codex/accounts.test.ts
@@ -77,7 +77,7 @@ test("buildCodexAccountCandidates marks manual Codex entries without account IDs
   assert.equal(candidates[0].needsAccountId, true);
 });
 
-test("buildCodexAccountCandidates marks discovered Codex entries without account IDs as unsafe to fetch", () => {
+test("buildCodexAccountCandidates lets discovered Codex entries without account IDs fetch their default account", () => {
   const discoveredWithoutAccountId: CodexOAuthAccount = {
     id: "codex-active-missing-account",
     label: "Active",
@@ -93,5 +93,5 @@ test("buildCodexAccountCandidates marks discovered Codex entries without account
   assert.equal(candidates.length, 1);
   assert.equal(candidates[0].id, "codex-active-missing-account");
   assert.equal(candidates[0].accountId, null);
-  assert.equal(candidates[0].needsAccountId, true);
+  assert.equal(candidates[0].needsAccountId, false);
 });

--- a/extensions/agent-usage/src/codex/accounts.test.ts
+++ b/extensions/agent-usage/src/codex/accounts.test.ts
@@ -66,6 +66,41 @@ test("buildCodexAccountCandidates skips manual accounts duplicated by token or a
   );
 });
 
+test("buildCodexAccountCandidates backfills a manual account ID onto a token-matched discovered account that lacks one", () => {
+  const discoveredWithoutAccountId: CodexOAuthAccount = {
+    id: "codex-active-missing-account",
+    label: "Active",
+    token: "active-token",
+    accountId: null,
+    userId: null,
+    source: "active",
+    authFilePath: "/tmp/.codex/auth.json",
+  };
+  const manualAccounts: AccountEntry[] = [
+    { id: "manual-work", label: "Manual Work", token: "active-token", accountId: "acct_manual" },
+  ];
+
+  const candidates = buildCodexAccountCandidates([discoveredWithoutAccountId], manualAccounts);
+
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].id, "codex-active-missing-account");
+  assert.equal(candidates[0].source, "codex-home");
+  assert.equal(candidates[0].accountId, "acct_manual");
+  assert.equal(candidates[0].needsAccountId, false);
+});
+
+test("buildCodexAccountCandidates keeps a discovered account ID over a token-matched manual one", () => {
+  const manualAccounts: AccountEntry[] = [
+    { id: "manual-work", label: "Manual Work", token: "active-token", accountId: "acct_manual" },
+  ];
+
+  const candidates = buildCodexAccountCandidates([discoveredAccount], manualAccounts);
+
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].id, "codex-active");
+  assert.equal(candidates[0].accountId, "acct_active");
+});
+
 test("buildCodexAccountCandidates marks manual Codex entries without account IDs as unsafe to fetch", () => {
   const manualAccounts: AccountEntry[] = [{ id: "manual-no-account", label: "Manual", token: "manual-token" }];
 

--- a/extensions/agent-usage/src/codex/accounts.test.ts
+++ b/extensions/agent-usage/src/codex/accounts.test.ts
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildCodexAccountCandidates } from "./accounts";
+import type { CodexOAuthAccount } from "./auth";
+import type { AccountEntry } from "../accounts/types";
+
+const discoveredAccount: CodexOAuthAccount = {
+  id: "codex-active",
+  label: "Active",
+  token: "active-token",
+  accountId: "acct_active",
+  userId: "user_active",
+  source: "active",
+  authFilePath: "/tmp/.codex/auth.json",
+};
+
+test("buildCodexAccountCandidates prefers file-backed Codex OAuth accounts before manual accounts", () => {
+  const manualAccounts: AccountEntry[] = [
+    { id: "manual-work", label: "Manual Work", token: "manual-token", accountId: "acct_manual" },
+  ];
+
+  const candidates = buildCodexAccountCandidates([discoveredAccount], manualAccounts);
+
+  assert.deepEqual(
+    candidates.map((candidate) => ({
+      id: candidate.id,
+      label: candidate.label,
+      token: candidate.token,
+      accountId: candidate.accountId,
+      source: candidate.source,
+      needsAccountId: candidate.needsAccountId,
+    })),
+    [
+      {
+        id: "codex-active",
+        label: "Active",
+        token: "active-token",
+        accountId: "acct_active",
+        source: "codex-home",
+        needsAccountId: false,
+      },
+      {
+        id: "manual-work",
+        label: "Manual Work",
+        token: "manual-token",
+        accountId: "acct_manual",
+        source: "manual",
+        needsAccountId: false,
+      },
+    ],
+  );
+});
+
+test("buildCodexAccountCandidates skips manual accounts duplicated by token or account ID", () => {
+  const manualAccounts: AccountEntry[] = [
+    { id: "same-token", label: "Same Token", token: "active-token", accountId: "acct_other" },
+    { id: "same-account", label: "Same Account", token: "other-token", accountId: "acct_active" },
+    { id: "unique", label: "Unique", token: "unique-token", accountId: "acct_unique" },
+  ];
+
+  const candidates = buildCodexAccountCandidates([discoveredAccount], manualAccounts);
+
+  assert.deepEqual(
+    candidates.map((candidate) => candidate.id),
+    ["codex-active", "unique"],
+  );
+});
+
+test("buildCodexAccountCandidates marks manual Codex entries without account IDs as unsafe to fetch", () => {
+  const manualAccounts: AccountEntry[] = [{ id: "manual-no-account", label: "Manual", token: "manual-token" }];
+
+  const candidates = buildCodexAccountCandidates([], manualAccounts);
+
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].id, "manual-no-account");
+  assert.equal(candidates[0].accountId, null);
+  assert.equal(candidates[0].needsAccountId, true);
+});
+
+test("buildCodexAccountCandidates marks discovered Codex entries without account IDs as unsafe to fetch", () => {
+  const discoveredWithoutAccountId: CodexOAuthAccount = {
+    id: "codex-active-missing-account",
+    label: "Active",
+    token: "active-token-no-account",
+    accountId: null,
+    userId: null,
+    source: "active",
+    authFilePath: "/tmp/.codex/auth.json",
+  };
+
+  const candidates = buildCodexAccountCandidates([discoveredWithoutAccountId], []);
+
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].id, "codex-active-missing-account");
+  assert.equal(candidates[0].accountId, null);
+  assert.equal(candidates[0].needsAccountId, true);
+});

--- a/extensions/agent-usage/src/codex/accounts.ts
+++ b/extensions/agent-usage/src/codex/accounts.ts
@@ -17,14 +17,20 @@ export function buildCodexAccountCandidates(
   manualAccounts: AccountEntry[],
 ): CodexAccountCandidate[] {
   const candidates: CodexAccountCandidate[] = [];
-  const candidatesByToken = new Map<string, CodexAccountCandidate>();
+  const seenTokens = new Set<string>();
   const seenAccountIds = new Set<string>();
+  // Candidates added without an account ID, keyed by token. A later entry that
+  // supplies an explicit account ID for the same token enriches one of these
+  // rather than adding a redundant token-default entry.
+  const tokenDefaultCandidate = new Map<string, CodexAccountCandidate>();
 
   const registerCandidate = (candidate: CodexAccountCandidate): void => {
     candidates.push(candidate);
-    candidatesByToken.set(candidate.token, candidate);
+    seenTokens.add(candidate.token);
     if (candidate.accountId) {
       seenAccountIds.add(candidate.accountId);
+    } else {
+      tokenDefaultCandidate.set(candidate.token, candidate);
     }
   };
 
@@ -43,21 +49,28 @@ export function buildCodexAccountCandidates(
 
   for (const account of manualAccounts) {
     const accountId = account.accountId?.trim() || null;
-    const existing = candidatesByToken.get(account.token);
 
-    if (existing) {
-      // Same token as an already-added account. Keep the existing (file-backed)
-      // token, but adopt this entry's explicit account ID if the existing one
-      // lacked it — otherwise the manually configured account would be lost and
-      // the fetch would fall back to the token's default account.
-      if (!existing.accountId && accountId) {
-        existing.accountId = accountId;
-        seenAccountIds.add(accountId);
+    if (accountId) {
+      // The (token, account ID) pair determines the usage the API returns, so an
+      // account ID already represented — even via a different token — is a true
+      // duplicate. Distinct account IDs on the same token are separate accounts
+      // and must each be kept.
+      if (seenAccountIds.has(accountId)) {
+        continue;
       }
-      continue;
-    }
 
-    if (accountId && seenAccountIds.has(accountId)) {
+      const tokenDefault = tokenDefaultCandidate.get(account.token);
+      if (tokenDefault) {
+        // Enrich a same-token candidate that was added without an account ID
+        // instead of adding a redundant entry; the configured account would
+        // otherwise be lost and the fetch would use the token's default account.
+        tokenDefault.accountId = accountId;
+        seenAccountIds.add(accountId);
+        tokenDefaultCandidate.delete(account.token);
+        continue;
+      }
+    } else if (seenTokens.has(account.token)) {
+      // No account ID to distinguish it and the token is already represented.
       continue;
     }
 

--- a/extensions/agent-usage/src/codex/accounts.ts
+++ b/extensions/agent-usage/src/codex/accounts.ts
@@ -37,7 +37,9 @@ export function buildCodexAccountCandidates(
       token: account.token,
       accountId,
       source: "codex-home",
-      needsAccountId: !accountId,
+      // Discovered OAuth tokens can fetch their default account even without an
+      // explicit account ID (matching the single-account useCodexUsage path).
+      needsAccountId: false,
     });
     seenTokens.add(account.token);
     if (accountId) {

--- a/extensions/agent-usage/src/codex/accounts.ts
+++ b/extensions/agent-usage/src/codex/accounts.ts
@@ -12,48 +12,56 @@ export interface CodexAccountCandidate {
   needsAccountId: boolean;
 }
 
-function hasDuplicateManualAccount(
-  candidate: AccountEntry,
-  seenTokens: Set<string>,
-  seenAccountIds: Set<string>,
-): boolean {
-  const accountId = candidate.accountId?.trim();
-  return seenTokens.has(candidate.token) || Boolean(accountId && seenAccountIds.has(accountId));
-}
-
 export function buildCodexAccountCandidates(
   discoveredAccounts: CodexOAuthAccount[],
   manualAccounts: AccountEntry[],
 ): CodexAccountCandidate[] {
   const candidates: CodexAccountCandidate[] = [];
-  const seenTokens = new Set<string>();
+  const candidatesByToken = new Map<string, CodexAccountCandidate>();
   const seenAccountIds = new Set<string>();
 
+  const registerCandidate = (candidate: CodexAccountCandidate): void => {
+    candidates.push(candidate);
+    candidatesByToken.set(candidate.token, candidate);
+    if (candidate.accountId) {
+      seenAccountIds.add(candidate.accountId);
+    }
+  };
+
   for (const account of discoveredAccounts) {
-    const accountId = account.accountId?.trim() || null;
-    candidates.push({
+    registerCandidate({
       id: account.id,
       label: account.label,
       token: account.token,
-      accountId,
+      accountId: account.accountId?.trim() || null,
       source: "codex-home",
       // Discovered OAuth tokens can fetch their default account even without an
       // explicit account ID (matching the single-account useCodexUsage path).
       needsAccountId: false,
     });
-    seenTokens.add(account.token);
-    if (accountId) {
-      seenAccountIds.add(accountId);
-    }
   }
 
   for (const account of manualAccounts) {
-    if (hasDuplicateManualAccount(account, seenTokens, seenAccountIds)) {
+    const accountId = account.accountId?.trim() || null;
+    const existing = candidatesByToken.get(account.token);
+
+    if (existing) {
+      // Same token as an already-added account. Keep the existing (file-backed)
+      // token, but adopt this entry's explicit account ID if the existing one
+      // lacked it — otherwise the manually configured account would be lost and
+      // the fetch would fall back to the token's default account.
+      if (!existing.accountId && accountId) {
+        existing.accountId = accountId;
+        seenAccountIds.add(accountId);
+      }
       continue;
     }
 
-    const accountId = account.accountId?.trim() || null;
-    candidates.push({
+    if (accountId && seenAccountIds.has(accountId)) {
+      continue;
+    }
+
+    registerCandidate({
       id: account.id,
       label: account.label,
       token: account.token,
@@ -61,10 +69,6 @@ export function buildCodexAccountCandidates(
       source: "manual",
       needsAccountId: !accountId,
     });
-    seenTokens.add(account.token);
-    if (accountId) {
-      seenAccountIds.add(accountId);
-    }
   }
 
   return candidates;

--- a/extensions/agent-usage/src/codex/accounts.ts
+++ b/extensions/agent-usage/src/codex/accounts.ts
@@ -1,0 +1,69 @@
+import type { AccountEntry } from "../accounts/types";
+import type { CodexOAuthAccount } from "./auth";
+
+export type CodexAccountCandidateSource = "codex-home" | "manual";
+
+export interface CodexAccountCandidate {
+  id: string;
+  label: string;
+  token: string;
+  accountId: string | null;
+  source: CodexAccountCandidateSource;
+  needsAccountId: boolean;
+}
+
+function hasDuplicateManualAccount(
+  candidate: AccountEntry,
+  seenTokens: Set<string>,
+  seenAccountIds: Set<string>,
+): boolean {
+  const accountId = candidate.accountId?.trim();
+  return seenTokens.has(candidate.token) || Boolean(accountId && seenAccountIds.has(accountId));
+}
+
+export function buildCodexAccountCandidates(
+  discoveredAccounts: CodexOAuthAccount[],
+  manualAccounts: AccountEntry[],
+): CodexAccountCandidate[] {
+  const candidates: CodexAccountCandidate[] = [];
+  const seenTokens = new Set<string>();
+  const seenAccountIds = new Set<string>();
+
+  for (const account of discoveredAccounts) {
+    const accountId = account.accountId?.trim() || null;
+    candidates.push({
+      id: account.id,
+      label: account.label,
+      token: account.token,
+      accountId,
+      source: "codex-home",
+      needsAccountId: !accountId,
+    });
+    seenTokens.add(account.token);
+    if (accountId) {
+      seenAccountIds.add(accountId);
+    }
+  }
+
+  for (const account of manualAccounts) {
+    if (hasDuplicateManualAccount(account, seenTokens, seenAccountIds)) {
+      continue;
+    }
+
+    const accountId = account.accountId?.trim() || null;
+    candidates.push({
+      id: account.id,
+      label: account.label,
+      token: account.token,
+      accountId,
+      source: "manual",
+      needsAccountId: !accountId,
+    });
+    seenTokens.add(account.token);
+    if (accountId) {
+      seenAccountIds.add(accountId);
+    }
+  }
+
+  return candidates;
+}

--- a/extensions/agent-usage/src/codex/auth.test.ts
+++ b/extensions/agent-usage/src/codex/auth.test.ts
@@ -11,6 +11,33 @@ function makeTempFile(content: string): { dir: string; filePath: string } {
   return { dir, filePath };
 }
 
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "codex-home-test-"));
+}
+
+function writeJsonFile(filePath: string, data: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+}
+
+function makeCodexIdToken(userId: string, accountId: string): string {
+  const payload = {
+    email: `${userId}@example.com`,
+    name: `Name for ${userId}`,
+    "https://api.openai.com/auth": {
+      user_id: userId,
+      chatgpt_user_id: userId,
+      chatgpt_account_id: accountId,
+    },
+  };
+
+  return `header.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+}
+
+function makeCodexAuthFileName(userId: string, accountId: string): string {
+  return `${Buffer.from(`${userId}::${accountId}`).toString("base64url")}.auth.json`;
+}
+
 test("resolveCodexAuthToken prefers local Codex login token over preference token", async () => {
   const { resolveCodexAuthToken } = await import("./auth");
   const { dir, filePath } = makeTempFile(
@@ -129,4 +156,222 @@ test("shouldFallbackToPreferenceToken is true only for unauthorized local-token 
     }),
     false,
   );
+});
+
+test("resolveCodexHome honors CODEX_HOME when it is an existing directory", async () => {
+  const { resolveCodexHome } = await import("./auth");
+  const dir = makeTempDir();
+
+  try {
+    assert.equal(resolveCodexHome({ CODEX_HOME: dir } as NodeJS.ProcessEnv), dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveCodexHome rejects invalid CODEX_HOME without falling back", async () => {
+  const { resolveCodexHome } = await import("./auth");
+  const dir = makeTempDir();
+  const invalidOverride = path.join(dir, "missing");
+  const homeCodexDir = path.join(dir, ".codex");
+  fs.mkdirSync(homeCodexDir);
+
+  try {
+    assert.equal(
+      resolveCodexHome({ CODEX_HOME: invalidOverride, HOME: dir, USERPROFILE: dir } as NodeJS.ProcessEnv),
+      null,
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveCodexHome falls back to HOME then USERPROFILE", async () => {
+  const { resolveCodexHome } = await import("./auth");
+  const homeDir = makeTempDir();
+  const userProfileDir = makeTempDir();
+  fs.mkdirSync(path.join(homeDir, ".codex"));
+  fs.mkdirSync(path.join(userProfileDir, ".codex"));
+
+  try {
+    assert.equal(
+      resolveCodexHome({ HOME: homeDir, USERPROFILE: userProfileDir } as NodeJS.ProcessEnv),
+      path.join(homeDir, ".codex"),
+    );
+    assert.equal(
+      resolveCodexHome({ USERPROFILE: userProfileDir } as NodeJS.ProcessEnv),
+      path.join(userProfileDir, ".codex"),
+    );
+  } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(userProfileDir, { recursive: true, force: true });
+  }
+});
+
+test("listCodexOAuthAccounts reads active and stored OAuth auth files", async () => {
+  const { listCodexOAuthAccounts } = await import("./auth");
+  const codexHome = makeTempDir();
+
+  try {
+    writeJsonFile(path.join(codexHome, "auth.json"), {
+      tokens: { access_token: "active-token", account_id: "acct_active" },
+    });
+    writeJsonFile(path.join(codexHome, "accounts", "work.auth.json"), {
+      tokens: { access_token: "work-token", account_id: "acct_work" },
+    });
+    writeJsonFile(path.join(codexHome, "accounts", "api-key.auth.json"), {
+      OPENAI_API_KEY: "sk-not-used",
+    });
+    writeJsonFile(path.join(codexHome, "accounts", "missing-account.auth.json"), {
+      tokens: { access_token: "ambiguous-token" },
+    });
+
+    const accounts = listCodexOAuthAccounts({ codexHome });
+
+    assert.deepEqual(
+      accounts.map((account) => ({
+        id: account.id,
+        label: account.label,
+        token: account.token,
+        accountId: account.accountId,
+        source: account.source,
+      })),
+      [
+        {
+          id: "codex-active",
+          label: "Active",
+          token: "active-token",
+          accountId: "acct_active",
+          source: "active",
+        },
+        {
+          id: "codex-work",
+          label: "work",
+          token: "work-token",
+          accountId: "acct_work",
+          source: "stored",
+        },
+      ],
+    );
+  } finally {
+    fs.rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("listCodexOAuthAccounts uses readable OAuth identity claims for labels", async () => {
+  const { listCodexOAuthAccounts } = await import("./auth");
+  const codexHome = makeTempDir();
+  const accountId = "acct_labels";
+  const userId = "user-label";
+
+  try {
+    writeJsonFile(path.join(codexHome, "auth.json"), {
+      tokens: { access_token: "active-token", account_id: accountId, id_token: makeCodexIdToken(userId, accountId) },
+    });
+    writeJsonFile(path.join(codexHome, "accounts", makeCodexAuthFileName("user-other", accountId)), {
+      tokens: {
+        access_token: "stored-token",
+        account_id: accountId,
+        id_token: makeCodexIdToken("user-other", accountId),
+      },
+    });
+
+    const accounts = listCodexOAuthAccounts({ codexHome });
+
+    assert.deepEqual(
+      accounts.map((account) => ({ id: account.id, label: account.label })),
+      [
+        { id: "codex-active", label: "user-label@example.com" },
+        {
+          id: `codex-${makeCodexAuthFileName("user-other", accountId).slice(0, -".auth.json".length)}`,
+          label: "user-other@example.com",
+        },
+      ],
+    );
+  } finally {
+    fs.rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("listCodexOAuthAccounts deduplicates active auth against stored accounts by Codex user identity", async () => {
+  const { listCodexOAuthAccounts } = await import("./auth");
+  const codexHome = makeTempDir();
+  const accountId = "acct_same";
+  const userId = "user-same";
+
+  try {
+    writeJsonFile(path.join(codexHome, "auth.json"), {
+      tokens: { access_token: "active-token", account_id: accountId, id_token: makeCodexIdToken(userId, accountId) },
+    });
+    writeJsonFile(path.join(codexHome, "accounts", makeCodexAuthFileName(userId, accountId)), {
+      tokens: { access_token: "stored-token", account_id: accountId, id_token: makeCodexIdToken(userId, accountId) },
+    });
+
+    const accounts = listCodexOAuthAccounts({ codexHome });
+
+    assert.equal(accounts.length, 1);
+    assert.equal(accounts[0].id, "codex-active");
+    assert.equal(accounts[0].token, "active-token");
+  } finally {
+    fs.rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("listCodexOAuthAccounts keeps stored Codex users that share a ChatGPT account ID", async () => {
+  const { listCodexOAuthAccounts } = await import("./auth");
+  const codexHome = makeTempDir();
+  const accountId = "acct_team";
+  const firstUserId = "user-one";
+  const secondUserId = "user-two";
+  const firstFileName = makeCodexAuthFileName(firstUserId, accountId);
+  const secondFileName = makeCodexAuthFileName(secondUserId, accountId);
+
+  try {
+    writeJsonFile(path.join(codexHome, "accounts", firstFileName), {
+      tokens: {
+        access_token: "first-token",
+        account_id: accountId,
+        id_token: makeCodexIdToken(firstUserId, accountId),
+      },
+    });
+    writeJsonFile(path.join(codexHome, "accounts", secondFileName), {
+      tokens: {
+        access_token: "second-token",
+        account_id: accountId,
+        id_token: makeCodexIdToken(secondUserId, accountId),
+      },
+    });
+
+    const accounts = listCodexOAuthAccounts({ codexHome });
+
+    assert.deepEqual(
+      accounts
+        .map((account) => ({
+          id: account.id,
+          label: account.label,
+          token: account.token,
+          accountId: account.accountId,
+          source: account.source,
+        }))
+        .sort((a, b) => a.token.localeCompare(b.token)),
+      [
+        {
+          id: `codex-${firstFileName.slice(0, -".auth.json".length)}`,
+          label: `${firstUserId}@example.com`,
+          token: "first-token",
+          accountId,
+          source: "stored",
+        },
+        {
+          id: `codex-${secondFileName.slice(0, -".auth.json".length)}`,
+          label: `${secondUserId}@example.com`,
+          token: "second-token",
+          accountId,
+          source: "stored",
+        },
+      ],
+    );
+  } finally {
+    fs.rmSync(codexHome, { recursive: true, force: true });
+  }
 });

--- a/extensions/agent-usage/src/codex/auth.test.ts
+++ b/extensions/agent-usage/src/codex/auth.test.ts
@@ -38,46 +38,6 @@ function makeCodexAuthFileName(userId: string, accountId: string): string {
   return `${Buffer.from(`${userId}::${accountId}`).toString("base64url")}.auth.json`;
 }
 
-test("resolveCodexAuthToken prefers local Codex login token over preference token", async () => {
-  const { resolveCodexAuthToken } = await import("./auth");
-  const { dir, filePath } = makeTempFile(
-    JSON.stringify({ tokens: { access_token: "local-token", account_id: "account-id" } }),
-  );
-
-  try {
-    const token = resolveCodexAuthToken({
-      preferenceToken: "pref-token",
-      authFilePath: filePath,
-    });
-
-    assert.equal(token, "local-token");
-  } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("resolveCodexAuthToken falls back to preference token when local auth file is missing", async () => {
-  const { resolveCodexAuthToken } = await import("./auth");
-
-  const token = resolveCodexAuthToken({
-    preferenceToken: "pref-token",
-    authFilePath: path.join(os.tmpdir(), `missing-${Date.now()}.json`),
-  });
-
-  assert.equal(token, "pref-token");
-});
-
-test("resolveCodexAuthToken returns null when both local and preference tokens are unavailable", async () => {
-  const { resolveCodexAuthToken } = await import("./auth");
-
-  const token = resolveCodexAuthToken({
-    preferenceToken: "   ",
-    authFilePath: path.join(os.tmpdir(), `missing-${Date.now()}-empty.json`),
-  });
-
-  assert.equal(token, null);
-});
-
 test("normalizeCodexAuthorizationHeader adds Bearer prefix when missing", async () => {
   const { normalizeCodexAuthorizationHeader } = await import("./auth");
 
@@ -85,77 +45,32 @@ test("normalizeCodexAuthorizationHeader adds Bearer prefix when missing", async 
   assert.equal(normalizeCodexAuthorizationHeader("Bearer already"), "Bearer already");
 });
 
-test("resolveCodexAuthTokens exposes primary/local/preference tokens", async () => {
+test("resolveCodexAuthTokens returns the local login token and account ID", async () => {
   const { resolveCodexAuthTokens } = await import("./auth");
   const { dir, filePath } = makeTempFile(
     JSON.stringify({ tokens: { access_token: "local-token", account_id: "account-id" } }),
   );
 
   try {
-    const tokens = resolveCodexAuthTokens({
-      preferenceToken: "pref-token",
-      authFilePath: filePath,
-    });
+    const tokens = resolveCodexAuthTokens({ authFilePath: filePath });
 
     assert.deepEqual(tokens, {
       primaryToken: "local-token",
       primaryAccountId: "account-id",
-      localToken: "local-token",
-      localAccountId: "account-id",
-      preferenceToken: "pref-token",
     });
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("shouldFallbackToPreferenceToken is true only for unauthorized local-token failures", async () => {
-  const { shouldFallbackToPreferenceToken } = await import("./auth");
+test("resolveCodexAuthTokens returns nulls when the local auth file is missing", async () => {
+  const { resolveCodexAuthTokens } = await import("./auth");
 
-  assert.equal(
-    shouldFallbackToPreferenceToken({
-      localToken: "local-token",
-      preferenceToken: "pref-token",
-      errorType: "unauthorized",
-    }),
-    true,
-  );
+  const tokens = resolveCodexAuthTokens({
+    authFilePath: path.join(os.tmpdir(), `missing-${Date.now()}.json`),
+  });
 
-  assert.equal(
-    shouldFallbackToPreferenceToken({
-      localToken: "local-token",
-      preferenceToken: "local-token",
-      errorType: "unauthorized",
-    }),
-    false,
-  );
-
-  assert.equal(
-    shouldFallbackToPreferenceToken({
-      localToken: "local-token",
-      preferenceToken: "pref-token",
-      errorType: "network_error",
-    }),
-    false,
-  );
-
-  assert.equal(
-    shouldFallbackToPreferenceToken({
-      localToken: null,
-      preferenceToken: "pref-token",
-      errorType: "unauthorized",
-    }),
-    false,
-  );
-
-  assert.equal(
-    shouldFallbackToPreferenceToken({
-      localToken: "local-token",
-      preferenceToken: null,
-      errorType: "unauthorized",
-    }),
-    false,
-  );
+  assert.deepEqual(tokens, { primaryToken: null, primaryAccountId: null });
 });
 
 test("resolveCodexHome honors CODEX_HOME when it is an existing directory", async () => {

--- a/extensions/agent-usage/src/codex/auth.ts
+++ b/extensions/agent-usage/src/codex/auth.ts
@@ -5,11 +5,30 @@ import * as path from "path";
 const DEFAULT_CODEX_AUTH_FILE = path.join(os.homedir(), ".codex", "auth.json");
 
 interface CodexAuthFile {
+  OPENAI_API_KEY?: string;
   tokens?: {
     access_token?: string;
     account_id?: string;
     accountId?: string;
+    id_token?: string;
   };
+}
+
+interface CodexAuthData {
+  token: string | null;
+  accountId: string | null;
+  userId: string | null;
+  displayName: string | null;
+}
+
+export interface CodexOAuthAccount {
+  id: string;
+  label: string;
+  token: string;
+  accountId: string | null;
+  userId: string | null;
+  source: "active" | "stored";
+  authFilePath: string;
 }
 
 interface ResolveCodexAuthTokenOptions {
@@ -31,32 +50,209 @@ interface ShouldFallbackToPreferenceTokenOptions {
   errorType?: string;
 }
 
-function cleanToken(token: string | undefined): string | null {
-  const trimmedToken = token?.trim();
-  return trimmedToken ? trimmedToken : null;
+interface ListCodexOAuthAccountsOptions {
+  codexHome?: string;
+  env?: NodeJS.ProcessEnv;
 }
 
-function readCodexLoginAuth(authFilePath: string): { token: string | null; accountId: string | null } {
+function trimToNull(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function trimUnknownStringToNull(value: unknown): string | null {
+  return typeof value === "string" ? trimToNull(value) : null;
+}
+
+function isExistingDirectory(dirPath: string): boolean {
+  try {
+    return fs.statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function getRecordValue(record: Record<string, unknown>, key: string): Record<string, unknown> | null {
+  const value = record[key];
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function readCodexIdentityFromIdToken(idToken: string | undefined): {
+  userId: string | null;
+  displayName: string | null;
+} {
+  const token = trimToNull(idToken);
+  if (!token) {
+    return { userId: null, displayName: null };
+  }
+
+  try {
+    const [, payload] = token.split(".");
+    if (!payload) {
+      return { userId: null, displayName: null };
+    }
+
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf-8")) as Record<string, unknown>;
+    const authClaims = getRecordValue(decoded, "https://api.openai.com/auth");
+    return {
+      userId: trimUnknownStringToNull(authClaims?.user_id) ?? trimUnknownStringToNull(authClaims?.chatgpt_user_id),
+      displayName: trimUnknownStringToNull(decoded.email) ?? trimUnknownStringToNull(decoded.name),
+    };
+  } catch {
+    return { userId: null, displayName: null };
+  }
+}
+
+function readStoredAccountIdentity(fileName: string): { userId: string; accountId: string } | null {
+  if (!fileName.endsWith(".auth.json")) {
+    return null;
+  }
+
+  try {
+    const stem = fileName.slice(0, -".auth.json".length);
+    const decoded = Buffer.from(stem, "base64url").toString("utf-8");
+    const separatorIndex = decoded.indexOf("::");
+    if (separatorIndex === -1) {
+      return null;
+    }
+
+    const userId = trimToNull(decoded.slice(0, separatorIndex));
+    const accountId = trimToNull(decoded.slice(separatorIndex + 2));
+    return userId && accountId ? { userId, accountId } : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveCodexHome(env: NodeJS.ProcessEnv = process.env): string | null {
+  const override = trimToNull(env.CODEX_HOME);
+  if (override) {
+    return isExistingDirectory(override) ? override : null;
+  }
+
+  const home = trimToNull(env.HOME) ?? trimToNull(env.USERPROFILE);
+  if (!home) {
+    return null;
+  }
+
+  const codexHome = path.join(home, ".codex");
+  return isExistingDirectory(codexHome) ? codexHome : null;
+}
+
+function readCodexLoginAuth(authFilePath: string): CodexAuthData {
   try {
     if (!fs.existsSync(authFilePath)) {
-      return { token: null, accountId: null };
+      return { token: null, accountId: null, userId: null, displayName: null };
     }
 
     const raw = fs.readFileSync(authFilePath, "utf-8");
     const parsed = JSON.parse(raw) as CodexAuthFile;
+    const identity = readCodexIdentityFromIdToken(parsed.tokens?.id_token);
     return {
-      token: cleanToken(parsed.tokens?.access_token),
-      accountId: cleanToken(parsed.tokens?.account_id ?? parsed.tokens?.accountId),
+      token: trimToNull(parsed.tokens?.access_token),
+      accountId: trimToNull(parsed.tokens?.account_id ?? parsed.tokens?.accountId),
+      userId: identity.userId,
+      displayName: identity.displayName,
     };
   } catch {
-    return { token: null, accountId: null };
+    return { token: null, accountId: null, userId: null, displayName: null };
   }
 }
 
+function formatStoredAccountLabel(fileName: string, accountId: string, userId: string | null): string {
+  if (userId) {
+    return userId;
+  }
+
+  const stem = fileName.endsWith(".auth.json") ? fileName.slice(0, -".auth.json".length) : fileName;
+  const normalized = stem.replace(/[-_]+/g, " ").trim();
+  return normalized || accountId;
+}
+
+function getCodexAccountDedupeKeys(account: CodexOAuthAccount): string[] {
+  const keys = [`token:${account.token}`];
+  if (account.userId && account.accountId) {
+    keys.unshift(`user-account:${account.userId}:${account.accountId}`);
+  }
+  return keys;
+}
+
+export function listCodexOAuthAccounts(options: ListCodexOAuthAccountsOptions = {}): CodexOAuthAccount[] {
+  const codexHome = options.codexHome ?? resolveCodexHome(options.env);
+  if (!codexHome) {
+    return [];
+  }
+
+  const accounts: CodexOAuthAccount[] = [];
+  const seen = new Set<string>();
+
+  const addAccount = (account: CodexOAuthAccount): void => {
+    const dedupeKeys = getCodexAccountDedupeKeys(account);
+    if (dedupeKeys.some((key) => seen.has(key))) {
+      return;
+    }
+    for (const key of dedupeKeys) {
+      seen.add(key);
+    }
+    accounts.push(account);
+  };
+
+  const activeAuthPath = path.join(codexHome, "auth.json");
+  const activeAuth = readCodexLoginAuth(activeAuthPath);
+  if (activeAuth.token) {
+    addAccount({
+      id: "codex-active",
+      label: activeAuth.displayName ?? "Active",
+      token: activeAuth.token,
+      accountId: activeAuth.accountId,
+      userId: activeAuth.userId,
+      source: "active",
+      authFilePath: activeAuthPath,
+    });
+  }
+
+  const accountsDir = path.join(codexHome, "accounts");
+  let storedFileNames: string[] = [];
+  try {
+    storedFileNames = fs
+      .readdirSync(accountsDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".auth.json"))
+      .map((entry) => entry.name)
+      .sort((a, b) => a.localeCompare(b));
+  } catch {
+    storedFileNames = [];
+  }
+
+  for (const fileName of storedFileNames) {
+    const authFilePath = path.join(accountsDir, fileName);
+    const auth = readCodexLoginAuth(authFilePath);
+    const storedIdentity = readStoredAccountIdentity(fileName);
+    const accountId = auth.accountId ?? storedIdentity?.accountId ?? null;
+    const userId = auth.userId ?? storedIdentity?.userId ?? null;
+    if (!auth.token || !accountId) {
+      continue;
+    }
+
+    addAccount({
+      id: `codex-${fileName.slice(0, -".auth.json".length)}`,
+      label: auth.displayName ?? formatStoredAccountLabel(fileName, accountId, userId),
+      token: auth.token,
+      accountId,
+      userId,
+      source: "stored",
+      authFilePath,
+    });
+  }
+
+  return accounts;
+}
+
 export function resolveCodexAuthTokens(options: ResolveCodexAuthTokenOptions = {}): ResolveCodexAuthTokensResult {
-  const localAuth = readCodexLoginAuth(options.authFilePath ?? DEFAULT_CODEX_AUTH_FILE);
+  const authFilePath =
+    options.authFilePath ?? path.join(resolveCodexHome() ?? path.dirname(DEFAULT_CODEX_AUTH_FILE), "auth.json");
+  const localAuth = readCodexLoginAuth(authFilePath);
   const localToken = localAuth.token;
-  const preferenceToken = cleanToken(options.preferenceToken);
+  const preferenceToken = trimToNull(options.preferenceToken);
 
   return {
     primaryToken: localToken ?? preferenceToken,

--- a/extensions/agent-usage/src/codex/auth.ts
+++ b/extensions/agent-usage/src/codex/auth.ts
@@ -31,23 +31,13 @@ export interface CodexOAuthAccount {
   authFilePath: string;
 }
 
-interface ResolveCodexAuthTokenOptions {
-  preferenceToken?: string;
+interface ResolveCodexAuthTokensOptions {
   authFilePath?: string;
 }
 
 interface ResolveCodexAuthTokensResult {
   primaryToken: string | null;
   primaryAccountId: string | null;
-  localToken: string | null;
-  localAccountId: string | null;
-  preferenceToken: string | null;
-}
-
-interface ShouldFallbackToPreferenceTokenOptions {
-  localToken: string | null;
-  preferenceToken: string | null;
-  errorType?: string;
 }
 
 interface ListCodexOAuthAccountsOptions {
@@ -247,33 +237,15 @@ export function listCodexOAuthAccounts(options: ListCodexOAuthAccountsOptions = 
   return accounts;
 }
 
-export function resolveCodexAuthTokens(options: ResolveCodexAuthTokenOptions = {}): ResolveCodexAuthTokensResult {
+export function resolveCodexAuthTokens(options: ResolveCodexAuthTokensOptions = {}): ResolveCodexAuthTokensResult {
   const authFilePath =
     options.authFilePath ?? path.join(resolveCodexHome() ?? path.dirname(DEFAULT_CODEX_AUTH_FILE), "auth.json");
   const localAuth = readCodexLoginAuth(authFilePath);
-  const localToken = localAuth.token;
-  const preferenceToken = trimToNull(options.preferenceToken);
 
   return {
-    primaryToken: localToken ?? preferenceToken,
-    primaryAccountId: localToken ? localAuth.accountId : null,
-    localToken,
-    localAccountId: localAuth.accountId,
-    preferenceToken,
+    primaryToken: localAuth.token,
+    primaryAccountId: localAuth.token ? localAuth.accountId : null,
   };
-}
-
-export function resolveCodexAuthToken(options: ResolveCodexAuthTokenOptions = {}): string | null {
-  return resolveCodexAuthTokens(options).primaryToken;
-}
-
-export function shouldFallbackToPreferenceToken(options: ShouldFallbackToPreferenceTokenOptions): boolean {
-  return (
-    options.errorType === "unauthorized" &&
-    options.localToken !== null &&
-    options.preferenceToken !== null &&
-    options.localToken !== options.preferenceToken
-  );
 }
 
 export { normalizeBearerToken as normalizeCodexAuthorizationHeader } from "../agents/http";

--- a/extensions/agent-usage/src/codex/fetcher.ts
+++ b/extensions/agent-usage/src/codex/fetcher.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { CodexUsage, CodexError } from "./types";
-import { resolveCodexAuthTokens } from "./auth";
+import { listCodexOAuthAccounts, resolveCodexAuthTokens } from "./auth";
+import { buildCodexAccountCandidates } from "./accounts";
 import { httpFetch } from "../agents/http";
 import { parseDate } from "../agents/format";
 import { loadAccounts } from "../accounts/storage";
@@ -282,11 +283,10 @@ export function useCodexUsage(enabled = true) {
 }
 
 /**
- * Returns one UsageState per named Codex account stored in LocalStorage.
- * Falls back to the auto-detected token from ~/.codex/auth.json if no accounts are stored.
+ * Returns one UsageState per discovered or manually configured Codex account.
+ * File-backed Codex OAuth accounts are preferred so refreshed local tokens are used.
  *
  * Each entry in the returned array corresponds to one account.
- * The array is stable in order (matches LocalStorage order).
  */
 export function useCodexAccounts(enabled = true): AccountUsageState<CodexUsage, CodexError>[] {
   const [accountStates, setAccountStates] = useState<AccountUsageState<CodexUsage, CodexError>[]>([]);
@@ -295,23 +295,9 @@ export function useCodexAccounts(enabled = true): AccountUsageState<CodexUsage, 
   const fetchAll = useCallback(async () => {
     const requestId = ++requestIdRef.current;
 
+    const discoveredAccounts = listCodexOAuthAccounts();
     const manualAccounts = await loadAccounts("codex");
-
-    // Get auto-detected token from codex auth file
-    const { localToken, localAccountId } = resolveCodexAuthTokens();
-
-    // Build list of all accounts: manual + auto-detected (if not duplicate)
-    const accounts = [...manualAccounts];
-
-    // Add auto-detected token as separate account if not already present
-    if (localToken && !accounts.some((a) => a.token === localToken)) {
-      accounts.push({
-        id: "codex-auto",
-        label: "Auto-detected",
-        token: localToken,
-        ...(localAccountId ? { accountId: localAccountId } : {}),
-      });
-    }
+    const accounts = buildCodexAccountCandidates(discoveredAccounts, manualAccounts);
 
     // Fallback: if no accounts at all, show not configured
     if (accounts.length === 0) {
@@ -338,8 +324,7 @@ export function useCodexAccounts(enabled = true): AccountUsageState<CodexUsage, 
     // Kick off all fetches in parallel
     const results = await Promise.all(
       accounts.map(async (account) => {
-        const accountId = account.accountId ?? (account.token === localToken ? localAccountId : null);
-        if (!accountId && account.token !== localToken) {
+        if (account.needsAccountId) {
           return {
             account,
             result: {
@@ -347,12 +332,13 @@ export function useCodexAccounts(enabled = true): AccountUsageState<CodexUsage, 
               error: {
                 type: "not_configured" as const,
                 message:
-                  "Add the ChatGPT account ID for this Codex account to avoid showing the token's default account.",
+                  "Add the ChatGPT account ID for this manual Codex account, or run 'codex login' and let Agent Usage read the OAuth account from CODEX_HOME.",
               },
             },
           };
         }
-        const result = await fetchCodexUsage(account.token, accountId);
+
+        const result = await fetchCodexUsage(account.token, account.accountId);
         return { account, result };
       }),
     );
@@ -367,7 +353,7 @@ export function useCodexAccounts(enabled = true): AccountUsageState<CodexUsage, 
         isLoading: false,
         usage: result.usage,
         error: result.error,
-        isOpenCodeActive: false, // Codex uses different auth source
+        isOpenCodeActive: false,
         revalidate: async () => {
           await fetchAll();
         },


### PR DESCRIPTION
## Description

Add support for multiple Codex OAuth accounts

This follows the format/style used by https://github.com/loongphy/codex-auth - hopefully that's acceptable, also open to feedback/suggestions on other ways to support this!

I could use some assistance testing this in combination with OpenAI/ChatGPT API key based auth. And potentially a second set of eyes that this doesn't regress the common-case / single account usage.

## Screencast

<img width="735" height="341" alt="image" src="https://github.com/user-attachments/assets/b4b6f19b-55e8-41d7-b42c-41dee489481c" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
