### PR TITLE
2FAS Authenticator: correct author handle

### DIFF
--- a/extensions/2fas-authenticator/CHANGELOG.md
+++ b/extensions/2fas-authenticator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Fix Author Attribution] - {PR_MERGE_DATE}
+
+- Correct the extension author handle so it is credited to the right Raycast account
+
 ## [Initial Version] - 2026-06-30
 
 ### Commands

--- a/extensions/2fas-authenticator/CHANGELOG.md
+++ b/extensions/2fas-authenticator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix Author Attribution] - {PR_MERGE_DATE}
+## [Fix Author Attribution] - 2026-07-01
 
 - Correct the extension author handle so it is credited to the right Raycast account
 

--- a/extensions/2fas-authenticator/README.md
+++ b/extensions/2fas-authenticator/README.md
@@ -2,7 +2,7 @@
 
 Search and copy TOTP codes from [2FAS](https://2fas.com) exports directly in Raycast. No cloud, no network calls. Your secrets stay local in a Keychain-encrypted vault.
 
-<a href="https://www.raycast.com/Locke/2fas-authenticator"><img src="https://www.raycast.com/Locke/2fas-authenticator/install_button@2x.png" height="64" alt="Install 2FAS Authenticator" style="height: 64px;" /></a>
+<a href="https://www.raycast.com/Lock/2fas-authenticator"><img src="https://www.raycast.com/Lock/2fas-authenticator/install_button@2x.png" height="64" alt="Install 2FAS Authenticator" style="height: 64px;" /></a>
 
 ## Features
 
@@ -57,31 +57,31 @@ Contributions are welcome. Please open an issue first to discuss what you'd like
 ### Development Setup
 
 ```bash
-# Fork and clone the repo
-git clone https://github.com/<your-username>/raycast-2fas-authenticator.git
+# Clone the repo (this project uses pnpm)
+git clone https://github.com/LockeAG/raycast-2fas-authenticator.git
 cd raycast-2fas-authenticator
 
 # Install dependencies
-npm install
+pnpm install
 
 # Start development mode (opens in Raycast)
-npm run dev
+pnpm dev
 
 # Build
-npm run build
+pnpm build
 
 # Lint
-npm run lint
+pnpm lint
 
 # Fix lint issues
-npm run fix-lint
+pnpm fix-lint
 ```
 
 ### Pull Request Guidelines
 
 1. Fork the repository and create your branch from `main`
 2. If you've added functionality, update the README if needed
-3. Make sure `npm run lint` passes
+3. Make sure `pnpm lint` passes
 4. Keep PRs focused. One feature or fix per PR.
 5. Write a clear description of what your change does and why
 

--- a/extensions/2fas-authenticator/README.md
+++ b/extensions/2fas-authenticator/README.md
@@ -26,24 +26,24 @@ Search and copy TOTP codes from [2FAS](https://2fas.com) exports directly in Ray
 
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| Search OTP | Search all services, copy codes with live countdown |
-| Recent OTP | Access pinned and recently used services |
-| Import Vault | Import a `.2fas` export file |
-| Setup | View vault status and manage configuration |
+| Command      | Description                                         |
+| ------------ | --------------------------------------------------- |
+| Search OTP   | Search all services, copy codes with live countdown |
+| Recent OTP   | Access pinned and recently used services            |
+| Import Vault | Import a `.2fas` export file                        |
+| Setup        | View vault status and manage configuration          |
 
 ## Security Model
 
-| Layer | Detail |
-|-------|--------|
-| Vault key | Random 256-bit key stored in macOS login Keychain via `/usr/bin/security` |
-| Vault file | AES-256-GCM encrypted at `~/Library/Application Support/Raycast/extensions/.../vault.enc` with `0600` permissions |
-| Import | Decrypts `.2fas` in memory (PBKDF2 + AES-256-GCM), re-encrypts into local vault |
-| Secrets at rest | No plaintext secrets on disk. Secrets exist only in memory during runtime |
-| Network | Zero network calls. Everything is offline |
-| Clipboard | Concealed copy. OTP codes are excluded from clipboard history |
-| Dependencies | Zero external crypto dependencies. Node.js `crypto` module only |
+| Layer           | Detail                                                                                                            |
+| --------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Vault key       | Random 256-bit key stored in macOS login Keychain via `/usr/bin/security`                                         |
+| Vault file      | AES-256-GCM encrypted at `~/Library/Application Support/Raycast/extensions/.../vault.enc` with `0600` permissions |
+| Import          | Decrypts `.2fas` in memory (PBKDF2 + AES-256-GCM), re-encrypts into local vault                                   |
+| Secrets at rest | No plaintext secrets on disk. Secrets exist only in memory during runtime                                         |
+| Network         | Zero network calls. Everything is offline                                                                         |
+| Clipboard       | Concealed copy. OTP codes are excluded from clipboard history                                                     |
+| Dependencies    | Zero external crypto dependencies. Node.js `crypto` module only                                                   |
 
 ### Known Limitations
 
@@ -57,37 +57,38 @@ Contributions are welcome. Please open an issue first to discuss what you'd like
 ### Development Setup
 
 ```bash
-# Clone the repo (this project uses pnpm)
+# Clone the repo
 git clone https://github.com/LockeAG/raycast-2fas-authenticator.git
 cd raycast-2fas-authenticator
 
 # Install dependencies
-pnpm install
+npm install
 
 # Start development mode (opens in Raycast)
-pnpm dev
+npm run dev
 
 # Build
-pnpm build
+npm run build
 
 # Lint
-pnpm lint
+npm run lint
 
 # Fix lint issues
-pnpm fix-lint
+npm run fix-lint
 ```
 
 ### Pull Request Guidelines
 
 1. Fork the repository and create your branch from `main`
 2. If you've added functionality, update the README if needed
-3. Make sure `pnpm lint` passes
+3. Make sure `npm run lint` passes
 4. Keep PRs focused. One feature or fix per PR.
 5. Write a clear description of what your change does and why
 
 ### Reporting Bugs
 
 Open an issue with:
+
 - Steps to reproduce
 - Expected vs actual behavior
 - macOS version and Raycast version

--- a/extensions/2fas-authenticator/SECURITY.md
+++ b/extensions/2fas-authenticator/SECURITY.md
@@ -117,7 +117,7 @@ itself, not by this extension. Use a strong export password.
   PBKDF2-SHA256 (10 000 iterations, 32-byte key) per the 2FAS
   export schema.
 - **Service IDs:** SHA-256 of `issuer + "\0" + account + "\0" +
-  secret`, truncated to 32 hex chars. IDs are stored only inside
+secret`, truncated to 32 hex chars. IDs are stored only inside
   the encrypted vault and in Raycast's `LocalStorage` for recents;
   the secret itself never leaves the encrypted vault.
 

--- a/extensions/2fas-authenticator/package.json
+++ b/extensions/2fas-authenticator/package.json
@@ -4,7 +4,7 @@
   "title": "2FAS Authenticator",
   "description": "Search and copy TOTP codes from 2FAS exports with a Keychain-encrypted local vault",
   "icon": "extension-icon.png",
-  "author": "Locke",
+  "author": "Lock",
   "categories": [
     "Security"
   ],


### PR DESCRIPTION
This corrects the `author` field for the 2FAS Authenticator extension.

The extension was merged in #27908 with `author: "Locke"`, but `Locke` is a different, pre-existing Raycast user. My account is `Lock` (https://www.raycast.com/Lock), so the extension is currently attributed to the wrong person on the store. Every commit in #27908 is authored by me (GitHub `LockeAG`); this only fixes the handle so the extension is credited correctly.

Changes:
- `package.json`: `author` `Locke` -> `Lock`
- `README.md`: store install badge URL updated to `/Lock/`
- `README.md`: development setup referenced the wrong package manager (`npm`), which fails because the source repo enforces pnpm via an `only-allow pnpm` preinstall hook. Switched the documented commands to pnpm and pointed the clone URL at the actual repo.

No functional or code changes.