### PR TITLE
Update Circleback extension

### DIFF
--- a/extensions/circleback/.gitignore
+++ b/extensions/circleback/.gitignore
@@ -1,0 +1,14 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# Raycast specific files
+raycast-env.d.ts
+.raycast-swift-build
+.swiftpm
+compiled_raycast_swift
+compiled_raycast_rust
+
+# misc
+.DS_Store

--- a/extensions/circleback/.prettierrc
+++ b/extensions/circleback/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 120,
+  "singleQuote": false
+}

--- a/extensions/circleback/CHANGELOG.md
+++ b/extensions/circleback/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Circleback Changelog
 
-## [Updated app URL] - {PR_MERGE_DATE}
+## [Updated app URL] - 2026-07-01
 
 - Updated the Circleback app URL from app.circleback.ai to circleback.ai.
 

--- a/extensions/circleback/CHANGELOG.md
+++ b/extensions/circleback/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Circleback Changelog
 
-## [Moved extension to organization] - 2025-09-09
+## [Updated app URL] - {PR_MERGE_DATE}
+
+- Updated the Circleback app URL from app.circleback.ai to circleback.ai.
 
 ## [Initial Version] - 2025-09-09
 

--- a/extensions/circleback/README.md
+++ b/extensions/circleback/README.md
@@ -3,20 +3,24 @@
 Circleback helps teams get the most out of every conversation with best-in-class AI-powered meeting notes, action items, automations, and search. It works with all meeting platforms, including Zoom, Google Meet, Microsoft Teams, and Slack huddles, as well as in-person conversations. This Raycast extension brings Circleback's capabilities directly to your Mac desktop, enabling you to record meetings, access notes, and search conversations seamlessly.
 
 ## Getting Started
+
 To use this extension, ensure the following:
+
 - The [Circleback app](https://circleback.ai/desktop) is installed and running on your computer.
 - You are logged into the Circleback app.
 
 ## Setup Instructions
+
 1. **Install Circleback**: Download and install the Circleback app from [circleback.ai/desktop](https://circleback.ai/desktop).
 2. **Install the Extension**: Add this extension from the Raycast Store.
 3. **Authenticate**: Try opening the "Search meetings" command in Raycast, and follow the prompts to authenticate with your Circleback account.
 
 ## Circleback Commands
+
 - **New Meeting**: Record a new meeting in Circleback.
 - **Open Last Meeting**: Open your most recent meeting in Circleback.
 - **Search Meetings**: Search your meetings in Circleback.
 
-
 ## Support
+
 For issues or feedback, go to [support.circleback.ai](https://support.circleback.ai)

--- a/extensions/circleback/package-lock.json
+++ b/extensions/circleback/package-lock.json
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@raycast/eslint-config": "^2.0.4",
         "@types/node": "22.13.10",
-        "@types/react": "19.0.10",
+        "@types/react": "~19.1.9",
         "eslint": "^9.22.0",
         "prettier": "^3.5.3",
         "typescript": "^5.8.2"
@@ -1148,6 +1148,15 @@
         }
       }
     },
