### PR TITLE
feat(quick-event): add timezone support (ET, CT, GMT-1, UTC+5:30, etc.)

### DIFF
--- a/extensions/quick-event/CHANGELOG.md
+++ b/extensions/quick-event/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quick Event Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-07-09
 
 - Add timezone support. Specify a timezone abbreviation (ET, CT, PT, CET, JST, GMT-1, UTC+5:30, etc.) in your query and the event time is automatically converted to your local timezone. Named zones handle DST correctly.
 

--- a/extensions/quick-event/CHANGELOG.md
+++ b/extensions/quick-event/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Quick Event Changelog
 
+## [Update] - 2025-07-08
+
+- Add timezone support. Specify a timezone abbreviation (ET, CT, PT, CET, JST, GMT-1, UTC+5:30, etc.) in your query and the event time is automatically converted to your local timezone. Named zones handle DST correctly.
+
 ## [Update] - 2025-06-10
 
 - Update location parsing to use "@" and replace AI.ask. It now supports locations in `@location`, `@location-location`, or `@(location)`

--- a/extensions/quick-event/CHANGELOG.md
+++ b/extensions/quick-event/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quick Event Changelog
 
-## [Update] - 2025-07-08
+## [Update] - {PR_MERGE_DATE}
 
 - Add timezone support. Specify a timezone abbreviation (ET, CT, PT, CET, JST, GMT-1, UTC+5:30, etc.) in your query and the event time is automatically converted to your local timezone. Named zones handle DST correctly.
 

--- a/extensions/quick-event/README.md
+++ b/extensions/quick-event/README.md
@@ -52,6 +52,30 @@ Optional Preferences:
 - Bake a cake tomorrow.
 - Use Tabule today!
 
+## Timezone Support
+
+Specify a timezone in your query and the event time will be converted to your local timezone automatically. The original timezone time is shown in the subtitle for reference.
+
+### Supported Timezone Abbreviations
+
+**US:** ET, EST, EDT, CT, CST, CDT, MT, MST, MDT, PT, PST, PDT, AKST, AKDT, HST, HDT
+
+**Europe:** GMT, UTC, BST, CET, CEST, EET, EEST, WET, WEST, MSK, TRT
+
+**Asia/Pacific:** IST, JST, KST, SGT, HKT, PHT, ICT, WIB, GST, PKT, AEST, AEDT, ACST, ACDT, AWST, NZST, NZDT
+
+**Explicit Offsets:** GMT-1, GMT+5, UTC-3, UTC+5:30, etc.
+
+### Timezone Examples
+
+- Meeting at 3pm ET
+- Call at 10am CT tomorrow
+- Sync at 9am PT on Friday
+- Lunch at noon GMT-1
+- Standup at 8am GMT+5:30
+- Review at 2pm JST next Monday
+- Demo at 4pm CET
+
 ## Author
 
 **Matthew Blode** (mblode)

--- a/extensions/quick-event/src/dates.ts
+++ b/extensions/quick-event/src/dates.ts
@@ -1,6 +1,6 @@
 import { addHours, addMinutes, differenceInCalendarDays, format, roundToNearestMinutes } from 'date-fns';
 import { CalendarEvent } from './types';
-import { adjustDateForTimezone, formatOffsetLabel } from './timezones';
+import { formatOffsetLabel, unadjustDateForTimezone } from './timezones';
 
 export const getHumanDateFormat = 'MMM dd, yyyy';
 export const getHumanTimeFormat = 'h:mm aa';
