### PR TITLE
[LLM Stats] Fix crash when sorting the model list by throughput

### DIFF
--- a/extensions/llm-stats/CHANGELOG.md
+++ b/extensions/llm-stats/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LLM Stats Changelog
 
-## [Fix crash when sorting the model list by throughput] - {PR_MERGE_DATE}
+## [Fix crash when sorting the model list by throughput] - 2026-07-06
 
 ### Fixed
 - Sorting the model list by throughput no longer crashes with "TypeError: match is not a function" when the API returns the throughput value as a number

--- a/extensions/llm-stats/CHANGELOG.md
+++ b/extensions/llm-stats/CHANGELOG.md
@@ -1,5 +1,10 @@
 # LLM Stats Changelog
 
+## [Fix crash when sorting the model list by throughput] - {PR_MERGE_DATE}
+
+### Fixed
+- Sorting the model list by throughput no longer crashes with "TypeError: match is not a function" when the API returns the throughput value as a number
+
 ## [0.1.1] - 2026-01-19
 
 ### Changed

--- a/extensions/llm-stats/src/llm-models.tsx
+++ b/extensions/llm-stats/src/llm-models.tsx
@@ -158,10 +158,11 @@ function comparePrices(a: string | null, b: string | null): number {
 }
 
 /**
- * Parses a price string like "$0.50/1M tokens" to a number
+ * Parses a price to a number. Accepts either a formatted string like
+ * "$0.50/1M tokens" or a raw numeric value (the API returns numbers for some models).
  */
-function parsePrice(priceStr: string): number | null {
-  const match = priceStr.match(/\$?([\d.]+)/);
+function parsePrice(priceStr: string | number): number | null {
+  const match = String(priceStr).match(/\$?([\d.]+)/);
   if (!match) return null;
   return parseFloat(match[1]);
 }
@@ -197,10 +198,11 @@ function compareThroughput(a: string | null, b: string | null): number {
 }
 
 /**
- * Parses a throughput string like "100 tokens/second" to a number
+ * Parses a throughput to a number. Accepts either a formatted string like
+ * "100 tokens/second" or a raw numeric value (the API returns numbers for some models).
  */
-function parseThroughput(throughputStr: string): number | null {
-  const match = throughputStr.match(/([\d.]+)/);
+function parseThroughput(throughputStr: string | number): number | null {
+  const match = String(throughputStr).match(/([\d.]+)/);
   if (!match) return null;
   return parseFloat(match[1]);
 }

--- a/extensions/llm-stats/src/utils/formatting.ts
+++ b/extensions/llm-stats/src/utils/formatting.ts
@@ -35,13 +35,15 @@ export function formatPrice(pricePerMillion: number): string {
 }
 
 /**
- * Formats price from string (e.g., "$0.50/1M tokens" -> "$0.50/1M tokens" with proper formatting)
- * Parses the price value and formats it with toFixed(2)
+ * Formats a price for display (e.g., "$0.50/1M tokens" -> "$0.50/1M").
+ * Accepts either a formatted string or a raw numeric value (the API returns
+ * numbers for some models), so coerce before matching.
  */
-export function formatPriceFromString(priceStr: string): string {
-  const match = priceStr.match(/\$?([\d.]+)/);
+export function formatPriceFromString(priceStr: string | number): string {
+  const str = String(priceStr);
+  const match = str.match(/\$?([\d.]+)/);
   if (!match) {
-    return priceStr; // Return original if parsing fails
+    return str; // Return original if parsing fails
   }
   const price = parseFloat(match[1]);
   return `$${price.toFixed(2)}/1M`;


### PR DESCRIPTION
## Summary

Fixes the crash in the **LLM Stats** extension where the *View LLM Models* command throws when the sort filter is set to **Throughput**:

```
TypeError: <x>.match is not a function
```

Closes #29251

## Root cause

`ModelListItem` types `throughput` as `string | null`, but the zeroeval API (`/leaderboard/models/full`) returns it as a **number** for some models. At the time of writing, **47 of 324 models** have a numeric `throughput` (e.g. `Claude Haiku 4.5` → `throughput: 100.0`).

The throughput sort comparator calls `String.prototype.match` on that value:

```ts
function parseThroughput(throughputStr: string): number | null {
  const match = throughputStr.match(/([\d.]+)/);  // throughputStr is actually a number
  ...
}
```

When the value is a number, `.match` is `undefined`, so choosing the Throughput sort throws inside `Array.prototype.sort` (matching the reporter's stack trace at `Array.sort`). The `params` / `context-window` sorts use a numeric comparator, so those are unaffected — which is why only the Throughput filter crashes.

## Change

Coerce the value with `String(...)` before matching and widen the parameter type to `string | number`, so a numeric throughput of `100` parses to `100` and string inputs like `"100 tokens/second"` are unchanged. Scoped entirely to `extensions/llm-stats/`.

The two price helpers with the identical `.match` pattern — `parsePrice` (sort comparator) and `formatPriceFromString` (price accessory renderer) — get the same one-line guard. This is defensive rather than a currently-reproducible crash; see the note below.

## Validation

`npx ray lint` passes (package.json validation, ESLint, Prettier); `tsc --noEmit` is clean.

Verified headlessly (no Raycast app) by driving the real code paths with a numeric throughput, and against the live API response:

**Before:** selecting the Throughput sort throws `TypeError: throughputStr.match is not a function`.

**After:**
```
sort by throughput (numeric):        model-B:250 > model-A:100 > model-C:42
parseThroughput(100)              => 100
parseThroughput('100 tokens/sec') => 100      // string input unchanged
```

## Note for maintainers (a related, separate issue)

While confirming this against the live API I noticed the price fields are affected by a **field-name mismatch** that's independent of #29251:

- The code reads `model.price_per_input_token` / `model.price_per_output_token` (for the price sort at `comparePrices(...)` and the price accessories via `formatPriceFromString`), but the current API response contains **no such fields** — it returns `input_price` / `output_price` instead (both numeric, e.g. `input_price: 1.0`).
- So today those fields are `undefined` at runtime: the price sort is a no-op and the price accessories never render. That also means the price half of the crash can't currently fire — only Throughput can.
- Because `input_price` / `output_price` are themselves numeric, reconciling the field names (a separate change) would immediately reintroduce the same `.match`-on-number crash in the price path. That's exactly why I applied the same `String(...)` guard to `parsePrice` / `formatPriceFromString` here, even though it isn't reachable yet.

I kept this PR to the minimal fix for the reported Throughput crash and left the field-name reconciliation (and the corresponding `ModelListItem` type correction) out of scope — happy to follow up on it separately if useful.
