### PR TITLE
Fix Clean Text active app paste

### DIFF
--- a/extensions/clean-text/CHANGELOG.md
+++ b/extensions/clean-text/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Clean Text Changelog
 
+## [Fix Active App Paste] - 2026-07-07
+
+- Fixed a crash that could occur when pasting cleaned text if Raycast couldn't resolve the active app bundle.
+- Falls back to copying the cleaned text when pasting to the active app fails.
+
 ## [Initial Version] - 2025-10-09
 
 - Initial release of Clean Text Raycast Extension

--- a/extensions/clean-text/CHANGELOG.md
+++ b/extensions/clean-text/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clean Text Changelog
 
-## [Fix Active App Paste] - {PR_MERGE_DATE}
+## [Fix Active App Paste] - 2026-07-07
 
 - Fixed a crash that could occur when pasting cleaned text if Raycast couldn't resolve the active app bundle.
 - Falls back to copying the cleaned text when pasting to the active app fails.

--- a/extensions/clean-text/CHANGELOG.md
+++ b/extensions/clean-text/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clean Text Changelog
 
-## [Fix Active App Paste] - 2026-07-07
+## [Fix Active App Paste] - {PR_MERGE_DATE}
 
 - Fixed a crash that could occur when pasting cleaned text if Raycast couldn't resolve the active app bundle.
 - Falls back to copying the cleaned text when pasting to the active app fails.