@@ -49,8 +49,8 @@ export const formatDate = (item: CalendarEvent): string => {
     )} to ${format(item.endDate, getHumanTimeFormat)}`;
 
     if (item.timezone) {
-      const originalStart = adjustDateForTimezone(item.startDate, item.timezone);
-      const originalEnd = adjustDateForTimezone(item.endDate, item.timezone);
+      const originalStart = unadjustDateForTimezone(item.startDate, item.timezone);
+      const originalEnd = unadjustDateForTimezone(item.endDate, item.timezone);
       const tzLabel = formatOffsetLabel(item.timezone);
       const originalTimes = `${format(originalStart, getHumanTimeFormat)}–${format(originalEnd, getHumanTimeFormat)} ${tzLabel}`;
       return `${base} (${originalTimes})`;

--- a/extensions/quick-event/src/dates.ts
+++ b/extensions/quick-event/src/dates.ts
@@ -1,5 +1,6 @@
 import { addHours, addMinutes, differenceInCalendarDays, format, roundToNearestMinutes } from 'date-fns';
 import { CalendarEvent } from './types';
+import { adjustDateForTimezone, formatOffsetLabel } from './timezones';
 
 export const getHumanDateFormat = 'MMM dd, yyyy';
 export const getHumanTimeFormat = 'h:mm aa';
@@ -42,10 +43,20 @@ export const formatDate = (item: CalendarEvent): string => {
   if (item.isAllDay) {
     return `${formatRelativeDay(item.startDate, new Date())} all-day`;
   } else {
-    return `${formatRelativeDay(item.startDate, new Date())} from ${format(
+    const base = `${formatRelativeDay(item.startDate, new Date())} from ${format(
       item.startDate,
       getHumanTimeFormat,
     )} to ${format(item.endDate, getHumanTimeFormat)}`;
+
+    if (item.timezone) {
+      const originalStart = adjustDateForTimezone(item.startDate, item.timezone);
+      const originalEnd = adjustDateForTimezone(item.endDate, item.timezone);
+      const tzLabel = formatOffsetLabel(item.timezone);
+      const originalTimes = `${format(originalStart, getHumanTimeFormat)}–${format(originalEnd, getHumanTimeFormat)} ${tzLabel}`;
+      return `${base} (${originalTimes})`;
+    }
+
+    return base;
   }
 };
 

--- a/extensions/quick-event/src/index.tsx
+++ b/extensions/quick-event/src/index.tsx
@@ -1,7 +1,8 @@
-import { ActionPanel, closeMainWindow, Icon, List, getPreferenceValues, Action, Keyboard } from '@raycast/api';
+import { ActionPanel, closeMainWindow, Icon, List, getPreferenceValues, Action, Keyboard, Color } from '@raycast/api';
 import { formatDate } from './dates';
 import { CalendarEvent } from './types';
 import { executeJxa, useCalendar } from './useCalendar';
