### PR TITLE
Update teak-raycast extension

### DIFF
--- a/extensions/teak-raycast/CHANGELOG.md
+++ b/extensions/teak-raycast/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Existing API keys keep working as before
 - AI tools and background save commands no longer pop open a browser sign-in window unexpectedly
 
-## 1.0.30 - {PR_MERGE_DATE}
+## 1.0.30 - 2026-05-06
 
 - Add **Save to Teak** fallback command so you can capture text or URLs from Raycast root search
 - Add **Save Selected Text** command to send the currently highlighted text from any app to Teak

--- a/extensions/teak-raycast/CHANGELOG.md
+++ b/extensions/teak-raycast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Sign in with your browser] - {PR_MERGE_DATE}
+## [Sign in with your browser] - 2026-07-03
 
 - Sign in with your browser in one step — copying an API key is no longer required to get started
 - Existing API keys keep working as before

--- a/extensions/teak-raycast/CHANGELOG.md
+++ b/extensions/teak-raycast/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 1.0.30 - 2026-05-06
+## [Sign in with your browser] - {PR_MERGE_DATE}
+
+- Sign in with your browser in one step — copying an API key is no longer required to get started
+- Existing API keys keep working as before
+- AI tools and background save commands no longer pop open a browser sign-in window unexpectedly
+
+## 1.0.30 - {PR_MERGE_DATE}
 
 - Add **Save to Teak** fallback command so you can capture text or URLs from Raycast root search
 - Add **Save Selected Text** command to send the currently highlighted text from any app to Teak

--- a/extensions/teak-raycast/README.md
+++ b/extensions/teak-raycast/README.md
@@ -15,6 +15,6 @@ Keyboard-first Teak workflows for capture and retrieval directly inside Raycast.
 
 ## Troubleshooting
 
-- Invalid key errors: regenerate key in Teak Settings > API Keys, then update extension preferences.
+- Invalid key errors: regenerate key in Teak Settings > Manage API Keys, then update extension preferences.
 - Rate limited errors: wait briefly and retry.
 - Network errors: verify connectivity to `app.teakvault.com` and `api.teakvault.com`.

--- a/extensions/teak-raycast/package-lock.json
+++ b/extensions/teak-raycast/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "teak-raycast",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teak-raycast",
-      "version": "1.0.45",
+      "version": "1.0.46",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.19"
+        "@raycast/api": "^1.104.19",
+        "@raycast/utils": "^2.2.7"
       },
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -1098,6 +1099,24 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/@raycast/utils": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.7.tgz",
+      "integrity": "sha512-1jV9tKLluP0Av/ICcl/yvVzCj7mY6F3wnKsh8SJpy/Fsqq/LCFXcI6TgMabIJ45AaDVhEV+JH9jS1lJSwBgiMw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@raycast/api": ">=1.99.4",
+        "react": ">=19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1596,6 +1615,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",

--- a/extensions/teak-raycast/package-lock.json
+++ b/extensions/teak-raycast/package-lock.json
@@ -1,27 +1,27 @@
 {
   "name": "teak-raycast",
-  "version": "1.0.30",
+  "version": "1.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teak-raycast",
-      "version": "1.0.30",
+      "version": "1.0.45",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.15"
+        "@raycast/api": "^1.104.19"
       },
       "devDependencies": {
-        "@types/node": "^25.6.0",
-        "@types/react": "19.2.14",
+        "@types/node": "^25.9.3",
+        "@types/react": "19.2.17",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.59.1"
+        "typescript-eslint": "^8.61.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -99,9 +99,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -131,9 +131,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -147,9 +147,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -195,9 +195,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -291,9 +291,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -307,9 +307,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -323,9 +323,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -339,9 +339,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -387,9 +387,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -403,9 +403,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -419,9 +419,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -532,9 +532,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1037,9 +1037,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.15",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.15.tgz",
-      "integrity": "sha512-jQK0J1E8MRrjIDoG1QP/Py+eMdDRfxS2wRHd8z40Fa8bBxUQyDr+A4zJ+7s61V8vPCzqiGgET6pvH61AYmR25g==",
+      "version": "1.104.19",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.19.tgz",
+      "integrity": "sha512-SAVg56BAzxZGy/OPQ0jekUG3pJaoX5pCqleALvFo9JRE7P2tvKoglWnYRcIJArRhLlvV8FtFNMDafd+NNwXXCw==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
@@ -1107,9 +1107,9 @@
       "peer": true
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -1123,19 +1123,19 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1143,17 +1143,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/type-utils": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/type-utils": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1166,7 +1166,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.2",
+        "@typescript-eslint/parser": "^8.61.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1182,16 +1182,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1207,14 +1207,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.2",
-        "@typescript-eslint/types": "^8.59.2",
+        "@typescript-eslint/tsconfig-utils": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1229,14 +1229,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2"
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1247,9 +1247,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1264,15 +1264,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1289,9 +1289,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1303,16 +1303,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.2",
-        "@typescript-eslint/tsconfig-utils": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/project-service": "8.61.1",
+        "@typescript-eslint/tsconfig-utils": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1331,16 +1331,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2"
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1355,13 +1355,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/types": "8.61.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1373,9 +1373,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1479,9 +1479,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1619,9 +1619,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1631,32 +1631,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1672,19 +1672,22 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -2551,16 +2554,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.2",
-        "@typescript-eslint/parser": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2"
+        "@typescript-eslint/eslint-plugin": "8.61.1",
+        "@typescript-eslint/parser": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2575,9 +2578,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/extensions/teak-raycast/package.json
+++ b/extensions/teak-raycast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "teak-raycast",
   "title": "Teak",
-  "version": "1.0.30",
+  "version": "1.0.46",
   "private": true,
   "license": "MIT",
   "description": "Save ideas fast, search your Teak cards, and access favorites directly from Raycast.",
@@ -18,8 +18,8 @@
       "name": "apiKey",
       "title": "API Key",
       "type": "password",
-      "required": true,
-      "description": "Generate in Teak Settings > API Keys, then paste it here."
+      "required": false,
+      "description": "Optional — only if you prefer an API key over browser sign-in. Generate in Teak Settings > Manage API Keys."
     }
   ],
   "commands": [
@@ -133,12 +133,16 @@
     "test": "bun test src/__tests__ --coverage --dots"
   },
   "dependencies": {
-    "@raycast/api": "^1.104.15"
+    "@raycast/api": "^1.104.19",
+    "@raycast/utils": "^2.2.7"
+  },
+  "overrides": {
+    "esbuild": "0.28.1"
   },
   "devDependencies": {
-    "@types/node": "^25.6.0",
-    "@types/react": "19.2.14",
+    "@types/node": "^25.9.3",
+    "@types/react": "19.2.17",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.59.1"
+    "typescript-eslint": "^8.61.1"
   }
 }

--- a/extensions/teak-raycast/src/__tests__/api.test.ts
+++ b/extensions/teak-raycast/src/__tests__/api.test.ts
@@ -64,6 +64,32 @@ describe("raycast api helpers", () => {
     expect(getRecoveryHint(error)).toContain("Check network connectivity");
   });
 
