### PR TITLE
Update dev-servers extension

### DIFF
--- a/extensions/dev-servers/CHANGELOG.md
+++ b/extensions/dev-servers/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dev Servers Changelog
 
-## [Menu Bar Command] - {PR_MERGE_DATE}
+## [Menu Bar Command] - 2026-07-02
 
 - Adds **Dev Servers Menu Bar**, a compact menu bar command that shows running dev servers by project and keeps the count visible when you want it.
 - Each running server gets quick actions for opening, restarting, killing, copying the URL or port, and jumping into your editor or terminal.

--- a/extensions/dev-servers/CHANGELOG.md
+++ b/extensions/dev-servers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Dev Servers Changelog
 
+## [Menu Bar Command] - {PR_MERGE_DATE}
+
+- Adds **Dev Servers Menu Bar**, a compact menu bar command that shows running dev servers by project and keeps the count visible when you want it.
+- Each running server gets quick actions for opening, restarting, killing, copying the URL or port, and jumping into your editor or terminal.
+- Recent stopped projects appear in a Start section, ranked by use, and hand off to the dashboard so the normal startup toast and progress flow stay intact.
+- Projects with two or more servers get a kill-all item at the bottom of their section: "Kill Both Servers" for a pair, "Kill All 3 Servers" beyond. It acts on click without a dialog (menus can't confirm), so the label always names the blast radius and single-server projects don't show it at all.
+
 ## [Automatic port fallback for Shopify themes] - 2026-07-02
 
 - **Two copies of a theme now run side by side.** `shopify theme dev` has no next-free-port fallback: when its fixed default port 9292 is taken (say, by the main checkout while you start a git worktree of the same theme), the CLI just dies with `EADDRINUSE` ([Shopify/cli#5554](https://github.com/Shopify/cli/issues/5554)). Starting a theme now probes the default port first and, when it's taken, exports `SHOPIFY_FLAG_PORT` with the next free one. Because it's an environment variable, the fix reaches the CLI through any wrapping — a bare theme root started as `shopify theme dev` and a `dev` script that nests it under `concurrently` both come up on their own port. A `--port` written explicitly into your own script still wins.

--- a/extensions/dev-servers/README.md
+++ b/extensions/dev-servers/README.md
@@ -1,91 +1,44 @@
 # Dev Servers
 
-A keyboard-first way to manage and start your local dev servers from Raycast. See everything running grouped by project, jump into any one in the browser or your terminal, kill stragglers individually or in bulk, restart with the right package manager, and spin up a new server from a Finder selection or a recent project, all without leaving Raycast.
+See every dev server running on your Mac, grouped by project. Kill, restart, open, or start servers without leaving Raycast, and keep a live count in your menu bar.
 
 ## Commands
 
-- **Dev Servers**: the dashboard. A live, auto-refreshing list of every dev server currently running, grouped by project.
-- **Start Dev Server**: spin up a server from a Finder selection, a recently-seen project, or any folder you pick. The dashboard opens and shows it coming up.
+- **Dev Servers**: a live dashboard of everything running, grouped by project.
+- **Start Dev Server**: spin up a server from a Finder selection, a recent project, or any folder.
+- **Dev Servers Menu Bar**: the running count in your menu bar, with quick actions in the dropdown.
 
-## Dev Servers (dashboard)
+## Dashboard
 
-- **Auto-detects** running dev servers including Vite, Next.js, Astro, SvelteKit, Nuxt, Webpack, Parcel, Gatsby, Remix, Turbo, esbuild, serve, http-server, Shopify CLI dev servers, anything that runs out of `node_modules/`, plus servers running on the Bun runtime
-- **Custom domain aware** so a dev server fronted by [portless](https://github.com/vercel-labs/portless) shows its named URL (e.g. `myapp.localhost`) as the row title, with the `localhost:PORT` pill alongside for when you still need the raw loopback target
-- **Grouped by project** so servers from the same directory appear under one section
-- **Worktree-aware** so multiple git worktrees of the same repo collapse into one section, with a per-row branch tag to tell them apart. It also surfaces the current branch on single-worktree projects so you can tell which branch a long-running server is on
-- **Favicons** (PNG, ICO, or SVG) are pulled from each site (with `/favicon.ico` fallback), inlined so they render even when the dev server isn't CORS-friendly, and cached across refreshes
-- **Runtime tag** shows a yellow `bun` badge when the listening process is genuinely running on Bun
-- **Uptime tracking** shows how long each server has been running. Hover for the exact start time
-- **Smart restart** picks the right package manager (npm, pnpm, yarn, bun) from the project's lockfile, polls until the new server binds a port, and surfaces failures with a link to the log
-- **Start another server** without leaving the dashboard: `⌘N` from any row, or `↵` from the empty state, opens the Start Dev Server picker
-- **View startup logs** with `⌘L` on any row; the view live-tails the captured stdout/stderr while open, so you can watch a slow boot or diagnose a crash in place
-- **Copy Network URL** (`⌘⌥C`) copies `http://<lan-ip>:<port>` for testing on a phone or another device, offered only when the server is actually bound beyond loopback. **Copy Port** (`⌘⌥P`) grabs just the number for env files
-- **Open in your editor** with `⌘E` once you set the Editor App preference (VS Code, Cursor, Zed, …)
-- **Confirm dialogs on bulk-kill** ensure destructive actions ask first, with a "Don't ask again" option for project-scoped kills
-- **Open in your terminal** uses a configurable terminal app preference (Terminal, iTerm, Warp, Ghostty, etc.)
-- **Search and filter** by typing a project name, branch, or port into the search bar; a framework dropdown appears when you have multiple frameworks running
-- **Stays open** because the window never closes after an action, so you can chain kills and restarts in one session
-- **Auto-refresh** updates the list automatically on a configurable interval, plus manual `⌘R`
+- Auto-detects Vite, Next.js, SvelteKit, Astro, Nuxt, Webpack, Remix, Shopify CLI, Bun, and anything else running out of `node_modules`
+- Groups servers by project; git worktrees collapse into one section with per-row branch tags
+- Kill one server (`⌃X`), a whole project (`⌃⇧X`), or everything (`⌃⌥X`); bulk kills ask first
+- Restart (`⌘⇧R`) with the right package manager, detected from the lockfile (npm, pnpm, yarn, bun)
+- Shows [portless](https://github.com/vercel-labs/portless) custom domains, real favicons, uptime, and framework tags
+- Open in browser, editor (`⌘E`), or terminal (`⌘T`); copy the URL, network URL for phone testing (`⌘⌥C`), or port (`⌘⌥P`)
+- View any server's startup log (`⌘L`), live-tailed while open
+- Auto-refreshes on your interval; search by project, branch, or port
 
 ## Start Dev Server
 
-Spin up a dev server without opening a terminal. There are three ways in:
+- Works from a Finder selection (multi-folder too), a picker of recently seen projects, or the native folder dialog
+- Finds the right script automatically: `dev`, `start`, `develop`, then monorepo names like `dev:web`
+- Shopify support: themes start with `shopify theme dev` (with automatic port fallback when 9292 is taken), app roots with `shopify app dev`, and Hydrogen storefronts through their normal scripts
+- If a server doesn't bind a port within 15 seconds, the toast escalates with a **View Startup Log** action so you can see what went wrong
+- First-run note for Shopify: run `shopify theme dev --store <your-store>` once in a terminal so the CLI remembers your store; a background spawn can't answer its login prompt
 
-- **From Finder**: select a project folder (or any file inside one) and run the command. It walks up to the nearest project root (a `package.json`, or a Shopify theme/app root), detects the package manager, picks the right dev script, and starts it. Select several folders to start them together (monorepo siblings, a "frontend + backend" pair). The dashboard opens immediately and a "Starting…" toast tracks each one until it binds a port.
-- **From recents**: run the command with nothing selected and you get a picker over projects the extension has recently seen running. Recents populate automatically from the dashboard, with no bookmarking. Each row shows last-seen time, git branch, a framework tag, and the project's real favicon once it's been seen running. Currently-running projects are hidden here (they live in the dashboard) and reappear once stopped.
-- **From anywhere**: the picker's **Choose Folder…** entry opens the native macOS folder dialog directly, for a one-off project that isn't in your recents.
+## Menu Bar
 
-If a target is already running, you get a single consolidated prompt to restart it (or restart the running ones and start the rest) rather than a cascade of dialogs. If a server doesn't bind a port within 15 seconds, the toast escalates to a failure with a **View Startup Log** action so a misconfigured setup is diagnosable in place.
-
-The script picker tries `dev` → `start` → `develop` first, then scans script values for known dev-server tools, so monorepo conventions like `dev:web` and `start:dev` resolve out of the box.
-
-**Shopify projects** work too: a theme folder (marked by `layout/theme.liquid`, no `package.json` needed) starts with `shopify theme dev`, and an app root (`shopify.app.toml`) without a dev script falls back to `shopify app dev`. Scaffolded Shopify apps and Hydrogen storefronts start through their normal `dev` scripts. Because `shopify theme dev` insists on port 9292 and simply crashes when it's taken, starting a theme checks that port first and hands the CLI the next free one (via `SHOPIFY_FLAG_PORT`) when needed — so a second copy of a theme, like a git worktree next to your main checkout, starts cleanly alongside the first. One caveat: the Shopify CLI prompts for login and store selection on first use, which a background spawn can't answer; run `shopify theme dev --store <your-store>` once in a terminal, after which the CLI remembers the store and the extension starts it cleanly.
-
-**Picker row actions:** Start (`↵`), Open in Editor (`⌘E`, when the Editor App preference is set), Open in Terminal (`⌘T`), Show in Finder (`⌘⇧F`), Copy Path (`⌘C`), Remove from Recents (`⌃X`).
-
-## Keyboard Shortcuts
-
-Dashboard (Dev Servers):
-
-| Action | Shortcut |
-|---|---|
-| Open in Browser | `↵` Enter |
-| Open Localhost URL | `⌘` `↵` |
-| Restart Server | `⌘` `⇧` `R` |
-| Kill Server | `⌃` `X` |
-| Copy URL | `⌘` `C` |
-| Copy Localhost URL | `⌘` `⇧` `C` |
-| Copy Network URL | `⌘` `⌥` `C` |
-| Copy Port | `⌘` `⌥` `P` |
-| Open in Editor | `⌘` `E` |
-| Open in Terminal | `⌘` `T` |
-| Show in Finder | `⌘` `⇧` `F` |
-| Start Dev Server | `⌘` `N` |
-| View Startup Log | `⌘` `L` |
-| Refresh | `⌘` `R` |
-| Kill All for Project | `⌃` `⇧` `X` |
-| Kill All Servers | `⌃` `⌥` `X` |
+- Live count of running servers next to the icon (toggleable)
+- Each server gets a submenu: open, restart, kill, copy URL or port, editor, terminal
+- Projects running several servers get a one-click kill-all item ("Kill Both Servers", "Kill All 3 Servers")
+- A **Start** section lists your recent projects, ranked by how often you start them
+- Starts hand off to the dashboard so you see the usual progress toast
 
 ## Preferences
 
-**Shared**
-
-- **Terminal App** sets which terminal `⌘T` opens, for both commands. Defaults to macOS Terminal if unset.
-- **Editor App** sets which editor `⌘E` opens a project in (VS Code, Cursor, Zed, …). The action is hidden until this is set.
-
-**Dev Servers**
-
-- **Refresh Interval** sets how often to refresh the server list (2s, 5s, 10s, or 30s).
-- **Project Display** shows the full directory path in section headers instead of just the project folder name.
-- **Row Accessories** independently toggle uptime, the git branch tag, the framework tag, and the `localhost:PORT` pill that appears alongside custom domains.
-
-**Start Dev Server**
-
-- **Open in browser when the port binds** auto-opens each new server's URL once it starts listening. Off by default.
-- **Confirm when starting multiple folders at once** asks before spawning more than one server from a multi-folder Finder selection. On by default.
+Pick your terminal and editor apps once (shared by all commands), set the dashboard refresh interval and row accessories, choose whether new servers auto-open in the browser, and toggle the menu bar count.
 
 ## How it differs from Port Manager
 
-Port Manager is built around ports. Dev Servers is built around projects.
-
-Port Manager shows every listening process the same way (Postgres, Docker, SSH tunnels, dev servers). Dev Servers shows only the dev servers, groups them by project, identifies the framework, restarts with the right package manager, and can start new ones for you. The two are complementary.
+Port Manager is built around ports; Dev Servers is built around projects. It shows only dev servers, knows their framework and package manager, and can restart or start them. The two are complementary.

--- a/extensions/dev-servers/package.json
+++ b/extensions/dev-servers/package.json
@@ -151,6 +151,24 @@
           "required": false
         }
       ]
+    },
+    {
+      "name": "menubar",
+      "title": "Dev Servers Menu Bar",
+      "description": "See running dev servers in the menu bar; kill, restart, open, or start one from the dropdown",
+      "mode": "menu-bar",
+      "interval": "1m",
+      "preferences": [
+        {
+          "name": "showCount",
+          "type": "checkbox",
+          "title": "Menu Bar",
+          "label": "Show running-server count",
+          "description": "Show the number of running dev servers next to the menu bar icon",
+          "default": true,
+          "required": false
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/extensions/dev-servers/src/index.tsx
+++ b/extensions/dev-servers/src/index.tsx
@@ -38,6 +38,7 @@ import {
   spawnLogPath,
   startDevServer,
 } from "./servers";
+import { pokeMenuBar, writeSnapshot } from "./snapshot";
 import { toolColor, toolLabel } from "./tool-display";
 import { DevServer } from "./types";
 
@@ -658,6 +659,7 @@ export default function Command(
     let last: DevServer[] = [];
     return async (): Promise<DevServer[]> => {
       const next = await fetchServers();
+      writeSnapshot(next);
       if (sameServers(next, last)) return last;
       last = next;
       return next;
@@ -895,6 +897,7 @@ export default function Command(
         if (s) open(s.url).catch(() => {});
       }
     }
+    pokeMenuBar();
     const toast = toastRef.current;
     if (toast) {
       toast.style = Toast.Style.Success;
@@ -986,6 +989,7 @@ export default function Command(
           (current ?? []).filter((s) => s.pid !== pid),
         rollbackOnError: true,
       });
+      pokeMenuBar();
     } catch (err) {
       await showFailureToast(err, { title: "Failed to kill server" });
     }
@@ -1016,6 +1020,7 @@ export default function Command(
           rollbackOnError: true,
         },
       );
+      pokeMenuBar();
     } catch (err) {
       await showFailureToast(err, {
         title: `Failed to kill servers for ${projectName}`,
@@ -1045,6 +1050,7 @@ export default function Command(
           rollbackOnError: true,
         },
       );
+      pokeMenuBar();
     } catch (err) {
       await showFailureToast(err, { title: "Failed to kill all servers" });
     }
@@ -1098,6 +1104,7 @@ export default function Command(
         const replacement =
           sameCwd.find((s) => !priorPids.has(s.pid)) ?? sameCwd[0];
         if (replacement) setSelectedItemId(String(replacement.pid));
+        pokeMenuBar();
       } else {
         toast.style = Toast.Style.Failure;
         toast.title = "Restart timed out";

--- a/extensions/dev-servers/src/menubar.tsx
+++ b/extensions/dev-servers/src/menubar.tsx
@@ -18,7 +18,7 @@ import {
   killServer,
   restartServer,
 } from "./servers";
-import { pokeMenuBar, readSnapshot, writeSnapshot } from "./snapshot";
+import { readSnapshot, writeSnapshot } from "./snapshot";
 import { toolColor } from "./tool-display";
 import { DevServer } from "./types";
 
@@ -187,7 +187,6 @@ export default function Command() {
                     void (async () => {
                       await restartServer(server);
                       await refresh();
-                      pokeMenuBar();
                     })();
                   }}
                 />
@@ -198,7 +197,6 @@ export default function Command() {
                     void (async () => {
                       await killServer(server.pid);
                       await refresh();
-                      pokeMenuBar();
                     })();
                   }}
                 />
@@ -255,7 +253,6 @@ export default function Command() {
                       projectServers.map((server) => killServer(server.pid)),
                     );
                     await refresh();
-                    pokeMenuBar();
                   })();
                 }}
               />
