### PR TITLE
[Vortex] Fix Web Crypto startup crash

### DIFF
--- a/extensions/vortex/CHANGELOG.md
+++ b/extensions/vortex/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Alby Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Fixed Vortex commands failing to open when Raycast already provides the Web Crypto API.
+
 ## [Security Maintenance] - 2026-05-21
 
 - Updated the extension to address security advisories.

--- a/extensions/vortex/CHANGELOG.md
+++ b/extensions/vortex/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Alby Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-07-06
 
 - Fixed Vortex commands failing to open when Raycast already provides the Web Crypto API.
 

--- a/extensions/vortex/src/utils/wallet.ts
+++ b/extensions/vortex/src/utils/wallet.ts
@@ -1,9 +1,6 @@
 import { webln } from "@getalby/sdk";
 import { getPreferenceValues } from "@raycast/api";
 import "websocket-polyfill";
-import * as crypto from "crypto";
-// eslint-disable-next-line
-globalThis.crypto = crypto as any;
 
 // Function to connect the wallet using the NWC URL components
 export const connectWallet = async () => {

--- a/extensions/vortex/src/utils/wallet.ts
+++ b/extensions/vortex/src/utils/wallet.ts
@@ -1,6 +1,11 @@
 import { webln } from "@getalby/sdk";
 import { getPreferenceValues } from "@raycast/api";
+import { webcrypto } from "crypto";
 import "websocket-polyfill";
+
+if (!globalThis.crypto) {
+  globalThis.crypto = webcrypto as Crypto;
+}
 
 // Function to connect the wallet using the NWC URL components
 export const connectWallet = async () => {


### PR DESCRIPTION
## Description

Vortex commands no longer crash during startup when Raycast exposes the Web Crypto API as a getter-only global. The extension now uses Raycast's existing Web Crypto implementation while retaining its WebSocket polyfill for NWC connections.

Fixes #28847.

## Validation

- `npm run build`
- `npm run lint`
- Manually opened the local development extension in Raycast and successfully created an invoice with the Receive command

## Screencast

Not applicable; this fixes a startup crash without changing the UI.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested the extension in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with the metadata tool

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
