### PR TITLE
Handy: Improve Linux/Vicinae compatibility

### DIFF
--- a/extensions/handy/CHANGELOG.md
+++ b/extensions/handy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Handy Changelog
 
-## [Improve Linux/Vicinae compatibility] - {PR_MERGE_DATE}
+## [Improve Linux/Vicinae compatibility] - 2026-08-04
 
 ### Changed
 

--- a/extensions/handy/CHANGELOG.md
+++ b/extensions/handy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Handy Changelog
 
+## [Improve Linux/Vicinae compatibility] - {PR_MERGE_DATE}
+
+### Changed
+
+- Use platform-aware Handy data paths and platform-neutral Raycast file actions
+
 ## [Fix Model Discovery] - 2026-07-12
 
 ### Fixed

--- a/extensions/handy/README.md
+++ b/extensions/handy/README.md
@@ -9,11 +9,11 @@ Control [Handy](https://handy.computer) — offline speech-to-text — directly 
 | **Toggle Recording**       | Toggle Handy's transcription recording on/off           |
 | **Copy Last Transcript**   | Copy the most recent transcription to clipboard         |
 | **Paste Last Transcript**  | Paste the most recent transcription into the active app |
-| **Search Transcripts**     | Browse history, copy, save, delete, reveal in Finder    |
+| **Search Transcripts**     | Browse history, copy, save, delete, reveal recordings   |
 | **Add Dictionary Word**    | Quickly add a word to Handy's custom dictionary         |
 | **Manage Dictionary**      | View, add, and delete custom dictionary words           |
 | **Select Model**           | Switch the active transcription model                   |
-| **Open Recordings Folder** | Open the recordings directory in Finder                 |
+| **Open Recordings Folder** | Open the recordings directory                           |
 
 ## Screenshots
 

--- a/extensions/handy/package.json
+++ b/extensions/handy/package.json
@@ -79,7 +79,7 @@
       "name": "open-recordings-folder",
       "title": "Open Recordings Folder",
       "subtitle": "Handy",
-      "description": "Open the recordings directory in Finder",
+      "description": "Open the recordings directory",
       "mode": "no-view"
     },
     {

--- a/extensions/handy/src/lib/constants.ts
+++ b/extensions/handy/src/lib/constants.ts
@@ -1,12 +1,25 @@
 import { homedir } from "os";
-import { join } from "path";
+import { isAbsolute, join } from "path";
 
-const HANDY_SUPPORT_DIR = join(
-  homedir(),
-  "Library",
-  "Application Support",
-  "com.pais.handy",
-);
+const HANDY_APP_ID = "com.pais.handy";
+
+export function getHandySupportDir(
+  platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  home = homedir(),
+): string {
+  if (platform === "darwin") {
+    return join(home, "Library", "Application Support", HANDY_APP_ID);
+  }
+
+  const dataDir =
+    env.XDG_DATA_HOME && isAbsolute(env.XDG_DATA_HOME)
+      ? env.XDG_DATA_HOME
+      : join(home, ".local", "share");
+  return join(dataDir, HANDY_APP_ID);
+}
+
+const HANDY_SUPPORT_DIR = getHandySupportDir();
 
 export const DB_PATH = join(HANDY_SUPPORT_DIR, "history.db");
 export const SETTINGS_PATH = join(HANDY_SUPPORT_DIR, "settings_store.json");

--- a/extensions/handy/src/open-recordings-folder.ts
+++ b/extensions/handy/src/open-recordings-folder.ts
@@ -1,10 +1,9 @@
-import { showHUD, showToast, Toast } from "@raycast/api";
-import { execa } from "execa";
+import { open, showHUD, showToast, Toast } from "@raycast/api";
 import { RECORDINGS_DIR } from "./lib/constants";
 
 export default async function main() {
   try {
-    await execa("open", [RECORDINGS_DIR]);
+    await open(RECORDINGS_DIR);
     await showHUD("Opening recordings folder");
   } catch (err) {
     await showToast({

--- a/extensions/handy/src/search-transcripts.tsx
+++ b/extensions/handy/src/search-transcripts.tsx
@@ -7,7 +7,6 @@ import {
   Toast,
 } from "@raycast/api";
 import { useCallback, useEffect, useState } from "react";
-import { execa } from "execa";
 import { join } from "path";
 import {
   deleteEntry,
@@ -66,18 +65,6 @@ export default function SearchTranscripts() {
     }
   }
 
-  async function handleOpenRecording(entry: HistoryEntry) {
-    try {
-      await execa("open", ["-R", join(RECORDINGS_DIR, entry.file_name)]);
-    } catch (err) {
-      await showToast({
-        style: Toast.Style.Failure,
-        title: "Could not open recording",
-        message: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
-
   return (
     <List
       isLoading={isLoading}
@@ -130,11 +117,11 @@ export default function SearchTranscripts() {
                     shortcut={{ modifiers: ["cmd"], key: "s" }}
                     onAction={() => handleToggleSaved(entry)}
                   />
-                  <Action
-                    title="Open Recording in Finder"
+                  <Action.ShowInFinder
+                    title="Reveal Recording"
                     icon={Icon.Finder}
                     shortcut={{ modifiers: ["cmd"], key: "o" }}
-                    onAction={() => handleOpenRecording(entry)}
+                    path={join(RECORDINGS_DIR, entry.file_name)}
                   />
                   <Action
                     title="Delete"

--- a/extensions/handy/tests/lib/constants.test.ts
+++ b/extensions/handy/tests/lib/constants.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getHandySupportDir } from "../../src/lib/constants";
+
+describe("getHandySupportDir", () => {
+  it("uses Application Support on macOS", () => {
+    expect(getHandySupportDir("darwin", {}, "/Users/me")).toBe(
+      "/Users/me/Library/Application Support/com.pais.handy",
+    );
+  });
+
+  it("uses XDG_DATA_HOME on Linux", () => {
+    expect(
+      getHandySupportDir("linux", { XDG_DATA_HOME: "/data" }, "/home/me"),
+    ).toBe("/data/com.pais.handy");
+  });
+
+  it.each([undefined, "", "relative/path"])(
+    "falls back to ~/.local/share when XDG_DATA_HOME is %s",
+    (xdgDataHome) => {
+      expect(
+        getHandySupportDir("linux", { XDG_DATA_HOME: xdgDataHome }, "/home/me"),
+      ).toBe("/home/me/.local/share/com.pais.handy");
+    },
+  );
+});


### PR DESCRIPTION
## Description

This PR addresses a couple of compatibility issues I ran into when using the Handy extension with Vicinae on Linux, while preserving the existing Raycast/macOS path.

The extension previously always read Handy data from:

```text
~/Library/Application Support/com.pais.handy
```

That works for Handy on macOS, but Raycast-compatible hosts on Linux, such as Vicinae, need to read Handy's data from the XDG data directory instead. This change resolves Handy's support directory from the current platform:

- macOS still uses `~/Library/Application Support/com.pais.handy`
- Linux and other compatibility hosts use `$XDG_DATA_HOME/com.pais.handy`, falling back to `~/.local/share/com.pais.handy`

I checked this against Handy's source as well: history, recordings, models, and settings are resolved through Tauri's app data directory for the `com.pais.handy` identifier. On Linux, that follows `$XDG_DATA_HOME` only when it is set to an absolute path, otherwise falling back to `~/.local/share`, so the extension mirrors that behavior.

I also replaced direct `open` shell calls with Raycast's own APIs:

- `open()` for opening the recordings folder
- `Action.ShowInFinder` for revealing individual recordings

That seems more idiomatic for a Raycast extension, keeps the macOS behavior delegated to Raycast, and gives compatibility layers such as Vicinae a better chance to map those actions to the host platform.

I tested this locally by building the extension and installing the built copy over the Vicinae store extension on Linux. After the change, `Search Transcripts` can read my Handy history from `~/.local/share/com.pais.handy`, and revealing/opening recordings works through the extension UI.

I assume this should keep the macOS behavior unchanged, but I do not have a macOS Raycast setup available to test against, so confirmation that the macOS behavior still looks right would be appreciated.


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build`
- [ ] I tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

I tested the distribution build locally in Vicinae on Linux, but I do not have a macOS Raycast setup available to verify the Raycast distribution build directly.
