### PR TITLE
[GitHub] Add "Ready for Review" action for draft pull requests

### DIFF
--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitHub Changelog
 
+## [Mark draft pull requests as ready for review] - {PR_MERGE_DATE}
+
+- Added a "Ready for Review" action to pull request lists, shown for your own draft pull requests.
+
 ## [Fix opening GitHub URLs on Windows] - 2026-05-28
 
 - Updated the extension runtime dependencies so GitHub URLs open correctly in the default browser on Windows.

--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Changelog
 
-## [Mark draft pull requests as ready for review] - {PR_MERGE_DATE}
+## [Mark draft pull requests as ready for review] - 2026-07-09
 
 - Added a "Ready for Review" action to pull request lists, shown for your own draft pull requests.
 

--- a/extensions/github/src/api/pullRequest.graphql
+++ b/extensions/github/src/api/pullRequest.graphql
@@ -281,6 +281,14 @@ mutation reopenPullRequest($nodeId: ID!) {
   }
 }
 
+mutation markPullRequestReadyForReview($nodeId: ID!) {
+  markPullRequestReadyForReview(input: { pullRequestId: $nodeId }) {
+    pullRequest {
+      id
+    }
+  }
+}
+
 mutation addPullRequestReview($nodeId: ID!, $event: PullRequestReviewEvent, $body: String) {
   addPullRequestReview(input: { pullRequestId: $nodeId, event: $event, body: $body }) {
     pullRequestReview {

--- a/extensions/github/src/components/PullRequestActions.tsx
+++ b/extensions/github/src/components/PullRequestActions.tsx
@@ -79,6 +79,30 @@ export default function PullRequestActions({
     }
   }
 
+  async function markReadyForReview() {
+    try {
+      await showToast({
+        style: Toast.Style.Animated,
+        title: `Marking pull request #${pullRequest.number} as ready for review`,
+      });
+
+      await github.markPullRequestReadyForReview({ nodeId: pullRequest.id });
+
+      await mutate();
+
+      await showToast({
+        style: Toast.Style.Success,
+        title: `Pull request #${pullRequest.number} is ready for review`,
+      });
+    } catch (error) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Failed marking pull request as ready for review",
+        message: getErrorMessage(error),
+      });
+    }
+  }
+
   async function closePullRequest() {
     try {
       await showToast({
@@ -289,6 +313,13 @@ export default function PullRequestActions({
     pullRequest.mergeStateStatus !== MergeStateStatus.Blocked;
 
   const isOpen = !pullRequest.closed && !pullRequest.merged;
+
+  const isAuthoredByViewer = pullRequest.author
+    ? "isViewer" in pullRequest.author
+      ? pullRequest.author.isViewer
+      : pullRequest.author.login === viewer?.login
+    : false;
+  const canMarkReadyForReview = isOpen && pullRequest.isDraft && isAuthoredByViewer;
   const allowedMergeMethods = [
     pullRequest.repository.mergeCommitAllowed && PullRequestMergeMethod.Merge,
     pullRequest.repository.squashMergeAllowed && PullRequestMergeMethod.Squash,
@@ -461,6 +492,18 @@ export default function PullRequestActions({
       </ActionPanel.Section>
 
       <ActionPanel.Section>
+        {canMarkReadyForReview ? (
+          <Action
+            title="Ready for Review"
+            icon={{
+              source: "pull-request-open.svg",
+              tintColor: Color.PrimaryText,
+            }}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
+            onAction={() => markReadyForReview()}
+          />
+        ) : null}
+
         {pullRequest.closed && !pullRequest.merged ? (
           <Action
             title="Reopen Pull Request"

--- a/extensions/github/src/generated/graphql.ts
+++ b/extensions/github/src/generated/graphql.ts
@@ -39477,6 +39477,18 @@ export type ReopenPullRequestMutation = {
   } | null;
 };
 
+export type MarkPullRequestReadyForReviewMutationVariables = Exact<{
+  nodeId: Scalars["ID"]["input"];
+}>;
+
+export type MarkPullRequestReadyForReviewMutation = {
+  __typename?: "Mutation";
+  markPullRequestReadyForReview?: {
+    __typename?: "MarkPullRequestReadyForReviewPayload";
+    pullRequest?: { __typename?: "PullRequest"; id: string } | null;
+  } | null;
+};
+
 export type AddPullRequestReviewMutationVariables = Exact<{
   nodeId: Scalars["ID"]["input"];
   event?: InputMaybe<PullRequestReviewEvent>;
@@ -41211,6 +41223,15 @@ export const ReopenPullRequestDocument = gql`
     }
   }
 `;
+export const MarkPullRequestReadyForReviewDocument = gql`
+  mutation markPullRequestReadyForReview($nodeId: ID!) {
+    markPullRequestReadyForReview(input: { pullRequestId: $nodeId }) {
+      pullRequest {
+        id
+      }
+    }
+  }
+`;
 export const AddPullRequestReviewDocument = gql`
   mutation addPullRequestReview($nodeId: ID!, $event: PullRequestReviewEvent, $body: String) {
     addPullRequestReview(input: { pullRequestId: $nodeId, event: $event, body: $body }) {
@@ -42155,6 +42176,24 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             signal,
           }),
         "reopenPullRequest",
+        "mutation",
+        variables,
+      );
+    },
+    markPullRequestReadyForReview(
+      variables: MarkPullRequestReadyForReviewMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<MarkPullRequestReadyForReviewMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<MarkPullRequestReadyForReviewMutation>({
+            document: MarkPullRequestReadyForReviewDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "markPullRequestReadyForReview",
         "mutation",
         variables,
       );


### PR DESCRIPTION
## Description

Adds a **Ready for Review** action to the pull request action panel in the GitHub extension. It calls the GitHub `markPullRequestReadyForReview` GraphQL mutation to take a draft pull request out of draft state.

The action is guarded to appear only for **open draft pull requests authored by the current user**, so it surfaces in the **My Pull Requests** command (and the other PR lists that share the action panel) exactly where marking a draft ready makes sense. It sits alongside the existing state-transition actions (Reopen/Close), shows an animated/success/failure toast, and refreshes the list on success — matching the pattern of the surrounding actions such as Reopen Pull Request.

## Changes

- Added the `markPullRequestReadyForReview` mutation to `src/api/pullRequest.graphql` and the corresponding generated SDK entries in `src/generated/graphql.ts`.
- Added a `markReadyForReview` handler and a `Ready for Review` action to `src/components/PullRequestActions.tsx`, guarded by `isOpen && isDraft && authored-by-viewer`.
- Added a `CHANGELOG.md` entry.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build for issues](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder