### PR TITLE
Lunch Money: Fix transaction sign, multi-currency totals, and deep links

### DIFF
--- a/extensions/lunchmoney/CHANGELOG.md
+++ b/extensions/lunchmoney/CHANGELOG.md
@@ -1,5 +1,23 @@
 # LunchMoney Changelog
 
+## [Bug Fixes] - {PR_MERGE_DATE}
+
+### Fixes
+
+- Fix refunds and credits inflating spending totals — the transaction's own sign is now
+  authoritative, so a refund in an expense category reduces spend instead of adding to it
+- Fix multi-currency totals: category totals, transaction summaries, and net worth now convert
+  each amount to your primary currency (via `to_base`) before summing, and are labeled with your
+  primary currency instead of always assuming USD
+- Fix category percentages so income and expense categories are each shown relative to their own
+  section total (no more percentages over 100%)
+- Fix "Open in Lunch Money" to deep-link directly to the transaction, and remove a timezone
+  off-by-one that could open the wrong month
+- Show pending transactions, which were previously never fetched
+- Exclude categories marked "exclude from totals" from Category Totals, matching the web app
+- Guard against a pagination edge case that could loop forever on an empty page
+- Guard against missing tags to prevent the transaction detail and edit views from crashing
+
 ## [Major Overhaul] - 2025-12-05
 
 ### New Features

--- a/extensions/lunchmoney/CHANGELOG.md
+++ b/extensions/lunchmoney/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LunchMoney Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-07-10
 
 ### Fixes
 

--- a/extensions/lunchmoney/src/accounts.tsx
+++ b/extensions/lunchmoney/src/accounts.tsx
@@ -1,6 +1,6 @@
 import { ActionPanel, Action, Icon, List, Color, showToast, Toast } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
