### PR TITLE
Update video-downloader extension

### DIFF
--- a/extensions/video-downloader/.gitignore
+++ b/extensions/video-downloader/.gitignore
@@ -24,6 +24,8 @@ compiled_raycast_rust
 .swiftpm
 compiled_raycast_swift
 compiled_raycast_rust
+
 # misc
+.claude
 .DS_Store
 raycast-env.d.ts

--- a/extensions/video-downloader/CHANGELOG.md
+++ b/extensions/video-downloader/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Video Downloader Changelog
 
+## [Improvement] - {PR_MERGE_DATE}
+
+- The download action and progress toasts now say "audio" instead of "video" when you pick an audio-only format (MP3, M4A, etc.) — the button reads "Download Audio", and toasts read "Downloading Audio", "Formatting Audio", and "Audio Downloaded"
+
 ## [Improvement] - 2026-06-04
 
 - Added a "Use Cookies from Browser" preference to fix X/Twitter "Bad guest token" failures by using your logged-in session (also helps with age-restricted and private posts)

--- a/extensions/video-downloader/CHANGELOG.md
+++ b/extensions/video-downloader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Video Downloader Changelog
 
-## [Improvement] - {PR_MERGE_DATE}
+## [Improvement] - 2026-07-09
 
 - The download action and progress toasts now say "audio" instead of "video" when you pick an audio-only format (MP3, M4A, etc.) — the button reads "Download Audio", and toasts read "Downloading Audio", "Formatting Audio", and "Audio Downloaded"
 

--- a/extensions/video-downloader/README.md
+++ b/extensions/video-downloader/README.md
@@ -6,7 +6,7 @@
 
 ## Features
 
-- **Download from anywhere yt-dlp supports** — paste a URL, pick a format, and download. Audio-only (MP3) is included.
+- **Download from anywhere yt-dlp supports** — paste a URL, pick a format, and download. Audio-only formats (MP3, M4A, and more) are included, and the download action and progress toasts say "audio" instead of "video" when you pick one.
 - **Auto-fill the URL** — optionally load the link from your clipboard, selected text, or the active browser tab (see preferences).
 - **Use your browser's cookies** — work around auth-protected media, age restrictions, and "Bad guest token" rate-limit errors on X/Twitter by passing your logged-in browser's cookies (see the _Use Cookies from Browser_ preference).
 - **Playlists, opt-in** — for a playlist URL, a _Download entire playlist_ checkbox appears; leave it unchecked to grab just the linked video.

--- a/extensions/video-downloader/package-lock.json
+++ b/extensions/video-downloader/package-lock.json
@@ -1139,9 +1139,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.19",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.19.tgz",
-      "integrity": "sha512-SAVg56BAzxZGy/OPQ0jekUG3pJaoX5pCqleALvFo9JRE7P2tvKoglWnYRcIJArRhLlvV8FtFNMDafd+NNwXXCw==",
+      "version": "1.104.21",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.21.tgz",
+      "integrity": "sha512-0s6OLx/cIgAIhZPQp3dmMCCZoWFbtgnQUTbnpTzhitwKuPVy20DpnyKJPwqsODHBLmNlhO3FgzpzkkoIrRkjjQ==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
@@ -2637,10 +2637,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/extensions/video-downloader/package.json
+++ b/extensions/video-downloader/package.json
@@ -133,14 +133,38 @@
       "default": "none",
       "required": false,
       "data": [
-        { "title": "None", "value": "none" },
-        { "title": "Safari", "value": "safari" },
-        { "title": "Chrome", "value": "chrome" },
-        { "title": "Brave", "value": "brave" },
-        { "title": "Microsoft Edge", "value": "edge" },
-        { "title": "Firefox", "value": "firefox" },
-        { "title": "Opera", "value": "opera" },
-        { "title": "Vivaldi", "value": "vivaldi" }
+        {
+          "title": "None",
+          "value": "none"
+        },
+        {
+          "title": "Safari",
+          "value": "safari"
+        },
+        {
+          "title": "Chrome",
+          "value": "chrome"
+        },
+        {
+          "title": "Brave",
+          "value": "brave"
+        },
+        {
+          "title": "Microsoft Edge",
+          "value": "edge"
+        },
+        {
+          "title": "Firefox",
+          "value": "firefox"
+        },
+        {
+          "title": "Opera",
+          "value": "opera"
+        },
+        {
+          "title": "Vivaldi",
+          "value": "vivaldi"
+        }
       ]
     }
   ],

