### PR TITLE
Update Remo: pinned notes section and improved note rendering

### DIFF
--- a/extensions/remo-notes/CHANGELOG.md
+++ b/extensions/remo-notes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Remo Changelog
 
-## [Pinned notes & improved rendering] - {PR_MERGE_DATE}
+## [Pinned notes & improved rendering] - 2026-06-30
 
 - Pinned notes now appear in a dedicated "Pinned" section in search and folders, with a count
 - The Pinned Notes menu bar now shows how many notes are pinned

--- a/extensions/remo-notes/CHANGELOG.md
+++ b/extensions/remo-notes/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Remo Changelog
 
+## [Pinned notes & improved rendering] - {PR_MERGE_DATE}
+
+- Pinned notes now appear in a dedicated "Pinned" section in search and folders, with a count
+- The Pinned Notes menu bar now shows how many notes are pinned
+- Notes now render with more faithful formatting (tables, task lists, headings and styles) in detail, previews and Copy Content
+
 ## [Note editing, AI Extension and performance] - 2026-06-15
 
 - Added a Raycast AI Extension: Raycast AI can now search your notes and answer questions from them

--- a/extensions/remo-notes/src/ask-ai.tsx
+++ b/extensions/remo-notes/src/ask-ai.tsx
@@ -50,7 +50,7 @@ export default function Command() {
         placeholder="What did I decide about the project roadmap?"
         enableMarkdown
       />
-      <Form.Description text="🔒 Locked notes are excluded from AI search and source list." />
+      <Form.Description text="Locked notes are excluded from AI search and source list." />
     </Form>
   );
 }

--- a/extensions/remo-notes/src/components/NoteListItem.tsx
+++ b/extensions/remo-notes/src/components/NoteListItem.tsx
@@ -5,7 +5,7 @@ import { buildAppUrl } from "../config";
 import type { Folder, Note } from "../types";
 import { remoApi } from "../utils/api";
 import { handleError } from "../utils/errors";
