### PR TITLE
Update caaals extension

### DIFF
--- a/extensions/caaals/.eslintrc.json
+++ b/extensions/caaals/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": ["@raycast"]
+}

--- a/extensions/caaals/CHANGELOG.md
+++ b/extensions/caaals/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Caaals Food Tracker Changelog
 
-## [Quick Log, Weight, Menu Bar & More] - {PR_MERGE_DATE}
+## [Quick Log, Weight, Menu Bar & More] - 2026-07-07
 
 ### New commands
 

--- a/extensions/caaals/CHANGELOG.md
+++ b/extensions/caaals/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Caaals Food Tracker Changelog
 
+## [Quick Log, Weight, Menu Bar & More] - {PR_MERGE_DATE}
+
+### New commands
+
+- **Quick Log** — log favorites and recent foods in one keystroke, with no AI wait. Pick a meal, adjust quantity/serving, and manage favorites from the action panel
+- **Log Weight** — record today's weight with optional body fat % and note; shows your current weight, 7-day change, and goal (kg or lb per your Caaals unit preference)
+- **Today's Calories in Menu Bar** — menu bar item with remaining calories, refreshed every 15 minutes; dropdown shows macros vs goals and your nutrition score, and the command's root-search entry shows your live status
+
+### Log Food
+
+- Type the food description directly as an argument from Raycast root search
+- Adjust quantity, serving, and meal on the confirmation screen before logging
+- "Log and Add to Favorites" action
+- Confirmation screen shows AI confidence, nutrition data source, review warnings, and your monthly AI token balance
+- Logged entries are now linked to their AI analysis, so your corrections improve Caaals' accuracy tracking
+
+### Browse Diary
+
+- Daily calorie goal and nutrition score in each day's header
+- Confirm entries flagged as "Needs review" so they count toward your totals
+- Log an entry again today, move it to another meal, copy a whole meal to today, or add its food to favorites
+- Loads the week in a single request (faster, no partial-failure toasts)
+
 ## [Security Maintenance] - 2026-05-21
 
 - Updated the extension to address security advisories.

--- a/extensions/caaals/README.md
+++ b/extensions/caaals/README.md
@@ -1,8 +1,8 @@
 # Caaals Food Tracker
 
-Log food with AI and browse your diary — all from Raycast.
+Log food with AI, re-log favorites in a keystroke, track your weight, and keep today's calories in your menu bar — all from Raycast.
 
