### PR TITLE
Brew manage services

### DIFF
--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Manage Services] - {PR_MERGE_DATE}
 
-- Added a "Manage Services" command to list Homebrew services and start, stop, or restart them individually or all at once.
+- Added a "Manage Services" command to list Homebrew services and start, stop, or restart them individually or all at once. Actions update the list optimistically so it reflects the new state immediately.
+- Added a "Services Menu Bar" command to control Homebrew services from the menu bar, with a submenu per service and start/stop/restart all. The menu refreshes on a configurable interval.
 
 ## [Bug fix] - {PR_MERGE_DATE}
 

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Brew Changelog
 
-## [Manage Services] - {PR_MERGE_DATE}
+## [Manage Services] - 2026-07-09
 
 - Added a "Manage Services" command to list Homebrew services and start, stop, or restart them individually or all at once. Actions update the list optimistically so it reflects the new state immediately.
 - Added a "Services Menu Bar" command to control Homebrew services from the menu bar, with a submenu per service and start/stop/restart all. The menu refreshes on a configurable interval.
 
-## [Bug fix] - {PR_MERGE_DATE}
+## [Bug fix] -  2026-05-21
 
 - Improves reliability of index cache
 - Improves toast error message if fetch fails

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Brew Changelog
 
+## [Manage Services] - {PR_MERGE_DATE}
+
+- Added a "Manage Services" command to list Homebrew services and start, stop, or restart them individually or all at once.
+
 ## [Bug fix] - {PR_MERGE_DATE}
 
 - Improves reliability of index cache

--- a/extensions/brew/assets/services-menubar.svg
+++ b/extensions/brew/assets/services-menubar.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path fill="black" d="M2.6 7.8a3.4 3.4 0 1 0 6.8 0 3.4 3.4 0 1 0-6.8 0ZM6.2 6.8a3.8 3.8 0 1 0 7.6 0 3.8 3.8 0 1 0-7.6 0ZM10.3 7.8a3.2 3.2 0 1 0 6.4 0 3.2 3.2 0 1 0-6.4 0Z" />
+  <path fill="black" d="M6 8h6.5a2.5 2.5 0 0 1 2.5 2.5v9a2.5 2.5 0 0 1-2.5 2.5H6a2.5 2.5 0 0 1-2.5-2.5v-9A2.5 2.5 0 0 1 6 8Z" />
+  <path fill="none" stroke="black" stroke-width="2.2" d="M15 11.8h1.8a3.2 3.2 0 0 1 0 6.4H15" />
+</svg>

