### PR TITLE
[linkcleaner extension update] Add Bilibili and Spotify support with updated rules

### DIFF
--- a/extensions/link-cleaner/CHANGELOG.md
+++ b/extensions/link-cleaner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Link Cleaner Changelog
 
+## [Add Bilibili and Spotify rules] - 2026-07-09
+
+- Add Bilibili rule.
+- Add Spotify rule.
+- Remove trailing `?` when all query parameters are filtered out.
+
 ## [Add options to close Raycast after cleaning] - 2025-09-09
 
 ## [Added Clean Selected Text Functionality] - 2025-04-15

--- a/extensions/link-cleaner/CHANGELOG.md
+++ b/extensions/link-cleaner/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Link Cleaner Changelog
 
-## [Add Bilibili and Spotify rules] - {PR_MERGE_DATE}
+## [Add Bilibili and Spotify rules] - 2026-07-09
 
 - Add Bilibili rule.
 - Add Spotify rule.

--- a/extensions/link-cleaner/CHANGELOG.md
+++ b/extensions/link-cleaner/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Link Cleaner Changelog
 
-## [Add Bilibili and Spotify rules] - 2026-07-09
+## [Add Bilibili and Spotify rules] - {PR_MERGE_DATE}
 
 - Add Bilibili rule.
 - Add Spotify rule.

--- a/extensions/link-cleaner/README.md
+++ b/extensions/link-cleaner/README.md
@@ -8,8 +8,10 @@ Supported:
 2. Baidu Search
 3. Bing Search
 4. Netease Music
-5. Youtube
-6. Instagram
+5. Bilibili
+6. Youtube
+7. Spotify
+8. Instagram
 
 ## Example
 

--- a/extensions/link-cleaner/package.json
+++ b/extensions/link-cleaner/package.json
@@ -57,5 +57,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/link-cleaner/src/main.ts
+++ b/extensions/link-cleaner/src/main.ts
@@ -29,6 +29,9 @@ function removeQueryParams(url: string, allowParmas: string[]): string {
   // if params is not empty, match params to remove
   if (allowParmas.length > 0) {
     const newQuery = query.filter((param) => allowParmas.includes(param.split("=")[0]));
+    if (newQuery.length === 0) {
+      return urlParts[0];
+    }
     return `${urlParts[0]}?${newQuery.join("&")}`;
   }
   // if params is empty, remove all query params

--- a/extensions/link-cleaner/src/rules.ts
+++ b/extensions/link-cleaner/src/rules.ts
@@ -26,9 +26,19 @@ const rules: Rule[] = [
     allowParams: ["id"],
   },
   {
+    name: "Bilibili",
+    url: "bilibili.com",
+    allowParams: ["keyword", "page", "p", "t"],
+  },
+  {
     name: "Youtube",
     url: "youtube.com",
     allowParams: ["v", "search_query"],
+  },
+  {
+    name: "Spotify",
+    url: "open.spotify.com",
+    allowParams: ["context", "highlight", "t"],
   },
   {
     name: "Instagram Reel",

--- a/extensions/link-cleaner/src/utils/rules.ts
+++ b/extensions/link-cleaner/src/utils/rules.ts
@@ -26,9 +26,19 @@ const rules: Rule[] = [
     allowParams: ["id"],
   },
   {
+    name: "Bilibili",
+    url: "bilibili.com",
+    allowParams: ["keyword", "page", "p", "t"],
+  },
+  {
     name: "Youtube",
     url: "youtube.com",
     allowParams: ["v", "search_query"],
+  },
+  {
+    name: "Spotify",
+    url: "open.spotify.com",
+    allowParams: ["context", "highlight", "t"],
   },
   {
     name: "Instagram Reel",

--- a/extensions/link-cleaner/src/utils/url-utils.ts
+++ b/extensions/link-cleaner/src/utils/url-utils.ts
@@ -26,6 +26,9 @@ function removeQueryParams(url: string, allowParams: string[]): string {
   // if params is not empty, match params to remove
   if (allowParams.length > 0) {
     const newQuery = query.filter((param) => allowParams.includes(param.split("=")[0]));
+    if (newQuery.length === 0) {
+      return urlParts[0];
+    }
     return `${urlParts[0]}?${newQuery.join("&")}`;
   }
   // if params is empty, remove all query params


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->
add bilibili and spotify support in the extension, and fix a small bug with the parsed link with `?`. 
## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