@@ -264,22 +261,27 @@ export default function Command() {
         ))
       )}
 
-      <MenuBarExtra.Section title="Start">
-        {sortedRecents.slice(0, 6).map((recent) => (
-          <MenuBarExtra.Item
-            key={recent.cwd}
-            title={recent.projectName}
-            subtitle={recent.branch}
-            icon={recent.favicon ?? Icon.Folder}
-            onAction={() => {
-              void (async () => {
-                await visitItem(recent);
-                await launchRecent(recent);
-              })();
-            }}
-          />
-        ))}
-      </MenuBarExtra.Section>
+      {sortedRecents.length > 0 ? (
+        // Section titles render even over zero children, so an empty recents
+        // list (or one fully hidden by the running set) must drop the whole
+        // section rather than strand a bare "Start" header.
+        <MenuBarExtra.Section title="Start">
+          {sortedRecents.slice(0, 6).map((recent) => (
+            <MenuBarExtra.Item
+              key={recent.cwd}
+              title={recent.projectName}
+              subtitle={recent.branch}
+              icon={recent.favicon ?? Icon.Folder}
+              onAction={() => {
+                void (async () => {
+                  await visitItem(recent);
+                  await launchRecent(recent);
+                })();
+              }}
+            />
+          ))}
+        </MenuBarExtra.Section>
+      ) : null}
 
       <MenuBarExtra.Section>
         <MenuBarExtra.Item

