### PR TITLE
Update navidrome extension

### DIFF
--- a/extensions/navidrome/CHANGELOG.md
+++ b/extensions/navidrome/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Navidrome Changelog
 
+## [Playlists] - {PR_MERGE_DATE}
+
+- Playlists command for browsing all playlists
+- Playlists now appear in Search results
+- Open Playlist in Navidrome from either view
+
 ## [Initial Release] - 2026-03-09
 
 - Search (with recent searches)

--- a/extensions/navidrome/CHANGELOG.md
+++ b/extensions/navidrome/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Navidrome Changelog
 
-## [Playlists] - {PR_MERGE_DATE}
+## [Playlists] - 2026-07-06
 
 - Playlists command for browsing all playlists
 - Playlists now appear in Search results

--- a/extensions/navidrome/README.md
+++ b/extensions/navidrome/README.md
@@ -4,19 +4,20 @@ Search and browse your [Navidrome](https://www.navidrome.org/) music library dir
 
 ## Commands
 
-| Command               | Description                                                  | View |
-| --------------------- | ------------------------------------------------------------ | ---- |
-| Search                | Search artists, albums, and songs with recent search history | List |
-| Recently Added Albums | Browse your newest albums with cover art                     | Grid |
-| Most Played Albums    | Browse your most frequently played albums                    | Grid |
+| Command               | Description                                                             | View |
+| --------------------- | ----------------------------------------------------------------------- | ---- |
+| Search                | Search artists, albums, songs, and playlists with recent search history | List |
+| Recently Added Albums | Browse your newest albums with cover art                                | Grid |
+| Most Played Albums    | Browse your most frequently played albums                               | Grid |
+| Playlists             | Browse all your Navidrome playlists                                     | List |
 
 ## Features
 
-- **Unified search** across artists, albums, and songs
+- **Unified search** across artists, albums, songs, and playlists
 - **Recent searches** — your last 10 queries are saved and shown when the search bar is empty
 - **Album art** — cover art thumbnails in search results and grid views
 - **Star indicators** — see which items you've favorited at a glance
-- **Open in browser** — jump straight to the artist/album page in Navidrome's web UI
+- **Open in browser** — jump straight to the artist/album/playlist page in Navidrome's web UI
 - **Copy to clipboard** — copy names, titles, or URLs
 
 ## Setup

--- a/extensions/navidrome/package.json
+++ b/extensions/navidrome/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "navidrome",
   "title": "Navidrome",
-  "description": "Search and browse your Navidrome music library. Find artists, albums, and songs, then open them directly in your browser.",
+  "description": "Search and browse your Navidrome music library. Find artists, albums, songs, and playlists, then open them directly in your browser.",
   "icon": "extension-icon.png",
   "author": "alexandervarney",
   "categories": [
@@ -14,7 +14,7 @@
       "name": "search",
       "title": "Search",
       "subtitle": "Navidrome",
-      "description": "Search for artists, albums, and songs in your Navidrome library",
+      "description": "Search for artists, albums, songs, and playlists in your Navidrome library",
       "mode": "view"
     },
     {
@@ -29,6 +29,13 @@
       "title": "Most Played Albums",
       "subtitle": "Navidrome",
       "description": "Browse your most played albums in Navidrome",
+      "mode": "view"
+    },
+    {
+      "name": "playlists",
+      "title": "Playlists",
+      "subtitle": "Navidrome",
+      "description": "Browse your Navidrome playlists",
       "mode": "view"
     }
   ],

--- a/extensions/navidrome/src/api.ts
+++ b/extensions/navidrome/src/api.ts
@@ -37,6 +37,19 @@ export interface Song {
   starred?: string;
 }
 
+export interface Playlist {
+  id: string;
+  name: string;
+  comment?: string;
+  owner?: string;
+  public?: boolean;
+  songCount?: number;
+  duration?: number;
+  created?: string;
+  changed?: string;
+  coverArt?: string;
+}
+
 export interface SearchResult {
   artists: Artist[];
   albums: Album[];
@@ -140,6 +153,34 @@ export async function search3(query: string): Promise<SearchResult> {
   };
 }
 