-[Caaals](https://caaals.com) is an AI-powered calorie tracker. This extension lets you quickly log meals by describing them in plain text and review your recent diary entries without leaving Raycast.
+[Caaals](https://caaals.com) is an AI-powered calorie tracker. This extension brings the daily loop — log, review, repeat — to your Mac without opening the app.
 
 ## Setup
 
@@ -17,8 +17,22 @@ Log food with AI and browse your diary — all from Raycast.
 
 ### Log Food
 
-Describe what you ate in plain text (e.g. "200g chicken breast with rice and salad"). The AI analyzes the food, shows you the nutritional breakdown, and lets you log it to your diary with one action.
+Describe what you ate in plain text (e.g. "200g chicken breast with rice and salad"). The AI analyzes the food and shows a full nutritional breakdown with its confidence and data source. Adjust the quantity, serving, or meal right from the confirmation screen, then log it — optionally adding it to your favorites at the same time.
+
+Tip: type the description directly as an argument in Raycast's root search ("Log Food 2 eggs and toast") to skip the form entirely.
+
+### Quick Log
+
+Your favorites and recent foods in one list. Hit Enter to log a food to the meal matching the time of day — no AI call, no wait, no tokens. Use the action panel to pick a different meal, adjust quantity and serving before logging, or manage favorites.
 
 ### Browse Diary
 
-View your diary entries from the past 7 days grouped by date. You can see full nutritional details for any entry, copy nutrition info, or delete entries you no longer want.
+Your last 7 days grouped by date, with daily totals, calorie goal, and nutrition score in each section header. From any entry you can view details, log it again today, move it to another meal, copy its whole meal to today, add the food to favorites, confirm entries flagged for review, copy nutrition info, or delete it.
+
+### Log Weight
+
+Record today's weight (with optional body fat % and note). Shows your current weight, 7-day change, and goal — in kg or lb following your Caaals unit preference.
+
+### Today's Calories in Menu Bar
+
+A menu bar item with your remaining calories for the day, refreshed every 15 minutes. The dropdown shows calories and macros against your goals, your nutrition score, and shortcuts to the other commands. Running the command from root search activates or refreshes the menu bar item — its root-search entry always shows your current status (e.g. "743 kcal left today").

--- a/extensions/caaals/package.json
+++ b/extensions/caaals/package.json
@@ -18,6 +18,21 @@
       "title": "Log Food",
       "subtitle": "Caaals",
       "description": "Log food to your diary using AI text analysis",
+      "mode": "view",
+      "arguments": [
+        {
+          "name": "description",
+          "placeholder": "e.g. 2 eggs and toast",
+          "type": "text",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "quick-log",
+      "title": "Quick Log",
+      "subtitle": "Caaals",
+      "description": "Re-log favorites and recent foods in one keystroke, no AI wait",
       "mode": "view"
     },
     {
@@ -26,6 +41,36 @@
       "subtitle": "Caaals",
       "description": "View and manage recent diary entries",
       "mode": "view"
+    },
+    {
+      "name": "log-weight",
+      "title": "Log Weight",
+      "subtitle": "Caaals",
+      "description": "Record today's weight and see your trend",
+      "mode": "view"
+    },
+    {
+      "name": "today",
+      "title": "Today's Calories in Menu Bar",
+      "subtitle": "Caaals",
+      "description": "Adds a menu bar item with your remaining calories and macros. Running the command activates or refreshes it.",
+      "mode": "menu-bar",
+      "interval": "15m",
+      "preferences": [
+        {
+          "name": "menuBarStyle",
+          "title": "Menu Bar Display",
+          "description": "How much text to show next to the icon. Smaller styles help on notched MacBooks with crowded menu bars.",
+          "type": "dropdown",
+          "required": false,
+          "default": "full",
+          "data": [
+            { "title": "Calories + label (743 left)", "value": "full" },
+            { "title": "Calories only (743)", "value": "number" },
+            { "title": "Icon only", "value": "icon" }
+          ]
+        }
+      ]
     }
   ],
   "preferences": [

--- a/extensions/caaals/src/api.ts
+++ b/extensions/caaals/src/api.ts
@@ -1,5 +1,19 @@
 import { getPreferenceValues, openExtensionPreferences, showToast, Toast } from "@raycast/api";
-import type { AIFoodAnalysisResult, DailySummary, DiaryEntry, DiaryEntryFromSnapshotInput } from "./types";
+import type {
+  AnalyzeTextResponse,
+  AIFoodAnalysisResult,
+  CopyMealInput,
+  DailySummary,
+  DiaryEntry,
+  DiaryEntryFromSnapshotInput,
+  DiaryEntryInput,
+  Food,
+  TokenBalance,
+  UpdateDiaryEntryInput,
+  UserProfile,
+  WeightEntry,
+  WeightStats,
+} from "./types";
 
 const API_BASE_PATH = "/api/v1";
 
@@ -67,16 +81,46 @@ async function apiFetch<T>(path: string, opts: FetchOptions = {}): Promise<T> {
   return (await res.json()) as T;
 }
 
-export async function analyzeText(description: string): Promise<AIFoodAnalysisResult> {
-  const result = await apiFetch<{ data: AIFoodAnalysisResult }>("/foods/analyze/text", {
+// ============================================
+// AI Analysis
+// ============================================
+
+export async function analyzeText(description: string): Promise<AnalyzeTextResponse> {
+  const response = await apiFetch<{ data: AIFoodAnalysisResult; tokenBalance?: TokenBalance }>("/foods/analyze/text", {
     method: "POST",
     body: { description },
   });
-  return result.data;
+  return { result: response.data, tokenBalance: response.tokenBalance };
 }
+
+// ============================================
+// Diary
+// ============================================
 
 export async function getDiaryByDate(date: string, opts?: { quiet?: boolean }): Promise<DailySummary> {
   const result = await apiFetch<{ data: DailySummary }>(`/diary?date=${encodeURIComponent(date)}`, opts);
+  return result.data;
+}
+
+/** Fetch a whole date range in one request (unlike getDiaryByDate's single day). */
+export async function getDiarySummary(from: string, to: string): Promise<DailySummary[]> {
+  const result = await apiFetch<{ data: DailySummary[] }>(
+    `/diary/summary?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`,
+  );
+  return result.data;
+}
+
+export async function createDiaryEntry(data: DiaryEntryInput): Promise<DiaryEntry> {
+  const result = await apiFetch<{ data: DiaryEntry }>("/diary", {
+    method: "POST",
+    body: {
+      food_id: data.foodId,
+      serving_id: data.servingId,
+      quantity: data.quantity,
+      meal: data.meal,
+      logged_at: data.loggedAt,
+    },
+  });
   return result.data;
 }
 
@@ -90,11 +134,109 @@ export async function createDiaryFromSnapshot(data: DiaryEntryFromSnapshotInput)
       quantity: data.quantity,
       meal: data.meal,
       logged_at: data.loggedAt,
+      ...(data.aiAnalysisId ? { ai_analysis_id: data.aiAnalysisId } : {}),
     },
+  });
+  return result.data;
+}
+
+export async function updateDiaryEntry(id: string, data: UpdateDiaryEntryInput): Promise<DiaryEntry> {
+  const result = await apiFetch<{ data: DiaryEntry }>(`/diary/${encodeURIComponent(id)}`, {
+    method: "PUT",
+    body: {
+      ...(data.servingId !== undefined ? { serving_id: data.servingId } : {}),
+      ...(data.quantity !== undefined ? { quantity: data.quantity } : {}),
+      ...(data.meal !== undefined ? { meal: data.meal } : {}),
+      ...(data.status !== undefined ? { status: data.status } : {}),
+    },
+  });
+  return result.data;
+}
+
+/** Server-side "copy yesterday's meal" — duplicates snapshots, costs no AI tokens. */
+export async function copyMeal(data: CopyMealInput): Promise<DiaryEntry[]> {
+  const result = await apiFetch<{ data: DiaryEntry[] }>("/diary/copy", {
+    method: "POST",
+    body: { from_date: data.fromDate, to_date: data.toDate, meal: data.meal },
   });
   return result.data;
 }
 
 export async function deleteDiaryEntry(id: string): Promise<void> {
   await apiFetch(`/diary/${encodeURIComponent(id)}`, { method: "DELETE" });
+}
+
+// ============================================
+// Foods (recents + favorites)
+// ============================================
+
+export async function getRecentFoods(): Promise<Food[]> {
+  const result = await apiFetch<{ data: Food[] }>("/foods/recent");
+  return result.data;
+}
+
+export async function getFavoriteFoods(): Promise<Food[]> {
+  const result = await apiFetch<{ data: Food[] }>("/foods/favorites");
+  return result.data;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function addFavorite(food: Food): Promise<void> {
+  // Cached foods are keyed by UUID; AI/custom foods by their 16-hex food key
+  // and need the snapshot in the body.
+  await apiFetch(`/foods/${encodeURIComponent(food.id)}/favorite`, {
+    method: "POST",
+    body: UUID_RE.test(food.id) ? undefined : { food },
+  });
+}
+
+export async function removeFavorite(idOrKey: string): Promise<void> {
+  await apiFetch(`/foods/${encodeURIComponent(idOrKey)}/favorite`, { method: "DELETE" });
+}
+
+/**
+ * Log a food the way the mobile app does: cached foods (UUID id) go through
+ * POST /diary; AI/custom foods carry their snapshot through /diary/from-snapshot.
+ */
+export async function logFood(
+  food: Food,
+  opts: {
+    servingId: string;
+    quantity: number;
+    meal: DiaryEntryInput["meal"];
+    loggedAt: string;
+  },
+): Promise<DiaryEntry> {
+  if (food.source === "ai" || food.source === "custom" || !UUID_RE.test(food.id)) {
+    return createDiaryFromSnapshot({ food, foodKey: food.id, ...opts });
+  }
+  return createDiaryEntry({ foodId: food.id, ...opts });
+}
+
+// ============================================
+// User + Weight
+// ============================================
+
+export async function getProfile(): Promise<UserProfile> {
+  const result = await apiFetch<{ data: UserProfile }>("/user/profile");
+  return result.data;
+}
+
+export async function getWeightStats(): Promise<WeightStats> {
+  const result = await apiFetch<{ data: WeightStats }>("/weight/stats");
+  return result.data;
+}
+
+export async function logWeight(data: { weightKg: number; bodyFatPct?: number; note?: string }): Promise<WeightEntry> {
+  const result = await apiFetch<{ data: WeightEntry }>("/weight", {
+    method: "POST",
+    body: {
+      weight_kg: data.weightKg,
+      ...(data.bodyFatPct !== undefined ? { body_fat_pct: data.bodyFatPct } : {}),
+      ...(data.note ? { note: data.note } : {}),
+      logged_at: new Date().toISOString(),
+    },
+  });
+  return result.data;
 }

--- a/extensions/caaals/src/api.ts
+++ b/extensions/caaals/src/api.ts
@@ -202,14 +202,16 @@ export async function removeFavorite(idOrKey: string): Promise<void> {
 export async function logFood(
   food: Food,
   opts: {
+    foodKey?: string | null;
     servingId: string;
     quantity: number;
     meal: DiaryEntryInput["meal"];
     loggedAt: string;
   },
 ): Promise<DiaryEntry> {
-  if (food.source === "ai" || food.source === "custom" || !UUID_RE.test(food.id)) {
-    return createDiaryFromSnapshot({ food, foodKey: food.id, ...opts });
+  const foodKey = opts.foodKey ?? food.id;
+  if (food.source === "ai" || food.source === "custom" || foodKey !== food.id || !UUID_RE.test(foodKey)) {
+    return createDiaryFromSnapshot({ ...opts, food, foodKey });
   }
   return createDiaryEntry({ foodId: food.id, ...opts });
 }

--- a/extensions/caaals/src/browse-diary.tsx
+++ b/extensions/caaals/src/browse-diary.tsx
@@ -13,7 +13,7 @@ import {
 } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { addFavorite, copyMeal, deleteDiaryEntry, getDiarySummary, logFood, updateDiaryEntry } from "./api";
-import type { DailySummary, DiaryEntry, MealType } from "./types";
+import type { DailySummary, DiaryEntry, Food, MealType } from "./types";
 import {
   daysAgo,
   formatDate,
@@ -34,14 +34,14 @@ export default function BrowseDiary() {
   } = useCachedPromise(async () => {
     const days = await getDiarySummary(daysAgo(6), formatDate(new Date()));
     // Newest first, skip empty days.
-    return days.filter((d) => d.entries.length > 0).reverse();
+    return days.filter((d) => d.entries.length > 0).sort((a, b) => b.date.localeCompare(a.date));
   });
 
   async function handleDelete(entry: DiaryEntry) {
     if (
       await confirmAlert({
         title: "Delete Entry",
-        message: `Remove "${entry.food.name}" from your diary?`,
+        message: `Remove "${entryTitle(entry)}" from your diary?`,
         primaryAction: { title: "Delete", style: Alert.ActionStyle.Destructive },
       })
     ) {
@@ -89,9 +89,19 @@ export default function BrowseDiary() {
   }
 
   async function handleLogAgain(entry: DiaryEntry) {
+    if (!entry.food) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Cannot Log Yet",
+        message: "This entry is still analyzing",
+      });
+      return;
+    }
+
     const toast = await showToast({ style: Toast.Style.Animated, title: "Logging..." });
     try {
       await logFood(entry.food, {
+        foodKey: entry.foodKey,
         servingId: entry.servingId,
         quantity: entry.quantity,
         meal: entry.meal,
@@ -99,7 +109,7 @@ export default function BrowseDiary() {
       });
       toast.style = Toast.Style.Success;
       toast.title = `Logged ${entry.food.name} today`;
-      toast.message = `${entry.nutrition.calories} kcal`;
+      toast.message = `${entry.nutrition?.calories ?? 0} kcal`;
       revalidate();
     } catch (err) {
       toast.style = Toast.Style.Failure;
@@ -127,6 +137,15 @@ export default function BrowseDiary() {
   }
 
   async function handleAddFavorite(entry: DiaryEntry) {
+    if (!entry.food) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Cannot Add Favorite Yet",
+        message: "This entry is still analyzing",
+      });
+      return;
+    }
+
     const toast = await showToast({ style: Toast.Style.Animated, title: "Adding to favorites..." });
     try {
       await addFavorite(entry.food);
@@ -149,11 +168,12 @@ export default function BrowseDiary() {
       {summaries?.map((summary) => (
         <List.Section key={summary.date} title={formatDateSection(summary.date)} subtitle={sectionSubtitle(summary)}>
           {summary.entries.map((entry) => {
+            const food = entry.food;
             return (
               <List.Item
                 key={entry.id}
-                title={entry.food?.name ?? entry.analysisText ?? "Analyzing..."}
-                subtitle={formatServingWithQuantity(entryServing(entry), entry.quantity)}
+                title={entryTitle(entry)}
+                subtitle={entrySubtitle(entry)}
                 accessories={[
                   ...(entry.status === "needs_confirmation"
                     ? [{ tag: { value: "Needs review", color: Color.Yellow } }]
@@ -161,7 +181,7 @@ export default function BrowseDiary() {
                   ...(entry.status === "analyzing"
                     ? [{ tag: { value: "Analyzing", color: Color.SecondaryText } }]
                     : []),
-                  { text: `${entry.nutrition.calories} kcal` },
+                  { text: `${entry.nutrition?.calories ?? 0} kcal` },
                   {
                     tag: {
                       value: `${MEAL_ICONS[entry.meal]} ${formatMealType(entry.meal)}`,
@@ -175,12 +195,14 @@ export default function BrowseDiary() {
                     {entry.status === "needs_confirmation" && (
                       <Action title="Confirm Entry" icon={Icon.CheckCircle} onAction={() => handleConfirm(entry)} />
                     )}
-                    <Action
-                      title="Log Again Today"
-                      icon={Icon.Plus}
-                      shortcut={{ modifiers: ["cmd"], key: "l" }}
-                      onAction={() => handleLogAgain(entry)}
-                    />
+                    {food && (
+                      <Action
+                        title="Log Again Today"
+                        icon={Icon.Plus}
+                        shortcut={{ modifiers: ["cmd"], key: "l" }}
+                        onAction={() => handleLogAgain(entry)}
+                      />
+                    )}
                     <ActionPanel.Submenu
                       title="Change Meal"
                       icon={Icon.Calendar}
@@ -202,24 +224,28 @@ export default function BrowseDiary() {
                         onAction={() => handleCopyMealToToday(summary.date, entry.meal)}
                       />
                     )}
-                    <Action
-                      title="Add to Favorites"
-                      icon={Icon.Star}
-                      shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
-                      onAction={() => handleAddFavorite(entry)}
-                    />
-                    <Action
-                      title="Copy Nutrition"
-                      icon={Icon.Clipboard}
-                      shortcut={{ modifiers: ["cmd"], key: "c" }}
-                      onAction={async () => {
-                        const n = entry.nutrition;
-                        await Clipboard.copy(
-                          `${entry.food.name}: ${n.calories} kcal | P: ${n.protein}g | C: ${n.carbs}g | F: ${n.fat}g`,
-                        );
-                        await showToast({ style: Toast.Style.Success, title: "Copied" });
-                      }}
-                    />
+                    {food && (
+                      <Action
+                        title="Add to Favorites"
+                        icon={Icon.Star}
+                        shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
+                        onAction={() => handleAddFavorite(entry)}
+                      />
+                    )}
+                    {food && (
+                      <Action
+                        title="Copy Nutrition"
+                        icon={Icon.Clipboard}
+                        shortcut={{ modifiers: ["cmd"], key: "c" }}
+                        onAction={async () => {
+                          const n = entry.nutrition;
+                          await Clipboard.copy(
+                            `${food.name}: ${n.calories} kcal | P: ${n.protein}g | C: ${n.carbs}g | F: ${n.fat}g`,
+                          );
+                          await showToast({ style: Toast.Style.Success, title: "Copied" });
+                        }}
+                      />
+                    )}
                     <Action
                       title="Refresh"
                       icon={Icon.ArrowClockwise}
@@ -251,13 +277,44 @@ function sectionSubtitle(summary: DailySummary): string {
   return `${calories}${score}`;
 }
 
-function entryServing(entry: DiaryEntry) {
-  return entry.food.servings.find((s) => s.id === entry.servingId) ?? getDefaultServing(entry.food);
+function entryTitle(entry: DiaryEntry): string {
+  return entry.food?.name ?? entry.analysisText ?? "Analyzing...";
+}
+
+function entrySubtitle(entry: DiaryEntry): string {
+  if (!entry.food) {
+    return entry.status === "analyzing" ? "Analyzing..." : "Food details unavailable";
+  }
+  return formatServingWithQuantity(entryServing(entry.food, entry.servingId), entry.quantity);
+}
+
+function entryServing(food: Food, servingId: string) {
+  return food.servings.find((s) => s.id === servingId) ?? getDefaultServing(food);
 }
 
 function EntryDetail({ entry }: { entry: DiaryEntry }) {
   const { food, nutrition, meal } = entry;
   const n = nutrition;
+
+  if (!food) {
+    return (
+      <Detail
+        markdown={`# ${entryTitle(entry)}\n\n> This entry is still analyzing.`}
+        metadata={
+          <Detail.Metadata>
+            <Detail.Metadata.Label title="Status" text={entry.status} />
+            <Detail.Metadata.TagList title="Meal">
+              <Detail.Metadata.TagList.Item
+                text={`${MEAL_ICONS[meal]} ${formatMealType(meal)}`}
+                color={mealColor(meal)}
+              />
+            </Detail.Metadata.TagList>
+            <Detail.Metadata.Label title="Logged" text={new Date(entry.loggedAt).toLocaleString()} />
+          </Detail.Metadata>
+        }
+      />
+    );
+  }
 
   const markdown = `# ${food.name}${food.brand ? ` — ${food.brand}` : ""}${
     entry.status === "needs_confirmation" ? "\n\n> ⚠️ This entry needs review before it counts toward your totals." : ""
@@ -278,7 +335,7 @@ function EntryDetail({ entry }: { entry: DiaryEntry }) {
           <Detail.Metadata.Separator />
           <Detail.Metadata.Label
             title="Serving"
-            text={formatServingWithQuantity(entryServing(entry), entry.quantity)}
+            text={formatServingWithQuantity(entryServing(food, entry.servingId), entry.quantity)}
           />
           <Detail.Metadata.TagList title="Meal">
             <Detail.Metadata.TagList.Item

--- a/extensions/caaals/src/browse-diary.tsx
+++ b/extensions/caaals/src/browse-diary.tsx
@@ -2,6 +2,7 @@ import {
   Action,
   ActionPanel,
   Alert,
+  Clipboard,
   Color,
   confirmAlert,
   Detail,
@@ -9,72 +10,32 @@ import {
   List,
   showToast,
   Toast,
-  Clipboard,
 } from "@raycast/api";
-import { useCallback, useEffect, useState } from "react";
-import { deleteDiaryEntry, getDiaryByDate } from "./api";
-import type { DailySummary, DiaryEntry } from "./types";
+import { useCachedPromise } from "@raycast/utils";
+import { addFavorite, copyMeal, deleteDiaryEntry, getDiarySummary, logFood, updateDiaryEntry } from "./api";
+import type { DailySummary, DiaryEntry, MealType } from "./types";
 import {
+  daysAgo,
   formatDate,
   formatDateSection,
   formatMealType,
   formatServingWithQuantity,
   getDefaultServing,
   MEAL_ICONS,
+  MEALS,
+  mealColor,
 } from "./utils";
 
-function getDatesForLastNDays(n: number): string[] {
-  const dates: string[] = [];
-  for (let i = 0; i < n; i++) {
-    const d = new Date();
-    d.setDate(d.getDate() - i);
-    dates.push(formatDate(d));
-  }
-  return dates;
-}
-
 export default function BrowseDiary() {
-  const [summaries, setSummaries] = useState<DailySummary[] | undefined>();
-  const [isLoading, setIsLoading] = useState(true);
-
-  const fetchDiary = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const dates = getDatesForLastNDays(7);
-      const results = await Promise.allSettled(dates.map((d) => getDiaryByDate(d, { quiet: true })));
-      const fulfilled = results
-        .filter((r): r is PromiseFulfilledResult<DailySummary> => r.status === "fulfilled")
-        .map((r) => r.value);
-
-      if (fulfilled.length === 0 && results.some((r) => r.status === "rejected")) {
-        const firstErr = (results.find((r) => r.status === "rejected") as PromiseRejectedResult).reason;
-        await showToast({
-          style: Toast.Style.Failure,
-          title: "Failed to Load Diary",
-          message: firstErr instanceof Error ? firstErr.message : "Unknown error",
-        });
-        setSummaries([]);
-        return;
-      }
-
-      setSummaries(fulfilled.filter((s) => s.entries.length > 0));
-
-      const failedCount = results.filter((r) => r.status === "rejected").length;
-      if (failedCount > 0 && fulfilled.length > 0) {
-        await showToast({
-          style: Toast.Style.Failure,
-          title: "Some days failed to load",
-          message: `${failedCount} of ${results.length} days could not be fetched`,
-        });
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchDiary();
-  }, [fetchDiary]);
+  const {
+    data: summaries,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(async () => {
+    const days = await getDiarySummary(daysAgo(6), formatDate(new Date()));
+    // Newest first, skip empty days.
+    return days.filter((d) => d.entries.length > 0).reverse();
+  });
 
   async function handleDelete(entry: DiaryEntry) {
     if (
@@ -89,7 +50,7 @@ export default function BrowseDiary() {
         await deleteDiaryEntry(entry.id);
         toast.style = Toast.Style.Success;
         toast.title = "Entry Deleted";
-        await fetchDiary();
+        revalidate();
       } catch (err) {
         toast.style = Toast.Style.Failure;
         toast.title = "Delete Failed";
@@ -98,25 +59,108 @@ export default function BrowseDiary() {
     }
   }
 
+  async function handleConfirm(entry: DiaryEntry) {
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Confirming..." });
+    try {
+      await updateDiaryEntry(entry.id, { status: "confirmed" });
+      toast.style = Toast.Style.Success;
+      toast.title = "Entry Confirmed";
+      toast.message = "Now counts toward your daily totals";
+      revalidate();
+    } catch (err) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Confirm Failed";
+      toast.message = err instanceof Error ? err.message : "Unknown error";
+    }
+  }
+
+  async function handleChangeMeal(entry: DiaryEntry, meal: MealType) {
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Moving entry..." });
+    try {
+      await updateDiaryEntry(entry.id, { meal });
+      toast.style = Toast.Style.Success;
+      toast.title = `Moved to ${formatMealType(meal)}`;
+      revalidate();
+    } catch (err) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Update Failed";
+      toast.message = err instanceof Error ? err.message : "Unknown error";
+    }
+  }
+
+  async function handleLogAgain(entry: DiaryEntry) {
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Logging..." });
+    try {
+      await logFood(entry.food, {
+        servingId: entry.servingId,
+        quantity: entry.quantity,
+        meal: entry.meal,
+        loggedAt: new Date().toISOString(),
+      });
+      toast.style = Toast.Style.Success;
+      toast.title = `Logged ${entry.food.name} today`;
+      toast.message = `${entry.nutrition.calories} kcal`;
+      revalidate();
+    } catch (err) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Failed to Log";
+      toast.message = err instanceof Error ? err.message : "Unknown error";
+    }
+  }
+
+  async function handleCopyMealToToday(date: string, meal: MealType) {
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: `Copying ${formatMealType(meal).toLowerCase()}...`,
+    });
+    try {
+      const copies = await copyMeal({ fromDate: date, toDate: formatDate(new Date()), meal });
+      toast.style = Toast.Style.Success;
+      toast.title = `Copied ${formatMealType(meal)} to Today`;
+      toast.message = `${copies.length} ${copies.length === 1 ? "entry" : "entries"}`;
+      revalidate();
+    } catch (err) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Copy Failed";
+      toast.message = err instanceof Error ? err.message : "Unknown error";
+    }
+  }
+
+  async function handleAddFavorite(entry: DiaryEntry) {
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Adding to favorites..." });
+    try {
+      await addFavorite(entry.food);
+      toast.style = Toast.Style.Success;
+      toast.title = "Added to Favorites";
+    } catch (err) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Failed to Add Favorite";
+      toast.message = err instanceof Error ? err.message : "Unknown error";
+    }
+  }
+
+  const today = formatDate(new Date());
+
   return (
     <List isLoading={isLoading} searchBarPlaceholder="Filter diary entries...">
       {summaries !== undefined && summaries.length === 0 && (
         <List.EmptyView title="No Diary Entries" description="Nothing logged in the past 7 days" />
       )}
       {summaries?.map((summary) => (
-        <List.Section
-          key={summary.date}
-          title={formatDateSection(summary.date)}
-          subtitle={`${summary.totals.calories} kcal total`}
-        >
+        <List.Section key={summary.date} title={formatDateSection(summary.date)} subtitle={sectionSubtitle(summary)}>
           {summary.entries.map((entry) => {
-            const serving = entry.food.servings.find((s) => s.id === entry.servingId) ?? getDefaultServing(entry.food);
             return (
               <List.Item
                 key={entry.id}
-                title={entry.food.name}
-                subtitle={formatServingWithQuantity(serving, entry.quantity)}
+                title={entry.food?.name ?? entry.analysisText ?? "Analyzing..."}
+                subtitle={formatServingWithQuantity(entryServing(entry), entry.quantity)}
                 accessories={[
+                  ...(entry.status === "needs_confirmation"
+                    ? [{ tag: { value: "Needs review", color: Color.Yellow } }]
+                    : []),
+                  ...(entry.status === "analyzing"
+                    ? [{ tag: { value: "Analyzing", color: Color.SecondaryText } }]
+                    : []),
                   { text: `${entry.nutrition.calories} kcal` },
                   {
                     tag: {
@@ -128,6 +172,42 @@ export default function BrowseDiary() {
                 actions={
                   <ActionPanel>
                     <Action.Push title="View Details" icon={Icon.Eye} target={<EntryDetail entry={entry} />} />
+                    {entry.status === "needs_confirmation" && (
+                      <Action title="Confirm Entry" icon={Icon.CheckCircle} onAction={() => handleConfirm(entry)} />
+                    )}
+                    <Action
+                      title="Log Again Today"
+                      icon={Icon.Plus}
+                      shortcut={{ modifiers: ["cmd"], key: "l" }}
+                      onAction={() => handleLogAgain(entry)}
+                    />
+                    <ActionPanel.Submenu
+                      title="Change Meal"
+                      icon={Icon.Calendar}
+                      shortcut={{ modifiers: ["cmd"], key: "m" }}
+                    >
+                      {MEALS.filter((m) => m !== entry.meal).map((m) => (
+                        <Action
+                          key={m}
+                          title={`${MEAL_ICONS[m]} ${formatMealType(m)}`}
+                          onAction={() => handleChangeMeal(entry, m)}
+                        />
+                      ))}
+                    </ActionPanel.Submenu>
+                    {summary.date !== today && (
+                      <Action
+                        title={`Copy ${formatMealType(entry.meal)} to Today`}
+                        icon={Icon.Duplicate}
+                        shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+                        onAction={() => handleCopyMealToToday(summary.date, entry.meal)}
+                      />
+                    )}
+                    <Action
+                      title="Add to Favorites"
+                      icon={Icon.Star}
+                      shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
+                      onAction={() => handleAddFavorite(entry)}
+                    />
                     <Action
                       title="Copy Nutrition"
                       icon={Icon.Clipboard}
@@ -139,6 +219,12 @@ export default function BrowseDiary() {
                         );
                         await showToast({ style: Toast.Style.Success, title: "Copied" });
                       }}
+                    />
+                    <Action
+                      title="Refresh"
+                      icon={Icon.ArrowClockwise}
+                      shortcut={{ modifiers: ["cmd"], key: "r" }}
+                      onAction={revalidate}
                     />
                     <Action
                       title="Delete Entry"
@@ -158,53 +244,57 @@ export default function BrowseDiary() {
   );
 }
 
-function mealColor(meal: string): Color {
-  switch (meal) {
-    case "breakfast":
-      return Color.Orange;
-    case "lunch":
-      return Color.Yellow;
-    case "dinner":
-      return Color.Blue;
-    case "snack":
-      return Color.Purple;
-    default:
-      return Color.SecondaryText;
-  }
+function sectionSubtitle(summary: DailySummary): string {
+  const goal = summary.goals.calories;
+  const calories = `${summary.totals.calories}${goal ? ` / ${goal}` : ""} kcal`;
+  const score = summary.score?.value != null ? ` · Score ${summary.score.value}` : "";
+  return `${calories}${score}`;
+}
+
+function entryServing(entry: DiaryEntry) {
+  return entry.food.servings.find((s) => s.id === entry.servingId) ?? getDefaultServing(entry.food);
 }
 
 function EntryDetail({ entry }: { entry: DiaryEntry }) {
-  const { food, nutrition, meal, quantity } = entry;
-  const serving = food.servings.find((s) => s.id === entry.servingId) ?? getDefaultServing(food);
-  const fn = food.nutrition;
-  const multiplier = serving.multiplier * quantity;
+  const { food, nutrition, meal } = entry;
+  const n = nutrition;
 
-  const markdown = `# ${food.name}${food.brand ? ` — ${food.brand}` : ""}
-
-| Nutrient | Amount |
-|----------|--------|
-| Calories | **${nutrition.calories} kcal** |
-| Protein | ${nutrition.protein}g |
-| Carbs | ${nutrition.carbs}g |
-| Fat | ${nutrition.fat}g |
-${fn.fiber != null ? `| Fiber | ${Math.round(fn.fiber * multiplier * 10) / 10}g |` : ""}
-${fn.sugar != null ? `| Sugar | ${Math.round(fn.sugar * multiplier * 10) / 10}g |` : ""}
-${fn.sodium != null ? `| Sodium | ${Math.round(fn.sodium * multiplier * 10) / 10}mg |` : ""}
-
-**Serving:** ${formatServingWithQuantity(serving, quantity)}
-**Meal:** ${MEAL_ICONS[meal]} ${formatMealType(meal)}
-**Logged:** ${new Date(entry.loggedAt).toLocaleString("en-US")}`;
+  const markdown = `# ${food.name}${food.brand ? ` — ${food.brand}` : ""}${
+    entry.status === "needs_confirmation" ? "\n\n> ⚠️ This entry needs review before it counts toward your totals." : ""
+  }`;
 
   return (
     <Detail
       markdown={markdown}
+      metadata={
+        <Detail.Metadata>
+          <Detail.Metadata.Label title="Calories" text={`${n.calories} kcal`} />
+          <Detail.Metadata.Label title="Protein" text={`${n.protein} g`} />
+          <Detail.Metadata.Label title="Carbs" text={`${n.carbs} g`} />
+          <Detail.Metadata.Label title="Fat" text={`${n.fat} g`} />
+          <Detail.Metadata.Label title="Fiber" text={`${n.fiber} g`} />
+          <Detail.Metadata.Label title="Sugar" text={`${n.sugar} g`} />
+          <Detail.Metadata.Label title="Sodium" text={`${n.sodium} mg`} />
+          <Detail.Metadata.Separator />
+          <Detail.Metadata.Label
+            title="Serving"
+            text={formatServingWithQuantity(entryServing(entry), entry.quantity)}
+          />
+          <Detail.Metadata.TagList title="Meal">
+            <Detail.Metadata.TagList.Item
+              text={`${MEAL_ICONS[meal]} ${formatMealType(meal)}`}
+              color={mealColor(meal)}
+            />
+          </Detail.Metadata.TagList>
+          <Detail.Metadata.Label title="Logged" text={new Date(entry.loggedAt).toLocaleString()} />
+        </Detail.Metadata>
+      }
       actions={
         <ActionPanel>
           <Action
             title="Copy Nutrition"
             icon={Icon.Clipboard}
             onAction={async () => {
-              const n = nutrition;
               await Clipboard.copy(
                 `${food.name}: ${n.calories} kcal | P: ${n.protein}g | C: ${n.carbs}g | F: ${n.fat}g`,
               );

--- a/extensions/caaals/src/log-food.tsx
+++ b/extensions/caaals/src/log-food.tsx
@@ -1,7 +1,19 @@
-import { Action, ActionPanel, Detail, Form, popToRoot, showToast, Toast, useNavigation } from "@raycast/api";
-import { useState } from "react";
-import { analyzeText, createDiaryFromSnapshot } from "./api";
-import type { AIFoodAnalysisResult, MealType } from "./types";
+import {
+  Action,
+  ActionPanel,
+  Color,
+  Detail,
+  Form,
+  Icon,
+  LaunchProps,
+  popToRoot,
+  showToast,
+  Toast,
+  useNavigation,
+} from "@raycast/api";
+import { useEffect, useState } from "react";
+import { addFavorite, analyzeText, createDiaryFromSnapshot } from "./api";
+import type { AnalyzeTextResponse, MealType, NutritionSource } from "./types";
 import {
   formatMealType,
   formatServingWithQuantity,
@@ -9,45 +21,52 @@ import {
   getDefaultServing,
   MEAL_ICONS,
   MEALS,
+  mealColor,
+  scaleNutrition,
 } from "./utils";
 
-export default function LogFood() {
+const QUANTITIES = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3];
+
+const SOURCE_LABELS: Record<NutritionSource, string> = {
+  database: "Nutrition database",
+  ai_estimated: "AI estimate",
+  label_extracted: "Label",
+};
+
+export default function LogFood(props: LaunchProps<{ arguments: Arguments.LogFood }>) {
+  // launchCommand (e.g. from the menu bar) may not pass an arguments object.
+  const initialDescription = props.arguments?.description?.trim();
+
+  // Launched from root search with an argument — skip the form entirely.
+  if (initialDescription) {
+    return <FoodConfirmation description={initialDescription} meal={getDefaultMeal()} />;
+  }
+
+  return <LogFoodForm />;
+}
+
+function LogFoodForm() {
   const { push } = useNavigation();
-  const [isLoading, setIsLoading] = useState(false);
   const [descriptionError, setDescriptionError] = useState<string | undefined>();
 
-  async function handleSubmit(values: { description: string; meal: MealType }) {
-    if (!values.description.trim()) {
+  function handleSubmit(values: { description: string; meal: MealType }) {
+    const description = values.description.trim();
+    if (!description) {
       setDescriptionError("Description is required");
       return;
     }
-    if (values.description.trim().length < 2) {
+    if (description.length < 2) {
       setDescriptionError("At least 2 characters");
       return;
     }
-
-    setIsLoading(true);
-    const toast = await showToast({ style: Toast.Style.Animated, title: "Analyzing food..." });
-
-    try {
-      const result = await analyzeText(values.description.trim());
-      toast.hide();
-      push(<FoodConfirmation result={result} meal={values.meal} />);
-    } catch (err) {
-      toast.style = Toast.Style.Failure;
-      toast.title = "Analysis Failed";
-      toast.message = err instanceof Error ? err.message : "Unknown error";
-    } finally {
-      setIsLoading(false);
-    }
+    push(<FoodConfirmation description={description} meal={values.meal} />);
   }
 
   return (
     <Form
-      isLoading={isLoading}
       actions={
         <ActionPanel>
-          <Action.SubmitForm title="Analyze Food" onSubmit={handleSubmit} />
+          <Action.SubmitForm title="Analyze Food" icon={Icon.Wand} onSubmit={handleSubmit} />
         </ActionPanel>
       }
     >
@@ -77,40 +96,74 @@ export default function LogFood() {
   );
 }
 
-function FoodConfirmation({ result, meal }: { result: AIFoodAnalysisResult; meal: MealType }) {
+function FoodConfirmation({ description, meal: initialMeal }: { description: string; meal: MealType }) {
+  const [analysis, setAnalysis] = useState<AnalyzeTextResponse | undefined>();
+  const [error, setError] = useState<string | undefined>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [attempt, setAttempt] = useState(0);
+
+  const [meal, setMeal] = useState<MealType>(initialMeal);
+  const [quantity, setQuantity] = useState<number | undefined>();
+  const [servingId, setServingId] = useState<string | undefined>();
   const [isLogging, setIsLogging] = useState(false);
-  const { food, quantity: suggestedQuantity, confidence, warnings, foodKey } = result;
-  const serving = getDefaultServing(food);
-  const quantity = suggestedQuantity ?? 1;
 
-  const n = food.nutrition;
-  const multiplier = serving.multiplier * quantity;
-  const cals = Math.round(n.calories * multiplier);
-  const protein = Math.round(n.protein * multiplier * 10) / 10;
-  const carbs = Math.round(n.carbs * multiplier * 10) / 10;
-  const fat = Math.round(n.fat * multiplier * 10) / 10;
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(undefined);
+    analyzeText(description)
+      .then((response) => {
+        if (cancelled) return;
+        setAnalysis(response);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Unknown error");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [description, attempt]);
 
-  const confidenceIcon = confidence === "high" ? "🟢" : confidence === "medium" ? "🟡" : "🔴";
-  const warningLines = warnings?.length ? warnings.map((w) => `> ⚠️ ${w}`).join("\n") : "";
+  if (error) {
+    return (
+      <Detail
+        markdown={`# Analysis Failed\n\n> ${error}\n\n**Description:** ${description}`}
+        actions={
+          <ActionPanel>
+            <Action title="Try Again" icon={Icon.ArrowClockwise} onAction={() => setAttempt((a) => a + 1)} />
+          </ActionPanel>
+        }
+      />
+    );
+  }
 
-  const markdown = `# ${food.name}${food.brand ? ` — ${food.brand}` : ""}
+  if (isLoading || !analysis) {
+    return <Detail isLoading markdown={`# Analyzing...\n\n_${description}_`} />;
+  }
 
-${warningLines}
+  const { result, tokenBalance } = analysis;
+  const { food, confidence, warnings, foodKey, analysisId, nutritionSource, requiresConfirmation } = result;
 
-| Nutrient | Amount |
-|----------|--------|
-| Calories | **${cals} kcal** |
-| Protein | ${protein}g |
-| Carbs | ${carbs}g |
-| Fat | ${fat}g |
-${n.fiber != null ? `| Fiber | ${Math.round(n.fiber * multiplier * 10) / 10}g |` : ""}
-${n.sugar != null ? `| Sugar | ${Math.round(n.sugar * multiplier * 10) / 10}g |` : ""}
+  const serving = food.servings.find((s) => s.id === servingId) ?? getDefaultServing(food);
+  const qty = quantity ?? result.quantity ?? 1;
+  const scaled = scaleNutrition(food.nutrition, serving, qty);
 
-**Serving:** ${formatServingWithQuantity(serving, quantity)}
-**Meal:** ${MEAL_ICONS[meal]} ${formatMealType(meal)}
-**Confidence:** ${confidenceIcon} ${confidence}`;
+  const callouts = [
+    ...(requiresConfirmation
+      ? ["> ⚠️ **Review this estimate** — unusually high calories or an uncertain analysis."]
+      : []),
+    ...(warnings ?? []).map((w) => `> ⚠️ ${w}`),
+  ].join("\n>\n");
 
-  async function handleLog() {
+  const markdown = `# ${food.name}${food.brand ? ` — ${food.brand}` : ""}\n\n${callouts}`;
+
+  const confidenceColor = confidence === "high" ? Color.Green : confidence === "medium" ? Color.Yellow : Color.Red;
+
+  async function handleLog(alsoFavorite: boolean) {
     setIsLogging(true);
     const toast = await showToast({ style: Toast.Style.Animated, title: "Logging to diary..." });
 
@@ -119,13 +172,19 @@ ${n.sugar != null ? `| Sugar | ${Math.round(n.sugar * multiplier * 10) / 10}g |`
         food,
         foodKey,
         servingId: serving.id,
-        quantity,
+        quantity: qty,
         meal,
         loggedAt: new Date().toISOString(),
+        aiAnalysisId: analysisId,
       });
+      if (alsoFavorite) {
+        await addFavorite(food).catch(() => {
+          // Entry is logged either way; favoriting is best-effort.
+        });
+      }
       toast.style = Toast.Style.Success;
       toast.title = `Logged ${food.name}`;
-      toast.message = `${cals} kcal`;
+      toast.message = `${scaled.calories} kcal${alsoFavorite ? " · added to favorites" : ""}`;
       await popToRoot();
     } catch (err) {
       toast.style = Toast.Style.Failure;
@@ -139,10 +198,75 @@ ${n.sugar != null ? `| Sugar | ${Math.round(n.sugar * multiplier * 10) / 10}g |`
     <Detail
       markdown={markdown}
       isLoading={isLogging}
+      metadata={
+        <Detail.Metadata>
+          <Detail.Metadata.Label title="Calories" text={`${scaled.calories} kcal`} />
+          <Detail.Metadata.Label title="Protein" text={`${scaled.protein} g`} />
+          <Detail.Metadata.Label title="Carbs" text={`${scaled.carbs} g`} />
+          <Detail.Metadata.Label title="Fat" text={`${scaled.fat} g`} />
+          {scaled.fiber != null && <Detail.Metadata.Label title="Fiber" text={`${scaled.fiber} g`} />}
+          {scaled.sugar != null && <Detail.Metadata.Label title="Sugar" text={`${scaled.sugar} g`} />}
+          {scaled.sodium != null && <Detail.Metadata.Label title="Sodium" text={`${scaled.sodium} mg`} />}
+          <Detail.Metadata.Separator />
+          <Detail.Metadata.Label title="Serving" text={formatServingWithQuantity(serving, qty)} />
+          <Detail.Metadata.TagList title="Meal">
+            <Detail.Metadata.TagList.Item
+              text={`${MEAL_ICONS[meal]} ${formatMealType(meal)}`}
+              color={mealColor(meal)}
+            />
+          </Detail.Metadata.TagList>
+          <Detail.Metadata.TagList title="Confidence">
+            <Detail.Metadata.TagList.Item text={confidence} color={confidenceColor} />
+          </Detail.Metadata.TagList>
+          {nutritionSource && <Detail.Metadata.Label title="Source" text={SOURCE_LABELS[nutritionSource]} />}
+          {tokenBalance && (
+            <Detail.Metadata.Label
+              title="AI Tokens"
+              text={`${Math.round(tokenBalance.used / 1000)}k / ${Math.round(tokenBalance.limit / 1000)}k`}
+            />
+          )}
+        </Detail.Metadata>
+      }
       actions={
         <ActionPanel>
-          <Action title="Log to Diary" onAction={handleLog} />
-          <Action title="Cancel" onAction={popToRoot} shortcut={{ modifiers: ["cmd"], key: "." }} />
+          <Action title="Log to Diary" icon={Icon.Checkmark} onAction={() => handleLog(false)} />
+          <Action
+            title="Log and Add to Favorites"
+            icon={Icon.Star}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
+            onAction={() => handleLog(true)}
+          />
+          <ActionPanel.Submenu title="Change Quantity" icon={Icon.Hashtag} shortcut={{ modifiers: ["cmd"], key: "u" }}>
+            {QUANTITIES.map((q) => (
+              <Action key={q} title={`${q} ×${q === qty ? "  ✓" : ""}`} onAction={() => setQuantity(q)} />
+            ))}
+          </ActionPanel.Submenu>
+          {food.servings.length > 1 && (
+            <ActionPanel.Submenu title="Change Serving" icon={Icon.Ruler} shortcut={{ modifiers: ["cmd"], key: "s" }}>
+              {food.servings.map((s) => (
+                <Action
+                  key={s.id}
+                  title={`${s.description}${s.id === serving.id ? "  ✓" : ""}`}
+                  onAction={() => setServingId(s.id)}
+                />
+              ))}
+            </ActionPanel.Submenu>
+          )}
+          <ActionPanel.Submenu title="Change Meal" icon={Icon.Calendar} shortcut={{ modifiers: ["cmd"], key: "m" }}>
+            {MEALS.map((m) => (
+              <Action
+                key={m}
+                title={`${MEAL_ICONS[m]} ${formatMealType(m)}${m === meal ? "  ✓" : ""}`}
+                onAction={() => setMeal(m)}
+              />
+            ))}
+          </ActionPanel.Submenu>
+          <Action
+            title="Cancel"
+            icon={Icon.XMarkCircle}
+            onAction={popToRoot}
+            shortcut={{ modifiers: ["cmd"], key: "." }}
+          />
         </ActionPanel>
       }
     />

--- a/extensions/caaals/src/log-food.tsx
+++ b/extensions/caaals/src/log-food.tsx
@@ -178,9 +178,15 @@ function FoodConfirmation({ description, meal: initialMeal }: { description: str
         aiAnalysisId: analysisId,
       });
       if (alsoFavorite) {
-        await addFavorite(food).catch(() => {
-          // Entry is logged either way; favoriting is best-effort.
-        });
+        try {
+          await addFavorite(food);
+        } catch (err) {
+          toast.style = Toast.Style.Failure;
+          toast.title = "Logged, Favorite Failed";
+          toast.message = err instanceof Error ? err.message : "Unknown error";
+          await popToRoot();
+          return;
+        }
       }
       toast.style = Toast.Style.Success;
       toast.title = `Logged ${food.name}`;

--- a/extensions/caaals/src/log-weight.tsx
+++ b/extensions/caaals/src/log-weight.tsx
@@ -1,0 +1,109 @@
+import { Action, ActionPanel, Form, Icon, popToRoot, showToast, Toast } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { useState } from "react";
+import { getProfile, getWeightStats, logWeight } from "./api";
+import { kgToLb, lbToKg } from "./utils";
+
+export default function LogWeight() {
+  const [weightError, setWeightError] = useState<string | undefined>();
+  const [bodyFatError, setBodyFatError] = useState<string | undefined>();
+
+  const { data, isLoading } = useCachedPromise(async () => {
+    const [profile, stats] = await Promise.all([getProfile(), getWeightStats()]);
+    return { profile, stats };
+  });
+
+  const isImperial = data?.profile.unitSystem === "imperial";
+  const unit = isImperial ? "lb" : "kg";
+  const stats = data?.stats;
+
+  const currentDisplay =
+    stats?.current != null ? `${isImperial ? kgToLb(stats.current) : stats.current} ${unit}` : null;
+
+  const statusParts = [
+    ...(currentDisplay ? [`Current: ${currentDisplay}`] : []),
+    ...(stats?.change7d != null
+      ? [`7-day change: ${formatDelta(isImperial ? kgToLb(stats.change7d) : stats.change7d, unit)}`]
+      : []),
+    ...(stats?.goal != null ? [`Goal: ${isImperial ? kgToLb(stats.goal) : stats.goal} ${unit}`] : []),
+  ];
+
+  async function handleSubmit(values: { weight: string; bodyFat: string; note: string }) {
+    const weightInput = parseFloat(values.weight.replace(",", "."));
+    if (Number.isNaN(weightInput)) {
+      setWeightError("Enter your weight as a number");
+      return;
+    }
+    const weightKg = isImperial ? lbToKg(weightInput) : Math.round(weightInput * 10) / 10;
+    if (weightKg < 20 || weightKg > 500) {
+      setWeightError(`Weight must be between ${isImperial ? "44 and 1100 lb" : "20 and 500 kg"}`);
+      return;
+    }
+
+    let bodyFatPct: number | undefined;
+    if (values.bodyFat.trim() !== "") {
+      bodyFatPct = parseFloat(values.bodyFat.replace(",", "."));
+      if (Number.isNaN(bodyFatPct) || bodyFatPct < 3 || bodyFatPct > 70) {
+        setBodyFatError("Body fat must be between 3 and 70%");
+        return;
+      }
+    }
+
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Logging weight..." });
+    try {
+      await logWeight({ weightKg, bodyFatPct, note: values.note.trim() || undefined });
+      toast.style = Toast.Style.Success;
+      toast.title = `Logged ${isImperial ? `${kgToLb(weightKg)} lb` : `${weightKg} kg`}`;
+      if (stats?.current != null) {
+        const deltaKg = Math.round((weightKg - stats.current) * 10) / 10;
+        if (deltaKg !== 0) {
+          toast.message = `${formatDelta(isImperial ? kgToLb(deltaKg) : deltaKg, unit)} since last entry`;
+        }
+      }
+      await popToRoot();
+    } catch (err) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Failed to Log Weight";
+      toast.message = err instanceof Error ? err.message : "Unknown error";
+    }
+  }
+
+  return (
+    <Form
+      isLoading={isLoading}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Log Weight" icon={Icon.LineChart} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      {statusParts.length > 0 && <Form.Description title="Trend" text={statusParts.join("  ·  ")} />}
+      {stats?.weeklyInsight && <Form.Description text={stats.weeklyInsight} />}
+      <Form.TextField
+        id="weight"
+        title={`Weight (${unit})`}
+        placeholder={stats?.current != null ? String(isImperial ? kgToLb(stats.current) : stats.current) : "e.g. 72.5"}
+        error={weightError}
+        onChange={() => {
+          if (weightError) setWeightError(undefined);
+        }}
+        autoFocus
+      />
+      <Form.TextField
+        id="bodyFat"
+        title="Body Fat % (optional)"
+        placeholder="e.g. 18.5"
+        error={bodyFatError}
+        onChange={() => {
+          if (bodyFatError) setBodyFatError(undefined);
+        }}
+      />
+      <Form.TextField id="note" title="Note (optional)" placeholder="e.g. after vacation" />
+    </Form>
+  );
+}
+
+function formatDelta(value: number, unit: string): string {
+  const rounded = Math.round(value * 10) / 10;
+  return `${rounded > 0 ? "+" : ""}${rounded} ${unit}`;
+}

--- a/extensions/caaals/src/quick-log.tsx
+++ b/extensions/caaals/src/quick-log.tsx
@@ -1,0 +1,208 @@
+import { Action, ActionPanel, Form, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { useState } from "react";
+import { addFavorite, getFavoriteFoods, getRecentFoods, logFood, removeFavorite } from "./api";
+import type { Food, MealType } from "./types";
+import {
+  formatMacros,
+  formatMealType,
+  getDefaultMeal,
+  getDefaultServing,
+  MEAL_ICONS,
+  MEALS,
+  scaleNutrition,
+} from "./utils";
+
+export default function QuickLog() {
+  const { data, isLoading, revalidate } = useCachedPromise(async () => {
+    const [favorites, recents] = await Promise.all([getFavoriteFoods(), getRecentFoods()]);
+    const favoriteIds = new Set(favorites.map((f) => f.id));
+    return {
+      favorites,
+      recents: recents.filter((f) => !favoriteIds.has(f.id)),
+    };
+  });
+
+  async function handleLog(food: Food, meal: MealType) {
+    const serving = getDefaultServing(food);
+    const scaled = scaleNutrition(food.nutrition, serving, 1);
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: `Logging ${food.name}...`,
+    });
+    try {
+      await logFood(food, {
+        servingId: serving.id,
+        quantity: 1,
+        meal,
+        loggedAt: new Date().toISOString(),
+      });
+      toast.style = Toast.Style.Success;
+      toast.title = `Logged ${food.name}`;
+      toast.message = `${scaled.calories} kcal · ${MEAL_ICONS[meal]} ${formatMealType(meal)}`;
+    } catch (err) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Failed to Log";
+      toast.message = err instanceof Error ? err.message : "Unknown error";
+    }
+  }
+
+  async function handleToggleFavorite(food: Food, isFavorite: boolean) {
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Updating favorites..." });
+    try {
+      if (isFavorite) {
+        await removeFavorite(food.id);
+        toast.title = "Removed from Favorites";
+      } else {
+        await addFavorite(food);
+        toast.title = "Added to Favorites";
+      }
+      toast.style = Toast.Style.Success;
+      revalidate();
+    } catch (err) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Failed to Update Favorites";
+      toast.message = err instanceof Error ? err.message : "Unknown error";
+    }
+  }
+
+  const renderItem = (food: Food, isFavorite: boolean) => {
+    const serving = getDefaultServing(food);
+    const scaled = scaleNutrition(food.nutrition, serving, 1);
+    const defaultMeal = getDefaultMeal();
+
+    return (
+      <List.Item
+        key={`${isFavorite ? "fav" : "recent"}-${food.id}`}
+        title={food.name}
+        subtitle={food.brand ?? serving.description}
+        icon={isFavorite ? Icon.Star : Icon.Clock}
+        keywords={food.brand ? [food.brand] : undefined}
+        accessories={[
+          { text: formatMacros(scaled), tooltip: `Per ${serving.description}` },
+          { text: `${scaled.calories} kcal` },
+        ]}
+        actions={
+          <ActionPanel>
+            <Action
+              title={`Log to ${formatMealType(defaultMeal)}`}
+              icon={Icon.Plus}
+              onAction={() => handleLog(food, defaultMeal)}
+            />
+            <ActionPanel.Submenu title="Log to Meal" icon={Icon.Calendar}>
+              {MEALS.map((m) => (
+                <Action key={m} title={`${MEAL_ICONS[m]} ${formatMealType(m)}`} onAction={() => handleLog(food, m)} />
+              ))}
+            </ActionPanel.Submenu>
+            <Action.Push
+              title="Adjust and Log"
+              icon={Icon.Pencil}
+              shortcut={{ modifiers: ["cmd"], key: "e" }}
+              target={<AdjustAndLog food={food} />}
+            />
+            <Action
+              title={isFavorite ? "Remove from Favorites" : "Add to Favorites"}
+              icon={isFavorite ? Icon.StarDisabled : Icon.Star}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
+              onAction={() => handleToggleFavorite(food, isFavorite)}
+            />
+            <Action
+              title="Refresh"
+              icon={Icon.ArrowClockwise}
+              shortcut={{ modifiers: ["cmd"], key: "r" }}
+              onAction={revalidate}
+            />
+          </ActionPanel>
+        }
+      />
+    );
+  };
+
+  const isEmpty = data !== undefined && data.favorites.length === 0 && data.recents.length === 0;
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Filter favorites and recent foods...">
+      {isEmpty && (
+        <List.EmptyView
+          title="Nothing to Quick-Log Yet"
+          description="Foods you log and favorite in Caaals will show up here"
+        />
+      )}
+      {data && data.favorites.length > 0 && (
+        <List.Section title="Favorites">{data.favorites.map((f) => renderItem(f, true))}</List.Section>
+      )}
+      {data && data.recents.length > 0 && (
+        <List.Section title="Recents">{data.recents.map((f) => renderItem(f, false))}</List.Section>
+      )}
+    </List>
+  );
+}
+
+function AdjustAndLog({ food }: { food: Food }) {
+  const { pop } = useNavigation();
+  const [quantityError, setQuantityError] = useState<string | undefined>();
+  const servings = food.servings.length > 0 ? food.servings : [getDefaultServing(food)];
+
+  async function handleSubmit(values: { quantity: string; servingId: string; meal: MealType }) {
+    const quantity = parseFloat(values.quantity.replace(",", "."));
+    if (Number.isNaN(quantity) || quantity <= 0 || quantity > 100) {
+      setQuantityError("Enter a number between 0 and 100");
+      return;
+    }
+
+    const serving = servings.find((s) => s.id === values.servingId) ?? servings[0]!;
+    const scaled = scaleNutrition(food.nutrition, serving, quantity);
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: `Logging ${food.name}...`,
+    });
+    try {
+      await logFood(food, {
+        servingId: serving.id,
+        quantity,
+        meal: values.meal,
+        loggedAt: new Date().toISOString(),
+      });
+      toast.style = Toast.Style.Success;
+      toast.title = `Logged ${food.name}`;
+      toast.message = `${scaled.calories} kcal · ${MEAL_ICONS[values.meal]} ${formatMealType(values.meal)}`;
+      pop();
+    } catch (err) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Failed to Log";
+      toast.message = err instanceof Error ? err.message : "Unknown error";
+    }
+  }
+
+  return (
+    <Form
+      navigationTitle={food.name}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Log to Diary" icon={Icon.Checkmark} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.Description title="Food" text={`${food.name}${food.brand ? ` — ${food.brand}` : ""}`} />
+      <Form.TextField
+        id="quantity"
+        title="Quantity"
+        defaultValue="1"
+        error={quantityError}
+        onChange={() => {
+          if (quantityError) setQuantityError(undefined);
+        }}
+      />
+      <Form.Dropdown id="servingId" title="Serving">
+        {servings.map((s) => (
+          <Form.Dropdown.Item key={s.id} value={s.id} title={s.description} />
+        ))}
+      </Form.Dropdown>
+      <Form.Dropdown id="meal" title="Meal" defaultValue={getDefaultMeal()}>
+        {MEALS.map((m) => (
+          <Form.Dropdown.Item key={m} value={m} title={`${MEAL_ICONS[m]} ${formatMealType(m)}`} />
+        ))}
+      </Form.Dropdown>
+    </Form>
+  );
+}

--- a/extensions/caaals/src/today.tsx
+++ b/extensions/caaals/src/today.tsx
@@ -1,0 +1,102 @@
+import {
+  getPreferenceValues,
+  Icon,
+  launchCommand,
+  LaunchType,
+  MenuBarExtra,
+  openExtensionPreferences,
+  updateCommandMetadata,
+} from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { useEffect } from "react";
+import { getDiaryByDate } from "./api";
+import { formatDate } from "./utils";
+
+export default function Today() {
+  // quiet: background refreshes can't show toasts.
+  const { data, isLoading, error, revalidate } = useCachedPromise(() =>
+    getDiaryByDate(formatDate(new Date()), { quiet: true }),
+  );
+
+  const goal = data?.goals.calories ?? null;
+  const consumed = data?.totals.calories ?? null;
+  const remaining = goal != null && consumed != null ? goal - consumed : null;
+
+  const { menuBarStyle } = getPreferenceValues<Preferences.Today>();
+  const title =
+    consumed == null || menuBarStyle === "icon"
+      ? undefined
+      : remaining == null
+        ? menuBarStyle === "number"
+          ? consumed.toLocaleString()
+          : `${consumed.toLocaleString()} kcal`
+        : menuBarStyle === "number"
+          ? remaining.toLocaleString()
+          : remaining >= 0
+            ? `${remaining.toLocaleString()} left`
+            : `${Math.abs(remaining).toLocaleString()} over`;
+
+  // Running a menu-bar command from root search gives no visible feedback, so
+  // surface the live numbers as the command's root-search subtitle instead.
+  useEffect(() => {
+    if (consumed == null) return;
+    const subtitle =
+      remaining == null
+        ? `${consumed.toLocaleString()} kcal logged today`
+        : remaining >= 0
+          ? `${remaining.toLocaleString()} kcal left today`
+          : `${Math.abs(remaining).toLocaleString()} kcal over today`;
+    updateCommandMetadata({ subtitle });
+  }, [consumed, remaining]);
+
+  return (
+    <MenuBarExtra icon="icon.png" title={title} isLoading={isLoading} tooltip="Caaals — today's calories">
+      {error && !data ? (
+        <>
+          <MenuBarExtra.Item title="Could Not Load Today's Diary" />
+          <MenuBarExtra.Item title="Open Preferences" icon={Icon.Gear} onAction={() => openExtensionPreferences()} />
+        </>
+      ) : (
+        data && (
+          <MenuBarExtra.Section title="Today">
+            <MenuBarExtra.Item
+              title={`Calories: ${macroText(data.totals.calories, data.goals.calories, "kcal")}`}
+              icon={Icon.Bolt}
+            />
+            <MenuBarExtra.Item
+              title={`Protein: ${macroText(data.totals.protein, data.goals.protein, "g")}`}
+              icon={Icon.Circle}
+            />
+            <MenuBarExtra.Item
+              title={`Carbs: ${macroText(data.totals.carbs, data.goals.carbs, "g")}`}
+              icon={Icon.Circle}
+            />
+            <MenuBarExtra.Item title={`Fat: ${macroText(data.totals.fat, data.goals.fat, "g")}`} icon={Icon.Circle} />
+            {data.score?.value != null && (
+              <MenuBarExtra.Item title={`Nutrition Score: ${data.score.value}`} icon={Icon.Gauge} />
+            )}
+          </MenuBarExtra.Section>
+        )
+      )}
+      <MenuBarExtra.Section>
+        <MenuBarExtra.Item title="Log Food" icon={Icon.Plus} onAction={() => launch("log-food")} />
+        <MenuBarExtra.Item title="Quick Log" icon={Icon.Star} onAction={() => launch("quick-log")} />
+        <MenuBarExtra.Item title="Browse Diary" icon={Icon.List} onAction={() => launch("browse-diary")} />
+        <MenuBarExtra.Item title="Refresh" icon={Icon.ArrowClockwise} onAction={() => revalidate()} />
+      </MenuBarExtra.Section>
+    </MenuBarExtra>
+  );
+}
+
+function macroText(consumed: number, goal: number | null | undefined, unit: string): string {
+  const value = Math.round(consumed).toLocaleString();
+  return goal ? `${value} / ${Math.round(goal).toLocaleString()} ${unit}` : `${value} ${unit}`;
+}
+
+async function launch(name: string) {
+  try {
+    await launchCommand({ name, type: LaunchType.UserInitiated });
+  } catch {
+    // Command may be disabled by the user — nothing sensible to do from the menu bar.
+  }
+}

--- a/extensions/caaals/src/types.ts
+++ b/extensions/caaals/src/types.ts
@@ -55,7 +55,7 @@ export interface DiaryEntry {
   id: string;
   foodId?: string | null;
   foodKey?: string | null;
-  food: Food;
+  food?: Food | null;
   servingId: string;
   quantity: number;
   meal: MealType;

--- a/extensions/caaals/src/types.ts
+++ b/extensions/caaals/src/types.ts
@@ -1,4 +1,4 @@
-export type FoodSource = "openfoodfacts" | "usda" | "edamam" | "custom" | "ai";
+export type FoodSource = "openfoodfacts" | "usda" | "edamam" | "custom" | "ai" | "internal";
 
 export interface Serving {
   id: string;
@@ -12,9 +12,10 @@ export interface FoodNutrition {
   protein: number;
   carbs: number;
   fat: number;
-  fiber?: number;
-  sugar?: number;
-  sodium?: number;
+  fiber?: number | null;
+  sugar?: number | null;
+  sodium?: number | null;
+  saturatedFat?: number | null;
 }
 
 export interface Food {
@@ -23,7 +24,7 @@ export interface Food {
   source: FoodSource;
   barcode?: string;
   name: string;
-  brand?: string;
+  brand?: string | null;
   servingSize: number;
   servingUnit: string;
   servings: Serving[];
@@ -38,35 +39,100 @@ export interface DiaryEntryNutrition {
   protein: number;
   carbs: number;
   fat: number;
+  fiber: number;
+  sugar: number;
+  sodium: number;
+  saturatedFat?: number;
 }
+
+/**
+ * Entry lifecycle. Pending states (`analyzing`, `needs_confirmation`) are
+ * excluded from daily totals and the nutrition score.
+ */
+export type DiaryEntryStatus = "analyzing" | "needs_confirmation" | "confirmed";
 
 export interface DiaryEntry {
   id: string;
-  foodId?: string;
-  foodKey?: string;
+  foodId?: string | null;
+  foodKey?: string | null;
   food: Food;
   servingId: string;
   quantity: number;
   meal: MealType;
   loggedAt: string;
   nutrition: DiaryEntryNutrition;
+  status: DiaryEntryStatus;
+  analysisText?: string | null;
+}
+
+export interface NutritionScore {
+  value: number | null;
+}
+
+export interface UserGoals {
+  calories: number | null;
+  protein: number | null;
+  carbs: number | null;
+  fat: number | null;
+  fiber?: number | null;
+  sugar?: number | null;
+  sodium?: number | null;
+  saturatedFat?: number | null;
 }
 
 export interface DailySummary {
   date: string;
   totals: DiaryEntryNutrition;
-  goals: DiaryEntryNutrition;
+  goals: UserGoals;
   entries: DiaryEntry[];
+  score?: NutritionScore | null;
+}
+
+export type UnitSystem = "metric" | "imperial";
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  name: string;
+  goals: UserGoals;
+  timezone: string;
+  unitSystem: UnitSystem;
 }
 
 export type AIConfidence = "high" | "medium" | "low";
 
+export type NutritionSource = "database" | "ai_estimated" | "label_extracted";
+
+export interface TokenBalance {
+  used: number;
+  limit: number;
+  resetsAt: string;
+}
+
 export interface AIFoodAnalysisResult {
   food: Food;
+  foodKey: string;
   quantity?: number;
   confidence: AIConfidence;
   warnings?: string[];
-  foodKey: string;
+  nutritionSource?: NutritionSource;
+  /** True when the API flags the estimate for review (implausible or very high calories). */
+  requiresConfirmation?: boolean;
+  /** Persisted analysis id — pass back when logging so corrections feed the accuracy loop. */
+  analysisId?: string;
+}
+
+export interface AnalyzeTextResponse {
+  result: AIFoodAnalysisResult;
+  tokenBalance?: TokenBalance;
+}
+
+export interface DiaryEntryInput {
+  foodId: string;
+  servingId: string;
+  quantity: number;
+  meal: MealType;
+  loggedAt: string;
 }
 
 export interface DiaryEntryFromSnapshotInput {
@@ -76,4 +142,39 @@ export interface DiaryEntryFromSnapshotInput {
   quantity: number;
   meal: MealType;
   loggedAt: string;
+  aiAnalysisId?: string;
+}
+
+export interface UpdateDiaryEntryInput {
+  servingId?: string;
+  quantity?: number;
+  meal?: MealType;
+  status?: "confirmed";
+}
+
+export interface CopyMealInput {
+  fromDate: string;
+  toDate: string;
+  meal: MealType;
+}
+
+export interface WeightEntry {
+  id: string;
+  weightKg: number;
+  bodyFatPct?: number | null;
+  note?: string | null;
+  loggedDate: string;
+  loggedAt: string;
+  source: string;
+}
+
+export interface WeightStats {
+  current: number | null;
+  goal: number | null;
+  change7d: number | null;
+  ratePerWeek: number | null;
+  streak: number;
+  calorieAvg7d: number | null;
+  bodyFatPct: number | null;
+  weeklyInsight: string | null;
 }

--- a/extensions/caaals/src/utils.ts
+++ b/extensions/caaals/src/utils.ts
@@ -1,4 +1,5 @@
-import type { Food, MealType, Serving } from "./types";
+import { Color } from "@raycast/api";
+import type { Food, FoodNutrition, MealType, Serving } from "./types";
 
 export const MEAL_ICONS: Record<MealType, string> = {
   breakfast: "🌅",
@@ -21,6 +22,19 @@ export function formatMealType(meal: MealType): string {
   return meal.charAt(0).toUpperCase() + meal.slice(1);
 }
 
+export function mealColor(meal: MealType): Color {
+  switch (meal) {
+    case "breakfast":
+      return Color.Orange;
+    case "lunch":
+      return Color.Yellow;
+    case "dinner":
+      return Color.Blue;
+    case "snack":
+      return Color.Purple;
+  }
+}
+
 export function getDefaultServing(food: Food): Serving {
   if (food.servings.length > 0) {
     return food.servings[0]!;
@@ -38,6 +52,45 @@ export function formatServingWithQuantity(serving: Serving, quantity: number): s
   return `${quantity} × ${serving.description}`;
 }
 
+export interface ScaledNutrition {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber: number | null;
+  sugar: number | null;
+  sodium: number | null;
+}
+
+/** Nutrition for `quantity × serving` of a food (per-base-serving values scaled). */
+export function scaleNutrition(nutrition: FoodNutrition, serving: Serving, quantity: number): ScaledNutrition {
+  const m = serving.multiplier * quantity;
+  const round1 = (x: number) => Math.round(x * m * 10) / 10;
+  return {
+    calories: Math.round(nutrition.calories * m),
+    protein: round1(nutrition.protein),
+    carbs: round1(nutrition.carbs),
+    fat: round1(nutrition.fat),
+    fiber: nutrition.fiber != null ? round1(nutrition.fiber) : null,
+    sugar: nutrition.sugar != null ? round1(nutrition.sugar) : null,
+    sodium: nutrition.sodium != null ? Math.round(nutrition.sodium * m) : null,
+  };
+}
+
+export function formatMacros(n: { protein: number; carbs: number; fat: number }): string {
+  return `P ${n.protein}g · C ${n.carbs}g · F ${n.fat}g`;
+}
+
+export const KG_PER_LB = 0.45359237;
+
+export function kgToLb(kg: number): number {
+  return Math.round((kg / KG_PER_LB) * 10) / 10;
+}
+
+export function lbToKg(lb: number): number {
+  return Math.round(lb * KG_PER_LB * 10) / 10;
+}
+
 export function formatDate(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
@@ -45,15 +98,15 @@ export function formatDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+export function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return formatDate(d);
+}
+
 export function formatDateSection(dateStr: string): string {
-  const today = formatDate(new Date());
-
-  const yesterday = new Date();
-  yesterday.setDate(yesterday.getDate() - 1);
-  const yesterdayStr = formatDate(yesterday);
-
-  if (dateStr === today) return "Today";
-  if (dateStr === yesterdayStr) return "Yesterday";
+  if (dateStr === formatDate(new Date())) return "Today";
+  if (dateStr === daysAgo(1)) return "Yesterday";
 
   const [year, month, day] = dateStr.split("-").map(Number);
   const date = new Date(Date.UTC(year!, month! - 1, day!));


### PR DESCRIPTION
## Description

Major feature update for the **Caaals Food Tracker** extension (I'm the extension author and the developer of the Caaals app/API).

### New commands
- **Quick Log** — favorites + recent foods in a list; Enter logs 1 serving to the time-appropriate meal instantly (no AI call). Actions to pick a meal, adjust quantity/serving, and manage favorites.
- **Log Weight** — record today's weight with optional body fat % and note; shows current weight, 7-day change, and goal. Follows the user's metric/imperial preference.
- **Today's Calories in Menu Bar** — menu-bar command (15 min background interval) showing remaining calories; dropdown has macros vs goals and nutrition score. Includes a display-style preference (full / number only / icon only) for crowded menu bars, and updates its root-search subtitle with live status via `updateCommandMetadata`.

### Improved commands
- **Log Food** — optional root-search argument to skip the form; quantity/serving/meal adjustment on the confirmation screen; AI confidence, nutrition source, and token balance shown; entries link back to their AI analysis for accuracy tracking.
- **Browse Diary** — one summary request for the whole week instead of 7; daily goal + nutrition score per section; confirm flagged entries; log again today, change meal, copy meal to today, add to favorites.

### Notes for review
- Pulled and merged the latest store contributions (eslint flat config, prettier 120, compressed assets) before submitting.
- `ray build`, `ray lint`, and `tsc --noEmit` all pass.
- All endpoints exercised against a live Caaals API instance.

## Type of change
- [x] Improvement (non-breaking change which improves an existing extension)

## Checklist
- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder