### PR TITLE
Update gif-search extension

### DIFF
--- a/extensions/gif-search/CHANGELOG.md
+++ b/extensions/gif-search/CHANGELOG.md
@@ -1,5 +1,12 @@
 # GIF Search Changelog
 
+## [Klipy API proxy & copy shortcut fix] - {PR_MERGE_DATE}
+
+- Klipy now routes requests through Raycast's API proxy, removing the need for a personal API key
+- Removed the Klipy API Key preference field
+- Fixed GIF favorites loading for Klipy (individual GIF lookup now works)
+- Use `Keyboard.Shortcut.Common.Copy` for the "Copy Page Link" action shortcut
+
 ## [Remove Tenor support] - 2026-06-30
 
 - Removed Tenor from the GIF provider dropdown, preferences, API integration, URL detection, and extension metadata

--- a/extensions/gif-search/CHANGELOG.md
+++ b/extensions/gif-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GIF Search Changelog
 
-## [Klipy API proxy & copy shortcut fix] - {PR_MERGE_DATE}
+## [Klipy API proxy & copy shortcut fix] - 2026-07-01
 
 - Klipy now routes requests through Raycast's API proxy, removing the need for a personal API key
 - Removed the Klipy API Key preference field

--- a/extensions/gif-search/package-lock.json
+++ b/extensions/gif-search/package-lock.json
@@ -1314,6 +1314,7 @@
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1372,6 +1373,7 @@
       "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.1",
         "@typescript-eslint/types": "8.62.1",
@@ -1576,6 +1578,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2046,6 +2049,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3086,6 +3090,7 @@
       "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3388,6 +3393,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3451,6 +3457,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/gif-search/package.json
+++ b/extensions/gif-search/package.json
@@ -19,7 +19,8 @@
     "YourMCGeek",
     "thomas",
     "tim_gailey",
-    "clins1994"
+    "clins1994",
+    "0xdhrv"
   ],
   "license": "MIT",
   "categories": [
@@ -323,13 +324,6 @@
           "value": "uk"
         }
       ]
