### PR TITLE
Fuzzy File Search: add Cmd+Enter shortcut for Show in Finder

### DIFF
--- a/extensions/fuzzy-file-search/CHANGELOG.md
+++ b/extensions/fuzzy-file-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fuzzy File Search Changelog
 
-## [Show in Finder Shortcut] - {PR_MERGE_DATE}
+## [Show in Finder Shortcut] - 2026-07-06
 
 - Add Cmd+Enter shortcut to reveal the selected file in Finder by placing Show in Finder as the secondary action
 

--- a/extensions/fuzzy-file-search/CHANGELOG.md
+++ b/extensions/fuzzy-file-search/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Fuzzy File Search Changelog
 
+## [Show in Finder Shortcut] - {PR_MERGE_DATE}
+
+- Add Cmd+Enter shortcut to reveal the selected file in Finder by placing Show in Finder as the secondary action
+
 ## [Directory and File Search Directives] - 2026-06-17
 
 - Add `-d` / `-f` query directives to search directories or files only

--- a/extensions/fuzzy-file-search/src/search-for-files.tsx
+++ b/extensions/fuzzy-file-search/src/search-for-files.tsx
@@ -327,8 +327,8 @@ export default function Command() {
             actions={
               <ActionPanel>
                 <Action.Open title="Open" target={filepath} />
-                <Action.OpenWith path={filepath} shortcut={{ modifiers: ["cmd"], key: "o" }} />
                 <Action.ShowInFinder title="Show in Finder" path={filepath} />
+                <Action.OpenWith path={filepath} shortcut={{ modifiers: ["cmd"], key: "o" }} />
                 <Action.CopyToClipboard
                   title="Copy Path to Clipboard"
                   content={filepath}


### PR DESCRIPTION
## Summary
- Reorder actions so **Show in Finder** is the secondary action and receives **Cmd+Enter**
- **Open With** remains on **Cmd+O**

## Motivation
In Raycast List views, the 1st action gets Enter and the 2nd gets Cmd+Enter. Open With was second, so Cmd+Enter opened the app picker instead of revealing the file in Finder.