### PR TITLE
fix(trakt-manager): send redirect_uri on token refresh

### DIFF
--- a/extensions/trakt-manager/CHANGELOG.md
+++ b/extensions/trakt-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Trakt Manager Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed token refresh failing because the `redirect_uri` sent to Trakt's token endpoint didn't match the one used during authorization
+
 ## [Update] - 2026-06-29
 
 ### Added

--- a/extensions/trakt-manager/CHANGELOG.md
+++ b/extensions/trakt-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Trakt Manager Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-07-03
 
 - Fixed token refresh failing because the `redirect_uri` sent to Trakt's token endpoint didn't match the one used during authorization
 

--- a/extensions/trakt-manager/package.json
+++ b/extensions/trakt-manager/package.json
@@ -73,7 +73,8 @@
   ],
   "contributors": [
     "vishalbalaji3",
-    "Berenger"
+    "Berenger",
+    "burhanrashid52"
   ],
   "dependencies": {
     "@raycast/api": "^1.104.20",

--- a/extensions/trakt-manager/src/lib/oauth.ts
+++ b/extensions/trakt-manager/src/lib/oauth.ts
@@ -45,6 +45,8 @@ async function refreshTokens(token: string): Promise<OAuth.TokenResponse | undef
   params.append("client_id", TRAKT_CLIENT_ID);
   params.append("refresh_token", token);
   params.append("grant_type", "refresh_token");
+  // redirect_uri must match the one used during authorization
+  params.append("redirect_uri", "https://raycast.com/redirect?packageName=trakt-manager");
 
   const response = await fetch(TOKEN_URL, {
     method: "POST",


### PR DESCRIPTION
## Description

**Issue:** After authorizing Trakt via OAuth, the extension works fine initially, but reopening it the next day (once the access token expires) prompts for re-authentication every time, instead of silently refreshing the token. Rather than refreshing in the background, it opens the sign-in URL and requires clicking "Sign in" again, going through the full OAuth redirect flow from scratch — same as the very first authorization. The underlying error was a redirect URI mismatch, a known issue also reported on the [Trakt forums](https://forums.trakt.tv/t/the-authorization-token-is-not-renewed-every-few-days/80365) and in [trakt/trakt-api#48 "Unable to refresh access tokens"](https://github.com/trakt/api-help/issues/48).

**Root cause:** Trakt's OAuth token endpoint requires `redirect_uri` to match the one used during the initial authorization request. The token **refresh** flow (`refreshTokens` in `src/lib/oauth.ts`) omitted this parameter, so Trakt rejected the refresh request due to a redirect URI mismatch, forcing a full re-authentication instead of a silent token refresh.

This PR adds the `redirect_uri` parameter to the refresh token request, matching the same value used during authorization.

## Screencast

N/A — auth/token-refresh fix, not a UI change.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about the extension icon](https://developers.raycast.com/basics/prepare-an-extension-for-store#extension-icon)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I ran `npm run lint` and fixed any issues
- [x] I added a `CHANGELOG.md` entry