-import { ManualAccount, PlaidAccount, useLunchMoney } from "./api";
+import { ManualAccount, PlaidAccount, useLunchMoney, usePrimaryCurrency } from "./api";
 import { getAmountValue, formatCurrency } from "./format";
 
 interface Account {
@@ -10,6 +10,7 @@ interface Account {
   name: string;
   display_name: string | null;
   balance: string;
+  to_base: number;
   balance_as_of: string;
   currency: string;
   institution_name: string | null;
@@ -70,6 +71,7 @@ export default function Command() {
         name: account.name,
         display_name: account.display_name ?? null,
         balance: account.balance,
+        to_base: account.to_base ?? parseFloat(account.balance),
         balance_as_of: account.balance_as_of ?? new Date().toISOString(),
         currency: account.currency,
         institution_name: account.institution_name ?? null,
@@ -83,6 +85,7 @@ export default function Command() {
         name: plaid.name,
         display_name: plaid.display_name ?? null,
         balance: plaid.balance,
+        to_base: plaid.to_base ?? parseFloat(plaid.balance),
         balance_as_of: plaid.last_import ?? new Date().toISOString(),
         currency: plaid.currency || "usd",
         institution_name: plaid.institution_name ?? null,
@@ -95,6 +98,7 @@ export default function Command() {
   });
 
   const accounts = data ?? [];
+  const primaryCurrency = usePrimaryCurrency();
 
   async function handleSync() {
     try {
@@ -154,17 +158,18 @@ export default function Command() {
 
   const otherAccounts = activeAccounts.filter((acc) => !cashAccounts.includes(acc) && !creditAccounts.includes(acc));
 
-  // Calculate net worth (assets minus liabilities)
+  // Net worth (assets minus liabilities) in the user's primary currency. Uses each account's
+  // `to_base` so balances in different currencies are converted before summing, rather than
+  // adding raw amounts across currencies.
   const netWorth = activeAccounts.reduce((sum, acc) => {
-    const balance = getAmountValue(acc.balance);
     const isLiability =
       acc.type_name.toLowerCase().includes("credit") ||
       acc.type_name.toLowerCase().includes("loan") ||
       acc.type_name.toLowerCase().includes("mortgage");
-    return sum + (isLiability ? -balance : balance);
+    return sum + (isLiability ? -acc.to_base : acc.to_base);
   }, 0);
 
-  const formattedNetWorth = formatCurrency(netWorth, "USD");
+  const formattedNetWorth = formatCurrency(netWorth, primaryCurrency);
 
   const renderAccount = (account: Account) => {
     const balance = getAmountValue(account.balance);

--- a/extensions/lunchmoney/src/api.ts
+++ b/extensions/lunchmoney/src/api.ts
@@ -1,4 +1,5 @@
 import { getPreferenceValues } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
 import createClient, { Middleware } from "openapi-fetch";
 import { useMemo } from "react";
 import type { components, paths } from "./lunchmoney-api";
@@ -53,4 +54,18 @@ export function useLunchMoney() {
   }, [token]);
 
   return client;
+}
+
+/**
+ * The user's primary currency (from account settings), for labeling aggregate totals that
+ * are computed in the primary currency via each object's `to_base`. Defaults to "usd" until
+ * loaded. Lowercase ISO 4217, as returned by the API.
+ */
+export function usePrimaryCurrency(): string {
+  const client = useLunchMoney();
+  const { data } = useCachedPromise(async () => {
+    const { data } = await client.GET("/me");
+    return data?.primary_currency ?? "usd";
+  });
+  return data ?? "usd";
 }

--- a/extensions/lunchmoney/src/api.ts
+++ b/extensions/lunchmoney/src/api.ts
@@ -56,16 +56,21 @@ export function useLunchMoney() {
   return client;
 }
 
+async function fetchPrimaryCurrency(client: ReturnType<typeof useLunchMoney>): Promise<string> {
+  const { data } = await client.GET("/me");
+  return data?.primary_currency ?? "usd";
+}
+
 /**
  * The user's primary currency (from account settings), for labeling aggregate totals that
  * are computed in the primary currency via each object's `to_base`. Defaults to "usd" until
  * loaded. Lowercase ISO 4217, as returned by the API.
+ *
+ * Uses a module-level fetch function (stable reference) so useCachedPromise shares one cache
+ * entry across every component that calls this hook, rather than one /me request per caller.
  */
 export function usePrimaryCurrency(): string {
   const client = useLunchMoney();
-  const { data } = useCachedPromise(async () => {
-    const { data } = await client.GET("/me");
-    return data?.primary_currency ?? "usd";
-  });
+  const { data } = useCachedPromise(fetchPrimaryCurrency, [client]);
   return data ?? "usd";
 }

--- a/extensions/lunchmoney/src/category-totals.tsx
+++ b/extensions/lunchmoney/src/category-totals.tsx
@@ -132,7 +132,7 @@ export default function Command() {
 
       while (hasMore) {
         const { data, error } = await client.GET("/transactions", {
-          params: { query: { start_date: startDate, end_date: endDate, offset } },
+          params: { query: { start_date: startDate, end_date: endDate, offset, include_pending: true } },
         });
         if (error) {
           console.error("Transactions fetch error:", error);

--- a/extensions/lunchmoney/src/category-totals.tsx
+++ b/extensions/lunchmoney/src/category-totals.tsx
@@ -1,8 +1,8 @@
 import { ActionPanel, Action, Icon, List, Color } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { useState, useMemo } from "react";
-import { type Transaction, type Category, type Tag, useLunchMoney } from "./api";
-import { getAmountValue, formatCurrency, buildLunchMoneyUrl, formatTransactionsAsText } from "./format";
+import { type Transaction, type Category, type Tag, useLunchMoney, usePrimaryCurrency } from "./api";
+import { getTransactionBaseValue, formatCurrency, buildLunchMoneyUrl, formatTransactionsAsText } from "./format";
 import { TransactionListItem, getDateRangeForFilter, DateRangeDropdown } from "./components";
 
 interface CategoryTotal {
@@ -24,21 +24,18 @@ function calculateCategoryTotals(transactions: Transaction[], categories: Catego
       isIncome: boolean;
     }
   >();
-  let grandTotal = 0;
-
-  // Group all transactions by category
+  // Group all transactions by category, accumulating signed amounts so refunds
+  // (negative amounts in an expense category) subtract from the total.
   transactions.forEach((transaction) => {
     // Look up category to get name and is_income
     const category = categories.find((c) => c.id === transaction.category_id);
+    // Honor LunchMoney's "exclude from totals" flag (e.g. transfers, reimbursements) so
+    // these don't inflate spending/income figures — matching the web app's behavior.
+    if (category?.exclude_from_totals) return;
     const isIncome = category?.is_income ?? false;
 
-    const amount = getAmountValue(transaction.amount, isIncome);
+    const amount = getTransactionBaseValue(transaction);
     const categoryName = category?.name || "Uncategorized";
-
-    // Only count non-income towards grand total
-    if (!isIncome) {
-      grandTotal += Math.abs(amount);
-    }
 
     const existing = categoryMap.get(categoryName) || {
       total: 0,
@@ -47,22 +44,37 @@ function calculateCategoryTotals(transactions: Transaction[], categories: Catego
       isIncome: isIncome,
     };
     categoryMap.set(categoryName, {
-      total: existing.total + Math.abs(amount),
+      total: existing.total + amount,
       count: existing.count + 1,
       transactions: [...existing.transactions, transaction],
       isIncome: isIncome,
     });
   });
 
+  // Percentages are relative to each category's own section, so income and expense
+  // categories each sum to 100% within their section (not against each other).
+  let incomeGrandTotal = 0;
+  let expenseGrandTotal = 0;
+  categoryMap.forEach((data) => {
+    if (data.isIncome) {
+      incomeGrandTotal += Math.abs(data.total);
+    } else {
+      expenseGrandTotal += Math.abs(data.total);
+    }
+  });
+
   const totals: CategoryTotal[] = Array.from(categoryMap.entries())
-    .map(([name, data]) => ({
-      name,
-      total: data.total,
-      count: data.count,
-      percentage: grandTotal > 0 ? (data.total / grandTotal) * 100 : 0,
-      transactions: data.transactions.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
-      isIncome: data.isIncome,
-    }))
+    .map(([name, data]) => {
+      const sectionTotal = data.isIncome ? incomeGrandTotal : expenseGrandTotal;
+      return {
+        name,
+        total: Math.abs(data.total),
+        count: data.count,
+        percentage: sectionTotal > 0 ? (Math.abs(data.total) / sectionTotal) * 100 : 0,
+        transactions: data.transactions.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
+        isIncome: data.isIncome,
+      };
+    })
     .sort((a, b) => b.total - a.total);
 
   return totals;
@@ -73,17 +85,14 @@ function CategoryTransactionsList({
   categories,
   tags,
   onRevalidate,
-  start,
-  end,
 }: {
   category: CategoryTotal;
   categories: Category[];
   tags: Tag[];
   onRevalidate?: () => void;
-  start: string;
-  end: string;
 }) {
-  const formattedTotal = formatCurrency(category.total, "USD");
+  const primaryCurrency = usePrimaryCurrency();
+  const formattedTotal = formatCurrency(category.total, primaryCurrency);
 
   const allTransactionsText = useMemo(
     () => formatTransactionsAsText(category.transactions, categories),
@@ -93,7 +102,7 @@ function CategoryTransactionsList({
   return (
     <List navigationTitle={`${category.name} - ${formattedTotal}`} searchBarPlaceholder="Search transactions...">
       {category.transactions.map((transaction) => {
-        const lunchMoneyUrl = buildLunchMoneyUrl({ transaction, start, end });
+        const lunchMoneyUrl = buildLunchMoneyUrl(transaction);
         return (
           <TransactionListItem
             key={transaction.id}
@@ -129,9 +138,12 @@ export default function Command() {
           console.error("Transactions fetch error:", error);
           throw new Error(JSON.stringify(error));
         }
-        allTransactions.push(...(data?.transactions || []));
-        hasMore = data?.has_more ?? false;
-        offset += data?.transactions?.length ?? 0;
+        const batch = data?.transactions || [];
+        allTransactions.push(...batch);
+        // Stop on an empty page even if the API still reports has_more, so offset always
+        // advances and the loop can't spin forever.
+        hasMore = (data?.has_more ?? false) && batch.length > 0;
+        offset += batch.length;
       }
 
       return allTransactions;
@@ -169,8 +181,9 @@ export default function Command() {
   const totalIncome = incomeTotals.reduce((sum, cat) => sum + cat.total, 0);
   const totalExpenses = expenseTotals.reduce((sum, cat) => sum + cat.total, 0);
 
-  const formattedTotalIncome = formatCurrency(totalIncome, "USD");
-  const formattedTotalExpenses = formatCurrency(totalExpenses, "USD");
+  const primaryCurrency = usePrimaryCurrency();
+  const formattedTotalIncome = formatCurrency(totalIncome, primaryCurrency);
+  const formattedTotalExpenses = formatCurrency(totalExpenses, primaryCurrency);
 
   return (
     <List
@@ -181,7 +194,7 @@ export default function Command() {
       {incomeTotals.length > 0 && (
         <List.Section title={`Income: ${formattedTotalIncome}`}>
           {incomeTotals.map((category) => {
-            const formattedTotal = formatCurrency(category.total, "USD");
+            const formattedTotal = formatCurrency(category.total, primaryCurrency);
 
             return (
               <List.Item
@@ -208,8 +221,6 @@ export default function Command() {
                           categories={categories}
                           tags={tags}
                           onRevalidate={revalidate}
-                          start={start}
-                          end={end}
                         />
                       }
                     />
@@ -228,7 +239,7 @@ export default function Command() {
       {expenseTotals.length > 0 && (
         <List.Section title={`Expenses: ${formattedTotalExpenses}`}>
           {expenseTotals.map((category) => {
-            const formattedTotal = formatCurrency(category.total, "USD");
+            const formattedTotal = formatCurrency(category.total, primaryCurrency);
 
             return (
               <List.Item
@@ -255,8 +266,6 @@ export default function Command() {
                           categories={categories}
                           tags={tags}
                           onRevalidate={revalidate}
-                          start={start}
-                          end={end}
                         />
                       }
                     />

--- a/extensions/lunchmoney/src/components.tsx
+++ b/extensions/lunchmoney/src/components.tsx
@@ -328,7 +328,7 @@ export function EditTransactionForm({
   const client = useLunchMoney();
 
   const currentCategory = categories.find((c) => c.id === transaction.category_id);
-  const transactionTags = transaction.tag_ids
+  const transactionTags = (transaction.tag_ids || [])
     .map((tagId) => tags.find((t) => t.id === tagId))
     .filter((t): t is Tag => t !== undefined);
 
@@ -440,7 +440,7 @@ export function TransactionDetail({
   const isReviewed = transaction.status === "reviewed";
 
   // Get tag objects from tag_ids
-  const transactionTags = transaction.tag_ids
+  const transactionTags = (transaction.tag_ids || [])
     .map((tagId) => tags.find((t) => t.id === tagId))
     .filter((t): t is Tag => t !== undefined);
 

--- a/extensions/lunchmoney/src/format.ts
+++ b/extensions/lunchmoney/src/format.ts
@@ -28,6 +28,22 @@ export function getAmountValue(amount: string | number, isIncome?: boolean): num
 }
 
 /**
+ * Signed transaction amount in the user's primary currency.
+ *
+ * Uses LunchMoney's `to_base` (amount converted to the primary currency) so totals over
+ * mixed-currency transactions add up correctly; falls back to the raw `amount` when
+ * `to_base` is absent. Sign follows LunchMoney's convention: positive = debit (money out /
+ * expense), negative = credit (money in / income or refund). The transaction's own sign is
+ * authoritative — a refund sitting in an expense category is still a credit.
+ */
+export function getTransactionBaseValue(transaction: { amount: string; to_base?: number | null }): number {
+  if (transaction.to_base !== null && transaction.to_base !== undefined) {
+    return transaction.to_base;
+  }
+  return parseFloat(transaction.amount);
+}
+
+/**
  * Formats a currency amount using Intl.NumberFormat
  * Respects mock mode for screenshots
  */
@@ -65,37 +81,19 @@ export function formatSignedCurrency(
 }
 
 /**
- * Builds a LunchMoney URL for a transaction with date range filters
+ * Builds a direct deep-link to a single transaction in the LunchMoney web app.
+ * Format matches the web app's "Copy Link" action: /transactions?transaction_id=<id>
  */
-export function buildLunchMoneyUrl({
-  transaction,
-  start,
-  end,
-}: {
-  transaction: { date: string; category_id?: number | null };
-  start: string;
-  end: string;
-}): string {
-  const transactionDate = new Date(transaction.date);
-  const year = transactionDate.getFullYear().toString();
-  const month = (transactionDate.getMonth() + 1).toString().padStart(2, "0");
-
-  const url = new URL(`https://my.lunchmoney.app/transactions/${year}/${month}`);
-  if (transaction.category_id) {
-    url.searchParams.set("category", transaction.category_id.toString());
-  }
-  url.searchParams.set("end_date", end);
-  url.searchParams.set("match", "all");
-  url.searchParams.set("start_date", start);
-  url.searchParams.set("time", "custom");
-  return url.toString();
+export function buildLunchMoneyUrl(transaction: { id: number }): string {
+  return `https://my.lunchmoney.app/transactions?transaction_id=${transaction.id}`;
 }
 
 export function formatTransactionsAsText(transactions: Transaction[], categories: Category[]): string {
   const data = transactions.map((t) => {
     const category = categories.find((c) => c.id === t.category_id);
-    const isIncome = category?.is_income ?? false;
-    const formattedAmount = formatSignedCurrency(t.amount, t.currency, { isIncome, isExpense: !isIncome });
+    // Sign comes from the transaction amount (positive = expense, negative = credit),
+    // not the category — a refund/credit sitting in an expense category is still a credit.
+    const formattedAmount = formatSignedCurrency(t.amount, t.currency);
 
     return {
       Date: t.date,

--- a/extensions/lunchmoney/src/format.ts
+++ b/extensions/lunchmoney/src/format.ts
@@ -37,10 +37,14 @@ export function getAmountValue(amount: string | number, isIncome?: boolean): num
  * authoritative — a refund sitting in an expense category is still a credit.
  */
 export function getTransactionBaseValue(transaction: { amount: string; to_base?: number | null }): number {
-  if (transaction.to_base !== null && transaction.to_base !== undefined) {
-    return transaction.to_base;
+  const value = transaction.to_base ?? parseFloat(transaction.amount);
+  if (!isMockMode) {
+    return value;
   }
-  return parseFloat(transaction.amount);
+  // In mock mode, randomize the magnitude (as getAmountValue does for screenshots) while
+  // preserving the debit/credit sign, so totals never show real figures.
+  const mockAmount = getMockAmount();
+  return value < 0 ? -mockAmount : mockAmount;
 }
 
 /**

--- a/extensions/lunchmoney/src/transactions.tsx
+++ b/extensions/lunchmoney/src/transactions.tsx
@@ -1,9 +1,9 @@
 import { List } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { useState, useMemo } from "react";
-import { type Transaction, type Category, type Tag, useLunchMoney } from "./api";
+import { type Transaction, type Category, type Tag, useLunchMoney, usePrimaryCurrency } from "./api";
 import { TransactionListItem, getDateRangeForFilter, DateRangeDropdown } from "./components";
-import { formatCurrency, buildLunchMoneyUrl, formatTransactionsAsText } from "./format";
+import { formatCurrency, buildLunchMoneyUrl, formatTransactionsAsText, getTransactionBaseValue } from "./format";
 
 function filterTransactions(
   transactions: Transaction[],
@@ -46,15 +46,18 @@ export default function Command() {
 
       while (hasMore) {
         const { data, error } = await client.GET("/transactions", {
-          params: { query: { start_date: startDate, end_date: endDate, offset } },
+          params: { query: { start_date: startDate, end_date: endDate, offset, include_pending: true } },
         });
         if (error) {
           console.error("Transactions fetch error:", error);
           throw new Error(JSON.stringify(error));
         }
-        allTransactions.push(...(data?.transactions || []));
-        hasMore = data?.has_more ?? false;
-        offset += data?.transactions?.length ?? 0;
+        const batch = data?.transactions || [];
+        allTransactions.push(...batch);
+        // Stop on an empty page even if the API still reports has_more, so offset always
+        // advances and the loop can't spin forever.
+        hasMore = (data?.has_more ?? false) && batch.length > 0;
+        offset += batch.length;
       }
 
       return allTransactions;
@@ -86,6 +89,7 @@ export default function Command() {
 
   const categories = categoriesData ?? [];
   const tags = tagsData ?? [];
+  const primaryCurrency = usePrimaryCurrency();
 
   // Filter transactions based on search text
   const filteredTransactions = useMemo(
@@ -101,35 +105,22 @@ export default function Command() {
     [filteredTransactions, categories],
   );
 
-  // Calculate total for filtered transactions
-  const totalAmount = useMemo(() => {
-    return filteredTransactions.reduce((sum, t) => {
-      const category = categories.find((c) => c.id === t.category_id);
-      const isIncome = category?.is_income ?? false;
-      const amount = Math.abs(parseFloat(t.amount));
-      return sum + (isIncome ? amount : -amount);
-    }, 0);
-  }, [filteredTransactions, categories]);
+  // Net total in the user's primary currency. getTransactionBaseValue is positive for debits
+  // (money out), so we negate: a positive total means net income, negative means net spent.
+  const totalAmount = useMemo(
+    () => filteredTransactions.reduce((sum, t) => sum - getTransactionBaseValue(t), 0),
+    [filteredTransactions],
+  );
 
-  // Calculate total for pending transactions
-  const pendingTotal = useMemo(() => {
-    return pendingTransactions.reduce((sum, t) => {
-      const category = categories.find((c) => c.id === t.category_id);
-      const isIncome = category?.is_income ?? false;
-      const amount = Math.abs(parseFloat(t.amount));
-      return sum + (isIncome ? amount : -amount);
-    }, 0);
-  }, [pendingTransactions, categories]);
+  const pendingTotal = useMemo(
+    () => pendingTransactions.reduce((sum, t) => sum - getTransactionBaseValue(t), 0),
+    [pendingTransactions],
+  );
 
-  // Calculate total for non-pending transactions
-  const nonPendingTotal = useMemo(() => {
-    return nonPendingTransactions.reduce((sum, t) => {
-      const category = categories.find((c) => c.id === t.category_id);
-      const isIncome = category?.is_income ?? false;
-      const amount = Math.abs(parseFloat(t.amount));
-      return sum + (isIncome ? amount : -amount);
-    }, 0);
-  }, [nonPendingTransactions, categories]);
+  const nonPendingTotal = useMemo(
+    () => nonPendingTransactions.reduce((sum, t) => sum - getTransactionBaseValue(t), 0),
+    [nonPendingTransactions],
+  );
 
   return (
     <List
@@ -141,15 +132,15 @@ export default function Command() {
     >
       <List.Section
         title="Summary"
-        subtitle={`${filteredTransactions.length} transaction${filteredTransactions.length === 1 ? "" : "s"} • Total: ${formatCurrency(Math.abs(totalAmount))}${totalAmount > 0 ? " income" : " spent"}`}
+        subtitle={`${filteredTransactions.length} transaction${filteredTransactions.length === 1 ? "" : "s"} • Total: ${formatCurrency(Math.abs(totalAmount), primaryCurrency)}${totalAmount > 0 ? " income" : " spent"}`}
       />
       {pendingTransactions.length > 0 && (
         <List.Section
           title="Pending"
-          subtitle={`${pendingTransactions.length} transaction${pendingTransactions.length === 1 ? "" : "s"} • ${formatCurrency(Math.abs(pendingTotal))}${pendingTotal > 0 ? " income" : " spent"}`}
+          subtitle={`${pendingTransactions.length} transaction${pendingTransactions.length === 1 ? "" : "s"} • ${formatCurrency(Math.abs(pendingTotal), primaryCurrency)}${pendingTotal > 0 ? " income" : " spent"}`}
         >
           {pendingTransactions.map((transaction: Transaction) => {
-            const lunchMoneyUrl = buildLunchMoneyUrl({ transaction, start, end });
+            const lunchMoneyUrl = buildLunchMoneyUrl(transaction);
 
             return (
               <TransactionListItem
@@ -167,10 +158,10 @@ export default function Command() {
       )}
       <List.Section
         title="Transactions"
-        subtitle={`${nonPendingTransactions.length} transaction${nonPendingTransactions.length === 1 ? "" : "s"} • ${formatCurrency(Math.abs(nonPendingTotal))}${nonPendingTotal > 0 ? " income" : " spent"}`}
+        subtitle={`${nonPendingTransactions.length} transaction${nonPendingTransactions.length === 1 ? "" : "s"} • ${formatCurrency(Math.abs(nonPendingTotal), primaryCurrency)}${nonPendingTotal > 0 ? " income" : " spent"}`}
       >
         {nonPendingTransactions.map((transaction: Transaction) => {
-          const lunchMoneyUrl = buildLunchMoneyUrl({ transaction, start, end });
+          const lunchMoneyUrl = buildLunchMoneyUrl(transaction);
 
           return (
             <TransactionListItem


### PR DESCRIPTION
## Description
Bug fixes for the Lunch Money extension, all in the money/transaction paths:

- Refunds/credits no longer inflate spending totals — the transaction's own sign is authoritative, so a refund in an expense category reduces spend instead of adding to it
- Multi-currency totals (category totals, transaction summaries) and net worth convert each amount to the user's primary currency via `to_base` before summing, and are labeled with the primary currency (from `/me`) instead of always assuming USD
- Category percentages are relative to each section, so income and expense categories are each shown against their own section total (no more percentages over 100%)
- "Open in Lunch Money" now deep-links directly to the transaction (`?transaction_id=`), fixing a timezone off-by-one that could open the wrong month
- Pending transactions are now fetched (`include_pending`) so the Pending section can render
- Categories marked "exclude from totals" are excluded from Category Totals, matching the web app
- Guarded a pagination edge case that could loop forever on an empty page
- Guarded missing `tag_ids` so the transaction detail and edit views can't crash

## Checklist
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Updated `CHANGELOG.md`

https://claude.ai/code/session_01UHjJY26zEqqh574jjg7TMx