### PR TITLE
Skills: document custom package registry configuration

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Document Custom Registry Configuration] - {PR_MERGE_DATE}
+## [Document Custom Registry Configuration] - 2026-07-03
 
 - Add README guidance for pointing `bunx`/`npx` at a custom package registry (corporate proxy) via `~/.npmrc` and `~/.bunfig.toml`, since Raycast does not inherit shell environment variables
 

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Skills Changelog
 
+## [Document Custom Registry Configuration] - {PR_MERGE_DATE}
+
+- Add README guidance for pointing `bunx`/`npx` at a custom package registry (corporate proxy) via `~/.npmrc` and `~/.bunfig.toml`, since Raycast does not inherit shell environment variables
+
 ## [Use Security Audit API] - 2026-06-26
 
 - Use the Skills security audit API instead of parsing audit data from the skills.sh HTML page

--- a/extensions/skills/README.md
+++ b/extensions/skills/README.md
@@ -30,6 +30,27 @@ Search for agent skills from skills.sh with real-time results. Results show whic
 
 View, update, and remove installed skills. Outdated skills are highlighted with an orange icon and grouped in the "Updates Available" section. Filter by agent to see which skills are available for each AI agent.
 
+## Using a Custom Package Registry (Corporate Proxy)
+
+This extension runs the Skills CLI via `bunx`/`npx`, which download the `skills` package from a package registry. If your machine installs packages through a corporate proxy instead of the public npm registry, note that Raycast is launched by the OS and does **not** inherit environment variables from your shell profile (`~/.zshrc`, `~/.bash_profile`, etc.). Registry overrides set only as shell environment variables (for example `NPM_CONFIG_REGISTRY` or `BUN_CONFIG_REGISTRY`) will not reach the CLI.
+
+Configure your registry in **files in your home directory**, which every launch context reads:
+
+- **npm / npx** — `~/.npmrc`:
+
+  ```
+  registry=https://your-proxy.example.com/
+  ```
+
+- **bun / bunx** (tried first by this extension) — `~/.bunfig.toml`:
+
+  ```toml
+  [install]
+  registry = "https://your-proxy.example.com/"
+  ```
+
+After editing these files, fully quit and relaunch Raycast so it re-reads the configuration. If automatic `npx` detection also fails, set **Custom npx Path** in the extension preferences.
+
 ## Screenshots
 
 ![Search Skills - Owner Filter](metadata/skills-1.png)


### PR DESCRIPTION
## Description

Adds a short README section to the **Skills** extension explaining how to point its `bunx`/`npx`-driven CLI at a custom package registry (e.g. a corporate proxy).

### Motivation

The extension runs the Skills CLI via `bunx --silent skills@latest` / `npx -y skills@latest`, inheriting `process.env` from Raycast. Because Raycast is launched by the OS (launchd on macOS), it does **not** source the user's shell profile — so registry overrides set only as shell environment variables (`NPM_CONFIG_REGISTRY`, `BUN_CONFIG_REGISTRY`, etc.) never reach the spawned CLI. Users behind a corporate proxy find their terminal installs work but the extension fails to resolve `skills@latest`.

The fix requires no code change: registry config placed in home-directory files (`~/.npmrc`, `~/.bunfig.toml`) is read regardless of launch context. This PR documents that so users can self-serve.

### Changes

- **README.md** — new "Using a Custom Package Registry (Corporate Proxy)" section
- **CHANGELOG.md** — new entry with the `{PR_MERGE_DATE}` placeholder

Docs-only; no code or behavior changes.

### Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I updated the CHANGELOG with a `{PR_MERGE_DATE}` entry
- [x] Change touches a single extension (`skills`)