### PR TITLE
[Quick Notes] Show clear errors when opening a note externally fails

### DIFF
--- a/extensions/quick-notes/CHANGELOG.md
+++ b/extensions/quick-notes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quick Notes Changelog
 
-## [Clear Errors for Open Note Externally] - {PR_MERGE_DATE}
+## [Clear Errors for Open Note Externally] - 2026-07-07
 
 - `Open Note Externally` now shows a clear error toast instead of a cryptic macOS "-50" dialog when the auto save folder is unset, missing on disk, or the note's markdown file doesn't exist
 - Error toasts for a missing or unset auto save location include a shortcut to open the extension settings

--- a/extensions/quick-notes/CHANGELOG.md
+++ b/extensions/quick-notes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Quick Notes Changelog
 
+## [Clear Errors for Open Note Externally] - {PR_MERGE_DATE}
+
+- `Open Note Externally` now shows a clear error toast instead of a cryptic macOS "-50" dialog when the auto save folder is unset, missing on disk, or the note's markdown file doesn't exist
+- Error toasts for a missing or unset auto save location include a shortcut to open the extension settings
+
 ## [YAML Frontmatter] - 2026-07-07
 
 - Notes saved or exported as markdown now include YAML frontmatter (`title`, `date`, `tags`) and an H1 title, ready for GitHub Pages / Jekyll blogs and Obsidian

--- a/extensions/quick-notes/src/components/actions.tsx
+++ b/extensions/quick-notes/src/components/actions.tsx
@@ -1,4 +1,15 @@
-import { ActionPanel, Action, Icon, Clipboard, showToast, Toast, environment, open, AI } from "@raycast/api";
+import {
+  ActionPanel,
+  Action,
+  Icon,
+  Clipboard,
+  showToast,
+  Toast,
+  environment,
+  open,
+  openExtensionPreferences,
+  AI,
+} from "@raycast/api";
 import { preferences } from "../services/config";
 import CreateEditNoteForm from "./createEditNoteForm";
 import CreateTag from "./createTag";
@@ -11,6 +22,7 @@ import { useCachedState } from "@raycast/utils";
 import { useResetAtom } from "jotai/utils";
 import slugify from "slugify";
 import path from "path";
+import fs from "fs";
 
 const Actions = ({
   noNotes,
@@ -81,12 +93,43 @@ const Actions = ({
               title="Open Note Externally"
               icon={{ source: Icon.Folder, tintColor: getTintColor("turquoise") }}
               shortcut={{ modifiers: ["cmd"], key: "o" }}
-              onAction={() => {
+              onAction={async () => {
+                const openPreferencesAction = {
+                  title: "Open Extension Settings",
+                  onAction: () => openExtensionPreferences(),
+                };
                 if (!preferences.fileLocation) {
-                  showToast({ style: Toast.Style.Failure, title: "No Auto Save Location Set" });
+                  await showToast({
+                    style: Toast.Style.Failure,
+                    title: "No Auto Save Location Set",
+                    message: "Set a folder in the extension settings",
+                    primaryAction: openPreferencesAction,
+                  });
                   return;
                 }
-                open(path.join(preferences.fileLocation, `${slugify(`${title}`)}.md`));
+                if (!fs.existsSync(preferences.fileLocation)) {
+                  await showToast({
+                    style: Toast.Style.Failure,
+                    title: "Auto Save Location Not Found",
+                    message: "The folder no longer exists — update it in the extension settings",
+                    primaryAction: openPreferencesAction,
+                  });
+                  return;
+                }
+                const notePath = path.join(preferences.fileLocation, `${slugify(`${title}`)}.md`);
+                if (!fs.existsSync(notePath)) {
+                  await showToast({
+                    style: Toast.Style.Failure,
+                    title: "Note File Not Found",
+                    message: "Save the note or run Sync with Folder to export it first",
+                  });
+                  return;
+                }
+                try {
+                  await open(notePath);
+                } catch {
+                  await showToast({ style: Toast.Style.Failure, title: "Failed to Open Note", message: notePath });
+                }
               }}
             />
           </>

--- a/extensions/quick-notes/src/sync.tsx
+++ b/extensions/quick-notes/src/sync.tsx
@@ -1,4 +1,4 @@
-import { Toast, showToast, trash } from "@raycast/api";
+import { Toast, showToast, trash, openExtensionPreferences } from "@raycast/api";
 import { TAGS_FILE_PATH, TODO_FILE_PATH, preferences } from "./services/config";
 import { exportNotes, getInitialValuesFromFile, getRandomColor, getSyncWithDirectory } from "./utils/utils";
 import { Tag } from "./services/atoms";
@@ -7,7 +7,15 @@ import fs from "fs";
 export default async function Command() {
   const filePath = preferences.fileLocation;
   if (!filePath) {
-    await showToast({ style: Toast.Style.Failure, title: "No Auto Save Location Set" });
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "No Auto Save Location Set",
+      message: "Set a folder in the extension settings",
+      primaryAction: {
+        title: "Open Extension Settings",
+        onAction: () => openExtensionPreferences(),
+      },
+    });
     return;
   }
   try {


### PR DESCRIPTION
## Description

`Open Note Externally` (⌘O) could surface a cryptic macOS dialog — *"The application can't be opened. -50"* — because the note path was handed to `open()` without checking it exists. This happens when the auto save folder was deleted/moved since it was set, or the note's markdown file was never exported to it.

Now, before opening:

- **No auto save location set** → failure toast telling the user to set a folder in the extension settings, with a primary action that opens the extension settings directly
- **Folder set but missing on disk** → failure toast with the same settings shortcut
- **Note file missing** → failure toast suggesting saving the note or running `Sync with Folder` first
- `open()` is awaited in a try/catch so any remaining failure shows a toast instead of a macOS error dialog

The `Sync with Folder` command's existing "No Auto Save Location Set" toast gets the same message and open-settings action for consistency.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder