### PR TITLE
Add Secret Manager to Google Cloud Platform Search

### DIFF
--- a/extensions/google-cloud-platform-search/CHANGELOG.md
+++ b/extensions/google-cloud-platform-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Cloud Platform Search Changelog
 
-## [Enhancement] - {PR_MERGE_DATE}
+## [Enhancement] - 2026-07-09
 
 - Add Secret Manager to the list of searchable console products.
 

--- a/extensions/google-cloud-platform-search/CHANGELOG.md
+++ b/extensions/google-cloud-platform-search/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Cloud Platform Search Changelog
 
+## [Enhancement] - {PR_MERGE_DATE}
+
+- Add Secret Manager to the list of searchable console products.
+
 ## [Fix] - 2024-09-05
 
 - Use REST fallback when fetching projects using GCP's `ProjectsClient`.

--- a/extensions/google-cloud-platform-search/package.json
+++ b/extensions/google-cloud-platform-search/package.json
@@ -49,7 +49,7 @@
     "@types/react": "18.2.27",
     "eslint": "^8.51.0",
     "prettier": "^3.0.3",
-        "typescript": "^5.2.2"
+    "typescript": "^5.2.2"
   },
   "scripts": {
     "build": "ray build -e dist",
@@ -57,5 +57,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/google-cloud-platform-search/src/consoleProducts.tsx
+++ b/extensions/google-cloud-platform-search/src/consoleProducts.tsx
@@ -135,6 +135,10 @@ export const consoleProducts: ConsoleProduct[] = [
   { name: "Capacity Planner", toUrl: (projectId) => `https://console.cloud.google.com/capacity?project=${projectId}` },
   { name: "App Hub", toUrl: (projectId) => `https://console.cloud.google.com/apphub?project=${projectId}` },
   { name: "Security", toUrl: (projectId) => `https://console.cloud.google.com/security?project=${projectId}` },
+  {
+    name: "Secret Manager",
+    toUrl: (projectId) => `https://console.cloud.google.com/security/secret-manager?project=${projectId}`,
+  },
   { name: "Compliance", toUrl: (projectId) => `https://console.cloud.google.com/compliance?project=${projectId}` },
   { name: "Cloud Build", toUrl: (projectId) => `https://console.cloud.google.com/cloud-build?project=${projectId}` },
   { name: "Container Registry", toUrl: (projectId) => `https://console.cloud.google.com/gcr?project=${projectId}` },


### PR DESCRIPTION
## Description

Adds **Secret Manager** to the list of GCP console products that can be searched and opened via the Google Cloud Platform Search extension.

Secret Manager was missing from the hardcoded product list in `src/consoleProducts.tsx`, so it could not be found when browsing a project's console products. The new entry opens `https://console.cloud.google.com/security/secret-manager?project=<projectId>`, matching the live console path (grouped under Security, next to the existing "Security" product).

## Screencast

<img width="624" height="381" alt="image" src="https://github.com/user-attachments/assets/6d714933-541d-4a1d-b655-9892fcc87e1d" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