--- a/extensions/video-downloader/src/index.tsx
+++ b/extensions/video-downloader/src/index.tsx
@@ -64,6 +64,9 @@ export default function DownloadVideo() {
       const options = ["-o", path.join(downloadPath, `${video?.title || "video"} (%(id)s).%(ext)s`)];
       const [downloadFormat, recodeFormat] = values.format.split("#");
 
+      // `medium` ("Audio"/"Video") is derived at component scope from the selected
+      // format and reused here for the progress toasts below.
+
       // The metadata preview is always for the single video, so default to
       // --no-playlist; only pull the whole list when the user opted in via the
       // "Download entire playlist" checkbox (shown only for playlist URLs).
@@ -81,7 +84,7 @@ export default function DownloadVideo() {
       }
 
       const toast = await showToast({
-        title: "Downloading Video",
+        title: `Downloading ${medium}`,
         style: Toast.Style.Animated,
         message: "0%",
       });
@@ -108,7 +111,7 @@ export default function DownloadVideo() {
           const currentProgress = Number(toast.message?.replace("%", ""));
 
           if (progress < currentProgress) {
-            toast.title = "Formatting Video";
+            toast.title = `Formatting ${medium}`;
           }
           toast.message = `${Math.floor(progress)}%`;
         }
@@ -170,7 +173,7 @@ export default function DownloadVideo() {
           return;
         }
 
-        toast.title = "Video Downloaded";
+        toast.title = `${medium} Downloaded`;
         toast.style = Toast.Style.Success;
         toast.message = video?.title;
 
@@ -330,6 +333,19 @@ export default function DownloadVideo() {
 
   const formats = useMemo(() => getFormats(video), [video]);
 
+  // "Audio" when the selected format is audio-only (MP3 via --extract-audio, or a
+  // raw audio stream like M4A/Opus — every "Audio Only" entry has vcodec "none"),
+  // else "Video". Drives both the submit button label and the progress toasts, so
+  // the whole flow agrees on what's being downloaded. MP3_FORMAT_ID is a hardcoded
+  // value with no backing Format in the list, so it's checked explicitly.
+  const medium = useMemo(() => {
+    const selectedFormat = Object.values(formats)
+      .flat()
+      .find((format) => getFormatValue(format) === values.format);
+    const isAudio = values.format === MP3_FORMAT_ID || selectedFormat?.vcodec === "none";
+    return isAudio ? "Audio" : "Video";
+  }, [formats, values.format]);
+
   // Classify the load error once so the placeholder, the Title row, and the
   // Try Again action all agree on whether a retry would help.
   const friendlyError = videoError ? describeYtdlpError(videoError) : null;
@@ -353,7 +369,7 @@ export default function DownloadVideo() {
           <ActionPanel.Section>
             <Action.SubmitForm
               icon={Icon.Download}
-              title="Download Video"
+              title={`Download ${medium}`}
               onSubmit={(values) => {
                 setWarning("");
                 handleSubmit({ ...values, copyToClipboard: false } as DownloadOptions);


### PR DESCRIPTION
## Description

Makes the Download Video command audio-aware. When an audio-only format (MP3, M4A, Opus, etc.) is selected, the submit button and progress toasts now say "Audio" instead of "Video":

- Button: Download Audio (was always "Download Video")
- Toasts: Downloading Audio → Formatting Audio → Audio Downloaded

Detection is a single component-scope medium derived from the selected format's vcodec (audio-only formats have vcodec: "none"), plus the existing `MP3_FORMAT_ID` constant. It's reused by both the button label and the toasts so the whole flow agrees on what's being downloaded. 

Copy-only — no change to the yt-dlp invocation. Video downloads are unchanged.

Also bumps @raycast/api 1.104.19 → 1.104.21.

## Screenshot

<img width="862" height="587" alt="image" src="https://github.com/user-attachments/assets/a27850f5-3422-46d1-bae5-a7ee5359cb53" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