-    },
-    {
-      "name": "klipyApiKey",
-      "type": "password",
-      "required": false,
-      "title": "Klipy API Key",
-      "description": "API key for Klipy service. Get your key at partner.klipy.com"
     },
     {
       "name": "klipyLocale",

--- a/extensions/gif-search/src/components/GifActions.tsx
+++ b/extensions/gif-search/src/components/GifActions.tsx
@@ -9,6 +9,7 @@ import {
   open,
   closeMainWindow,
   Clipboard,
+  Keyboard,
 } from "@raycast/api";
 import path from "path";
 
@@ -315,10 +316,7 @@ export function GifActions({ item, showViewDetails, visitGifItem, mutate }: GifA
       key="copyPageUrl"
       title="Copy Page Link"
       content={url}
-      shortcut={{
-        macOS: { modifiers: ["cmd", "shift"], key: "c" },
-        Windows: { modifiers: ["ctrl", "shift"], key: "c" },
-      }}
+      shortcut={Keyboard.Shortcut.Common.Copy}
       onCopy={trackUsage}
     />
   ) : undefined;

--- a/extensions/gif-search/src/models/klipy.ts
+++ b/extensions/gif-search/src/models/klipy.ts
@@ -1,7 +1,7 @@
 import { formatRelative, fromUnixTime } from "date-fns";
 
 import { APIOpt, IGif, IGifAPI, slugify } from "../models/gif";
-import { getKlipyLocale, getKlipyApiKey } from "../preferences";
+import { getKlipyLocale } from "../preferences";
 
 export interface KlipyResults {
   results: KlipyGif[];
@@ -32,70 +32,45 @@ interface KlipyMediaFormat {
   size: number;
 }
 
-const API_BASE_URL = "https://api.klipy.com";
+const API_BASE_URL = "https://extensions-api-proxy.raycast.com/klipy";
+const RAYCAST_HEADERS = { "User-Agent": "Raycast" };
+
+async function fetchKlipy(url: URL): Promise<KlipyResults> {
+  const response = await fetch(url.toString(), { headers: RAYCAST_HEADERS });
+  if (!response.ok) {
+    throw new Error(`Klipy request failed. Status: ${response.status}`);
+  }
+  return response.json() as Promise<KlipyResults>;
+}
 
 export default async function klipy() {
   return <IGifAPI>{
     async search(term: string, opt?: APIOpt) {
-      const apiKey = getKlipyApiKey();
-      if (!apiKey) {
-        throw new Error("Klipy API key is required. Please add it in extension preferences.");
-      }
-
-      const reqUrl = new URL(`${API_BASE_URL}/v2/search`);
+      const reqUrl = new URL(API_BASE_URL);
       reqUrl.searchParams.set("locale", getKlipyLocale());
       reqUrl.searchParams.set("q", term);
       reqUrl.searchParams.set("media_filter", "gif,nanogif,tinygif");
       reqUrl.searchParams.set("limit", opt?.limit?.toString() ?? "10");
-      reqUrl.searchParams.set("key", apiKey);
 
       if (opt?.next) {
         reqUrl.searchParams.set("pos", opt.next);
       }
 
-      const response = await fetch(reqUrl.toString());
-      if (!response.ok) {
-        throw new Error(`Could not search gifs from Klipy. Status: ${response.status}`);
-      }
-
-      const responseText = await response.text();
-      if (!responseText) {
-        throw new Error("Empty response from Klipy API");
-      }
-
-      const results = JSON.parse(responseText) as KlipyResults;
-
+      const results = await fetchKlipy(reqUrl);
       return { results: results.results?.map(mapKlipyResponse) ?? [], next: results.next };
     },
 
     async trending(opt?: APIOpt) {
-      const apiKey = getKlipyApiKey();
-      if (!apiKey) {
-        throw new Error("Klipy API key is required. Please add it in extension preferences.");
-      }
-
-      const reqUrl = new URL(`${API_BASE_URL}/v2/featured`);
+      const reqUrl = new URL(API_BASE_URL);
       reqUrl.searchParams.set("locale", getKlipyLocale());
       reqUrl.searchParams.set("media_filter", "gif,nanogif,tinygif");
       reqUrl.searchParams.set("limit", opt?.limit?.toString() ?? "10");
-      reqUrl.searchParams.set("key", apiKey);
 
       if (opt?.next) {
         reqUrl.searchParams.set("pos", opt.next);
       }
 
-      const response = await fetch(reqUrl.toString());
-      if (!response.ok) {
-        throw new Error(`Could not get trending gifs from Klipy. Status: ${response.status}`);
-      }
-
-      const responseText = await response.text();
-      if (!responseText) {
-        throw new Error("Empty response from Klipy API");
-      }
-
-      const results = JSON.parse(responseText) as KlipyResults;
-
+      const results = await fetchKlipy(reqUrl);
       return { results: results.results?.map(mapKlipyResponse) ?? [], next: results.next };
     },
 
@@ -104,14 +79,11 @@ export default async function klipy() {
         return [];
       }
 
-      const apiKey = getKlipyApiKey();
-      if (!apiKey) {
-        throw new Error("Klipy API key is required. Please add it in extension preferences.");
-      }
+      const reqUrl = new URL(API_BASE_URL);
+      reqUrl.searchParams.set("ids", ids.join(","));
 
-      // Note: Klipy /v2/gifs endpoint currently returns empty responses
-      // GIFs are saved but individual loading requires production access
-      return [];
+      const results = await fetchKlipy(reqUrl);
+      return results.results?.map(mapKlipyResponse) ?? [];
     },
   };
 }

--- a/extensions/gif-search/src/models/klipy.ts
+++ b/extensions/gif-search/src/models/klipy.ts
@@ -32,11 +32,10 @@ interface KlipyMediaFormat {
   size: number;
 }
 
-const API_BASE_URL = "https://extensions-api-proxy.raycast.com/klipy";
-const RAYCAST_HEADERS = { "User-Agent": "Raycast" };
+const API_BASE_URL = "https://gif-search.raycast.com/api/klipy";
 
 async function fetchKlipy(url: URL): Promise<KlipyResults> {
-  const response = await fetch(url.toString(), { headers: RAYCAST_HEADERS });
+  const response = await fetch(url.toString());
   if (!response.ok) {
     throw new Error(`Klipy request failed. Status: ${response.status}`);
   }

--- a/extensions/gif-search/src/preferences.ts
+++ b/extensions/gif-search/src/preferences.ts
@@ -71,7 +71,3 @@ export function getGiphyLocale(): string {
 export function getKlipyLocale(): string {
   return preferences.klipyLocale;
 }
-
-export function getKlipyApiKey(): string | undefined {
-  return preferences.klipyApiKey;
-}


### PR DESCRIPTION
## Description

- Add support for Klipy GIF search

## Screencast

<img width="2000" height="1250" alt="Raycast 2026-07-01 01 39 44" src="https://github.com/user-attachments/assets/dca7c89f-7650-4e71-bd07-888ab4401b52" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