+    "node_modules/@raycast/api/node_modules/@types/react": {
+      "version": "19.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
+      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@raycast/eslint-config": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.0.4.tgz",
@@ -1232,7 +1241,10 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.0.10",
+      "version": "19.1.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
+      "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"

--- a/extensions/circleback/package.json
+++ b/extensions/circleback/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@raycast/eslint-config": "^2.0.4",
     "@types/node": "22.13.10",
-    "@types/react": "19.0.10",
+    "@types/react": "~19.1.9",
     "eslint": "^9.22.0",
     "prettier": "^3.5.3",
     "typescript": "^5.8.2"

--- a/extensions/circleback/package.json
+++ b/extensions/circleback/package.json
@@ -50,5 +50,8 @@
     "fix-lint": "ray lint --fix",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/circleback/src/constants/raycast.ts
+++ b/extensions/circleback/src/constants/raycast.ts
@@ -1,2 +1,5 @@
-export const APP_URL = "https://app.circleback.ai";
+// Mirrors APP_URL in packages/constants/url.ts. Hardcoded here because the
+// Raycast extension is published standalone to the Raycast Store and can't
+// depend on a workspace package.
+export const APP_URL = "https://circleback.ai";
 export const DEFAULT_MEETING_NAME = "New meeting";

--- a/extensions/circleback/src/open-last-meeting.ts
+++ b/extensions/circleback/src/open-last-meeting.ts
@@ -6,20 +6,19 @@ import { withAccessToken } from "@raycast/utils";
 
 type Meeting = {
   id: number;
+  linkId: string;
   name: string;
   createdAt: string | Date;
 };
 
 const openLastMeeting = async () => {
-  const meetings = await fetchJson<Meeting[]>(
-    "/api/user/meetings?statuses=READY",
-  );
+  const meetings = await fetchJson<Meeting[]>("/api/user/meetings?statuses=READY");
   const latest = meetings[0];
   if (!latest) {
     await showHUD("No meetings found");
     return;
   }
-  await openMeeting(latest.id);
+  await openMeeting(latest.linkId);
   await showHUD("Opening last meeting");
 };
 

--- a/extensions/circleback/src/search-meetings.tsx
+++ b/extensions/circleback/src/search-meetings.tsx
@@ -7,6 +7,7 @@ import { APP_URL, DEFAULT_MEETING_NAME } from "./constants/raycast";
 
 type MeetingSearchResult = {
   id: number;
+  linkId: string;
   name: string;
   createdAt: string | Date;
 };
@@ -18,9 +19,7 @@ type SearchResponse = {
 const SearchMeetings = () => {
   const [searchText, setSearchText] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [searchedMeetings, setSearchedMeetings] = useState<
-    MeetingSearchResult[]
-  >([]);
+  const [searchedMeetings, setSearchedMeetings] = useState<MeetingSearchResult[]>([]);
 
   useEffect(() => {
     let canceled = false;
@@ -29,9 +28,7 @@ const SearchMeetings = () => {
       try {
         const params = new URLSearchParams();
         if (searchText) params.set("searchTerm", searchText);
-        const data = await fetchJson<SearchResponse>(
-          `/api/search?${params.toString()}`,
-        );
+        const data = await fetchJson<SearchResponse>(`/api/search?${params.toString()}`);
         if (!canceled) setSearchedMeetings(data.meetings?.result ?? []);
       } catch (error) {
         showFailureToast(error, {
@@ -49,28 +46,17 @@ const SearchMeetings = () => {
   }, [searchText]);
 
   return (
-    <List
-      isLoading={isLoading}
-      onSearchTextChange={setSearchText}
-      searchBarPlaceholder="Search meetings…"
-    >
+    <List isLoading={isLoading} onSearchTextChange={setSearchText} searchBarPlaceholder="Search meetings…">
       {searchedMeetings.map((meeting) => (
         <List.Item
           key={meeting.id}
           icon="fire.svg"
           title={meeting.name ?? DEFAULT_MEETING_NAME}
-          accessories={
-            meeting.createdAt
-              ? [{ text: new Date(meeting.createdAt).toLocaleDateString() }]
-              : []
-          }
+          accessories={meeting.createdAt ? [{ text: new Date(meeting.createdAt).toLocaleDateString() }] : []}
           actions={
             <ActionPanel>
-              <Action.OpenInBrowser url={`${APP_URL}/meetings/${meeting.id}`} />
-              <Action.CopyToClipboard
-                content={`${APP_URL}/meetings/${meeting.id}`}
-                title="Copy Link"
-              />
+              <Action.OpenInBrowser url={`${APP_URL}/meetings/${meeting.linkId}`} />
+              <Action.CopyToClipboard content={`${APP_URL}/meetings/${meeting.linkId}`} title="Copy Link" />
             </ActionPanel>
           }
         />

--- a/extensions/circleback/src/utils/api.ts
+++ b/extensions/circleback/src/utils/api.ts
@@ -1,10 +1,7 @@
 import { getAccessToken } from "@raycast/utils";
 import { APP_URL } from "../constants/raycast";
 
-export async function fetchJson<T>(
-  path: string,
-  init?: RequestInit,
-): Promise<T> {
+export async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
   const url = new URL(path, APP_URL).toString();
   const { token } = getAccessToken();
   const res = await fetch(url, {

--- a/extensions/circleback/src/utils/deepLink.ts
+++ b/extensions/circleback/src/utils/deepLink.ts
@@ -7,8 +7,7 @@ const CIRCLEBACK_APP_NAME = "Circleback";
 async function isDesktopAppInstalled() {
   const systemApps = await getApplications();
   const userApps = await getApplications("~/Applications");
-  const hasAppInstalled = (apps: typeof systemApps) =>
-    apps.some(({ name }) => name === CIRCLEBACK_APP_NAME);
+  const hasAppInstalled = (apps: typeof systemApps) => apps.some(({ name }) => name === CIRCLEBACK_APP_NAME);
   return hasAppInstalled(systemApps) || hasAppInstalled(userApps);
 }
 
@@ -27,7 +26,7 @@ async function resolveUrl(path: string): Promise<string> {
   return buildWebUrl(path);
 }
 
-export async function openMeeting(meetingId: number) {
+export async function openMeeting(meetingId: string) {
   const url = await resolveUrl(`/meetings/${meetingId}`);
   await open(url);
 }

--- a/extensions/circleback/tsconfig.json
+++ b/extensions/circleback/tsconfig.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "include": ["src/**/*", "raycast-env.d.ts"],
   "compilerOptions": {
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "DOM"],
     "module": "commonjs",
     "target": "ES2023",
     "strict": true,


### PR DESCRIPTION
## Description

Updates the Circleback extension to use the new app URL. We changed our app domain from `app.circleback.ai` to `circleback.ai`, so the extension's links, OAuth endpoints, and API calls need to point at the new domain.

All URLs in the extension derive from a single `APP_URL` constant, so this is a one-line domain change plus the supporting updates that have shipped to our app since the last store version.

## Changes

- Update `APP_URL` from `https://app.circleback.ai` to `https://circleback.ai`
- Add a changelog entry documenting the URL update
- Pin a local Prettier config so the extension formats consistently with the store's validator

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that this version is not breaking existing functionality
- [x] I updated the CHANGELOG.md