### PR TITLE
Fix live formula preview in Quick LaTeX

### DIFF
--- a/extensions/quick-latex/CHANGELOG.md
+++ b/extensions/quick-latex/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Quick LaTeX Changelog
 
+## [Fix live formula preview] - {PR_MERGE_DATE}
+
+- Open the command directly so formulas can be entered and previewed before copying
+- Render the preview continuously while typing in light and dark mode
+
 ## [Improve preview sizing] - 2026-06-24
 
 - Automatically scale LaTeX previews to fit within the Raycast window

--- a/extensions/quick-latex/README.md
+++ b/extensions/quick-latex/README.md
@@ -3,9 +3,8 @@
 Converts LaTeX text to image. Copy the image to the Clipboard.
 
 ## Usage
-    
-    Write some LaTeX text in the text box.
-    Press Enter or click the "Copy LaTeX image to Clipboard" button.
-    Paste the image into your document.
 
-    
+1. Open Quick LaTeX and type a formula into the search field.
+2. Check the preview as it updates while you type.
+3. Press Enter to copy the image to the Clipboard.
+4. Paste the image into your document.

--- a/extensions/quick-latex/package.json
+++ b/extensions/quick-latex/package.json
@@ -6,7 +6,8 @@
   "icon": "bird.png",
   "author": "Noamko",
   "contributors": [
-    "FariaF22"
+    "FariaF22",
+    "aleksei_chebotarev"
   ],
   "categories": [
     "Design Tools",
@@ -56,14 +57,6 @@
           "type": "textfield",
           "default": "0 0 50 50",
           "required": false
-        }
-      ],
-      "arguments": [
-        {
-          "name": "latex",
-          "type": "text",
-          "required": false,
-          "placeholder": "LaTeX"
         }
       ]
     }

--- a/extensions/quick-latex/src/api.tsx
+++ b/extensions/quick-latex/src/api.tsx
@@ -1,10 +1,8 @@
 import { getPreferenceValues, showHUD } from "@raycast/api";
 import { BASE_URL, DISPLAY_LATEX_URL, DOWNLOAD_DIR, ExportType, QuickLatexPreferences } from "./utils";
 import { parse, stringify } from "svgson";
-import fetch, { RequestInit } from "node-fetch";
+import fetch from "node-fetch";
 import fs from "fs";
-
-export type PreviewAbortSignal = NonNullable<RequestInit["signal"]>;
 
 async function editSVG(text: string) {
   const preferences = getPreferenceValues<QuickLatexPreferences>();
@@ -50,45 +48,12 @@ export async function downloadLatex(exportType: ExportType, searchText: string) 
 }
 
 export function getDisplayLatex(searchText: string) {
-  return {
-    source: {
-      light: DISPLAY_LATEX_URL + encodeURIComponent(searchText),
-      dark: DISPLAY_LATEX_URL + encodeURIComponent(`{\\color{White} ${searchText}}`),
-    },
-  };
-}
-
-export async function getPreviewImage(searchText: string, signal?: PreviewAbortSignal) {
   const latex = searchText === "" ? "LaTeX" : searchText;
-  const res = await fetch(getPreviewUrl(latex), { signal });
-
-  if (!res.ok) {
-    throw new Error("Failed to fetch preview SVG");
-  }
-
-  const lightSvg = await res.text();
-  const darkSvgNode = await parse(lightSvg);
-  darkSvgNode.attributes.fill = "white";
-  darkSvgNode.attributes.style = [darkSvgNode.attributes.style, "color:white;fill:white"].filter(Boolean).join(";");
-  const darkSvg = stringify(darkSvgNode);
 
   return {
     source: {
-      light: createPreviewCanvas(lightSvg),
-      dark: createPreviewCanvas(darkSvg),
+      light: DISPLAY_LATEX_URL + encodeURIComponent(latex),
+      dark: DISPLAY_LATEX_URL + encodeURIComponent(`{\\color{White} ${latex}}`),
     },
   };
-}
-
-function getPreviewUrl(latex: string) {
-  return BASE_URL + "svg.image?" + encodeURIComponent(latex);
-}
-
-function createPreviewCanvas(svg: string) {
-  const embeddedSvg = Buffer.from(svg).toString("base64");
-  const canvas = `<svg xmlns="http://www.w3.org/2000/svg" width="640px" height="280px" viewBox="0 0 640 280">
-    <image x="32" y="24" width="576" height="232" preserveAspectRatio="xMidYMid meet" href="data:image/svg+xml;base64,${embeddedSvg}" />
-  </svg>`;
-
-  return `data:image/svg+xml;utf8,${encodeURIComponent(canvas)}`;
 }

