### PR TITLE
[Safari] Search tabs across local Safari variants

### DIFF
--- a/extensions/safari/package.json
+++ b/extensions/safari/package.json
@@ -185,7 +185,7 @@
       "type": "dropdown",
       "required": false,
       "title": "Local Safari Browser",
-      "description": "Switch between Safari or Safari Technology Preview",
+      "description": "Default Safari browser for single-browser commands. Search Tabs scans installed Safari variants automatically.",
       "default": "Safari",
       "data": [
         {
@@ -580,6 +580,7 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test --experimental-strip-types tests/**/*.test.mts",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
   },

--- a/extensions/safari/src/cloud-tabs.tsx
+++ b/extensions/safari/src/cloud-tabs.tsx
@@ -8,7 +8,7 @@ import { Device, Tab } from "./types";
 import { search } from "./utils";
 
 export default function Command() {
-  const { devices, permissionView, refreshDevices } = useDevices();
+  const { devices, isLoading, permissionView, refreshDevices } = useDevices();
   const [searchText, setSearchText] = useState("");
   const throttleSearchText = useThrottle(searchText, { wait: 200 });
 
@@ -17,7 +17,7 @@ export default function Command() {
   }
 
   return (
-    <List isLoading={!devices} onSearchTextChange={setSearchText}>
+    <List isLoading={isLoading} onSearchTextChange={setSearchText}>
       {_.map(devices, (device: Device) => {
         const tabs = search(
           typeof device.tabs === "undefined" ? [] : device.tabs,

--- a/extensions/safari/src/cloud-tabs.tsx
+++ b/extensions/safari/src/cloud-tabs.tsx
@@ -12,8 +12,8 @@ export default function Command() {
   const [searchText, setSearchText] = useState("");
   const throttleSearchText = useThrottle(searchText, { wait: 200 });
 
-  if (permissionView.current) {
-    return permissionView.current;
+  if (permissionView) {
+    return permissionView;
   }
 
   return (

--- a/extensions/safari/src/components/CloseLocalTabAction.tsx
+++ b/extensions/safari/src/components/CloseLocalTabAction.tsx
@@ -2,14 +2,14 @@ import { Action, Icon } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
 import { LocalTab, Tab } from "../types";
 import { safariAppIdentifier } from "../utils";
-import { getLocalTabApplicationName } from "../tab-utils";
+import { getLocalTabApplicationTarget } from "../tab-utils";
 
 function escapeAppleScriptString(value: string) {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
 async function closeLocalTab(tab: LocalTab) {
-  const appTarget = escapeAppleScriptString(getLocalTabApplicationName(tab, safariAppIdentifier));
+  const appTarget = escapeAppleScriptString(getLocalTabApplicationTarget(tab, safariAppIdentifier));
 
   const script = `
     tell application "${appTarget}"

--- a/extensions/safari/src/components/CloseLocalTabAction.tsx
+++ b/extensions/safari/src/components/CloseLocalTabAction.tsx
@@ -2,13 +2,14 @@ import { Action, Icon } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
 import { LocalTab, Tab } from "../types";
 import { safariAppIdentifier } from "../utils";
+import { getLocalTabApplicationName } from "../tab-utils";
 
 function escapeAppleScriptString(value: string) {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
 async function closeLocalTab(tab: LocalTab) {
-  const appTarget = escapeAppleScriptString(tab.app_path || safariAppIdentifier);
+  const appTarget = escapeAppleScriptString(getLocalTabApplicationName(tab, safariAppIdentifier));
 
   const script = `
     tell application "${appTarget}"

--- a/extensions/safari/src/components/CloseLocalTabAction.tsx
+++ b/extensions/safari/src/components/CloseLocalTabAction.tsx
@@ -3,9 +3,15 @@ import { runAppleScript } from "@raycast/utils";
 import { LocalTab, Tab } from "../types";
 import { safariAppIdentifier } from "../utils";
 
+function escapeAppleScriptString(value: string) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
 async function closeLocalTab(tab: LocalTab) {
+  const appTarget = escapeAppleScriptString(tab.app_path || safariAppIdentifier);
+
   const script = `
-    tell application "${safariAppIdentifier}"
+    tell application "${appTarget}"
       set windowID to ${tab.window_id}
       set tabID to ${tab.index}
       tell window id windowID

--- a/extensions/safari/src/components/OpenTabAction.tsx
+++ b/extensions/safari/src/components/OpenTabAction.tsx
@@ -2,14 +2,14 @@ import { Action, closeMainWindow, Icon } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
 import { LocalTab, Tab } from "../types";
 import { safariAppIdentifier } from "../utils";
-import { getLocalTabApplicationName } from "../tab-utils";
+import { getLocalTabApplicationTarget } from "../tab-utils";
 
 function escapeAppleScriptString(value: string) {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
 async function activateLocalTab(tab: LocalTab) {
-  const appTarget = escapeAppleScriptString(getLocalTabApplicationName(tab, safariAppIdentifier));
+  const appTarget = escapeAppleScriptString(getLocalTabApplicationTarget(tab, safariAppIdentifier));
 
   const script = `
     tell application "${appTarget}"

--- a/extensions/safari/src/components/OpenTabAction.tsx
+++ b/extensions/safari/src/components/OpenTabAction.tsx
@@ -3,9 +3,15 @@ import { runAppleScript } from "@raycast/utils";
 import { LocalTab, Tab } from "../types";
 import { safariAppIdentifier } from "../utils";
 
+function escapeAppleScriptString(value: string) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
 async function activateLocalTab(tab: LocalTab) {
+  const appTarget = escapeAppleScriptString(tab.app_path || safariAppIdentifier);
+
   const script = `
-    tell application "${safariAppIdentifier}"
+    tell application "${appTarget}"
       set windowID to ${tab.window_id}
       set tabID to ${tab.index}
       set windowObj to window id windowID

--- a/extensions/safari/src/components/OpenTabAction.tsx
+++ b/extensions/safari/src/components/OpenTabAction.tsx
@@ -2,13 +2,14 @@ import { Action, closeMainWindow, Icon } from "@raycast/api";
 import { runAppleScript } from "@raycast/utils";
 import { LocalTab, Tab } from "../types";
 import { safariAppIdentifier } from "../utils";
+import { getLocalTabApplicationName } from "../tab-utils";
 
 function escapeAppleScriptString(value: string) {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
 async function activateLocalTab(tab: LocalTab) {
-  const appTarget = escapeAppleScriptString(tab.app_path || safariAppIdentifier);
+  const appTarget = escapeAppleScriptString(getLocalTabApplicationName(tab, safariAppIdentifier));
 
   const script = `
     tell application "${appTarget}"

--- a/extensions/safari/src/device-tab-sections.ts
+++ b/extensions/safari/src/device-tab-sections.ts
@@ -1,0 +1,10 @@
+import type { Device, Tab } from "./types";
+
+export interface DeviceTabSection {
+  device: Device;
+  tabs: Tab[];
+}
+
+export function getDeviceTabSections(devices: Device[], getTabs: (device: Device) => Tab[]): DeviceTabSection[] {
+  return devices.map((device) => ({ device, tabs: getTabs(device) })).filter((section) => section.tabs.length > 0);
+}

--- a/extensions/safari/src/hooks/useDevices.ts
+++ b/extensions/safari/src/hooks/useDevices.ts
@@ -7,7 +7,7 @@ import { Device, LocalTab, RemoteTab } from "../types";
 import { useMemo } from "react";
 import { getLocalTabs } from "swift:../../swift/SafariTabs";
 import { getInstalledSafariApps } from "../safari-apps";
-import { isStartPageTab } from "../tab-utils";
+import { shouldHideTab } from "../tab-utils";
 
 const DATABASE_PATH = `${resolve(homedir(), `Library/Containers/com.apple.Safari/Data/Library/Safari`)}/CloudTabs.db`;
 
@@ -18,7 +18,7 @@ async function fetchLocalDevices(deviceName: string): Promise<Device[]> {
     safariApps.map(async (app) => {
       try {
         const tabs = ((await getLocalTabs(app.path, app.id, app.name)) as LocalTab[]).filter(
-          (tab) => !isStartPageTab(tab),
+          (tab) => !shouldHideTab(tab),
         );
 
         return {
@@ -72,7 +72,7 @@ export default function useDevices() {
   const remoteDevices = useMemo(
     () =>
       _.chain(remoteTabs.data)
-        .reject(isStartPageTab)
+        .reject(shouldHideTab)
         .groupBy("device_uuid")
         .transform((accumulator: Device[], tabs: RemoteTab[], device_uuid: string) => {
           accumulator.push({

--- a/extensions/safari/src/hooks/useDevices.ts
+++ b/extensions/safari/src/hooks/useDevices.ts
@@ -4,7 +4,7 @@ import _ from "lodash";
 import { homedir } from "os";
 import { resolve } from "path";
 import { Device, LocalTab, RemoteTab } from "../types";
-import { JSX, useLayoutEffect, useRef, useState } from "react";
+import { useMemo } from "react";
 import { getLocalTabs } from "swift:../../swift/SafariTabs";
 import { getInstalledSafariApps } from "../safari-apps";
 import { isStartPageTab } from "../tab-utils";
@@ -67,18 +67,11 @@ export default function useDevices() {
   const { data: deviceName } = useDeviceName();
   const localDevices = useLocalDevices(deviceName);
   const remoteTabs = useRemoteTabs();
-  const [devices, setDevices] = useState<Device[]>([]);
-  const permissionView = useRef<JSX.Element | null>(null);
+  const preferences = getPreferenceValues();
 
-  useLayoutEffect(() => {
-    if (localDevices.isLoading) {
-      setDevices([]);
-      return;
-    }
-
-    const preferences = getPreferenceValues();
-    if (preferences.areRemoteTabsUsed) {
-      const remoteDevices = _.chain(remoteTabs.data)
+  const remoteDevices = useMemo(
+    () =>
+      _.chain(remoteTabs.data)
         .reject(isStartPageTab)
         .groupBy("device_uuid")
         .transform((accumulator: Device[], tabs: RemoteTab[], device_uuid: string) => {
@@ -89,14 +82,14 @@ export default function useDevices() {
           });
         }, [])
         .reject(["name", deviceName])
-        .value();
+        .value(),
+    [remoteTabs.data, deviceName],
+  );
 
-      setDevices([...(localDevices.data || []), ...remoteDevices]);
-      permissionView.current = remoteTabs.permissionView || null;
-    } else {
-      setDevices(localDevices.data || []);
-    }
-  }, [localDevices.data, localDevices.isLoading, remoteTabs.data, deviceName]);
+  const localData = localDevices.isLoading ? [] : localDevices.data || [];
+  const devices = preferences.areRemoteTabsUsed ? [...localData, ...remoteDevices] : localData;
+  const isLoading = localDevices.isLoading || (preferences.areRemoteTabsUsed && remoteTabs.isLoading);
+  const permissionView = preferences.areRemoteTabsUsed ? remoteTabs.permissionView || null : null;
 
-  return { devices, isLoading: localDevices.isLoading, permissionView, refreshDevices: localDevices.revalidate };
+  return { devices, isLoading, permissionView, refreshDevices: localDevices.revalidate };
 }

--- a/extensions/safari/src/hooks/useDevices.ts
+++ b/extensions/safari/src/hooks/useDevices.ts
@@ -4,14 +4,43 @@ import _ from "lodash";
 import { homedir } from "os";
 import { resolve } from "path";
 import { Device, LocalTab, RemoteTab } from "../types";
-import { safariAppIdentifier } from "../utils";
-import { JSX, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { JSX, useLayoutEffect, useRef, useState } from "react";
 import { getLocalTabs } from "swift:../../swift/SafariTabs";
+import { getInstalledSafariApps } from "../safari-apps";
+import { isStartPageTab } from "../tab-utils";
 
 const DATABASE_PATH = `${resolve(homedir(), `Library/Containers/com.apple.Safari/Data/Library/Safari`)}/CloudTabs.db`;
 
-function fetchLocalTabs(): Promise<LocalTab[]> {
-  return getLocalTabs(safariAppIdentifier) as Promise<LocalTab[]>;
+async function fetchLocalDevices(deviceName: string): Promise<Device[]> {
+  const safariApps = await getInstalledSafariApps();
+
+  const localDevices = await Promise.all(
+    safariApps.map(async (app) => {
+      try {
+        const tabs = ((await getLocalTabs(app.path, app.id, app.name)) as LocalTab[]).filter(
+          (tab) => !isStartPageTab(tab),
+        );
+
+        return {
+          uuid: `local:${app.id}`,
+          name: `${deviceName} ★ - ${app.name}`,
+          tabs,
+        };
+      } catch (error) {
+        if (process.env.NODE_ENV === "development") {
+          console.error(`Failed to get tabs for ${app.name}`, error);
+        }
+
+        return {
+          uuid: `local:${app.id}`,
+          name: `${deviceName} ★ - ${app.name}`,
+          tabs: [],
+        };
+      }
+    }),
+  );
+
+  return localDevices.filter((device) => device.tabs.length > 0);
 }
 
 function useRemoteTabs() {
@@ -30,30 +59,27 @@ function useDeviceName() {
   });
 }
 
-function useLocalTabs() {
-  return useCachedPromise(fetchLocalTabs, [], { keepPreviousData: true });
+function useLocalDevices(deviceName?: string) {
+  return useCachedPromise(fetchLocalDevices, [deviceName || "This Mac"], { keepPreviousData: false });
 }
 
 export default function useDevices() {
   const { data: deviceName } = useDeviceName();
-  const localTabs = useLocalTabs();
+  const localDevices = useLocalDevices(deviceName);
   const remoteTabs = useRemoteTabs();
   const [devices, setDevices] = useState<Device[]>([]);
   const permissionView = useRef<JSX.Element | null>(null);
 
-  const localDevice: Device = useMemo(
-    () => ({
-      uuid: "local",
-      name: `${deviceName} ★`,
-      tabs: localTabs.data || [],
-    }),
-    [deviceName, localTabs.data],
-  );
-
   useLayoutEffect(() => {
+    if (localDevices.isLoading) {
+      setDevices([]);
+      return;
+    }
+
     const preferences = getPreferenceValues();
     if (preferences.areRemoteTabsUsed) {
       const remoteDevices = _.chain(remoteTabs.data)
+        .reject(isStartPageTab)
         .groupBy("device_uuid")
         .transform((accumulator: Device[], tabs: RemoteTab[], device_uuid: string) => {
           accumulator.push({
@@ -65,12 +91,12 @@ export default function useDevices() {
         .reject(["name", deviceName])
         .value();
 
-      setDevices([localDevice, ...remoteDevices]);
+      setDevices([...(localDevices.data || []), ...remoteDevices]);
       permissionView.current = remoteTabs.permissionView || null;
     } else {
-      setDevices([localDevice]);
+      setDevices(localDevices.data || []);
     }
-  }, [localTabs.data, remoteTabs.data, deviceName]);
+  }, [localDevices.data, localDevices.isLoading, remoteTabs.data, deviceName]);
 
-  return { devices, permissionView, refreshDevices: localTabs.revalidate };
+  return { devices, isLoading: localDevices.isLoading, permissionView, refreshDevices: localDevices.revalidate };
 }

--- a/extensions/safari/src/safari-apps.ts
+++ b/extensions/safari/src/safari-apps.ts
@@ -1,0 +1,69 @@
+import { access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { SafariApp } from "./types";
+
+type KnownSafariApp = Omit<SafariApp, "path"> & {
+  relativePaths: string[];
+};
+
+const APPLICATION_DIRECTORIES = ["/Applications", join(homedir(), "Applications")];
+
+const KNOWN_SAFARI_APPS: KnownSafariApp[] = [
+  {
+    id: "safari",
+    name: "Safari",
+    bundleIdentifier: "com.apple.Safari",
+    relativePaths: ["Safari.app"],
+  },
+  {
+    id: "safari-technology-preview",
+    name: "Safari Technology Preview",
+    bundleIdentifier: "com.apple.SafariTechnologyPreview",
+    relativePaths: ["Safari Technology Preview.app"],
+  },
+  {
+    id: "safari-nightly",
+    name: "Safari Nightly",
+    bundleIdentifier: "com.apple.Safari",
+    relativePaths: ["Safari Nightly.app"],
+  },
+];
+
+type PathExists = (path: string) => Promise<boolean>;
+
+async function pathExists(path: string) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getInstalledSafariApps(
+  exists: PathExists = pathExists,
+  applicationDirectories = APPLICATION_DIRECTORIES,
+): Promise<SafariApp[]> {
+  const apps = await Promise.all(
+    KNOWN_SAFARI_APPS.map(async (app) => {
+      for (const applicationDirectory of applicationDirectories) {
+        for (const relativePath of app.relativePaths) {
+          const appPath = join(applicationDirectory, relativePath);
+          if (await exists(appPath)) {
+            return {
+              id: app.id,
+              name: app.name,
+              path: appPath,
+              bundleIdentifier: app.bundleIdentifier,
+            };
+          }
+        }
+      }
+
+      return null;
+    }),
+  );
+
+  return apps.filter((app): app is SafariApp => Boolean(app));
+}

--- a/extensions/safari/src/search-all.tsx
+++ b/extensions/safari/src/search-all.tsx
@@ -3,10 +3,11 @@ import { useThrottle } from "ahooks";
 import { useMemo, useState } from "react";
 import { FallbackSearchSection, PermissionError } from "./components";
 import BookmarkListItem from "./components/BookmarkListItem";
+import DeviceListSection from "./components/DeviceListSection";
 import HistoryListItem from "./components/HistoryListItem";
-import TabListItem from "./components/TabListItem";
+import { getDeviceTabSections } from "./device-tab-sections";
 import { useBookmarks, useDevices, useHistorySearch } from "./hooks";
-import { Device, GeneralBookmark, HistoryItem, Tab } from "./types";
+import { GeneralBookmark, HistoryItem, Tab } from "./types";
 import { search } from "./utils";
 
 const LIMITS = { tabs: 6, bookmarks: 6, history: 8 };
@@ -30,17 +31,16 @@ export default function Command() {
     isLoading: isLoadingHistory,
   } = useHistorySearch(hasSearchText ? throttledSearchText : undefined);
 
-  const allTabs = useMemo<Tab[]>(
-    () => (devices ?? []).flatMap((device: Device): Tab[] => device.tabs ?? []),
-    [devices],
-  );
-
   // Memoize the searches so re-renders triggered by unrelated state changes
   // (e.g. history results arriving) don't rebuild the Fuse indexes.
-  const tabSection = useMemo(() => {
-    const filteredTabs = search(allTabs, SEARCH_KEYS, throttledSearchText) as Tab[];
-    return hasSearchText ? filteredTabs.slice(0, LIMITS.tabs) : filteredTabs;
-  }, [allTabs, throttledSearchText, hasSearchText]);
+  const tabSections = useMemo(
+    () =>
+      getDeviceTabSections(devices ?? [], (device) => {
+        const filteredTabs = search(device.tabs, SEARCH_KEYS, throttledSearchText) as Tab[];
+        return hasSearchText ? filteredTabs.slice(0, LIMITS.tabs) : filteredTabs;
+      }),
+    [devices, throttledSearchText, hasSearchText],
+  );
 
   const bookmarkSection = useMemo(
     () =>
@@ -55,8 +55,8 @@ export default function Command() {
 
   const historySection: HistoryItem[] = hasSearchText ? (historyEntries ?? []).slice(0, LIMITS.history) : [];
 
-  if (permissionView.current) {
-    return permissionView.current;
+  if (permissionView) {
+    return permissionView;
   }
 
   if (historyPermissionView) {
@@ -73,13 +73,9 @@ export default function Command() {
       onSearchTextChange={setSearchText}
       searchBarPlaceholder="Search tabs, bookmarks and history"
     >
-      {tabSection.length > 0 && (
-        <List.Section title="Open Tabs">
-          {tabSection.map((tab) => (
-            <TabListItem key={tab.uuid} tab={tab} refresh={refreshDevices} />
-          ))}
-        </List.Section>
-      )}
+      {tabSections.map(({ device, tabs }) => (
+        <DeviceListSection key={device.uuid} device={device} filteredTabs={tabs} refresh={refreshDevices} />
+      ))}
       {bookmarkSection.length > 0 && (
         <List.Section title="Bookmarks">
           {bookmarkSection.map((bookmark) => (

--- a/extensions/safari/src/tab-utils.ts
+++ b/extensions/safari/src/tab-utils.ts
@@ -4,6 +4,10 @@ export function isStartPageTab(tab: Pick<LocalTab | RemoteTab, "title">) {
   return tab.title === "Start Page";
 }
 
-export function getLocalTabApplicationName(tab: LocalTab, fallback: string) {
-  return tab.app_name || fallback;
+export function shouldHideTab(tab: Pick<LocalTab | RemoteTab, "title" | "url">) {
+  return isStartPageTab(tab) || !tab.url;
+}
+
+export function getLocalTabApplicationTarget(tab: LocalTab, fallback: string) {
+  return tab.app_path || tab.app_name || fallback;
 }

--- a/extensions/safari/src/tab-utils.ts
+++ b/extensions/safari/src/tab-utils.ts
@@ -3,3 +3,7 @@ import type { LocalTab, RemoteTab } from "./types";
 export function isStartPageTab(tab: Pick<LocalTab | RemoteTab, "title">) {
   return tab.title === "Start Page";
 }
+
+export function getLocalTabApplicationName(tab: LocalTab, fallback: string) {
+  return tab.app_name || fallback;
+}

--- a/extensions/safari/src/tab-utils.ts
+++ b/extensions/safari/src/tab-utils.ts
@@ -1,0 +1,5 @@
+import type { LocalTab, RemoteTab } from "./types";
+
+export function isStartPageTab(tab: Pick<LocalTab | RemoteTab, "title">) {
+  return tab.title === "Start Page";
+}

--- a/extensions/safari/src/types.ts
+++ b/extensions/safari/src/types.ts
@@ -57,6 +57,13 @@ export interface LooseTab {
 }
 
 // Tabs
+export interface SafariApp {
+  id: string;
+  name: string;
+  path: string;
+  bundleIdentifier: string;
+}
+
 export interface Tab extends LooseTab {
   is_local: boolean;
 }
@@ -69,6 +76,9 @@ export interface RemoteTab extends Tab {
 export interface LocalTab extends Tab {
   window_id: number;
   index: number;
+  app_id?: string;
+  app_name?: string;
+  app_path?: string;
 }
 
 export interface Device {

--- a/extensions/safari/swift/SafariTabs/Sources/SafariTabs.swift
+++ b/extensions/safari/swift/SafariTabs/Sources/SafariTabs.swift
@@ -28,21 +28,26 @@ struct LocalTab: Codable {
   let url: String
   let window_id: Int
   let index: Int
+  let app_id: String
+  let app_name: String
+  let app_path: String
   let is_local: Bool
 }
 
 // MARK: - Raycast Functions
 
-@raycast func getLocalTabs(appName: String) -> [LocalTab] {
-  let bundleIdentifier: String
-  switch appName {
-  case "Safari Technology Preview":
-    bundleIdentifier = "com.apple.SafariTechnologyPreview"
-  default:
-    bundleIdentifier = "com.apple.Safari"
+@raycast func getLocalTabs(appPath: String, appId: String, appName: String) -> [LocalTab] {
+  let appURL = URL(fileURLWithPath: appPath)
+
+  guard let safariApplication = SBApplication(url: appURL) else {
+    return []
   }
 
-  guard let safari = SBApplication(bundleIdentifier: bundleIdentifier) as? SafariApplication else {
+  guard safariApplication.isRunning else {
+    return []
+  }
+
+  guard let safari = safariApplication as? SafariApplication else {
     return []
   }
 
@@ -68,12 +73,20 @@ struct LocalTab: Codable {
       let tabTitle = safariTab.name ?? ""
       let tabUrl = safariTab.URL ?? ""
 
+      if tabTitle == "Start Page" {
+        tabIndex += 1
+        continue
+      }
+
       tabs.append(LocalTab(
-        uuid: "\(windowId)-\(tabIndex)",
+        uuid: "\(appId):\(windowId)-\(tabIndex)",
         title: tabTitle,
         url: tabUrl,
         window_id: windowId,
         index: tabIndex,
+        app_id: appId,
+        app_name: appName,
+        app_path: appPath,
         is_local: true
       ))
 

--- a/extensions/safari/tests/device-tab-sections.test.mts
+++ b/extensions/safari/tests/device-tab-sections.test.mts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getDeviceTabSections } from "../src/device-tab-sections.ts";
+import type { Device, Tab } from "../src/types.ts";
+
+const devices: Device[] = [
+  {
+    uuid: "local:safari",
+    name: "This Mac - Safari",
+    tabs: [
+      {
+        uuid: "safari-tab",
+        title: "Safari Result",
+        url: "https://safari.example.com",
+        is_local: true,
+        window_id: 1,
+        index: 1,
+      },
+    ],
+  },
+  {
+    uuid: "local:safari-technology-preview",
+    name: "This Mac - Safari Technology Preview",
+    tabs: [
+      {
+        uuid: "technology-preview-tab",
+        title: "Technology Preview Result",
+        url: "https://technology-preview.example.com",
+        is_local: true,
+        window_id: 2,
+        index: 1,
+      },
+    ],
+  },
+  {
+    uuid: "local:safari-nightly",
+    name: "This Mac - Safari Nightly",
+    tabs: [
+      {
+        uuid: "nightly-tab",
+        title: "Nightly Result",
+        url: "https://nightly.example.com",
+        is_local: true,
+        window_id: 3,
+        index: 1,
+      },
+    ],
+  },
+];
+
+test("preserves Safari browser locations in combined tab results", () => {
+  const sections = getDeviceTabSections(devices, (device) => device.tabs as Tab[]);
+
+  assert.deepEqual(
+    sections.map(({ device, tabs }) => ({
+      device: device.name,
+      tabs: tabs.map((tab) => tab.title),
+    })),
+    [
+      { device: "This Mac - Safari", tabs: ["Safari Result"] },
+      { device: "This Mac - Safari Technology Preview", tabs: ["Technology Preview Result"] },
+      { device: "This Mac - Safari Nightly", tabs: ["Nightly Result"] },
+    ],
+  );
+});
+
+test("omits browser locations with no matching tabs", () => {
+  const sections = getDeviceTabSections(devices, (device) =>
+    device.uuid === "local:safari-technology-preview" ? [] : (device.tabs as Tab[]),
+  );
+
+  assert.deepEqual(
+    sections.map(({ device }) => device.uuid),
+    ["local:safari", "local:safari-nightly"],
+  );
+});

--- a/extensions/safari/tests/safari-apps.test.mts
+++ b/extensions/safari/tests/safari-apps.test.mts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getInstalledSafariApps } from "../src/safari-apps.ts";
+
+test("returns installed known Safari variants in display order", async () => {
+  const installedPaths = new Set([
+    "/Applications/Safari.app",
+    "/Applications/Safari Technology Preview.app",
+    "/Applications/Safari Nightly.app",
+  ]);
+
+  const apps = await getInstalledSafariApps(async (path) => installedPaths.has(path), [
+    "/Applications",
+    "/Users/tester/Applications",
+  ]);
+
+  assert.deepEqual(apps, [
+    {
+      id: "safari",
+      name: "Safari",
+      path: "/Applications/Safari.app",
+      bundleIdentifier: "com.apple.Safari",
+    },
+    {
+      id: "safari-technology-preview",
+      name: "Safari Technology Preview",
+      path: "/Applications/Safari Technology Preview.app",
+      bundleIdentifier: "com.apple.SafariTechnologyPreview",
+    },
+    {
+      id: "safari-nightly",
+      name: "Safari Nightly",
+      path: "/Applications/Safari Nightly.app",
+      bundleIdentifier: "com.apple.Safari",
+    },
+  ]);
+});
+
+test("falls back to user Applications when a variant is not in /Applications", async () => {
+  const installedPaths = new Set(["/Users/tester/Applications/Safari Nightly.app"]);
+
+  const apps = await getInstalledSafariApps(async (path) => installedPaths.has(path), [
+    "/Applications",
+    "/Users/tester/Applications",
+  ]);
+
+  assert.deepEqual(apps, [
+    {
+      id: "safari-nightly",
+      name: "Safari Nightly",
+      path: "/Users/tester/Applications/Safari Nightly.app",
+      bundleIdentifier: "com.apple.Safari",
+    },
+  ]);
+});

--- a/extensions/safari/tests/tab-utils.test.mts
+++ b/extensions/safari/tests/tab-utils.test.mts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { getLocalTabApplicationName, isStartPageTab } from "../src/tab-utils.ts";
+import { getLocalTabApplicationTarget, isStartPageTab, shouldHideTab } from "../src/tab-utils.ts";
 
 test("hides Safari Start Page tabs regardless of URL", () => {
   assert.equal(isStartPageTab({ title: "Start Page" }), true);
@@ -10,7 +10,15 @@ test("keeps regular tabs", () => {
   assert.equal(isStartPageTab({ title: "Raycast Extensions" }), false);
 });
 
-test("targets a local tab by its Safari application name", () => {
+test("hides URL-less Safari placeholder tabs", () => {
+  assert.equal(shouldHideTab({ title: "Untitled", url: "" }), true);
+});
+
+test("keeps tabs with navigable URLs", () => {
+  assert.equal(shouldHideTab({ title: "Raycast Extensions", url: "https://www.raycast.com/extensions" }), false);
+});
+
+test("targets a local tab by its exact Safari application path", () => {
   const tab = {
     uuid: "local-tab",
     title: "Raycast Extensions",
@@ -22,7 +30,21 @@ test("targets a local tab by its Safari application name", () => {
     app_path: "/Applications/Safari Nightly.app",
   };
 
-  assert.equal(getLocalTabApplicationName(tab, "Safari"), "Safari Nightly");
+  assert.equal(getLocalTabApplicationTarget(tab, "Safari"), "/Applications/Safari Nightly.app");
+});
+
+test("falls back to a Safari application name when no path is available", () => {
+  const tab = {
+    uuid: "named-tab",
+    title: "Raycast Extensions",
+    url: "https://www.raycast.com/extensions",
+    is_local: true,
+    window_id: 1,
+    index: 1,
+    app_name: "Safari Technology Preview",
+  };
+
+  assert.equal(getLocalTabApplicationTarget(tab, "Safari"), "Safari Technology Preview");
 });
 
 test("falls back to the configured Safari application for legacy tabs", () => {
@@ -35,5 +57,5 @@ test("falls back to the configured Safari application for legacy tabs", () => {
     index: 1,
   };
 
-  assert.equal(getLocalTabApplicationName(tab, "Safari Technology Preview"), "Safari Technology Preview");
+  assert.equal(getLocalTabApplicationTarget(tab, "Safari Technology Preview"), "Safari Technology Preview");
 });

--- a/extensions/safari/tests/tab-utils.test.mts
+++ b/extensions/safari/tests/tab-utils.test.mts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isStartPageTab } from "../src/tab-utils.ts";
+
+test("hides Safari Start Page tabs regardless of URL", () => {
+  assert.equal(isStartPageTab({ title: "Start Page" }), true);
+});
+
+test("keeps regular tabs", () => {
+  assert.equal(isStartPageTab({ title: "Raycast Extensions" }), false);
+});

--- a/extensions/safari/tests/tab-utils.test.mts
+++ b/extensions/safari/tests/tab-utils.test.mts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { isStartPageTab } from "../src/tab-utils.ts";
+import { getLocalTabApplicationName, isStartPageTab } from "../src/tab-utils.ts";
 
 test("hides Safari Start Page tabs regardless of URL", () => {
   assert.equal(isStartPageTab({ title: "Start Page" }), true);
@@ -8,4 +8,32 @@ test("hides Safari Start Page tabs regardless of URL", () => {
 
 test("keeps regular tabs", () => {
   assert.equal(isStartPageTab({ title: "Raycast Extensions" }), false);
+});
+
+test("targets a local tab by its Safari application name", () => {
+  const tab = {
+    uuid: "local-tab",
+    title: "Raycast Extensions",
+    url: "https://www.raycast.com/extensions",
+    is_local: true,
+    window_id: 1,
+    index: 1,
+    app_name: "Safari Nightly",
+    app_path: "/Applications/Safari Nightly.app",
+  };
+
+  assert.equal(getLocalTabApplicationName(tab, "Safari"), "Safari Nightly");
+});
+
+test("falls back to the configured Safari application for legacy tabs", () => {
+  const tab = {
+    uuid: "legacy-tab",
+    title: "Raycast Extensions",
+    url: "https://www.raycast.com/extensions",
+    is_local: true,
+    window_id: 1,
+    index: 1,
+  };
+
+  assert.equal(getLocalTabApplicationName(tab, "Safari Technology Preview"), "Safari Technology Preview");
 });


### PR DESCRIPTION
## What changed

- Search Tabs now discovers installed local Safari variants in `/Applications` and `~/Applications`:
  - Safari
  - Safari Technology Preview
  - Safari Nightly
- Each running local Safari variant is rendered as its own local location section.
- Local tab actions now carry app path metadata so opening/closing a tab targets the Safari variant it came from.
- The Swift tab bridge uses app paths and skips non-running apps to avoid launching Safari variants while searching tabs.
- Start Page tabs are filtered out, and locations with no remaining tabs are hidden.
- Local tab refresh no longer keeps previous data, avoiding stale sections after a Safari variant is closed.

## Why

The extension previously used a single `safariAppIdentifier` preference for local tabs, which meant users had to choose between Safari and Safari Technology Preview and could not search all installed Safari variants at once. Safari Nightly can also share the stable Safari bundle identifier, so app path targeting is required to address it reliably.

## Tests

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run build -- --environment dist --output /tmp/raycast-safari-pr-dist`

## Notes

- Existing single-browser commands continue to use the global `safariAppIdentifier` preference.
- AI tool schemas are unchanged in this PR.