--- a/extensions/clean-text/src/clean-text.tsx
+++ b/extensions/clean-text/src/clean-text.tsx
@@ -1,12 +1,10 @@
 import {
   Action,
   ActionPanel,
-  Application,
   Clipboard,
   closeMainWindow,
   Color,
   environment,
-  getFrontmostApplication,
   getPreferenceValues,
   getSelectedText,
   Icon,
@@ -20,6 +18,7 @@ import {
   LocalStorage,
 } from "@raycast/api";
 import React, { useEffect, useState } from "react";
+import { pasteOrCopy } from "./clipboard";
 import { functions, aliases, convert, modifyTextWrapper, ModificationType } from "./modifications";
 
 class NoTextError extends Error {
@@ -94,13 +93,12 @@ export default function Command(props: LaunchProps) {
         const modified = convert(content, applyModification);
 
         if (preferredAction === "paste") {
-          Clipboard.paste(modified);
-          Clipboard.copy(modified);
+          await pasteOrCopy(modified, `Applied ${applyModification}`);
         } else {
-          Clipboard.copy(modified);
+          await Clipboard.copy(modified);
+          await showHUD(`Applied ${applyModification}`);
         }
 
-        showHUD(`Applied ${applyModification}`);
         popToRoot();
       } catch (error) {
         showToast({
@@ -114,7 +112,6 @@ export default function Command(props: LaunchProps) {
   }
 
   const [content, setContent] = useState<string>("");
-  const [frontmostApp, setFrontmostApp] = useState<Application>();
 
   const [pinned, setPinned] = useState<ModificationType[]>([]);
   const [recent, setRecent] = useState<ModificationType[]>([]);
@@ -135,7 +132,6 @@ export default function Command(props: LaunchProps) {
     };
 
     loadFromCache();
-    getFrontmostApplication().then(setFrontmostApp);
   }, []);
 
   useEffect(() => {
@@ -200,17 +196,15 @@ export default function Command(props: LaunchProps) {
     pinned?: boolean;
     recent?: boolean;
   }) => {
-    return frontmostApp ? (
+    return (
       <Action
-        title={`Paste in ${frontmostApp.name}`}
-        icon={{ fileIcon: frontmostApp.path }}
-        onAction={() => {
+        title="Paste to Active App"
+        icon={Icon.Clipboard}
+        onAction={async () => {
           setRecent(
             [props.modification, ...recent.filter((c) => c !== props.modification)].slice(0, 4 + pinned.length),
           );
-          showHUD(`Pasted in ${frontmostApp.name}`);
-          Clipboard.paste(props.modified);
-          Clipboard.copy(props.modified);
+          await pasteOrCopy(props.modified, "Pasted to active app");
           if (preferences.popToRoot) {
             popToRoot();
           } else {
@@ -218,7 +212,7 @@ export default function Command(props: LaunchProps) {
           }
         }}
       />
-    ) : null;
+    );
   };
 
   const ModificationItem = (props: {

--- a/extensions/clean-text/src/clipboard.ts
+++ b/extensions/clean-text/src/clipboard.ts
@@ -1,12 +1,14 @@
 import { Clipboard, showHUD } from "@raycast/api";
 
 export async function pasteOrCopy(text: string, pastedMessage: string) {
+  let didPaste = true;
+
   try {
     await Clipboard.paste(text);
-    await Clipboard.copy(text);
-    await showHUD(pastedMessage);
   } catch {
-    await Clipboard.copy(text);
-    await showHUD("Couldn't paste; copied to Clipboard");
+    didPaste = false;
   }
+
+  await Clipboard.copy(text);
+  await showHUD(didPaste ? pastedMessage : "Couldn't paste; copied to Clipboard");
 }

--- a/extensions/clean-text/src/clipboard.ts
+++ b/extensions/clean-text/src/clipboard.ts
@@ -1,0 +1,12 @@
+import { Clipboard, showHUD } from "@raycast/api";
+
+export async function pasteOrCopy(text: string, pastedMessage: string) {
+  try {
+    await Clipboard.paste(text);
+    await Clipboard.copy(text);
+    await showHUD(pastedMessage);
+  } catch {
+    await Clipboard.copy(text);
+    await showHUD("Couldn't paste; copied to Clipboard");
+  }
+}

--- a/extensions/clean-text/src/combo1.tsx
+++ b/extensions/clean-text/src/combo1.tsx
@@ -8,6 +8,7 @@ import {
   showToast,
   Toast,
 } from "@raycast/api";
+import { pasteOrCopy } from "./clipboard";
 import { convert } from "./modifications";
 
 async function getSelection() {
@@ -96,8 +97,7 @@ export default async function Combo1Command() {
     }
 
     if (preferences.action === "paste") {
-      await Clipboard.paste(result);
-      await showHUD(`Combo 1: Applied ${modificationCount} modifications and pasted`);
+      await pasteOrCopy(result, `Combo 1: Applied ${modificationCount} modifications and pasted`);
     } else {
       await Clipboard.copy(result);
       await showHUD(`Combo 1: Applied ${modificationCount} modifications and copied`);

--- a/extensions/clean-text/src/combo2.tsx
+++ b/extensions/clean-text/src/combo2.tsx
@@ -8,6 +8,7 @@ import {
   showToast,
   Toast,
 } from "@raycast/api";
+import { pasteOrCopy } from "./clipboard";
 import { convert } from "./modifications";
 
 async function getSelection() {
@@ -96,8 +97,7 @@ export default async function Combo2Command() {
     }
 
     if (preferences.action === "paste") {
-      await Clipboard.paste(result);
-      await showHUD(`Combo 2: Applied ${modificationCount} modifications and pasted`);
+      await pasteOrCopy(result, `Combo 2: Applied ${modificationCount} modifications and pasted`);
     } else {
       await Clipboard.copy(result);
       await showHUD(`Combo 2: Applied ${modificationCount} modifications and copied`);


### PR DESCRIPTION
## Summary

- remove Clean Text's explicit frontmost application lookup before rendering the paste action
- use Raycast's standard `Clipboard.paste()` path for active-app paste behavior
- add a shared paste fallback that copies the cleaned text if pasting fails

## Why

Clean Text rendered a paste action by calling `getFrontmostApplication()` and using the returned app path as a file icon. When Raycast cannot resolve the active application's bundle, the command can fail with `Cannot get bundle for application`.

Other text-focused extensions generally rely on `Clipboard.paste()` directly instead of resolving the frontmost app first. This keeps Clean Text aligned with that pattern and avoids the fragile bundle lookup.

## Validation

- `npm run lint`
- `npm run build`
- `npx tsc --noEmit`