--- a/extensions/quick-latex/src/quick-latex.tsx
+++ b/extensions/quick-latex/src/quick-latex.tsx
@@ -1,50 +1,20 @@
-import { Action, ActionPanel, Image, LaunchProps, List, popToRoot, showHUD } from "@raycast/api";
+import { Action, ActionPanel, List, popToRoot, showHUD } from "@raycast/api";
 import { useEffect, useState } from "react";
 
-import { downloadLatex, getPreviewImage, PreviewAbortSignal } from "./api";
-import { ExportType, QuickLatexArguments, makeDonwloadDir, toClipboard } from "./utils";
+import { downloadLatex, getDisplayLatex } from "./api";
+import { ExportType, makeDonwloadDir, toClipboard } from "./utils";
 
-export default function CommandWithCustoEmptyView(props: LaunchProps<{ arguments: QuickLatexArguments }>) {
-  const [searchText, setSearchText] = useState(props.arguments.latex ?? "");
-  const [previewImage, setPreviewImage] = useState<Image.ImageLike>();
-  const [isLoading, setIsLoading] = useState(true);
+export default function QuickLatexCommand() {
+  const [searchText, setSearchText] = useState("");
 
   useEffect(() => {
     makeDonwloadDir();
   }, []);
 
-  useEffect(() => {
-    let isCurrent = true;
-    const abortController = new AbortController();
-    setIsLoading(true);
-
-    const timeout = setTimeout(() => {
-      getPreviewImage(searchText, abortController.signal as PreviewAbortSignal)
-        .then((image) => {
-          if (isCurrent) {
-            setPreviewImage(image);
-            setIsLoading(false);
-          }
-        })
-        .catch((error: unknown) => {
-          if (isCurrent && !(error instanceof Error && error.name === "AbortError")) {
-            setPreviewImage(undefined);
-            setIsLoading(false);
-          }
-        });
-    }, 200);
-
-    return () => {
-      isCurrent = false;
-      clearTimeout(timeout);
-      abortController.abort();
-    };
-  }, [searchText]);
-
   return (
-    <List isLoading={isLoading} onSearchTextChange={setSearchText} searchText={searchText}>
+    <List onSearchTextChange={setSearchText} searchBarPlaceholder="Type a LaTeX formula…" searchText={searchText}>
       <List.EmptyView
-        icon={previewImage}
+        icon={getDisplayLatex(searchText)}
         actions={
           <ActionPanel>
             {Object.values(ExportType).map((exportType) => (

--- a/extensions/quick-latex/src/utils.tsx
+++ b/extensions/quick-latex/src/utils.tsx
@@ -10,13 +10,6 @@ export enum ExportType {
   EMF = "emf",
 }
 
-enum DownloadFormat {
-  IMAGE = "image",
-  JSON = "json",
-  JS = "javascript",
-  DOWNLOAD = "download",
-}
-
 export const DOWNLOAD_DIR = resolve(environment.supportPath, "download");
 
 export const BASE_URL = "https://latex.codecogs.com/";
@@ -36,10 +29,6 @@ export interface QuickLatexPreferences {
   svgHeight: string;
   svgViewbox: string;
   background: string;
-}
-
-export interface QuickLatexArguments {
-  latex: string | undefined;
 }
 
 export async function toClipboard(file: string) {


### PR DESCRIPTION
## Description

- Open Quick LaTeX directly into its input so formulas can be previewed before copying.
- Replace the unsupported generated SVG data URI with the existing theme-aware CodeCogs PNG source.
- Keep the preview synchronized with the search text in light and dark mode.
- Update the usage documentation and changelog.

## Validation

- `ray lint`
- `ray build -e dist`
- Verified the preview endpoint returns a valid PNG for `a^2`.

## Checklist

- [x] I read the extension guidelines.
- [x] I read the documentation about publishing.
- [x] I ran the extension lint and production build checks.
- [x] I checked that files in the `assets` folder are used by the extension itself.
- [x] I checked that assets used by the README are placed outside of the `metadata` folder.