-import { noteHasContent, noteMarkdown, notePlainText } from "../utils/noteDisplay";
+import { noteHasContent, noteMarkdown, notePlainText, truncate } from "../utils/noteDisplay";
 
 interface NoteListItemProps {
   note: Note;
@@ -83,7 +83,7 @@ export function NoteListItem({ note, onRefresh, isShowingDetail, onToggleDetail,
             ? "Locked Note"
             : note.isE2E
               ? "Encrypted Note"
-              : (note.summary || notePlainText(note)).substring(0, 50)
+              : truncate(note.summary || notePlainText(note), 50)
       }
       accessories={
         isShowingDetail

--- a/extensions/remo-notes/src/components/NoteListItem.tsx
+++ b/extensions/remo-notes/src/components/NoteListItem.tsx
@@ -5,9 +5,7 @@ import { buildAppUrl } from "../config";
 import type { Folder, Note } from "../types";
 import { remoApi } from "../utils/api";
 import { handleError } from "../utils/errors";
-import { sortByPinned } from "../utils/notes";
-import { stripHtml } from "../utils/stripHtml";
-import { toMarkdown } from "../utils/toMarkdown";
+import { noteHasContent, noteMarkdown, notePlainText } from "../utils/noteDisplay";
 
 interface NoteListItemProps {
   note: Note;
@@ -27,7 +25,7 @@ export function NoteListItem({ note, onRefresh, isShowingDetail, onToggleDetail,
       if (mutate) {
         await mutate(remoApi.togglePin(note._id), {
           optimisticUpdate: (data) =>
-            sortByPinned((data ?? []).map((n) => (n._id === note._id ? { ...n, isPinned: !n.isPinned } : n))),
+            (data ?? []).map((n) => (n._id === note._id ? { ...n, isPinned: !n.isPinned } : n)),
         });
       } else {
         await remoApi.togglePin(note._id);
@@ -82,28 +80,29 @@ export function NoteListItem({ note, onRefresh, isShowingDetail, onToggleDetail,
         isShowingDetail
           ? undefined
           : note.isLocked
-            ? "🔒 Locked Note"
+            ? "Locked Note"
             : note.isE2E
-              ? "🛡️ Encrypted Note"
-              : (note.summary || stripHtml(note.content || "")).substring(0, 50)
+              ? "Encrypted Note"
+              : (note.summary || notePlainText(note)).substring(0, 50)
       }
       accessories={
         isShowingDetail
           ? []
-          : [
+          : ([
               { text: new Date(note.updatedAt).toLocaleDateString("en-US") },
-              note.isPinned ? { icon: Icon.Pin } : {},
-              note.isLocked ? { icon: Icon.Lock } : {},
-            ]
+              note.isPinned && { icon: Icon.Pin, tooltip: "Pinned" },
+              note.isLocked && { icon: Icon.Lock, tooltip: "Locked" },
+              note.isE2E && { icon: Icon.Shield, tooltip: "Encrypted" },
+            ].filter(Boolean) as List.Item.Accessory[])
       }
       detail={
         <List.Item.Detail
           markdown={
             note.isLocked
-              ? "### 🔒 This note is locked\nUnlock it in the web app to view the content."
+              ? "### This note is locked\nUnlock it in the web app to view the content."
               : note.isE2E
-                ? "### 🛡️ This note is encrypted\nUnlock it in the web app to view the content."
-                : toMarkdown(note.content || "") || "_No content_"
+                ? "### This note is encrypted\nUnlock it in the web app to view the content."
+                : noteMarkdown(note) || "_No content_"
           }
           metadata={
             <List.Item.Detail.Metadata>
@@ -174,9 +173,9 @@ export function NoteListItem({ note, onRefresh, isShowingDetail, onToggleDetail,
               onAction={handleDelete}
             />
           )}
-          {note.isLocked || note.isE2E || !note.content ? null : (
+          {note.isLocked || note.isE2E || !noteHasContent(note) ? null : (
             <Action.CopyToClipboard
-              content={toMarkdown(note.content)}
+              content={noteMarkdown(note)}
               title="Copy Content"
               shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
             />

--- a/extensions/remo-notes/src/components/NoteSections.tsx
+++ b/extensions/remo-notes/src/components/NoteSections.tsx
@@ -1,0 +1,41 @@
+import { List } from "@raycast/api";
+import type { MutatePromise } from "@raycast/utils";
+import { NoteListItem } from "./NoteListItem";
+import type { Folder, Note } from "../types";
+
+interface NoteSectionsProps {
+  notes: Note[];
+  onRefresh: () => void;
+  isShowingDetail: boolean;
+  onToggleDetail: () => void;
+  mutate?: MutatePromise<Note[] | undefined>;
+  folders?: Folder[];
+  othersTitle?: string;
+  groupPinned?: boolean;
+}
+
+export function NoteSections({ notes, othersTitle = "Notes", groupPinned = true, ...itemProps }: NoteSectionsProps) {
+  const renderItem = (note: Note) => <NoteListItem key={note._id} note={note} {...itemProps} />;
+
+  if (!groupPinned) {
+    return <>{notes.map(renderItem)}</>;
+  }
+
+  const pinned = notes.filter((note) => note.isPinned);
+  const others = notes.filter((note) => !note.isPinned);
+
+  return (
+    <>
+      {pinned.length > 0 && (
+        <List.Section title="Pinned" subtitle={`${pinned.length}`}>
+          {pinned.map(renderItem)}
+        </List.Section>
+      )}
+      {others.length > 0 && (
+        <List.Section title={othersTitle} subtitle={`${others.length}`}>
+          {others.map(renderItem)}
+        </List.Section>
+      )}
+    </>
+  );
+}

--- a/extensions/remo-notes/src/pinned-notes.tsx
+++ b/extensions/remo-notes/src/pinned-notes.tsx
@@ -3,7 +3,7 @@ import { useCachedPromise } from "@raycast/utils";
 import { buildAppUrl, buildWebUrl } from "./config";
 import type { Note } from "./types";
 import { remoApi } from "./utils/api";
-import { stripHtml } from "./utils/stripHtml";
+import { notePlainText } from "./utils/noteDisplay";
 import { handleError } from "./utils/errors";
 
 export default function Command() {
@@ -20,25 +20,27 @@ export default function Command() {
 
   return (
     <MenuBarExtra icon={Icon.Pin} isLoading={isLoading} tooltip="Remo Pinned Notes">
-      {notes.length === 0 ? (
-        <MenuBarExtra.Item title="No pinned notes" />
-      ) : (
-        notes.map((note) => (
-          <MenuBarExtra.Item
-            key={note._id}
-            title={note.title || "Untitled"}
-            subtitle={
-              note.isLocked
-                ? "Locked Note"
-                : note.isE2E
-                  ? "Encrypted Note"
-                  : (note.summary || stripHtml(note.content || "")).substring(0, 30)
-            }
-            icon={note.isLocked || note.isE2E ? Icon.Lock : Icon.Document}
-            onAction={() => open(buildAppUrl(`/notes/${note._id}`))}
-          />
-        ))
-      )}
+      <MenuBarExtra.Section title={notes.length > 0 ? `Pinned (${notes.length})` : undefined}>
+        {notes.length === 0 ? (
+          <MenuBarExtra.Item title="No pinned notes" />
+        ) : (
+          notes.map((note) => (
+            <MenuBarExtra.Item
+              key={note._id}
+              title={note.title || "Untitled"}
+              subtitle={
+                note.isLocked
+                  ? "Locked Note"
+                  : note.isE2E
+                    ? "Encrypted Note"
+                    : (note.summary || notePlainText(note)).substring(0, 30)
+              }
+              icon={note.isLocked || note.isE2E ? Icon.Lock : Icon.Document}
+              onAction={() => open(buildAppUrl(`/notes/${note._id}`))}
+            />
+          ))
+        )}
+      </MenuBarExtra.Section>
       <MenuBarExtra.Section>
         <MenuBarExtra.Item title="Open Web App" icon={Icon.Globe} onAction={() => open(buildWebUrl())} />
       </MenuBarExtra.Section>

--- a/extensions/remo-notes/src/pinned-notes.tsx
+++ b/extensions/remo-notes/src/pinned-notes.tsx
@@ -3,7 +3,7 @@ import { useCachedPromise } from "@raycast/utils";
 import { buildAppUrl, buildWebUrl } from "./config";
 import type { Note } from "./types";
 import { remoApi } from "./utils/api";
-import { notePlainText } from "./utils/noteDisplay";
+import { notePlainText, truncate } from "./utils/noteDisplay";
 import { handleError } from "./utils/errors";
 
 export default function Command() {
@@ -33,7 +33,7 @@ export default function Command() {
                   ? "Locked Note"
                   : note.isE2E
                     ? "Encrypted Note"
-                    : (note.summary || notePlainText(note)).substring(0, 30)
+                    : truncate(note.summary || notePlainText(note), 30)
               }
               icon={note.isLocked || note.isE2E ? Icon.Lock : Icon.Document}
               onAction={() => open(buildAppUrl(`/notes/${note._id}`))}

--- a/extensions/remo-notes/src/search-folders.tsx
+++ b/extensions/remo-notes/src/search-folders.tsx
@@ -1,11 +1,10 @@
 import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { useState } from "react";
-import { NoteListItem } from "./components/NoteListItem";
+import { NoteSections } from "./components/NoteSections";
 import type { Folder, Note } from "./types";
 import { remoApi } from "./utils/api";
 import { handleError } from "./utils/errors";
-import { sortByPinned } from "./utils/notes";
 
 export default function SearchFolders() {
   const { isLoading, data } = useCachedPromise(() => remoApi.listFolders(), [], {
@@ -138,7 +137,7 @@ function FolderNotesList({
         result = await remoApi.listNotes({ folderId: fid as Folder["_id"], limit: 50 });
       }
 
-      return sortByPinned(result);
+      return result;
     },
     [filterType, folderId],
     { onError: (error) => handleError(error, "Failed to fetch notes") },
@@ -158,17 +157,14 @@ function FolderNotesList({
       {notes.length === 0 && !isLoading ? (
         <List.EmptyView title={`No notes in ${title}`} icon={Icon.Document} />
       ) : (
-        notes.map((note) => (
-          <NoteListItem
-            key={note._id}
-            note={note}
-            onRefresh={fetchNotes}
-            mutate={mutate}
-            folders={folders}
-            isShowingDetail={isShowingDetail}
-            onToggleDetail={() => setIsShowingDetail((prev) => !prev)}
-          />
-        ))
+        <NoteSections
+          notes={notes}
+          onRefresh={fetchNotes}
+          mutate={mutate}
+          folders={folders}
+          isShowingDetail={isShowingDetail}
+          onToggleDetail={() => setIsShowingDetail((prev) => !prev)}
+        />
       )}
     </List>
   );

--- a/extensions/remo-notes/src/search-notes.tsx
+++ b/extensions/remo-notes/src/search-notes.tsx
@@ -1,19 +1,18 @@
 import { List } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { useState } from "react";
-import { NoteListItem } from "./components/NoteListItem";
+import { NoteSections } from "./components/NoteSections";
 import { remoApi } from "./utils/api";
 import { handleError } from "./utils/errors";
-import { sortByPinned } from "./utils/notes";
 
 export default function SearchNotes() {
   const [searchText, setSearchText] = useState("");
   const [isShowingDetail, setIsShowingDetail] = useState(false);
+  const isSearching = searchText.trim() !== "";
 
   const { isLoading, data, revalidate, mutate } = useCachedPromise(
     async (text: string) => {
-      const result = text.trim() === "" ? await remoApi.recentNotes(20) : await remoApi.searchNotes(text);
-      return sortByPinned(result);
+      return text.trim() === "" ? await remoApi.recentNotes(20) : await remoApi.searchNotes(text);
     },
     [searchText],
     {
@@ -40,17 +39,16 @@ export default function SearchNotes() {
           searchText ? "Try a different search term or check your spelling." : "You haven't added any notes yet."
         }
       />
-      {notes.map((note) => (
-        <NoteListItem
-          key={note._id}
-          note={note}
-          onRefresh={revalidate}
-          mutate={mutate}
-          folders={folders}
-          isShowingDetail={isShowingDetail}
-          onToggleDetail={() => setIsShowingDetail((prev) => !prev)}
-        />
-      ))}
+      <NoteSections
+        notes={notes}
+        onRefresh={revalidate}
+        mutate={mutate}
+        folders={folders}
+        isShowingDetail={isShowingDetail}
+        onToggleDetail={() => setIsShowingDetail((prev) => !prev)}
+        othersTitle="Recent"
+        groupPinned={!isSearching}
+      />
     </List>
   );
 }

--- a/extensions/remo-notes/src/tools/search-notes.ts
+++ b/extensions/remo-notes/src/tools/search-notes.ts
@@ -1,5 +1,5 @@
 import { remoApi } from "../utils/api";
-import { notePlainText } from "../utils/noteDisplay";
+import { notePlainText, truncate } from "../utils/noteDisplay";
 
 type Input = {
   /**
@@ -19,6 +19,6 @@ export default async function tool(input: Input) {
     title: note.title || "Untitled",
     isLocked: note.isLocked ?? false,
     updatedAt: new Date(note.updatedAt).toISOString(),
-    snippet: note.summary || notePlainText(note).slice(0, 200),
+    snippet: note.summary || truncate(notePlainText(note), 200),
   }));
 }

--- a/extensions/remo-notes/src/tools/search-notes.ts
+++ b/extensions/remo-notes/src/tools/search-notes.ts
@@ -1,5 +1,5 @@
 import { remoApi } from "../utils/api";
-import { stripHtml } from "../utils/stripHtml";
+import { notePlainText } from "../utils/noteDisplay";
 
 type Input = {
   /**
@@ -19,6 +19,6 @@ export default async function tool(input: Input) {
     title: note.title || "Untitled",
     isLocked: note.isLocked ?? false,
     updatedAt: new Date(note.updatedAt).toISOString(),
-    snippet: note.summary || stripHtml(note.content || "").slice(0, 200),
+    snippet: note.summary || notePlainText(note).slice(0, 200),
   }));
 }

--- a/extensions/remo-notes/src/trash.tsx
+++ b/extensions/remo-notes/src/trash.tsx
@@ -5,7 +5,7 @@ import { buildAppUrl } from "./config";
 import type { Note } from "./types";
 import { remoApi } from "./utils/api";
 import { handleError } from "./utils/errors";
-import { noteMarkdown, notePlainText } from "./utils/noteDisplay";
+import { noteMarkdown, notePlainText, truncate } from "./utils/noteDisplay";
 
 export default function Trash() {
   const [isShowingDetail, setIsShowingDetail] = useState(false);
@@ -71,7 +71,7 @@ export default function Trash() {
           <List.Item
             key={note._id}
             title={note.title || "Untitled"}
-            subtitle={isShowingDetail ? undefined : notePlainText(note).substring(0, 50)}
+            subtitle={isShowingDetail ? undefined : truncate(notePlainText(note), 50)}
             icon={{ source: Icon.Trash, tintColor: Color.Red }}
             accessories={
               isShowingDetail

--- a/extensions/remo-notes/src/trash.tsx
+++ b/extensions/remo-notes/src/trash.tsx
@@ -5,8 +5,7 @@ import { buildAppUrl } from "./config";
 import type { Note } from "./types";
 import { remoApi } from "./utils/api";
 import { handleError } from "./utils/errors";
-import { stripHtml } from "./utils/stripHtml";
-import { toMarkdown } from "./utils/toMarkdown";
+import { noteMarkdown, notePlainText } from "./utils/noteDisplay";
 
 export default function Trash() {
   const [isShowingDetail, setIsShowingDetail] = useState(false);
@@ -72,7 +71,7 @@ export default function Trash() {
           <List.Item
             key={note._id}
             title={note.title || "Untitled"}
-            subtitle={isShowingDetail ? undefined : stripHtml(note.content || "").substring(0, 50)}
+            subtitle={isShowingDetail ? undefined : notePlainText(note).substring(0, 50)}
             icon={{ source: Icon.Trash, tintColor: Color.Red }}
             accessories={
               isShowingDetail
@@ -86,7 +85,7 @@ export default function Trash() {
             }
             detail={
               <List.Item.Detail
-                markdown={toMarkdown(note.content || "") || "_No content_"}
+                markdown={noteMarkdown(note) || "_No content_"}
                 metadata={
                   <List.Item.Detail.Metadata>
                     <List.Item.Detail.Metadata.Label title="Title" text={note.title || "Untitled"} />

--- a/extensions/remo-notes/src/types.ts
+++ b/extensions/remo-notes/src/types.ts
@@ -5,6 +5,8 @@ export interface Note {
   _creationTime: number;
   title: string;
   content?: string;
+  contentText?: string;
+  contentMarkdown?: string;
   tags: string[];
   source: "web" | "raycast";
   summary?: string;

--- a/extensions/remo-notes/src/utils/noteDisplay.ts
+++ b/extensions/remo-notes/src/utils/noteDisplay.ts
@@ -1,0 +1,21 @@
+import type { Note } from "../types";
+import { stripHtml } from "./stripHtml";
+import { toMarkdown } from "./toMarkdown";
+
+/** Plain-text view: server-derived `contentText`, falling back to stripped HTML. */
+export function notePlainText(note: Pick<Note, "content" | "contentText">): string {
+  return note.contentText ?? stripHtml(note.content ?? "");
+}
+
+/**
+ * Markdown view: the API derives `contentMarkdown` from the canonical JSON.
+ * Falls back to turndown(HTML) for responses from an older server.
+ */
+export function noteMarkdown(note: Pick<Note, "content" | "contentMarkdown">): string {
+  return note.contentMarkdown || toMarkdown(note.content ?? "");
+}
+
+/** Whether the note carries any renderable body. */
+export function noteHasContent(note: Pick<Note, "content" | "contentMarkdown" | "contentText">): boolean {
+  return Boolean(note.contentMarkdown || note.content || note.contentText);
+}

--- a/extensions/remo-notes/src/utils/noteDisplay.ts
+++ b/extensions/remo-notes/src/utils/noteDisplay.ts
@@ -2,9 +2,23 @@ import type { Note } from "../types";
 import { stripHtml } from "./stripHtml";
 import { toMarkdown } from "./toMarkdown";
 
+/**
+ * Drop unpaired UTF-16 surrogates. Raycast's render-tree serializer throws
+ * ("Cannot parse render tree JSON … expected low-surrogate") when one reaches
+ * the UI — which also happens when a fixed-length truncation splits an emoji.
+ */
+export function stripLoneSurrogates(text: string): string {
+  return text.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "");
+}
+
+/** Truncate to `max` chars without leaving a split surrogate pair at the edge. */
+export function truncate(text: string, max: number): string {
+  return stripLoneSurrogates(text.slice(0, max));
+}
+
 /** Plain-text view: server-derived `contentText`, falling back to stripped HTML. */
 export function notePlainText(note: Pick<Note, "content" | "contentText">): string {
-  return note.contentText ?? stripHtml(note.content ?? "");
+  return stripLoneSurrogates(note.contentText ?? stripHtml(note.content ?? ""));
 }
 
 /**
@@ -12,7 +26,7 @@ export function notePlainText(note: Pick<Note, "content" | "contentText">): stri
  * Falls back to turndown(HTML) for responses from an older server.
  */
 export function noteMarkdown(note: Pick<Note, "content" | "contentMarkdown">): string {
-  return note.contentMarkdown || toMarkdown(note.content ?? "");
+  return stripLoneSurrogates(note.contentMarkdown || toMarkdown(note.content ?? ""));
 }
 
 /** Whether the note carries any renderable body. */

--- a/extensions/remo-notes/src/utils/notes.ts
+++ b/extensions/remo-notes/src/utils/notes.ts
@@ -1,8 +1,0 @@
-import type { Note } from "../types";
-
-export function sortByPinned(notes: Note[]): Note[] {
-  return [...notes].sort((a, b) => {
-    if (a.isPinned === b.isPinned) return 0;
-    return a.isPinned ? -1 : 1;
-  });
-}


### PR DESCRIPTION
## Description

Updates the **Remo** extension (`remo-notes`).

- Pinned notes now appear in a dedicated "Pinned" section in search and folders, with a count, and the Pinned Notes menu bar shows how many notes are pinned.
- Notes render with more faithful formatting (tables, task lists, headings and styles) in detail, previews and Copy Content — the extension now renders the Markdown the API derives from the note's canonical document instead of converting HTML client-side (with a graceful fallback for older API responses).

No new dependencies.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that screenshots and metadata are up to date
- [x] I updated the CHANGELOG with `{PR_MERGE_DATE}`
