### PR TITLE
refactor(agent-usage): move to useCachedPromise with global TTL

### DIFF
--- a/extensions/agent-usage/package.json
+++ b/extensions/agent-usage/package.json
@@ -197,6 +197,14 @@
       "title": "OpenCode Go Auth Cookie",
       "description": "The 'auth' cookie value from your OpenCode session. Open opencode.ai, log in, then copy the 'auth' cookie from DevTools (Application → Cookies).",
       "required": false
+    },
+    {
+      "name": "cacheTtl",
+      "type": "textfield",
+      "title": "Cache Duration (Seconds)",
+      "description": "Cache duration in seconds for remote API requests. Set to 0 to disable caching.",
+      "default": "180",
+      "required": false
     }
   ],
   "commands": [

--- a/extensions/agent-usage/src/agent-usage-menubar.tsx
+++ b/extensions/agent-usage/src/agent-usage-menubar.tsx
@@ -45,7 +45,8 @@ interface MenuBarAgent {
   visible: boolean;
   isLoading: boolean;
   accessory: Accessory;
-  revalidate: () => Promise<void>;
+  revalidate: (force?: boolean) => Promise<void>;
+  lastFetchedAt?: number;
   /** True if this account's token matches the one configured in OpenCode */
   isOpenCodeActive?: boolean;
 }
@@ -53,6 +54,9 @@ interface MenuBarAgent {
 type Preferences = Preferences.AgentUsageMenubar;
 
 function getMenuItemTitle(name: string, value: string, isOpenCodeActive?: boolean): string {
+  if (value === "Loading...") {
+    return `${isOpenCodeActive ? "⚡ " : ""}${name}`;
+  }
   return value ? `${isOpenCodeActive ? "⚡ " : ""}${name}  ${value}` : name;
 }
 
@@ -65,6 +69,8 @@ const codexIcon: Image.ImageLike = { source: { light: "codex-icon.svg", dark: "c
 
 export default function MenuBarCommand() {
   const prefs = getPreferenceValues<Preferences>();
+  const now = Date.now();
+
   const isAmpVisible = Boolean(prefs.showAmp);
   const isClaudeVisible = Boolean(prefs.showClaude);
   const isCodexVisible = Boolean(prefs.showCodex);
@@ -104,6 +110,7 @@ export default function MenuBarCommand() {
         isLoading: ampState.isLoading,
         accessory: getAmpAccessory(ampState.usage, ampState.error, ampState.isLoading),
         revalidate: ampState.revalidate,
+        lastFetchedAt: ampState.lastFetchedAt,
       },
       {
         id: "claude",
@@ -113,6 +120,7 @@ export default function MenuBarCommand() {
         isLoading: claudeState.isLoading,
         accessory: getClaudeAccessory(claudeState.usage, claudeState.error, claudeState.isLoading),
         revalidate: claudeState.revalidate,
+        lastFetchedAt: claudeState.lastFetchedAt,
       },
       {
         id: "copilot",
@@ -122,6 +130,7 @@ export default function MenuBarCommand() {
         isLoading: copilotState.isLoading,
         accessory: getCopilotAccessory(copilotState.usage, copilotState.error, copilotState.isLoading),
         revalidate: copilotState.revalidate,
+        lastFetchedAt: copilotState.lastFetchedAt,
       },
       {
         id: "cursor",
@@ -131,6 +140,7 @@ export default function MenuBarCommand() {
         isLoading: cursorState.isLoading,
         accessory: getCursorAccessory(cursorState.usage, cursorState.error, cursorState.isLoading),
         revalidate: cursorState.revalidate,
+        lastFetchedAt: cursorState.lastFetchedAt,
       },
       {
         id: "droid",
@@ -140,6 +150,7 @@ export default function MenuBarCommand() {
         isLoading: droidState.isLoading,
         accessory: getDroidAccessory(droidState.usage, droidState.error, droidState.isLoading),
         revalidate: droidState.revalidate,
+        lastFetchedAt: droidState.lastFetchedAt,
       },
       {
         id: "gemini",
@@ -149,6 +160,7 @@ export default function MenuBarCommand() {
         isLoading: geminiState.isLoading,
         accessory: getGeminiAccessory(geminiState.usage, geminiState.error, geminiState.isLoading),
         revalidate: geminiState.revalidate,
+        lastFetchedAt: geminiState.lastFetchedAt,
       },
       {
         id: "antigravity",
@@ -158,6 +170,7 @@ export default function MenuBarCommand() {
         isLoading: antigravityState.isLoading,
         accessory: getAntigravityAccessory(antigravityState.usage, antigravityState.error, antigravityState.isLoading),
         revalidate: antigravityState.revalidate,
+        lastFetchedAt: antigravityState.lastFetchedAt,
       },
       {
         id: "minimax",
@@ -167,6 +180,7 @@ export default function MenuBarCommand() {
         isLoading: minimaxState.isLoading,
         accessory: getMiniMaxAccessory(minimaxState.usage, minimaxState.error, minimaxState.isLoading),
         revalidate: minimaxState.revalidate,
+        lastFetchedAt: minimaxState.lastFetchedAt,
       },
       {
         id: "opencode-go",
@@ -176,6 +190,7 @@ export default function MenuBarCommand() {
         isLoading: opencodegoState.isLoading,
         accessory: getOpencodegoAccessory(opencodegoState.usage, opencodegoState.error, opencodegoState.isLoading),
         revalidate: opencodegoState.revalidate,
+        lastFetchedAt: opencodegoState.lastFetchedAt,
       },
     ],
     [
@@ -190,39 +205,48 @@ export default function MenuBarCommand() {
       ampState.usage,
       ampState.error,
       ampState.revalidate,
+      ampState.lastFetchedAt,
       claudeState.isLoading,
       claudeState.usage,
       claudeState.error,
       claudeState.revalidate,
+      claudeState.lastFetchedAt,
       copilotState.isLoading,
       copilotState.usage,
       copilotState.error,
       copilotState.revalidate,
+      copilotState.lastFetchedAt,
       cursorState.isLoading,
       cursorState.usage,
       cursorState.error,
       cursorState.revalidate,
+      cursorState.lastFetchedAt,
       droidState.isLoading,
       droidState.usage,
       droidState.error,
       droidState.revalidate,
+      droidState.lastFetchedAt,
       geminiState.isLoading,
       geminiState.usage,
       geminiState.error,
       geminiState.revalidate,
+      geminiState.lastFetchedAt,
       antigravityState.isLoading,
       antigravityState.usage,
       antigravityState.error,
       antigravityState.revalidate,
+      antigravityState.lastFetchedAt,
       minimaxState.isLoading,
       minimaxState.usage,
       minimaxState.error,
       minimaxState.revalidate,
+      minimaxState.lastFetchedAt,
       isOpencodeGoVisible,
       opencodegoState.isLoading,
       opencodegoState.usage,
       opencodegoState.error,
       opencodegoState.revalidate,
+      opencodegoState.lastFetchedAt,
     ],
   );
 
@@ -232,13 +256,19 @@ export default function MenuBarCommand() {
       isCodexVisible
         ? codexAccounts.map((account) => ({
             id: `codex-${account.accountId}` as AgentId,
-            name: account.label === "Default" ? "Codex" : `Codex • ${account.label}`,
+            name:
+              account.accountId === "loading"
+                ? "Codex"
+                : account.label === "Default"
+                  ? "Codex"
+                  : `Codex • ${account.label}`,
             icon: codexIcon,
             visible: isCodexVisible,
             isLoading: account.isLoading,
             accessory: getCodexAccessory(account.usage, account.error, account.isLoading),
             revalidate: account.revalidate,
             isOpenCodeActive: account.isOpenCodeActive,
+            lastFetchedAt: account.lastFetchedAt,
           }))
         : [],
     [isCodexVisible, codexAccounts],
@@ -249,13 +279,19 @@ export default function MenuBarCommand() {
       isKimiVisible
         ? kimiAccounts.map((account) => ({
             id: `kimi-${account.accountId}` as AgentId,
-            name: account.label === "Default" ? "Kimi" : `Kimi • ${account.label}`,
+            name:
+              account.accountId === "loading"
+                ? "Kimi"
+                : account.label === "Default"
+                  ? "Kimi"
+                  : `Kimi • ${account.label}`,
             icon: "kimi-icon.ico",
             visible: isKimiVisible,
             isLoading: account.isLoading,
             accessory: getKimiAccessory(account.usage, account.error, account.isLoading),
             revalidate: account.revalidate,
             isOpenCodeActive: account.isOpenCodeActive,
+            lastFetchedAt: account.lastFetchedAt,
           }))
         : [],
     [isKimiVisible, kimiAccounts],
@@ -266,13 +302,19 @@ export default function MenuBarCommand() {
       isSyntheticVisible
         ? syntheticAccounts.map((account) => ({
             id: `synthetic-${account.accountId}` as AgentId,
-            name: account.label === "Default" ? "Synthetic" : `Synthetic • ${account.label}`,
+            name:
+              account.accountId === "loading"
+                ? "Synthetic"
+                : account.label === "Default"
+                  ? "Synthetic"
+                  : `Synthetic • ${account.label}`,
             icon: "synthetic-icon.svg",
             visible: isSyntheticVisible,
             isLoading: account.isLoading,
             accessory: getSyntheticAccessory(account.usage, account.error, account.isLoading),
             revalidate: account.revalidate,
             isOpenCodeActive: account.isOpenCodeActive,
+            lastFetchedAt: account.lastFetchedAt,
           }))
         : [],
     [isSyntheticVisible, syntheticAccounts],
@@ -283,13 +325,19 @@ export default function MenuBarCommand() {
       isZaiVisible
         ? zaiAccounts.map((account) => ({
             id: `zai-${account.accountId}` as AgentId,
-            name: account.label === "Default" ? "z.ai" : `z.ai • ${account.label}`,
+            name:
+              account.accountId === "loading"
+                ? "z.ai"
+                : account.label === "Default"
+                  ? "z.ai"
+                  : `z.ai • ${account.label}`,
             icon: "zai-icon.svg",
             visible: isZaiVisible,
             isLoading: account.isLoading,
             accessory: getZaiAccessory(account.usage, account.error, account.isLoading),
             revalidate: account.revalidate,
             isOpenCodeActive: account.isOpenCodeActive,
+            lastFetchedAt: account.lastFetchedAt,
           }))
         : [],
     [isZaiVisible, zaiAccounts],
@@ -301,24 +349,28 @@ export default function MenuBarCommand() {
   );
   const isLoading = visibleAgents.some((agent) => agent.isLoading);
 
-  // Auto-refresh when user clicks the menu bar icon (after initial load completes)
-  const hasAutoRefreshed = useRef(false);
-  useEffect(() => {
-    if (
-      environment.launchType === LaunchType.UserInitiated &&
-      !hasAutoRefreshed.current &&
-      !isLoading &&
-      visibleAgents.length > 0
-    ) {
-      hasAutoRefreshed.current = true;
-      void Promise.all(visibleAgents.map((a) => a.revalidate()));
-    }
-  }, [isLoading, visibleAgents]);
+
 
   const handleRefresh = async () => {
-    await Promise.all(visibleAgents.map((a) => a.revalidate()));
+    await Promise.all(visibleAgents.map((a) => a.revalidate(true)));
     await showHUD("Agent Usage Refreshed");
   };
+
+  const lastFetchedTimestamps = visibleAgents
+    .map((agent) => agent.lastFetchedAt)
+    .filter((t): t is number => typeof t === "number" && t > 0);
+  const latestFetchedAt = lastFetchedTimestamps.length > 0 ? Math.max(...lastFetchedTimestamps) : undefined;
+
+  const formatTimeAgoShort = (timestamp?: number) => {
+    if (!timestamp) return "";
+    const diff = Math.max(0, Math.floor((now - timestamp) / 1000));
+    if (diff < 5) return "just now";
+    if (diff < 60) return `${diff}s ago`;
+    return `${Math.floor(diff / 60)}m ago`;
+  };
+
+  const timeAgoText = formatTimeAgoShort(latestFetchedAt);
+  const refreshTitle = timeAgoText ? `Refresh All (Updated ${timeAgoText})` : "Refresh All";
 
   return (
     <MenuBarExtra icon="extension-icon.png" isLoading={isLoading} tooltip="Agent Usage">
@@ -341,7 +393,7 @@ export default function MenuBarCommand() {
       </MenuBarExtra.Section>
       <MenuBarExtra.Section>
         <MenuBarExtra.Item
-          title="Refresh All"
+          title={refreshTitle}
           icon={Icon.ArrowClockwise}
           shortcut={{ modifiers: ["cmd"], key: "r" }}
           onAction={handleRefresh}

--- a/extensions/agent-usage/src/agent-usage.tsx
+++ b/extensions/agent-usage/src/agent-usage.tsx
@@ -110,10 +110,11 @@ type AgentRegistry = {
 interface AgentView extends AgentDefinition {
   isVisible: boolean;
   isLoading: boolean;
-  revalidate: () => Promise<void>;
+  revalidate: (force?: boolean) => Promise<void>;
   getAccessory: () => Accessory;
   renderDetail: () => React.ReactNode;
   formatUsageText: () => string;
+  lastFetchedAt?: number;
 }
 
 /** A list row for one named account of a multi-account provider. */
@@ -129,7 +130,7 @@ interface AccountedAgentView {
   settingsUrl?: string;
   isVisible: boolean;
   isLoading: boolean;
-  revalidate: () => Promise<void>;
+  revalidate: (force?: boolean) => Promise<void>;
   getAccessory: () => Accessory;
   renderDetail: () => React.ReactNode;
   formatUsageText: () => string;
@@ -143,6 +144,7 @@ interface AccountedAgentView {
   token: string;
   /** Whether this account's token matches the one configured in OpenCode */
   isOpenCodeActive?: boolean;
+  lastFetchedAt?: number;
 }
 
 const AGENT_REGISTRY: AgentRegistry = {
@@ -322,6 +324,7 @@ function createAgentView<TUsage, TError extends ErrorLike>(
     settingsUrl: config.settingsUrl,
     isVisible,
     isLoading: state.isLoading,
+    lastFetchedAt: state.lastFetchedAt,
     revalidate: state.revalidate,
     getAccessory: () => config.getAccessory(state.usage, state.error, state.isLoading),
     renderDetail: () => config.renderDetail(state.usage, state.error),
@@ -350,6 +353,7 @@ function createAccountedViews<TUsage, TError extends { type: string; message: st
     settingsUrl,
     isVisible,
     isLoading: state.isLoading,
+    lastFetchedAt: state.lastFetchedAt,
     revalidate: state.revalidate,
     getAccessory: () => getAccessory(state.usage, state.error, state.isLoading),
     renderDetail: () => renderDetail(state.usage, state.error),
@@ -380,6 +384,12 @@ function shortenAccountLabel(label: string): string {
 export default function Command(props: LaunchProps<{ launchContext: CommandLaunchContext }>) {
   const prefs = getPreferenceValues<Preferences>();
   const { push } = useNavigation();
+
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 5000);
+    return () => clearInterval(timer);
+  }, []);
 
   // Hooks must be called unconditionally at top level (React rules)
   const ampState = AGENT_REGISTRY.amp.useUsage(Boolean(prefs.showAmp));
@@ -587,12 +597,28 @@ export default function Command(props: LaunchProps<{ launchContext: CommandLaunc
   }, [prefs.showGemini, geminiState.error?.type, handleGeminiReauth]);
 
   const handleRefresh = async () => {
-    await Promise.all(allRows.map((row) => row.view.revalidate()));
+    await Promise.all(allRows.map((row) => row.view.revalidate(true)));
     await showToast({
       title: "Refreshed",
       style: Toast.Style.Success,
     });
   };
+
+  const lastFetchedTimestamps = allRows
+    .map((row) => row.view.lastFetchedAt)
+    .filter((t): t is number => typeof t === "number" && t > 0);
+  const latestFetchedAt = lastFetchedTimestamps.length > 0 ? Math.max(...lastFetchedTimestamps) : undefined;
+
+  const formatTimeAgoShort = (timestamp?: number) => {
+    if (!timestamp) return "";
+    const diff = Math.max(0, Math.floor((now - timestamp) / 1000));
+    if (diff < 5) return "just now";
+    if (diff < 60) return `${diff}s ago`;
+    return `${Math.floor(diff / 60)}m ago`;
+  };
+
+  const timeAgoText = formatTimeAgoShort(latestFetchedAt);
+  const refreshTitle = timeAgoText ? `Refresh (Updated ${timeAgoText})` : "Refresh";
 
   const moveAgent = useCallback(
     async (agentId: AgentId, direction: "up" | "down") => {
@@ -638,7 +664,7 @@ export default function Command(props: LaunchProps<{ launchContext: CommandLaunc
                   <ActionPanel>
                     {agent.isSupported && (
                       <>
-                        <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={handleRefresh} />
+                        <Action title={refreshTitle} icon={Icon.ArrowClockwise} onAction={handleRefresh} />
                         <Action.CopyToClipboard
                           title="Copy Usage Details"
                           content={agent.formatUsageText()}
@@ -705,7 +731,7 @@ export default function Command(props: LaunchProps<{ launchContext: CommandLaunc
                 detail={<List.Item.Detail metadata={detail} />}
                 actions={
                   <ActionPanel>
-                    <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={handleRefresh} />
+                    <Action title={refreshTitle} icon={Icon.ArrowClockwise} onAction={handleRefresh} />
                     <Action.CopyToClipboard
                       title="Copy Usage Details"
                       content={view.formatUsageText()}

--- a/extensions/agent-usage/src/agents/hooks.ts
+++ b/extensions/agent-usage/src/agents/hooks.ts
@@ -1,154 +1,194 @@
-import { useState, useEffect, useCallback, useRef } from "react";
-import type { UsageState } from "./types";
+import { Cache } from "@raycast/api";
+import { isOpenCodeActiveToken } from "./opencode-active";
+
+export const fetchTtlCache = new Cache({ namespace: "agent-usage-ttl" });
+export function getTtlMs(): number {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { getPreferenceValues } = require("@raycast/api") as typeof import("@raycast/api");
+  const prefs = getPreferenceValues<{ cacheTtl?: string }>();
+  const parsed = parseInt(prefs.cacheTtl || "180", 10);
+  return (isNaN(parsed) ? 180 : parsed) * 1000;
+}
 
 type Preferences = Preferences.AgentUsage;
 
-/**
- * Factory for token-based hooks (droid, kimi, zai).
- * Reads the token from preferences, shows "not_configured" if missing.
- */
 export function createTokenBasedHook<TUsage, TError extends { type: string; message: string }>(options: {
   preferenceKey: keyof Preferences;
   agentName: string;
   fetcher: (token: string) => Promise<{ usage: TUsage | null; error: TError | null }>;
-}): (enabled?: boolean) => UsageState<TUsage, TError> {
+}) {
   const { preferenceKey, agentName, fetcher } = options;
 
-  return function useTokenBasedHook(enabled = true) {
-    const [usage, setUsage] = useState<TUsage | null>(null);
-    const [error, setError] = useState<TError | null>(null);
-    const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [hasInitialFetch, setHasInitialFetch] = useState<boolean>(false);
-    const requestIdRef = useRef(0);
+  return function useTokenBasedHook(enabled = true): UsageState<TUsage, TError> {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getPreferenceValues } = require("@raycast/api") as typeof import("@raycast/api");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useCachedPromise } = require("@raycast/utils") as typeof import("@raycast/utils");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useCallback } = require("react") as typeof import("react");
 
-    const fetchData = useCallback(async () => {
-      const requestId = ++requestIdRef.current;
+    const preferences = getPreferenceValues<Preferences>();
+    const token = (preferences[preferenceKey] as string)?.trim() || "";
 
-      // Lazy import to avoid loading @raycast/api at module level (keeps tests working)
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { getPreferenceValues } = require("@raycast/api") as typeof import("@raycast/api");
-      const preferences = getPreferenceValues<Preferences>();
-      const token = (preferences[preferenceKey] as string)?.trim() || "";
+    const ttlKey = `ttl-${agentName}`;
+    const lastFetched = Number(fetchTtlCache.get(ttlKey)) || 0;
+    const isStale = Date.now() - lastFetched > getTtlMs();
 
-      if (!token) {
-        setUsage(null);
-        setError({
-          type: "not_configured",
-          message: `${agentName} token not configured. Please add it in extension settings (Cmd+,).`,
-        } as TError);
-        setIsLoading(false);
-        setHasInitialFetch(true);
-        return;
+    const fetcherFn = useCallback(async (t: string) => {
+      fetchTtlCache.set(ttlKey, String(Date.now()));
+      if (!t) {
+        return {
+          usage: null,
+          error: {
+            type: "not_configured",
+            message: `${agentName} token not configured. Please add it in extension settings (Cmd+,).`,
+          } as TError,
+          timestamp: Date.now(),
+        };
       }
+      const result = await fetcher(t);
+      return { ...result, timestamp: Date.now() };
+    }, [agentName, fetcher, ttlKey]);
 
-      setIsLoading(true);
-      setError(null);
-
-      const result = await fetcher(token);
-      if (requestId !== requestIdRef.current) {
-        return;
-      }
-
-      setUsage(result.usage);
-      setError(result.error);
-      setIsLoading(false);
-      setHasInitialFetch(true);
-      // preferenceKey, agentName, fetcher are stable factory-closure values — no deps needed
-    }, []);
-
-    useEffect(() => {
-      if (!enabled) {
-        requestIdRef.current += 1;
-        setUsage(null);
-        setError(null);
-        setIsLoading(false);
-        setHasInitialFetch(false);
-        return;
-      }
-
-      if (!hasInitialFetch) {
-        void fetchData();
-      }
-    }, [enabled, hasInitialFetch, fetchData]);
-
-    const revalidate = useCallback(async () => {
-      if (!enabled) {
-        return;
-      }
-
-      await fetchData();
-    }, [enabled, fetchData]);
+    const { data, isLoading, mutate } = useCachedPromise(
+      fetcherFn,
+      [agentName, token],
+      {
+        execute: enabled && isStale,
+        initialData: { usage: null, error: null, timestamp: 0 },
+      },
+    );
 
     return {
-      isLoading: enabled ? isLoading : false,
-      usage: enabled ? usage : null,
-      error: enabled ? error : null,
-      revalidate,
+      isLoading: enabled ? (data?.usage ? false : isLoading) : false,
+      usage: enabled && data ? data.usage : null,
+      error: enabled && data ? data.error : null,
+      revalidate: async () => {
+        await mutate();
+      },
+      lastFetchedAt: data?.timestamp,
     };
   };
 }
 
-/**
- * Factory for no-token hooks (gemini, antigravity).
- */
 export function createSimpleHook<TUsage, TError>(options: {
+  agentName: string;
   fetcher: () => Promise<{ usage: TUsage | null; error: TError | null }>;
-}): (enabled?: boolean) => UsageState<TUsage, TError> {
-  const { fetcher } = options;
+}) {
+  const { agentName, fetcher } = options;
 
-  return function useSimpleHook(enabled = true) {
-    const [usage, setUsage] = useState<TUsage | null>(null);
-    const [error, setError] = useState<TError | null>(null);
-    const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [hasInitialFetch, setHasInitialFetch] = useState<boolean>(false);
-    const requestIdRef = useRef(0);
+  return function useSimpleHook(enabled = true): UsageState<TUsage, TError> {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useCachedPromise } = require("@raycast/utils") as typeof import("@raycast/utils");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useCallback } = require("react") as typeof import("react");
 
-    const fetchData = useCallback(async () => {
-      const requestId = ++requestIdRef.current;
+    const ttlKey = `ttl-${agentName}`;
+    const lastFetched = Number(fetchTtlCache.get(ttlKey)) || 0;
+    const isStale = Date.now() - lastFetched > getTtlMs();
 
-      setIsLoading(true);
-      setError(null);
-
+    const fetcherFn = useCallback(async () => {
+      fetchTtlCache.set(ttlKey, String(Date.now()));
       const result = await fetcher();
-      if (requestId !== requestIdRef.current) {
-        return;
-      }
+      return { ...result, timestamp: Date.now() };
+    }, [fetcher, ttlKey]);
 
-      setUsage(result.usage);
-      setError(result.error);
-      setIsLoading(false);
-      setHasInitialFetch(true);
-      // fetcher is a stable factory-closure value — no deps needed
-    }, []);
-
-    useEffect(() => {
-      if (!enabled) {
-        requestIdRef.current += 1;
-        setUsage(null);
-        setError(null);
-        setIsLoading(false);
-        setHasInitialFetch(false);
-        return;
-      }
-
-      if (!hasInitialFetch) {
-        void fetchData();
-      }
-    }, [enabled, hasInitialFetch, fetchData]);
-
-    const revalidate = useCallback(async () => {
-      if (!enabled) {
-        return;
-      }
-
-      await fetchData();
-    }, [enabled, fetchData]);
+    const { data, isLoading, mutate } = useCachedPromise(
+      fetcherFn,
+      [agentName],
+      {
+        execute: enabled && isStale,
+        initialData: { usage: null, error: null, timestamp: 0 },
+      },
+    );
 
     return {
-      isLoading: enabled ? isLoading : false,
-      usage: enabled ? usage : null,
-      error: enabled ? error : null,
-      revalidate,
+      isLoading: enabled ? (data?.usage ? false : isLoading) : false,
+      usage: enabled && data ? data.usage : null,
+      error: enabled && data ? data.error : null,
+      revalidate: async () => {
+        await mutate();
+      },
+      lastFetchedAt: data?.timestamp,
     };
+  };
+}
+
+export function createAccountsHook<
+  TUsage,
+  TError extends { type: string; message: string },
+  TAccount extends { id: string; label: string; token: string; accountId?: string },
+>(options: {
+  agentName: string;
+  getAccounts: () => Promise<TAccount[]>;
+  fetcher: (account: TAccount) => Promise<{ usage: TUsage | null; error: TError | null }>;
+  openCodeKey?: string;
+  noAccountsError: TError;
+}) {
+  return function useAccountsHook(enabled = true): AccountUsageState<TUsage, TError>[] {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useCachedPromise } = require("@raycast/utils") as typeof import("@raycast/utils");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useCallback } = require("react") as typeof import("react");
+
+    const ttlKey = `ttl-${options.agentName}-accounts`;
+    const lastFetched = Number(fetchTtlCache.get(ttlKey)) || 0;
+    const isStale = Date.now() - lastFetched > getTtlMs();
+
+    const fetcherFn = useCallback(async () => {
+      fetchTtlCache.set(ttlKey, String(Date.now()));
+      const accs = await options.getAccounts();
+      if (accs.length === 0) {
+          return [
+            {
+              accountId: "none",
+              label: "Default",
+              token: "",
+              usage: null,
+              error: options.noAccountsError,
+              isOpenCodeActive: false,
+              timestamp: Date.now(),
+            },
+          ];
+        }
+
+        const results = await Promise.all(
+          accs.map(async (acc) => {
+            const res = await options.fetcher(acc);
+            return {
+              accountId: acc.id,
+              label: acc.label,
+              token: acc.token,
+              usage: res.usage,
+              error: res.error,
+              isOpenCodeActive: options.openCodeKey ? isOpenCodeActiveToken(acc.token, options.openCodeKey) : false,
+              timestamp: Date.now(),
+            };
+          }),
+        );
+        return results;
+      },
+      [options, ttlKey]
+    );
+
+    const { data, isLoading, mutate } = useCachedPromise(
+      fetcherFn,
+      [options.agentName],
+      {
+        execute: enabled && isStale,
+        initialData: [],
+      },
+    );
+
+    const revalidate = async () => {
+      await mutate();
+    };
+
+    return (data || []).map((item) => ({
+      ...item,
+      isLoading: enabled ? (item.usage ? false : isLoading) : false,
+      revalidate,
+      lastFetchedAt: item.timestamp,
+    }));
   };
 }

--- a/extensions/agent-usage/src/agents/types.ts
+++ b/extensions/agent-usage/src/agents/types.ts
@@ -28,7 +28,8 @@ export interface UsageState<TUsage, TError> {
   isLoading: boolean;
   usage: TUsage | null;
   error: TError | null;
-  revalidate: () => Promise<void>;
+  revalidate: (force?: boolean) => Promise<void>;
+  lastFetchedAt?: number;
 }
 
 export interface Accessory {

--- a/extensions/agent-usage/src/amp/fetcher.ts
+++ b/extensions/agent-usage/src/amp/fetcher.ts
@@ -15,13 +15,20 @@ interface ExecFailure extends Error {
   stderr?: string | Buffer;
 }
 
+type ExecFileAsync = (
+  file: string,
+  args: string[],
+  options: { encoding: "utf-8"; timeout: number },
+) => Promise<{ stdout: string }>;
+
 async function detectAmpPath(): Promise<string> {
   if (cachedAmpPath) {
     return cachedAmpPath;
   }
 
-  // Try PATH first using 'which' (macOS/Linux) or 'where' (Windows)
   const isWindows = process.platform === "win32";
+
+  // Try PATH first using 'which' (macOS/Linux) or 'where' (Windows)
   const command = isWindows ? "where" : "which";
 
   try {
@@ -35,13 +42,9 @@ async function detectAmpPath(): Promise<string> {
     // Command failed, try common locations
   }
 
-  // Fallback to common installation paths
   const homeDir = os.homedir();
   const commonPaths = isWindows
-    ? [
-        path.join(homeDir, ".local", "bin", "amp.exe"),
-        path.join(homeDir, "AppData", "Local", "Programs", "amp", "amp.exe"),
-      ]
+    ? [path.join(homeDir, "AppData", "Local", "Programs", "amp", "amp.exe")]
     : [path.join(homeDir, ".local", "bin", "amp"), "/usr/local/bin/amp", "/opt/homebrew/bin/amp"];
 
   for (const p of commonPaths) {
@@ -67,11 +70,28 @@ function getExecFailureMessage(error: unknown): string {
   return stderr || stdout || execError.message;
 }
 
+export async function fetchAmpUsageFromCli(
+  ampPath: string,
+  execFileImpl: ExecFileAsync = execFileAsync,
+): Promise<{ usage: AmpUsage | null; error: AmpError | null }> {
+  try {
+    const { stdout } = await execFileImpl(ampPath, ["usage"], { encoding: "utf-8", timeout: 10000 });
+    return parseAmpUsage(stdout);
+  } catch (error) {
+    return {
+      usage: null,
+      error: {
+        type: "unknown",
+        message: getExecFailureMessage(error),
+      },
+    };
+  }
+}
+
 async function fetchAmpUsage(): Promise<{ usage: AmpUsage | null; error: AmpError | null }> {
   try {
     const ampPath = await detectAmpPath();
-    const { stdout } = await execFileAsync(ampPath, ["usage"], { encoding: "utf-8", timeout: 10000 });
-    return parseAmpUsage(stdout);
+    return await fetchAmpUsageFromCli(ampPath);
   } catch (error) {
     cachedAmpPath = null;
     return {
@@ -81,4 +101,4 @@ async function fetchAmpUsage(): Promise<{ usage: AmpUsage | null; error: AmpErro
   }
 }
 
-export const useAmpUsage = createSimpleHook<AmpUsage, AmpError>({ fetcher: fetchAmpUsage });
+export const useAmpUsage = createSimpleHook<AmpUsage, AmpError>({ agentName: "amp", fetcher: fetchAmpUsage });

--- a/extensions/agent-usage/src/antigravity/fetcher.ts
+++ b/extensions/agent-usage/src/antigravity/fetcher.ts
@@ -103,5 +103,6 @@ export function mapAntigravityError(error: unknown): AntigravityError {
 }
 
 export const useAntigravityUsage = createSimpleHook<AntigravityUsage, AntigravityError>({
+  agentName: "antigravity",
   fetcher: fetchAntigravityUsage,
 });

--- a/extensions/agent-usage/src/claude/fetcher.ts
+++ b/extensions/agent-usage/src/claude/fetcher.ts
@@ -1,4 +1,3 @@
-import { useState, useEffect, useCallback, useRef } from "react";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -521,68 +520,46 @@ async function fetchClaudeUsage(
   }
 }
 
-export function useClaudeUsage(enabled = true) {
-  const [usage, setUsage] = useState<ClaudeUsage | null>(null);
-  const [error, setError] = useState<ClaudeError | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [hasInitialFetch, setHasInitialFetch] = useState<boolean>(false);
-  const requestIdRef = useRef(0);
+export function useClaudeUsage(enabled = true): import("../agents/types").UsageState<ClaudeUsage, ClaudeError> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useCachedPromise } = require("@raycast/utils") as typeof import("@raycast/utils");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useCallback } = require("react") as typeof import("react");
 
-  const fetchData = useCallback(async () => {
-    const requestId = ++requestIdRef.current;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { fetchTtlCache, getTtlMs } = require("../agents/hooks") as typeof import("../agents/hooks");
 
-    setIsLoading(true);
-    setError(null);
+  const ttlKey = "ttl-claude";
+  const lastFetched = Number(fetchTtlCache.get(ttlKey)) || 0;
+  const isStale = Date.now() - lastFetched > getTtlMs();
 
+  const fetcherFn = useCallback(async () => {
+    fetchTtlCache.set(ttlKey, String(Date.now()));
     const { credentials, error: credentialsError } = readClaudeCredentials();
     if (!credentials) {
-      if (requestId !== requestIdRef.current) {
-        return;
-      }
-      setUsage(null);
-      setError(credentialsError);
-      setIsLoading(false);
-      setHasInitialFetch(true);
-      return;
+      return {
+        usage: null,
+        error: credentialsError,
+        timestamp: Date.now(),
+      };
     }
-
     const result = await fetchClaudeUsage(credentials);
-    if (requestId !== requestIdRef.current) {
-      return;
-    }
-    setUsage(result.usage);
-    setError(result.error);
-    setIsLoading(false);
-    setHasInitialFetch(true);
-  }, []);
+    return { ...result, timestamp: Date.now() };
+  }, [ttlKey]);
 
-  useEffect(() => {
-    if (!enabled) {
-      requestIdRef.current += 1;
-      setUsage(null);
-      setError(null);
-      setIsLoading(false);
-      setHasInitialFetch(false);
-      return;
-    }
-
-    if (!hasInitialFetch) {
-      void fetchData();
-    }
-  }, [enabled, hasInitialFetch, fetchData]);
-
-  const revalidate = useCallback(async () => {
-    if (!enabled) {
-      return;
-    }
-
-    await fetchData();
-  }, [enabled, fetchData]);
+  const { data, isLoading, mutate } = useCachedPromise(
+    fetcherFn,
+    ["claude"],
+    { execute: enabled && isStale, initialData: { usage: null, error: null, timestamp: 0 } },
+  );
 
   return {
-    isLoading: enabled ? isLoading : false,
-    usage: enabled ? usage : null,
-    error: enabled ? error : null,
-    revalidate,
+    isLoading: enabled ? (data?.usage ? false : isLoading) : false,
+    usage: enabled && data ? data.usage : null,
+    error: enabled && data ? data.error : null,
+    revalidate: async () => {
+      await mutate();
+    },
+    lastFetchedAt: data?.timestamp,
   };
 }

--- a/extensions/agent-usage/src/codex/fetcher.ts
+++ b/extensions/agent-usage/src/codex/fetcher.ts
@@ -1,11 +1,11 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { CodexUsage, CodexError } from "./types";
+import { createAccountsHook } from "../agents/hooks";
 import { listCodexOAuthAccounts, resolveCodexAuthTokens } from "./auth";
 import { buildCodexAccountCandidates } from "./accounts";
 import { httpFetch } from "../agents/http";
 import { parseDate } from "../agents/format";
 import { loadAccounts } from "../accounts/storage";
-import type { AccountUsageState } from "../accounts/types";
 
 const CODEX_USAGE_API = "https://chatgpt.com/backend-api/wham/usage";
 const CODEX_RESET_CREDITS_API = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
@@ -226,17 +226,29 @@ function getResetsInSeconds(window: { reset_after_seconds?: number; reset_at?: n
 export { formatDuration } from "../agents/format";
 
 export function useCodexUsage(enabled = true) {
-  const [usage, setUsage] = useState<CodexUsage | null>(null);
-  const [error, setError] = useState<CodexError | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [hasInitialFetch, setHasInitialFetch] = useState<boolean>(false);
+  const getCachedState = () => {
+    try {
+      const { primaryToken: token, primaryAccountId } = resolveCodexAuthTokens();
+      if (!token) return null;
+
+      const cacheKey = `codex-${token}-${primaryAccountId || "default"}`;
+      return getSharedCacheEntry(cacheKey);
+    } catch {
+      // Safe fallback
+    }
+    return null;
+  };
+
+  const cached = getCachedState();
+  const [usage, setUsage] = useState<CodexUsage | null>(cached ? (cached.usage as CodexUsage) : null);
+  const [error, setError] = useState<CodexError | null>(cached ? (cached.error as CodexError) : null);
+  const [isLoading, setIsLoading] = useState<boolean>(enabled && !cached);
+  const [hasInitialFetch, setHasInitialFetch] = useState<boolean>(!!cached);
+  const [lastFetchedAt, setLastFetchedAt] = useState<number | undefined>(cached ? cached.timestamp : undefined);
   const requestIdRef = useRef(0);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (force = false) => {
     const requestId = ++requestIdRef.current;
-
-    setIsLoading(true);
-    setError(null);
 
     const { primaryToken: token, primaryAccountId } = resolveCodexAuthTokens();
 
@@ -251,15 +263,37 @@ export function useCodexUsage(enabled = true) {
       return;
     }
 
+    const cacheKey = `codex-${token}-${primaryAccountId || "default"}`;
+    const cachedEntry = getSharedCacheEntry(cacheKey);
+
+    if (!force && cachedEntry) {
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      setUsage(cachedEntry.usage as CodexUsage);
+      setError(cachedEntry.error as CodexError);
+      setIsLoading(false);
+      setHasInitialFetch(true);
+      setLastFetchedAt(cachedEntry.timestamp);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
     const result = await fetchCodexUsage(token, primaryAccountId);
     if (requestId !== requestIdRef.current) {
       return;
     }
 
+    const fetchTime = Date.now();
+    setSharedCacheEntry(cacheKey, result.usage, result.error, fetchTime);
+
     setUsage(result.usage);
     setError(result.error);
     setIsLoading(false);
     setHasInitialFetch(true);
+    setLastFetchedAt(fetchTime);
   }, []);
 
   useEffect(() => {
@@ -273,135 +307,56 @@ export function useCodexUsage(enabled = true) {
     }
 
     if (!hasInitialFetch) {
-      fetchData();
+      fetchData(false);
     }
   }, [enabled, hasInitialFetch, fetchData]);
 
-  const revalidate = useCallback(async () => {
-    if (!enabled) {
-      return;
-    }
+  const revalidate = useCallback(
+    async (force = true) => {
+      if (!enabled) {
+        return;
+      }
 
-    await fetchData();
-  }, [enabled, fetchData]);
+      await fetchData(force);
+    },
+    [enabled, fetchData],
+  );
 
   return {
     isLoading: enabled ? isLoading : false,
     usage: enabled ? usage : null,
     error: enabled ? error : null,
     revalidate,
+    lastFetchedAt,
   };
 }
 
-/**
- * Returns one UsageState per discovered or manually configured Codex account.
- * File-backed Codex OAuth accounts are preferred so refreshed local tokens are used.
- *
- * Each entry in the returned array corresponds to one account.
- */
-export function useCodexAccounts(enabled = true): AccountUsageState<CodexUsage, CodexError>[] {
-  const [accountStates, setAccountStates] = useState<AccountUsageState<CodexUsage, CodexError>[]>([]);
-  const requestIdRef = useRef(0);
-
-  const fetchAll = useCallback(async () => {
-    const requestId = ++requestIdRef.current;
-
+export const useCodexAccounts = createAccountsHook<
+  CodexUsage,
+  CodexError,
+  { id: string; label: string; token: string; accountId?: string; needsAccountId?: boolean }
+>({
+  agentName: "codex",
+  getAccounts: async () => {
     const discoveredAccounts = listCodexOAuthAccounts();
     const manualAccounts = await loadAccounts("codex");
-    const accounts = buildCodexAccountCandidates(discoveredAccounts, manualAccounts);
-
-    // Fallback: if no accounts at all, show not configured
-    if (accounts.length === 0) {
-      setAccountStates([
-        {
-          accountId: "none",
-          label: "Default",
-          token: "",
-          isLoading: false,
-          usage: null,
-          error: {
-            type: "not_configured",
-            message:
-              "Codex is not configured. Run 'codex login' to authenticate or add an account via Manage Accounts.",
-          },
-          revalidate: async () => {
-            await fetchAll();
-          },
+    return buildCodexAccountCandidates(discoveredAccounts, manualAccounts);
+  },
+  fetcher: async (acc) => {
+    if (acc.needsAccountId) {
+      return {
+        usage: null,
+        error: {
+          type: "not_configured" as const,
+          message:
+            "Add the ChatGPT account ID for this manual Codex account, or run 'codex login' and let Agent Usage read the OAuth account from CODEX_HOME.",
         },
-      ]);
-      return;
+      };
     }
-
-    // Kick off all fetches in parallel
-    const results = await Promise.all(
-      accounts.map(async (account) => {
-        if (account.needsAccountId) {
-          return {
-            account,
-            result: {
-              usage: null,
-              error: {
-                type: "not_configured" as const,
-                message:
-                  "Add the ChatGPT account ID for this manual Codex account, or run 'codex login' and let Agent Usage read the OAuth account from CODEX_HOME.",
-              },
-            },
-          };
-        }
-
-        const result = await fetchCodexUsage(account.token, account.accountId);
-        return { account, result };
-      }),
-    );
-
-    if (requestId !== requestIdRef.current) return;
-
-    setAccountStates(
-      results.map(({ account, result }) => ({
-        accountId: account.id,
-        label: account.label,
-        token: account.token,
-        isLoading: false,
-        usage: result.usage,
-        error: result.error,
-        isOpenCodeActive: false,
-        revalidate: async () => {
-          await fetchAll();
-        },
-      })),
-    );
-  }, []);
-
-  useEffect(() => {
-    if (!enabled) {
-      requestIdRef.current += 1;
-      setAccountStates([]);
-      return;
-    }
-    void fetchAll();
-  }, [enabled, fetchAll]);
-
-  // Set initial loading state only if no data exists
-  useEffect(() => {
-    if (!enabled) return;
-    setAccountStates((prev) =>
-      prev.length === 0 || prev.some((s) => s.accountId === "none")
-        ? [
-            {
-              accountId: "loading",
-              label: "Loading…",
-              token: "",
-              isLoading: true,
-              usage: null,
-              error: null,
-              revalidate: async () => {
-                await fetchAll();
-              },
-            },
-          ]
-        : prev,
-    );
-  }, [enabled, fetchAll]);
-
-  return accountStates;
-}
+    return fetchCodexUsage(acc.token, acc.accountId);
+  },
+  noAccountsError: {
+    type: "not_configured",
+    message: "Codex is not configured. Run 'codex login' to authenticate or add an account via Manage Accounts.",
+  },
+});

--- a/extensions/agent-usage/src/copilot/fetcher.ts
+++ b/extensions/agent-usage/src/copilot/fetcher.ts
@@ -1,5 +1,3 @@
-import { getPreferenceValues } from "@raycast/api";
-import { useCallback, useEffect, useRef, useState } from "react";
 import { resolveCopilotAuthTokens, shouldFallbackToPreferenceToken } from "./auth";
 import type { CopilotError, CopilotUsage } from "./types";
 
@@ -176,48 +174,48 @@ async function fetchCopilotUsage(token: string): Promise<{ usage: CopilotUsage |
   }
 }
 
-export function useCopilotUsage(enabled = true) {
-  const [usage, setUsage] = useState<CopilotUsage | null>(null);
-  const [error, setError] = useState<CopilotError | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [hasInitialFetch, setHasInitialFetch] = useState<boolean>(false);
-  const requestIdRef = useRef(0);
+export function useCopilotUsage(enabled = true): import("../agents/types").UsageState<CopilotUsage, CopilotError> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { getPreferenceValues } = require("@raycast/api") as typeof import("@raycast/api");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useCachedPromise } = require("@raycast/utils") as typeof import("@raycast/utils");
 
-  const fetchData = useCallback(async () => {
-    const requestId = ++requestIdRef.current;
+  const preferences = getPreferenceValues<Preferences>();
+  const preferenceToken = preferences.copilotAuthToken?.trim() || "";
 
-    setIsLoading(true);
-    setError(null);
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useCallback } = require("react") as typeof import("react");
 
-    const preferences = getPreferenceValues<Preferences>();
-    const preferenceToken = preferences.copilotAuthToken?.trim() || "";
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { fetchTtlCache, getTtlMs } = require("../agents/hooks") as typeof import("../agents/hooks");
+
+  const ttlKey = "ttl-copilot";
+  const lastFetched = Number(fetchTtlCache.get(ttlKey)) || 0;
+  const isStale = Date.now() - lastFetched > getTtlMs();
+
+  const fetcherFn = useCallback(async (prefToken: string) => {
+    fetchTtlCache.set(ttlKey, String(Date.now()));
     const {
       primaryToken,
       localToken,
       preferenceToken: cleanedPreferenceToken,
     } = await resolveCopilotAuthTokens({
-      preferenceToken,
+      preferenceToken: prefToken,
     });
 
     if (!primaryToken) {
-      if (requestId !== requestIdRef.current) {
-        return;
-      }
-
-      setUsage(null);
-      setError({
-        type: "not_configured",
-        message: "Copilot is not configured. Set GH_TOKEN/GITHUB_TOKEN or add a token in extension settings (Cmd+,).",
-      });
-      setIsLoading(false);
-      setHasInitialFetch(true);
-      return;
+      return {
+        usage: null,
+        error: {
+          type: "not_configured",
+          message:
+            "Copilot is not configured. Set GH_TOKEN/GITHUB_TOKEN or add a token in extension settings (Cmd+,).",
+        } as CopilotError,
+        timestamp: Date.now(),
+      };
     }
 
     let result = await fetchCopilotUsage(primaryToken);
-    if (requestId !== requestIdRef.current) {
-      return;
-    }
 
     if (
       cleanedPreferenceToken &&
@@ -228,44 +226,24 @@ export function useCopilotUsage(enabled = true) {
       })
     ) {
       result = await fetchCopilotUsage(cleanedPreferenceToken);
-      if (requestId !== requestIdRef.current) {
-        return;
-      }
     }
 
-    setUsage(result.usage);
-    setError(result.error);
-    setIsLoading(false);
-    setHasInitialFetch(true);
-  }, []);
+    return { ...result, timestamp: Date.now() };
+  }, [ttlKey]);
 
-  useEffect(() => {
-    if (!enabled) {
-      requestIdRef.current += 1;
-      setUsage(null);
-      setError(null);
-      setIsLoading(false);
-      setHasInitialFetch(false);
-      return;
-    }
-
-    if (!hasInitialFetch) {
-      void fetchData();
-    }
-  }, [enabled, hasInitialFetch, fetchData]);
-
-  const revalidate = useCallback(async () => {
-    if (!enabled) {
-      return;
-    }
-
-    await fetchData();
-  }, [enabled, fetchData]);
+  const { data, isLoading, mutate } = useCachedPromise(
+    fetcherFn,
+    [preferenceToken],
+    { execute: enabled && isStale, initialData: { usage: null, error: null, timestamp: 0 } },
+  );
 
   return {
-    isLoading: enabled ? isLoading : false,
-    usage: enabled ? usage : null,
-    error: enabled ? error : null,
-    revalidate,
+    isLoading: enabled ? (data?.usage ? false : isLoading) : false,
+    usage: enabled && data ? data.usage : null,
+    error: enabled && data ? data.error : null,
+    revalidate: async () => {
+      await mutate();
+    },
+    lastFetchedAt: data?.timestamp,
   };
 }

--- a/extensions/agent-usage/src/cursor/fetcher.ts
+++ b/extensions/agent-usage/src/cursor/fetcher.ts
@@ -105,4 +105,7 @@ export async function fetchCursorUsage(): Promise<{ usage: CursorUsage | null; e
   }
 }
 
-export const useCursorUsage = createSimpleHook<CursorUsage, CursorError>({ fetcher: fetchCursorUsage });
+export const useCursorUsage = createSimpleHook<CursorUsage, CursorError>({
+  agentName: "cursor",
+  fetcher: fetchCursorUsage,
+});

--- a/extensions/agent-usage/src/droid/fetcher.ts
+++ b/extensions/agent-usage/src/droid/fetcher.ts
@@ -70,67 +70,52 @@ function parseDroidApiResponse(data: unknown): { usage: DroidUsage | null; error
   }
 }
 
-export function useDroidUsage(enabled = true) {
-  const [usage, setUsage] = useState<DroidUsage | null>(null);
-  const [error, setError] = useState<DroidError | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [hasInitialFetch, setHasInitialFetch] = useState<boolean>(false);
-  const requestIdRef = useRef(0);
+export function useDroidUsage(enabled = true): import("../agents/types").UsageState<DroidUsage, DroidError> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useCachedPromise } = require("@raycast/utils") as typeof import("@raycast/utils");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useCallback } = require("react") as typeof import("react");
 
-  const fetchData = useCallback(async () => {
-    const requestId = ++requestIdRef.current;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { fetchTtlCache, getTtlMs } = require("../agents/hooks") as typeof import("../agents/hooks");
 
-    setIsLoading(true);
-    setError(null);
+  const ttlKey = "ttl-droid";
+  const lastFetched = Number(fetchTtlCache.get(ttlKey)) || 0;
+  const isStale = Date.now() - lastFetched > getTtlMs();
 
+  const fetcherFn = useCallback(async () => {
+    fetchTtlCache.set(ttlKey, String(Date.now()));
     const { accessToken } = await resolveDroidAuth();
-    if (requestId !== requestIdRef.current) return;
 
     if (!accessToken) {
-      setUsage(null);
-      setError({
-        type: "not_configured",
-        message:
-          "Droid not configured. Run `droid` to log in (auto-detected from ~/.factory/auth.v2.* or ~/.factory/auth.*).",
-      });
-      setIsLoading(false);
-      setHasInitialFetch(true);
-      return;
+      return {
+        usage: null,
+        error: {
+          type: "not_configured",
+          message:
+            "Droid not configured. Run `droid` to log in (auto-detected from ~/.factory/auth.v2.* or ~/.factory/auth.*).",
+        } as DroidError,
+        timestamp: Date.now(),
+      };
     }
 
     const result = await fetchDroidUsage(accessToken);
-    if (requestId !== requestIdRef.current) return;
+    return { ...result, timestamp: Date.now() };
+  }, [ttlKey]);
 
-    setUsage(result.usage);
-    setError(result.error);
-    setIsLoading(false);
-    setHasInitialFetch(true);
-  }, []);
-
-  useEffect(() => {
-    if (!enabled) {
-      requestIdRef.current += 1;
-      setUsage(null);
-      setError(null);
-      setIsLoading(false);
-      setHasInitialFetch(false);
-      return;
-    }
-
-    if (!hasInitialFetch) {
-      void fetchData();
-    }
-  }, [enabled, hasInitialFetch, fetchData]);
-
-  const revalidate = useCallback(async () => {
-    if (!enabled) return;
-    await fetchData();
-  }, [enabled, fetchData]);
+  const { data, isLoading, mutate } = useCachedPromise(
+    fetcherFn,
+    ["droid"],
+    { execute: enabled && isStale, initialData: { usage: null, error: null, timestamp: 0 } }
+  );
 
   return {
-    isLoading: enabled ? isLoading : false,
-    usage: enabled ? usage : null,
-    error: enabled ? error : null,
-    revalidate,
+    isLoading: enabled ? (data?.usage ? false : isLoading) : false,
+    usage: enabled && data ? data.usage : null,
+    error: enabled && data ? data.error : null,
+    revalidate: async () => {
+      await mutate();
+    },
+    lastFetchedAt: data?.timestamp,
   };
 }

--- a/extensions/agent-usage/src/gemini/fetcher.ts
+++ b/extensions/agent-usage/src/gemini/fetcher.ts
@@ -307,4 +307,7 @@ async function fetchGeminiUsage(): Promise<{ usage: GeminiUsage | null; error: G
   }
 }
 
-export const useGeminiUsage = createSimpleHook<GeminiUsage, GeminiError>({ fetcher: fetchGeminiUsage });
+export const useGeminiUsage = createSimpleHook<GeminiUsage, GeminiError>({
+  agentName: "gemini",
+  fetcher: fetchGeminiUsage,
+});

--- a/extensions/agent-usage/src/gemini/reauth.test.ts
+++ b/extensions/agent-usage/src/gemini/reauth.test.ts
@@ -21,6 +21,7 @@ test("getGeminiReauthCommand prefers GEMINI_PATH when provided", async () => {
   const customGeminiPath = path.join(tempDir, "gemini");
 
   fs.writeFileSync(customGeminiPath, "#!/bin/sh\n", "utf-8");
+  fs.chmodSync(customGeminiPath, 0o755);
   process.env.GEMINI_PATH = customGeminiPath;
 
   try {

--- a/extensions/agent-usage/src/kimi/fetcher.ts
+++ b/extensions/agent-usage/src/kimi/fetcher.ts
@@ -2,11 +2,12 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { getPreferenceValues } from "@raycast/api";
 import type { UsageState } from "../agents/types";
 import { KimiUsage, KimiError } from "./types";
+
+import { createAccountsHook } from "../agents/hooks";
 import { httpFetch } from "../agents/http";
 import { readOpencodeAuthToken } from "../agents/opencode-auth";
-import { isOpenCodeActiveToken } from "../agents/opencode-active";
+
 import { loadAccounts } from "../accounts/storage";
-import type { AccountUsageState } from "../accounts/types";
 
 const KIMI_OPENCODE_KEY = "kimi-for-coding";
 
@@ -170,130 +171,26 @@ export function useKimiUsage(enabled = true): UsageState<KimiUsage, KimiError> {
   };
 }
 
-/**
- * Returns one UsageState per named Kimi account stored in LocalStorage.
- * Falls back to the preference/OpenCode token if no accounts are stored.
- *
- * Each entry in the returned array corresponds to one account.
- * The array is stable in order (matches LocalStorage order).
- */
-export function useKimiAccounts(enabled = true): AccountUsageState<KimiUsage, KimiError>[] {
-  // We store per-account state in parallel arrays indexed by accountId.
-  // Because hooks can't be called in loops, we fetch all accounts up front
-  // and manage state as a single Record keyed by accountId.
-
-  const [accountStates, setAccountStates] = useState<AccountUsageState<KimiUsage, KimiError>[]>([]);
-  const requestIdRef = useRef(0);
-
-  const fetchAll = useCallback(async () => {
-    const requestId = ++requestIdRef.current;
-
+export const useKimiAccounts = createAccountsHook<KimiUsage, KimiError, { id: string; label: string; token: string }>({
+  agentName: "kimi",
+  getAccounts: async () => {
     const prefs = getPreferenceValues<AgentUsagePrefs>();
     const manualAccounts = await loadAccounts("kimi");
-
-    // Get auto-detected token from OpenCode
     const autoToken = readOpencodeAuthToken("kimi-for-coding");
     const prefToken = (prefs.kimiAuthToken as string | undefined)?.trim() || "";
-
-    // Build list of all accounts: manual + auto-detected (if not duplicate)
     const accounts = [...manualAccounts];
-
-    // Add preference token as "Manual" if different from manual accounts
     if (prefToken && !accounts.some((a) => a.token === prefToken)) {
-      accounts.push({
-        id: "kimi-pref",
-        label: "Manual",
-        token: prefToken,
-      });
+      accounts.push({ id: "kimi-pref", label: "Manual", token: prefToken });
     }
-
-    // Add auto-detected token as "Auto-detected" if different from existing
     if (autoToken && !accounts.some((a) => a.token === autoToken)) {
-      accounts.push({
-        id: "kimi-opencode",
-        label: "Auto-detected",
-        token: autoToken,
-      });
+      accounts.push({ id: "kimi-opencode", label: "Auto-detected", token: autoToken });
     }
-
-    // Fallback: if no accounts at all, show not configured
-    if (accounts.length === 0) {
-      setAccountStates([
-        {
-          accountId: "none",
-          label: "Default",
-          token: "",
-          isLoading: false,
-          usage: null,
-          error: {
-            type: "not_configured",
-            message:
-              "Kimi token not found. Login via OpenCode (kimi-for-coding) or add an account via Manage Accounts.",
-          },
-          revalidate: async () => {
-            await fetchAll();
-          },
-        },
-      ]);
-      return;
-    }
-
-    // Kick off all fetches in parallel
-    const results = await Promise.all(
-      accounts.map(async (account) => {
-        const result = await fetchKimiUsage(account.token);
-        return { account, result };
-      }),
-    );
-
-    if (requestId !== requestIdRef.current) return;
-
-    setAccountStates(
-      results.map(({ account, result }) => ({
-        accountId: account.id,
-        label: account.label,
-        token: account.token,
-        isLoading: false,
-        usage: result.usage,
-        error: result.error,
-        isOpenCodeActive: isOpenCodeActiveToken(account.token, KIMI_OPENCODE_KEY),
-        revalidate: async () => {
-          await fetchAll();
-        },
-      })),
-    );
-  }, []);
-
-  useEffect(() => {
-    if (!enabled) {
-      requestIdRef.current += 1;
-      setAccountStates([]);
-      return;
-    }
-    void fetchAll();
-  }, [enabled, fetchAll]);
-
-  // Set initial loading state only if no data exists
-  useEffect(() => {
-    if (!enabled) return;
-    setAccountStates((prev) =>
-      prev.length === 0 || prev.some((s) => s.accountId === "none")
-        ? [
-            {
-              accountId: "loading",
-              label: "Loading…",
-              token: "",
-              isLoading: true,
-              usage: null,
-              error: null,
-              revalidate: async () => {
-                await fetchAll();
-              },
-            },
-          ]
-        : prev,
-    );
-  }, [enabled, fetchAll]);
-
-  return accountStates;
-}
+    return accounts;
+  },
+  fetcher: async (acc) => fetchKimiUsage(acc.token),
+  openCodeKey: KIMI_OPENCODE_KEY,
+  noAccountsError: {
+    type: "not_configured",
+    message: "Kimi token not found. Login via OpenCode (kimi-for-coding) or add an account via Manage Accounts.",
+  },
+});

--- a/extensions/agent-usage/src/minimax/fetcher.ts
+++ b/extensions/agent-usage/src/minimax/fetcher.ts
@@ -69,71 +69,57 @@ async function fetchMiniMaxUsage(token: string): Promise<{ usage: MiniMaxUsage |
   return parseMiniMaxApiResponse(data);
 }
 
-export function useMiniMaxUsage(enabled = true) {
-  const [usage, setUsage] = useState<MiniMaxUsage | null>(null);
-  const [error, setError] = useState<MiniMaxError | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [hasInitialFetch, setHasInitialFetch] = useState<boolean>(false);
-  const requestIdRef = useRef(0);
+export function useMiniMaxUsage(enabled = true): import("../agents/types").UsageState<MiniMaxUsage, MiniMaxError> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { getPreferenceValues } = require("@raycast/api") as typeof import("@raycast/api");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useCachedPromise } = require("@raycast/utils") as typeof import("@raycast/utils");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useCallback } = require("react") as typeof import("react");
 
-  const fetchData = useCallback(async () => {
-    const requestId = ++requestIdRef.current;
+  const preferences = getPreferenceValues<Preferences>();
+  const preferenceToken = preferences.minimaxApiToken?.trim() || "";
 
-    setIsLoading(true);
-    setError(null);
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { fetchTtlCache, getTtlMs } = require("../agents/hooks") as typeof import("../agents/hooks");
 
-    const preferences = getPreferenceValues<Preferences>();
-    const preferenceToken = preferences.minimaxApiToken?.trim() || "";
-    const { primaryToken } = await resolveMiniMaxAuthTokens({ preferenceToken });
+  const ttlKey = "ttl-minimax";
+  const lastFetched = Number(fetchTtlCache.get(ttlKey)) || 0;
+  const isStale = Date.now() - lastFetched > getTtlMs();
+
+  const fetcherFn = useCallback(async (prefToken: string) => {
+    fetchTtlCache.set(ttlKey, String(Date.now()));
+    const { primaryToken } = await resolveMiniMaxAuthTokens({ preferenceToken: prefToken });
 
     if (!primaryToken) {
-      setUsage(null);
-      setError({
-        type: "not_configured",
-        message:
-          "MiniMax token not configured. Add it in extension settings (Cmd+,) or set MINIMAX_API_KEY in your shell.",
-      });
-      setIsLoading(false);
-      setHasInitialFetch(true);
-      return;
+      return {
+        usage: null,
+        error: {
+          type: "not_configured",
+          message:
+            "MiniMax token not configured. Add it in extension settings (Cmd+,) or set MINIMAX_API_KEY in your shell.",
+        } as MiniMaxError,
+        timestamp: Date.now(),
+      };
     }
 
     const result = await fetchMiniMaxUsage(primaryToken);
-    if (requestId !== requestIdRef.current) return;
+    return { ...result, timestamp: Date.now() };
+  }, [ttlKey]);
 
-    setUsage(result.usage);
-    setError(result.error);
-    setIsLoading(false);
-    setHasInitialFetch(true);
-  }, []);
-
-  useEffect(() => {
-    if (!enabled) {
-      requestIdRef.current += 1;
-      setUsage(null);
-      setError(null);
-      setIsLoading(false);
-      setHasInitialFetch(false);
-      return;
-    }
-
-    if (!hasInitialFetch) {
-      void fetchData();
-    }
-  }, [enabled, hasInitialFetch, fetchData]);
-
-  const revalidate = useCallback(async () => {
-    if (!enabled) {
-      return;
-    }
-
-    await fetchData();
-  }, [enabled, fetchData]);
+  const { data, isLoading, mutate } = useCachedPromise(
+    fetcherFn,
+    [preferenceToken],
+    { execute: enabled && isStale, initialData: { usage: null, error: null, timestamp: 0 } }
+  );
 
   return {
-    isLoading: enabled ? isLoading : false,
-    usage: enabled ? usage : null,
-    error: enabled ? error : null,
-    revalidate,
+    isLoading: enabled ? (data?.usage ? false : isLoading) : false,
+    usage: enabled && data ? data.usage : null,
+    error: enabled && data ? data.error : null,
+    revalidate: async () => {
+      await mutate();
+    },
+    lastFetchedAt: data?.timestamp,
   };
 }

--- a/extensions/agent-usage/src/opencode-go/fetcher.ts
+++ b/extensions/agent-usage/src/opencode-go/fetcher.ts
@@ -1,5 +1,3 @@
-import { useState, useEffect, useCallback, useRef } from "react";
-
 import type { UsageState } from "../agents/types";
 import type { OpencodegoUsage, OpencodegoError } from "./types";
 import { parseOpencodegoHtml } from "./parser";
@@ -97,91 +95,75 @@ export async function fetchOpencodegoUsage(
 }
 
 export function useOpencodegoUsage(enabled = true): UsageState<OpencodegoUsage, OpencodegoError> {
-  const [usage, setUsage] = useState<OpencodegoUsage | null>(null);
-  const [error, setError] = useState<OpencodegoError | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [hasInitialFetch, setHasInitialFetch] = useState<boolean>(false);
-  const requestIdRef = useRef(0);
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { getPreferenceValues: getPrefs } = require("@raycast/api") as typeof import("@raycast/api");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useCachedPromise } = require("@raycast/utils") as typeof import("@raycast/utils");
 
-  const fetchData = useCallback(async () => {
-    const requestId = ++requestIdRef.current;
+  const preferences = getPrefs<Preferences.AgentUsage>();
+  const workspaceId = (preferences.opencodegoWorkspaceId as string)?.trim() || "";
+  const authCookie = (preferences.opencodegoAuthCookie as string)?.trim() || "";
 
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { getPreferenceValues: getPrefs } = require("@raycast/api") as typeof import("@raycast/api");
-    const preferences = getPrefs<Preferences.AgentUsage>();
-    const workspaceId = (preferences.opencodegoWorkspaceId as string)?.trim() || "";
-    const authCookie = (preferences.opencodegoAuthCookie as string)?.trim() || "";
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useCallback } = require("react") as typeof import("react");
 
-    if (!workspaceId && !authCookie) {
-      setUsage(null);
-      setError({
-        type: "not_configured",
-        message:
-          "OpenCode Go workspace ID and auth cookie not configured. Please add them in extension settings (Cmd+,).",
-      });
-      setIsLoading(false);
-      setHasInitialFetch(true);
-      return;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { fetchTtlCache, getTtlMs } = require("../agents/hooks") as typeof import("../agents/hooks");
+
+  const ttlKey = "ttl-opencodego";
+  const lastFetched = Number(fetchTtlCache.get(ttlKey)) || 0;
+  const isStale = Date.now() - lastFetched > getTtlMs();
+
+  const fetcherFn = useCallback(async (wId: string, aCookie: string) => {
+    fetchTtlCache.set(ttlKey, String(Date.now()));
+    if (!wId && !aCookie) {
+      return {
+        usage: null,
+        error: {
+          type: "not_configured",
+          message:
+            "OpenCode Go workspace ID and auth cookie not configured. Please add them in extension settings (Cmd+,).",
+        } as OpencodegoError,
+        timestamp: Date.now(),
+      };
     }
-
-    if (!workspaceId) {
-      setUsage(null);
-      setError({
-        type: "not_configured",
-        message: "OpenCode Go workspace ID not configured. Please add it in extension settings (Cmd+,).",
-      });
-      setIsLoading(false);
-      setHasInitialFetch(true);
-      return;
+    if (!wId) {
+      return {
+        usage: null,
+        error: {
+          type: "not_configured",
+          message: "OpenCode Go workspace ID not configured. Please add it in extension settings (Cmd+,).",
+        } as OpencodegoError,
+        timestamp: Date.now(),
+      };
     }
-
-    if (!authCookie) {
-      setUsage(null);
-      setError({
-        type: "not_configured",
-        message: "OpenCode Go auth cookie not configured. Please add it in extension settings (Cmd+,).",
-      });
-      setIsLoading(false);
-      setHasInitialFetch(true);
-      return;
+    if (!aCookie) {
+      return {
+        usage: null,
+        error: {
+          type: "not_configured",
+          message: "OpenCode Go auth cookie not configured. Please add it in extension settings (Cmd+,).",
+        } as OpencodegoError,
+        timestamp: Date.now(),
+      };
     }
+    const result = await fetchOpencodegoUsage(wId, aCookie);
+    return { ...result, timestamp: Date.now() };
+  }, [ttlKey]);
 
-    setIsLoading(true);
-    setError(null);
-
-    const result = await fetchOpencodegoUsage(workspaceId, authCookie);
-    if (requestId !== requestIdRef.current) return;
-
-    setUsage(result.usage);
-    setError(result.error);
-    setIsLoading(false);
-    setHasInitialFetch(true);
-  }, []);
-
-  useEffect(() => {
-    if (!enabled) {
-      requestIdRef.current += 1;
-      setUsage(null);
-      setError(null);
-      setIsLoading(false);
-      setHasInitialFetch(false);
-      return;
-    }
-
-    if (!hasInitialFetch) {
-      void fetchData();
-    }
-  }, [enabled, hasInitialFetch, fetchData]);
-
-  const revalidate = useCallback(async () => {
-    if (!enabled) return;
-    await fetchData();
-  }, [enabled, fetchData]);
+  const { data, isLoading, mutate } = useCachedPromise(
+    fetcherFn,
+    [workspaceId, authCookie],
+    { execute: enabled && isStale, initialData: { usage: null, error: null, timestamp: 0 } },
+  );
 
   return {
-    isLoading: enabled ? isLoading : false,
-    usage: enabled ? usage : null,
-    error: enabled ? error : null,
-    revalidate,
+    isLoading: enabled ? (data?.usage ? false : isLoading) : false,
+    usage: enabled && data ? data.usage : null,
+    error: enabled && data ? data.error : null,
+    revalidate: async () => {
+      await mutate();
+    },
+    lastFetchedAt: data?.timestamp,
   };
 }

--- a/extensions/agent-usage/src/opencode-go/parser.ts
+++ b/extensions/agent-usage/src/opencode-go/parser.ts
@@ -169,12 +169,12 @@ function extractSolidHydrationData(html: string): SolidHydrationData {
   // Try multiple patterns for usage data
   // Pattern 1: Original with specific indices
   let usageSection = script.match(
-    /\$R\[24\]\(\$R\[18\],\$R\[\d+\]=\{([^}]*rollingUsage[\s\S]*?)\}\);\$R\[24\]\(\$R\[20\]/,
+    /(?:\$R\[24\]\(|\)\()\$R\[18\],\$R\[\d+\]=\{([^}]*rollingUsage[\s\S]*?)\}\);\s*\$R\[24\]\(\$R\[20\]/,
   );
 
   // Pattern 2: More generic
   if (!usageSection) {
-    usageSection = script.match(/\$R\[24\]\([^,]+,\$R\[\d+\]=\{([^}]*rollingUsage[^}]+weeklyUsage[\s\S]*?)\}\);/);
+    usageSection = script.match(/\$R\[24\]\([^,]+,\$R\[\d+\]=\{([^}]*rollingUsage[\s\S]*?weeklyUsage[\s\S]*?)\}\);/);
   }
 
   // Pattern 3: Find by rollingUsage field

--- a/extensions/agent-usage/src/synthetic/fetcher.ts
+++ b/extensions/agent-usage/src/synthetic/fetcher.ts
@@ -2,12 +2,13 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { getPreferenceValues } from "@raycast/api";
 import type { UsageState } from "../agents/types";
 import { SyntheticUsage, SyntheticError } from "./types";
+
+import { createAccountsHook } from "../agents/hooks";
 import { resolveSyntheticToken } from "./auth";
 import { httpFetch } from "../agents/http";
 import { loadAccounts } from "../accounts/storage";
-import type { AccountUsageState } from "../accounts/types";
+
 import { readOpencodeAuthToken } from "../agents/opencode-auth";
-import { isOpenCodeActiveToken } from "../agents/opencode-active";
 
 const SYNTHETIC_OPENCODE_KEY = "synthetic";
 
@@ -164,125 +165,30 @@ export function useSyntheticUsage(enabled = true): UsageState<SyntheticUsage, Sy
   };
 }
 
-/**
- * Returns one UsageState per named Synthetic account stored in LocalStorage.
- * Falls back to the preference/OpenCode token if no accounts are stored.
- *
- * Each entry in the returned array corresponds to one account.
- * The array is stable in order (matches LocalStorage order).
- */
-export function useSyntheticAccounts(enabled = true): AccountUsageState<SyntheticUsage, SyntheticError>[] {
-  const [accountStates, setAccountStates] = useState<AccountUsageState<SyntheticUsage, SyntheticError>[]>([]);
-  const requestIdRef = useRef(0);
-
-  const fetchAll = useCallback(async () => {
-    const requestId = ++requestIdRef.current;
-
+export const useSyntheticAccounts = createAccountsHook<
+  SyntheticUsage,
+  SyntheticError,
+  { id: string; label: string; token: string }
+>({
+  agentName: "synthetic",
+  getAccounts: async () => {
     const prefs = getPreferenceValues<AgentUsagePrefs>();
     const manualAccounts = await loadAccounts("synthetic");
-
-    // Get tokens from different sources
     const preferenceToken = (prefs.syntheticApiToken as string | undefined)?.trim() || "";
     const opencodeToken = readOpencodeAuthToken("synthetic");
-
-    // Build list of all accounts: manual + auto-detected (if not duplicate)
     const accounts = [...manualAccounts];
-
-    // Add preference token as "Manual" if different from manual accounts
     if (preferenceToken && !accounts.some((a) => a.token === preferenceToken)) {
-      accounts.push({
-        id: "synthetic-pref",
-        label: "Manual",
-        token: preferenceToken,
-      });
+      accounts.push({ id: "synthetic-pref", label: "Manual", token: preferenceToken });
     }
-
-    // Add OpenCode token as "Auto-detected" if different from existing
     if (opencodeToken && !accounts.some((a) => a.token === opencodeToken)) {
-      accounts.push({
-        id: "synthetic-opencode",
-        label: "Auto-detected",
-        token: opencodeToken,
-      });
+      accounts.push({ id: "synthetic-opencode", label: "Auto-detected", token: opencodeToken });
     }
-
-    // Fallback: if no accounts at all, show not configured
-    if (accounts.length === 0) {
-      setAccountStates([
-        {
-          accountId: "none",
-          label: "Default",
-          token: "",
-          isLoading: false,
-          usage: null,
-          error: {
-            type: "not_configured",
-            message: "Synthetic token not found. Login via OpenCode (synthetic) or add an account via Manage Accounts.",
-          },
-          revalidate: async () => {
-            await fetchAll();
-          },
-        },
-      ]);
-      return;
-    }
-
-    // Kick off all fetches in parallel
-    const results = await Promise.all(
-      accounts.map(async (account) => {
-        const result = await fetchSyntheticUsage(account.token);
-        return { account, result };
-      }),
-    );
-
-    if (requestId !== requestIdRef.current) return;
-
-    setAccountStates(
-      results.map(({ account, result }) => ({
-        accountId: account.id,
-        label: account.label,
-        token: account.token,
-        isLoading: false,
-        usage: result.usage,
-        error: result.error,
-        isOpenCodeActive: isOpenCodeActiveToken(account.token, SYNTHETIC_OPENCODE_KEY),
-        revalidate: async () => {
-          await fetchAll();
-        },
-      })),
-    );
-  }, []);
-
-  useEffect(() => {
-    if (!enabled) {
-      requestIdRef.current += 1;
-      setAccountStates([]);
-      return;
-    }
-    void fetchAll();
-  }, [enabled, fetchAll]);
-
-  // Set initial loading state only if no data exists
-  useEffect(() => {
-    if (!enabled) return;
-    setAccountStates((prev) =>
-      prev.length === 0 || prev.some((s) => s.accountId === "none")
-        ? [
-            {
-              accountId: "loading",
-              label: "Loading…",
-              token: "",
-              isLoading: true,
-              usage: null,
-              error: null,
-              revalidate: async () => {
-                await fetchAll();
-              },
-            },
-          ]
-        : prev,
-    );
-  }, [enabled, fetchAll]);
-
-  return accountStates;
-}
+    return accounts;
+  },
+  fetcher: async (acc) => fetchSyntheticUsage(acc.token),
+  openCodeKey: SYNTHETIC_OPENCODE_KEY,
+  noAccountsError: {
+    type: "not_configured",
+    message: "Synthetic token not found. Login via OpenCode (synthetic) or add an account via Manage Accounts.",
+  },
+});

--- a/extensions/agent-usage/src/zai/fetcher.ts
+++ b/extensions/agent-usage/src/zai/fetcher.ts
@@ -4,9 +4,10 @@ import { ZaiUsage, ZaiError } from "./types";
 import { parseZaiApiResponse } from "./parser";
 import { httpFetch } from "../agents/http";
 import { resolveZaiAuthTokens } from "./auth";
-import { isOpenCodeActiveToken } from "../agents/opencode-active";
+
 import { loadAccounts } from "../accounts/storage";
-import type { AccountUsageState } from "../accounts/types";
+
+import { createAccountsHook } from "../agents/hooks";
 
 const ZAI_OPENCODE_KEY = "zai-coding-plan";
 
@@ -99,24 +100,14 @@ export function useZaiUsage(enabled = true) {
   };
 }
 
-export function useZaiAccounts(enabled = true): AccountUsageState<ZaiUsage, ZaiError>[] {
-  const [accountStates, setAccountStates] = useState<AccountUsageState<ZaiUsage, ZaiError>[]>([]);
-  const requestIdRef = useRef(0);
-
-  const fetchAll = useCallback(async () => {
-    const requestId = ++requestIdRef.current;
-
+export const useZaiAccounts = createAccountsHook<ZaiUsage, ZaiError, { id: string; label: string; token: string }>({
+  agentName: "zai",
+  getAccounts: async () => {
     const preferences = getPreferenceValues<Preferences>();
     const manualAccounts = await loadAccounts("zai");
-
-    // Get all auto-detected tokens
     const preferenceToken = preferences.zaiApiToken?.trim() || "";
     const { allTokens: autoTokens } = await resolveZaiAuthTokens({ preferenceToken });
-
-    // Build list of all accounts: manual + auto-detected (if not duplicate)
     const accounts = [...manualAccounts];
-
-    // Add auto-detected tokens as separate accounts if not already present
     for (let i = 0; i < autoTokens.length; i++) {
       const token = autoTokens[i];
       if (!accounts.some((a) => a.token === token)) {
@@ -126,82 +117,12 @@ export function useZaiAccounts(enabled = true): AccountUsageState<ZaiUsage, ZaiE
         accounts.push({ id, label, token });
       }
     }
-
-    // Fallback: if no accounts at all, show not configured
-    if (accounts.length === 0) {
-      setAccountStates([
-        {
-          accountId: "none",
-          label: "Default",
-          token: "",
-          isLoading: false,
-          usage: null,
-          error: {
-            type: "not_configured",
-            message: "z.ai token not configured. Add an account via Manage Accounts or set ZAI_API_KEY in your shell.",
-          },
-          revalidate: async () => {
-            await fetchAll();
-          },
-        },
-      ]);
-      return;
-    }
-
-    const results = await Promise.all(
-      accounts.map(async (account) => {
-        const result = await fetchZaiUsage(account.token);
-        return { account, result };
-      }),
-    );
-
-    if (requestId !== requestIdRef.current) return;
-
-    setAccountStates(
-      results.map(({ account, result }) => ({
-        accountId: account.id,
-        label: account.label,
-        token: account.token,
-        isLoading: false,
-        usage: result.usage,
-        error: result.error,
-        isOpenCodeActive: isOpenCodeActiveToken(account.token, ZAI_OPENCODE_KEY),
-        revalidate: async () => {
-          await fetchAll();
-        },
-      })),
-    );
-  }, []);
-
-  useEffect(() => {
-    if (!enabled) {
-      requestIdRef.current += 1;
-      setAccountStates([]);
-      return;
-    }
-    void fetchAll();
-  }, [enabled, fetchAll]);
-
-  useEffect(() => {
-    if (!enabled) return;
-    setAccountStates((prev) =>
-      prev.length === 0 || prev.some((s) => s.accountId === "none")
-        ? [
-            {
-              accountId: "loading",
-              label: "Loading…",
-              token: "",
-              isLoading: true,
-              usage: null,
-              error: null,
-              revalidate: async () => {
-                await fetchAll();
-              },
-            },
-          ]
-        : prev,
-    );
-  }, [enabled, fetchAll]);
-
-  return accountStates;
-}
+    return accounts;
+  },
+  fetcher: async (acc) => fetchZaiUsage(acc.token),
+  openCodeKey: ZAI_OPENCODE_KEY,
+  noAccountsError: {
+    type: "not_configured",
+    message: "z.ai token not configured. Add an account via Manage Accounts or set ZAI_API_KEY in your shell.",
+  },
+});


### PR DESCRIPTION
###
  Description
    This PR refactors the state management for agent fetching to use `@raycast/utils` `useCachedPromise`, vastly
  reducing boilerplate (deleting ~900 lines of manual `useState` and `useEffect` logic!).

More importantly, it implements a configurable, global disk cache with a standard TTL limit (defaulting to 3
  minutes) via Raycast`s `Cache` API.

    **Why?**
Previously, having the menubar extension run in the background (or even just frequently opening the main
  command) would blast the APIs on every single mount. This was causing constant loading screens ("spinners
  flashing" / UI jank), but much worse, I kept getting hit with **429 Rate Limit Exceeded** errors from Claude and
  other services because the undocumented internal usage endpoints were being hammered automatically.

By introducing a global TTL cache and syncing it across all views, we completely eliminate those redundant
  network hits, protect against rate-limiting bans, and make the UI buttery smooth.

    - Replaced boilerplate fetching logic with unified factory hooks in `hooks.ts`
    - Added an editable `cacheTtl` Extension Preference (default: 3 minutes)
    - Re-wired all 12 agents to check the TTL disk cache and smartly hold off on execution (`execute: enabled &&
  isStale`) unless the TTL has actually expired.
    - Removed aggressive auto-revalidating overrides from the menubar view, restoring the native `isStale` SWR
  fallback.