+// Subsonic's search3 endpoint doesn't cover playlists, so the Search command
+// fetches the playlist list once and filters it client-side per query.
+export function filterPlaylists(
+  playlists: Playlist[],
+  query: string,
+  limit = 10,
+): Playlist[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [];
+  return playlists
+    .filter(
+      (p) =>
+        p.name?.toLowerCase().includes(needle) ||
+        p.comment?.toLowerCase().includes(needle),
+    )
+    .slice(0, limit);
+}
+
+export async function getPlaylists(): Promise<Playlist[]> {
+  const result = await apiCall<{
+    playlists?: {
+      playlist?: Playlist | Playlist[];
+    };
+  }>("getPlaylists");
+
+  return toArray(result.playlists?.playlist);
+}
+
 export async function getAlbumList(
   type: string,
   size = 25,
@@ -175,7 +216,7 @@ export function getCoverArtUrl(coverArtId: string, size = 100): string {
 }
 
 export function getNavidromeWebUrl(
-  type: "artist" | "album" | "song",
+  type: "artist" | "album" | "song" | "playlist",
   id: string,
 ): string {
   const baseUrl = getBaseUrl();
@@ -187,6 +228,8 @@ export function getNavidromeWebUrl(
       return `${baseUrl}/app/#/album/${id}/show`;
     case "song":
       return `${baseUrl}/app/#/album/${id}/show`;
+    case "playlist":
+      return `${baseUrl}/app/#/playlist/${id}/show`;
     default:
       return baseUrl;
   }
@@ -197,6 +240,17 @@ export function formatDuration(seconds?: number): string {
   const mins = Math.floor(seconds / 60);
   const secs = seconds % 60;
   return `${mins}:${secs.toString().padStart(2, "0")}`;
+}
+
+export function formatLongDuration(seconds?: number): string {
+  if (!seconds) return "";
+  const hours = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  if (hours > 0) {
+    return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  }
+  if (mins > 0) return `${mins}m`;
+  return `< 1m`;
 }
 
 export async function ping(): Promise<boolean> {

--- a/extensions/navidrome/src/components.tsx
+++ b/extensions/navidrome/src/components.tsx
@@ -1,0 +1,102 @@
+import { ActionPanel, Action, List, Icon, Image, Color } from "@raycast/api";
+import {
+  getCoverArtUrl,
+  getNavidromeWebUrl,
+  formatLongDuration,
+  type Playlist,
+} from "./api";
+
+// List.EmptyView and Grid.EmptyView are the same component in @raycast/api,
+// so this works inside both containers.
+export function FetchEmptyView({
+  error,
+  isLoading,
+  errorTitle,
+  emptyIcon,
+  emptyTitle,
+  emptyDescription,
+}: {
+  error: Error | undefined;
+  isLoading: boolean;
+  errorTitle: string;
+  emptyIcon: Icon;
+  emptyTitle: string;
+  emptyDescription: string;
+}) {
+  if (error) {
+    return (
+      <List.EmptyView
+        icon={Icon.ExclamationMark}
+        title={errorTitle}
+        description="Check your server URL and credentials in Raycast preferences"
+      />
+    );
+  }
+  if (isLoading) return null;
+  return (
+    <List.EmptyView
+      icon={emptyIcon}
+      title={emptyTitle}
+      description={emptyDescription}
+    />
+  );
+}
+
+export function PlaylistItem({
+  playlist,
+  onAction,
+}: {
+  playlist: Playlist;
+  onAction?: () => void;
+}) {
+  const url = getNavidromeWebUrl("playlist", playlist.id);
+  const subtitleParts: string[] = [];
+  if (playlist.comment) subtitleParts.push(playlist.comment);
+  else if (playlist.owner) subtitleParts.push(`by ${playlist.owner}`);
+
+  const accessories: List.Item.Accessory[] = [];
+  if (playlist.songCount !== undefined) {
+    accessories.push({
+      text: `${playlist.songCount} track${playlist.songCount !== 1 ? "s" : ""}`,
+    });
+  }
+  if (playlist.duration) {
+    accessories.push({ text: formatLongDuration(playlist.duration) });
+  }
+  accessories.push({ tag: { value: "Playlist", color: Color.Orange } });
+
+  return (
+    <List.Item
+      icon={
+        playlist.coverArt
+          ? {
+              source: getCoverArtUrl(playlist.coverArt),
+              mask: Image.Mask.RoundedRectangle,
+            }
+          : Icon.List
+      }
+      title={playlist.name}
+      subtitle={subtitleParts.join(" · ")}
+      accessories={accessories}
+      actions={
+        <ActionPanel>
+          <Action.OpenInBrowser
+            title="Open in Navidrome"
+            url={url}
+            onOpen={onAction}
+          />
+          <Action.CopyToClipboard
+            title="Copy Playlist Name"
+            content={playlist.name}
+            shortcut={{ modifiers: ["cmd"], key: "c" }}
+          />
+          <Action.CopyToClipboard
+            title="Copy URL"
+            content={url}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}

--- a/extensions/navidrome/src/most-played.tsx
+++ b/extensions/navidrome/src/most-played.tsx
@@ -1,32 +1,22 @@
-import {
-  ActionPanel,
-  Action,
-  Grid,
-  Icon,
-  showToast,
-  Toast,
-} from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
+import { ActionPanel, Action, Grid, Icon } from "@raycast/api";
+import { showFailureToast, useCachedPromise } from "@raycast/utils";
 import {
   getMostPlayed,
   getCoverArtUrl,
   getNavidromeWebUrl,
   type Album,
 } from "./api";
+import { FetchEmptyView } from "./components";
 
 export default function MostPlayedCommand() {
-  const { data, isLoading } = useCachedPromise(
+  const { data, isLoading, error } = useCachedPromise(
     async () => {
       return await getMostPlayed(40);
     },
     [],
     {
       onError: (err) => {
-        showToast({
-          style: Toast.Style.Failure,
-          title: "Failed to load most played albums",
-          message: err.message,
-        });
+        showFailureToast(err, { title: "Failed to load most played albums" });
       },
     },
   );
@@ -37,15 +27,18 @@ export default function MostPlayedCommand() {
       columns={5}
       searchBarPlaceholder="Filter most played albums..."
     >
-      {!data || data.length === 0
-        ? !isLoading && (
-            <Grid.EmptyView
-              icon={Icon.Music}
-              title="No Albums Found"
-              description="Play some music first!"
-            />
-          )
-        : data.map((album) => <AlbumGridItem key={album.id} album={album} />)}
+      {!data || data.length === 0 ? (
+        <FetchEmptyView
+          error={error}
+          isLoading={isLoading}
+          errorTitle="Could Not Load Albums"
+          emptyIcon={Icon.Music}
+          emptyTitle="No Albums Found"
+          emptyDescription="Play some music first!"
+        />
+      ) : (
+        data.map((album) => <AlbumGridItem key={album.id} album={album} />)
+      )}
     </Grid>
   );
 }

--- a/extensions/navidrome/src/playlists.tsx
+++ b/extensions/navidrome/src/playlists.tsx
@@ -1,0 +1,31 @@
+import { List, Icon } from "@raycast/api";
+import { showFailureToast, useCachedPromise } from "@raycast/utils";
+import { getPlaylists } from "./api";
+import { FetchEmptyView, PlaylistItem } from "./components";
+
+export default function PlaylistsCommand() {
+  const { data, isLoading, error } = useCachedPromise(getPlaylists, [], {
+    onError: (err) => {
+      showFailureToast(err, { title: "Failed to load playlists" });
+    },
+  });
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Filter playlists...">
+      {!data || data.length === 0 ? (
+        <FetchEmptyView
+          error={error}
+          isLoading={isLoading}
+          errorTitle="Could Not Load Playlists"
+          emptyIcon={Icon.List}
+          emptyTitle="No Playlists Found"
+          emptyDescription="Create a playlist in Navidrome to see it here"
+        />
+      ) : (
+        data.map((playlist) => (
+          <PlaylistItem key={playlist.id} playlist={playlist} />
+        ))
+      )}
+    </List>
+  );
+}

--- a/extensions/navidrome/src/recently-added.tsx
+++ b/extensions/navidrome/src/recently-added.tsx
@@ -1,31 +1,23 @@
-import {
-  ActionPanel,
-  Action,
-  Grid,
-  Icon,
-  showToast,
-  Toast,
-} from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
+import { ActionPanel, Action, Grid, Icon } from "@raycast/api";
+import { showFailureToast, useCachedPromise } from "@raycast/utils";
 import {
   getRecentlyAdded,
   getCoverArtUrl,
   getNavidromeWebUrl,
   type Album,
 } from "./api";
+import { FetchEmptyView } from "./components";
 
 export default function RecentlyAddedCommand() {
-  const { data, isLoading } = useCachedPromise(
+  const { data, isLoading, error } = useCachedPromise(
     async () => {
       return await getRecentlyAdded(40);
     },
     [],
     {
       onError: (err) => {
-        showToast({
-          style: Toast.Style.Failure,
+        showFailureToast(err, {
           title: "Failed to load recently added albums",
-          message: err.message,
         });
       },
     },
@@ -37,15 +29,18 @@ export default function RecentlyAddedCommand() {
       columns={5}
       searchBarPlaceholder="Filter recently added albums..."
     >
-      {!data || data.length === 0
-        ? !isLoading && (
-            <Grid.EmptyView
-              icon={Icon.Music}
-              title="No Albums Found"
-              description="Your library appears to be empty"
-            />
-          )
-        : data.map((album) => <AlbumGridItem key={album.id} album={album} />)}
+      {!data || data.length === 0 ? (
+        <FetchEmptyView
+          error={error}
+          isLoading={isLoading}
+          errorTitle="Could Not Load Albums"
+          emptyIcon={Icon.Music}
+          emptyTitle="No Albums Found"
+          emptyDescription="Your library appears to be empty"
+        />
+      ) : (
+        data.map((album) => <AlbumGridItem key={album.id} album={album} />)
+      )}
     </Grid>
   );
 }

--- a/extensions/navidrome/src/search.tsx
+++ b/extensions/navidrome/src/search.tsx
@@ -6,13 +6,13 @@ import {
   Image,
   Color,
   LocalStorage,
-  showToast,
-  Toast,
 } from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
+import { showFailureToast, useCachedPromise } from "@raycast/utils";
 import { useState, useEffect, useCallback, useRef } from "react";
 import {
   search3,
+  getPlaylists,
+  filterPlaylists,
   getCoverArtUrl,
   getNavidromeWebUrl,
   formatDuration,
@@ -20,6 +20,7 @@ import {
   type Album,
   type Song,
 } from "./api";
+import { PlaylistItem } from "./components";
 
 const RECENT_SEARCHES_KEY = "recent-searches";
 const MAX_RECENT_SEARCHES = 10;
@@ -75,7 +76,7 @@ export default function SearchCommand() {
     await LocalStorage.removeItem(RECENT_SEARCHES_KEY);
   }, []);
 
-  const { data, isLoading } = useCachedPromise(
+  const { data, isLoading, error } = useCachedPromise(
     async (q: string) => {
       if (!q.trim()) return null;
       return await search3(q);
@@ -84,25 +85,30 @@ export default function SearchCommand() {
     {
       keepPreviousData: true,
       onError: (err) => {
-        showToast({
-          style: Toast.Style.Failure,
-          title: "Search failed",
-          message: err.message,
-        });
+        showFailureToast(err, { title: "Search failed" });
       },
     },
   );
 
+  // Playlists aren't covered by search3, so fetch the list once and filter
+  // it locally per query. Failures degrade silently to no playlist results.
+  const { data: allPlaylists } = useCachedPromise(getPlaylists, [], {
+    keepPreviousData: true,
+    onError: () => {},
+  });
+  const playlists = filterPlaylists(allPlaylists ?? [], query);
+
   const hasResults =
-    data &&
-    (data.artists.length > 0 ||
-      data.albums.length > 0 ||
-      data.songs.length > 0);
+    (data &&
+      (data.artists.length > 0 ||
+        data.albums.length > 0 ||
+        data.songs.length > 0)) ||
+    playlists.length > 0;
 
   return (
     <List
       isLoading={isLoading}
-      searchBarPlaceholder="Search artists, albums, and songs..."
+      searchBarPlaceholder="Search artists, albums, songs, and playlists..."
       onSearchTextChange={(text) => {
         setQuery(text);
         searchTextRef.current = setQuery;
@@ -150,9 +156,15 @@ export default function SearchCommand() {
           <List.EmptyView
             icon={Icon.MagnifyingGlass}
             title="Search Your Library"
-            description="Type to search for artists, albums, and songs"
+            description="Type to search for artists, albums, songs, and playlists"
           />
         )
+      ) : error && !hasResults ? (
+        <List.EmptyView
+          icon={Icon.ExclamationMark}
+          title="Search Failed"
+          description="Check your server URL and credentials in Raycast preferences"
+        />
       ) : !hasResults && !isLoading ? (
         <List.EmptyView
           icon={Icon.MagnifyingGlass}
@@ -191,6 +203,18 @@ export default function SearchCommand() {
             <SongItem
               key={song.id}
               song={song}
+              onAction={() => addRecentSearch(query)}
+            />
+          ))}
+        </List.Section>
+      )}
+
+      {playlists.length > 0 && (
+        <List.Section title="Playlists" subtitle={`${playlists.length}`}>
+          {playlists.map((playlist) => (
+            <PlaylistItem
+              key={playlist.id}
+              playlist={playlist}
               onAction={() => addRecentSearch(query)}
             />
           ))}


### PR DESCRIPTION
## Description

- **Playlists** command — browse all of your Navidrome playlists in a list, with cover art, track count, and total duration.
- Playlists now appear as a section in **Search** results, matched by name and comment.
- "Open in Navidrome" action for playlists, available from both the Playlists command and Search.

## Screencast

https://github.com/user-attachments/assets/d04dadac-9fe6-40a8-ad01-d3b420ca4efa

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
