### PR TITLE
Update `Wave` extension - show subhead in Invoice (one line change)

### DIFF
--- a/extensions/wave/CHANGELOG.md
+++ b/extensions/wave/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Wave Changelog
 
-## [Subhead in Invoice] - {PR_MERGE_DATE}
+## [Subhead in Invoice] - 2026-07-05
 
 - In **Invoices**, Show "subhead"
 

--- a/extensions/wave/CHANGELOG.md
+++ b/extensions/wave/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Wave Changelog
 
+## [Subhead in Invoice] - {PR_MERGE_DATE}
+
+- In **Invoices**, Show "subhead"
+
 ## [Last Sent, Last Viewed in Invoice] - 2026-01-29
 
 - In **Invoices**, Show "Last Sent" and "Last Viewed"
-
 
 ## [More Invoice Enhancements] - 2026-01-21
 

--- a/extensions/wave/src/manage-wave.tsx
+++ b/extensions/wave/src/manage-wave.tsx
@@ -109,6 +109,7 @@ function BusinessInvoices({ business }: { business: Business }) {
           {filteredInvoices.map((invoice) => {
             const title = `${invoice.title} - ${invoice.invoiceNumber}`;
             const markdown = `# ${title}
+## ${invoice.subhead}
 | BILL TO | - | - | - |
 | ------- | - | - | - |
 | ${invoice.customer.name} | | **Invoice Date** | ${invoice.invoiceDate} |


### PR DESCRIPTION
## Description

- In **Invoices**, Show "subhead"

## Screencast

N/A

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
