### PR TITLE
Update plexus extension

### DIFF
--- a/extensions/plexus/CHANGELOG.md
+++ b/extensions/plexus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plexus Changelog
 
-## [Detect slow dev servers, instant loading, and a richer list] - {PR_MERGE_DATE}
+## [Detect slow dev servers, instant loading, and a richer list] - 2026-07-01
 
 ### Added
 

--- a/extensions/plexus/CHANGELOG.md
+++ b/extensions/plexus/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Plexus Changelog
 
+## [Detect slow dev servers, instant loading, and a richer list] - {PR_MERGE_DATE}
+
+### Added
+
+- Toggleable detail panel (⌘Y) showing each server's framework, URL, port, PID, source (including WSL distro), project path, and page title.
+- Color-coded framework tags, with the fallback icon tinted to match, so each server is identifiable at a glance.
+- Refresh action (⌘R) and a clearer empty state.
+
+### Fixed
+
+- Slow dev servers (Next.js, Nuxt, Angular, …) that take about a second to render their first response are now detected instead of being missed.
+
+### Changed
+
+- Servers stream into the list as each is confirmed rather than waiting for the slowest, and the last results are cached so reopening is instant.
+- A single unresponsive port can no longer fail the whole scan.
+
 ## [Fix favicon and title caching] - 2026-06-23
 
 ### Fixed

--- a/extensions/plexus/src/plexus.tsx
+++ b/extensions/plexus/src/plexus.tsx
@@ -1,41 +1,130 @@
-import { ActionPanel, Action, Icon, List, showToast, Toast, confirmAlert, closeMainWindow } from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
+import { ActionPanel, Action, Icon, List, Color, showToast, Toast, confirmAlert, closeMainWindow } from "@raycast/api";
+import { useCachedState } from "@raycast/utils";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { LocalhostItem } from "./types/LocalhostItem";
-import { getLocalhostItems } from "./services/localhostService";
-import { useServiceIcon, usePageTitle } from "./utils/webHooks";
-import { createDisplayName, getProjectName } from "./utils/projectUtils";
+import { streamLocalhostItems } from "./services/localhostService";
+import { useServiceIcon } from "./utils/webHooks";
+import { getProjectName } from "./utils/projectUtils";
 import { execFile } from "child_process";
+
+const byPort = (a: LocalhostItem, b: LocalhostItem) => parseInt(a.port) - parseInt(b.port);
 
 const isWindows = process.platform === "win32";
 
+// A color per framework so each server carries an at-a-glance identity — used both for the
+// framework tag and to tint the fallback globe when a server has no favicon of its own.
+const FRAMEWORK_COLORS: Record<string, Color> = {
+  Laravel: Color.Red,
+  Vite: Color.Purple,
+  "Next.js": Color.PrimaryText,
+  Nuxt: Color.Green,
+  "Create React App": Color.Blue,
+  "Webpack Dev Server": Color.Blue,
+  Express: Color.Yellow,
+  Nodemon: Color.Green,
+  Django: Color.Green,
+  Flask: Color.SecondaryText,
+  Uvicorn: Color.Orange,
+  Gunicorn: Color.Orange,
+  Rails: Color.Red,
+  PHP: Color.Purple,
+  Nginx: Color.Green,
+};
+
+function frameworkColor(framework: string): Color | undefined {
+  return FRAMEWORK_COLORS[framework];
+}
+
 export default function Command() {
-  // useCachedPromise shows the previous result instantly on reopen, then revalidates.
-  const {
-    data: items = [],
-    isLoading,
-    revalidate,
-  } = useCachedPromise(getLocalhostItems, [], {
-    onError: (error) => {
-      showToast({ style: Toast.Style.Failure, title: error.message || "Failed to get localhost servers" });
-    },
-  });
+  const { items, isLoading, revalidate } = useLocalhostServers();
+  const [isShowingDetail, setIsShowingDetail] = useState(false);
+  const toggleDetail = useCallback(() => setIsShowingDetail((shown) => !shown), []);
 
   return (
-    <List isLoading={isLoading} searchBarPlaceholder="Search local servers...">
+    <List isLoading={isLoading} isShowingDetail={isShowingDetail} searchBarPlaceholder="Search local servers...">
       {items.length === 0 && !isLoading ? (
-        <List.EmptyView title="No local web servers found" />
+        <List.EmptyView
+          icon={Icon.Globe}
+          title="No local web servers found"
+          description="Start a dev server and it will show up here automatically."
+          actions={
+            <ActionPanel>
+              <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={revalidate} />
+            </ActionPanel>
+          }
+        />
       ) : (
         items.map((item: LocalhostItem) => (
-          <LocalhostListItem key={item.id} item={item} onActionComplete={revalidate} />
+          <LocalhostListItem
+            key={item.id}
+            item={item}
+            isShowingDetail={isShowingDetail}
+            onToggleDetail={toggleDetail}
+            onActionComplete={revalidate}
+          />
         ))
       )}
     </List>
   );
 }
 
