### PR TITLE
Add memo to MCP registry community entries

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add memo MCP Server] - {PR_MERGE_DATE}
+## [Add memo MCP Server] - 2026-07-06
 
 Add memo to the community registry — local-first persistent memory for AI agents: MLX embeddings on Apple Silicon (CPU fallback elsewhere), sqlite-vec + BM25 hybrid search, markdown-on-disk storage compatible with Obsidian. No cloud APIs.
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Add memo MCP Server] - {PR_MERGE_DATE}
+
+Add memo to the community registry — local-first persistent memory for AI agents: MLX embeddings on Apple Silicon (CPU fallback elsewhere), sqlite-vec + BM25 hybrid search, markdown-on-disk storage compatible with Obsidian. No cloud APIs.
+
 ## [Add Jellypod MCP Server] - 2026-06-19
 
 Add official Jellypod MCP Server to registry for creating, editing, and publishing conversational AI podcasts (podcasts, hosts, sources, episodes, and analytics). Remote endpoint via mcp-remote.

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -902,6 +902,18 @@ export const COMMUNITY_ENTRIES: RegistryEntry[] = [
     },
   },
   {
+    name: "memo",
+    title: "memo",
+    description:
+      "Local-first persistent memory for AI agents. MLX embeddings on Apple Silicon (CPU fallback elsewhere), sqlite-vec + BM25 hybrid search, and markdown-on-disk storage compatible with Obsidian. No cloud APIs or accounts required.",
+    icon: "https://raw.githubusercontent.com/jagoff/memo/master/docs/logo-400.png",
+    homepage: "https://github.com/jagoff/memo",
+    configuration: {
+      command: "uvx",
+      args: ["--from", "mlx-memo", "memo-mcp"],
+    },
+  },
+  {
     name: "monday",
     title: "Monday",
     description:


### PR DESCRIPTION
## Description

Adds **memo** to `COMMUNITY_ENTRIES` in the Model Context Protocol Registry extension. Registry-data-only change: one entry in `entries.ts` (inserted alphabetically) + a CHANGELOG item with the `{PR_MERGE_DATE}` placeholder, following the pattern of previous registry-entry PRs (#28853, #28744).

memo is a local-first persistent memory MCP server for AI agents: MLX embeddings on Apple Silicon (CPU fallback elsewhere), sqlite-vec + BM25 hybrid search, and markdown-on-disk storage compatible with Obsidian. No cloud APIs, no accounts, no API keys — the configuration is a single `uvx` command with no env vars.

- Repo: https://github.com/jagoff/memo
- PyPI: https://pypi.org/project/mlx-memo/
- Official MCP registry: `io.github.jagoff/memo`

## Screencast

Not applicable — data-only registry entry, no UI or code changes.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast — N/A: registry-data-only change (no code touched)
- [x] I checked that files in the `assets` folder are used by the extension itself — N/A: icon is a remote URL, no assets added
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder — N/A: README untouched