+  test("maps API config errors to local setup guidance", () => {
+    const error = new RaycastApiError("CONFIG_ERROR", 500);
+
+    expect(getUserFacingErrorMessage(error)).toContain(
+      "missing required configuration",
+    );
+    expect(getRecoveryHint(error)).toContain("CONVEX_HTTP_BASE_URL");
+  });
+
+  test("maps missing local api gateway errors to dev guidance", () => {
+    const error = new RaycastApiError("DEV_API_UNAVAILABLE", 404);
+
+    expect(getUserFacingErrorMessage(error)).toContain("API gateway");
+    expect(getRecoveryHint(error)).toContain("bun run dev:api");
+  });
+
+  test("maps not found errors without implying a card was deleted", () => {
+    const error = new RaycastApiError("NOT_FOUND", 404);
+
+    expect(getUserFacingErrorMessage(error)).toContain("requested resource");
+    expect(getUserFacingErrorMessage(error)).not.toContain(
+      "card no longer exists",
+    );
+    expect(getRecoveryHint(error)).toContain("API URL");
+  });
+
   test("handles unknown error values", () => {
     expect(getUserFacingErrorMessage(null)).toContain(
       "temporarily unavailable",

--- a/extensions/teak-raycast/src/__tests__/constants.test.ts
+++ b/extensions/teak-raycast/src/__tests__/constants.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("@raycast/api", () => ({
   environment: { isDevelopment: true },
@@ -16,7 +16,7 @@ describe("raycast local constants", () => {
 
   test("uses the canonical portless API URL in development", async () => {
     const { getApiBaseUrl } = await loadLocalConstants();
-    expect(getApiBaseUrl()).toBe("http://api.teak.localhost:1355/v1");
+    expect(getApiBaseUrl()).toBe("https://api.teak.localhost:1355/v1");
   });
 
   test("builds local card URLs from the portless app origin", async () => {
@@ -24,5 +24,67 @@ describe("raycast local constants", () => {
     expect(getTeakCardUrl("card_123")).toBe(
       "http://app.teak.localhost:1355/?card=card_123",
     );
+  });
+});
+
+describe("raycast OAuth token base URL", () => {
+  const originalTokenEnv = process.env.TEAK_DEV_CONVEX_SITE_URL;
+  const originalSiteEnv = process.env.NEXT_PUBLIC_CONVEX_SITE_URL;
+
+  const restoreEnv = (key: string, value: string | undefined) => {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  };
+
+  afterEach(() => {
+    restoreEnv("TEAK_DEV_CONVEX_SITE_URL", originalTokenEnv);
+    restoreEnv("NEXT_PUBLIC_CONVEX_SITE_URL", originalSiteEnv);
+    // Restore the file-level development mock for any following tests.
+    mock.module("@raycast/api", () => ({
+      environment: { isDevelopment: true },
+    }));
+  });
+
+  test("ignores NEXT_PUBLIC_CONVEX_SITE_URL and uses the default deployment", async () => {
+    delete process.env.TEAK_DEV_CONVEX_SITE_URL;
+    // A Vercel-pulled .env.local may point this at a stale deployment; the
+    // token URL must not follow it.
+    process.env.NEXT_PUBLIC_CONVEX_SITE_URL =
+      "https://uncommon-ladybug-882.convex.site";
+
+    const { getOAuthTokenBaseUrl } = await loadLocalConstants();
+    expect(getOAuthTokenBaseUrl()).toBe(
+      "https://reminiscent-kangaroo-59.convex.site",
+    );
+  });
+
+  test("prefers TEAK_DEV_CONVEX_SITE_URL and normalizes it", async () => {
+    process.env.TEAK_DEV_CONVEX_SITE_URL =
+      "https://override.convex.site/path?tab=1#frag";
+
+    const { getOAuthTokenBaseUrl } = await loadLocalConstants();
+    expect(getOAuthTokenBaseUrl()).toBe("https://override.convex.site");
+  });
+
+  test("uses the default dev Convex site when no env override is set", async () => {
+    delete process.env.TEAK_DEV_CONVEX_SITE_URL;
+    delete process.env.NEXT_PUBLIC_CONVEX_SITE_URL;
+
+    const { getOAuthTokenBaseUrl } = await loadLocalConstants();
+    expect(getOAuthTokenBaseUrl()).toBe(
+      "https://reminiscent-kangaroo-59.convex.site",
+    );
+  });
+
+  test("uses the production app origin outside development", async () => {
+    mock.module("@raycast/api", () => ({
+      environment: { isDevelopment: false },
+    }));
+
+    const { getOAuthTokenBaseUrl } = await loadLocalConstants();
+    expect(getOAuthTokenBaseUrl()).toBe("https://app.teakvault.com");
   });
 });

--- a/extensions/teak-raycast/src/__tests__/request.test.ts
+++ b/extensions/teak-raycast/src/__tests__/request.test.ts
@@ -2,13 +2,29 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { parseCardsResponse } from "../lib/apiParsers";
 
 const getPreferenceValuesMock = mock(() => ({ apiKey: "valid-test-key" }));
+const authorizeMock = mock(() => Promise.resolve("oauth-access-token"));
+const removeTokensMock = mock(() => Promise.resolve());
+const getTokensMock = mock(() => Promise.resolve(undefined));
 
 const mockRaycastApi = (isDevelopment: boolean) => {
   mock.module("@raycast/api", () => ({
     environment: { isDevelopment },
     getPreferenceValues: getPreferenceValuesMock,
+    OAuth: {
+      PKCEClient: class {},
+      RedirectMethod: { App: "app", AppURI: "appURI", Web: "web" },
+    },
   }));
 };
+
+// OAuthService is instantiated at module load of ../lib/oauth; provide a stub
+// whose authorize() / client.removeTokens() we can assert against.
+mock.module("@raycast/utils", () => ({
+  OAuthService: class {
+    authorize = authorizeMock;
+    client = { getTokens: getTokensMock, removeTokens: removeTokensMock };
+  },
+}));
 
 mockRaycastApi(false);
 
@@ -76,18 +92,22 @@ afterEach(() => {
   getPreferenceValuesMock.mockImplementation(() => ({
     apiKey: "valid-test-key",
   }));
+  authorizeMock.mockReset();
+  authorizeMock.mockImplementation(() => Promise.resolve("oauth-access-token"));
+  removeTokensMock.mockReset();
+  removeTokensMock.mockImplementation(() => Promise.resolve());
+  getTokensMock.mockReset();
+  getTokensMock.mockImplementation(() => Promise.resolve(undefined));
   mockRaycastApi(false);
 });
 
 describe("raycast request handling", () => {
   test("enforces auth/content-type headers while preserving custom headers", async () => {
     let capturedHeaders: Headers | null = null;
-    const fetchMock = mock(
-      async (_input: RequestInfo | URL, init?: RequestInit) => {
-        capturedHeaders = new Headers(init?.headers);
-        return createCardsResponse();
-      },
-    );
+    const fetchMock = mock((_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers);
+      return createCardsResponse();
+    });
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     await request("/cards/search?limit=1", parseCardsResponse, {
@@ -143,8 +163,8 @@ describe("raycast request handling", () => {
     }
 
     expect(capturedUrls).toEqual([
-      "http://api.teak.localhost:1355/v1/cards/search?limit=1",
-      "http://127.0.0.1:1355/v1/cards/search?limit=1",
+      "https://api.teak.localhost:1355/v1/cards/search?limit=1",
+      "https://127.0.0.1:1355/v1/cards/search?limit=1",
     ]);
   });
 
@@ -218,22 +238,77 @@ describe("raycast request handling", () => {
     }
   });
 
+  test("maps API configuration failures to CONFIG_ERROR", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            code: "CONFIG_ERROR",
+            error: "Missing or invalid CONVEX_HTTP_BASE_URL",
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 500,
+          },
+        ),
+    ) as unknown as typeof fetch;
+
+    try {
+      await searchCards({ limit: 1 });
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(RaycastApiError);
+      expect((error as InstanceType<typeof RaycastApiError>).code).toBe(
+        "CONFIG_ERROR",
+      );
+    }
+  });
+
+  test("maps missing Portless dev API registration to DEV_API_UNAVAILABLE", async () => {
+    mockRaycastApi(true);
+    const { searchCards: searchCardsInDev } = await import(
+      `../lib/api?missing-dev-api=${crypto.randomUUID()}`
+    );
+
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          "<!doctype html><html><body>No app registered for api.teak.localhost</body></html>",
+          {
+            headers: {
+              "Content-Type": "text/html",
+              "X-Portless": "1",
+            },
+            status: 404,
+          },
+        ),
+    ) as unknown as typeof fetch;
+
+    try {
+      await searchCardsInDev({ limit: 1 });
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(RaycastApiError);
+      expect((error as InstanceType<typeof RaycastApiError>).code).toBe(
+        "DEV_API_UNAVAILABLE",
+      );
+    }
+  });
+
   test("setCardFavorite patches favorite state on the favorite endpoint", async () => {
     let capturedUrl: string | null = null;
     let capturedMethod: string | null = null;
     let capturedBody: unknown = null;
 
-    globalThis.fetch = mock(
-      async (input: RequestInfo | URL, init?: RequestInit) => {
-        capturedUrl = String(input);
-        capturedMethod = init?.method ?? null;
-        capturedBody = init?.body ? JSON.parse(String(init.body)) : null;
-        return createCardsResponse(200, {
-          ...sampleCard,
-          isFavorited: false,
-        });
-      },
-    ) as unknown as typeof fetch;
+    globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+      capturedUrl = String(input);
+      capturedMethod = init?.method ?? null;
+      capturedBody = init?.body ? JSON.parse(String(init.body)) : null;
+      return createCardsResponse(200, {
+        ...sampleCard,
+        isFavorited: false,
+      });
+    }) as unknown as typeof fetch;
 
     const updated = await setCardFavorite("card_123", false);
 
@@ -247,13 +322,11 @@ describe("raycast request handling", () => {
     let capturedUrl: string | null = null;
     let capturedMethod: string | null = null;
 
-    globalThis.fetch = mock(
-      async (input: RequestInfo | URL, init?: RequestInit) => {
-        capturedUrl = String(input);
-        capturedMethod = init?.method ?? null;
-        return createEmptyResponse(204);
-      },
-    ) as unknown as typeof fetch;
+    globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+      capturedUrl = String(input);
+      capturedMethod = init?.method ?? null;
+      return createEmptyResponse(204);
+    }) as unknown as typeof fetch;
 
     await softDeleteCard("card_123");
 
@@ -264,17 +337,15 @@ describe("raycast request handling", () => {
   test("createCard posts structured bookmark payloads", async () => {
     let capturedBody: unknown = null;
 
-    globalThis.fetch = mock(
-      async (_input: RequestInfo | URL, init?: RequestInit) => {
-        capturedBody = init?.body ? JSON.parse(String(init.body)) : null;
-        return createCardsResponse(200, {
-          appUrl: sampleCard.appUrl,
-          card: sampleCard,
-          cardId: sampleCard.id,
-          status: "created",
-        });
-      },
-    ) as unknown as typeof fetch;
+    globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedBody = init?.body ? JSON.parse(String(init.body)) : null;
+      return createCardsResponse(200, {
+        appUrl: sampleCard.appUrl,
+        card: sampleCard,
+        cardId: sampleCard.id,
+        status: "created",
+      });
+    }) as unknown as typeof fetch;
 
     const result = await createCard({
       content: "Teak",
@@ -295,12 +366,10 @@ describe("raycast request handling", () => {
   test("getCardById sends a GET request to the card endpoint", async () => {
     let capturedMethod: string | null = null;
 
-    globalThis.fetch = mock(
-      async (_input: RequestInfo | URL, init?: RequestInit) => {
-        capturedMethod = init?.method ?? null;
-        return createCardsResponse(200, sampleCard);
-      },
-    ) as unknown as typeof fetch;
+    globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedMethod = init?.method ?? null;
+      return createCardsResponse(200, sampleCard);
+    }) as unknown as typeof fetch;
 
     const result = await getCardById("card_123");
 
@@ -312,16 +381,14 @@ describe("raycast request handling", () => {
     let capturedBody: unknown = null;
     let capturedMethod: string | null = null;
 
-    globalThis.fetch = mock(
-      async (_input: RequestInfo | URL, init?: RequestInit) => {
-        capturedMethod = init?.method ?? null;
-        capturedBody = init?.body ? JSON.parse(String(init.body)) : null;
-        return createCardsResponse(200, {
-          ...sampleCard,
-          notes: "Updated note",
-        });
-      },
-    ) as unknown as typeof fetch;
+    globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedMethod = init?.method ?? null;
+      capturedBody = init?.body ? JSON.parse(String(init.body)) : null;
+      return createCardsResponse(200, {
+        ...sampleCard,
+        notes: "Updated note",
+      });
+    }) as unknown as typeof fetch;
 
     const result = await updateCard("card_123", {
       notes: "Updated note",
@@ -336,21 +403,43 @@ describe("raycast request handling", () => {
     expect(result.notes).toBe("Updated note");
   });
 
-  test("fails fast when API key is missing", async () => {
-    const fetchMock = mock(async () => createCardsResponse());
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  test("falls back to browser OAuth when no API key is set", async () => {
     getPreferenceValuesMock.mockImplementation(() => ({ apiKey: "   " }));
 
-    try {
-      await searchCards({ limit: 1 });
-      expect.unreachable();
-    } catch (error) {
-      expect(error).toBeInstanceOf(RaycastApiError);
-      expect((error as InstanceType<typeof RaycastApiError>).code).toBe(
-        "MISSING_API_KEY",
-      );
-    }
+    let capturedHeaders: Headers | null = null;
+    const fetchMock = mock((_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers);
+      return createCardsResponse();
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    await searchCards({ limit: 1 });
+
+    expect(authorizeMock).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalled();
+    expect(capturedHeaders?.get("authorization")).toBe(
+      "Bearer oauth-access-token",
+    );
+  });
+
+  test("refreshes the OAuth token once after a 401", async () => {
+    getPreferenceValuesMock.mockImplementation(() => ({ apiKey: "" }));
+    authorizeMock.mockReset();
+    authorizeMock
+      .mockImplementationOnce(() => Promise.resolve("stale-token"))
+      .mockImplementationOnce(() => Promise.resolve("fresh-token"));
+
+    const seenTokens: string[] = [];
+    let call = 0;
+    globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => {
+      seenTokens.push(new Headers(init?.headers).get("authorization") ?? "");
+      call += 1;
+      return call === 1 ? createCardsResponse(401) : createCardsResponse();
+    }) as unknown as typeof fetch;
+
+    await searchCards({ limit: 1 });
+
+    expect(removeTokensMock).toHaveBeenCalledTimes(1);
+    expect(seenTokens).toEqual(["Bearer stale-token", "Bearer fresh-token"]);
   });
 });

--- a/extensions/teak-raycast/src/__tests__/searchFilters.test.ts
+++ b/extensions/teak-raycast/src/__tests__/searchFilters.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  applyTagFilter,
+  applyTypeFilter,
+  buildSearchText,
+  clearSearchFilters,
+  parseSearchFilters,
+} from "../lib/searchFilters";
+
+describe("parseSearchFilters", () => {
+  test("parses a simple single-word tag", () => {
+    const parsed = parseSearchFilters("tag:design");
+    expect(parsed.tag).toBe("design");
+    expect(parsed.query).toBe("");
+  });
+
+  test("keeps a quoted tag with spaces intact", () => {
+    const parsed = parseSearchFilters('tag:"design systems"');
+    expect(parsed.tag).toBe("design systems");
+    expect(parsed.query).toBe("");
+  });
+
+  test("separates a quoted tag from free-text query terms", () => {
+    const parsed = parseSearchFilters('hello tag:"design systems" world');
+    expect(parsed.tag).toBe("design systems");
+    expect(parsed.query).toBe("hello world");
+  });
+
+  test("handles escaped quotes inside a quoted value", () => {
+    const parsed = parseSearchFilters('tag:"a \\"quoted\\" tag"');
+    expect(parsed.tag).toBe('a "quoted" tag');
+  });
+
+  test("treats a bare colon value as the tag (legacy unquoted)", () => {
+    const parsed = parseSearchFilters("tag:design");
+    expect(parsed.tag).toBe("design");
+  });
+});
+
+describe("buildSearchText", () => {
+  test("quotes a tag containing spaces", () => {
+    expect(buildSearchText({ tag: "design systems" })).toBe(
+      'tag:"design systems"',
+    );
+  });
+
+  test("leaves a simple tag unquoted", () => {
+    expect(buildSearchText({ tag: "design" })).toBe("tag:design");
+  });
+
+  test("escapes quotes and backslashes in a tag", () => {
+    expect(buildSearchText({ tag: 'a "b" \\c' })).toBe('tag:"a \\"b\\" \\\\c"');
+  });
+});
+
+describe("filter round-trips", () => {
+  test("applyTagFilter round-trips a multi-word tag", () => {
+    const next = applyTagFilter("", "design systems");
+    expect(next).toBe('tag:"design systems"');
+    expect(parseSearchFilters(next).tag).toBe("design systems");
+  });
+
+  test("applyTagFilter preserves existing free text and type", () => {
+    const next = applyTagFilter("type:link inspiration", "design systems");
+    const parsed = parseSearchFilters(next);
+    expect(parsed.tag).toBe("design systems");
+    expect(parsed.type).toBe("link");
+    expect(parsed.query).toBe("inspiration");
+  });
+
+  test("applyTypeFilter does not corrupt an existing multi-word tag", () => {
+    const withTag = applyTagFilter("", "design systems");
+    const next = applyTypeFilter(withTag, "image");
+    const parsed = parseSearchFilters(next);
+    expect(parsed.tag).toBe("design systems");
+    expect(parsed.type).toBe("image");
+  });
+
+  test("clearSearchFilters keeps free text and drops the tag", () => {
+    const next = clearSearchFilters('hello tag:"design systems"');
+    expect(next).toBe("hello");
+  });
+});

--- a/extensions/teak-raycast/src/components/CardDetail.tsx
+++ b/extensions/teak-raycast/src/components/CardDetail.tsx
@@ -27,24 +27,25 @@ import {
 import { formatDateTime } from "../lib/dateFormat";
 import { EditCardForm } from "./EditCardForm";
 import { SetApiKeyAction } from "./SetApiKeyAction";
+import { SignOutAction } from "./SignOutAction";
 
 const FAVORITE_MUTATION_DEBOUNCE_MS = 300;
 const MAX_METADATA_URL_LENGTH = 64;
 
-type FavoriteMutationState = {
+interface FavoriteMutationState {
   desired: boolean;
   inFlight: boolean;
   lastServer: boolean;
   timer: ReturnType<typeof setTimeout> | null;
-};
+}
 
-export type CardDetailProps = {
+export interface CardDetailProps {
   card: RaycastCard;
   onCardDeleted: (cardId: string) => void;
   onCardUpdated: (next: RaycastCard) => void;
   onFilterByTag: (tag: string) => void;
   onNavigateBackAfterDelete: () => void;
-};
+}
 
 const truncateMiddle = (value: string, maxLength: number): string => {
   if (value.length <= maxLength) {
@@ -299,6 +300,10 @@ export function CardDetail({
 
   const statusChips = getDetailStatusChips(cardState);
 
+  const urlMetadataFallback = cardState.url ? (
+    <Detail.Metadata.Label text={metadataUrl ?? cardState.url} title="URL" />
+  ) : null;
+
   return (
     <Detail
       actions={
@@ -354,6 +359,7 @@ export function CardDetail({
             url={getTeakUrl(cardState)}
           />
           <SetApiKeyAction />
+          <SignOutAction />
         </ActionPanel>
       }
       markdown={markdown}
@@ -365,12 +371,9 @@ export function CardDetail({
               text={metadataUrl ?? openableUrl}
               title="URL"
             />
-          ) : cardState.url ? (
-            <Detail.Metadata.Label
-              text={metadataUrl ?? cardState.url}
-              title="URL"
-            />
-          ) : null}
+          ) : (
+            urlMetadataFallback
+          )}
           {cardState.url ? <Detail.Metadata.Separator /> : null}
           {domain ? (
             <Detail.Metadata.Label text={domain} title="Domain" />

--- a/extensions/teak-raycast/src/components/CardsListCommand.tsx
+++ b/extensions/teak-raycast/src/components/CardsListCommand.tsx
@@ -13,7 +13,6 @@ import {
   getTeakUrl,
 } from "../lib/cardDetailModel";
 import { removeCardById, upsertCard } from "../lib/cardListState";
-import { getPreferences } from "../lib/preferences";
 import {
   applyFavoritedFilter,
   applySortFilter,
@@ -23,12 +22,14 @@ import {
   parseSearchFilters,
   type RaycastCardType,
 } from "../lib/searchFilters";
+import { useTeakAuth } from "../lib/useTeakAuth";
 import { CardDetail } from "./CardDetail";
 import { EditCardForm } from "./EditCardForm";
 import { MissingApiKeyDetail } from "./MissingApiKeyDetail";
 import { SetApiKeyAction } from "./SetApiKeyAction";
+import { SignOutAction } from "./SignOutAction";
 
-type CardsListCommandProps = {
+interface CardsListCommandProps {
   emptyDescription: string;
   emptyIcon: Icon;
   emptyTitle: string;
@@ -36,9 +37,10 @@ type CardsListCommandProps = {
   latestSectionTitle: string;
   loadCards: (input: CardSearchInput) => Promise<{ items: RaycastCard[] }>;
   navigationTitle: string;
+  removeTagFilterFromList?: boolean;
   removeUnfavoritedFromList?: boolean;
   searchBarPlaceholder: string;
-};
+}
 
 const TYPE_OPTIONS: Array<{ title: string; value?: RaycastCardType }> = [
   { title: "All Types" },
@@ -100,6 +102,7 @@ export function CardsListCommand({
   latestSectionTitle,
   loadCards,
   navigationTitle,
+  removeTagFilterFromList = false,
   removeUnfavoritedFromList = false,
   searchBarPlaceholder,
 }: CardsListCommandProps) {
@@ -108,8 +111,11 @@ export function CardsListCommand({
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const { apiKey } = getPreferences();
-  const hasApiKey = Boolean(apiKey?.trim());
+  const {
+    isAuthenticated,
+    isLoading: isCheckingAuth,
+    refresh: refreshAuth,
+  } = useTeakAuth();
 
   const parsedFilters = useMemo(() => parseSearchFilters(query), [query]);
   const requestInput = useMemo<CardSearchInput>(
@@ -145,7 +151,11 @@ export function CardsListCommand({
   );
 
   useEffect(() => {
-    if (!hasApiKey) {
+    if (isCheckingAuth) {
+      return;
+    }
+
+    if (!isAuthenticated) {
       setItems([]);
       setError(null);
       setIsLoading(false);
@@ -153,7 +163,7 @@ export function CardsListCommand({
     }
 
     void load(requestInput);
-  }, [hasApiKey, load, requestInput]);
+  }, [isCheckingAuth, isAuthenticated, load, requestInput]);
 
   const handleCardUpdated = useCallback(
     (next: RaycastCard) => {
@@ -198,8 +208,12 @@ export function CardsListCommand({
     [handleCardUpdated],
   );
 
-  if (!hasApiKey) {
-    return <MissingApiKeyDetail />;
+  if (isCheckingAuth) {
+    return <List isLoading navigationTitle={navigationTitle} />;
+  }
+
+  if (!isAuthenticated) {
+    return <MissingApiKeyDetail onSignedIn={refreshAuth} />;
   }
 
   return (
@@ -234,6 +248,7 @@ export function CardsListCommand({
                 />
               ) : null}
               <SetApiKeyAction />
+              <SignOutAction onSignedOut={refreshAuth} />
             </ActionPanel>
           }
           description="Check your API key and network connection, then retry."
@@ -352,7 +367,7 @@ export function CardsListCommand({
                         title="Oldest First"
                       />
                     </ActionPanel.Submenu>
-                    {tagOptions.length > 0 ? (
+                    {tagOptions.length > 0 && !removeTagFilterFromList ? (
                       <ActionPanel.Submenu
                         icon={Icon.Tag}
                         title="Filter by Tag"
@@ -393,6 +408,7 @@ export function CardsListCommand({
                     ) : null}
                   </ActionPanel.Section>
                   <SetApiKeyAction />
+                  <SignOutAction onSignedOut={refreshAuth} />
                 </ActionPanel>
               }
               icon={getItemIcon ? getItemIcon(card) : Icon.Document}

--- a/extensions/teak-raycast/src/components/EditCardForm.tsx
+++ b/extensions/teak-raycast/src/components/EditCardForm.tsx
@@ -15,15 +15,15 @@ import {
   updateCard,
 } from "../lib/api";
 
-type EditCardFormProps = {
+interface EditCardFormProps {
   card: RaycastCard;
   onCardUpdated: (next: RaycastCard) => void;
-};
+}
 
-type EditCardFormValues = {
+interface EditCardFormValues {
   notes: string;
   tags: string;
-};
+}
 
 const parseTags = (value: string): string[] => {
   return Array.from(

--- a/extensions/teak-raycast/src/components/MissingApiKeyDetail.tsx
+++ b/extensions/teak-raycast/src/components/MissingApiKeyDetail.tsx
@@ -1,12 +1,18 @@
 import { Action, ActionPanel, Detail } from "@raycast/api";
 import { TEAK_SETTINGS_URL } from "../lib/constants";
 import { SetApiKeyAction } from "./SetApiKeyAction";
+import { SignInWithBrowserAction } from "./SignInWithBrowserAction";
 
-export function MissingApiKeyDetail() {
+interface MissingApiKeyDetailProps {
+  onSignedIn?: () => void;
+}
+
+export function MissingApiKeyDetail({ onSignedIn }: MissingApiKeyDetailProps) {
   return (
     <Detail
       actions={
         <ActionPanel>
+          <SignInWithBrowserAction onSignedIn={onSignedIn} />
           <SetApiKeyAction />
           <Action.OpenInBrowser
             title="Open Teak Settings"
@@ -15,11 +21,11 @@ export function MissingApiKeyDetail() {
         </ActionPanel>
       }
       markdown={[
-        "# API key required",
+        "# Sign in to Teak",
         "",
-        "Create an API key in **Teak Settings > API Keys** and add it to Raycast preferences.",
+        "Sign in with your browser to start saving and searching cards. No API key required.",
         "",
-        "Use **Set API Key** to open extension preferences instantly.",
+        "Prefer an API key? Use **Set API Key** to open extension preferences and paste one from **Teak Settings → Manage API Keys**.",
       ].join("\n")}
     />
   );

--- a/extensions/teak-raycast/src/components/SignInWithBrowserAction.tsx
+++ b/extensions/teak-raycast/src/components/SignInWithBrowserAction.tsx
@@ -1,0 +1,30 @@
+import { Action, Icon, showToast, Toast } from "@raycast/api";
+import { getUserFacingErrorMessage } from "../lib/api";
+import { authorizeTeak } from "../lib/oauth";
+
+interface SignInWithBrowserActionProps {
+  onSignedIn?: () => void;
+}
+
+export function SignInWithBrowserAction({
+  onSignedIn,
+}: SignInWithBrowserActionProps) {
+  return (
+    <Action
+      icon={Icon.Globe}
+      onAction={async () => {
+        try {
+          await authorizeTeak();
+          onSignedIn?.();
+        } catch (error) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Sign-in failed",
+            message: getUserFacingErrorMessage(error),
+          });
+        }
+      }}
+      title="Sign in with Browser"
+    />
+  );
+}

--- a/extensions/teak-raycast/src/components/SignOutAction.tsx
+++ b/extensions/teak-raycast/src/components/SignOutAction.tsx
@@ -1,0 +1,32 @@
+import { Action, Icon, showToast, Toast } from "@raycast/api";
+import { teakOAuth } from "../lib/oauth";
+import { getPreferences } from "../lib/preferences";
+
+interface SignOutActionProps {
+  onSignedOut?: () => void;
+}
+
+export function SignOutAction({ onSignedOut }: SignOutActionProps) {
+  // Sign-out only applies to browser (OAuth) sessions. API-key users manage
+  // their credential in extension preferences, so hide the action for them.
+  if (getPreferences().apiKey?.trim()) {
+    return null;
+  }
+
+  return (
+    <Action
+      icon={Icon.Logout}
+      onAction={async () => {
+        await teakOAuth.client.removeTokens();
+        await showToast({
+          style: Toast.Style.Success,
+          title: "Signed out of Teak",
+        });
+        onSignedOut?.();
+      }}
+      shortcut={{ key: "x", modifiers: ["cmd", "shift"] }}
+      style={Action.Style.Destructive}
+      title="Sign Out"
+    />
+  );
+}

--- a/extensions/teak-raycast/src/lib/api.ts
+++ b/extensions/teak-raycast/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { environment } from "@raycast/api";
 import {
   buildCardsSearchParams,
   DEFAULT_LIMIT,
@@ -17,6 +18,11 @@ import {
   type TagsResponse,
 } from "./apiParsers";
 import { getApiBaseUrl } from "./constants";
+import {
+  authorizeTeak,
+  getStoredTeakAccessToken,
+  reauthorizeTeak,
+} from "./oauth";
 import { getPreferences } from "./preferences";
 import type { RaycastCardType, RaycastSort } from "./searchFilters";
 
@@ -31,7 +37,7 @@ export {
 export type { RaycastCard } from "./apiParsers";
 export type { TagSummary, TagsResponse } from "./apiParsers";
 
-export type CardSearchInput = {
+export interface CardSearchInput {
   createdAfter?: number;
   createdBefore?: number;
   favorited?: boolean;
@@ -40,22 +46,22 @@ export type CardSearchInput = {
   sort?: RaycastSort;
   tag?: string;
   type?: RaycastCardType;
-};
+}
 
-export type CreateCardInput = {
+export interface CreateCardInput {
   content?: string;
   notes?: string | null;
   source?: string;
   tags?: string[];
   url?: string;
-};
+}
 
-export type UpdateCardInput = {
+export interface UpdateCardInput {
   content?: string;
   notes?: string | null;
   tags?: string[];
   url?: string;
-};
+}
 
 const getErrorCodeFromResponse = (
   payloadCode: string | undefined,
@@ -74,6 +80,30 @@ const getErrorCodeFromResponse = (
   }
 
   return toErrorCode(payloadCode, "REQUEST_FAILED");
+};
+
+const isMissingDevApiGatewayResponse = (
+  response: Response,
+  payload: unknown,
+  requestUrl: string,
+): boolean => {
+  if (!environment.isDevelopment || response.status !== 404 || payload) {
+    return false;
+  }
+
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(requestUrl);
+  } catch {
+    return false;
+  }
+
+  return (
+    parsedUrl.hostname === "api.teak.localhost" &&
+    response.headers.get("x-portless") === "1" &&
+    !response.headers.get("content-type")?.includes("application/json")
+  );
 };
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
@@ -110,7 +140,7 @@ const withLoopbackFallback = (url: string): string => {
   return parsedUrl.toString();
 };
 
-const parseJson = async (response: Response): Promise<unknown> => {
+const parseJson = (response: Response): Promise<unknown> => {
   return response.json().catch(() => null);
 };
 
@@ -121,19 +151,63 @@ const buildHeaders = (apiKey: string, initHeaders?: HeadersInit): Headers => {
   return headers;
 };
 
-export const request = async <T>(
-  path: string,
-  parseResponse: (payload: unknown) => T,
-  init?: RequestInit,
-): Promise<T> => {
-  const { apiKey } = getPreferences();
-  const normalizedApiKey = apiKey?.trim();
+const logApiRequestFailure = (
+  context: Record<string, unknown>,
+  error?: unknown,
+) => {
+  console.error("[Teak Raycast] API request failed", {
+    ...context,
+    error:
+      error instanceof Error
+        ? {
+            message: error.message,
+            name: error.name,
+          }
+        : error,
+  });
+};
 
-  if (!normalizedApiKey) {
-    throw new RaycastApiError("MISSING_API_KEY");
+interface ResolvedBearer {
+  source: "apiKey" | "oauth";
+  token: string;
+}
+
+// When `interactive` is false (background / no-view commands), auth is resolved
+// only from an API key or an existing/refreshable OAuth session — the browser
+// sign-in overlay is never opened.
+export interface RequestAuthOptions {
+  interactive?: boolean;
+}
+
+// Grandfathered API keys take precedence over browser sign-in. When no key is
+// configured, fall back to OAuth. Interactive callers may open the browser
+// sign-in overlay; non-interactive callers resolve from a stored/refreshable
+// session only and fail (rather than prompting) when none is available.
+const resolveBearerToken = async (
+  options?: RequestAuthOptions,
+): Promise<ResolvedBearer> => {
+  const apiKey = getPreferences().apiKey?.trim();
+  if (apiKey) {
+    return { source: "apiKey", token: apiKey };
   }
 
-  let response: Response;
+  if (options?.interactive === false) {
+    const storedToken = await getStoredTeakAccessToken();
+    if (!storedToken) {
+      throw new RaycastApiError("INVALID_API_KEY", 401);
+    }
+    return { source: "oauth", token: storedToken };
+  }
+
+  const accessToken = await authorizeTeak();
+  return { source: "oauth", token: accessToken };
+};
+
+const executeHttpRequest = async (
+  path: string,
+  bearerToken: string,
+  init?: RequestInit,
+): Promise<{ requestUrl: string; response: Response }> => {
   const baseUrl = getApiBaseUrl();
   const timeoutMs = getRequestTimeoutMs();
   const abortController = new AbortController();
@@ -145,24 +219,75 @@ export const request = async <T>(
   const fallbackUrl = withLoopbackFallback(requestUrl);
   const requestInit: RequestInit = {
     ...init,
-    headers: buildHeaders(normalizedApiKey, init?.headers),
+    headers: buildHeaders(bearerToken, init?.headers),
     signal: abortController.signal,
   };
 
   try {
-    response = await fetch(requestUrl, requestInit);
-  } catch {
+    return { requestUrl, response: await fetch(requestUrl, requestInit) };
+  } catch (requestError) {
     if (fallbackUrl !== requestUrl) {
       try {
-        response = await fetch(fallbackUrl, requestInit);
-      } catch {
+        return {
+          requestUrl,
+          response: await fetch(fallbackUrl, requestInit),
+        };
+      } catch (fallbackError) {
+        logApiRequestFailure(
+          {
+            fallbackUrl,
+            method: requestInit.method ?? "GET",
+            path,
+            url: requestUrl,
+          },
+          fallbackError,
+        );
         throw new RaycastApiError("NETWORK_ERROR");
       }
-    } else {
-      throw new RaycastApiError("NETWORK_ERROR");
     }
+
+    logApiRequestFailure(
+      {
+        method: requestInit.method ?? "GET",
+        path,
+        url: requestUrl,
+      },
+      requestError,
+    );
+    throw new RaycastApiError("NETWORK_ERROR");
   } finally {
     clearTimeout(timeoutHandle);
+  }
+};
+
+export const request = async <T>(
+  path: string,
+  parseResponse: (payload: unknown) => T,
+  init?: RequestInit,
+  options?: RequestAuthOptions,
+): Promise<T> => {
+  const bearer = await resolveBearerToken(options);
+  let { requestUrl, response } = await executeHttpRequest(
+    path,
+    bearer.token,
+    init,
+  );
+
+  // An OAuth access token can be revoked or rotated server-side. Interactive
+  // callers drop the cached tokens, re-authorize once, and retry. Non-interactive
+  // callers (no-view commands) must not open the sign-in overlay, so they
+  // surface the error instead of re-authorizing.
+  if (
+    response.status === 401 &&
+    bearer.source === "oauth" &&
+    options?.interactive !== false
+  ) {
+    const refreshedToken = await reauthorizeTeak();
+    ({ requestUrl, response } = await executeHttpRequest(
+      path,
+      refreshedToken,
+      init,
+    ));
   }
 
   if (response.ok) {
@@ -172,23 +297,42 @@ export const request = async <T>(
 
   const payload = await parseJson(response);
   const payloadCode = getPayloadCode(payload);
+  const code = isMissingDevApiGatewayResponse(response, payload, requestUrl)
+    ? "DEV_API_UNAVAILABLE"
+    : getErrorCodeFromResponse(payloadCode, response.status);
 
-  throw new RaycastApiError(
-    getErrorCodeFromResponse(payloadCode, response.status),
-    response.status,
+  logApiRequestFailure({
+    code,
+    contentType: response.headers.get("content-type"),
+    method: init?.method ?? "GET",
+    path,
+    payload,
+    payloadCode,
+    status: response.status,
+    statusText: response.statusText,
+    url: response.url || requestUrl,
+    xPortless: response.headers.get("x-portless"),
+  });
+
+  throw new RaycastApiError(code, response.status);
+};
+
+export const createCard = (
+  input: CreateCardInput,
+  options?: RequestAuthOptions,
+): Promise<QuickSaveResponse> => {
+  return request<QuickSaveResponse>(
+    "/cards",
+    parseQuickSaveResponse,
+    {
+      body: JSON.stringify(input),
+      method: "POST",
+    },
+    options,
   );
 };
 
-export const createCard = async (
-  input: CreateCardInput,
-): Promise<QuickSaveResponse> => {
-  return request<QuickSaveResponse>("/cards", parseQuickSaveResponse, {
-    body: JSON.stringify(input),
-    method: "POST",
-  });
-};
-
-export const quickSaveCard = async (
+export const quickSaveCard = (
   input: string | CreateCardInput,
 ): Promise<QuickSaveResponse> => {
   return createCard(
@@ -200,8 +344,9 @@ export const quickSaveCard = async (
   );
 };
 
-export const searchCards = async (
+export const searchCards = (
   input: CardSearchInput = {},
+  options?: RequestAuthOptions,
 ): Promise<CardsResponse> => {
   return request<CardsResponse>(
     `/cards/search?${buildCardsSearchParams({
@@ -212,10 +357,11 @@ export const searchCards = async (
     {
       method: "GET",
     },
+    options,
   );
 };
 
-export const getFavoriteCards = async (
+export const getFavoriteCards = (
   input: CardSearchInput = {},
 ): Promise<CardsResponse> => {
   return request<CardsResponse>(
@@ -230,7 +376,10 @@ export const getFavoriteCards = async (
   );
 };
 
-export const getCardById = async (cardId: string): Promise<RaycastCard> => {
+export const getCardById = (
+  cardId: string,
+  options?: RequestAuthOptions,
+): Promise<RaycastCard> => {
   const normalizedCardId = cardId.trim();
   if (!normalizedCardId) {
     throw new RaycastApiError("INVALID_INPUT");
@@ -242,10 +391,11 @@ export const getCardById = async (cardId: string): Promise<RaycastCard> => {
     {
       method: "GET",
     },
+    options,
   );
 };
 
-export const updateCard = async (
+export const updateCard = (
   cardId: string,
   input: UpdateCardInput,
 ): Promise<RaycastCard> => {
@@ -264,9 +414,10 @@ export const updateCard = async (
   );
 };
 
-export const setCardFavorite = async (
+export const setCardFavorite = (
   cardId: string,
   isFavorited: boolean,
+  options?: RequestAuthOptions,
 ): Promise<RaycastCard> => {
   const normalizedCardId = cardId.trim();
   if (!normalizedCardId) {
@@ -280,6 +431,7 @@ export const setCardFavorite = async (
       body: JSON.stringify({ isFavorited }),
       method: "PATCH",
     },
+    options,
   );
 };
 
@@ -298,8 +450,15 @@ export const softDeleteCard = async (cardId: string): Promise<void> => {
   );
 };
 
-export const listTags = async (): Promise<TagsResponse> => {
-  return request<TagsResponse>("/tags", parseTagsResponse, {
-    method: "GET",
-  });
+export const listTags = (
+  options?: RequestAuthOptions,
+): Promise<TagsResponse> => {
+  return request<TagsResponse>(
+    "/tags",
+    parseTagsResponse,
+    {
+      method: "GET",
+    },
+    options,
+  );
 };

--- a/extensions/teak-raycast/src/lib/apiErrors.ts
+++ b/extensions/teak-raycast/src/lib/apiErrors.ts
@@ -3,6 +3,8 @@ export const MAX_LIMIT = 100;
 
 const KNOWN_ERROR_CODES = [
   "BAD_REQUEST",
+  "CONFIG_ERROR",
+  "DEV_API_UNAVAILABLE",
   "INTERNAL_ERROR",
   "INVALID_API_KEY",
   "INVALID_INPUT",
@@ -31,13 +33,17 @@ const getErrorMessage = (code: RaycastApiErrorCode): string => {
       return "Set your Teak API key in extension preferences to continue.";
     case "INVALID_API_KEY":
     case "UNAUTHORIZED":
-      return "Your Teak API key is invalid or revoked. Generate a new key in Teak Settings > API Keys.";
+      return "Your Teak API key is invalid or revoked. Generate a new key in Teak Settings > Manage API Keys.";
     case "RATE_LIMITED":
       return "Too many requests right now. Please wait a moment and try again.";
     case "NETWORK_ERROR":
       return "Unable to reach Teak. Check your internet connection and try again.";
+    case "CONFIG_ERROR":
+      return "Teak API is missing required configuration.";
+    case "DEV_API_UNAVAILABLE":
+      return "Local Teak API gateway is not running.";
     case "NOT_FOUND":
-      return "This card no longer exists in Teak.";
+      return "Teak could not find the requested resource.";
     case "INVALID_INPUT":
     case "BAD_REQUEST":
       return "The request could not be processed. Please check your input and try again.";
@@ -150,8 +156,12 @@ export const getRecoveryHint = (error: unknown): string | null => {
       return "Wait a few seconds, then retry.";
     case "NETWORK_ERROR":
       return "Check network connectivity, then retry.";
+    case "CONFIG_ERROR":
+      return "For local development, set CONVEX_HTTP_BASE_URL in apps/api/.env and restart bun run dev:api.";
+    case "DEV_API_UNAVAILABLE":
+      return "Run bun run dev:api from the Teak repo, or set TEAK_DEV_API_URL to a running API URL.";
     case "NOT_FOUND":
-      return "Refresh the card list and try again.";
+      return "Check your API key, API URL, and network connection, then retry.";
     default:
       return null;
   }

--- a/extensions/teak-raycast/src/lib/apiParsers.ts
+++ b/extensions/teak-raycast/src/lib/apiParsers.ts
@@ -1,46 +1,46 @@
 import { RaycastApiError } from "./apiErrors";
 
-export type RaycastCard = {
-  appUrl: string | null;
-  id: string;
-  type: string;
-  content: string;
-  notes: string | null;
-  url: string | null;
-  tags: string[];
-  aiTags: string[];
+export interface RaycastCard {
   aiSummary: string | null;
-  isFavorited: boolean;
+  aiTags: string[];
+  appUrl: string | null;
+  content: string;
   createdAt: number;
-  updatedAt: number;
   fileUrl: string | null;
-  thumbnailUrl: string | null;
-  screenshotUrl: string | null;
+  id: string;
+  isFavorited: boolean;
   linkPreviewImageUrl: string | null;
-  metadataTitle: string | null;
   metadataDescription: string | null;
-};
+  metadataTitle: string | null;
+  notes: string | null;
+  screenshotUrl: string | null;
+  tags: string[];
+  thumbnailUrl: string | null;
+  type: string;
+  updatedAt: number;
+  url: string | null;
+}
 
-export type TagSummary = {
-  name: string;
+export interface TagSummary {
   count: number;
-};
+  name: string;
+}
 
-export type TagsResponse = {
+export interface TagsResponse {
   items: TagSummary[];
-};
+}
 
-export type CardsResponse = {
+export interface CardsResponse {
   items: RaycastCard[];
   total: number;
-};
+}
 
-export type QuickSaveResponse = {
-  status: "created";
-  cardId: string;
+export interface QuickSaveResponse {
   appUrl: string | null;
   card: RaycastCard | null;
-};
+  cardId: string;
+  status: "created";
+}
 
 type JsonObject = Record<string, unknown>;
 
@@ -158,12 +158,15 @@ export const parseQuickSaveResponse = (payload: unknown): QuickSaveResponse => {
     typeof status === "string" &&
     QUICK_SAVE_STATUSES.includes(status as QuickSaveStatus);
 
-  const card =
-    payload.card === undefined || payload.card === null
-      ? null
-      : isRaycastCard(payload.card)
-        ? payload.card
-        : undefined;
+  const parseNullableCard = (
+    value: unknown,
+  ): RaycastCard | null | undefined => {
+    if (value === undefined || value === null) {
+      return null;
+    }
+    return isRaycastCard(value) ? value : undefined;
+  };
+  const card = parseNullableCard(payload.card);
   const appUrl = isNullableString(payload.appUrl) ? payload.appUrl : undefined;
 
   if (

--- a/extensions/teak-raycast/src/lib/capture.ts
+++ b/extensions/teak-raycast/src/lib/capture.ts
@@ -5,8 +5,36 @@ import {
   getRecoveryHint,
   getUserFacingErrorMessage,
 } from "./api";
+import { getStoredTeakAccessToken } from "./oauth";
+import { getPreferences } from "./preferences";
 
 const URL_INLINE_PATTERN = /(https?:\/\/[^\s]+)/i;
+
+// Shared guard for no-view save commands. Confirms usable credentials WITHOUT
+// launching sign-in: an API key, or an existing OAuth session (silently
+// refreshing an expired access token when possible). Refreshing here also means
+// the subsequent request path finds a valid token and never opens the browser
+// overlay. When there is no usable session (missing or stale/revoked), it shows
+// a sign-in prompt and returns false so the command stops instead of triggering
+// interactive reauthorization from a background command.
+export const ensureCredentialsForNoViewCommand = async (): Promise<boolean> => {
+  if (getPreferences().apiKey?.trim()) {
+    return true;
+  }
+
+  const token = await getStoredTeakAccessToken();
+  if (token) {
+    return true;
+  }
+
+  await showToast({
+    message:
+      "Open the Search or Quick Save command to sign in with your browser, then run this command again.",
+    style: Toast.Style.Failure,
+    title: "Sign in to Teak",
+  });
+  return false;
+};
 
 export const extractFirstHttpUrl = (value: string): string | null => {
   const trimmed = value.trim();
@@ -50,21 +78,24 @@ export const saveCardWithFeedback = async (
   });
 
   try {
-    const result = await createCard(input);
+    // No-view command: never open the sign-in overlay from the request path.
+    const result = await createCard(input, { interactive: false });
 
-    if (result.appUrl) {
+    const appUrl = result.appUrl;
+    if (appUrl) {
       toast.primaryAction = {
         onAction: () => {
-          void open(result.appUrl!);
+          void open(appUrl);
         },
         title: "Open Card",
       };
     }
 
-    if (result.card?.url) {
+    const sourceUrl = result.card?.url;
+    if (sourceUrl) {
       toast.secondaryAction = {
         onAction: () => {
-          void open(result.card!.url!);
+          void open(sourceUrl);
         },
         title: "Open Source URL",
       };

--- a/extensions/teak-raycast/src/lib/cardDetailModel.ts
+++ b/extensions/teak-raycast/src/lib/cardDetailModel.ts
@@ -119,10 +119,10 @@ export const getHeroMediaUrl = (card: RaycastCard): string | null => {
   return null;
 };
 
-export type DetailStatusChip = {
+export interface DetailStatusChip {
   kind: "type" | "favorite" | "aiSummary" | "aiTags";
   text: string;
-};
+}
 
 export const getDetailStatusChips = (card: RaycastCard): DetailStatusChip[] => {
   return [

--- a/extensions/teak-raycast/src/lib/constants.ts
+++ b/extensions/teak-raycast/src/lib/constants.ts
@@ -1,7 +1,21 @@
 import { environment } from "@raycast/api";
 
 const DEFAULT_TEAK_DEV_APP_URL = "http://app.teak.localhost:1355";
-const DEFAULT_TEAK_DEV_API_URL = "http://api.teak.localhost:1355";
+// HTTPS so the token-authenticated card API calls reach portless directly.
+// Over http, portless 302-upgrades to https and undici drops the Authorization
+// header across the scheme change (cross-origin redirect), so the gateway 401s.
+// undici trusts the portless cert (verified: the redirected https request
+// returns a real 401 rather than a TLS error), so hitting https up front is safe.
+const DEFAULT_TEAK_DEV_API_URL = "https://api.teak.localhost:1355";
+// Dev Convex deployment that `convex dev` targets and where the OAuth server
+// (Better Auth `mcp` plugin) and its seeded clients live. The token exchange
+// must reach THIS deployment — see getOAuthTokenBaseUrl. Overridable via
+// TEAK_DEV_CONVEX_SITE_URL. NOTE: this must match the deployment the web app's
+// authorize step proxies to (i.e. the running `convex dev` deployment), NOT
+// necessarily the NEXT_PUBLIC_CONVEX_SITE_URL baked into a Vercel-pulled
+// `.env.local`, which can point at a different/stale deployment.
+const DEFAULT_TEAK_DEV_CONVEX_SITE_URL =
+  "https://reminiscent-kangaroo-59.convex.site";
 
 const normalizeBaseUrl = (label: string, rawUrl: string): string => {
   let parsedUrl: URL;
@@ -43,6 +57,42 @@ const normalizeUrl = (url: string): string =>
 
 export const getApiBaseUrl = (): string =>
   normalizeUrl(environment.isDevelopment ? DEV_API_URL : PROD_API_URL);
+
+// App (web) origin that hosts the OAuth authorize endpoint
+// (`/api/auth/mcp/authorize`). The browser sign-in step must run here so the
+// session cookie is read on the web domain.
+export const getAppBaseUrl = (): string =>
+  normalizeUrl(environment.isDevelopment ? TEAK_DEV_APP_URL : TEAK_APP_URL);
+
+const readEnvUrl = (value: unknown): string | null => {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed || null;
+};
+
+// Dev Convex site origin. Prefers an explicit TEAK_DEV_CONVEX_SITE_URL override,
+// otherwise the canonical dev deployment default. We intentionally do NOT read
+// NEXT_PUBLIC_CONVEX_SITE_URL here: a Vercel-pulled `.env.local` can point it at
+// a different/stale deployment than the one `convex dev` deploys to, and env
+// vars are not guaranteed to reach the Raycast extension sandbox anyway.
+const resolveDevConvexSiteUrl = (): string => {
+  const override = readEnvUrl(process.env.TEAK_DEV_CONVEX_SITE_URL);
+  return normalizeBaseUrl(
+    "TEAK_DEV_CONVEX_SITE_URL",
+    override ?? DEFAULT_TEAK_DEV_CONVEX_SITE_URL,
+  );
+};
+
+// Base origin for the OAuth token exchange (POST `/api/auth/mcp/token`).
+//
+// The token POST must reach Better Auth without crossing a redirecting proxy.
+// In local dev, portless upgrades http -> https with a 302 that Raycast's token
+// fetch (undici, default redirect: "follow") replays as a GET, so the POST 404s
+// and sign-in bounces back. Convex's own site origin serves the same endpoint
+// over publicly-trusted HTTPS with no redirect, so we hit it directly in dev.
+// In production the app origin already serves the token endpoint without any
+// redirect, so it stays there.
+export const getOAuthTokenBaseUrl = (): string =>
+  environment.isDevelopment ? resolveDevConvexSiteUrl() : TEAK_APP_URL;
 
 export const TEAK_SETTINGS_URL = environment.isDevelopment
   ? `${TEAK_DEV_APP_URL}/settings`

--- a/extensions/teak-raycast/src/lib/oauth.ts
+++ b/extensions/teak-raycast/src/lib/oauth.ts
@@ -1,0 +1,128 @@
+import { OAuth } from "@raycast/api";
+import { OAuthService } from "@raycast/utils";
+import { getAppBaseUrl, getOAuthTokenBaseUrl } from "./constants";
+
+// Teak's authorization server (Better Auth `mcp` plugin) exposes the OAuth
+// endpoints on the web origin. `teak-raycast` is registered server-side as a
+// trusted public client (PKCE, no secret), so the browser sign-in flow needs no
+// manual key entry. OAuthService handles token storage and automatic refresh.
+//
+// `authorize` runs in the browser and must hit the web origin so the session
+// cookie authenticates the request. The `token`/refresh exchange is a
+// server-to-server POST that only needs to reach Better Auth, so it targets the
+// token base URL directly — avoiding the dev-only proxy redirect that would
+// otherwise downgrade the POST to a GET (see getOAuthTokenBaseUrl).
+const authorizeUrl = `${getAppBaseUrl()}/api/auth/mcp/authorize`;
+const tokenUrl = `${getOAuthTokenBaseUrl()}/api/auth/mcp/token`;
+
+const client = new OAuth.PKCEClient({
+  redirectMethod: OAuth.RedirectMethod.Web,
+  providerName: "Teak",
+  providerId: "teak",
+  providerIcon: "icon.png",
+  description: "Connect your Teak account to save and search cards.",
+});
+
+export const teakOAuth = new OAuthService({
+  client,
+  clientId: "teak-raycast",
+  scope: "openid profile email offline_access",
+  authorizeUrl,
+  tokenUrl,
+  refreshTokenUrl: tokenUrl,
+  // OAuth 2.1 token endpoint expects form-encoded bodies.
+  bodyEncoding: "url-encoded",
+});
+
+// Dedupe concurrent authorize() calls. Raycast dev mode can invoke effects
+// twice (strict-mode style); without this, two authorization requests would be
+// started with two different `state` values, and the browser callback for the
+// first would fail Raycast's state check against the second ("OAuth state
+// mismatch"). All callers share a single in-flight authorization (one `state`).
+let inFlightAuthorize: Promise<string> | null = null;
+
+export function authorizeTeak(): Promise<string> {
+  if (!inFlightAuthorize) {
+    inFlightAuthorize = teakOAuth.authorize().finally(() => {
+      inFlightAuthorize = null;
+    });
+  }
+  return inFlightAuthorize;
+}
+
+// Force a brand-new authorization: drop stored tokens and any in-flight guard,
+// then re-authorize. Used after a 401 when the current token is rejected.
+export async function reauthorizeTeak(): Promise<string> {
+  await teakOAuth.client.removeTokens();
+  inFlightAuthorize = null;
+  return authorizeTeak();
+}
+
+// Non-interactive check for an existing stored session. Unlike authorizeTeak(),
+// this NEVER opens the browser sign-in overlay — it only reports whether we
+// already hold a usable (or refreshable) token. Used to gate views so merely
+// opening a command does not trigger sign-in as a side effect; the visible
+// "Sign in with Browser" action remains the explicit entry point.
+export async function hasStoredTeakSession(): Promise<boolean> {
+  const tokenSet = await client.getTokens();
+  if (!tokenSet?.accessToken) {
+    return false;
+  }
+  // A non-expired access token is usable as-is; an expired one is still fine
+  // when a refresh token exists, since the request path refreshes on demand.
+  return !tokenSet.isExpired() || Boolean(tokenSet.refreshToken);
+}
+
+// Resolve a usable access token WITHOUT ever launching the interactive sign-in
+// overlay. When the stored access token is expired, attempt a silent refresh
+// with the stored refresh token. Returns null when there is no stored token or
+// the refresh fails (stale/revoked) — callers then prompt the user to sign in
+// explicitly rather than popping the browser overlay from a background command.
+export async function getStoredTeakAccessToken(): Promise<string | null> {
+  const tokenSet = await client.getTokens();
+  if (!tokenSet?.accessToken) {
+    return null;
+  }
+  if (!tokenSet.isExpired()) {
+    return tokenSet.accessToken;
+  }
+  if (!tokenSet.refreshToken) {
+    return null;
+  }
+
+  try {
+    const body = new URLSearchParams({
+      client_id: teakOAuth.clientId,
+      grant_type: "refresh_token",
+      refresh_token: tokenSet.refreshToken,
+    });
+    const response = await fetch(tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const parsed = (await response.json()) as {
+      access_token?: unknown;
+      refresh_token?: unknown;
+      expires_in?: unknown;
+    };
+    if (typeof parsed.access_token !== "string" || !parsed.access_token) {
+      return null;
+    }
+    await client.setTokens({
+      accessToken: parsed.access_token,
+      expiresIn:
+        typeof parsed.expires_in === "number" ? parsed.expires_in : undefined,
+      refreshToken:
+        typeof parsed.refresh_token === "string"
+          ? parsed.refresh_token
+          : tokenSet.refreshToken,
+    });
+    return parsed.access_token;
+  } catch {
+    return null;
+  }
+}

--- a/extensions/teak-raycast/src/lib/searchFilters.ts
+++ b/extensions/teak-raycast/src/lib/searchFilters.ts
@@ -14,7 +14,7 @@ export const SORT_OPTIONS = ["newest", "oldest"] as const;
 export type RaycastCardType = (typeof CARD_TYPES)[number];
 export type RaycastSort = (typeof SORT_OPTIONS)[number];
 
-export type ParsedSearchFilters = {
+export interface ParsedSearchFilters {
   favorited?: boolean;
   hasExplicitFilters: boolean;
   query: string;
@@ -22,7 +22,7 @@ export type ParsedSearchFilters = {
   sort: RaycastSort;
   tag?: string;
   type?: RaycastCardType;
-};
+}
 
 const CARD_TYPE_SET = new Set<string>(CARD_TYPES);
 
@@ -60,9 +60,79 @@ const normalizeFavorited = (value?: string): boolean | undefined => {
   return undefined;
 };
 
+const WHITESPACE = /\s/;
+const NEEDS_QUOTING = /[\s":\\]/;
+
+// Tokenizes the raw search text while keeping double-quoted spans intact so a
+// value such as `tag:"design systems"` survives as a single token. Quotes are
+// stripped from the emitted token and `\"`/`\\` escapes are unwrapped.
+const tokenizeSearchText = (rawQuery: string): string[] => {
+  const tokens: string[] = [];
+  let current = "";
+  let hasContent = false;
+  let inQuotes = false;
+
+  for (let index = 0; index < rawQuery.length; index += 1) {
+    const char = rawQuery[index];
+
+    if (inQuotes) {
+      if (char === "\\" && index + 1 < rawQuery.length) {
+        const next = rawQuery[index + 1];
+        if (next === '"' || next === "\\") {
+          current += next;
+          index += 1;
+          continue;
+        }
+      }
+
+      if (char === '"') {
+        inQuotes = false;
+        continue;
+      }
+
+      current += char;
+      hasContent = true;
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+      hasContent = true;
+      continue;
+    }
+
+    if (WHITESPACE.test(char)) {
+      if (hasContent) {
+        tokens.push(current);
+        current = "";
+        hasContent = false;
+      }
+      continue;
+    }
+
+    current += char;
+    hasContent = true;
+  }
+
+  if (hasContent) {
+    tokens.push(current);
+  }
+
+  return tokens;
+};
+
+const formatFilterValue = (value: string): string => {
+  if (!NEEDS_QUOTING.test(value)) {
+    return value;
+  }
+
+  const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escaped}"`;
+};
+
 export const parseSearchFilters = (rawQuery: string): ParsedSearchFilters => {
   const queryTerms: string[] = [];
-  const tokens = rawQuery.trim().split(/\s+/).filter(Boolean);
+  const tokens = tokenizeSearchText(rawQuery);
 
   let favorited: boolean | undefined;
   let sort: RaycastSort = "newest";
@@ -146,11 +216,11 @@ export const buildSearchText = (filters: {
   }
 
   if (filters.type) {
-    tokens.push(`type:${filters.type}`);
+    tokens.push(`type:${formatFilterValue(filters.type)}`);
   }
 
   if (filters.tag) {
-    tokens.push(`tag:${filters.tag}`);
+    tokens.push(`tag:${formatFilterValue(filters.tag)}`);
   }
 
   if (filters.favorited) {

--- a/extensions/teak-raycast/src/lib/useTeakAuth.ts
+++ b/extensions/teak-raycast/src/lib/useTeakAuth.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from "react";
+import { hasStoredTeakSession } from "./oauth";
+import { getPreferences } from "./preferences";
+
+export interface TeakAuthState {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  refresh: () => void;
+}
+
+/**
+ * Resolve whether the extension has usable credentials. A grandfathered API key
+ * (from preferences) is used as-is; otherwise we check for an already-stored
+ * OAuth session WITHOUT starting sign-in. Opening a command therefore never
+ * launches the browser OAuth overlay on its own — the visible "Sign in with
+ * Browser" action is the explicit entry point, and callers re-check via
+ * `refresh()` after it completes. Callers render a loading state while
+ * `isLoading` is true.
+ */
+export function useTeakAuth(): TeakAuthState {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [reloadNonce, setReloadNonce] = useState(0);
+
+  const refresh = useCallback(() => {
+    setReloadNonce((value) => value + 1);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    const resolve = async () => {
+      setIsLoading(true);
+
+      // Grandfathered API key takes precedence — no browser sign-in needed.
+      if (getPreferences().apiKey?.trim()) {
+        if (active) {
+          setIsAuthenticated(true);
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      let authorized = false;
+      try {
+        // Read-only: reports an existing stored session without prompting, so
+        // navigation never triggers the OAuth overlay as a side effect.
+        authorized = await hasStoredTeakSession();
+      } catch {
+        authorized = false;
+      }
+
+      if (active) {
+        setIsAuthenticated(authorized);
+        setIsLoading(false);
+      }
+    };
+
+    void resolve();
+
+    return () => {
+      active = false;
+    };
+  }, [reloadNonce]);
+
+  return { isAuthenticated, isLoading, refresh };
+}

--- a/extensions/teak-raycast/src/quick-save.tsx
+++ b/extensions/teak-raycast/src/quick-save.tsx
@@ -11,34 +11,37 @@ import {
 import { useEffect, useState } from "react";
 import { MissingApiKeyDetail } from "./components/MissingApiKeyDetail";
 import { SetApiKeyAction } from "./components/SetApiKeyAction";
+import { SignOutAction } from "./components/SignOutAction";
 import {
   getRecoveryHint,
   getUserFacingErrorMessage,
   quickSaveCard,
 } from "./lib/api";
-import { getPreferences } from "./lib/preferences";
+import { useTeakAuth } from "./lib/useTeakAuth";
 
-type FormValues = {
+interface FormValues {
   content: string;
-};
+}
 
 const addSuccessActions = (
   toast: Toast,
   result: Awaited<ReturnType<typeof quickSaveCard>>,
 ) => {
-  if (result.appUrl) {
+  const appUrl = result.appUrl;
+  if (appUrl) {
     toast.primaryAction = {
       onAction: () => {
-        void open(result.appUrl!);
+        void open(appUrl);
       },
       title: "Open Card",
     };
   }
 
-  if (result.card?.url) {
+  const sourceUrl = result.card?.url;
+  if (sourceUrl) {
     toast.secondaryAction = {
       onAction: () => {
-        void open(result.card!.url!);
+        void open(sourceUrl);
       },
       title: "Open Source URL",
     };
@@ -49,8 +52,11 @@ export default function QuickSaveCommand() {
   const [content, setContent] = useState("");
   const [isSaving, setIsSaving] = useState(false);
 
-  const { apiKey } = getPreferences();
-  const hasApiKey = Boolean(apiKey?.trim());
+  const {
+    isAuthenticated,
+    isLoading: isCheckingAuth,
+    refresh: refreshAuth,
+  } = useTeakAuth();
 
   useEffect(() => {
     let isMounted = true;
@@ -112,8 +118,12 @@ export default function QuickSaveCommand() {
     }
   };
 
-  if (!hasApiKey) {
-    return <MissingApiKeyDetail />;
+  if (isCheckingAuth) {
+    return <Form isLoading navigationTitle="Quick Save to Teak" />;
+  }
+
+  if (!isAuthenticated) {
+    return <MissingApiKeyDetail onSignedIn={refreshAuth} />;
   }
 
   return (
@@ -126,6 +136,7 @@ export default function QuickSaveCommand() {
             title={isSaving ? "Saving..." : "Save to Teak"}
           />
           <SetApiKeyAction />
+          <SignOutAction onSignedOut={refreshAuth} />
         </ActionPanel>
       }
       navigationTitle="Quick Save to Teak"

--- a/extensions/teak-raycast/src/save-clipboard-url.ts
+++ b/extensions/teak-raycast/src/save-clipboard-url.ts
@@ -1,26 +1,12 @@
+import { Clipboard, showToast, Toast } from "@raycast/api";
 import {
-  Clipboard,
-  openExtensionPreferences,
-  showToast,
-  Toast,
-} from "@raycast/api";
-import { extractFirstHttpUrl, saveCardWithFeedback } from "./lib/capture";
-import { getPreferences } from "./lib/preferences";
+  ensureCredentialsForNoViewCommand,
+  extractFirstHttpUrl,
+  saveCardWithFeedback,
+} from "./lib/capture";
 
 export default async function SaveClipboardCommand() {
-  const { apiKey } = getPreferences();
-  if (!apiKey?.trim()) {
-    await showToast({
-      message: "Set your Teak API key in extension preferences to continue.",
-      primaryAction: {
-        onAction: () => {
-          void openExtensionPreferences();
-        },
-        title: "Open Preferences",
-      },
-      style: Toast.Style.Failure,
-      title: "Missing API key",
-    });
+  if (!(await ensureCredentialsForNoViewCommand())) {
     return;
   }
 

--- a/extensions/teak-raycast/src/save-current-browser-tab.ts
+++ b/extensions/teak-raycast/src/save-current-browser-tab.ts
@@ -1,12 +1,8 @@
+import { BrowserExtension, environment, showToast, Toast } from "@raycast/api";
 import {
-  BrowserExtension,
-  environment,
-  openExtensionPreferences,
-  showToast,
-  Toast,
-} from "@raycast/api";
-import { saveCardWithFeedback } from "./lib/capture";
-import { getPreferences } from "./lib/preferences";
+  ensureCredentialsForNoViewCommand,
+  saveCardWithFeedback,
+} from "./lib/capture";
 
 const isHttpUrl = (value: string): boolean => {
   try {
@@ -18,19 +14,7 @@ const isHttpUrl = (value: string): boolean => {
 };
 
 export default async function SaveCurrentBrowserTabCommand() {
-  const { apiKey } = getPreferences();
-  if (!apiKey?.trim()) {
-    await showToast({
-      message: "Set your Teak API key in extension preferences to continue.",
-      primaryAction: {
-        onAction: () => {
-          void openExtensionPreferences();
-        },
-        title: "Open Preferences",
-      },
-      style: Toast.Style.Failure,
-      title: "Missing API key",
-    });
+  if (!(await ensureCredentialsForNoViewCommand())) {
     return;
   }
 

--- a/extensions/teak-raycast/src/save-selected-text.ts
+++ b/extensions/teak-raycast/src/save-selected-text.ts
@@ -1,26 +1,12 @@
+import { getSelectedText, showToast, Toast } from "@raycast/api";
 import {
-  getSelectedText,
-  openExtensionPreferences,
-  showToast,
-  Toast,
-} from "@raycast/api";
-import { extractFirstHttpUrl, saveCardWithFeedback } from "./lib/capture";
-import { getPreferences } from "./lib/preferences";
+  ensureCredentialsForNoViewCommand,
+  extractFirstHttpUrl,
+  saveCardWithFeedback,
+} from "./lib/capture";
 
 export default async function SaveSelectedTextCommand() {
-  const { apiKey } = getPreferences();
-  if (!apiKey?.trim()) {
-    await showToast({
-      message: "Set your Teak API key in extension preferences to continue.",
-      primaryAction: {
-        onAction: () => {
-          void openExtensionPreferences();
-        },
-        title: "Open Preferences",
-      },
-      style: Toast.Style.Failure,
-      title: "Missing API key",
-    });
+  if (!(await ensureCredentialsForNoViewCommand())) {
     return;
   }
 

--- a/extensions/teak-raycast/src/save-text.ts
+++ b/extensions/teak-raycast/src/save-text.ts
@@ -1,28 +1,14 @@
+import { type LaunchProps, showToast, Toast } from "@raycast/api";
 import {
-  type LaunchProps,
-  openExtensionPreferences,
-  showToast,
-  Toast,
-} from "@raycast/api";
-import { extractFirstHttpUrl, saveCardWithFeedback } from "./lib/capture";
-import { getPreferences } from "./lib/preferences";
+  ensureCredentialsForNoViewCommand,
+  extractFirstHttpUrl,
+  saveCardWithFeedback,
+} from "./lib/capture";
 
 export default async function SaveTextCommand(
   props: LaunchProps<{ arguments: Arguments.SaveText }>,
 ) {
-  const { apiKey } = getPreferences();
-  if (!apiKey?.trim()) {
-    await showToast({
-      message: "Set your Teak API key in extension preferences to continue.",
-      primaryAction: {
-        onAction: () => {
-          void openExtensionPreferences();
-        },
-        title: "Open Preferences",
-      },
-      style: Toast.Style.Failure,
-      title: "Missing API key",
-    });
+  if (!(await ensureCredentialsForNoViewCommand())) {
     return;
   }
 

--- a/extensions/teak-raycast/src/tags.tsx
+++ b/extensions/teak-raycast/src/tags.tsx
@@ -10,13 +10,14 @@ import { useEffect, useMemo, useState } from "react";
 import { CardsListCommand } from "./components/CardsListCommand";
 import { MissingApiKeyDetail } from "./components/MissingApiKeyDetail";
 import { SetApiKeyAction } from "./components/SetApiKeyAction";
+import { SignOutAction } from "./components/SignOutAction";
 import {
   getUserFacingErrorMessage,
   listTags,
   searchCards,
   type TagSummary,
 } from "./lib/api";
-import { getPreferences } from "./lib/preferences";
+import { useTeakAuth } from "./lib/useTeakAuth";
 
 function TagCardsView({ tag }: { tag: string }) {
   return (
@@ -28,14 +29,18 @@ function TagCardsView({ tag }: { tag: string }) {
       latestSectionTitle={`Cards tagged "${tag}"`}
       loadCards={(input) => searchCards({ ...input, limit: 50, tag })}
       navigationTitle={`Tag: ${tag}`}
+      removeTagFilterFromList
       searchBarPlaceholder={`Search within "${tag}" or use type:, sort:oldest`}
     />
   );
 }
 
 export default function TagsCommand() {
-  const { apiKey } = getPreferences();
-  const hasApiKey = Boolean(apiKey?.trim());
+  const {
+    isAuthenticated,
+    isLoading: isCheckingAuth,
+    refresh: refreshAuth,
+  } = useTeakAuth();
 
   const [tags, setTags] = useState<TagSummary[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -45,7 +50,11 @@ export default function TagsCommand() {
   const { push } = useNavigation();
 
   useEffect(() => {
-    if (!hasApiKey) {
+    if (isCheckingAuth) {
+      return;
+    }
+
+    if (!isAuthenticated) {
       setTags([]);
       setIsLoading(false);
       return;
@@ -62,7 +71,8 @@ export default function TagsCommand() {
         }
       } catch (requestError) {
         if (isMounted) {
-          setError(getUserFacingErrorMessage(requestError));
+          const message = getUserFacingErrorMessage(requestError);
+          setError(message);
           setTags([]);
         }
       } finally {
@@ -77,7 +87,7 @@ export default function TagsCommand() {
     return () => {
       isMounted = false;
     };
-  }, [hasApiKey]);
+  }, [isCheckingAuth, isAuthenticated]);
 
   const filteredTags = useMemo(() => {
     const normalized = searchText.trim().toLowerCase();
@@ -87,8 +97,12 @@ export default function TagsCommand() {
     return tags.filter((tag) => tag.name.toLowerCase().includes(normalized));
   }, [searchText, tags]);
 
-  if (!hasApiKey) {
-    return <MissingApiKeyDetail />;
+  if (isCheckingAuth) {
+    return <List isLoading navigationTitle="Teak Tags" />;
+  }
+
+  if (!isAuthenticated) {
+    return <MissingApiKeyDetail onSignedIn={refreshAuth} />;
   }
 
   return (
@@ -142,6 +156,7 @@ export default function TagsCommand() {
                 title="Copy Tag Name"
               />
               <SetApiKeyAction />
+              <SignOutAction onSignedOut={refreshAuth} />
             </ActionPanel>
           }
           icon={Icon.Tag}

--- a/extensions/teak-raycast/src/tools/favorite-card.ts
+++ b/extensions/teak-raycast/src/tools/favorite-card.ts
@@ -17,7 +17,9 @@ export default async function tool(input: Input) {
     throw new Error("cardId is required");
   }
 
-  const updated = await setCardFavorite(cardId, input.isFavorited);
+  const updated = await setCardFavorite(cardId, input.isFavorited, {
+    interactive: false,
+  });
 
   return {
     appUrl: updated.appUrl,
@@ -28,8 +30,8 @@ export default async function tool(input: Input) {
   };
 }
 
-export const confirmation: Tool.Confirmation<Input> = async (input) => {
-  return {
+export const confirmation: Tool.Confirmation<Input> = (input) => {
+  return Promise.resolve({
     info: [
       { name: "Card ID", value: input.cardId },
       { name: "Action", value: input.isFavorited ? "Favorite" : "Unfavorite" },
@@ -37,5 +39,5 @@ export const confirmation: Tool.Confirmation<Input> = async (input) => {
     message: input.isFavorited
       ? "Mark this Teak card as a favorite?"
       : "Remove this Teak card from favorites?",
-  };
+  });
 };

--- a/extensions/teak-raycast/src/tools/get-card.ts
+++ b/extensions/teak-raycast/src/tools/get-card.ts
@@ -6,7 +6,7 @@ type Input = {
 };
 
 export default async function tool(input: Input) {
-  const card = await getCardById(input.cardId);
+  const card = await getCardById(input.cardId, { interactive: false });
 
   return {
     aiSummary: card.aiSummary,

--- a/extensions/teak-raycast/src/tools/get-recent.ts
+++ b/extensions/teak-raycast/src/tools/get-recent.ts
@@ -1,6 +1,14 @@
 import { searchCards } from "../lib/api";
 
 type Input = {
+  /** Only include cards created after this timestamp (milliseconds since epoch). */
+  createdAfter?: number;
+  /** Only include cards created before this timestamp (milliseconds since epoch). */
+  createdBefore?: number;
+  /** When true, only include favorited cards. */
+  favorited?: boolean;
+  /** Maximum number of cards to return. Defaults to 10, max 50. */
+  limit?: number;
   /** Optional card type filter. */
   type?:
     | "audio"
@@ -11,14 +19,6 @@ type Input = {
     | "quote"
     | "text"
     | "video";
-  /** When true, only include favorited cards. */
-  favorited?: boolean;
-  /** Only include cards created after this timestamp (milliseconds since epoch). */
-  createdAfter?: number;
-  /** Only include cards created before this timestamp (milliseconds since epoch). */
-  createdBefore?: number;
-  /** Maximum number of cards to return. Defaults to 10, max 50. */
-  limit?: number;
 };
 
 /**
@@ -28,14 +28,18 @@ type Input = {
 export default async function tool(input: Input = {}) {
   const limit = Math.max(1, Math.min(input.limit ?? 10, 50));
 
-  const result = await searchCards({
-    createdAfter: input.createdAfter,
-    createdBefore: input.createdBefore,
-    favorited: input.favorited,
-    limit,
-    sort: "newest",
-    type: input.type,
-  });
+  const result = await searchCards(
+    {
+      createdAfter: input.createdAfter,
+      createdBefore: input.createdBefore,
+      favorited: input.favorited,
+      limit,
+      sort: "newest",
+      type: input.type,
+    },
+    // AI tools run headless — never open the browser sign-in overlay.
+    { interactive: false },
+  );
 
   return result.items.map((card) => ({
     aiSummary: card.aiSummary,

--- a/extensions/teak-raycast/src/tools/list-tags.ts
+++ b/extensions/teak-raycast/src/tools/list-tags.ts
@@ -11,7 +11,7 @@ type Input = {
  * List the user's Teak tags with per-tag card counts.
  */
 export default async function tool(input: Input = {}) {
-  const { items } = await listTags();
+  const { items } = await listTags({ interactive: false });
 
   const normalizedFilter = input.filter?.trim().toLowerCase();
   const filtered = normalizedFilter

--- a/extensions/teak-raycast/src/tools/save-card.ts
+++ b/extensions/teak-raycast/src/tools/save-card.ts
@@ -13,11 +13,15 @@ export default async function tool(content: string) {
 
   const url = extractFirstHttpUrl(normalizedContent);
 
-  const result = await createCard({
-    content: normalizedContent,
-    source: "raycast_ai_tool",
-    url: url ?? undefined,
-  });
+  const result = await createCard(
+    {
+      content: normalizedContent,
+      source: "raycast_ai_tool",
+      url: url ?? undefined,
+    },
+    // AI tools run headless — never open the browser sign-in overlay.
+    { interactive: false },
+  );
 
   return `Saved to Teak: ${result.cardId}`;
 }

--- a/extensions/teak-raycast/src/tools/search-cards.ts
+++ b/extensions/teak-raycast/src/tools/search-cards.ts
@@ -1,8 +1,16 @@
 import { searchCards } from "../lib/api";
 
 type Input = {
+  /** When true, limit results to favorited cards. */
+  favorited?: boolean;
+  /** Maximum number of cards to return. Defaults to 10. */
+  limit?: number;
   /** Optional free-text query to search across Teak cards. */
   query?: string;
+  /** Sort results by newest or oldest creation date. */
+  sort?: "newest" | "oldest";
+  /** Optional exact tag filter. */
+  tag?: string;
   /** Optional card type filter. */
   type?:
     | "audio"
@@ -13,25 +21,21 @@ type Input = {
     | "quote"
     | "text"
     | "video";
-  /** Optional exact tag filter. */
-  tag?: string;
-  /** When true, limit results to favorited cards. */
-  favorited?: boolean;
-  /** Sort results by newest or oldest creation date. */
-  sort?: "newest" | "oldest";
-  /** Maximum number of cards to return. Defaults to 10. */
-  limit?: number;
 };
 
 export default async function tool(input: Input = {}) {
-  const result = await searchCards({
-    favorited: input.favorited,
-    limit: input.limit ?? 10,
-    query: input.query,
-    sort: input.sort,
-    tag: input.tag,
-    type: input.type,
-  });
+  const result = await searchCards(
+    {
+      favorited: input.favorited,
+      limit: input.limit ?? 10,
+      query: input.query,
+      sort: input.sort,
+      tag: input.tag,
+      type: input.type,
+    },
+    // AI tools run headless — never open the browser sign-in overlay.
+    { interactive: false },
+  );
 
   return result.items.map((card) => ({
     aiSummary: card.aiSummary,


### PR DESCRIPTION
## Description

Updates the **Teak** extension to add browser-based sign-in.

- Sign in with your browser in one step. Copying an API key is no longer required to get started.
- Existing API keys keep working exactly as before.
- AI tools and background (no-view) save commands no longer open a browser sign-in window unexpectedly.

### Validation

- `ray build` succeeds (8 commands + 6 AI tools compile, TS defs generated).
- `ray lint` clean (package.json, icons, metadata, ESLint, Prettier).
- 58 unit tests pass (`bun test`).

## Screencast


https://github.com/user-attachments/assets/1ca12afa-db8e-4439-a67a-32f5e14647bc



## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