--- a/extensions/dev-servers/src/menubar.tsx
+++ b/extensions/dev-servers/src/menubar.tsx
@@ -1,0 +1,302 @@
+import {
+  Clipboard,
+  Icon,
+  LaunchType,
+  MenuBarExtra,
+  getPreferenceValues,
+  launchCommand,
+  open,
+  updateCommandMetadata,
+} from "@raycast/api";
+import { useFrecencySorting, useLocalStorage } from "@raycast/utils";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { DEFAULT_TERMINAL } from "./constants";
+import { RecentProject, STORAGE_KEY } from "./recents";
+import {
+  canonicalCwd,
+  fetchServers,
+  killServer,
+  restartServer,
+} from "./servers";
+import { pokeMenuBar, readSnapshot, writeSnapshot } from "./snapshot";
+import { toolColor } from "./tool-display";
+import { DevServer } from "./types";
+
+function metadataSubtitle(count: number): string {
+  return count === 1 ? "1 running" : `${count} running`;
+}
+
+function serverHost(server: DevServer): string {
+  const url =
+    server.customUrls && server.customUrls.length > 0
+      ? server.customUrls[0]
+      : server.localUrl;
+  try {
+    return new URL(url).host;
+  } catch {
+    return server.customUrls && server.customUrls.length > 0
+      ? server.customUrls[0]
+      : `localhost:${server.port}`;
+  }
+}
+
+function serverTitle(server: DevServer): string {
+  const branch = server.branch ? ` (${server.branch})` : "";
+  return `${serverHost(server)}${branch}`;
+}
+
+function groupByProject(servers: DevServer[]): DevServer[][] {
+  const groups = new Map<string, DevServer[]>();
+  for (const server of servers) {
+    const group = groups.get(server.projectKey) ?? [];
+    group.push(server);
+    groups.set(server.projectKey, group);
+  }
+  return [...groups.values()];
+}
+
+async function launchDashboard(): Promise<void> {
+  await launchCommand({
+    name: "index",
+    type: LaunchType.UserInitiated,
+  });
+}
+
+async function launchStartPicker(): Promise<void> {
+  await launchCommand({
+    name: "start",
+    type: LaunchType.UserInitiated,
+    context: { forcePicker: true },
+  });
+}
+
+async function launchRecent(recent: RecentProject): Promise<void> {
+  await launchCommand({
+    name: "index",
+    type: LaunchType.UserInitiated,
+    context: {
+      spawn: {
+        targets: [{ cwd: recent.cwd, name: recent.projectName }],
+        confirmMulti: false,
+        autoOpen: false,
+        showAutoOpenHint: false,
+      },
+    },
+  });
+}
+
+export default function Command() {
+  const prefs = getPreferenceValues<Preferences.Menubar>();
+  const [servers, setServers] = useState<DevServer[]>(
+    () => readSnapshot() ?? [],
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const { value: recents = [] } = useLocalStorage<RecentProject[]>(
+    STORAGE_KEY,
+    [],
+  );
+
+  const refresh = useCallback(async () => {
+    const next = await fetchServers();
+    setServers(next);
+    writeSnapshot(next);
+    await updateCommandMetadata({ subtitle: metadataSubtitle(next.length) });
+    return next;
+  }, []);
+
+  useEffect(() => {
+    refresh()
+      .catch(() => {})
+      .finally(() => setIsLoading(false));
+  }, [refresh]);
+
+  const runningCwds = useMemo(
+    () => new Set(servers.map((server) => canonicalCwd(server.cwd))),
+    [servers],
+  );
+
+  const startableRecents = useMemo(
+    () =>
+      recents
+        .filter((recent) => !runningCwds.has(canonicalCwd(recent.cwd)))
+        .sort((a, b) => b.lastSeen - a.lastSeen),
+    [recents, runningCwds],
+  );
+
+  const { data: sortedRecents, visitItem } = useFrecencySorting(
+    startableRecents,
+    {
+      namespace: "project-starts",
+      key: (item) => item.cwd,
+      sortUnvisited: (a, b) => b.lastSeen - a.lastSeen,
+    },
+  );
+
+  const terminalApp = prefs.terminalApp ?? DEFAULT_TERMINAL;
+  const editorApp = prefs.editorApp;
+  const title =
+    (prefs.showCount ?? true) && servers.length > 0
+      ? String(servers.length)
+      : undefined;
+
+  return (
+    <MenuBarExtra
+      icon={Icon.Bolt}
+      title={title}
+      tooltip="Dev Servers"
+      isLoading={isLoading}
+    >
+      {servers.length === 0 ? (
+        <MenuBarExtra.Item title="No dev servers running" />
+      ) : (
+        groupByProject(servers).map((projectServers) => (
+          <MenuBarExtra.Section
+            key={projectServers[0].projectKey}
+            title={projectServers[0].projectName}
+          >
+            {projectServers.map((server) => (
+              <MenuBarExtra.Submenu
+                key={`${server.pid}:${server.port}`}
+                title={serverTitle(server)}
+                icon={{
+                  source: Icon.CircleFilled,
+                  tintColor: toolColor(server.tool),
+                }}
+              >
+                <MenuBarExtra.Item
+                  title="Open in Browser"
+                  icon={Icon.Globe}
+                  onAction={() => {
+                    void open(server.url);
+                  }}
+                />
+                {server.customUrls && server.customUrls.length > 0 ? (
+                  <MenuBarExtra.Item
+                    title="Open Localhost URL"
+                    icon={Icon.Link}
+                    onAction={() => {
+                      void open(server.localUrl);
+                    }}
+                  />
+                ) : null}
+                <MenuBarExtra.Separator />
+                <MenuBarExtra.Item
+                  title="Restart"
+                  icon={Icon.ArrowClockwise}
+                  onAction={() => {
+                    void (async () => {
+                      await restartServer(server);
+                      await refresh();
+                      pokeMenuBar();
+                    })();
+                  }}
+                />
+                <MenuBarExtra.Item
+                  title="Kill"
+                  icon={Icon.Trash}
+                  onAction={() => {
+                    void (async () => {
+                      await killServer(server.pid);
+                      await refresh();
+                      pokeMenuBar();
+                    })();
+                  }}
+                />
+                <MenuBarExtra.Separator />
+                <MenuBarExtra.Item
+                  title="Copy URL"
+                  icon={Icon.Clipboard}
+                  onAction={() => {
+                    void Clipboard.copy(server.url);
+                  }}
+                />
+                <MenuBarExtra.Item
+                  title="Copy Port"
+                  icon={Icon.NumberList}
+                  onAction={() => {
+                    void Clipboard.copy(server.port);
+                  }}
+                />
+                {editorApp ? (
+                  <MenuBarExtra.Item
+                    title="Open in Editor"
+                    icon={Icon.Code}
+                    onAction={() => {
+                      void open(server.cwd, editorApp);
+                    }}
+                  />
+                ) : null}
+                <MenuBarExtra.Item
+                  title="Open in Terminal"
+                  icon={Icon.Terminal}
+                  onAction={() => {
+                    void open(server.cwd, terminalApp);
+                  }}
+                />
+              </MenuBarExtra.Submenu>
+            ))}
+            {projectServers.length >= 2 ? (
+              // No confirmAlert in the menu bar context, so the guardrails are
+              // the label carrying the count, bottom placement, and hiding the
+              // item entirely for single-server projects (where the per-server
+              // Kill already covers it).
+              <MenuBarExtra.Item
+                title={
+                  projectServers.length === 2
+                    ? "Kill Both Servers"
+                    : `Kill All ${projectServers.length} Servers`
+                }
+                icon={Icon.Trash}
+                onAction={() => {
+                  void (async () => {
+                    // allSettled: a server can die between menu open and click,
+                    // and one stale pid must not stop the rest of the project.
+                    await Promise.allSettled(
+                      projectServers.map((server) => killServer(server.pid)),
+                    );
+                    await refresh();
+                    pokeMenuBar();
+                  })();
+                }}
+              />
+            ) : null}
+          </MenuBarExtra.Section>
+        ))
+      )}
+
+      <MenuBarExtra.Section title="Start">
+        {sortedRecents.slice(0, 6).map((recent) => (
+          <MenuBarExtra.Item
+            key={recent.cwd}
+            title={recent.projectName}
+            subtitle={recent.branch}
+            icon={recent.favicon ?? Icon.Folder}
+            onAction={() => {
+              void (async () => {
+                await visitItem(recent);
+                await launchRecent(recent);
+              })();
+            }}
+          />
+        ))}
+      </MenuBarExtra.Section>
+
+      <MenuBarExtra.Section>
+        <MenuBarExtra.Item
+          title="Open Dashboard"
+          icon={Icon.Window}
+          onAction={() => {
+            void launchDashboard();
+          }}
+        />
+        <MenuBarExtra.Item
+          title="Start Dev Server…"
+          icon={Icon.Plus}
+          onAction={() => {
+            void launchStartPicker();
+          }}
+        />
+      </MenuBarExtra.Section>
+    </MenuBarExtra>
+  );
+}

--- a/extensions/dev-servers/src/snapshot.ts
+++ b/extensions/dev-servers/src/snapshot.ts
@@ -1,0 +1,52 @@
+import { Cache, LaunchType, launchCommand } from "@raycast/api";
+import { DevServer } from "./types";
+
+const SNAPSHOT_KEY = "servers-snapshot";
+const cache = new Cache();
+
+interface SnapshotPayload {
+  savedAt: string;
+  servers: Array<Omit<DevServer, "startedAt"> & { startedAt: string }>;
+}
+
+export function writeSnapshot(servers: DevServer[]): void {
+  const payload: SnapshotPayload = {
+    savedAt: new Date().toISOString(),
+    servers: servers.map((server) => ({
+      ...server,
+      startedAt: server.startedAt.toISOString(),
+    })),
+  };
+  cache.set(SNAPSHOT_KEY, JSON.stringify(payload));
+}
+
+export function readSnapshot(): DevServer[] | null {
+  const raw = cache.get(SNAPSHOT_KEY);
+  if (!raw) return null;
+  try {
+    const payload = JSON.parse(raw) as SnapshotPayload;
+    if (!payload || !Array.isArray(payload.servers)) return null;
+    return payload.servers.map((server) => {
+      const startedAt = new Date(server.startedAt);
+      if (Number.isNaN(startedAt.getTime())) throw new Error("Bad snapshot");
+      return {
+        ...server,
+        startedAt,
+      };
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function pokeMenuBar(): void {
+  try {
+    launchCommand({
+      name: "menubar",
+      type: LaunchType.Background,
+    }).catch(() => {});
+  } catch {
+    // The menu bar command can be disabled per-user; callers should never
+    // fail just because the optional companion surface is unavailable.
+  }
+}


### PR DESCRIPTION
## Description

- Added **Dev Servers Menu Bar**, a compact menu bar command that shows running dev servers by project and keeps the count visible when you want it.
- Each running server gets quick actions for opening, restarting, killing, copying the URL or port, and jumping into your editor or terminal.
- Recent stopped projects appear in a Start section, ranked by use, and hand off to the dashboard so the normal startup toast and progress flow stay intact.
- Projects with two or more servers get a kill-all item at the bottom of their section: "Kill Both Servers" for a pair, "Kill All 3 Servers" beyond. It acts on click without a dialog (menus can't confirm), so the label always names the blast radius and single-server projects don't show it at all.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