--- a/extensions/brew/package.json
+++ b/extensions/brew/package.json
@@ -79,6 +79,14 @@
       "mode": "view"
     },
     {
+      "name": "services-menu",
+      "title": "Services Menu Bar",
+      "subtitle": "Brew",
+      "description": "Control Homebrew services from the menu bar",
+      "mode": "menu-bar",
+      "interval": "1m"
+    },
+    {
       "name": "clean-up",
       "title": "Clean up",
       "subtitle": "Brew",

--- a/extensions/brew/package.json
+++ b/extensions/brew/package.json
@@ -72,6 +72,13 @@
       "mode": "view"
     },
     {
+      "name": "manage-services",
+      "title": "Manage Services",
+      "subtitle": "Brew",
+      "description": "Start, stop & restart Homebrew services",
+      "mode": "view"
+    },
+    {
       "name": "clean-up",
       "title": "Clean up",
       "subtitle": "Brew",

--- a/extensions/brew/src/components/serviceActions.tsx
+++ b/extensions/brew/src/components/serviceActions.tsx
@@ -1,0 +1,181 @@
+/**
+ * Action panel and status helpers for managing brew services.
+ */
+
+import { Action, ActionPanel, Color, Icon, Image, Keyboard } from "@raycast/api";
+import { homedir } from "os";
+import {
+  ALL_SERVICES,
+  brewRestartService,
+  brewServiceIsRunning,
+  brewStartService,
+  brewStopService,
+  ensureError,
+  findService,
+  brewFetchServices,
+  showActionToast,
+  showBrewFailureToast,
+  type Service,
+} from "../utils";
+
+/** Map a service status to a list icon. */
+export function serviceStatusIcon(status: string): Image.ImageLike {
+  switch (status) {
+    case "started":
+      return { source: Icon.CheckCircle, tintColor: Color.Green };
+    case "scheduled":
+      return { source: Icon.Clock, tintColor: Color.Blue };
+    case "stopped":
+    case "none":
+      return { source: Icon.Circle, tintColor: Color.SecondaryText };
+    case "error":
+      return { source: Icon.XMarkCircle, tintColor: Color.Red };
+    default:
+      return { source: Icon.QuestionMarkCircle, tintColor: Color.Orange };
+  }
+}
+
+type ServiceAction = "start" | "stop" | "restart";
+
+interface ActionCopy {
+  verb: string;
+  gerund: string;
+  past: string;
+}
+
+const COPY: Record<ServiceAction, ActionCopy> = {
+  start: { verb: "Start", gerund: "Starting", past: "Started" },
+  stop: { verb: "Stop", gerund: "Stopping", past: "Stopped" },
+  restart: { verb: "Restart", gerund: "Restarting", past: "Restarted" },
+};
+
+const RUNNERS: Record<ServiceAction, (name: string, cancel?: AbortSignal) => Promise<void>> = {
+  start: brewStartService,
+  stop: brewStopService,
+  restart: brewRestartService,
+};
+
+/**
+ * Run a service action, showing progress and confirming the outcome.
+ * Returns true on success so callers can refresh the list.
+ */
+async function runServiceAction(action: ServiceAction, name: string): Promise<boolean> {
+  const copy = COPY[action];
+  const target = name === ALL_SERVICES ? "all services" : name;
+  const toast = showActionToast({ title: `${copy.gerund} ${target}`, cancelable: false });
+
+  try {
+    await RUNNERS[action](name);
+
+    // For a single service, confirm the new state so we surface silent failures.
+    if (name !== ALL_SERVICES) {
+      const service = findService(await brewFetchServices(), name);
+      if (service?.status === "error") {
+        await toast.showFailureHUD(`Failed to ${copy.verb.toLowerCase()} ${name}`);
+        return false;
+      }
+    }
+
+    await toast.showSuccessHUD(`${copy.past} ${target}`);
+    return true;
+  } catch (err) {
+    toast.hide();
+    await showBrewFailureToast(`Failed to ${copy.verb.toLowerCase()} ${target}`, ensureError(err), {
+      retryAction: async () => {
+        await RUNNERS[action](name);
+      },
+    });
+    return false;
+  }
+}
+
+function ServiceActionItem(props: {
+  action: ServiceAction;
+  name: string;
+  icon: Image.ImageLike;
+  shortcut?: Keyboard.Shortcut;
+  onAction: () => void;
+}) {
+  const { action, name } = props;
+  const isAll = name === ALL_SERVICES;
+  const title = isAll ? `${COPY[action].verb} All Services` : `${COPY[action].verb} Service`;
+  return (
+    <Action
+      title={title}
+      icon={props.icon}
+      shortcut={props.shortcut}
+      style={action === "stop" ? Action.Style.Destructive : undefined}
+      onAction={async () => {
+        const ok = await runServiceAction(action, name);
+        if (ok) props.onAction();
+      }}
+    />
+  );
+}
+
+function AllServicesSection(props: { onAction: () => void }) {
+  return (
+    <ActionPanel.Section title="All Services">
+      <ServiceActionItem
+        action="start"
+        name={ALL_SERVICES}
+        icon={Icon.Play}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "s" }}
+        onAction={props.onAction}
+      />
+      <ServiceActionItem
+        action="stop"
+        name={ALL_SERVICES}
+        icon={Icon.Stop}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "x" }}
+        onAction={props.onAction}
+      />
+      <ServiceActionItem
+        action="restart"
+        name={ALL_SERVICES}
+        icon={Icon.ArrowClockwise}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "r" }}
+        onAction={props.onAction}
+      />
+    </ActionPanel.Section>
+  );
+}
+
+function PlistSection(props: { file: string }) {
+  const path = props.file.replace(/^~/, homedir());
+  return (
+    <ActionPanel.Section title="Plist">
+      <Action.ShowInFinder title="Show Plist in Finder" path={path} shortcut={{ modifiers: ["cmd"], key: "f" }} />
+      <Action.OpenWith title="Open Plist with" path={path} shortcut={Keyboard.Shortcut.Common.OpenWith} />
+      <Action.CopyToClipboard title="Copy Plist Path" content={path} shortcut={Keyboard.Shortcut.Common.CopyPath} />
+    </ActionPanel.Section>
+  );
+}
+
+export function ServiceActionPanel(props: { service: Service; onAction: () => void }) {
+  const { service, onAction } = props;
+  const running = brewServiceIsRunning(service);
+
+  return (
+    <ActionPanel>
+      <ActionPanel.Section title="Service">
+        {running ? (
+          <ServiceActionItem action="stop" name={service.name} icon={Icon.Stop} onAction={onAction} />
+        ) : (
+          <ServiceActionItem action="start" name={service.name} icon={Icon.Play} onAction={onAction} />
+        )}
+        <ServiceActionItem action="restart" name={service.name} icon={Icon.ArrowClockwise} onAction={onAction} />
+      </ActionPanel.Section>
+      <AllServicesSection onAction={onAction} />
+      {service.file ? <PlistSection file={service.file} /> : null}
+      <ActionPanel.Section>
+        <Action
+          title="Refresh"
+          icon={Icon.ArrowClockwise}
+          shortcut={Keyboard.Shortcut.Common.Refresh}
+          onAction={onAction}
+        />
+      </ActionPanel.Section>
+    </ActionPanel>
+  );
+}