+import { formatOffsetLabel } from './timezones';
 
 export default function Command() {
   const { isLoading, results, parse } = useCalendar();
@@ -46,7 +47,12 @@ export default function Command() {
   };
 
   return (
-    <List isLoading={isLoading} onSearchTextChange={parse} searchBarPlaceholder="E.g. Movie at 7pm on Friday" throttle>
+    <List
+      isLoading={isLoading}
+      onSearchTextChange={parse}
+      searchBarPlaceholder="E.g. Movie at 7pm ET on Friday"
+      throttle
+    >
       <List.Section title="Your quick event">
         {results.map((item) => (
           <List.Item
@@ -54,6 +60,15 @@ export default function Command() {
             title={item.eventTitle || 'Untitled event'}
             subtitle={formatDate(item) || 'No date'}
             icon={Icon.Calendar}
+            accessories={
+              item.timezone
+                ? [
+                    {
+                      tag: { value: formatOffsetLabel(item.timezone), color: Color.Blue },
+                    },
+                  ]
+                : []
+            }
             actions={
               <ActionPanel title="Add to a different calendar">
                 {calendars.map((calendar, index) => (

--- a/extensions/quick-event/src/timezones.ts
+++ b/extensions/quick-event/src/timezones.ts
@@ -66,10 +66,9 @@ export function extractTimezone(query: string): { query: string; timezone: Timez
       .replace(matchedText, '')
       .replace(/\s{2,}/g, ' ')
       .trim();
-    const label = `GMT${offsetMinutes >= 0 ? '+' : ''}${(offsetMinutes / 60) % 1 === 0 ? offsetMinutes / 60 : (offsetMinutes / 60).toFixed(1)}`;
     return {
       query: cleanQuery,
-      timezone: { abbreviation: label, offsetMinutes },
+      timezone: { abbreviation: matchedText.toUpperCase().replace(/\s+/g, ''), offsetMinutes },
     };
   }
 
@@ -155,6 +154,13 @@ export function adjustDateForTimezone(date: Date, timezone: TimezoneInfo): Date 
   const localOffset = getLocalOffset(date);
   const targetOffset = getOffsetForTimezone(timezone, date);
   const adjustmentMinutes = localOffset - targetOffset;
+  return new Date(date.getTime() + adjustmentMinutes * 60000);
+}
+
+export function unadjustDateForTimezone(date: Date, timezone: TimezoneInfo): Date {
+  const localOffset = getLocalOffset(date);
+  const targetOffset = getOffsetForTimezone(timezone, date);
+  const adjustmentMinutes = targetOffset - localOffset;
   return new Date(date.getTime() + adjustmentMinutes * 60000);
 }
 

--- a/extensions/quick-event/src/timezones.ts
+++ b/extensions/quick-event/src/timezones.ts
@@ -1,0 +1,176 @@
+export interface TimezoneInfo {
+  abbreviation: string;
+  ianaTimezone?: string;
+  offsetMinutes?: number;
+}
+
+const NAMED_TIMEZONES: Record<string, string> = {
+  ET: 'America/New_York',
+  EST: 'America/New_York',
+  EDT: 'America/New_York',
+  CT: 'America/Chicago',
+  CST: 'America/Chicago',
+  CDT: 'America/Chicago',
+  MT: 'America/Denver',
+  MST: 'America/Denver',
+  MDT: 'America/Denver',
+  PT: 'America/Los_Angeles',
+  PST: 'America/Los_Angeles',
+  PDT: 'America/Los_Angeles',
+  AKST: 'America/Anchorage',
+  AKDT: 'America/Anchorage',
+  HST: 'Pacific/Honolulu',
+  HDT: 'Pacific/Honolulu',
+  BST: 'Europe/London',
+  CET: 'Europe/Paris',
+  CEST: 'Europe/Paris',
+  EET: 'Europe/Athens',
+  EEST: 'Europe/Athens',
+  WET: 'Europe/Lisbon',
+  WEST: 'Europe/Lisbon',
+  MSK: 'Europe/Moscow',
+  TRT: 'Europe/Istanbul',
+  IST: 'Asia/Kolkata',
+  JST: 'Asia/Tokyo',
+  KST: 'Asia/Seoul',
+  SGT: 'Asia/Singapore',
+  HKT: 'Asia/Hong_Kong',
+  PHT: 'Asia/Manila',
+  ICT: 'Asia/Bangkok',
+  WIB: 'Asia/Jakarta',
+  GST: 'Asia/Dubai',
+  PKT: 'Asia/Karachi',
+  AEST: 'Australia/Sydney',
+  AEDT: 'Australia/Sydney',
+  ACST: 'Australia/Adelaide',
+  ACDT: 'Australia/Adelaide',
+  AWST: 'Australia/Perth',
+  NZST: 'Pacific/Auckland',
+  NZDT: 'Pacific/Auckland',
+};
+
+const OFFSET_PATTERN = /\b(?:GMT|UTC|UT)\s*([+-])\s*(\d{1,2})(?::(\d{2}))?\b/i;
+const NAMED_PATTERN =
+  /\b(ET|EST|EDT|CT|CST|CDT|MT|MST|MDT|PT|PST|PDT|AKST|AKDT|HST|HDT|BST|CET|CEST|EET|EEST|WET|WEST|MSK|TRT|IST|JST|KST|SGT|HKT|PHT|ICT|WIB|GST|PKT|AEST|AEDT|ACST|ACDT|AWST|NZST|NZDT)\b/i;
+const BARE_GMT_PATTERN = /\b(?:GMT|UTC|UT)\b/i;
+
+export function extractTimezone(query: string): { query: string; timezone: TimezoneInfo | null } {
+  const offsetMatch = query.match(OFFSET_PATTERN);
+  if (offsetMatch) {
+    const sign = offsetMatch[1] === '-' ? -1 : 1;
+    const hours = parseInt(offsetMatch[2], 10);
+    const minutes = offsetMatch[3] ? parseInt(offsetMatch[3], 10) : 0;
+    const offsetMinutes = sign * (hours * 60 + minutes);
+    const matchedText = offsetMatch[0];
+    const cleanQuery = query
+      .replace(matchedText, '')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+    const label = `GMT${offsetMinutes >= 0 ? '+' : ''}${(offsetMinutes / 60) % 1 === 0 ? offsetMinutes / 60 : (offsetMinutes / 60).toFixed(1)}`;
+    return {
+      query: cleanQuery,
+      timezone: { abbreviation: label, offsetMinutes },
+    };
+  }
+
+  const namedMatch = query.match(NAMED_PATTERN);
+  if (namedMatch) {
+    const abbr = namedMatch[1].toUpperCase();
+    const iana = NAMED_TIMEZONES[abbr];
+    if (iana) {
+      const cleanQuery = query
+        .replace(namedMatch[0], '')
+        .replace(/\s{2,}/g, ' ')
+        .trim();
+      return {
+        query: cleanQuery,
+        timezone: { abbreviation: abbr, ianaTimezone: iana },
+      };
+    }
+  }
+
+  const bareGmtMatch = query.match(BARE_GMT_PATTERN);
+  if (bareGmtMatch) {
+    const cleanQuery = query
+      .replace(bareGmtMatch[0], '')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+    return {
+      query: cleanQuery,
+      timezone: { abbreviation: 'GMT', offsetMinutes: 0 },
+    };
+  }
+
+  return { query, timezone: null };
+}
+
+function getIanaOffset(ianaTimezone: string, date: Date): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: ianaTimezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+
+  const parts = dtf.formatToParts(date);
+  const map: Record<string, string> = {};
+  for (const part of parts) {
+    if (part.type !== 'literal') {
+      map[part.type] = part.value;
+    }
+  }
+
+  const hour = map.hour === '24' ? 0 : parseInt(map.hour, 10);
+  const asUTC = Date.UTC(
+    parseInt(map.year, 10),
+    parseInt(map.month, 10) - 1,
+    parseInt(map.day, 10),
+    hour,
+    parseInt(map.minute, 10),
+    parseInt(map.second, 10),
+  );
+
+  return (asUTC - date.getTime()) / 60000;
+}
+
+export function getLocalOffset(date: Date): number {
+  return -date.getTimezoneOffset();
+}
+
+export function getOffsetForTimezone(timezone: TimezoneInfo, date: Date): number {
+  if (timezone.offsetMinutes !== undefined) {
+    return timezone.offsetMinutes;
+  }
+  if (timezone.ianaTimezone) {
+    return getIanaOffset(timezone.ianaTimezone, date);
+  }
+  return 0;
+}
+
+export function adjustDateForTimezone(date: Date, timezone: TimezoneInfo): Date {
+  const localOffset = getLocalOffset(date);
+  const targetOffset = getOffsetForTimezone(timezone, date);
+  const adjustmentMinutes = localOffset - targetOffset;
+  return new Date(date.getTime() + adjustmentMinutes * 60000);
+}
+
+export function formatOffsetLabel(timezone: TimezoneInfo): string {
+  if (timezone.offsetMinutes !== undefined) {
+    const mins = timezone.offsetMinutes;
+    const sign = mins >= 0 ? '+' : '-';
+    const abs = Math.abs(mins);
+    const h = Math.floor(abs / 60);
+    const m = abs % 60;
+    return m === 0
+      ? `${timezone.abbreviation} (UTC${sign}${h})`
+      : `${timezone.abbreviation} (UTC${sign}${h}:${m.toString().padStart(2, '0')})`;
+  }
+  if (timezone.ianaTimezone) {
+    return timezone.abbreviation;
+  }
+  return timezone.abbreviation;
+}

--- a/extensions/quick-event/src/types.ts
+++ b/extensions/quick-event/src/types.ts
@@ -1,3 +1,5 @@
+import { TimezoneInfo } from './timezones';
+
 export interface CalendarEvent {
   id: string;
   eventTitle?: string | null;
@@ -6,4 +8,5 @@ export interface CalendarEvent {
   isAllDay: boolean;
   validated: boolean;
   location?: string;
+  timezone?: TimezoneInfo | null;
 }

--- a/extensions/quick-event/src/useCalendar.tsx
+++ b/extensions/quick-event/src/useCalendar.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { nanoid } from 'nanoid';
 import { CalendarEvent } from './types';
 import { getEndDate, getStartDate, preprocessQuery } from './dates';
+import { adjustDateForTimezone, extractTimezone } from './timezones';
 import osascript from 'osascript-tag';
 import Sherlock from 'sherlockjs';
 
@@ -45,7 +46,9 @@ export function useCalendar() {
         }
         query = query.replace(/@(?:\(([^)]+)\)|([^@\s]+))/, '');
 
-        const preprocessedQuery = preprocessQuery(query);
+        const { query: queryWithoutTz, timezone } = extractTimezone(query);
+
+        const preprocessedQuery = preprocessQuery(queryWithoutTz);
 
         const parsedEvent = Sherlock.parse(preprocessedQuery);
 
@@ -53,6 +56,7 @@ export function useCalendar() {
           ...parsedEvent,
           location: location,
           id: nanoid(),
+          timezone: timezone,
         };
 
         if (!event.startDate) {
@@ -61,6 +65,11 @@ export function useCalendar() {
 
         if (!event.endDate) {
           event.endDate = getEndDate(event.startDate);
+        }
+
+        if (timezone) {
+          event.startDate = adjustDateForTimezone(event.startDate, timezone);
+          event.endDate = adjustDateForTimezone(event.endDate, timezone);
         }
 
         setResults([event]);


### PR DESCRIPTION
## Summary

Added timezone support to the Quick Event extension. Users can now specify a timezone abbreviation in their natural language query, and the event time is automatically converted to their local timezone.

## What Changed

### New File: `src/timezones.ts`
- **40+ named timezone abbreviations** mapped to IANA timezones: ET/EST/EDT, CT/CST/CDT, MT, PT/PST/PDT, GMT, UTC, CET/CEST, EET, BST, JST, KST, IST, AEST/AEDT, NZST, MSK, and many more
- **Explicit offset parsing** — supports `GMT-1`, `UTC+5`, `GMT+5:30`, etc.
- **DST-aware offset calculation** using `Intl.DateTimeFormat` for named zones (e.g., ET automatically handles EST→EDT transition)
- `extractTimezone()` — finds and strips the timezone token from the query before Sherlock parses it
- `adjustDateForTimezone()` — converts the parsed time from the specified zone to the user's local time

### Modified Files

| File | Change |
|------|--------|
| `src/types.ts` | Added `timezone?: TimezoneInfo \| null` field to `CalendarEvent` |
| `src/useCalendar.tsx` | Extracts timezone before Sherlock parsing; adjusts `startDate`/`endDate` to local time after |
| `src/dates.ts` | `formatDate()` shows original-zone times in parentheses (e.g., `from 9:00 PM to 10:00 PM (3:00 PM–4:00 PM ET)`) |
| `src/index.tsx` | Blue tag accessory showing the timezone label; updated search bar placeholder to `E.g. Movie at 7pm ET on Friday` |
| `README.md` | New "Timezone Support" section with full abbreviation list and usage examples |
| `CHANGELOG.md` | Added changelog entry |

## How It Works

1. User types: `Meeting at 3pm ET`
2. `extractTimezone()` finds `ET` → maps to `America/New_York` → computes current offset (DST-aware)
3. Sherlock parses `Meeting at 3pm` as a local 3pm
4. `adjustDateForTimezone()` shifts the time by the offset difference between local and ET
5. Calendar.app creates the event at the correct local time
6. UI shows: `from 9:00 PM to 10:00 PM (3:00 PM–4:00 PM ET)` with a blue `ET` tag

## Example Queries

```
Meeting at 3pm ET
Call at 10am CT tomorrow
Sync at 9am PT on Friday
Lunch at noon GMT-1
Standup at 8am GMT+5:30
Review at 2pm JST next Monday
Demo at 4pm CET
```

## Testing

- ✅ `npm run build` passes
- ✅ `npm run lint` passes (ESLint + Prettier)
- ✅ Extension loads in Raycast via `npm run dev`
- ✅ TypeScript type checking passes

## Backward Compatibility

No breaking changes. If no timezone is specified in the query, behavior is identical to before.