### PR TITLE
Update singularityapp extension

### DIFF
--- a/extensions/singularityapp/CHANGELOG.md
+++ b/extensions/singularityapp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # SingularityApp Changelog
 
-## [0.4.0] - {PR_MERGE_DATE}
+## [0.4.0] - 2026-07-03
 
 - Added Zen Mode to focus on one random active non-repeating task from Today, Inbox, Random, or a selected project
 - Added a skip workflow that requires updating the task title before rolling another task

--- a/extensions/singularityapp/CHANGELOG.md
+++ b/extensions/singularityapp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SingularityApp Changelog
 
+## [0.4.0] - {PR_MERGE_DATE}
+
+- Added Zen Mode to focus on one random active non-repeating task from Today, Inbox, Random, or a selected project
+- Added a skip workflow that requires updating the task title before rolling another task
+
 ## [0.3.0] - 2026-03-30
 
 - Added hierarchical project ordering with visual indentation

--- a/extensions/singularityapp/package.json
+++ b/extensions/singularityapp/package.json
@@ -64,6 +64,12 @@
       "title": "Add Task",
       "description": "Create a new task in SingularityApp",
       "mode": "view"
+    },
+    {
+      "name": "zen-mode",
+      "title": "Zen Mode",
+      "description": "Focus on one random non-repeating task from a selected bucket.",
+      "mode": "view"
     }
   ],
   "preferences": [

--- a/extensions/singularityapp/src/components/TaskUpdater.tsx
+++ b/extensions/singularityapp/src/components/TaskUpdater.tsx
@@ -17,9 +17,21 @@ type TaskUpdaterProps = {
   task: Task;
   projects?: Project[];
   onTaskUpdated?: () => void;
+  requireTitleChange?: boolean;
+  guidance?: string;
+  submitTitle?: string;
+  successTitle?: string;
 };
 
-export default function TaskUpdater({ task, projects: initialProjects, onTaskUpdated }: TaskUpdaterProps) {
+export default function TaskUpdater({
+  task,
+  projects: initialProjects,
+  onTaskUpdated,
+  requireTitleChange = false,
+  guidance,
+  submitTitle = "Save Changes",
+  successTitle = "Task Updated",
+}: TaskUpdaterProps) {
   const { pop } = useNavigation();
   const [title, setTitle] = useState(task.title || "");
   const [note, setNote] = useState("");
@@ -59,8 +71,19 @@ export default function TaskUpdater({ task, projects: initialProjects, onTaskUpd
   }, []);
 
   async function handleSubmit() {
-    if (!title.trim()) {
+    const trimmedTitle = title.trim();
+
+    if (!trimmedTitle) {
       await showToast({ style: Toast.Style.Failure, title: "Title Required", message: "Please enter a task title" });
+      return;
+    }
+
+    if (requireTitleChange && trimmedTitle === task.title.trim()) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Update Required",
+        message: "Change the task title before continuing.",
+      });
       return;
     }
 
@@ -75,7 +98,7 @@ export default function TaskUpdater({ task, projects: initialProjects, onTaskUpd
         deadline: string | null;
         projectId: string | null;
       } = {
-        title: title.trim(),
+        title: trimmedTitle,
         note: note.trim() || undefined,
         priority: parseInt(priority) as 0 | 1 | 2,
         start: startDate ? getAPIDateString(startDate) : null,
@@ -84,7 +107,7 @@ export default function TaskUpdater({ task, projects: initialProjects, onTaskUpd
       };
 
       await updateTask(task.id, params);
-      await showToast({ style: Toast.Style.Success, title: "Task Updated" });
+      await showToast({ style: Toast.Style.Success, title: successTitle });
       onTaskUpdated?.();
       pop();
     } catch {
@@ -97,10 +120,12 @@ export default function TaskUpdater({ task, projects: initialProjects, onTaskUpd
       isLoading={isLoading}
       actions={
         <ActionPanel>
-          <Action.SubmitForm title="Save Changes" icon={Icon.Check} onSubmit={handleSubmit} />
+          <Action.SubmitForm title={submitTitle} icon={Icon.Check} onSubmit={handleSubmit} />
         </ActionPanel>
       }
     >
+      {guidance ? <Form.Description text={guidance} /> : null}
+
       <Form.TextField id="title" title="Title" value={title} onChange={setTitle} autoFocus />
 
       <Form.TextArea id="note" title="Note" value={note} onChange={setNote} />

--- a/extensions/singularityapp/src/zen-mode.tsx
+++ b/extensions/singularityapp/src/zen-mode.tsx
@@ -181,21 +181,28 @@ function ZenTaskView({
   const isNoteId = task?.note && /^N-[A-Z]-[a-f0-9-]+$/i.test(task.note);
 
   useEffect(() => {
+    let cancelled = false;
+
     async function fetchNoteContent() {
       setNoteContent(null);
+      setIsLoadingNote(false);
 
       if (isNoteId && task?.note) {
         setIsLoadingNote(true);
         const note = await getNote(task.note);
-        if (note) {
+        if (!cancelled && note) {
           const content = note.text || note.content || (typeof note.delta === "string" ? note.delta : null);
           setNoteContent(content);
         }
-        setIsLoadingNote(false);
+        if (!cancelled) setIsLoadingNote(false);
       }
     }
 
     fetchNoteContent();
+
+    return () => {
+      cancelled = true;
+    };
   }, [task?.note, isNoteId]);
 
   if (!task) {

--- a/extensions/singularityapp/src/zen-mode.tsx
+++ b/extensions/singularityapp/src/zen-mode.tsx
@@ -1,0 +1,401 @@
+import { Action, ActionPanel, Detail, Form, Icon, Toast, popToRoot, showToast } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ApiError,
+  Project,
+  Task,
+  completeTask,
+  getInboxTasks,
+  getProjectIcon,
+  getProjectIndent,
+  getProjectTasks,
+  getProjects,
+  getNote,
+  getTasks,
+  getTasksForToday,
+  withErrorHandling,
+} from "./api";
+import TaskUpdater from "./components/TaskUpdater";
+import { ErrorView } from "./components/TaskList";
+import { parseNoteContent } from "./utils/delta-to-markdown";
+import { getPriorityConfig } from "./utils/priorities";
+
+type Bucket =
+  | { type: "today"; title: string }
+  | { type: "inbox"; title: string }
+  | { type: "random"; title: string }
+  | { type: "project"; title: string; projectId: string };
+
+type TaskWithUnknownProperties = Task & Record<string, unknown>;
+
+const RECURRENCE_MARKER_KEYS = [
+  "recurrence",
+  "recurrenceRule",
+  "recurrenceId",
+  "recurring",
+  "regular",
+  "regularId",
+  "regularTaskId",
+  "repeat",
+  "repeatRule",
+  "repeatType",
+  "rrule",
+];
+
+function isCompleted(task: Task): boolean {
+  return task.checked === 1 || task.complete === 1;
+}
+
+function isRepetitiveTask(task: Task): boolean {
+  const rawTask = task as TaskWithUnknownProperties;
+
+  return RECURRENCE_MARKER_KEYS.some((key) => {
+    const value = rawTask[key];
+    if (value === undefined || value === null || value === false || value === "" || value === 0) return false;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === "object") return Object.keys(value).length > 0;
+    return true;
+  });
+}
+
+function getEligibleTasks(tasks: Task[]): Task[] {
+  return tasks.filter((task) => !task.removed && !isCompleted(task) && !isRepetitiveTask(task));
+}
+
+function pickRandomTask(tasks: Task[], previousTaskId?: string): Task | null {
+  if (tasks.length === 0) return null;
+
+  const candidates = tasks.length > 1 ? tasks.filter((task) => task.id !== previousTaskId) : tasks;
+  return candidates[Math.floor(Math.random() * candidates.length)];
+}
+
+async function loadTasksForBucket(bucket: Bucket): Promise<Task[]> {
+  if (bucket.type === "today") return getTasksForToday();
+  if (bucket.type === "inbox") return getInboxTasks();
+  if (bucket.type === "project") return getProjectTasks(bucket.projectId);
+
+  return getTasks({
+    includeRemoved: false,
+    includeArchived: false,
+  });
+}
+
+function formatDateTime(value: string | undefined, fallback: string): string {
+  if (!value) return fallback;
+  return new Date(value).toLocaleString();
+}
+
+function formatProject(project: Project | undefined): string {
+  return project?.title ?? "Inbox";
+}
+
+function buildTaskMarkdown(task: Task, noteDisplay: string): string {
+  return `# ${task.title || "(Untitled task)"}\n\n${noteDisplay}`;
+}
+
+function BucketPicker({
+  projects,
+  isLoading,
+  onPick,
+}: {
+  projects: Project[];
+  isLoading: boolean;
+  onPick: (bucket: Bucket) => void;
+}) {
+  const [bucketId, setBucketId] = useState("today");
+
+  function handleSubmit() {
+    const project = projects.find((item) => `project:${item.id}` === bucketId);
+    if (project) {
+      onPick({ type: "project", title: project.title, projectId: project.id });
+      return;
+    }
+
+    if (bucketId === "inbox") {
+      onPick({ type: "inbox", title: "Inbox" });
+    } else if (bucketId === "random") {
+      onPick({ type: "random", title: "Random" });
+    } else {
+      onPick({ type: "today", title: "Today" });
+    }
+  }
+
+  return (
+    <Form
+      isLoading={isLoading}
+      navigationTitle="Zen Mode"
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Start Zen Mode" icon={Icon.Play} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.Description text="Long task lists can create choice overload and make it hard to decide where to start. Zen Mode removes that decision: pick a bucket and it will show one random active non-repeating task. Complete it, skip it by changing the title, or exit when you are done. Random includes every project and Inbox." />
+
+      <Form.Dropdown id="bucket" title="Bucket" value={bucketId} onChange={setBucketId}>
+        <Form.Dropdown.Item value="today" title="Today" icon={Icon.Calendar} />
+        <Form.Dropdown.Item value="inbox" title="Inbox" icon={Icon.Tray} />
+        <Form.Dropdown.Item value="random" title="Random" icon={Icon.Shuffle} />
+        {projects.length > 0 ? (
+          <Form.Dropdown.Section title="Projects">
+            {projects.map((project) => (
+              <Form.Dropdown.Item
+                key={project.id}
+                value={`project:${project.id}`}
+                title={`${getProjectIndent(project)}${getProjectIcon(project, true).source}  ${project.title}`}
+              />
+            ))}
+          </Form.Dropdown.Section>
+        ) : null}
+      </Form.Dropdown>
+    </Form>
+  );
+}
+
+function ZenTaskView({
+  bucket,
+  task,
+  projects,
+  projectsMap,
+  remainingTaskCount,
+  isLoading,
+  onComplete,
+  onSkip,
+  onTaskUpdated,
+}: {
+  bucket: Bucket;
+  task: Task | null;
+  projects: Project[];
+  projectsMap: Record<string, Project>;
+  remainingTaskCount: number;
+  isLoading: boolean;
+  onComplete: () => Promise<void>;
+  onSkip: () => void;
+  onTaskUpdated: () => void;
+}) {
+  const project = task?.projectId ? projectsMap[task.projectId] : undefined;
+  const priority = getPriorityConfig(task?.priority ?? 1);
+  const [noteContent, setNoteContent] = useState<string | null>(null);
+  const [isLoadingNote, setIsLoadingNote] = useState(false);
+  const isNoteId = task?.note && /^N-[A-Z]-[a-f0-9-]+$/i.test(task.note);
+
+  useEffect(() => {
+    async function fetchNoteContent() {
+      setNoteContent(null);
+
+      if (isNoteId && task?.note) {
+        setIsLoadingNote(true);
+        const note = await getNote(task.note);
+        if (note) {
+          const content = note.text || note.content || (typeof note.delta === "string" ? note.delta : null);
+          setNoteContent(content);
+        }
+        setIsLoadingNote(false);
+      }
+    }
+
+    fetchNoteContent();
+  }, [task?.note, isNoteId]);
+
+  if (!task) {
+    return (
+      <Detail
+        navigationTitle={`Zen Mode: ${bucket.title}`}
+        isLoading={isLoading}
+        markdown={
+          isLoading
+            ? "# Loading task..."
+            : `# No eligible tasks\n\nNo active non-repeating tasks were found in ${bucket.title}.`
+        }
+        actions={
+          <ActionPanel>
+            <Action title="Exit Zen Mode" icon={Icon.XMarkCircle} onAction={popToRoot} />
+          </ActionPanel>
+        }
+      />
+    );
+  }
+
+  let noteDisplay = "";
+  if (isLoadingNote) {
+    noteDisplay = "*Loading note...*";
+  } else if (noteContent) {
+    noteDisplay = parseNoteContent(noteContent);
+  } else if (task.note && !isNoteId) {
+    noteDisplay = parseNoteContent(task.note);
+  }
+
+  return (
+    <Detail
+      navigationTitle={`Zen Mode: ${bucket.title}`}
+      isLoading={isLoading || isLoadingNote}
+      markdown={buildTaskMarkdown(task, noteDisplay)}
+      metadata={
+        <Detail.Metadata>
+          <Detail.Metadata.Label
+            title="Project"
+            text={formatProject(project)}
+            icon={project ? getProjectIcon(project) : Icon.Tray}
+          />
+          <Detail.Metadata.Label
+            title="Priority"
+            text={priority.name}
+            icon={{ source: priority.icon, tintColor: priority.color }}
+          />
+          <Detail.Metadata.Label title="Start" text={formatDateTime(task.start, "Not set")} icon={Icon.Calendar} />
+          <Detail.Metadata.Label title="Deadline" text={formatDateTime(task.deadline, "Not set")} icon={Icon.Flag} />
+          <Detail.Metadata.Label title="Remaining in Bucket" text={`${remainingTaskCount}`} icon={Icon.List} />
+          {task.tags && task.tags.length > 0 ? (
+            <Detail.Metadata.TagList title="Tags">
+              {task.tags.map((tag, index) => (
+                <Detail.Metadata.TagList.Item key={index} text={tag} />
+              ))}
+            </Detail.Metadata.TagList>
+          ) : null}
+        </Detail.Metadata>
+      }
+      actions={
+        <ActionPanel>
+          <Action title="Complete Task" icon={Icon.Checkmark} onAction={onComplete} />
+          <Action.Push
+            title="Skip Task"
+            icon={Icon.Forward}
+            target={
+              <TaskUpdater
+                task={task}
+                projects={projects}
+                onTaskUpdated={onSkip}
+                requireTitleChange
+                guidance="To skip this task, update its title first. Other properties can be edited here too."
+                submitTitle="Update and Skip"
+                successTitle="Task Skipped"
+              />
+            }
+          />
+          <Action title="Exit Zen Mode" icon={Icon.XMarkCircle} onAction={popToRoot} />
+          <ActionPanel.Section>
+            <Action.Push
+              title="Edit Task"
+              icon={Icon.Pencil}
+              shortcut={{ modifiers: ["cmd"], key: "e" }}
+              target={<TaskUpdater task={task} projects={projects} onTaskUpdated={onTaskUpdated} />}
+            />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+export default function Command() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [bucket, setBucket] = useState<Bucket | null>(null);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [task, setTask] = useState<Task | null>(null);
+  const [isLoadingProjects, setIsLoadingProjects] = useState(true);
+  const [isLoadingTasks, setIsLoadingTasks] = useState(false);
+  const [hasLoadedBucketTasks, setHasLoadedBucketTasks] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const projectsMap = useMemo(() => Object.fromEntries(projects.map((project) => [project.id, project])), [projects]);
+
+  const rollTask = useCallback((taskPool: Task[], previousTaskId?: string) => {
+    setTask(pickRandomTask(getEligibleTasks(taskPool), previousTaskId));
+  }, []);
+
+  const loadProjects = useCallback(async () => {
+    const result = await withErrorHandling(() => getProjects(), "Failed to load projects", { showDetails: true });
+    if (result) setProjects(result);
+    setIsLoadingProjects(false);
+  }, []);
+
+  const loadBucketTasks = useCallback(
+    async (selectedBucket: Bucket, previousTaskId?: string) => {
+      setIsLoadingTasks(true);
+      setError(null);
+
+      try {
+        const loadedTasks = await loadTasksForBucket(selectedBucket);
+        setTasks(loadedTasks);
+        rollTask(loadedTasks, previousTaskId);
+      } catch (err) {
+        const errorMessage =
+          err instanceof ApiError
+            ? err.userFriendlyMessage
+            : err instanceof Error
+              ? err.message
+              : "An unexpected error occurred";
+        setError(errorMessage);
+      } finally {
+        setHasLoadedBucketTasks(true);
+        setIsLoadingTasks(false);
+      }
+    },
+    [rollTask],
+  );
+
+  useEffect(() => {
+    loadProjects();
+  }, [loadProjects]);
+
+  useEffect(() => {
+    if (bucket) {
+      loadBucketTasks(bucket);
+    }
+  }, [bucket, loadBucketTasks]);
+
+  async function handleCompleteTask() {
+    if (!task) return;
+
+    await showToast({ style: Toast.Style.Animated, title: "Completing task" });
+
+    try {
+      await completeTask(task.id);
+      await showToast({ style: Toast.Style.Success, title: "Task completed" });
+      await loadBucketTasks(bucket!, task.id);
+    } catch (err) {
+      await showFailureToast(err, { title: "Unable to complete task" });
+    }
+  }
+
+  async function handleSkipTask() {
+    if (!bucket || !task) return;
+    await loadBucketTasks(bucket, task.id);
+  }
+
+  async function handleTaskUpdated() {
+    if (!bucket) return;
+    await loadBucketTasks(bucket, task?.id);
+  }
+
+  function handlePickBucket(selectedBucket: Bucket) {
+    setHasLoadedBucketTasks(false);
+    setIsLoadingTasks(true);
+    setTasks([]);
+    setTask(null);
+    setBucket(selectedBucket);
+  }
+
+  if (!bucket) {
+    return <BucketPicker projects={projects} isLoading={isLoadingProjects} onPick={handlePickBucket} />;
+  }
+
+  if (error) {
+    return <ErrorView error={error} onRetry={() => loadBucketTasks(bucket, task?.id)} />;
+  }
+
+  return (
+    <ZenTaskView
+      bucket={bucket}
+      task={task}
+      projects={projects}
+      projectsMap={projectsMap}
+      remainingTaskCount={getEligibleTasks(tasks).length}
+      isLoading={isLoadingTasks || !hasLoadedBucketTasks}
+      onComplete={handleCompleteTask}
+      onSkip={handleSkipTask}
+      onTaskUpdated={handleTaskUpdated}
+    />
+  );
+}


### PR DESCRIPTION
## Description

Adds a new **Zen Mode** command for SingularityApp. Zen Mode helps reduce choice overload from long task lists by showing one random active non-repeating task at a time from Today, Inbox, Random, or a selected project.

In Zen Mode users can:

- Complete the shown task
- Skip the task after editing it; the title must be changed before another task is rolled
- Exit Zen Mode

The command fetches note content for note IDs, reuses the existing task editor for edits and skips, excludes recurring/repeating tasks from randomization, and includes onboarding copy explaining the workflow.

## Screencast

<img width="862" height="586" alt="image" src="https://github.com/user-attachments/assets/cb7e6d72-d8a4-4927-9a73-a160b08eb95f" />

<img width="862" height="586" alt="image" src="https://github.com/user-attachments/assets/67cca0fa-9ecd-45bf-a133-b52a697aecbc" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
