### PR TITLE
[Slack Extension README] Fix yaml codeblock

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Slack Changelog
 
+## [Fix YAML codeblock in README] - 2026-07-09
+
 ## [Add Slack thread reader AI tool, fix missing webhook author] - 2026-06-17
 
 - Add a paginated `read-thread` AI tool to fetch a bounded page of messages in a Slack thread using the channel ID and parent message timestamp. The tool returns `hasMore` and `nextCursor` when additional messages are available.

--- a/extensions/slack/README.md
+++ b/extensions/slack/README.md
@@ -38,61 +38,60 @@ If you don't want to log in through OAuth, you can use an access token instead. 
 4. Select a workspace to which you want to grant the extension access.
 5. Copy and paste the following manifest (Select `YAML`):
    _Feel free to exclude permission scope groups - see comments - if you don't want to have the full experience of this extension._
-
    ```
    display_information:
-   name: Raycast - Slack
+     name: Raycast - Slack
+   
    oauth_config:
-   scopes:
-    user:
-     # Command: Search & Unread Messages & Set Presence
-     - users:read
-
-     # Command: Search & Unread Messages
-     - channels:read
-     - groups:read
-     - im:read
-     - mpim:read
-
-     # Command: Search
-     - search:read
-
-     # Command: Unread Messages
-     - channels:history
-     - groups:history
-     - im:history
-     - mpim:history
-
-     # Command: Unread Messages (optional - needed for marking conversations as read)
-     - channels:write
-     - groups:write
-     - im:write
-     - mpim:write
-
-     # Command: Set Presence
-     - users:write
-
-     # Command: Set Snooze
-     - dnd:read
-     - dnd:write
-
-     # Command: Send Message
-     - chat:write
-
-     # Command: Search Emojis
-     - emoji:read
-
-     # Command: Set Status
-     - users.profile:write
-     - users.profile:read
+     scopes:
+       user:
+         # Command: Search & Unread Messages & Set Presence
+         - users:read
+   
+         # Command: Search & Unread Messages
+         - channels:read
+         - groups:read
+         - im:read
+         - mpim:read
+   
+         # Command: Search
+         - search:read
+   
+         # Command: Unread Messages
+         - channels:history
+         - groups:history
+         - im:history
+         - mpim:history
+   
+         # Command: Unread Messages (optional - needed for marking conversations as read)
+         - channels:write
+         - groups:write
+         - im:write
+         - mpim:write
+   
+         # Command: Set Presence
+         - users:write
+   
+         # Command: Set Snooze
+         - dnd:read
+         - dnd:write
+   
+         # Command: Send Message
+         - chat:write
+   
+         # Command: Search Emojis
+         - emoji:read
+   
+         # Command: Set Status
+         - users.profile:write
+         - users.profile:read
+   
+   settings:
+     org_deploy_enabled: false
+     socket_mode_enabled: false
+     token_rotation_enabled: false
    ```
 
-settings:
-org_deploy_enabled: false
-socket_mode_enabled: false
-token_rotation_enabled: false
-
-```
 
 6. Confirm creation of app
 7. Press `Install to Workspace`
@@ -115,4 +114,3 @@ The proxy URL is resolved in the following order:
 
 - Proxy support applies to **Slack API calls only**. The OAuth login flow uses Raycast's built-in networking, which does not go through the configured proxy.
 - If you are on a corporate network that blocks OAuth, use a **personal access token** instead (see above). Token-based authentication bypasses OAuth entirely and all subsequent API calls will use the proxy.
-```


### PR DESCRIPTION
## Description

Fix for minor formatting problems in Slack Extension README (https://www.raycast.com/mommertf/slack) - corrected indentations, and set correct boundaries of the codeblock (otherwise all end part of the readme was unnecessarily put in the codeblock with the yaml example)

## Screencast

<img width="1786" height="1532" alt="CleanShot 2026-07-09 at 10 23 10@2x" src="https://github.com/user-attachments/assets/04327479-cfd7-4052-a1e8-f298bb81bc2a" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
