### PR TITLE
[Agent Usage] Add z.ai weekly limit support

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [z.ai weekly limits] - {PR_MERGE_DATE}
+## [z.ai weekly limits] - 2026-07-01
 
 ### Improvements
 

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Agent Usage Changelog
 
+## [z.ai weekly limits] - {PR_MERGE_DATE}
+
+### Improvements
+
+- Show z.ai weekly usage limits (tokens and time) alongside the existing daily limits
+
 ## [Codex OAuth multi-account support] - 2026-06-30
 
 ### Improvements

--- a/extensions/agent-usage/src/zai/fetcher.ts
+++ b/extensions/agent-usage/src/zai/fetcher.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { getPreferenceValues } from "@raycast/api";
-import { ZaiUsage, ZaiError, ZaiLimitEntry, ZaiUsageDetail } from "./types";
+import { ZaiUsage, ZaiError } from "./types";
+import { parseZaiApiResponse } from "./parser";
 import { httpFetch } from "../agents/http";
 import { resolveZaiAuthTokens } from "./auth";
 import { isOpenCodeActiveToken } from "../agents/opencode-active";
@@ -12,131 +13,11 @@ const ZAI_OPENCODE_KEY = "zai-coding-plan";
 type Preferences = Preferences.AgentUsage;
 
 const ZAI_USAGE_API = "https://api.z.ai/api/monitor/usage/quota/limit";
