### PR TITLE
Update unsplash extension

### DIFF
--- a/extensions/unsplash/CHANGELOG.md
+++ b/extensions/unsplash/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unsplash Changelog
 
+## [Unsplash API ToS Compliance] - {PR_MERGE_DATE}
+
+- Call `photo.links.download_location` endpoint on all download-like actions (copy to clipboard, save image, set wallpaper) to properly track downloads with Unsplash
+- Add `utm_source=raycast_unsplash&utm_medium=referral` to all outbound links to Unsplash photo pages and author profiles
+- Add "Photo by [name] on Unsplash" photographer attribution in the photo Details view
+- Add `download_location` field to `SearchResult.links` type
+
 ## [Windows Support] - 2026-06-29
 
 - Added Windows support for setting wallpaper, copying images to clipboard, and saving images

--- a/extensions/unsplash/CHANGELOG.md
+++ b/extensions/unsplash/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unsplash Changelog
 
-## [Unsplash API ToS Compliance] - {PR_MERGE_DATE}
+## [Unsplash API ToS Compliance] - 2026-07-08
 
 - Call `photo.links.download_location` endpoint on all download-like actions (copy to clipboard, save image, set wallpaper) to properly track downloads with Unsplash
 - Add `utm_source=raycast_unsplash&utm_medium=referral` to all outbound links to Unsplash photo pages and author profiles