--- a/extensions/brew/src/components/serviceActions.tsx
+++ b/extensions/brew/src/components/serviceActions.tsx
@@ -3,20 +3,22 @@
  */
 
 import { Action, ActionPanel, Color, Icon, Image, Keyboard } from "@raycast/api";
+import { MutatePromise } from "@raycast/utils";
 import { homedir } from "os";
 import {
   ALL_SERVICES,
-  brewRestartService,
+  applyServiceAction,
   brewServiceIsRunning,
-  brewStartService,
-  brewStopService,
   ensureError,
-  findService,
-  brewFetchServices,
+  runServiceCommand,
+  SERVICE_ACTION_COPY,
   showActionToast,
   showBrewFailureToast,
   type Service,
+  type ServiceAction,
 } from "../utils";
+
+export type ServicesMutate = MutatePromise<Service[], undefined>;
 
 /** Map a service status to a list icon. */
 export function serviceStatusIcon(status: string): Image.ImageLike {
@@ -35,57 +37,30 @@ export function serviceStatusIcon(status: string): Image.ImageLike {
   }
 }
 
-type ServiceAction = "start" | "stop" | "restart";
-
-interface ActionCopy {
-  verb: string;
-  gerund: string;
-  past: string;
-}
-
-const COPY: Record<ServiceAction, ActionCopy> = {
-  start: { verb: "Start", gerund: "Starting", past: "Started" },
-  stop: { verb: "Stop", gerund: "Stopping", past: "Stopped" },
-  restart: { verb: "Restart", gerund: "Restarting", past: "Restarted" },
-};
-
-const RUNNERS: Record<ServiceAction, (name: string, cancel?: AbortSignal) => Promise<void>> = {
-  start: brewStartService,
-  stop: brewStopService,
-  restart: brewRestartService,
-};
-
 /**
- * Run a service action, showing progress and confirming the outcome.
- * Returns true on success so callers can refresh the list.
+ * Run a service action with an optimistic list update, showing progress.
+ *
+ * The list flips to the expected state immediately via `mutate`, then
+ * reconciles against a fresh `brew services list` in the background.
  */