-const ZAI_UNIT_DAYS = 1;
-const ZAI_WINDOW_DAILY = 1;
-const ZAI_WINDOW_WEEKLY = 7;
 
 async function fetchZaiUsage(token: string): Promise<{ usage: ZaiUsage | null; error: ZaiError | null }> {
   const { data, error } = await httpFetch({ url: ZAI_USAGE_API, token, headers: { Accept: "application/json" } });
   if (error) return { usage: null, error };
   return parseZaiApiResponse(data);
-}
-
-interface ZaiApiLimitEntry {
-  type: string;
-  unit: number;
-  number: number;
-  usage: number | null;
-  currentValue: number | null;
-  remaining: number | null;
-  percentage: number;
-  usageDetails?: Array<{ modelCode: string; usage: number }> | null;
-  nextResetTime: number | null;
-}
-
-interface ZaiApiResponse {
-  code: number;
-  msg: string;
-  success: boolean;
-  data?: {
-    limits?: ZaiApiLimitEntry[];
-    planName?: string;
-    plan?: string;
-    plan_type?: string;
-    packageName?: string;
-  };
-}
-
-function unitToLabel(unit: number): string {
-  switch (unit) {
-    case 1:
-      return "days";
-    case 3:
-      return "hours";
-    case 5:
-      return "minutes";
-    default:
-      return "units";
-  }
-}
-
-function buildWindowDescription(unit: number, num: number): string {
-  return `${num} ${unitToLabel(unit)}`;
-}
-
-function parseLimitEntry(entry: ZaiApiLimitEntry): ZaiLimitEntry {
-  const usageDetails: ZaiUsageDetail[] = (entry.usageDetails ?? []).map((d) => ({
-    modelCode: d.modelCode,
-    usage: d.usage,
-  }));
-
-  const resetTime = entry.nextResetTime != null ? new Date(entry.nextResetTime).toISOString() : null;
-
-  return {
-    type: entry.type as "TOKENS_LIMIT" | "TIME_LIMIT",
-    windowDescription: buildWindowDescription(entry.unit, entry.number),
-    usage: entry.usage ?? null,
-    currentValue: entry.currentValue ?? null,
-    remaining: entry.remaining ?? null,
-    percentage: entry.percentage,
-    usageDetails,
-    resetTime,
-  };
-}
-
-function parseZaiApiResponse(data: unknown): { usage: ZaiUsage | null; error: ZaiError | null } {
-  try {
-    if (!data || typeof data !== "object") {
-      return { usage: null, error: { type: "parse_error", message: "Invalid API response format" } };
-    }
-
-    const response = data as ZaiApiResponse;
-
-    if (response.success !== true || response.code !== 200) {
-      return { usage: null, error: { type: "api_error", message: response.msg || "API returned an error" } };
-    }
-
-    const limits = response.data?.limits;
-
-    if (!limits || !Array.isArray(limits)) {
-      return { usage: null, error: { type: "parse_error", message: "No limits data found in API response" } };
-    }
-
-    const tokenLimits = limits.filter((l) => l.type === "TOKENS_LIMIT");
-    const timeLimits = limits.filter((l) => l.type === "TIME_LIMIT");
-
-    const tokenEntry =
-      tokenLimits.find((l) => l.number === ZAI_WINDOW_DAILY && l.unit === ZAI_UNIT_DAYS) ?? tokenLimits[0] ?? null;
-    const weeklyTokenEntry =
-      tokenLimits.find((l) => l.number === ZAI_WINDOW_WEEKLY && l.unit === ZAI_UNIT_DAYS) ??
-      tokenLimits.find((l) => l !== tokenEntry) ??
-      null;
-
-    const timeEntry =
-      timeLimits.find((l) => l.number === ZAI_WINDOW_DAILY && l.unit === ZAI_UNIT_DAYS) ?? timeLimits[0] ?? null;
-    const weeklyTimeEntry =
-      timeLimits.find((l) => l.number === ZAI_WINDOW_WEEKLY && l.unit === ZAI_UNIT_DAYS) ??
-      timeLimits.find((l) => l !== timeEntry) ??
-      null;
-
-    const planName =
-      response.data?.planName ?? response.data?.plan ?? response.data?.plan_type ?? response.data?.packageName ?? null;
-
-    const usage: ZaiUsage = {
-      tokenLimit: tokenEntry ? parseLimitEntry(tokenEntry) : null,
-      weeklyTokenLimit: weeklyTokenEntry ? parseLimitEntry(weeklyTokenEntry) : null,
-      timeLimit: timeEntry ? parseLimitEntry(timeEntry) : null,
-      weeklyTimeLimit: weeklyTimeEntry ? parseLimitEntry(weeklyTimeEntry) : null,
-      planName,
-    };
-
-    return { usage, error: null };
-  } catch (error) {
-    return {
-      usage: null,
-      error: { type: "parse_error", message: error instanceof Error ? error.message : "Failed to parse API response" },
-    };
-  }
 }
 
 export function useZaiUsage(enabled = true) {

--- a/extensions/agent-usage/src/zai/fetcher.ts
+++ b/extensions/agent-usage/src/zai/fetcher.ts
@@ -12,6 +12,9 @@ const ZAI_OPENCODE_KEY = "zai-coding-plan";
 type Preferences = Preferences.AgentUsage;
 
 const ZAI_USAGE_API = "https://api.z.ai/api/monitor/usage/quota/limit";
+const ZAI_UNIT_DAYS = 1;
+const ZAI_WINDOW_DAILY = 1;
+const ZAI_WINDOW_WEEKLY = 7;
 
 async function fetchZaiUsage(token: string): Promise<{ usage: ZaiUsage | null; error: ZaiError | null }> {
   const { data, error } = await httpFetch({ url: ZAI_USAGE_API, token, headers: { Accept: "application/json" } });
@@ -99,15 +102,31 @@ function parseZaiApiResponse(data: unknown): { usage: ZaiUsage | null; error: Za
       return { usage: null, error: { type: "parse_error", message: "No limits data found in API response" } };
     }
 
-    const tokenEntry = limits.find((l) => l.type === "TOKENS_LIMIT");
-    const timeEntry = limits.find((l) => l.type === "TIME_LIMIT");
+    const tokenLimits = limits.filter((l) => l.type === "TOKENS_LIMIT");
+    const timeLimits = limits.filter((l) => l.type === "TIME_LIMIT");
+
+    const tokenEntry =
+      tokenLimits.find((l) => l.number === ZAI_WINDOW_DAILY && l.unit === ZAI_UNIT_DAYS) ?? tokenLimits[0] ?? null;
+    const weeklyTokenEntry =
+      tokenLimits.find((l) => l.number === ZAI_WINDOW_WEEKLY && l.unit === ZAI_UNIT_DAYS) ??
+      tokenLimits.find((l) => l !== tokenEntry) ??
+      null;
+
+    const timeEntry =
+      timeLimits.find((l) => l.number === ZAI_WINDOW_DAILY && l.unit === ZAI_UNIT_DAYS) ?? timeLimits[0] ?? null;
+    const weeklyTimeEntry =
+      timeLimits.find((l) => l.number === ZAI_WINDOW_WEEKLY && l.unit === ZAI_UNIT_DAYS) ??
+      timeLimits.find((l) => l !== timeEntry) ??
+      null;
 
     const planName =
       response.data?.planName ?? response.data?.plan ?? response.data?.plan_type ?? response.data?.packageName ?? null;
 
     const usage: ZaiUsage = {
       tokenLimit: tokenEntry ? parseLimitEntry(tokenEntry) : null,
+      weeklyTokenLimit: weeklyTokenEntry ? parseLimitEntry(weeklyTokenEntry) : null,
       timeLimit: timeEntry ? parseLimitEntry(timeEntry) : null,
+      weeklyTimeLimit: weeklyTimeEntry ? parseLimitEntry(weeklyTimeEntry) : null,
       planName,
     };
 

--- a/extensions/agent-usage/src/zai/parser.test.ts
+++ b/extensions/agent-usage/src/zai/parser.test.ts
@@ -57,10 +57,7 @@ test("parseZaiApiResponse classifies by window regardless of array order", async
 
 test("parseZaiApiResponse leaves weekly limits null when only a daily window is present", async () => {
   const { usage } = parseZaiApiResponse(
-    response([
-      limit({ type: "TOKENS_LIMIT", number: 1, unit: 1 }),
-      limit({ type: "TIME_LIMIT", number: 1, unit: 1 }),
-    ]),
+    response([limit({ type: "TOKENS_LIMIT", number: 1, unit: 1 }), limit({ type: "TIME_LIMIT", number: 1, unit: 1 })]),
   );
 
   assert.ok(usage?.tokenLimit);

--- a/extensions/agent-usage/src/zai/parser.test.ts
+++ b/extensions/agent-usage/src/zai/parser.test.ts
@@ -66,6 +66,17 @@ test("parseZaiApiResponse leaves weekly limits null when only a daily window is 
   assert.equal(usage?.weeklyTimeLimit, null);
 });
 
+test("parseZaiApiResponse does not alias a lone weekly window as both daily and weekly", async () => {
+  // Only a 7-day window is present, no daily entry. The daily slot falls back to
+  // it, but it must not also be surfaced as the weekly limit (duplicate data).
+  const { usage } = parseZaiApiResponse(
+    response([limit({ type: "TOKENS_LIMIT", number: 7, unit: 1, percentage: 25 })]),
+  );
+
+  assert.equal(usage?.tokenLimit?.percentage, 25);
+  assert.equal(usage?.weeklyTokenLimit, null);
+});
+
 test("parseZaiApiResponse falls back to the first entry and a distinct second when no exact daily window matches", async () => {
   // Neither entry matches number===1 && unit===1, so daily falls back to the
   // first entry and weekly to the first entry that is not the daily one.

--- a/extensions/agent-usage/src/zai/parser.test.ts
+++ b/extensions/agent-usage/src/zai/parser.test.ts
@@ -1,0 +1,126 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseZaiApiResponse } from "./parser";
+
+function limit(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "TOKENS_LIMIT",
+    unit: 1,
+    number: 1,
+    usage: 10,
+    currentValue: 10,
+    remaining: 90,
+    percentage: 10,
+    usageDetails: [],
+    nextResetTime: null,
+    ...overrides,
+  };
+}
+
+function response(limits: unknown[], dataOverrides: Record<string, unknown> = {}) {
+  return { code: 200, msg: "ok", success: true, data: { limits, ...dataOverrides } };
+}
+
+test("parseZaiApiResponse splits daily and weekly token/time limits by window", async () => {
+  const { usage, error } = parseZaiApiResponse(
+    response([
+      limit({ type: "TOKENS_LIMIT", number: 1, unit: 1, percentage: 10 }),
+      limit({ type: "TOKENS_LIMIT", number: 7, unit: 1, percentage: 25 }),
+      limit({ type: "TIME_LIMIT", number: 1, unit: 1, percentage: 30 }),
+      limit({ type: "TIME_LIMIT", number: 7, unit: 1, percentage: 40 }),
+    ]),
+  );
+
+  assert.equal(error, null);
+  assert.equal(usage?.tokenLimit?.windowDescription, "1 days");
+  assert.equal(usage?.tokenLimit?.percentage, 10);
+  assert.equal(usage?.weeklyTokenLimit?.windowDescription, "7 days");
+  assert.equal(usage?.weeklyTokenLimit?.percentage, 25);
+  assert.equal(usage?.timeLimit?.windowDescription, "1 days");
+  assert.equal(usage?.timeLimit?.percentage, 30);
+  assert.equal(usage?.weeklyTimeLimit?.windowDescription, "7 days");
+  assert.equal(usage?.weeklyTimeLimit?.percentage, 40);
+});
+
+test("parseZaiApiResponse classifies by window regardless of array order", async () => {
+  const { usage } = parseZaiApiResponse(
+    response([
+      limit({ type: "TOKENS_LIMIT", number: 7, unit: 1, percentage: 25 }),
+      limit({ type: "TOKENS_LIMIT", number: 1, unit: 1, percentage: 10 }),
+    ]),
+  );
+
+  assert.equal(usage?.tokenLimit?.percentage, 10);
+  assert.equal(usage?.weeklyTokenLimit?.percentage, 25);
+});
+
+test("parseZaiApiResponse leaves weekly limits null when only a daily window is present", async () => {
+  const { usage } = parseZaiApiResponse(
+    response([
+      limit({ type: "TOKENS_LIMIT", number: 1, unit: 1 }),
+      limit({ type: "TIME_LIMIT", number: 1, unit: 1 }),
+    ]),
+  );
+
+  assert.ok(usage?.tokenLimit);
+  assert.equal(usage?.weeklyTokenLimit, null);
+  assert.ok(usage?.timeLimit);
+  assert.equal(usage?.weeklyTimeLimit, null);
+});
+
+test("parseZaiApiResponse falls back to the first entry and a distinct second when no exact daily window matches", async () => {
+  // Neither entry matches number===1 && unit===1, so daily falls back to the
+  // first entry and weekly to the first entry that is not the daily one.
+  const { usage } = parseZaiApiResponse(
+    response([
+      limit({ type: "TOKENS_LIMIT", number: 3, unit: 3, percentage: 11 }),
+      limit({ type: "TOKENS_LIMIT", number: 30, unit: 1, percentage: 22 }),
+    ]),
+  );
+
+  assert.equal(usage?.tokenLimit?.percentage, 11);
+  assert.equal(usage?.weeklyTokenLimit?.percentage, 22);
+});
+
+test("parseZaiApiResponse maps usage details and reset time", async () => {
+  const resetMs = Date.UTC(2026, 0, 1, 0, 0, 0);
+  const { usage } = parseZaiApiResponse(
+    response([
+      limit({
+        type: "TOKENS_LIMIT",
+        number: 1,
+        unit: 1,
+        nextResetTime: resetMs,
+        usageDetails: [{ modelCode: "glm-4.6", usage: 42 }],
+      }),
+    ]),
+  );
+
+  assert.equal(usage?.tokenLimit?.resetTime, new Date(resetMs).toISOString());
+  assert.deepEqual(usage?.tokenLimit?.usageDetails, [{ modelCode: "glm-4.6", usage: 42 }]);
+});
+
+test("parseZaiApiResponse reads plan name from any of the supported fields", async () => {
+  const fromPlan = parseZaiApiResponse(response([limit()], { plan: "Pro" }));
+  assert.equal(fromPlan.usage?.planName, "Pro");
+
+  const fromPackage = parseZaiApiResponse(response([limit()], { packageName: "Lite" }));
+  assert.equal(fromPackage.usage?.planName, "Lite");
+
+  const none = parseZaiApiResponse(response([limit()]));
+  assert.equal(none.usage?.planName, null);
+});
+
+test("parseZaiApiResponse returns api_error when the response is unsuccessful", async () => {
+  const { usage, error } = parseZaiApiResponse({ code: 401, msg: "unauthorized", success: false });
+  assert.equal(usage, null);
+  assert.equal(error?.type, "api_error");
+  assert.equal(error?.message, "unauthorized");
+});
+
+test("parseZaiApiResponse returns parse_error for malformed or missing data", async () => {
+  assert.equal(parseZaiApiResponse(null).error?.type, "parse_error");
+  assert.equal(parseZaiApiResponse("not an object").error?.type, "parse_error");
+  assert.equal(parseZaiApiResponse(response(undefined as unknown as unknown[])).error?.type, "parse_error");
+});

--- a/extensions/agent-usage/src/zai/parser.ts
+++ b/extensions/agent-usage/src/zai/parser.ts
@@ -1,0 +1,122 @@
+import { ZaiUsage, ZaiError, ZaiLimitEntry, ZaiUsageDetail } from "./types";
+
+const ZAI_UNIT_DAYS = 1;
+const ZAI_WINDOW_DAILY = 1;
+const ZAI_WINDOW_WEEKLY = 7;
+
+interface ZaiApiLimitEntry {
+  type: string;
+  unit: number;
+  number: number;
+  usage: number | null;
+  currentValue: number | null;
+  remaining: number | null;
+  percentage: number;
+  usageDetails?: Array<{ modelCode: string; usage: number }> | null;
+  nextResetTime: number | null;
+}
+
+interface ZaiApiResponse {
+  code: number;
+  msg: string;
+  success: boolean;
+  data?: {
+    limits?: ZaiApiLimitEntry[];
+    planName?: string;
+    plan?: string;
+    plan_type?: string;
+    packageName?: string;
+  };
+}
+
+function unitToLabel(unit: number): string {
+  switch (unit) {
+    case 1:
+      return "days";
+    case 3:
+      return "hours";
+    case 5:
+      return "minutes";
+    default:
+      return "units";
+  }
+}
+
+function buildWindowDescription(unit: number, num: number): string {
+  return `${num} ${unitToLabel(unit)}`;
+}
+
+function parseLimitEntry(entry: ZaiApiLimitEntry): ZaiLimitEntry {
+  const usageDetails: ZaiUsageDetail[] = (entry.usageDetails ?? []).map((d) => ({
+    modelCode: d.modelCode,
+    usage: d.usage,
+  }));
+
+  const resetTime = entry.nextResetTime != null ? new Date(entry.nextResetTime).toISOString() : null;
+
+  return {
+    type: entry.type as "TOKENS_LIMIT" | "TIME_LIMIT",
+    windowDescription: buildWindowDescription(entry.unit, entry.number),
+    usage: entry.usage ?? null,
+    currentValue: entry.currentValue ?? null,
+    remaining: entry.remaining ?? null,
+    percentage: entry.percentage,
+    usageDetails,
+    resetTime,
+  };
+}
+
+export function parseZaiApiResponse(data: unknown): { usage: ZaiUsage | null; error: ZaiError | null } {
+  try {
+    if (!data || typeof data !== "object") {
+      return { usage: null, error: { type: "parse_error", message: "Invalid API response format" } };
+    }
+
+    const response = data as ZaiApiResponse;
+
+    if (response.success !== true || response.code !== 200) {
+      return { usage: null, error: { type: "api_error", message: response.msg || "API returned an error" } };
+    }
+
+    const limits = response.data?.limits;
+
+    if (!limits || !Array.isArray(limits)) {
+      return { usage: null, error: { type: "parse_error", message: "No limits data found in API response" } };
+    }
+
+    const tokenLimits = limits.filter((l) => l.type === "TOKENS_LIMIT");
+    const timeLimits = limits.filter((l) => l.type === "TIME_LIMIT");
+
+    const tokenEntry =
+      tokenLimits.find((l) => l.number === ZAI_WINDOW_DAILY && l.unit === ZAI_UNIT_DAYS) ?? tokenLimits[0] ?? null;
+    const weeklyTokenEntry =
+      tokenLimits.find((l) => l.number === ZAI_WINDOW_WEEKLY && l.unit === ZAI_UNIT_DAYS) ??
+      tokenLimits.find((l) => l !== tokenEntry) ??
+      null;
+
+    const timeEntry =
+      timeLimits.find((l) => l.number === ZAI_WINDOW_DAILY && l.unit === ZAI_UNIT_DAYS) ?? timeLimits[0] ?? null;
+    const weeklyTimeEntry =
+      timeLimits.find((l) => l.number === ZAI_WINDOW_WEEKLY && l.unit === ZAI_UNIT_DAYS) ??
+      timeLimits.find((l) => l !== timeEntry) ??
+      null;
+
+    const planName =
+      response.data?.planName ?? response.data?.plan ?? response.data?.plan_type ?? response.data?.packageName ?? null;
+
+    const usage: ZaiUsage = {
+      tokenLimit: tokenEntry ? parseLimitEntry(tokenEntry) : null,
+      weeklyTokenLimit: weeklyTokenEntry ? parseLimitEntry(weeklyTokenEntry) : null,
+      timeLimit: timeEntry ? parseLimitEntry(timeEntry) : null,
+      weeklyTimeLimit: weeklyTimeEntry ? parseLimitEntry(weeklyTimeEntry) : null,
+      planName,
+    };
+
+    return { usage, error: null };
+  } catch (error) {
+    return {
+      usage: null,
+      error: { type: "parse_error", message: error instanceof Error ? error.message : "Failed to parse API response" },
+    };
+  }
+}

--- a/extensions/agent-usage/src/zai/parser.ts
+++ b/extensions/agent-usage/src/zai/parser.ts
@@ -66,6 +66,21 @@ function parseLimitEntry(entry: ZaiApiLimitEntry): ZaiLimitEntry {
   };
 }
 
+function selectDailyAndWeekly(entries: ZaiApiLimitEntry[]): {
+  daily: ZaiApiLimitEntry | null;
+  weekly: ZaiApiLimitEntry | null;
+} {
+  const daily = entries.find((l) => l.number === ZAI_WINDOW_DAILY && l.unit === ZAI_UNIT_DAYS) ?? entries[0] ?? null;
+  const weeklyCandidate =
+    entries.find((l) => l.number === ZAI_WINDOW_WEEKLY && l.unit === ZAI_UNIT_DAYS) ??
+    entries.find((l) => l !== daily) ??
+    null;
+  // A single 7-day-only response makes both finds resolve to the same object;
+  // don't surface the daily entry a second time as the weekly one.
+  const weekly = weeklyCandidate !== daily ? weeklyCandidate : null;
+  return { daily, weekly };
+}
+
 export function parseZaiApiResponse(data: unknown): { usage: ZaiUsage | null; error: ZaiError | null } {
   try {
     if (!data || typeof data !== "object") {
@@ -87,19 +102,8 @@ export function parseZaiApiResponse(data: unknown): { usage: ZaiUsage | null; er
     const tokenLimits = limits.filter((l) => l.type === "TOKENS_LIMIT");
     const timeLimits = limits.filter((l) => l.type === "TIME_LIMIT");
 
-    const tokenEntry =
-      tokenLimits.find((l) => l.number === ZAI_WINDOW_DAILY && l.unit === ZAI_UNIT_DAYS) ?? tokenLimits[0] ?? null;
-    const weeklyTokenEntry =
-      tokenLimits.find((l) => l.number === ZAI_WINDOW_WEEKLY && l.unit === ZAI_UNIT_DAYS) ??
-      tokenLimits.find((l) => l !== tokenEntry) ??
-      null;
-
-    const timeEntry =
-      timeLimits.find((l) => l.number === ZAI_WINDOW_DAILY && l.unit === ZAI_UNIT_DAYS) ?? timeLimits[0] ?? null;
-    const weeklyTimeEntry =
-      timeLimits.find((l) => l.number === ZAI_WINDOW_WEEKLY && l.unit === ZAI_UNIT_DAYS) ??
-      timeLimits.find((l) => l !== timeEntry) ??
-      null;
+    const { daily: tokenEntry, weekly: weeklyTokenEntry } = selectDailyAndWeekly(tokenLimits);
+    const { daily: timeEntry, weekly: weeklyTimeEntry } = selectDailyAndWeekly(timeLimits);
 
     const planName =
       response.data?.planName ?? response.data?.plan ?? response.data?.plan_type ?? response.data?.packageName ?? null;

--- a/extensions/agent-usage/src/zai/renderer.tsx
+++ b/extensions/agent-usage/src/zai/renderer.tsx
@@ -52,71 +52,35 @@ export function formatZaiUsageText(usage: ZaiUsage | null, error: ZaiError | nul
   if (fallback !== null) return fallback;
   const u = usage as ZaiUsage;
 
+  function formatLimitText(label: string, perModelLabel: string, entry: ZaiLimitEntry | null): string {
+    if (!entry) return "";
+
+    let limitText = `\n\n${label} (${entry.windowDescription}): ${formatRemainingText(entry)}`;
+    limitText += `\n${formatRemainingPercent(entry)}`;
+    limitText += `\n${generateAsciiBar(getRemainingNumericPercent(entry) ?? 0, ZAI_ASCII_BAR_WIDTH)}`;
+    if (entry.resetTime) {
+      limitText += `\nResets In: ${formatResetTime(entry.resetTime)}`;
+    }
+    if (entry.usageDetails.length > 0) {
+      limitText += `\n\n${perModelLabel}:`;
+      for (const detail of entry.usageDetails) {
+        limitText += `\n  ${detail.modelCode}: ${detail.usage}`;
+      }
+    }
+
+    return limitText;
+  }
+
   let text = "z.ai Usage";
 
   if (u.planName) {
     text += `\nPlan: ${u.planName}`;
   }
 
-  if (u.tokenLimit) {
-    text += `\n\nToken Limit (${u.tokenLimit.windowDescription}): ${formatRemainingText(u.tokenLimit)}`;
-    text += `\n${formatRemainingPercent(u.tokenLimit)}`;
-    text += `\n${generateAsciiBar(getRemainingNumericPercent(u.tokenLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)}`;
-    if (u.tokenLimit.resetTime) {
-      text += `\nResets In: ${formatResetTime(u.tokenLimit.resetTime)}`;
-    }
-    if (u.tokenLimit.usageDetails.length > 0) {
-      text += "\n\nPer-Model Usage:";
-      for (const detail of u.tokenLimit.usageDetails) {
-        text += `\n  ${detail.modelCode}: ${detail.usage}`;
-      }
-    }
-  }
-
-  if (u.weeklyTokenLimit) {
-    text += `\n\nWeekly Tokens (${u.weeklyTokenLimit.windowDescription}): ${formatRemainingText(u.weeklyTokenLimit)}`;
-    text += `\n${formatRemainingPercent(u.weeklyTokenLimit)}`;
-    text += `\n${generateAsciiBar(getRemainingNumericPercent(u.weeklyTokenLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)}`;
-    if (u.weeklyTokenLimit.resetTime) {
-      text += `\nResets In: ${formatResetTime(u.weeklyTokenLimit.resetTime)}`;
-    }
-    if (u.weeklyTokenLimit.usageDetails.length > 0) {
-      text += "\n\nWeekly Per-Model Usage:";
-      for (const detail of u.weeklyTokenLimit.usageDetails) {
-        text += `\n  ${detail.modelCode}: ${detail.usage}`;
-      }
-    }
-  }
-
-  if (u.timeLimit) {
-    text += `\n\nTime Limit (${u.timeLimit.windowDescription}): ${formatRemainingText(u.timeLimit)}`;
-    text += `\n${formatRemainingPercent(u.timeLimit)}`;
-    text += `\n${generateAsciiBar(getRemainingNumericPercent(u.timeLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)}`;
-    if (u.timeLimit.resetTime) {
-      text += `\nResets In: ${formatResetTime(u.timeLimit.resetTime)}`;
-    }
-    if (u.timeLimit.usageDetails.length > 0) {
-      text += "\n\nPer-Model Usage:";
-      for (const detail of u.timeLimit.usageDetails) {
-        text += `\n  ${detail.modelCode}: ${detail.usage}`;
-      }
-    }
-  }
-
-  if (u.weeklyTimeLimit) {
-    text += `\n\nWeekly Time (${u.weeklyTimeLimit.windowDescription}): ${formatRemainingText(u.weeklyTimeLimit)}`;
-    text += `\n${formatRemainingPercent(u.weeklyTimeLimit)}`;
-    text += `\n${generateAsciiBar(getRemainingNumericPercent(u.weeklyTimeLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)}`;
-    if (u.weeklyTimeLimit.resetTime) {
-      text += `\nResets In: ${formatResetTime(u.weeklyTimeLimit.resetTime)}`;
-    }
-    if (u.weeklyTimeLimit.usageDetails.length > 0) {
-      text += "\n\nWeekly Per-Model Usage:";
-      for (const detail of u.weeklyTimeLimit.usageDetails) {
-        text += `\n  ${detail.modelCode}: ${detail.usage}`;
-      }
-    }
-  }
+  text += formatLimitText("Token Limit", "Per-Model Usage", u.tokenLimit);
+  text += formatLimitText("Weekly Tokens", "Weekly Per-Model Usage", u.weeklyTokenLimit);
+  text += formatLimitText("Time Limit", "Per-Model Usage", u.timeLimit);
+  text += formatLimitText("Weekly Time", "Weekly Per-Model Usage", u.weeklyTimeLimit);
 
   return text;
 }
@@ -126,89 +90,43 @@ export function renderZaiDetail(usage: ZaiUsage | null, error: ZaiError | null):
   if (fallback !== null) return fallback;
   const u = usage as ZaiUsage;
 
+  function renderLimitMetadata(
+    label: string,
+    entry: ZaiLimitEntry,
+    leadingSeparator: boolean | string | null,
+  ): React.ReactNode {
+    return (
+      <>
+        {leadingSeparator && <List.Item.Detail.Metadata.Separator />}
+        <List.Item.Detail.Metadata.Label
+          title={`${label} (${entry.windowDescription})`}
+          text={`${generateAsciiBar(getRemainingNumericPercent(entry) ?? 0, ZAI_ASCII_BAR_WIDTH)} ${formatRemainingText(entry)} remaining`}
+        />
+        {entry.resetTime && (
+          <List.Item.Detail.Metadata.Label title="Resets In" text={formatResetTime(entry.resetTime)} />
+        )}
+        {entry.usageDetails.map((detail) => (
+          <List.Item.Detail.Metadata.Label
+            key={detail.modelCode}
+            title={`  ${detail.modelCode}`}
+            text={`${detail.usage}`}
+          />
+        ))}
+      </>
+    );
+  }
+
   return (
     <List.Item.Detail.Metadata>
       {u.planName && <List.Item.Detail.Metadata.Label title="Plan" text={u.planName} />}
 
-      {u.tokenLimit && (
-        <>
-          {u.planName && <List.Item.Detail.Metadata.Separator />}
-          <List.Item.Detail.Metadata.Label
-            title={`Token Limit (${u.tokenLimit.windowDescription})`}
-            text={`${generateAsciiBar(getRemainingNumericPercent(u.tokenLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)} ${formatRemainingText(u.tokenLimit)} remaining`}
-          />
-          {u.tokenLimit.resetTime && (
-            <List.Item.Detail.Metadata.Label title="Resets In" text={formatResetTime(u.tokenLimit.resetTime)} />
-          )}
-          {u.tokenLimit.usageDetails.map((detail) => (
-            <List.Item.Detail.Metadata.Label
-              key={detail.modelCode}
-              title={`  ${detail.modelCode}`}
-              text={`${detail.usage}`}
-            />
-          ))}
-        </>
-      )}
+      {u.tokenLimit && renderLimitMetadata("Token Limit", u.tokenLimit, u.planName)}
 
-      {u.weeklyTokenLimit && (
-        <>
-          <List.Item.Detail.Metadata.Separator />
-          <List.Item.Detail.Metadata.Label
-            title={`Weekly Token Limit (${u.weeklyTokenLimit.windowDescription})`}
-            text={`${generateAsciiBar(getRemainingNumericPercent(u.weeklyTokenLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)} ${formatRemainingText(u.weeklyTokenLimit)} remaining`}
-          />
-          {u.weeklyTokenLimit.resetTime && (
-            <List.Item.Detail.Metadata.Label title="Resets In" text={formatResetTime(u.weeklyTokenLimit.resetTime)} />
-          )}
-          {u.weeklyTokenLimit.usageDetails.map((detail) => (
-            <List.Item.Detail.Metadata.Label
-              key={detail.modelCode}
-              title={`  ${detail.modelCode}`}
-              text={`${detail.usage}`}
-            />
-          ))}
-        </>
-      )}
+      {u.weeklyTokenLimit && renderLimitMetadata("Weekly Token Limit", u.weeklyTokenLimit, true)}
 
-      {u.timeLimit && (
-        <>
-          <List.Item.Detail.Metadata.Separator />
-          <List.Item.Detail.Metadata.Label
-            title={`Time Limit (${u.timeLimit.windowDescription})`}
-            text={`${generateAsciiBar(getRemainingNumericPercent(u.timeLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)} ${formatRemainingText(u.timeLimit)} remaining`}
-          />
-          {u.timeLimit.resetTime && (
-            <List.Item.Detail.Metadata.Label title="Resets In" text={formatResetTime(u.timeLimit.resetTime)} />
-          )}
-          {u.timeLimit.usageDetails.map((detail) => (
-            <List.Item.Detail.Metadata.Label
-              key={detail.modelCode}
-              title={`  ${detail.modelCode}`}
-              text={`${detail.usage}`}
-            />
-          ))}
-        </>
-      )}
+      {u.timeLimit && renderLimitMetadata("Time Limit", u.timeLimit, true)}
 
-      {u.weeklyTimeLimit && (
-        <>
-          <List.Item.Detail.Metadata.Separator />
-          <List.Item.Detail.Metadata.Label
-            title={`Weekly Time Limit (${u.weeklyTimeLimit.windowDescription})`}
-            text={`${generateAsciiBar(getRemainingNumericPercent(u.weeklyTimeLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)} ${formatRemainingText(u.weeklyTimeLimit)} remaining`}
-          />
-          {u.weeklyTimeLimit.resetTime && (
-            <List.Item.Detail.Metadata.Label title="Resets In" text={formatResetTime(u.weeklyTimeLimit.resetTime)} />
-          )}
-          {u.weeklyTimeLimit.usageDetails.map((detail) => (
-            <List.Item.Detail.Metadata.Label
-              key={detail.modelCode}
-              title={`  ${detail.modelCode}`}
-              text={`${detail.usage}`}
-            />
-          ))}
-        </>
-      )}
+      {u.weeklyTimeLimit && renderLimitMetadata("Weekly Time Limit", u.weeklyTimeLimit, true)}
     </List.Item.Detail.Metadata>
   );
 }
@@ -235,34 +153,29 @@ export function getZaiAccessory(usage: ZaiUsage | null, error: ZaiError | null, 
     return getNoDataAccessory();
   }
 
-  const parts: string[] = [];
+  type AccessoryLimit = {
+    label: string;
+    entry: ZaiLimitEntry | null;
+    group: "token" | "time";
+  };
 
-  const tokenPercent = usage.tokenLimit ? getRemainingNumericPercent(usage.tokenLimit) : undefined;
-  const weeklyTokenPercent = usage.weeklyTokenLimit ? getRemainingNumericPercent(usage.weeklyTokenLimit) : undefined;
-  const timePercent = usage.timeLimit ? getRemainingNumericPercent(usage.timeLimit) : undefined;
-  const weeklyTimePercent = usage.weeklyTimeLimit ? getRemainingNumericPercent(usage.weeklyTimeLimit) : undefined;
+  const limits: Array<AccessoryLimit & { percent: number }> = [
+    { label: "Tokens", entry: usage.tokenLimit, group: "token" },
+    { label: "Weekly Tokens", entry: usage.weeklyTokenLimit, group: "token" },
+    { label: "Time", entry: usage.timeLimit, group: "time" },
+    { label: "Weekly Time", entry: usage.weeklyTimeLimit, group: "time" },
+  ]
+    .map((limit) => ({ ...limit, percent: getRemainingNumericPercent(limit.entry) }))
+    .filter((limit): limit is AccessoryLimit & { percent: number } => limit.percent !== undefined);
 
-  if (tokenPercent !== undefined) {
-    parts.push(`Tokens: ${tokenPercent}%`);
-  }
-  if (weeklyTokenPercent !== undefined) {
-    parts.push(`Weekly Tokens: ${weeklyTokenPercent}%`);
-  }
-  if (timePercent !== undefined) {
-    parts.push(`Time: ${timePercent}%`);
-  }
-  if (weeklyTimePercent !== undefined) {
-    parts.push(`Weekly Time: ${weeklyTimePercent}%`);
-  }
+  const parts = limits.map((limit) => `${limit.label}: ${limit.percent}%`);
 
   // Get bottleneck/minimum of all active percentages
-  const activePercents = [tokenPercent, weeklyTokenPercent, timePercent, weeklyTimePercent].filter(
-    (p): p is number => p !== undefined,
-  );
+  const activePercents = limits.map((limit) => limit.percent);
   const numericPercent = activePercents.length > 0 ? Math.min(...activePercents) : undefined;
 
   // The displayed text should also show the bottleneck of tokens (daily vs weekly)
-  const tokenPercents = [tokenPercent, weeklyTokenPercent].filter((p): p is number => p !== undefined);
+  const tokenPercents = limits.filter((limit) => limit.group === "token").map((limit) => limit.percent);
   const minTokenPercent = tokenPercents.length > 0 ? Math.min(...tokenPercents) : undefined;
   const tokenText = minTokenPercent !== undefined ? `${minTokenPercent}%` : "—";
 

--- a/extensions/agent-usage/src/zai/renderer.tsx
+++ b/extensions/agent-usage/src/zai/renderer.tsx
@@ -11,6 +11,8 @@ import {
   generateAsciiBar,
 } from "../agents/ui";
 
+const ZAI_ASCII_BAR_WIDTH = 10;
+
 function getRemainingNumericPercent(entry: ZaiLimitEntry | undefined | null): number | undefined {
   if (!entry) return undefined;
   // API percentage field is "percentage used", so remaining = 100 - percentage
@@ -59,7 +61,7 @@ export function formatZaiUsageText(usage: ZaiUsage | null, error: ZaiError | nul
   if (u.tokenLimit) {
     text += `\n\nToken Limit (${u.tokenLimit.windowDescription}): ${formatRemainingText(u.tokenLimit)}`;
     text += `\n${formatRemainingPercent(u.tokenLimit)}`;
-    text += `\n${generateAsciiBar(getRemainingNumericPercent(u.tokenLimit) ?? 0)}`;
+    text += `\n${generateAsciiBar(getRemainingNumericPercent(u.tokenLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)}`;
     if (u.tokenLimit.resetTime) {
       text += `\nResets In: ${formatResetTime(u.tokenLimit.resetTime)}`;
     }
@@ -71,16 +73,46 @@ export function formatZaiUsageText(usage: ZaiUsage | null, error: ZaiError | nul
     }
   }
 
+  if (u.weeklyTokenLimit) {
+    text += `\n\nWeekly Tokens (${u.weeklyTokenLimit.windowDescription}): ${formatRemainingText(u.weeklyTokenLimit)}`;
+    text += `\n${formatRemainingPercent(u.weeklyTokenLimit)}`;
+    text += `\n${generateAsciiBar(getRemainingNumericPercent(u.weeklyTokenLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)}`;
+    if (u.weeklyTokenLimit.resetTime) {
+      text += `\nResets In: ${formatResetTime(u.weeklyTokenLimit.resetTime)}`;
+    }
+    if (u.weeklyTokenLimit.usageDetails.length > 0) {
+      text += "\n\nWeekly Per-Model Usage:";
+      for (const detail of u.weeklyTokenLimit.usageDetails) {
+        text += `\n  ${detail.modelCode}: ${detail.usage}`;
+      }
+    }
+  }
+
   if (u.timeLimit) {
     text += `\n\nTime Limit (${u.timeLimit.windowDescription}): ${formatRemainingText(u.timeLimit)}`;
     text += `\n${formatRemainingPercent(u.timeLimit)}`;
-    text += `\n${generateAsciiBar(getRemainingNumericPercent(u.timeLimit) ?? 0)}`;
+    text += `\n${generateAsciiBar(getRemainingNumericPercent(u.timeLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)}`;
     if (u.timeLimit.resetTime) {
       text += `\nResets In: ${formatResetTime(u.timeLimit.resetTime)}`;
     }
     if (u.timeLimit.usageDetails.length > 0) {
       text += "\n\nPer-Model Usage:";
       for (const detail of u.timeLimit.usageDetails) {
+        text += `\n  ${detail.modelCode}: ${detail.usage}`;
+      }
+    }
+  }
+
+  if (u.weeklyTimeLimit) {
+    text += `\n\nWeekly Time (${u.weeklyTimeLimit.windowDescription}): ${formatRemainingText(u.weeklyTimeLimit)}`;
+    text += `\n${formatRemainingPercent(u.weeklyTimeLimit)}`;
+    text += `\n${generateAsciiBar(getRemainingNumericPercent(u.weeklyTimeLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)}`;
+    if (u.weeklyTimeLimit.resetTime) {
+      text += `\nResets In: ${formatResetTime(u.weeklyTimeLimit.resetTime)}`;
+    }
+    if (u.weeklyTimeLimit.usageDetails.length > 0) {
+      text += "\n\nWeekly Per-Model Usage:";
+      for (const detail of u.weeklyTimeLimit.usageDetails) {
         text += `\n  ${detail.modelCode}: ${detail.usage}`;
       }
     }
@@ -103,7 +135,7 @@ export function renderZaiDetail(usage: ZaiUsage | null, error: ZaiError | null):
           {u.planName && <List.Item.Detail.Metadata.Separator />}
           <List.Item.Detail.Metadata.Label
             title={`Token Limit (${u.tokenLimit.windowDescription})`}
-            text={`${generateAsciiBar(getRemainingNumericPercent(u.tokenLimit) ?? 0)} ${formatRemainingText(u.tokenLimit)} remaining`}
+            text={`${generateAsciiBar(getRemainingNumericPercent(u.tokenLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)} ${formatRemainingText(u.tokenLimit)} remaining`}
           />
           {u.tokenLimit.resetTime && (
             <List.Item.Detail.Metadata.Label title="Resets In" text={formatResetTime(u.tokenLimit.resetTime)} />
@@ -118,17 +150,57 @@ export function renderZaiDetail(usage: ZaiUsage | null, error: ZaiError | null):
         </>
       )}
 
+      {u.weeklyTokenLimit && (
+        <>
+          <List.Item.Detail.Metadata.Separator />
+          <List.Item.Detail.Metadata.Label
+            title={`Weekly Token Limit (${u.weeklyTokenLimit.windowDescription})`}
+            text={`${generateAsciiBar(getRemainingNumericPercent(u.weeklyTokenLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)} ${formatRemainingText(u.weeklyTokenLimit)} remaining`}
+          />
+          {u.weeklyTokenLimit.resetTime && (
+            <List.Item.Detail.Metadata.Label title="Resets In" text={formatResetTime(u.weeklyTokenLimit.resetTime)} />
+          )}
+          {u.weeklyTokenLimit.usageDetails.map((detail) => (
+            <List.Item.Detail.Metadata.Label
+              key={detail.modelCode}
+              title={`  ${detail.modelCode}`}
+              text={`${detail.usage}`}
+            />
+          ))}
+        </>
+      )}
+
       {u.timeLimit && (
         <>
           <List.Item.Detail.Metadata.Separator />
           <List.Item.Detail.Metadata.Label
             title={`Time Limit (${u.timeLimit.windowDescription})`}
-            text={`${generateAsciiBar(getRemainingNumericPercent(u.timeLimit) ?? 0)} ${formatRemainingText(u.timeLimit)} remaining`}
+            text={`${generateAsciiBar(getRemainingNumericPercent(u.timeLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)} ${formatRemainingText(u.timeLimit)} remaining`}
           />
           {u.timeLimit.resetTime && (
             <List.Item.Detail.Metadata.Label title="Resets In" text={formatResetTime(u.timeLimit.resetTime)} />
           )}
           {u.timeLimit.usageDetails.map((detail) => (
+            <List.Item.Detail.Metadata.Label
+              key={detail.modelCode}
+              title={`  ${detail.modelCode}`}
+              text={`${detail.usage}`}
+            />
+          ))}
+        </>
+      )}
+
+      {u.weeklyTimeLimit && (
+        <>
+          <List.Item.Detail.Metadata.Separator />
+          <List.Item.Detail.Metadata.Label
+            title={`Weekly Time Limit (${u.weeklyTimeLimit.windowDescription})`}
+            text={`${generateAsciiBar(getRemainingNumericPercent(u.weeklyTimeLimit) ?? 0, ZAI_ASCII_BAR_WIDTH)} ${formatRemainingText(u.weeklyTimeLimit)} remaining`}
+          />
+          {u.weeklyTimeLimit.resetTime && (
+            <List.Item.Detail.Metadata.Label title="Resets In" text={formatResetTime(u.weeklyTimeLimit.resetTime)} />
+          )}
+          {u.weeklyTimeLimit.usageDetails.map((detail) => (
             <List.Item.Detail.Metadata.Label
               key={detail.modelCode}
               title={`  ${detail.modelCode}`}
@@ -165,15 +237,34 @@ export function getZaiAccessory(usage: ZaiUsage | null, error: ZaiError | null, 
 
   const parts: string[] = [];
 
-  if (usage.tokenLimit) {
-    parts.push(`Tokens: ${getRemainingNumericPercent(usage.tokenLimit) ?? 0}%`);
+  const tokenPercent = usage.tokenLimit ? getRemainingNumericPercent(usage.tokenLimit) : undefined;
+  const weeklyTokenPercent = usage.weeklyTokenLimit ? getRemainingNumericPercent(usage.weeklyTokenLimit) : undefined;
+  const timePercent = usage.timeLimit ? getRemainingNumericPercent(usage.timeLimit) : undefined;
+  const weeklyTimePercent = usage.weeklyTimeLimit ? getRemainingNumericPercent(usage.weeklyTimeLimit) : undefined;
+
+  if (tokenPercent !== undefined) {
+    parts.push(`Tokens: ${tokenPercent}%`);
   }
-  if (usage.timeLimit) {
-    parts.push(`Time: ${getRemainingNumericPercent(usage.timeLimit) ?? 0}%`);
+  if (weeklyTokenPercent !== undefined) {
+    parts.push(`Weekly Tokens: ${weeklyTokenPercent}%`);
+  }
+  if (timePercent !== undefined) {
+    parts.push(`Time: ${timePercent}%`);
+  }
+  if (weeklyTimePercent !== undefined) {
+    parts.push(`Weekly Time: ${weeklyTimePercent}%`);
   }
 
-  const tokenText = usage.tokenLimit ? `${getRemainingNumericPercent(usage.tokenLimit) ?? 0}%` : "—";
-  const numericPercent = getRemainingNumericPercent(usage.tokenLimit ?? usage.timeLimit);
+  // Get bottleneck/minimum of all active percentages
+  const activePercents = [tokenPercent, weeklyTokenPercent, timePercent, weeklyTimePercent].filter(
+    (p): p is number => p !== undefined,
+  );
+  const numericPercent = activePercents.length > 0 ? Math.min(...activePercents) : undefined;
+
+  // The displayed text should also show the bottleneck of tokens (daily vs weekly)
+  const tokenPercents = [tokenPercent, weeklyTokenPercent].filter((p): p is number => p !== undefined);
+  const minTokenPercent = tokenPercents.length > 0 ? Math.min(...tokenPercents) : undefined;
+  const tokenText = minTokenPercent !== undefined ? `${minTokenPercent}%` : "—";
 
   return {
     icon: numericPercent !== undefined ? generatePieIcon(numericPercent) : undefined,

--- a/extensions/agent-usage/src/zai/types.ts
+++ b/extensions/agent-usage/src/zai/types.ts
@@ -16,7 +16,9 @@ export interface ZaiLimitEntry {
 
 export interface ZaiUsage {
   tokenLimit: ZaiLimitEntry | null;
+  weeklyTokenLimit: ZaiLimitEntry | null;
   timeLimit: ZaiLimitEntry | null;
+  weeklyTimeLimit: ZaiLimitEntry | null;
   planName: string | null;
 }
 


### PR DESCRIPTION
## Description

Adds support for Weekly Usage Limits to z.ai inside Agent Usage. This was already in the response, just not parsed.

Related refactors:
- Consolidate rendering code since it was going to be pretty messy to just copy+paste 
- Extract parsing logic, matching other integrations, and add a few basic tests

## Screencast

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/df899503-4fbc-4b9d-9aee-d08eaa076cb4" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
