### PR TITLE
Scoop: Add update all and faster search

### DIFF
--- a/extensions/scoop/CHANGELOG.md
+++ b/extensions/scoop/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Scoop Changelog
 
-## [Feature] - {PR_MERGE_DATE}
+## [Feature] - 2026-07-07
 
 - Added a one-action update for all outdated packages.
 - Switched package search to scoop-search.

--- a/extensions/scoop/CHANGELOG.md
+++ b/extensions/scoop/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Scoop Changelog
 
+## [Feature] - {PR_MERGE_DATE}
+
+- Added a one-action update for all outdated packages.
+- Switched package search to scoop-search.
+- Documented ScoopDash Search installation requirements.
+
 ## [Initial Version] - 2025-09-12
 
 ## [Feature] - 2025-09-20

--- a/extensions/scoop/README.md
+++ b/extensions/scoop/README.md
@@ -1,6 +1,6 @@
 # Scoop Extension for Raycast
 
-A powerful Raycast extension for managing packages with [Scoop](https://scoop.sh/), the command-line installer for Windows.
+A powerful Raycast extension for managing packages with [Scoop](https://scoop.sh/), the command-line installer for Windows. Package search uses ScoopDash Search (`scoop-search`) for faster results.
 
 ***
 
@@ -10,7 +10,7 @@ A powerful Raycast extension for managing packages with [Scoop](https://scoop.sh
 * **Manage Packages** - Install or uninstall packages directly from Raycast with a single action.
 * **View Package Details** - Look up detailed information for any package, including its version, license, and dependencies.
 * **Check Installation Status** - Search results clearly indicate which packages are already installed on your system.
-* **Update Packages** - See a list of all outdated packages and update them individually.
+* **Update Packages** - See a list of all outdated packages and update one package or all packages at once.
 * **Manage Buckets** - View your currently installed buckets and add new ones from the community.
 
 ***
@@ -19,7 +19,7 @@ A powerful Raycast extension for managing packages with [Scoop](https://scoop.sh
 
 * **Search** - Search for packages, view their details, and install or uninstall them.
 * **Installed** - See a list of all packages currently installed on your system.
-* **Outdated** - Check for outdated packages and update them.
+* **Outdated** - Check for outdated packages and update one package or every outdated package.
 * **List Buckets** - View all your configured Scoop buckets.
 * **Add Bucket** - Add a new bucket to your Scoop installation.
 
@@ -30,3 +30,10 @@ A powerful Raycast extension for managing packages with [Scoop](https://scoop.sh
 * Windows
 * Raycast
 * Scoop
+* Scoop-search (`scoop-search`)
+
+Install Scoop-search before using the Search command:
+
+```powershell
+scoop install scoop-search
+```

--- a/extensions/scoop/README.md
+++ b/extensions/scoop/README.md
@@ -1,6 +1,6 @@
 # Scoop Extension for Raycast
 
-A powerful Raycast extension for managing packages with [Scoop](https://scoop.sh/), the command-line installer for Windows. Package search uses ScoopDash Search (`scoop-search`) for faster results.
+A powerful Raycast extension for managing packages with [Scoop](https://scoop.sh/), the command-line installer for Windows. Package search uses [ScoopDash Search](https://github.com/tokiedokie/scoop-search) (`scoop-search`) for faster results.
 
 ***
 
@@ -30,9 +30,9 @@ A powerful Raycast extension for managing packages with [Scoop](https://scoop.sh
 * Windows
 * Raycast
 * Scoop
-* Scoop-search (`scoop-search`)
+* [ScoopDash Search](https://github.com/tokiedokie/scoop-search) (`scoop-search`)
 
-Install Scoop-search before using the Search command:
+Install ScoopDash Search before using the Search command:
 
 ```powershell
 scoop install scoop-search

--- a/extensions/scoop/package.json
+++ b/extensions/scoop/package.json
@@ -4,7 +4,9 @@
   "title": "Scoop",
   "description": "Manage Scoop, the command-line installer for Windows.",
   "icon": "scoop.png",
-  "platforms": ["Windows"],
+  "platforms": [
+    "Windows"
+  ],
   "author": "zsombor_biro",
   "license": "MIT",
   "categories": [
@@ -12,7 +14,8 @@
     "System"
   ],
   "contributors": [
-    "shubham"
+    "shubham",
+    "Netizen"
   ],
   "keywords": [
     "scoop",

--- a/extensions/scoop/src/outdated.tsx
+++ b/extensions/scoop/src/outdated.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { List, ActionPanel, Action, Toast, showToast } from "@raycast/api";
 import { useScoop } from "./hooks/scoopHooks";
-import { withToast } from "./utils";
+import { withToast, withToastResult } from "./utils";
 import { OutdatedScoopPackage } from "./types/index.types";
 
 export default function OutdatedCommand() {
@@ -55,20 +55,22 @@ export default function OutdatedCommand() {
   const updateAllAndRefresh = async () => {
     const outdatedCount = packages.length;
 
-    await withToast(
+    await withToastResult(
       async () => {
         setIsLoading(true);
         try {
           await scoop.updateAll();
           const updatedPackages = await scoop.status();
+          const updatedCount = Math.max(outdatedCount - updatedPackages.length, 0);
           setPackages(updatedPackages);
+          return updatedCount;
         } finally {
           setIsLoading(false);
         }
       },
       {
         loading: `Updating ${packageLabel(outdatedCount)}...`,
-        success: `Updated ${packageLabel(outdatedCount)}.`,
+        success: (updatedCount) => `Updated ${packageLabel(updatedCount)}.`,
         failure: "Failed to update all packages.",
       },
     );

--- a/extensions/scoop/src/outdated.tsx
+++ b/extensions/scoop/src/outdated.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { List, ActionPanel, Action } from "@raycast/api";
+import { List, ActionPanel, Action, Toast, showToast } from "@raycast/api";
 import { useScoop } from "./hooks/scoopHooks";
 import { withToast } from "./utils";
 import { OutdatedScoopPackage } from "./types/index.types";
@@ -9,21 +9,40 @@ export default function OutdatedCommand() {
   const scoop = useScoop();
   const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    scoop.status().then((pkgs) => {
+  const packageLabel = (count: number) => `${count} ${count === 1 ? "package" : "packages"}`;
+
+  const refreshOutdated = async (showResultToast = false) => {
+    setIsLoading(true);
+    try {
+      const pkgs = await scoop.status();
       setPackages(pkgs);
+
+      if (showResultToast) {
+        await showToast({
+          style: Toast.Style.Success,
+          title: pkgs.length > 0 ? `Found ${packageLabel(pkgs.length)} to update.` : "Scoop is up to date.",
+        });
+      }
+    } finally {
       setIsLoading(false);
-    });
+    }
+  };
+
+  useEffect(() => {
+    refreshOutdated();
   }, []);
 
   const updateAndRefresh = async (packageName: string) => {
     await withToast(
       async () => {
         setIsLoading(true);
-        await scoop.update(packageName);
-        const updatedPackages = await scoop.status();
-        setPackages(updatedPackages);
-        setIsLoading(false);
+        try {
+          await scoop.update(packageName);
+          const updatedPackages = await scoop.status();
+          setPackages(updatedPackages);
+        } finally {
+          setIsLoading(false);
+        }
       },
       {
         loading: `Updating ${packageName}...`,
@@ -33,8 +52,59 @@ export default function OutdatedCommand() {
     );
   };
 
+  const updateAllAndRefresh = async () => {
+    const outdatedCount = packages.length;
+
+    await withToast(
+      async () => {
+        setIsLoading(true);
+        try {
+          await scoop.updateAll();
+          const updatedPackages = await scoop.status();
+          setPackages(updatedPackages);
+        } finally {
+          setIsLoading(false);
+        }
+      },
+      {
+        loading: `Updating ${packageLabel(outdatedCount)}...`,
+        success: `Updated ${packageLabel(outdatedCount)}.`,
+        failure: "Failed to update all packages.",
+      },
+    );
+  };
+
   return (
-    <List isLoading={isLoading}>
+    <List
+      isLoading={isLoading}
+      actions={
+        <ActionPanel>
+          <Action title="Refresh Outdated Packages" onAction={() => refreshOutdated(true)} />
+        </ActionPanel>
+      }
+    >
+      <List.EmptyView
+        title="Scoop is up to date"
+        description="No outdated packages found."
+        actions={
+          <ActionPanel>
+            <Action title="Refresh Outdated Packages" onAction={() => refreshOutdated(true)} />
+          </ActionPanel>
+        }
+      />
+      {packages.length > 0 && (
+        <List.Item
+          key="update-all"
+          title="Update All Packages"
+          subtitle={`${packageLabel(packages.length)} outdated`}
+          actions={
+            <ActionPanel>
+              <Action title="Update All Packages" onAction={updateAllAndRefresh} />
+              <Action title="Refresh Outdated Packages" onAction={() => refreshOutdated(true)} />
+            </ActionPanel>
+          }
+        />
+      )}
       {packages.map((pkg) => (
         <List.Item
           key={pkg.Name}
@@ -43,6 +113,8 @@ export default function OutdatedCommand() {
           actions={
             <ActionPanel>
               <Action title="Update Package" onAction={() => updateAndRefresh(pkg.Name)} />
+              <Action title="Update All Packages" onAction={updateAllAndRefresh} />
+              <Action title="Refresh Outdated Packages" onAction={() => refreshOutdated(true)} />
             </ActionPanel>
           }
         />

--- a/extensions/scoop/src/scoop.ts
+++ b/extensions/scoop/src/scoop.ts
@@ -80,6 +80,10 @@ export class ScoopManager {
       return this.parseScoopSearch(stdout);
     } catch (e) {
       const error = e as ExecException & { stdout: string; stderr: string };
+      if (error.code === "ENOENT") {
+        throw new Error("ScoopDash Search is not installed. Run `scoop install scoop-search` and try again.");
+      }
+
       if (
         error.stdout?.includes("No matches found") ||
         error.stderr?.includes("No matches found") ||

--- a/extensions/scoop/src/scoop.ts
+++ b/extensions/scoop/src/scoop.ts
@@ -1,4 +1,4 @@
-import { exec } from "node:child_process";
+import { exec, execFile } from "node:child_process";
 import type { ExecException } from "node:child_process";
 import { promisify } from "node:util";
 import {
@@ -10,6 +10,7 @@ import {
 } from "./types/index.types";
 
 export const execp = promisify(exec);
+export const execFilep = promisify(execFile);
 
 export class ScoopManager {
   private static instance: ScoopManager;
@@ -40,6 +41,32 @@ export class ScoopManager {
       });
   }
 
+  private parseScoopSearch(stdout: string): ScoopPackage[] {
+    const lines = this.stripAnsi(stdout).trim().split("\n");
+    const packages: ScoopPackage[] = [];
+    let bucket = "";
+
+    for (const line of lines) {
+      const bucketMatch = line.match(/^'(.+)' bucket:$/);
+      if (bucketMatch) {
+        bucket = bucketMatch[1];
+        continue;
+      }
+
+      const packageMatch = line.match(/^\s+(.+?)\s+\((.+)\)(?:\s+-->\s+includes\s+'(.+)')?$/);
+      if (!packageMatch) continue;
+
+      packages.push({
+        Name: packageMatch[1],
+        Version: packageMatch[2],
+        Source: bucket,
+        Binaries: packageMatch[3] || "",
+      });
+    }
+
+    return packages;
+  }
+
   public static getInstance() {
     if (!ScoopManager.instance) {
       ScoopManager.instance = new ScoopManager();
@@ -49,16 +76,15 @@ export class ScoopManager {
 
   public async search(query: string): Promise<ScoopPackage[]> {
     try {
-      const { stdout } = await execp(`scoop search ${query}`);
-      return this.parseScoopTable(stdout, (parts) => ({
-        Name: parts[0],
-        Version: parts[1],
-        Source: parts[2],
-        Binaries: parts[3] || "",
-      }));
+      const { stdout } = await execFilep("scoop-search", [query]);
+      return this.parseScoopSearch(stdout);
     } catch (e) {
       const error = e as ExecException & { stdout: string; stderr: string };
-      if (error.stdout?.includes("Couldn't find any packages")) {
+      if (
+        error.stdout?.includes("No matches found") ||
+        error.stderr?.includes("No matches found") ||
+        error.stdout?.includes("Couldn't find any packages")
+      ) {
         return [];
       }
       console.error("Error searching for scoop packages:", error);
@@ -154,6 +180,10 @@ export class ScoopManager {
 
   public async update(packageName: string): Promise<void> {
     await execp(`scoop update ${packageName}`);
+  }
+
+  public async updateAll(): Promise<void> {
+    await execp("scoop update *");
   }
 
   public async uninstall(packageName: string): Promise<void> {

--- a/extensions/scoop/src/scoop.ts
+++ b/extensions/scoop/src/scoop.ts
@@ -1,5 +1,4 @@
 import { exec, execFile } from "node:child_process";
-import type { ExecException } from "node:child_process";
 import { promisify } from "node:util";
 import {
   ScoopPackage,
@@ -79,7 +78,7 @@ export class ScoopManager {
       const { stdout } = await execFilep("scoop-search", [query]);
       return this.parseScoopSearch(stdout);
     } catch (e) {
-      const error = e as ExecException & { stdout: string; stderr: string };
+      const error = e as NodeJS.ErrnoException & { stdout?: string; stderr?: string };
       if (error.code === "ENOENT") {
         throw new Error("ScoopDash Search is not installed. Run `scoop install scoop-search` and try again.");
       }

--- a/extensions/scoop/src/search.tsx
+++ b/extensions/scoop/src/search.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { List, ActionPanel, Action, Icon, Color } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
 import { ScoopInfo } from "./components/ScoopInfo";
 import { withToast } from "./utils";
 import { useScoop } from "./hooks/scoopHooks";
@@ -24,10 +25,20 @@ export default function SearchCommand() {
     const search = async () => {
       if (query) {
         setIsLoading(true);
-        const pkgs = await scoop.search(query);
-        if (!cancelled) {
-          setPackages(pkgs);
-          setIsLoading(false);
+        try {
+          const pkgs = await scoop.search(query);
+          if (!cancelled) {
+            setPackages(pkgs);
+          }
+        } catch (error) {
+          if (!cancelled) {
+            setPackages([]);
+            await showFailureToast(error, { title: "Failed to search Scoop packages." });
+          }
+        } finally {
+          if (!cancelled) {
+            setIsLoading(false);
+          }
         }
       } else {
         setPackages([]);

--- a/extensions/scoop/src/utils.ts
+++ b/extensions/scoop/src/utils.ts
@@ -5,16 +5,23 @@ export async function withToast(
   action: () => Promise<void>,
   options: { loading: string; success: string; failure: string },
 ) {
+  await withToastResult(action, options);
+}
+
+export async function withToastResult<T>(
+  action: () => Promise<T>,
+  options: { loading: string; success: string | ((result: T) => string); failure: string },
+) {
   await showToast({
     style: Toast.Style.Animated,
     title: options.loading,
   });
 
   try {
-    await action();
+    const result = await action();
     await showToast({
       style: Toast.Style.Success,
-      title: options.success,
+      title: typeof options.success === "function" ? options.success(result) : options.success,
     });
   } catch (error) {
     await showFailureToast(error, { title: options.failure });


### PR DESCRIPTION
## Description

- Added a one-click **Update All Packages** action to the Scoop Outdated command, including refresh actions, empty state messaging, and clearer toast feedback.
- Switched package lookup from `scoop search` to [ `scoop-search`](https://github.com/tokiedokie/scoop-search). This makes searching dramatically faster in practice, multiple times faster than the built-in `scoop search`, while preserving package name, version, source, and binary details in the UI.
- Added user-visible error handling when `scoop-search` is missing, so users know to install it instead of seeing an empty results list.
- Documented the new ScoopDash Search requirement and installation command.
- Added contributor metadata for this extension.

## Screencast

N/A. This updates an existing extension and existing commands; no new extension or command was added. The visible UI change is the additional **Update All Packages** action/list item in the existing Outdated command.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
  - I ran `bun run lint` and `bun run build` successfully in this environment; `npm` is not available here.
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
  - No README assets were added.