-async function runServiceAction(action: ServiceAction, name: string): Promise<boolean> {
-  const copy = COPY[action];
+async function runServiceAction(action: ServiceAction, name: string, mutate: ServicesMutate): Promise<void> {
+  const copy = SERVICE_ACTION_COPY[action];
   const target = name === ALL_SERVICES ? "all services" : name;
+
+  const run = () =>
+    mutate(runServiceCommand(action, name), {
+      optimisticUpdate: (services) => applyServiceAction(services ?? [], action, name),
+    });
+
   const toast = showActionToast({ title: `${copy.gerund} ${target}`, cancelable: false });
-
   try {
-    await RUNNERS[action](name);
-
-    // For a single service, confirm the new state so we surface silent failures.
-    if (name !== ALL_SERVICES) {
-      const service = findService(await brewFetchServices(), name);
-      if (service?.status === "error") {
-        await toast.showFailureHUD(`Failed to ${copy.verb.toLowerCase()} ${name}`);
-        return false;
-      }
-    }
-
+    await run();
     await toast.showSuccessHUD(`${copy.past} ${target}`);
-    return true;
   } catch (err) {
     toast.hide();
     await showBrewFailureToast(`Failed to ${copy.verb.toLowerCase()} ${target}`, ensureError(err), {
-      retryAction: async () => {
-        await RUNNERS[action](name);
-      },
+      retryAction: run,
     });
-    return false;
   }
 }
 
@@ -94,26 +69,25 @@ function ServiceActionItem(props: {
   name: string;
   icon: Image.ImageLike;
   shortcut?: Keyboard.Shortcut;
-  onAction: () => void;
+  mutate: ServicesMutate;
 }) {
   const { action, name } = props;
   const isAll = name === ALL_SERVICES;
-  const title = isAll ? `${COPY[action].verb} All Services` : `${COPY[action].verb} Service`;
+  const title = isAll
+    ? `${SERVICE_ACTION_COPY[action].verb} All Services`
+    : `${SERVICE_ACTION_COPY[action].verb} Service`;
   return (
     <Action
       title={title}
       icon={props.icon}
       shortcut={props.shortcut}
       style={action === "stop" ? Action.Style.Destructive : undefined}
-      onAction={async () => {
-        const ok = await runServiceAction(action, name);
-        if (ok) props.onAction();
-      }}
+      onAction={() => runServiceAction(action, name, props.mutate)}
     />
   );
 }
 
-function AllServicesSection(props: { onAction: () => void }) {
+function AllServicesSection(props: { mutate: ServicesMutate }) {
   return (
     <ActionPanel.Section title="All Services">
       <ServiceActionItem
@@ -121,21 +95,21 @@ function AllServicesSection(props: { onAction: () => void }) {
         name={ALL_SERVICES}
         icon={Icon.Play}
         shortcut={{ modifiers: ["cmd", "shift"], key: "s" }}
-        onAction={props.onAction}
+        mutate={props.mutate}
       />
       <ServiceActionItem
         action="stop"
         name={ALL_SERVICES}
         icon={Icon.Stop}
         shortcut={{ modifiers: ["cmd", "shift"], key: "x" }}
-        onAction={props.onAction}
+        mutate={props.mutate}
       />
       <ServiceActionItem
         action="restart"
         name={ALL_SERVICES}
         icon={Icon.ArrowClockwise}
         shortcut={{ modifiers: ["cmd", "shift"], key: "r" }}
-        onAction={props.onAction}
+        mutate={props.mutate}
       />
     </ActionPanel.Section>
   );
@@ -152,28 +126,28 @@ function PlistSection(props: { file: string }) {
   );
 }
 
-export function ServiceActionPanel(props: { service: Service; onAction: () => void }) {
-  const { service, onAction } = props;
+export function ServiceActionPanel(props: { service: Service; mutate: ServicesMutate; revalidate: () => void }) {
+  const { service, mutate, revalidate } = props;
   const running = brewServiceIsRunning(service);
 
   return (
     <ActionPanel>
       <ActionPanel.Section title="Service">
         {running ? (
-          <ServiceActionItem action="stop" name={service.name} icon={Icon.Stop} onAction={onAction} />
+          <ServiceActionItem action="stop" name={service.name} icon={Icon.Stop} mutate={mutate} />
         ) : (
-          <ServiceActionItem action="start" name={service.name} icon={Icon.Play} onAction={onAction} />
+          <ServiceActionItem action="start" name={service.name} icon={Icon.Play} mutate={mutate} />
         )}
-        <ServiceActionItem action="restart" name={service.name} icon={Icon.ArrowClockwise} onAction={onAction} />
+        <ServiceActionItem action="restart" name={service.name} icon={Icon.ArrowClockwise} mutate={mutate} />
       </ActionPanel.Section>
-      <AllServicesSection onAction={onAction} />
+      <AllServicesSection mutate={mutate} />
       {service.file ? <PlistSection file={service.file} /> : null}
       <ActionPanel.Section>
         <Action
           title="Refresh"
           icon={Icon.ArrowClockwise}
           shortcut={Keyboard.Shortcut.Common.Refresh}
-          onAction={onAction}
+          onAction={revalidate}
         />
       </ActionPanel.Section>
     </ActionPanel>

--- a/extensions/brew/src/hooks/useBrewServices.ts
+++ b/extensions/brew/src/hooks/useBrewServices.ts
@@ -1,0 +1,38 @@
+/**
+ * Hook for fetching brew services.
+ */
+
+import { showToast, Toast } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { brewFetchServices, Service, isBrewLockError, getErrorMessage, fetchLogger } from "../utils";
+
+/**
+ * Hook to fetch and cache brew services.
+ *
+ * @returns Object containing loading state, data, and a revalidate function.
+ */
+export function useBrewServices() {
+  return useCachedPromise(
+    async (): Promise<Service[]> => {
+      return await brewFetchServices();
+    },
+    [],
+    {
+      keepPreviousData: true,
+      onError: async (error) => {
+        fetchLogger.error("Failed to fetch services", {
+          errorType: error.name,
+          message: error.message,
+          isLockError: isBrewLockError(error),
+        });
+
+        const isLock = isBrewLockError(error);
+        await showToast({
+          style: Toast.Style.Failure,
+          title: isLock ? "Brew is Busy" : "Failed to fetch services",
+          message: isLock ? "Another brew process is running. Please wait and try again." : getErrorMessage(error),
+        });
+      },
+    },
+  );
+}

--- a/extensions/brew/src/manage-services.tsx
+++ b/extensions/brew/src/manage-services.tsx
@@ -1,0 +1,82 @@
+/**
+ * Manage Services view for starting, stopping and restarting brew services.
+ */
+
+import { Icon, List } from "@raycast/api";
+import { getProgressIcon } from "@raycast/utils";
+import { brewServiceIsRunning, type Service } from "./utils";
+import { useBrewServices } from "./hooks/useBrewServices";
+import { ServiceActionPanel, serviceStatusIcon } from "./components/serviceActions";
+import { ErrorBoundary } from "./components/ErrorBoundary";
+
+function statusLabel(status: string): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function ServiceListItem(props: { service: Service; onAction: () => void }) {
+  const { service } = props;
+  const accessories: List.Item.Accessory[] = [];
+  if (service.user) {
+    accessories.push({ icon: Icon.Person, text: service.user, tooltip: `Running as ${service.user}` });
+  }
+
+  return (
+    <List.Item
+      id={service.name}
+      title={service.name}
+      subtitle={statusLabel(service.status)}
+      icon={serviceStatusIcon(service.status)}
+      accessories={accessories}
+      keywords={[service.status]}
+      actions={<ServiceActionPanel service={service} onAction={props.onAction} />}
+    />
+  );
+}
+
+function ManageServicesContent() {
+  const { isLoading, data, revalidate } = useBrewServices();
+
+  const services = data ?? [];
+  const running = services.filter(brewServiceIsRunning);
+  const stopped = services.filter((service) => !brewServiceIsRunning(service));
+  const onAction = () => revalidate();
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder={isLoading ? "Loading services…" : "Search services…"}>
+      {isLoading && !data && (
+        <List.EmptyView
+          icon={getProgressIcon(0.5)}
+          title="Loading services…"
+          description="Running brew services list"
+        />
+      )}
+
+      {!isLoading && services.length === 0 && data !== undefined && (
+        <List.EmptyView
+          icon={Icon.Gear}
+          title="No services found"
+          description="No Homebrew formulae provide services on this system."
+        />
+      )}
+
+      <List.Section title="Running" subtitle={running.length > 0 ? `${running.length}` : undefined}>
+        {running.map((service) => (
+          <ServiceListItem key={service.name} service={service} onAction={onAction} />
+        ))}
+      </List.Section>
+      <List.Section title="Stopped" subtitle={stopped.length > 0 ? `${stopped.length}` : undefined}>
+        {stopped.map((service) => (
+          <ServiceListItem key={service.name} service={service} onAction={onAction} />
+        ))}
+      </List.Section>
+    </List>
+  );
+}
+
+export default function Main() {
+  return (
+    <ErrorBoundary>
+      <ManageServicesContent />
+    </ErrorBoundary>
+  );
+}

--- a/extensions/brew/src/manage-services.tsx
+++ b/extensions/brew/src/manage-services.tsx
@@ -6,14 +6,14 @@ import { Icon, List } from "@raycast/api";
 import { getProgressIcon } from "@raycast/utils";
 import { brewServiceIsRunning, type Service } from "./utils";
 import { useBrewServices } from "./hooks/useBrewServices";
-import { ServiceActionPanel, serviceStatusIcon } from "./components/serviceActions";
+import { ServiceActionPanel, serviceStatusIcon, type ServicesMutate } from "./components/serviceActions";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 
 function statusLabel(status: string): string {
   return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
-function ServiceListItem(props: { service: Service; onAction: () => void }) {
+function ServiceListItem(props: { service: Service; mutate: ServicesMutate; revalidate: () => void }) {
   const { service } = props;
   const accessories: List.Item.Accessory[] = [];
   if (service.user) {
@@ -28,18 +28,17 @@ function ServiceListItem(props: { service: Service; onAction: () => void }) {
       icon={serviceStatusIcon(service.status)}
       accessories={accessories}
       keywords={[service.status]}
-      actions={<ServiceActionPanel service={service} onAction={props.onAction} />}
+      actions={<ServiceActionPanel service={service} mutate={props.mutate} revalidate={props.revalidate} />}
     />
   );
 }
 
 function ManageServicesContent() {
-  const { isLoading, data, revalidate } = useBrewServices();
+  const { isLoading, data, revalidate, mutate } = useBrewServices();
 
   const services = data ?? [];
   const running = services.filter(brewServiceIsRunning);
   const stopped = services.filter((service) => !brewServiceIsRunning(service));
-  const onAction = () => revalidate();
 
   return (
     <List isLoading={isLoading} searchBarPlaceholder={isLoading ? "Loading services…" : "Search services…"}>
@@ -61,12 +60,12 @@ function ManageServicesContent() {
 
       <List.Section title="Running" subtitle={running.length > 0 ? `${running.length}` : undefined}>
         {running.map((service) => (
-          <ServiceListItem key={service.name} service={service} onAction={onAction} />
+          <ServiceListItem key={service.name} service={service} mutate={mutate} revalidate={revalidate} />
         ))}
       </List.Section>
       <List.Section title="Stopped" subtitle={stopped.length > 0 ? `${stopped.length}` : undefined}>
         {stopped.map((service) => (
-          <ServiceListItem key={service.name} service={service} onAction={onAction} />
+          <ServiceListItem key={service.name} service={service} mutate={mutate} revalidate={revalidate} />
         ))}
       </List.Section>
     </List>

--- a/extensions/brew/src/services-menu.tsx
+++ b/extensions/brew/src/services-menu.tsx
@@ -1,0 +1,121 @@
+/**
+ * Menu bar command for quickly controlling brew services.
+ *
+ * Homebrew has no way to notify us when a service's state changes, so the menu
+ * is kept fresh by polling on the command's `interval` (configurable in the
+ * command preferences) and by an optimistic `mutate` after each action.
+ */
+
+import { Color, Icon, LaunchType, MenuBarExtra, launchCommand, showHUD } from "@raycast/api";
+import {
+  ALL_SERVICES,
+  applyServiceAction,
+  brewServiceIsRunning,
+  ensureError,
+  getErrorMessage,
+  runServiceCommand,
+  SERVICE_ACTION_COPY,
+  type Service,
+  type ServiceAction,
+} from "./utils";
+import { useBrewServices } from "./hooks/useBrewServices";
+import { serviceStatusIcon, type ServicesMutate } from "./components/serviceActions";
+
+const MENU_ICON = { source: "services-menubar.svg", tintColor: Color.PrimaryText };
+
+const ACTION_ICONS: Record<ServiceAction, Icon> = {
+  start: Icon.Play,
+  stop: Icon.Stop,
+  restart: Icon.ArrowClockwise,
+};
+
+async function handleAction(action: ServiceAction, name: string, mutate: ServicesMutate) {
+  const copy = SERVICE_ACTION_COPY[action];
+  const target = name === ALL_SERVICES ? "all services" : name;
+  try {
+    await mutate(runServiceCommand(action, name), {
+      optimisticUpdate: (services) => applyServiceAction(services ?? [], action, name),
+    });
+    await showHUD(`${copy.past} ${target}`);
+  } catch (err) {
+    await showHUD(`Failed to ${copy.verb.toLowerCase()} ${target}: ${getErrorMessage(ensureError(err))}`);
+  }
+}
+
+export default function Command() {
+  const { isLoading, data, revalidate, mutate } = useBrewServices();
+
+  const services = data ?? [];
+  const running = services.filter(brewServiceIsRunning);
+
+  return (
+    <MenuBarExtra
+      icon={MENU_ICON}
+      title={running.length > 0 ? `${running.length}` : undefined}
+      tooltip="Homebrew Services"
+      isLoading={isLoading}
+    >
+      <MenuBarExtra.Section title="All Services">
+        <MenuBarExtra.Item
+          title="Start All"
+          icon={ACTION_ICONS.start}
+          onAction={() => handleAction("start", ALL_SERVICES, mutate)}
+        />
+        <MenuBarExtra.Item
+          title="Stop All"
+          icon={ACTION_ICONS.stop}
+          onAction={() => handleAction("stop", ALL_SERVICES, mutate)}
+        />
+        <MenuBarExtra.Item
+          title="Restart All"
+          icon={ACTION_ICONS.restart}
+          onAction={() => handleAction("restart", ALL_SERVICES, mutate)}
+        />
+      </MenuBarExtra.Section>
+
+      <MenuBarExtra.Section title="Services">
+        {services.map((service) => (
+          <ServiceSubmenu key={service.name} service={service} mutate={mutate} />
+        ))}
+        {!isLoading && services.length === 0 && <MenuBarExtra.Item title="No services found" />}
+      </MenuBarExtra.Section>
+
+      <MenuBarExtra.Section>
+        <MenuBarExtra.Item
+          title="Open Manage Services"
+          icon={Icon.AppWindowList}
+          onAction={() => launchCommand({ name: "manage-services", type: LaunchType.UserInitiated })}
+        />
+        <MenuBarExtra.Item title="Refresh" icon={Icon.ArrowClockwise} onAction={() => revalidate()} />
+      </MenuBarExtra.Section>
+    </MenuBarExtra>
+  );
+}
+
+function ServiceSubmenu(props: { service: Service; mutate: ServicesMutate }) {
+  const { service, mutate } = props;
+  const running = brewServiceIsRunning(service);
+
+  return (
+    <MenuBarExtra.Submenu title={service.name} icon={serviceStatusIcon(service.status)}>
+      {running ? (
+        <MenuBarExtra.Item
+          title="Stop"
+          icon={ACTION_ICONS.stop}
+          onAction={() => handleAction("stop", service.name, mutate)}
+        />
+      ) : (
+        <MenuBarExtra.Item
+          title="Start"
+          icon={ACTION_ICONS.start}
+          onAction={() => handleAction("start", service.name, mutate)}
+        />
+      )}
+      <MenuBarExtra.Item
+        title="Restart"
+        icon={ACTION_ICONS.restart}
+        onAction={() => handleAction("restart", service.name, mutate)}
+      />
+    </MenuBarExtra.Submenu>
+  );
+}

--- a/extensions/brew/src/utils/brew/index.ts
+++ b/extensions/brew/src/utils/brew/index.ts
@@ -65,6 +65,18 @@ export {
 export { brewUpgradeWithProgress } from "./upgrade";
 export type { UpgradeStep, UpgradeStepStatus, UpgradeProgressCallback, UpgradeResult } from "./upgrade";
 
+// Services
+export {
+  ALL_SERVICES,
+  brewFetchServices,
+  brewStartService,
+  brewStopService,
+  brewRestartService,
+  brewServiceIsRunning,
+  findService,
+} from "./services";
+export type { Service, ServiceStatus } from "./services";
+
 // Helpers
 export {
   brewName,

--- a/extensions/brew/src/utils/brew/index.ts
+++ b/extensions/brew/src/utils/brew/index.ts
@@ -68,14 +68,16 @@ export type { UpgradeStep, UpgradeStepStatus, UpgradeProgressCallback, UpgradeRe
 // Services
 export {
   ALL_SERVICES,
+  SERVICE_ACTION_COPY,
+  applyServiceAction,
   brewFetchServices,
   brewStartService,
   brewStopService,
   brewRestartService,
   brewServiceIsRunning,
-  findService,
+  runServiceCommand,
 } from "./services";
-export type { Service, ServiceStatus } from "./services";
+export type { Service, ServiceStatus, ServiceAction } from "./services";
 
 // Helpers
 export {

--- a/extensions/brew/src/utils/brew/services.ts
+++ b/extensions/brew/src/utils/brew/services.ts
@@ -100,10 +100,39 @@ export function brewServiceIsRunning(service: Service): boolean {
   return service.status === "started" || service.status === "scheduled";
 }
 
+/** The three service operations exposed to the UI. */
+export type ServiceAction = "start" | "stop" | "restart";
+
+/** Display copy for each service action, in the tenses used across the UI. */
+export const SERVICE_ACTION_COPY: Record<ServiceAction, { verb: string; gerund: string; past: string }> = {
+  start: { verb: "Start", gerund: "Starting", past: "Started" },
+  stop: { verb: "Stop", gerund: "Stopping", past: "Stopped" },
+  restart: { verb: "Restart", gerund: "Restarting", past: "Restarted" },
+};
+
+const SERVICE_ACTION_RUNNERS: Record<ServiceAction, (name: string, cancel?: AbortSignal) => Promise<void>> = {
+  start: brewStartService,
+  stop: brewStopService,
+  restart: brewRestartService,
+};
+
 /**
- * Look up a service by name from a freshly fetched list.
- * Used to confirm the outcome of an action.
+ * Run a service action. Throws if the underlying brew command fails.
+ *
+ * UI-free so it can be shared by the list view and the menu bar command.
+ * Callers refresh their service list afterwards (ideally via an optimistic
+ * `mutate`) rather than paying for a second `brew services list` here.
  */
-export function findService(services: Service[], name: string): Service | undefined {
-  return services.find((service) => service.name === name);
+export async function runServiceCommand(action: ServiceAction, name: string): Promise<void> {
+  await SERVICE_ACTION_RUNNERS[action](name);
+}
+
+/**
+ * Produce the service list as it is expected to look immediately after an
+ * action, for optimistic UI updates. `restart` and `start` resolve to
+ * "started"; `stop` to "stopped". Pass `ALL_SERVICES` to update every service.
+ */
+export function applyServiceAction(services: Service[], action: ServiceAction, name: string): Service[] {
+  const status: ServiceStatus = action === "stop" ? "stopped" : "started";
+  return services.map((service) => (name === ALL_SERVICES || service.name === name ? { ...service, status } : service));
 }

--- a/extensions/brew/src/utils/brew/services.ts
+++ b/extensions/brew/src/utils/brew/services.ts
@@ -1,0 +1,109 @@
+/**
+ * Homebrew services utilities.
+ *
+ * Provides functions for listing and controlling brew services
+ * (start/stop/restart), backed by `brew services`.
+ */
+
+import { ParseError } from "../errors";
+import { actionsLogger, fetchLogger } from "../logger";
+import { execBrew } from "./commands";
+
+/**
+ * A brew service status as reported by `brew services list`.
+ *
+ * Known values include "started", "stopped", "none", "error", "scheduled",
+ * "other" and "unknown", but brew may report others so this stays a string.
+ */
+export type ServiceStatus =
+  | "started"
+  | "stopped"
+  | "none"
+  | "error"
+  | "scheduled"
+  | "other"
+  | "unknown"
+  | (string & {});
+
+/**
+ * A brew service, as returned by `brew services list --json`.
+ */
+export interface Service {
+  name: string;
+  status: ServiceStatus;
+  /** User the service runs as, or null when not running. */
+  user: string | null;
+  /** Path to the service's plist file. */
+  file: string;
+  /** Exit code of the last run, or null when unavailable. */
+  exit_code: number | null;
+}
+
+/** Sentinel used by brew to target every service. */
+export const ALL_SERVICES = "--all";
+
+/**
+ * Fetch the list of brew services.
+ *
+ * Uses the JSON output for robust parsing.
+ */
+export async function brewFetchServices(cancel?: AbortSignal): Promise<Service[]> {
+  fetchLogger.log("Fetching brew services");
+  const result = await execBrew("services list --json", cancel ? { signal: cancel } : undefined);
+
+  const stdout = result.stdout.trim();
+  if (stdout.length === 0) {
+    return [];
+  }
+
+  try {
+    const services = JSON.parse(stdout) as Service[];
+    fetchLogger.log("Fetched brew services", { count: services.length });
+    return services;
+  } catch (err) {
+    fetchLogger.error("Failed to parse brew services output", { error: `${err}` });
+    throw new ParseError("Failed to parse brew services output", { cause: err as Error });
+  }
+}
+
+/**
+ * Start a brew service. Pass `ALL_SERVICES` to start every service.
+ */
+export async function brewStartService(name: string, cancel?: AbortSignal): Promise<void> {
+  actionsLogger.log("Starting service", { name });
+  await execBrew(`services start ${name}`, cancel ? { signal: cancel } : undefined);
+  actionsLogger.log("Started service", { name });
+}
+
+/**
+ * Stop a brew service. Pass `ALL_SERVICES` to stop every service.
+ */
+export async function brewStopService(name: string, cancel?: AbortSignal): Promise<void> {
+  actionsLogger.log("Stopping service", { name });
+  await execBrew(`services stop ${name}`, cancel ? { signal: cancel } : undefined);
+  actionsLogger.log("Stopped service", { name });
+}
+
+/**
+ * Restart a brew service. Pass `ALL_SERVICES` to restart every service.
+ */
+export async function brewRestartService(name: string, cancel?: AbortSignal): Promise<void> {
+  actionsLogger.log("Restarting service", { name });
+  await execBrew(`services restart ${name}`, cancel ? { signal: cancel } : undefined);
+  actionsLogger.log("Restarted service", { name });
+}
+
+/**
+ * Whether a service is considered active (started, running or scheduled).
+ */
+export function brewServiceIsRunning(service: Service): boolean {
+  return service.status === "started" || service.status === "scheduled";
+}
+
+/**
+ * Look up a service by name from a freshly fetched list.
+ * Used to confirm the outcome of an action.
+ */
+export function findService(services: Service[], name: string): Service | undefined {
+  return services.find((service) => service.name === name);
+}


### PR DESCRIPTION
## Description

- Adds a _Manage Services_ command to list Homebrew services and start, stop, or restart them individually or all at once. Actions update the list optimistically so it reflects the new state immediately.
- Adds a _Services Menu Bar_ command to control Homebrew services from the menu bar, with a submenu per service and start/stop/restart all. The menu refreshes on a configurable interval.

## Screencast

<img width="862" height="587" alt="Screenshot 2026-07-09 at 17 23 07" src="https://github.com/user-attachments/assets/dcf11b02-2680-4b64-9a57-40d7b143f590" />

<img width="269" height="308" alt="Screenshot 2026-07-09 at 17 22 50" src="https://github.com/user-attachments/assets/c2949656-1643-428f-a70e-871b178b4461" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