-function LocalhostListItem({ item, onActionComplete }: { item: LocalhostItem; onActionComplete: () => void }) {
+// Streams confirmed web servers in as each probe resolves, so the list fills progressively instead
+// of blocking on the slowest server. The result is disk-cached (useCachedState) so reopening shows
+// the last servers instantly while a fresh scan runs in the background.
+function useLocalhostServers() {
+  const [items, setItems] = useCachedState<LocalhostItem[]>("localhost-servers", []);
+  const [isLoading, setIsLoading] = useState(true);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const revalidate = useCallback(async () => {
+    if (mounted.current) setIsLoading(true);
+    try {
+      const all = await streamLocalhostItems((item) => {
+        // Upsert by port (one row per port), keeping the list port-sorted as servers arrive.
+        if (!mounted.current) return;
+        setItems((prev) => [...prev.filter((i) => i.port !== item.port), item].sort(byPort));
+      });
+      // Reconcile to the authoritative scan: drops servers that are no longer listening.
+      if (mounted.current) setItems(all);
+    } catch (error) {
+      if (mounted.current) {
+        showToast({ style: Toast.Style.Failure, title: (error as Error).message || "Failed to get localhost servers" });
+      }
+    } finally {
+      if (mounted.current) setIsLoading(false);
+    }
+  }, [setItems]);
+
+  useEffect(() => {
+    revalidate();
+    // Run once on mount; revalidate is stable (depends only on the stable setItems setter).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { items, isLoading, revalidate };
+}
+
+function LocalhostListItem({
+  item,
+  isShowingDetail,
+  onToggleDetail,
+  onActionComplete,
+}: {
+  item: LocalhostItem;
+  isShowingDetail: boolean;
+  onToggleDetail: () => void;
+  onActionComplete: () => void;
+}) {
   const { favicon } = useServiceIcon(item.url);
-  const { title } = usePageTitle(item.url);
+  const color = frameworkColor(item.framework);
+  const name = item.title || getProjectName(item.projectPath);
 
   async function handleKillProcess() {
     if (
@@ -84,24 +173,44 @@ function LocalhostListItem({ item, onActionComplete }: { item: LocalhostItem; on
     }
   }
 
-  const accessories =
-    item.source === "wsl"
-      ? [{ tag: item.distro ? `WSL: ${item.distro}` : "WSL" }, { tag: item.port }]
-      : [{ tag: item.port }];
+  const accessories: List.Item.Accessory[] = [];
+  if (item.source === "wsl") {
+    accessories.push({
+      tag: item.distro ? `WSL: ${item.distro}` : "WSL",
+      tooltip: item.distro ? `Running in WSL distro ${item.distro}` : "Running in WSL",
+    });
+  }
+  if (item.framework) {
+    accessories.push({ tag: { value: item.framework, color }, tooltip: `Framework: ${item.framework}` });
+  }
+  accessories.push({ tag: { value: item.port, color: Color.Green }, tooltip: `Listening on port ${item.port}` });
 
   return (
     <List.Item
       key={item.id}
-      icon={favicon ? { source: favicon } : Icon.Globe}
-      title={createDisplayName(title || getProjectName(item.projectPath), item.framework)}
-      subtitle={item.url}
-      accessories={accessories}
+      icon={favicon ? { source: favicon } : { source: Icon.Globe, tintColor: color ?? Color.SecondaryText }}
+      title={name}
+      subtitle={isShowingDetail ? undefined : item.url}
+      accessories={isShowingDetail ? undefined : accessories}
+      detail={isShowingDetail ? <ServerDetail item={item} color={color} /> : undefined}
       actions={
         <ActionPanel>
           <ActionPanel.Section>
             <Action.OpenInBrowser url={item.url} />
             <Action.CopyToClipboard content={item.url} title="Copy URL" />
             <Action.CopyToClipboard content={item.pid} title="Copy Process ID" />
+            <Action
+              title="Toggle Details"
+              icon={Icon.AppWindowSidebarRight}
+              onAction={onToggleDetail}
+              shortcut={{ modifiers: ["cmd"], key: "y" }}
+            />
+            <Action
+              title="Refresh"
+              icon={Icon.ArrowClockwise}
+              onAction={onActionComplete}
+              shortcut={{ modifiers: ["cmd"], key: "r" }}
+            />
           </ActionPanel.Section>
           <ActionPanel.Section>
             <Action
@@ -113,6 +222,35 @@ function LocalhostListItem({ item, onActionComplete }: { item: LocalhostItem; on
             />
           </ActionPanel.Section>
         </ActionPanel>
+      }
+    />
+  );
+}
+
+// Side metadata panel shown when the user toggles details (⌘Y). Surfaces everything we know
+// about a server without cramming it into the row.
+function ServerDetail({ item, color }: { item: LocalhostItem; color?: Color }) {
+  const name = item.title || getProjectName(item.projectPath);
+  const source = item.source === "wsl" ? (item.distro ? `WSL · ${item.distro}` : "WSL") : "Host";
+  return (
+    <List.Item.Detail
+      metadata={
+        <List.Item.Detail.Metadata>
+          <List.Item.Detail.Metadata.Label title="Name" text={name} />
+          {item.framework ? (
+            <List.Item.Detail.Metadata.TagList title="Framework">
+              <List.Item.Detail.Metadata.TagList.Item text={item.framework} color={color} />
+            </List.Item.Detail.Metadata.TagList>
+          ) : null}
+          <List.Item.Detail.Metadata.Separator />
+          <List.Item.Detail.Metadata.Link title="URL" target={item.url} text={item.url} />
+          <List.Item.Detail.Metadata.Label title="Port" text={item.port} />
+          <List.Item.Detail.Metadata.Label title="Process ID" text={item.pid} />
+          <List.Item.Detail.Metadata.Separator />
+          <List.Item.Detail.Metadata.Label title="Source" text={source} />
+          {item.projectPath ? <List.Item.Detail.Metadata.Label title="Project Path" text={item.projectPath} /> : null}
+          {item.title ? <List.Item.Detail.Metadata.Label title="Page Title" text={item.title} /> : null}
+        </List.Item.Detail.Metadata>
       }
     />
   );

--- a/extensions/plexus/src/plexus.tsx
+++ b/extensions/plexus/src/plexus.tsx
@@ -102,11 +102,10 @@ function useLocalhostServers() {
     }
   }, [setItems]);
 
+  // revalidate is stable (memoized on the stable useCachedState setter), so this runs once on mount.
   useEffect(() => {
     revalidate();
-    // Run once on mount; revalidate is stable (depends only on the stable setItems setter).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [revalidate]);
 
   return { items, isLoading, revalidate };
 }

--- a/extensions/plexus/src/services/localhostService.ts
+++ b/extensions/plexus/src/services/localhostService.ts
@@ -1,41 +1,68 @@
 import { LocalhostItem } from "../types/LocalhostItem";
-import { findListeningServers, enrichHostServers } from "../utils/processUtils";
+import { findListeningServers, enrichHostServers, ListeningServer } from "../utils/processUtils";
 import { detectFramework, getProjectPath } from "../utils/projectUtils";
-import { respondsToHttp } from "../utils/probe";
+import { probeHttp } from "../utils/probe";
 
-export async function getLocalhostItems(): Promise<LocalhostItem[]> {
+const byPort = (a: LocalhostItem, b: LocalhostItem) => parseInt(a.port) - parseInt(b.port);
+
+// One row per port. Prefer the WSL entry on a collision since it carries command + cwd.
+async function gatherCandidates(): Promise<ListeningServer[]> {
   const servers = await findListeningServers();
-
-  // One row per port. Prefer the WSL entry on a collision since it carries command + cwd.
-  const byPort = new Map<string, (typeof servers)[number]>();
+  const deduped = new Map<string, ListeningServer>();
   for (const server of servers) {
-    const existing = byPort.get(server.port);
+    const existing = deduped.get(server.port);
     if (!existing || (server.source === "wsl" && existing.source !== "wsl")) {
-      byPort.set(server.port, server);
+      deduped.set(server.port, server);
     }
   }
-  const candidates = [...byPort.values()];
+  return [...deduped.values()];
+}
 
-  // Keep only the ports that actually answer an HTTP request (i.e. open in a browser).
-  const reachable = await Promise.all(candidates.map((server) => respondsToHttp(server.port)));
-  const webServers = candidates.filter((_, index) => reachable[index]);
+function toItem(server: ListeningServer, title?: string): LocalhostItem {
+  const projectPath = server.workingDir || getProjectPath(server.command);
+  return {
+    id: `${server.source}:${server.pid}:${server.port}`,
+    projectPath,
+    framework: detectFramework(server.command),
+    port: server.port,
+    pid: server.pid,
+    url: `http://localhost:${server.port}`,
+    title,
+    source: server.source,
+    distro: server.distro,
+  };
+}
 
-  // Fill in command line + working dir for native-host survivors (WSL ones already have them).
-  await enrichHostServers(webServers);
+// Probe every listening port in parallel and emit each confirmed web server via `onItem` the
+// moment its probe passes — so a fast server shows in milliseconds while a slow dev server (which
+// can take ~1s to render its first response) streams in later instead of blocking the whole list.
+// Resolves with the full, port-sorted list once every candidate has settled.
+export async function streamLocalhostItems(onItem: (item: LocalhostItem) => void): Promise<LocalhostItem[]> {
+  const candidates = await gatherCandidates();
+  const items: LocalhostItem[] = [];
 
-  return webServers
-    .map((server) => {
-      const projectPath = server.workingDir || getProjectPath(server.command);
-      return {
-        id: `${server.source}:${server.pid}:${server.port}`,
-        projectPath,
-        framework: detectFramework(server.command),
-        port: server.port,
-        pid: server.pid,
-        url: `http://localhost:${server.port}`,
-        source: server.source,
-        distro: server.distro,
-      };
-    })
-    .sort((a, b) => parseInt(a.port) - parseInt(b.port));
+  await Promise.all(
+    candidates.map(async (server) => {
+      try {
+        // Keep only ports that answer an HTTP request (i.e. open in a browser). The probe also
+        // returns the page <title> from the same response, so we never fetch the page twice.
+        const probe = await probeHttp(server.port);
+        if (!probe.ok) return;
+        // Fill in command line + working dir for native-host survivors (WSL ones already have them).
+        await enrichHostServers([server]);
+        const item = toItem(server, probe.title);
+        items.push(item);
+        onItem(item);
+      } catch {
+        // A single misbehaving port must not fail the whole scan — skip it and keep going.
+      }
+    }),
+  );
+
+  return items.sort(byPort);
+}
+
+// Non-streaming wrapper for callers that just want the full list once.
+export async function getLocalhostItems(): Promise<LocalhostItem[]> {
+  return streamLocalhostItems(() => {});
 }

--- a/extensions/plexus/src/types/LocalhostItem.ts
+++ b/extensions/plexus/src/types/LocalhostItem.ts
@@ -5,6 +5,7 @@ export type LocalhostItem = {
   port: string;
   pid: string;
   url: string;
+  title?: string;
   favicon?: string;
   source: "host" | "wsl";
   distro?: string;

--- a/extensions/plexus/src/utils/probe.ts
+++ b/extensions/plexus/src/utils/probe.ts
@@ -1,34 +1,65 @@
 import { connect } from "net";
 
-const PROBE_TIMEOUT_MS = 400;
+// Inactivity timeout, not a hard deadline: fast servers resolve the instant their first bytes
+// arrive, so this only caps how long we wait on a slow/silent responder. Dev servers (Next.js,
+// Nuxt, Angular, …) compile and server-render each request in dev mode and routinely take ~1s
+// to answer — the very servers Plexus exists to find — so the budget must comfortably clear
+// that. A non-HTTP service that accepts the connection but stays silent is the only case that
+// pays the full wait; databases reject fast because they send a handshake banner immediately.
+const PROBE_TIMEOUT_MS = 2500;
 
-// Decides whether a listening port is a real web page you can open in a browser.
-// We use a raw socket (not fetch): probing non-HTTP services like Postgres/Redis/MySQL can
-// make Node's HTTP parser throw uncaught errors. We send a minimal request and keep the port
-// only if it answers with an OK/redirect status AND HTML — that filters out databases as well
-// as desktop apps that run local HTTP/IPC servers (Steam, Logitech, SignalRGB, …) which reply
-// with errors or non-HTML content. Short timeout keeps the whole scan fast.
-export function respondsToHttp(port: string): Promise<boolean> {
+// Once a port is confirmed to be HTML, keep reading the body only far enough to find <title>.
+// <title> lives early in <head>, so this caps memory without missing it on real pages.
+const MAX_BODY_BYTES = 64 * 1024;
+
+export type ProbeResult = {
+  // Whether the port is a real web page you can open in a browser.
+  ok: boolean;
+  // The page <title>, lifted from the same response so we don't fetch the page a second time.
+  title?: string;
+};
+
+function extractTitle(buffer: string): string | undefined {
+  const match = buffer.match(/<title[^>]*>([^<]+)<\/title>/i);
+  return match && match[1] ? match[1].trim() || undefined : undefined;
+}
+
+// Probes a listening port with a raw socket (not fetch): probing non-HTTP services like
+// Postgres/Redis/MySQL can make Node's HTTP parser throw uncaught errors. We send a minimal
+// request and keep the port only if it answers with an OK/redirect status AND HTML — that filters
+// out databases as well as desktop apps that run local HTTP/IPC servers (Steam, Logitech,
+// SignalRGB, …) which reply with errors or non-HTML content. When it is a web page, we read on a
+// little further to capture <title> from the same response instead of fetching the page again.
+export function probeHttp(port: string): Promise<ProbeResult> {
   return new Promise((resolve) => {
     const socket = connect({ host: "localhost", port: Number(port) });
     let buffer = "";
     let settled = false;
+    let isWeb = false; // flips true once the headers confirm OK status + HTML
 
-    const finish = (result: boolean) => {
+    const finish = (result: ProbeResult) => {
       if (settled) return;
       settled = true;
       socket.destroy();
       resolve(result);
     };
 
-    const evaluate = () => {
+    // Returns true once headers confirm a web page; otherwise finishes the probe as non-web.
+    const confirmWeb = (): boolean => {
       const headEnd = buffer.indexOf("\r\n\r\n");
       const head = (headEnd === -1 ? buffer : buffer.slice(0, headEnd)).toLowerCase();
       const statusMatch = head.match(/^http\/\d\.\d (\d{3})/);
-      if (!statusMatch) return finish(false);
+      if (!statusMatch) {
+        finish({ ok: false });
+        return false;
+      }
       const status = Number(statusMatch[1]);
       const isHtml = /content-type:[^\r\n]*html/.test(head);
-      finish(status >= 200 && status < 400 && isHtml);
+      if (!(status >= 200 && status < 400 && isHtml)) {
+        finish({ ok: false });
+        return false;
+      }
+      return true;
     };
 
     socket.setTimeout(PROBE_TIMEOUT_MS);
@@ -37,12 +68,24 @@ export function respondsToHttp(port: string): Promise<boolean> {
     });
     socket.on("data", (chunk) => {
       buffer += chunk.toString("latin1");
-      if (buffer.indexOf("\r\n\r\n") !== -1 || buffer.length > 8192) evaluate();
+      if (!isWeb) {
+        // Wait until the full header block has arrived before judging.
+        if (buffer.indexOf("\r\n\r\n") === -1 && buffer.length <= 8192) return;
+        if (!confirmWeb()) return;
+        isWeb = true;
+      }
+      // Confirmed web: stop as soon as we have the title or have read enough of the body.
+      if (/<\/title>/i.test(buffer) || buffer.length > MAX_BODY_BYTES) {
+        finish({ ok: true, title: extractTitle(buffer) });
+      }
     });
-    socket.on("timeout", () => finish(false));
-    socket.on("error", () => finish(false));
+    // A slow body is still a web server — resolve ok with whatever title (if any) we captured.
+    socket.on("timeout", () => finish(isWeb ? { ok: true, title: extractTitle(buffer) } : { ok: false }));
+    socket.on("error", () => finish({ ok: false }));
     socket.on("close", () => {
-      if (!settled) evaluate();
+      if (settled) return;
+      if (isWeb) finish({ ok: true, title: extractTitle(buffer) });
+      else if (confirmWeb()) finish({ ok: true, title: extractTitle(buffer) });
     });
   });
 }

--- a/extensions/plexus/src/utils/projectUtils.ts
+++ b/extensions/plexus/src/utils/projectUtils.ts
@@ -99,10 +99,3 @@ export function getProjectPath(cmdResult: string): string {
   const dir = dirname(scriptPath);
   return dir === "." ? "" : dir;
 }
-
-export function createDisplayName(projectName: string, framework: string): string {
-  if (!framework || framework === projectName) return projectName;
-  if (projectName.toLowerCase().includes(framework.toLowerCase())) return projectName;
-
-  return `${projectName} (${framework})`;
-}

--- a/extensions/plexus/src/utils/webHooks.ts
+++ b/extensions/plexus/src/utils/webHooks.ts
@@ -15,26 +15,3 @@ export function useServiceIcon(url: string) {
     error,
   };
 }
-
-export function usePageTitle(url: string) {
-  const { isLoading, data, error } = useFetch<string | undefined>(url, {
-    execute: true,
-    keepPreviousData: false,
-    parseResponse: async (response) => (response.ok ? response.text() : undefined),
-  });
-
-  let title: string | undefined = undefined;
-  if (data) {
-    const html = data;
-    const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
-    if (titleMatch && titleMatch[1]) {
-      title = titleMatch[1].trim();
-    }
-  }
-
-  return {
-    isLoading,
-    title,
-    error,
-  };
-}


### PR DESCRIPTION
## Description

Update to the existing **Plexus – Localhost Search** extension. Three groups of changes, no new commands or permissions:

**Fix — slow dev servers were being missed.** The HTTP probe timed out before dev servers that server-render their first response (Next.js, Nuxt, Angular, …) could answer — those routinely take ~1s in dev mode. The probe now waits long enough, so they're detected reliably instead of silently skipped.

**Performance — faster, more resilient loading.** Servers now stream into the list as each one is confirmed by the probe instead of blocking on the slowest, and the last results are cached so reopening shows them instantly while a fresh scan runs in the background. A single unresponsive port can no longer fail the whole scan, and each page title is read from the same probe response (no second request per server).

**UI — a richer, friendlier list.**

- Toggleable detail panel (⌘Y) showing framework, URL, port, PID, source (incl. WSL distro), project path, and page title.
- Color-coded framework tags, with the fallback icon tinted to match, so each server is identifiable at a glance.
- Refresh action (⌘R) and a clearer empty state.

Existing behavior (open in browser, copy URL/PID, kill process, Windows + WSL support) is unchanged.

## Screencast

_Straightforward logic/UI update to an existing extension — happy to add a screen recording if the reviewers would like one._

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