--- a/extensions/unsplash/README.md
+++ b/extensions/unsplash/README.md
@@ -11,9 +11,7 @@ A [Raycast](https://raycast.com/) extension that lets you communicate with Unspl
 
 ### Installation
 
-You will need some additional steps to install this plugin.
-
-- Create an app on [Unsplash developers page](https://unsplash.com/developers).
+- Create an app on the [Unsplash developers page](https://unsplash.com/developers).
 - Copy your access key and secret key.
 - Scroll down to the "Redirect URI & Permissions" section:
   - Set the "Redirect URI" field to: `https://raycast.com/redirect`

--- a/extensions/unsplash/src/components/Actions.tsx
+++ b/extensions/unsplash/src/components/Actions.tsx
@@ -5,6 +5,7 @@ import Details from "@/views/Details";
 import { copyFileToClipboard } from "@/functions/copyFileToClipboard";
 import { saveImage } from "@/functions/saveImage";
 import { setWallpaper } from "@/functions/setWallpaper";
+import { addUtmParams } from "@/functions/utils";
 import { SearchResult } from "@/types";
 
 interface Props {
@@ -39,6 +40,7 @@ function ActionsContent({ details = false, item, unlike }: Props) {
 
   const imageUrl = item.urls.raw || item.urls.full || item.urls.regular || item.urls.small;
   const clipboardUrl = item.urls[downloadSize] || imageUrl;
+  const downloadLocation = item.links?.download_location;
 
   const handleLike = async () => {
     await likeOrDislike(item.id, liked);
@@ -58,11 +60,15 @@ function ActionsContent({ details = false, item, unlike }: Props) {
           onAction={handleLike}
         />
         {item.links?.html && (
-          <Action.OpenInBrowser url={item.links.html} title="Open Original" shortcut={Keyboard.Shortcut.Common.Open} />
+          <Action.OpenInBrowser
+            url={addUtmParams(item.links.html)}
+            title="Open Original"
+            shortcut={Keyboard.Shortcut.Common.Open}
+          />
         )}
         {item.user?.links?.html && (
           <Action.OpenInBrowser
-            url={item.user.links.html}
+            url={addUtmParams(item.user.links.html)}
             icon={Icon.Person}
             shortcut={Keyboard.Shortcut.Common.OpenWith}
             title="Open Author"
@@ -77,13 +83,15 @@ function ActionsContent({ details = false, item, unlike }: Props) {
               title="Copy to Clipboard"
               icon={Icon.Clipboard}
               shortcut={Keyboard.Shortcut.Common.Copy}
-              onAction={() => copyFileToClipboard({ url: clipboardUrl, id: `${item.id}-${downloadSize}` })}
+              onAction={() =>
+                copyFileToClipboard({ url: clipboardUrl, id: `${item.id}-${downloadSize}`, downloadLocation })
+              }
             />
             <Action
               title="Download Image"
               icon={Icon.Desktop}
               shortcut={Keyboard.Shortcut.Common.Save}
-              onAction={() => saveImage({ url: imageUrl, id: String(item.id) })}
+              onAction={() => saveImage({ url: imageUrl, id: String(item.id), downloadLocation })}
             />
           </ActionPanel.Section>
 
@@ -92,13 +100,13 @@ function ActionsContent({ details = false, item, unlike }: Props) {
               title="Current Monitor"
               icon={Icon.Desktop}
               shortcut={{ modifiers: ["cmd", "shift"], key: "w" }}
-              onAction={() => setWallpaper({ url: imageUrl, id: String(item.id) })}
+              onAction={() => setWallpaper({ url: imageUrl, id: String(item.id), downloadLocation })}
             />
             <Action
               title="Every Monitor"
               icon={Icon.Desktop}
               shortcut={{ modifiers: ["shift", "opt"], key: "w" }}
-              onAction={() => setWallpaper({ url: imageUrl, id: String(item.id), every: true })}
+              onAction={() => setWallpaper({ url: imageUrl, id: String(item.id), every: true, downloadLocation })}
             />
           </ActionPanel.Section>
         </>
@@ -107,7 +115,7 @@ function ActionsContent({ details = false, item, unlike }: Props) {
       <ActionPanel.Section title="Links">
         {item.links?.html && (
           <Action.CopyToClipboard
-            content={item.links.html}
+            content={addUtmParams(item.links.html)}
             title="Copy URL to Clipboard"
             icon={Icon.Clipboard}
             shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
@@ -123,7 +131,7 @@ function ActionsContent({ details = false, item, unlike }: Props) {
         )}
         {item.user?.links?.html && (
           <Action.CopyToClipboard
-            content={item.user.links.html}
+            content={addUtmParams(item.user.links.html)}
             title="Copy Author URL to Clipboard"
             icon={Icon.Clipboard}
             shortcut={Keyboard.Shortcut.Common.CopyName}

--- a/extensions/unsplash/src/functions/apiRequest.ts
+++ b/extensions/unsplash/src/functions/apiRequest.ts
@@ -31,6 +31,10 @@ export const apiRequest = async <T>(path: string, options?: RequestInit): Promis
   return result as T;
 };
 
+export const triggerDownload = (downloadLocation: string): void => {
+  apiRequest<unknown>(downloadLocation).catch(() => undefined);
+};
+
 async function refreshTokens(refreshToken: string) {
   const { accessKey } = getPreferenceValues<Preferences>();
   const params = new URLSearchParams();

--- a/extensions/unsplash/src/functions/copyFileToClipboard.ts
+++ b/extensions/unsplash/src/functions/copyFileToClipboard.ts
@@ -3,15 +3,18 @@ import { runAppleScript } from "@raycast/utils";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { existsSync, unlinkSync } from "fs";
+import { triggerDownload } from "./apiRequest";
 
 const execFileP = promisify(execFile);
 
 interface CopyFileToClipboardProps {
   url: string;
   id: string;
+  downloadLocation?: string;
 }
 
-export const copyFileToClipboard = async ({ url, id }: CopyFileToClipboardProps) => {
+export const copyFileToClipboard = async ({ url, id, downloadLocation }: CopyFileToClipboardProps) => {
+  if (downloadLocation) triggerDownload(downloadLocation);
   const toast = await showToast(Toast.Style.Animated, "Downloading and copying image...");
 
   const selectedPath = environment.supportPath;

--- a/extensions/unsplash/src/functions/saveImage.ts
+++ b/extensions/unsplash/src/functions/saveImage.ts
@@ -3,15 +3,18 @@ import { runAppleScript } from "@raycast/utils";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { join } from "path";
+import { triggerDownload } from "./apiRequest";
 
 const execFileP = promisify(execFile);
 
 interface SaveImageProps {
   url: string;
   id: string;
+  downloadLocation?: string;
 }
 
-export const saveImage = async ({ url, id }: SaveImageProps) => {
+export const saveImage = async ({ url, id, downloadLocation }: SaveImageProps) => {
+  if (downloadLocation) triggerDownload(downloadLocation);
   const { downloadSize } = getPreferenceValues<Preferences>();
 
   try {

--- a/extensions/unsplash/src/functions/setWallpaper.ts
+++ b/extensions/unsplash/src/functions/setWallpaper.ts
@@ -4,6 +4,7 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import { existsSync, unlinkSync } from "fs";
 import { resolveHome } from "./utils";
+import { triggerDownload } from "./apiRequest";
 
 const execFileP = promisify(execFile);
 
@@ -13,6 +14,7 @@ interface SetWallpaperProps {
   every?: boolean;
   useHud?: boolean;
   isBackground?: boolean;
+  downloadLocation?: string;
 }
 
 const displayMessage = async (msg: string, type: "hud" | "toast") => {
@@ -35,7 +37,15 @@ if ($r -eq 0) { throw "SystemParametersInfo returned 0" }`;
   await execFileP("powershell", ["-NoProfile", "-EncodedCommand", encoded]);
 }
 
-export const setWallpaper = async ({ url, id, every, useHud = false, isBackground = false }: SetWallpaperProps) => {
+export const setWallpaper = async ({
+  url,
+  id,
+  every,
+  useHud = false,
+  isBackground = false,
+  downloadLocation,
+}: SetWallpaperProps) => {
+  if (downloadLocation) triggerDownload(downloadLocation);
   const { downloadSize, wallpaperPath } = getPreferenceValues<Preferences>();
   const selectedPath = resolveHome(wallpaperPath || environment.supportPath);
 

--- a/extensions/unsplash/src/functions/utils.ts
+++ b/extensions/unsplash/src/functions/utils.ts
@@ -16,3 +16,8 @@ export const toTitleCase = (str: string): string =>
 
 export const resolveHome = (filepath: string): string =>
   filepath.startsWith("~") ? join(homedir(), filepath.slice(1)) : filepath;
+
+export const addUtmParams = (url: string): string => {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}utm_source=raycast_unsplash&utm_medium=referral`;
+};

--- a/extensions/unsplash/src/functions/utils.ts
+++ b/extensions/unsplash/src/functions/utils.ts
@@ -18,6 +18,7 @@ export const resolveHome = (filepath: string): string =>
   filepath.startsWith("~") ? join(homedir(), filepath.slice(1)) : filepath;
 
 export const addUtmParams = (url: string): string => {
+  if (url.includes("utm_source=")) return url;
   const sep = url.includes("?") ? "&" : "?";
   return `${url}${sep}utm_source=raycast_unsplash&utm_medium=referral`;
 };

--- a/extensions/unsplash/src/hooks/useRandom.ts
+++ b/extensions/unsplash/src/hooks/useRandom.ts
@@ -37,7 +37,7 @@ export const useRandom = async (nowTime: number) => {
     if (environment.launchType === LaunchType.UserInitiated) showHUD(`${error}`);
     return;
   }
-  const { urls, id } = response;
+  const { urls, id, links } = response;
 
   const image = urls?.raw || urls?.full || urls?.regular;
   const result = await setWallpaper({
@@ -46,6 +46,7 @@ export const useRandom = async (nowTime: number) => {
     useHud: true,
     every: true,
     isBackground: environment.launchType === LaunchType.Background,
+    downloadLocation: links?.download_location,
   });
 
   if (result) {

--- a/extensions/unsplash/src/types/index.d.ts
+++ b/extensions/unsplash/src/types/index.d.ts
@@ -46,7 +46,7 @@ export interface SearchResult {
   total_photos?: number;
   links: {
     html: string;
-    download_location: string;
+    download_location?: string;
   };
 }
 

--- a/extensions/unsplash/src/types/index.d.ts
+++ b/extensions/unsplash/src/types/index.d.ts
@@ -46,6 +46,7 @@ export interface SearchResult {
   total_photos?: number;
   links: {
     html: string;
+    download_location: string;
   };
 }
 

--- a/extensions/unsplash/src/views/Details.tsx
+++ b/extensions/unsplash/src/views/Details.tsx
@@ -1,19 +1,22 @@
 import { Detail, Icon } from "@raycast/api";
 import Actions from "@/components/Actions";
+import { addUtmParams } from "@/functions/utils";
 import { SearchResult } from "@/types";
 
 export function Details({ result }: { result: SearchResult }) {
   const image = result.urls.regular || result.urls.small || result.urls.thumb;
   const date = result.created_at ? new Date(result.created_at).toLocaleString() : "Unknown";
+  const authorUrl = addUtmParams(result.user.links.html);
+  const unsplashUrl = addUtmParams("https://unsplash.com");
 
   return (
     <Detail
-      markdown={`![${result.alt_description}](${image})`}
+      markdown={`![${result.alt_description}](${image})\n\nPhoto by [${result.user.name}](${authorUrl}) on [Unsplash](${unsplashUrl})`}
       navigationTitle={result.user?.name}
       metadata={
         <Detail.Metadata>
           {result.description && <Detail.Metadata.Label title="Description" text={result.description} />}
-          <Detail.Metadata.Link title="Author" text={result.user.username} target={result.user.links.html} />
+          <Detail.Metadata.Link title="Author" text={result.user.username} target={authorUrl} />
           <Detail.Metadata.Label title="Uploaded On" text={date} icon={Icon.Calendar} />
           <Detail.Metadata.Label title="Likes" text={String(result.likes)} icon={Icon.Heart} />
           <Detail.Metadata.Label title="Dimensions" text={`${result.width}x${result.height}`} icon={Icon.AppWindow} />


### PR DESCRIPTION
## Description

This PR updates the Unsplash integration to use the correct download endpoint and ensures that all outbound Unsplash links include the required UTM parameters. These changes improve compliance with the Unsplash API guidelines while preserving the existing functionality of the extension.

Changes made due to problems raised in #28914. We should keep on discussing it here @pernielsentikaer @0xdhrv @xmok.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
