### PR TITLE
Update wishapp extension

### DIFF
--- a/extensions/wishapp/CHANGELOG.md
+++ b/extensions/wishapp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # WishApp Changelog
 
+## [Fixes and Cleanup] - {PR_MERGE_DATE}
+
+- Item previews no longer name who reserved an item, matching the website and the mobile app, which only ever show how many are reserved
+- Fixed searching a wishlist for "reserved" filtering to the reserved items even when that wishlist is set to keep reservations hidden from you
+- Product URLs must now start with `https://`, so an unsupported link is caught in the form instead of failing against the server
+- Fixed product images served over `http://` not loading in previews
+- Fixed wishlist previews rendering a broken image when the image URL carried a query string
+- Fixed keyboard shortcuts not working on Windows: every shortcut now declares its macOS and Windows binding, and Copy uses the standard cross-platform shortcut
+- Fixed on-screen shortcut hints showing macOS-only ⌘ symbols to Windows users
+- Fixed image uploads skipping optimization when the file path contained a non-ASCII character, such as a temp folder under a user name with an accent
+- Fixed network errors showing two stacked toasts instead of one
+
 ## [Initial Version] - 2026-07-09
 
 - Add to Wishlist command: paste a product URL, autofill title, price, currency, and image from the page, pick a wishlist, and save

--- a/extensions/wishapp/CHANGELOG.md
+++ b/extensions/wishapp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # WishApp Changelog
 
-## [Fixes and Cleanup] - {PR_MERGE_DATE}
+## [Fixes and Cleanup] - 2026-07-10
 
 - Item previews no longer name who reserved an item, matching the website and the mobile app, which only ever show how many are reserved
 - Fixed searching a wishlist for "reserved" filtering to the reserved items even when that wishlist is set to keep reservations hidden from you

--- a/extensions/wishapp/README.md
+++ b/extensions/wishapp/README.md
@@ -1,27 +1,26 @@
 # WishApp for Raycast
 
-Add products to your WishApp wishlists and browse them, straight from Raycast.
+Save products to your WishApp wishlists and browse them without leaving Raycast.
 
 ## Commands
 
-- **Add to Wishlist** — paste a product URL, autofill title and price from the page, pick a wishlist, and save.
-- **My Wishlists** — browse all your wishlists; open one in the browser or copy its share link.
+- **Add to Wishlist**: paste a product URL, pull the title, price, currency, and image off the page, pick a wishlist, save. You can upload your own image instead.
+- **My Wishlists**: browse your wishlists, open one in the browser, or copy its share link.
 
 ## Setup
 
-The extension authenticates with a WishApp API key:
+You'll need a WishApp API key.
 
-1. Sign in at [getwish.app](https://www.getwish.app) (email, Google, or Apple — any method works) and open [Settings](https://www.getwish.app/settings).
+1. Sign in at [getwish.app](https://www.getwish.app) and open [Settings](https://www.getwish.app/settings).
 2. Generate an API key and copy it.
-3. Paste the key when Raycast prompts you the first time you run a command.
+3. Paste it when Raycast asks, the first time you run a command.
 
-To replace the key later, generate a new one on the settings page and update it in the extension preferences.
+Want to swap the key later? Generate a new one on the settings page and update it in the extension preferences.
 
-## Affiliate links
+## Privacy and links
 
-Opening or copying a product link routes it through WishApp's link redirector (`go.getwish.app`), the same one the WishApp website uses. The redirector logs the click and adds affiliate codes for partner merchants (Amazon and Adtraction partners), falling back to [Skimlinks](https://skimlinks.com) for other stores, then forwards you to the product page. WishApp may earn a commission on purchases made through these links, at no extra cost to you.
+Your API key stays in Raycast's preferences and only ever goes to WishApp. You can revoke it from the settings page at any time.
 
-## Privacy
+Product images are shown straight from the store that sells the item, so previewing a wishlist loads those images from the retailer's own servers, exactly as the WishApp website does.
 
-- Your API key is stored by Raycast's preferences and sent only to WishApp's API. You can revoke it at any time from the [settings page](https://www.getwish.app/settings).
-- Other than the affiliate redirects described above, the extension talks only to WishApp services (`getwish.app` and its image CDN).
+Product links open through `go.getwish.app`, the same redirector the WishApp website uses. It may add an affiliate code before sending you on to the store, which can earn WishApp a commission. You don't pay anything extra.

--- a/extensions/wishapp/src/add-to-wishlist.tsx
+++ b/extensions/wishapp/src/add-to-wishlist.tsx
@@ -1,39 +1,58 @@
-import { Action, ActionPanel, Detail, Form, Icon, List, PopToRootType, Toast, showHUD, showToast } from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Action, ActionPanel, Detail, Form, Icon, PopToRootType, Toast, showHUD, showToast } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { useEffect, useRef, useState } from "react";
 import { InvalidApiKeyView } from "./components/invalid-api-key";
-import { UnauthorizedError, apiFetch } from "./lib/api";
+import { NoWishlistsView } from "./components/no-wishlists";
+import { UnauthorizedError, apiFetch, useWishlists } from "./lib/api";
 import { CURRENCIES, CURRENCY_CODES } from "./lib/currencies";
-import { API_BASE, type CreateItemInput, type ProductInfoResponse, type WishlistsResponse } from "./lib/types";
+import { FETCH_DETAILS, PREVIEW_IMAGE, PREVIEW_IMAGE_HINT, SUBMIT_FORM, SUBMIT_HINT } from "./lib/shortcuts";
+import type { CreateItemInput, ProductInfoResponse, Wishlist } from "./lib/types";
 import { ALLOWED_IMAGE_EXTENSIONS, isAllowedImagePath, uploadItemImage } from "./lib/upload";
 
 type FormState = {
   wishlistId: string;
   url: string;
   title: string;
-  price: string;
-  currency: string;
+  description: string;
   image: string;
   imageFile: string[];
+  currency: string;
+  price: string;
   quantity: string;
   priorityWish: boolean;
-  description: string;
 };
 
-const emptyForm = (): FormState => ({
+const EMPTY_FORM: FormState = {
   wishlistId: "",
   url: "",
   title: "",
-  price: "",
-  currency: "",
+  description: "",
   image: "",
   imageFile: [],
+  currency: "",
+  price: "",
   quantity: "1",
   priorityWish: false,
-  description: "",
-});
+};
 
-const isHttpUrl = (s: string): boolean => /^https?:\/\/\S+/i.test(s.trim());
+/**
+ * The scraper rejects anything but https, and checks it with a literal
+ * `startsWith("https://")` (lib/server/product-info/fetch.ts: fetchProductSchema),
+ * so catch it here rather than round-tripping a 422 into a generic toast.
+ * Mirrors `validateUrl` in components/wishlists/items/wishlist-item-form.tsx.
+ *
+ * Returns the parsed href, not the raw input: `HTTPS://X.COM` and `https:/x.com`
+ * both parse as https yet fail the server's literal prefix check, so only the
+ * normalized form is ever sent.
+ */
+const httpsUrl = (value: string): string | undefined => {
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === "https:" ? url.href : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 export default function Command() {
   const [unauthorized, setUnauthorized] = useState(false);
@@ -44,249 +63,156 @@ export default function Command() {
 }
 
 function AddForm({ onUnauthorized }: { onUnauthorized: () => void }) {
-  const { data, isLoading, error, revalidate } = useCachedPromise(
-    () => apiFetch<WishlistsResponse>("/api/v1/wishlists"),
-    [],
-    { keepPreviousData: true },
-  );
-  const [values, setValues] = useState<FormState>(emptyForm);
+  const { sections, wishlists, isLoading, revalidate } = useWishlists(onUnauthorized);
+  const [values, setValues] = useState<FormState>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
-  // Synchronous re-entry guard: `submitting` state isn't observable within the
-  // same keypress tick, so a fast double ⌘↵ could create the item twice.
-  const submittingRef = useRef(false);
   const [fetchingDetails, setFetchingDetails] = useState(false);
+  // Synchronous re-entry guard: `submitting` state isn't observable within the
+  // same keypress tick, so a fast double submit could create the item twice.
+  const submittingRef = useRef(false);
 
+  // Seed the first wishlist as the default once data arrives.
+  const first = wishlists[0];
   useEffect(() => {
-    if (!error) return;
-    if (error instanceof UnauthorizedError) onUnauthorized();
-    else
-      showToast({
-        style: Toast.Style.Failure,
-        title: "Could not load wishlists",
-        message: error.message,
-      });
-  }, [error, onUnauthorized]);
-
-  const owned = data?.ownedWishlists ?? [];
-  const shared = data?.sharedWishlists ?? [];
-  const wishlists = [...owned, ...shared];
-
-  // Seed the first wishlist as default once data arrives.
-  useEffect(() => {
-    if (values.wishlistId || wishlists.length === 0) return;
-    const first = owned[0] ?? shared[0];
-    setValues((v) => ({
-      ...v,
+    if (!first || values.wishlistId) return;
+    setValues((previous) => ({
+      ...previous,
       wishlistId: first.id,
-      currency: v.currency || first.defaultCurrency,
+      currency: previous.currency || first.defaultCurrency,
     }));
-  }, [values.wishlistId, wishlists.length, owned, shared]);
+  }, [first, values.wishlistId]);
 
-  const onWishlistChange = useCallback(
-    (wishlistId: string) => {
-      const wl = wishlists.find((w) => w.id === wishlistId);
-      setValues((v) => ({
-        ...v,
-        wishlistId,
-        currency: wl ? wl.defaultCurrency : v.currency,
-      }));
-    },
-    [wishlists],
-  );
+  const selectWishlist = (wishlistId: string) => {
+    const wishlist = wishlists.find((candidate) => candidate.id === wishlistId);
+    setValues((previous) => ({
+      ...previous,
+      wishlistId,
+      currency: wishlist ? wishlist.defaultCurrency : previous.currency,
+    }));
+  };
 
-  const doFetchDetails = useCallback(async () => {
-    const trimmed = values.url.trim();
-    if (!isHttpUrl(trimmed)) {
-      await showToast({ style: Toast.Style.Failure, title: "Enter a valid URL first" });
+  const fetchProductDetails = async () => {
+    const url = httpsUrl(values.url);
+    if (!url) {
+      await showToast({ style: Toast.Style.Failure, title: "Enter a valid https:// URL first" });
       return;
     }
+
     setFetchingDetails(true);
     const toast = await showToast({ style: Toast.Style.Animated, title: "Fetching product details…" });
     try {
-      const res = await apiFetch<ProductInfoResponse>("/api/v1/product-info", {
+      const { data: product } = await apiFetch<ProductInfoResponse>("/api/v1/product-info", {
         method: "POST",
-        body: JSON.stringify({ url: trimmed }),
+        body: JSON.stringify({ url }),
       });
-      const { title, price, currency, image } = res.data;
+      const { title, price, currency, image } = product;
+      setValues((previous) => ({
+        ...previous,
+        ...(title && { title }),
+        ...(price != null && { price: String(price) }),
+        ...(currency && { currency }),
+        ...(image && { image }),
+      }));
+
       const filled: string[] = [];
       if (title) filled.push("title");
       if (price != null) filled.push("price");
       if (currency) filled.push("currency");
       if (image) filled.push("image");
-      setValues((v) => ({
-        ...v,
-        ...(title ? { title } : {}),
-        ...(price != null ? { price: String(price) } : {}),
-        ...(currency ? { currency } : {}),
-        ...(image ? { image } : {}),
-      }));
-      if (filled.length === 0) {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Couldn't read anything from that page";
-      } else {
-        toast.style = Toast.Style.Success;
-        toast.title = `Filled ${filled.join(", ")}`;
-      }
-    } catch (e) {
-      if (e instanceof UnauthorizedError) {
-        onUnauthorized();
-      } else {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Could not fetch details";
-        toast.message = e instanceof Error ? e.message : String(e);
-      }
+
+      toast.style = filled.length > 0 ? Toast.Style.Success : Toast.Style.Failure;
+      toast.title = filled.length > 0 ? `Filled ${filled.join(", ")}` : "Couldn't read anything from that page";
+    } catch (error) {
+      await toast.hide();
+      if (error instanceof UnauthorizedError) onUnauthorized();
+      else showFailureToast(error, { title: "Could not fetch details" });
     } finally {
       setFetchingDetails(false);
     }
-  }, [values.url, onUnauthorized]);
+  };
 
-  const submit = useCallback(async () => {
-    const wl = wishlists.find((w) => w.id === values.wishlistId);
-    if (!wl) {
+  const addItem = async () => {
+    const wishlist = wishlists.find((candidate) => candidate.id === values.wishlistId);
+    if (!wishlist) {
       await showToast({ style: Toast.Style.Failure, title: "Pick a wishlist" });
       return;
     }
-    if (!values.title.trim()) {
-      await showToast({ style: Toast.Style.Failure, title: "Title is required" });
-      return;
-    }
-    const priceNum = values.price.trim() ? Number(values.price) : undefined;
-    if (priceNum != null && (!Number.isFinite(priceNum) || priceNum < 0)) {
-      await showToast({ style: Toast.Style.Failure, title: "Price must be a positive number" });
-      return;
-    }
-    const quantityNum = values.quantity.trim() ? Number(values.quantity) : 1;
-    if (Number.isNaN(quantityNum) || quantityNum < 1 || !Number.isInteger(quantityNum)) {
-      await showToast({ style: Toast.Style.Failure, title: "Quantity must be a whole number ≥ 1" });
+
+    const price = values.price.trim() ? Number(values.price) : undefined;
+    const quantity = values.quantity.trim() ? Number(values.quantity) : 1;
+    const invalid = validate(values, price, quantity);
+    if (invalid) {
+      await showToast({ style: Toast.Style.Failure, title: invalid });
       return;
     }
     if (submittingRef.current) return;
     submittingRef.current = true;
     setSubmitting(true);
-    let inflightToast: Toast | undefined;
-    let imageKey: string | undefined;
-    const localFile = values.imageFile[0];
-    if (localFile) {
-      inflightToast = await showToast({ style: Toast.Style.Animated, title: "Uploading image…" });
-      try {
-        imageKey = await uploadItemImage(localFile);
-        inflightToast.title = "Adding to wishlist…";
-      } catch (e) {
-        if (e instanceof UnauthorizedError) {
-          await inflightToast.hide();
-          onUnauthorized();
-        } else {
-          inflightToast.style = Toast.Style.Failure;
-          inflightToast.title = "Upload failed";
-          inflightToast.message = e instanceof Error ? e.message : String(e);
-        }
-        submittingRef.current = false;
-        setSubmitting(false);
-        return;
-      }
-    }
 
-    const body: CreateItemInput = {
-      title: values.title.trim().slice(0, 255),
-      currency: (values.currency || wl.defaultCurrency).trim(),
-      priorityWish: values.priorityWish,
-      quantity: quantityNum,
-    };
-    if (values.description.trim()) body.description = values.description.trim();
-    if (values.url.trim()) body.link = values.url.trim();
-    if (imageKey) body.imageKey = imageKey;
-    else if (values.image.trim()) body.image = values.image.trim();
-    if (priceNum != null) body.price = priceNum;
+    const localFile = values.imageFile[0];
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: localFile ? "Uploading image…" : "Adding to wishlist…",
+    });
+    let uploaded = !localFile;
 
     try {
-      await apiFetch(`/api/v1/wishlists/${wl.id}/items`, {
+      const imageKey = localFile ? await uploadItemImage(localFile) : undefined;
+      uploaded = true;
+      toast.title = "Adding to wishlist…";
+
+      await apiFetch(`/api/v1/wishlists/${wishlist.id}/items`, {
         method: "POST",
-        body: JSON.stringify(body),
+        body: JSON.stringify(buildItem(values, wishlist, { price, quantity, imageKey })),
       });
+
       // Tear down the animated toast, then close with an immediate pop-to-root.
       // Raycast keeps commands warm by default (the user's "Pop to Root Search"
-      // preference), which would restore this filled-in form on reopen; forcing
+      // preference), which would restore this filled-in form on reopen. Forcing
       // Immediate exits to Raycast's root search so the next launch starts fresh.
-      await inflightToast?.hide();
-      await showHUD("Added to WishApp ✓", {
-        clearRootSearch: true,
-        popToRootType: PopToRootType.Immediate,
-      });
-    } catch (e) {
-      if (e instanceof UnauthorizedError) {
-        await inflightToast?.hide();
-        onUnauthorized();
-      } else {
-        if (inflightToast) {
-          inflightToast.style = Toast.Style.Failure;
-          inflightToast.title = "Could not add item";
-          inflightToast.message = e instanceof Error ? e.message : String(e);
-        } else {
-          await showToast({
-            style: Toast.Style.Failure,
-            title: "Could not add item",
-            message: e instanceof Error ? e.message : String(e),
-          });
-        }
-      }
+      await toast.hide();
+      await showHUD("Added to WishApp ✓", { clearRootSearch: true, popToRootType: PopToRootType.Immediate });
+    } catch (error) {
+      await toast.hide();
+      if (error instanceof UnauthorizedError) onUnauthorized();
+      else showFailureToast(error, { title: uploaded ? "Could not add item" : "Could not upload image" });
     } finally {
       submittingRef.current = false;
       setSubmitting(false);
     }
-  }, [values, wishlists, onUnauthorized]);
+  };
 
-  const hasUrl = isHttpUrl(values.url);
+  const hasUrl = httpsUrl(values.url) !== undefined;
   const titleEmpty = values.title.trim().length === 0;
-  // A scraped or wishlist-default currency may not be in the curated list
-  // (e.g. an uncommon ISO code). Surface it as its own item so the dropdown
-  // can still display the current selection.
+  // A scraped or wishlist-default currency may not be in the curated list (an
+  // uncommon ISO code, say). Surface it as its own item so the dropdown can
+  // still display the current selection.
   const selectedCurrency = values.currency.trim();
   const currencyMissing = selectedCurrency.length > 0 && !CURRENCY_CODES.has(selectedCurrency);
   // When the user pasted a URL but hasn't set a title, promote "Fetch Details"
-  // into the primary ⌘↵ slot so it reads as the expected next step.
+  // into the primary submit slot so it reads as the expected next step.
   const fetchIsPrimary = hasUrl && titleEmpty;
 
   const fetchAction = (
     <Action.SubmitForm
       title="Fetch Details from URL"
       icon={Icon.Download}
-      shortcut={fetchIsPrimary ? undefined : { modifiers: ["cmd"], key: "f" }}
-      onSubmit={doFetchDetails}
+      shortcut={fetchIsPrimary ? undefined : FETCH_DETAILS}
+      onSubmit={fetchProductDetails}
     />
   );
   const submitAction = (
     <Action.SubmitForm
       title="Add to Wishlist"
       icon={Icon.Plus}
-      shortcut={fetchIsPrimary ? { modifiers: ["cmd", "shift"], key: "return" } : undefined}
-      onSubmit={submit}
+      shortcut={fetchIsPrimary ? SUBMIT_FORM : undefined}
+      onSubmit={addItem}
     />
   );
 
-  // No wishlists to add to yet — mirror the My Wishlists empty state with a
-  // prompt to create one on the web, instead of dead-ending in an unusable form.
-  if (!isLoading && wishlists.length === 0) {
-    return (
-      <List>
-        <List.EmptyView
-          icon={Icon.Gift}
-          title="No wishlists yet"
-          description="Create your first wishlist at getwish.app, then come back here."
-          actions={
-            <ActionPanel>
-              <Action.OpenInBrowser title="Open Website" url={API_BASE} />
-              <Action
-                title="Refresh"
-                icon={Icon.ArrowClockwise}
-                shortcut={{ modifiers: ["cmd"], key: "r" }}
-                onAction={revalidate}
-              />
-            </ActionPanel>
-          }
-        />
-      </List>
-    );
-  }
+  // No wishlists to add to yet: prompt to create one on the web instead of
+  // dead-ending in an unusable form.
+  if (!isLoading && wishlists.length === 0) return <NoWishlistsView onRefresh={revalidate} />;
 
   return (
     <Form
@@ -299,36 +225,31 @@ function AddForm({ onUnauthorized }: { onUnauthorized: () => void }) {
             <Action.Push
               title="Preview Image"
               icon={Icon.Eye}
-              shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
+              shortcut={PREVIEW_IMAGE}
               target={<ImagePreview imageUrl={values.image.trim()} title={values.title || "Preview"} />}
             />
           )}
         </ActionPanel>
       }
     >
-      <Form.Dropdown id="wishlistId" title="Wishlist" value={values.wishlistId} onChange={onWishlistChange}>
-        {owned.length > 0 && (
-          <Form.Dropdown.Section title="My Wishlists">
-            {owned.map((w) => (
-              <Form.Dropdown.Item key={w.id} value={w.id} title={w.title} />
-            ))}
-          </Form.Dropdown.Section>
-        )}
-        {shared.length > 0 && (
-          <Form.Dropdown.Section title="Shared with Me">
-            {shared.map((w) => (
-              <Form.Dropdown.Item key={w.id} value={w.id} title={w.title} />
-            ))}
-          </Form.Dropdown.Section>
-        )}
+      <Form.Dropdown id="wishlistId" title="Wishlist" value={values.wishlistId} onChange={selectWishlist}>
+        {sections
+          .filter(([, sectionWishlists]) => sectionWishlists.length > 0)
+          .map(([title, sectionWishlists]) => (
+            <Form.Dropdown.Section key={title} title={title}>
+              {sectionWishlists.map((wishlist) => (
+                <Form.Dropdown.Item key={wishlist.id} value={wishlist.id} title={wishlist.title} />
+              ))}
+            </Form.Dropdown.Section>
+          ))}
       </Form.Dropdown>
       <Form.TextField
         id="url"
         title="URL"
         placeholder="Paste a product URL"
-        info={hasUrl && titleEmpty ? "Press ⌘↵ to fetch product details" : undefined}
+        info={fetchIsPrimary ? `Press ${SUBMIT_HINT} to fetch product details` : undefined}
         value={values.url}
-        onChange={(url) => setValues((v) => ({ ...v, url }))}
+        onChange={(url) => setValues((previous) => ({ ...previous, url }))}
       />
       <Form.Separator />
       <Form.TextField
@@ -336,22 +257,22 @@ function AddForm({ onUnauthorized }: { onUnauthorized: () => void }) {
         title="Title"
         placeholder={fetchingDetails ? "Fetching…" : "What is it?"}
         value={values.title}
-        onChange={(title) => setValues((v) => ({ ...v, title }))}
+        onChange={(title) => setValues((previous) => ({ ...previous, title }))}
       />
       <Form.TextArea
         id="description"
         title="Description"
         placeholder="Notes, size, color, specific variant…"
         value={values.description}
-        onChange={(description) => setValues((v) => ({ ...v, description }))}
+        onChange={(description) => setValues((previous) => ({ ...previous, description }))}
       />
       <Form.TextField
         id="image"
         title="Image URL"
         placeholder="https://…"
-        info={values.image ? "Press ⌘⇧P to preview" : undefined}
+        info={values.image ? `Press ${PREVIEW_IMAGE_HINT} to preview` : undefined}
         value={values.image}
-        onChange={(image) => setValues((v) => ({ ...v, image }))}
+        onChange={(image) => setValues((previous) => ({ ...previous, image }))}
       />
       <Form.FilePicker
         id="imageFile"
@@ -361,9 +282,8 @@ function AddForm({ onUnauthorized }: { onUnauthorized: () => void }) {
         canChooseDirectories={false}
         value={values.imageFile}
         onChange={(imageFile) => {
-          // Raycast's FilePicker has no native MIME filter — reject non-image
-          // selections right when the user picks one, instead of letting the
-          // form submit fail.
+          // Raycast's FilePicker has no MIME filter, so reject non-image
+          // selections as the user picks one rather than letting submit fail.
           const picked = imageFile[0];
           if (picked && !isAllowedImagePath(picked)) {
             showToast({
@@ -371,27 +291,31 @@ function AddForm({ onUnauthorized }: { onUnauthorized: () => void }) {
               title: "Unsupported file type",
               message: `Use ${ALLOWED_IMAGE_EXTENSIONS.join(", ")}`,
             });
-            setValues((v) => ({ ...v, imageFile: [] }));
+            setValues((previous) => ({ ...previous, imageFile: [] }));
             return;
           }
-          setValues((v) => ({ ...v, imageFile }));
+          setValues((previous) => ({ ...previous, imageFile }));
         }}
       />
       <Form.Separator />
-      {/* Only render once a currency is seeded. A Raycast dropdown always
-          forces a selection, so mounting it with an empty value would auto-pick
-          the first item and clobber the wishlist's default currency. */}
+      {/* Only render once a currency is seeded. A Raycast dropdown always forces
+          a selection, so mounting it with an empty value would auto-pick the
+          first item and clobber the wishlist's default currency. */}
       {values.currency ? (
         <Form.Dropdown
           id="currency"
           title="Currency"
           info="Defaults to the wishlist's currency."
           value={values.currency}
-          onChange={(currency) => setValues((v) => ({ ...v, currency }))}
+          onChange={(currency) => setValues((previous) => ({ ...previous, currency }))}
         >
           {currencyMissing && <Form.Dropdown.Item value={selectedCurrency} title={selectedCurrency} />}
-          {CURRENCIES.map((c) => (
-            <Form.Dropdown.Item key={c.code} value={c.code} title={`${c.code} — ${c.name}`} />
+          {CURRENCIES.map((currency) => (
+            <Form.Dropdown.Item
+              key={currency.code}
+              value={currency.code}
+              title={`${currency.code} · ${currency.name}`}
+            />
           ))}
         </Form.Dropdown>
       ) : null}
@@ -400,29 +324,57 @@ function AddForm({ onUnauthorized }: { onUnauthorized: () => void }) {
         title="Price"
         placeholder="Optional"
         value={values.price}
-        onChange={(price) => setValues((v) => ({ ...v, price }))}
+        onChange={(price) => setValues((previous) => ({ ...previous, price }))}
       />
       <Form.TextField
         id="quantity"
         title="Quantity"
+        placeholder="1"
         value={values.quantity}
-        onChange={(quantity) => setValues((v) => ({ ...v, quantity }))}
+        onChange={(quantity) => setValues((previous) => ({ ...previous, quantity }))}
       />
       <Form.Checkbox
         id="priorityWish"
         label="Priority Wish"
         value={values.priorityWish}
-        onChange={(priorityWish) => setValues((v) => ({ ...v, priorityWish }))}
+        onChange={(priorityWish) => setValues((previous) => ({ ...previous, priorityWish }))}
       />
     </Form>
   );
 }
 
+function validate(values: FormState, price: number | undefined, quantity: number): string | undefined {
+  if (!values.title.trim()) return "Title is required";
+  if (price !== undefined && (!Number.isFinite(price) || price < 0)) return "Price must be a positive number";
+  if (!Number.isInteger(quantity) || quantity < 1) return "Quantity must be a whole number of 1 or more";
+  return undefined;
+}
+
+function buildItem(
+  values: FormState,
+  wishlist: Wishlist,
+  extras: { price: number | undefined; quantity: number; imageKey: string | undefined },
+): CreateItemInput {
+  const item: CreateItemInput = {
+    title: values.title.trim().slice(0, 255),
+    currency: (values.currency || wishlist.defaultCurrency).trim(),
+    priorityWish: values.priorityWish,
+    quantity: extras.quantity,
+  };
+  if (values.description.trim()) item.description = values.description.trim();
+  // Store the same canonical href we scraped. An http link is valid to save
+  // even though it can't be scraped, so it passes through untouched.
+  if (values.url.trim()) item.link = httpsUrl(values.url) ?? values.url.trim();
+  if (extras.imageKey) item.imageKey = extras.imageKey;
+  else if (values.image.trim()) item.image = values.image.trim();
+  if (extras.price !== undefined) item.price = extras.price;
+  return item;
+}
+
 function ImagePreview({ imageUrl, title }: { imageUrl: string; title: string }) {
-  const markdown = `# ${title}\n\n![${title}](${imageUrl})`;
   return (
     <Detail
-      markdown={markdown}
+      markdown={`# ${title}\n\n![${title}](${imageUrl})`}
       navigationTitle="Image Preview"
       actions={
         <ActionPanel>

--- a/extensions/wishapp/src/components/invalid-api-key.tsx
+++ b/extensions/wishapp/src/components/invalid-api-key.tsx
@@ -1,5 +1,5 @@
 import { Action, ActionPanel, Icon, List, openExtensionPreferences } from "@raycast/api";
-import { API_BASE } from "../lib/types";
+import { API_BASE } from "../lib/constants";
 
 export function InvalidApiKeyView() {
   return (

--- a/extensions/wishapp/src/components/no-wishlists.tsx
+++ b/extensions/wishapp/src/components/no-wishlists.tsx
@@ -1,0 +1,21 @@
+import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import { API_BASE } from "../lib/constants";
+import { REFRESH } from "../lib/shortcuts";
+
+export function NoWishlistsView({ onRefresh }: { onRefresh: () => void }) {
+  return (
+    <List>
+      <List.EmptyView
+        icon={Icon.Gift}
+        title="No wishlists yet"
+        description="Create your first wishlist at getwish.app, then come back here."
+        actions={
+          <ActionPanel>
+            <Action.OpenInBrowser title="Open Website" url={API_BASE} />
+            <Action title="Refresh" icon={Icon.ArrowClockwise} shortcut={REFRESH} onAction={onRefresh} />
+          </ActionPanel>
+        }
+      />
+    </List>
+  );
+}

--- a/extensions/wishapp/src/components/wishlist-detail.tsx
+++ b/extensions/wishapp/src/components/wishlist-detail.tsx
@@ -1,10 +1,13 @@
-import { Action, ActionPanel, Color, Icon, List, Toast, showToast, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, Color, Icon, List, useNavigation } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
-import { useCallback, useEffect, useState } from "react";
-import { UnauthorizedError, apiFetch } from "../lib/api";
+import { useState } from "react";
+import { apiFetch, handleApiError } from "../lib/api";
+import { API_BASE } from "../lib/constants";
 import { getExternalLink } from "../lib/external-link";
-import { formatPrice, itemImageUrl } from "../lib/image";
-import { API_BASE, type WishlistDetailResponse, type WishlistItem } from "../lib/types";
+import { formatPrice } from "../lib/format";
+import { imageMarkdown, itemImageUrl } from "../lib/image";
+import { COPY_LINK, REFRESH, TOGGLE_PREVIEW } from "../lib/shortcuts";
+import type { WishlistDetailResponse, WishlistItem } from "../lib/types";
 
 type Props = {
   wishlistId: string;
@@ -15,30 +18,23 @@ type Props = {
 export function WishlistDetail({ wishlistId, title, onUnauthorized }: Props) {
   const [showDetail, setShowDetail] = useState(true);
   const { pop } = useNavigation();
-  const { data, isLoading, error, revalidate } = useCachedPromise(
-    (id: string) => apiFetch<WishlistDetailResponse>(`/api/v1/wishlists/${id}`),
-    [wishlistId],
-    { keepPreviousData: true },
-  );
 
-  // This view is pushed onto the nav stack, so swapping the root to the
-  // invalid-key view alone leaves it stranded on top — pop it first so a 401
-  // actually surfaces that screen.
-  const handleUnauthorized = useCallback(() => {
+  // This view is pushed onto the nav stack, so swapping the root for the
+  // invalid-key view alone would leave it stranded on top. Pop it first so a
+  // 401 actually surfaces that screen.
+  const handleUnauthorized = () => {
     pop();
     onUnauthorized();
-  }, [pop, onUnauthorized]);
+  };
 
-  useEffect(() => {
-    if (!error) return;
-    if (error instanceof UnauthorizedError) handleUnauthorized();
-    else
-      showToast({
-        style: Toast.Style.Failure,
-        title: "Could not load items",
-        message: error.message,
-      });
-  }, [error, handleUnauthorized]);
+  const { data, isLoading, revalidate } = useCachedPromise(
+    (id: string) => apiFetch<WishlistDetailResponse>(`/api/v1/wishlists/${id}`),
+    [wishlistId],
+    {
+      keepPreviousData: true,
+      onError: (error) => handleApiError(error, "Could not load items", handleUnauthorized),
+    },
+  );
 
   const items = data?.wishlist.items ?? [];
   const wishlistUrl = data ? `${API_BASE}/w/${data.wishlist.shareUrl}` : API_BASE;
@@ -59,12 +55,7 @@ export function WishlistDetail({ wishlistId, title, onUnauthorized }: Props) {
           actions={
             <ActionPanel>
               <Action.OpenInBrowser title="Open Wishlist in Browser" url={wishlistUrl} />
-              <Action
-                title="Refresh"
-                icon={Icon.ArrowClockwise}
-                shortcut={{ modifiers: ["cmd"], key: "r" }}
-                onAction={revalidate}
-              />
+              <Action title="Refresh" icon={Icon.ArrowClockwise} shortcut={REFRESH} onAction={revalidate} />
             </ActionPanel>
           }
         />
@@ -74,12 +65,12 @@ export function WishlistDetail({ wishlistId, title, onUnauthorized }: Props) {
             key={item.id}
             item={item}
             wishlistUrl={wishlistUrl}
-            // hideReservations is the wishlist-owner-privacy flag (default true).
-            // When true, mirror the web: owners never see reservation counts or
-            // who reserved what. Treat undefined as true defensively.
-            hideReservations={data?.wishlist.hideReservations ?? true}
+            // hideReservations is the wishlist owner's privacy flag (default
+            // true). When set, mirror the web app: owners never see reservation
+            // counts or who reserved what. Treat undefined as true defensively.
+            showReservations={!(data?.wishlist.hideReservations ?? true)}
             showDetail={showDetail}
-            onToggleDetail={() => setShowDetail((s) => !s)}
+            onToggleDetail={() => setShowDetail((shown) => !shown)}
             onRefresh={revalidate}
           />
         ))
@@ -91,107 +82,96 @@ export function WishlistDetail({ wishlistId, title, onUnauthorized }: Props) {
 function ItemRow({
   item,
   wishlistUrl,
-  hideReservations,
+  showReservations,
   showDetail,
   onToggleDetail,
   onRefresh,
 }: {
   item: WishlistItem;
   wishlistUrl: string;
-  hideReservations: boolean;
+  showReservations: boolean;
   showDetail: boolean;
   onToggleDetail: () => void;
   onRefresh: () => void;
 }) {
   const image = itemImageUrl(item.image);
   const price = formatPrice(item.price, item.currency);
-  const reserved = item.reservations.reduce((sum, r) => sum + r.quantity, 0);
-  const remaining = Math.max(0, item.quantity - reserved);
-  const showReservations = !hideReservations;
+  const reserved = item.reservations.reduce((sum, reservation) => sum + reservation.quantity, 0);
+  const someReserved = showReservations && reserved > 0;
   const productLink = item.link ? getExternalLink(item.link, item.id) : undefined;
-
-  const accessories: List.Item.Accessory[] = [];
-  if (!showDetail) {
-    if (item.priorityWish) {
-      accessories.push({ icon: { source: Icon.Star, tintColor: Color.Yellow }, tooltip: "Priority" });
-    }
-    if (showReservations && reserved > 0 && item.quantity > 1) {
-      accessories.push({ text: `${remaining}/${item.quantity}`, tooltip: "Remaining / total" });
-    } else if (item.quantity > 1) {
-      accessories.push({ text: `×${item.quantity}`, tooltip: "Quantity" });
-    }
-    if (showReservations && reserved > 0 && item.quantity === 1) {
-      accessories.push({ icon: Icon.CheckCircle, tooltip: "Reserved" });
-    }
-    if (price) accessories.push({ text: price });
-  }
 
   return (
     <List.Item
       icon={image}
       title={item.title}
       subtitle={showDetail ? undefined : (item.description ?? undefined)}
-      accessories={accessories.length > 0 ? accessories : undefined}
-      keywords={[item.currency, item.priorityWish ? "priority" : "", reserved > 0 ? "reserved" : ""].filter(Boolean)}
-      detail={
-        <List.Item.Detail markdown={buildItemMarkdown(item, image, { price, remaining, reserved, showReservations })} />
-      }
+      accessories={showDetail ? undefined : buildAccessories(item, { price, reserved, showReservations })}
+      // `keywords` are indexed by the search bar, so a "reserved" keyword would
+      // let an owner filter down to exactly the reserved items even when the
+      // reservation UI is hidden from them. Gate it on the same flag.
+      keywords={[item.currency, item.priorityWish ? "priority" : "", someReserved ? "reserved" : ""].filter(Boolean)}
+      detail={<List.Item.Detail markdown={buildItemMarkdown(item, image, { price, reserved, showReservations })} />}
       actions={
         <ActionPanel>
           {productLink && <Action.OpenInBrowser title="Open Product Link" url={productLink} />}
-          <Action.OpenInBrowser title="Open Wishlist in Browser" url={wishlistUrl} icon={Icon.Globe} />
+          <Action.OpenInBrowser title="Open Wishlist in Browser" url={wishlistUrl} />
           {productLink && (
-            <Action.CopyToClipboard
-              title="Copy Product Link"
-              content={productLink}
-              shortcut={{ modifiers: ["cmd"], key: "." }}
-            />
+            <Action.CopyToClipboard title="Copy Product Link" content={productLink} shortcut={COPY_LINK} />
           )}
           <Action.CopyToClipboard title="Copy Wishlist Link" content={wishlistUrl} />
           <Action
             title={showDetail ? "Hide Preview" : "Show Preview"}
             icon={Icon.AppWindowSidebarRight}
-            shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
+            shortcut={TOGGLE_PREVIEW}
             onAction={onToggleDetail}
           />
-          <Action
-            title="Refresh"
-            icon={Icon.ArrowClockwise}
-            shortcut={{ modifiers: ["cmd"], key: "r" }}
-            onAction={onRefresh}
-          />
+          <Action title="Refresh" icon={Icon.ArrowClockwise} shortcut={REFRESH} onAction={onRefresh} />
         </ActionPanel>
       }
     />
   );
 }
 
-function buildItemMarkdown(
-  item: WishlistItem,
-  image: string,
-  meta: { price: string | undefined; remaining: number; reserved: number; showReservations: boolean },
-): string {
-  const parts: string[] = [`# ${item.title}`];
+type ItemMeta = {
+  price: string | undefined;
+  reserved: number;
+  showReservations: boolean;
+};
+
+function buildAccessories(item: WishlistItem, { price, reserved, showReservations }: ItemMeta): List.Item.Accessory[] {
+  const accessories: List.Item.Accessory[] = [];
+  const someReserved = showReservations && reserved > 0;
+
+  if (item.priorityWish) {
+    accessories.push({ icon: { source: Icon.Star, tintColor: Color.Yellow }, tooltip: "Priority" });
+  }
+  if (someReserved && item.quantity > 1) {
+    const remaining = Math.max(0, item.quantity - reserved);
+    accessories.push({ text: `${remaining}/${item.quantity}`, tooltip: "Remaining / total" });
+  } else if (item.quantity > 1) {
+    accessories.push({ text: `×${item.quantity}`, tooltip: "Quantity" });
+  } else if (someReserved) {
+    accessories.push({ icon: Icon.CheckCircle, tooltip: "Reserved" });
+  }
+  if (price) accessories.push({ text: price });
+
+  return accessories;
+}
+
+function buildItemMarkdown(item: WishlistItem, image: string, { price, reserved, showReservations }: ItemMeta): string {
+  const parts = [`# ${item.title}`];
   if (item.description) parts.push("", item.description);
 
+  const someReserved = showReservations && reserved > 0;
   const chips: string[] = [];
-  if (meta.price) chips.push(`**${meta.price}**`);
-  if (meta.showReservations && meta.reserved > 0 && item.quantity > 1) {
-    chips.push(`${meta.remaining} of ${item.quantity} left`);
-  } else if (meta.showReservations && meta.reserved > 0 && item.quantity === 1) {
-    chips.push("Reserved");
-  } else if (item.quantity > 1) {
-    chips.push(`Qty ${item.quantity}`);
-  }
+  if (price) chips.push(`**${price}**`);
+  if (someReserved && item.quantity > 1)
+    chips.push(`${Math.max(0, item.quantity - reserved)} of ${item.quantity} left`);
+  else if (someReserved) chips.push("Reserved");
+  else if (item.quantity > 1) chips.push(`Qty ${item.quantity}`);
   if (item.priorityWish) chips.push("★ Priority");
   if (chips.length > 0) parts.push("", chips.join(" · "));
 
-  if (meta.showReservations && item.reservations.length > 0) {
-    parts.push("", `_Reserved by ${item.reservations.map((r) => r.user.name).join(", ")}_`);
-  }
-  // Constrain height like the wishlist markdown does; pick the right query
-  // separator since item images can be external URLs that already carry params.
-  const sep = image.includes("?") ? "&" : "?";
-  parts.push("", `![${item.title}](${image}${sep}raycast-height=200)`);
+  parts.push("", imageMarkdown(item.title, image));
   return parts.join("\n");
 }

--- a/extensions/wishapp/src/lib/api.ts
+++ b/extensions/wishapp/src/lib/api.ts
@@ -1,5 +1,7 @@
 import { getPreferenceValues } from "@raycast/api";
-import { API_BASE } from "./types";
+import { showFailureToast, useCachedPromise } from "@raycast/utils";
+import { API_BASE } from "./constants";
+import type { Wishlist, WishlistsResponse } from "./types";
 
 export class UnauthorizedError extends Error {
   constructor() {
@@ -28,4 +30,39 @@ export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise
   }
 
   return (await res.json()) as T;
+}
+
+/**
+ * A rejected API key swaps the whole view for the invalid-key screen; anything
+ * else is just a toast. Pass this as `useCachedPromise`'s `onError` so it
+ * replaces the hook's own "Failed to fetch latest data" toast rather than
+ * stacking a second one on top of it.
+ */
+export function handleApiError(error: unknown, title: string, onUnauthorized: () => void): void {
+  if (error instanceof UnauthorizedError) onUnauthorized();
+  else showFailureToast(error, { title });
+}
+
+/**
+ * Both commands open on the same wishlist list, split into the same two
+ * sections. `sections` keeps the display order; `wishlists` is the flat view
+ * for lookups and emptiness checks.
+ */
+export function useWishlists(onUnauthorized: () => void) {
+  const { data, isLoading, revalidate } = useCachedPromise(() => apiFetch<WishlistsResponse>("/api/v1/wishlists"), [], {
+    keepPreviousData: true,
+    onError: (error) => handleApiError(error, "Could not load wishlists", onUnauthorized),
+  });
+
+  const sections: [string, Wishlist[]][] = [
+    ["My Wishlists", data?.ownedWishlists ?? []],
+    ["Shared with Me", data?.sharedWishlists ?? []],
+  ];
+
+  return {
+    sections,
+    wishlists: sections.flatMap(([, sectionWishlists]) => sectionWishlists),
+    isLoading,
+    revalidate,
+  };
 }

--- a/extensions/wishapp/src/lib/constants.ts
+++ b/extensions/wishapp/src/lib/constants.ts
@@ -1,0 +1,2 @@
+export const API_BASE = "https://www.getwish.app";
+export const CDN_BASE = "https://cdn.getwish.app";

--- a/extensions/wishapp/src/lib/currencies.ts
+++ b/extensions/wishapp/src/lib/currencies.ts
@@ -1,32 +1,28 @@
-import { currencies as AllCurrencies } from "country-data-list";
+import { currencies as allCurrencies } from "country-data-list";
 
 export type Currency = {
   code: string;
   name: string;
-  symbol: string;
+};
+
+const NAME_OVERRIDES: Record<string, string> = {
+  USD: "US Dollar",
+  GBP: "British Pound",
 };
 
 // Mirrors the web app's `components/ui/currency-select.tsx`: keep currencies
 // that have a code, name and symbol, dedupe by code, tidy a couple of major
-// names, then sort by name so both clients show an identical list.
+// names, then sort by name so both clients show an identical list. The symbol
+// is only ever a filter here, never displayed, so it isn't kept.
 export const CURRENCIES: Currency[] = (() => {
   const byCode = new Map<string, Currency>();
 
-  for (const currency of AllCurrencies.all) {
-    if (!currency.code || !currency.name || !currency.symbol) continue;
-
-    let name = currency.name;
-    if (currency.code === "USD") name = "US Dollar";
-    else if (currency.code === "GBP") name = "British Pound";
-
-    byCode.set(currency.code, {
-      code: currency.code,
-      name,
-      symbol: currency.symbol,
-    });
+  for (const { code, name, symbol } of allCurrencies.all) {
+    if (!code || !name || !symbol) continue;
+    byCode.set(code, { code, name: NAME_OVERRIDES[code] ?? name });
   }
 
-  return Array.from(byCode.values()).sort((a, b) => a.name.localeCompare(b.name));
+  return [...byCode.values()].sort((a, b) => a.name.localeCompare(b.name));
 })();
 
 export const CURRENCY_CODES = new Set(CURRENCIES.map((c) => c.code));

--- a/extensions/wishapp/src/lib/external-link.ts
+++ b/extensions/wishapp/src/lib/external-link.ts
@@ -6,12 +6,12 @@ const AFFILIATE_WORKER_URL = "https://go.getwish.app";
  * known merchants (Amazon, Adtraction partners) and falls back to Skimlinks
  * for the rest, then 302-redirects.
  *
- * Mirrors `lib/client/links.ts:getExternalLink` in the main app — keep them
- * in sync.
+ * Mirrors `lib/client/links.ts:getExternalLink` in the main app. Keep them in
+ * sync.
  */
 export function getExternalLink(url: string, itemId?: string): string {
   if (!url) return url;
   const params = new URLSearchParams({ url });
   if (itemId) params.set("xcust", itemId);
-  return `${AFFILIATE_WORKER_URL}/?${params.toString()}`;
+  return `${AFFILIATE_WORKER_URL}?${params}`;
 }

--- a/extensions/wishapp/src/lib/format.ts
+++ b/extensions/wishapp/src/lib/format.ts
@@ -1,0 +1,9 @@
+export function formatPrice(price: number | null, currency: string): string | undefined {
+  if (price == null) return undefined;
+  try {
+    return new Intl.NumberFormat("en-US", { style: "currency", currency }).format(price);
+  } catch {
+    // Intl throws on currency codes it doesn't know.
+    return `${price} ${currency}`;
+  }
+}

--- a/extensions/wishapp/src/lib/image.ts
+++ b/extensions/wishapp/src/lib/image.ts
@@ -1,4 +1,4 @@
-import { API_BASE, CDN_BASE } from "./types";
+import { API_BASE, CDN_BASE } from "./constants";
 
 const DEFAULT_WISHLIST_IMAGE = `${API_BASE}/wishlist-images/wishlist.webp`;
 const DEFAULT_ITEM_IMAGE = `${API_BASE}/products/default.webp`;
@@ -11,28 +11,37 @@ export function itemImageUrl(image: string | null): string {
   return resolveImage(image, "items") ?? DEFAULT_ITEM_IMAGE;
 }
 
+/**
+ * A markdown image capped at `height`. Item images can be external URLs that
+ * already carry a query string, so the separator can't be a bare `?`.
+ */
+export function imageMarkdown(alt: string, url: string, height = 200): string {
+  const separator = url.includes("?") ? "&" : "?";
+  return `![${alt}](${url}${separator}raycast-height=${height})`;
+}
+
+/**
+ * Mirrors `lib/client/wishlist.ts:getImageDisplayProps` and
+ * `:getItemImageDisplayProps` in the main app. Keep them in sync.
+ */
 function resolveImage(image: string | null, kind: "items" | "wishlists"): string | undefined {
   if (!image) return undefined;
-  if (image.startsWith("http://") || image.startsWith("https://")) return image;
-  // Wishlist preset images live as static assets in the Next.js public folder
-  // (see lib/client/wishlist.ts:getImageDisplayProps). Items don't support
-  // presets — their schema rejects non-URL strings, so this branch is
-  // wishlists-only in practice.
+  // Wishlist preset images live as static assets in the Next.js public folder.
+  // Items don't support presets: their schema rejects non-URL strings, so this
+  // branch is wishlists-only in practice.
   if (image.startsWith("preset:")) {
     const id = image.slice("preset:".length);
     return `${API_BASE}/wishlist-images/${id}.webp`;
   }
+  // Scraped product images. The web app upgrades http to https before display,
+  // so a stored http image must not reach Raycast as-is.
+  if (image.startsWith("https://") || image.startsWith("http://")) {
+    return image.replace(/^http:\/\//i, "https://");
+  }
+  // A public asset served by Next.js rather than a storage key.
+  if (image.startsWith("/")) return `${API_BASE}${image}`;
   // Otherwise it's an R2 storage key. The production URL pattern is
-  // ${CDN_BASE}/wishapp/{wishlists|items}/full/{filename} — see
+  // ${CDN_BASE}/wishapp/{wishlists|items}/full/{filename}, see
   // lib/server/image-storage.ts:getWishlist(Item)?ImageUrl.
   return `${CDN_BASE}/wishapp/${kind}/full/${image}`;
-}
-
-export function formatPrice(price: number | null, currency: string): string | undefined {
-  if (price == null) return undefined;
-  try {
-    return new Intl.NumberFormat("en-US", { style: "currency", currency }).format(price);
-  } catch {
-    return `${price} ${currency}`;
-  }
 }

--- a/extensions/wishapp/src/lib/shortcuts.ts
+++ b/extensions/wishapp/src/lib/shortcuts.ts
@@ -1,0 +1,36 @@
+import { Keyboard } from "@raycast/api";
+
+/**
+ * Raycast calls `cmd`, `ctrl` and `windows` "ambiguous" modifiers: a shortcut
+ * built from them has to name both platforms explicitly, or it won't bind on
+ * the other one. The `Common.*` shortcuts are already cross-platform.
+ * See https://developers.raycast.com/api-reference/keyboard
+ */
+export const REFRESH = Keyboard.Shortcut.Common.Refresh;
+export const COPY_LINK = Keyboard.Shortcut.Common.Copy;
+
+export const TOGGLE_PREVIEW: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd", "shift"], key: "d" },
+  Windows: { modifiers: ["ctrl", "shift"], key: "d" },
+};
+
+export const FETCH_DETAILS: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd"], key: "f" },
+  Windows: { modifiers: ["ctrl"], key: "f" },
+};
+
+export const SUBMIT_FORM: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd", "shift"], key: "return" },
+  Windows: { modifiers: ["ctrl", "shift"], key: "return" },
+};
+
+export const PREVIEW_IMAGE: Keyboard.Shortcut = {
+  macOS: { modifiers: ["cmd", "shift"], key: "p" },
+  Windows: { modifiers: ["ctrl", "shift"], key: "p" },
+};
+
+// Form `info` hints are plain strings, so they spell the keys out themselves.
+// macOS glyphs mean nothing on a Windows keyboard.
+const isWindows = process.platform === "win32";
+export const SUBMIT_HINT = isWindows ? "Ctrl+Enter" : "⌘↵";
+export const PREVIEW_IMAGE_HINT = isWindows ? "Ctrl+Shift+P" : "⌘⇧P";

--- a/extensions/wishapp/src/lib/types.ts
+++ b/extensions/wishapp/src/lib/types.ts
@@ -1,7 +1,4 @@
-export const API_BASE = "https://www.getwish.app";
-export const CDN_BASE = "https://cdn.getwish.app";
-
-export type Wishlist = {
+type WishlistBase = {
   id: string;
   shareUrl: string;
   title: string;
@@ -9,6 +6,11 @@ export type Wishlist = {
   image: string | null;
   defaultCurrency: string;
   hideReservations: boolean;
+};
+
+export type Wishlist = WishlistBase & {
+  // `items` excludes items already marked received, matching the list route's
+  // `items: { where: { receivedAt: null } }`. `followers` is unfiltered.
   _count: { items: number; followers: number };
 };
 
@@ -28,27 +30,30 @@ export type WishlistItem = {
   link: string | null;
   quantity: number;
   priorityWish: boolean;
-  reservations: { id: string; quantity: number; user: { id: string; name: string } }[];
+  // Quantities only. The detail endpoint also returns each reserver's id and
+  // name, but no client surfaces them: the web and mobile apps show reserved
+  // counts and never say who reserved what, so a gift stays a surprise.
+  reservations: { quantity: number }[];
 };
 
 export type WishlistDetailResponse = {
   success: true;
-  wishlist: Wishlist & {
+  // The detail route returns the items themselves, so it counts followers only.
+  wishlist: WishlistBase & {
+    _count: { followers: number };
     user: { id: string; name: string; image: string | null };
     items: WishlistItem[];
   };
 };
 
-export type ProductInfo = {
-  title?: string;
-  price?: number;
-  currency?: string;
-  image?: string;
-};
-
 export type ProductInfoResponse = {
   success: true;
-  data: ProductInfo;
+  data: {
+    title?: string;
+    price?: number;
+    currency?: string;
+    image?: string;
+  };
 };
 
 export type CreateItemInput = {

--- a/extensions/wishapp/src/lib/upload.ts
+++ b/extensions/wishapp/src/lib/upload.ts
@@ -9,20 +9,20 @@ import { apiFetch } from "./api";
 
 const execFileAsync = promisify(execFile);
 
-export const ALLOWED_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".gif"];
-const ALLOWED_EXTS = new Set(ALLOWED_IMAGE_EXTENSIONS);
-const MAX_BYTES = 5 * 1024 * 1024;
+const MAX_UPLOAD_MB = 5;
+const MAX_UPLOAD_BYTES = MAX_UPLOAD_MB * 1024 * 1024;
+const POWERSHELL_TIMEOUT_MS = 20_000;
 
 // Matches the stored full size (lib/server/image-storage.ts resizes to height
 // 900), so the server's own resize of our pre-shrunk upload is a no-op and
 // never upscales.
 const MAX_HEIGHT = 900;
-// Near-lossless: this JPEG is only a transport format — the server re-encodes
-// to the stored webp (q85/80), so the intermediate must not add its own
-// compression loss on top.
+// Near-lossless. This JPEG is only a transport format: the server re-encodes to
+// the stored webp (q85/80), so the intermediate must not add compression loss
+// of its own on top.
 const JPEG_QUALITY = 100;
 
-const MIME_TYPES: Record<string, string> = {
+const MIME_TYPES: Record<string, string | undefined> = {
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
   ".png": "image/png",
@@ -30,13 +30,14 @@ const MIME_TYPES: Record<string, string> = {
   ".gif": "image/gif",
 };
 
-export function isAllowedImagePath(filePath: string): boolean {
-  return ALLOWED_EXTS.has(path.extname(filePath).toLowerCase());
-}
+export const ALLOWED_IMAGE_EXTENSIONS = Object.keys(MIME_TYPES);
 
-type UploadResponse = {
-  success: true;
-  key: string;
+/** `format` doubles as the value `sips -s format` expects. */
+type OutputFormat = "png" | "jpeg";
+
+const OUTPUT_FORMATS: Record<OutputFormat, { fileExtension: string; mimeType: string }> = {
+  png: { fileExtension: "png", mimeType: "image/png" },
+  jpeg: { fileExtension: "jpg", mimeType: "image/jpeg" },
 };
 
 type OptimizedImage = {
@@ -44,28 +45,42 @@ type OptimizedImage = {
   contentType: string;
 };
 
+type UploadResponse = {
+  success: true;
+  key: string;
+};
+
+/** Resizes `filePath` into `outPath`. Resolves false when there was nothing to do. */
+type Resize = (filePath: string, format: OutputFormat, outPath: string) => Promise<boolean>;
+
+export function isAllowedImagePath(filePath: string): boolean {
+  return ALLOWED_IMAGE_EXTENSIONS.includes(path.extname(filePath).toLowerCase());
+}
+
 /**
  * Pick a local image, shrink it with OS-native tools (macOS `sips`, Windows
- * PowerShell + System.Drawing — no npm image dependencies), and POST the bytes
- * to /api/v1/upload/items, which encodes the stored webp full + thumbnail with
- * the same sharp pipeline the web app uses. Optimization is best-effort: on
- * any failure the original file is uploaded and the server resizes it anyway.
- * Returns the storage filename to pass as `imageKey` on item create.
+ * PowerShell + System.Drawing, so no npm image dependencies), and POST the
+ * bytes to /api/v1/upload/items, which encodes the stored webp full size and
+ * thumbnail with the same sharp pipeline the web app uses. Optimization is
+ * best-effort: on any failure the original file is uploaded and the server
+ * resizes it anyway. Returns the storage filename to pass as `imageKey` on
+ * item create.
  */
 export async function uploadItemImage(filePath: string): Promise<string> {
   const ext = path.extname(filePath).toLowerCase();
-  if (!ALLOWED_EXTS.has(ext)) {
+  const originalType = MIME_TYPES[ext];
+  if (!originalType) {
     throw new Error(`Unsupported file type "${ext}". Use JPG, PNG, WebP, or GIF.`);
   }
 
   const original = await readFile(filePath);
   const optimized = await optimizeImage(filePath, ext);
   const upload =
-    optimized && optimized.body.length < original.length ? optimized : { body: original, contentType: MIME_TYPES[ext] };
+    optimized && optimized.body.length < original.length ? optimized : { body: original, contentType: originalType };
 
-  if (upload.body.length > MAX_BYTES) {
+  if (upload.body.length > MAX_UPLOAD_BYTES) {
     const mb = (upload.body.length / 1024 / 1024).toFixed(1);
-    throw new Error(`Image is too large (${mb} MB). Max is 5 MB.`);
+    throw new Error(`Image is too large (${mb} MB). Max is ${MAX_UPLOAD_MB} MB.`);
   }
 
   const { key } = await apiFetch<UploadResponse>("/api/v1/upload/items", {
@@ -76,89 +91,94 @@ export async function uploadItemImage(filePath: string): Promise<string> {
   return key;
 }
 
+function resizerFor(ext: string): Resize | undefined {
+  if (process.platform === "darwin") return resizeWithSips;
+  // GDI+ ships with every Windows 10/11 install but cannot decode WebP, so
+  // those upload as-is and the server shrinks them.
+  if (process.platform === "win32") return ext === ".webp" ? undefined : resizeWithPowerShell;
+  return undefined;
+}
+
 /**
- * Resize to height ≤900 before upload, per platform. Returns undefined when
- * there is nothing to gain (already ≤900 tall) or when the platform tool
- * can't handle the file — the caller then uploads the original bytes.
- * PNG stays PNG to preserve transparency; everything else becomes JPEG.
+ * Resize to a height of at most 900 before upload. Returns undefined whenever
+ * there is nothing to gain (already short enough) or the platform tool can't
+ * handle the file, and the caller then uploads the original bytes. PNG stays
+ * PNG to preserve transparency; everything else becomes JPEG.
  */
 async function optimizeImage(filePath: string, ext: string): Promise<OptimizedImage | undefined> {
+  const resize = resizerFor(ext);
+  if (!resize) return undefined;
+
+  const format: OutputFormat = ext === ".png" ? "png" : "jpeg";
+  const outPath = tempOutputPath(format);
+
   try {
-    if (process.platform === "darwin") return await optimizeWithSips(filePath, ext);
-    if (process.platform === "win32") return await optimizeWithPowerShell(filePath, ext);
+    if (!(await resize(filePath, format, outPath))) return undefined;
+    const body = await readFile(outPath);
+    // sips can exit 0 without writing anything, leaving an absent or empty file.
+    return body.length > 0 ? { body, contentType: OUTPUT_FORMATS[format].mimeType } : undefined;
   } catch {
-    // Best-effort only — fall through to uploading the original.
+    return undefined; // Best-effort only: fall back to uploading the original.
+  } finally {
+    // Windows can still hold a lock on the file, and `force` only swallows ENOENT.
+    await rm(outPath, { force: true }).catch(() => undefined);
   }
-  return undefined;
 }
 
 /**
  * macOS: one `sips` call decodes JPG/PNG/WebP/GIF (first frame), resizes by
  * height, and encodes the output. sips has no upscale guard, so the height is
  * checked first (`-g pixelHeight` prints `<nil>` for unreadable files, which
- * fails the regex). sips can exit 0 without writing output; readFile throwing
- * on the missing temp file surfaces that as a failure. EXIF orientation is
- * kept as a tag (sips never rotates pixels); the server's sharp `.rotate()`
- * bakes it in.
+ * fails the regex). EXIF orientation is kept as a tag, since sips never rotates
+ * pixels; the server's sharp `.rotate()` bakes it in.
  */
-async function optimizeWithSips(filePath: string, ext: string): Promise<OptimizedImage | undefined> {
+const resizeWithSips: Resize = async (filePath, format, outPath) => {
   const { stdout } = await execFileAsync("sips", ["-g", "pixelHeight", filePath]);
   const match = /pixelHeight: (\d+)/.exec(stdout);
-  if (!match || Number(match[1]) <= MAX_HEIGHT) return undefined;
+  if (!match || Number(match[1]) <= MAX_HEIGHT) return false;
 
-  const format = ext === ".png" ? "png" : "jpeg";
-  const outPath = tempOutputPath(format);
   const args = ["--resampleHeight", String(MAX_HEIGHT), "-s", "format", format];
   if (format === "jpeg") args.push("-s", "formatOptions", String(JPEG_QUALITY));
-  args.push(filePath, "--out", outPath);
-
-  try {
-    await execFileAsync("sips", args);
-    return await readOptimized(outPath, format);
-  } finally {
-    await rm(outPath, { force: true });
-  }
-}
+  await execFileAsync("sips", [...args, filePath, "--out", outPath]);
+  return true;
+};
 
 /**
- * Windows: PowerShell + System.Drawing (GDI+), which ships with every
- * Windows 10/11 install. GDI+ cannot decode WebP, so those upload as-is.
- * GDI+ does not auto-rotate, so EXIF orientation is baked in before resizing.
- * The script prints SKIP instead of writing output when the image is already
- * small enough.
+ * Windows: PowerShell + System.Drawing (GDI+). GDI+ does not auto-rotate, so
+ * EXIF orientation is baked into the pixels before resizing. The script prints
+ * SKIP instead of writing output when the image is already small enough.
  */
-async function optimizeWithPowerShell(filePath: string, ext: string): Promise<OptimizedImage | undefined> {
-  if (ext === ".webp") return undefined;
+const resizeWithPowerShell: Resize = async (filePath, format, outPath) => {
+  const result = await runPowerShellScript(buildResizeScript(filePath, outPath, format), {
+    timeout: POWERSHELL_TIMEOUT_MS,
+  });
+  return result.trim() !== "SKIP";
+};
 
-  const format = ext === ".png" ? "png" : "jpeg";
-  const outPath = tempOutputPath(format);
-
-  try {
-    const result = await runPowerShellScript(buildResizeScript(filePath, outPath, format), {
-      timeout: 20000,
-    });
-    if (result.trim() === "SKIP") return undefined;
-    return await readOptimized(outPath, format);
-  } finally {
-    await rm(outPath, { force: true });
-  }
+/**
+ * `runPowerShellScript` pipes the script into `powershell.exe -Command -`, and
+ * Windows PowerShell decodes stdin with the console's OEM code page rather than
+ * UTF-8. A path holding any non-ASCII byte (a temp dir under `C:\Users\Søren`,
+ * say) would arrive mangled, so paths travel as base64 and PowerShell rebuilds
+ * the exact string. This keeps the whole script pure ASCII, quotes included.
+ */
+function psPath(value: string): string {
+  return `[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${Buffer.from(value, "utf8").toString("base64")}'))`;
 }
 
-function buildResizeScript(inputPath: string, outputPath: string, format: "png" | "jpeg"): string {
-  // Single-quoted PowerShell literals: backslashes and unicode pass through;
-  // only embedded quotes need doubling.
-  const escape = (p: string) => p.replace(/'/g, "''");
+function buildResizeScript(inputPath: string, outputPath: string, format: OutputFormat): string {
   const save =
     format === "jpeg"
       ? `$codec = [System.Drawing.Imaging.ImageCodecInfo]::GetImageEncoders() | Where-Object { $_.MimeType -eq 'image/jpeg' }
     $params = New-Object System.Drawing.Imaging.EncoderParameters(1)
     $params.Param[0] = New-Object System.Drawing.Imaging.EncoderParameter([System.Drawing.Imaging.Encoder]::Quality, [int64]${JPEG_QUALITY})
-    $bmp.Save('${escape(outputPath)}', $codec, $params)`
-      : `$bmp.Save('${escape(outputPath)}', [System.Drawing.Imaging.ImageFormat]::Png)`;
+    $bmp.Save($outPath, $codec, $params)`
+      : `$bmp.Save($outPath, [System.Drawing.Imaging.ImageFormat]::Png)`;
 
   return `
 Add-Type -AssemblyName System.Drawing
-$src = [System.Drawing.Image]::FromFile('${escape(inputPath)}')
+$outPath = ${psPath(outputPath)}
+$src = [System.Drawing.Image]::FromFile(${psPath(inputPath)})
 try {
   if ($src.PropertyIdList -contains 0x0112) {
     switch ([int]$src.GetPropertyItem(0x0112).Value[0]) {
@@ -192,12 +212,6 @@ try {
 `;
 }
 
-function tempOutputPath(format: "png" | "jpeg"): string {
-  return path.join(os.tmpdir(), `wishapp-${randomUUID()}.${format === "png" ? "png" : "jpg"}`);
-}
-
-async function readOptimized(outPath: string, format: "png" | "jpeg"): Promise<OptimizedImage | undefined> {
-  const body = await readFile(outPath);
-  if (body.length === 0) return undefined;
-  return { body, contentType: format === "png" ? "image/png" : "image/jpeg" };
+function tempOutputPath(format: OutputFormat): string {
+  return path.join(os.tmpdir(), `wishapp-${randomUUID()}.${OUTPUT_FORMATS[format].fileExtension}`);
 }

--- a/extensions/wishapp/src/my-wishlists.tsx
+++ b/extensions/wishapp/src/my-wishlists.tsx
@@ -1,11 +1,13 @@
-import { Action, ActionPanel, Icon, List, Toast, showToast } from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
-import { useEffect, useState } from "react";
+import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import { useState } from "react";
 import { InvalidApiKeyView } from "./components/invalid-api-key";
+import { NoWishlistsView } from "./components/no-wishlists";
 import { WishlistDetail } from "./components/wishlist-detail";
-import { UnauthorizedError, apiFetch } from "./lib/api";
-import { wishlistImageUrl } from "./lib/image";
-import { API_BASE, type Wishlist, type WishlistsResponse } from "./lib/types";
+import { useWishlists } from "./lib/api";
+import { API_BASE } from "./lib/constants";
+import { imageMarkdown, wishlistImageUrl } from "./lib/image";
+import { COPY_LINK, REFRESH, TOGGLE_PREVIEW } from "./lib/shortcuts";
+import type { Wishlist } from "./lib/types";
 
 export default function Command() {
   const [unauthorized, setUnauthorized] = useState(false);
@@ -17,82 +19,29 @@ export default function Command() {
 
 function WishlistsList({ onUnauthorized }: { onUnauthorized: () => void }) {
   const [showDetail, setShowDetail] = useState(true);
-  const { data, isLoading, error, revalidate } = useCachedPromise(
-    () => apiFetch<WishlistsResponse>("/api/v1/wishlists"),
-    [],
-    { keepPreviousData: true },
-  );
+  const { sections, wishlists: allWishlists, isLoading, revalidate } = useWishlists(onUnauthorized);
+  const total = allWishlists.length;
 
-  useEffect(() => {
-    if (!error) return;
-    if (error instanceof UnauthorizedError) onUnauthorized();
-    else
-      showToast({
-        style: Toast.Style.Failure,
-        title: "Could not load wishlists",
-        message: error.message,
-      });
-  }, [error, onUnauthorized]);
-
-  const owned = data?.ownedWishlists ?? [];
-  const shared = data?.sharedWishlists ?? [];
-  const empty = !isLoading && owned.length === 0 && shared.length === 0;
+  if (!isLoading && total === 0) return <NoWishlistsView onRefresh={revalidate} />;
 
   return (
-    <List
-      isLoading={isLoading}
-      searchBarPlaceholder="Search wishlists"
-      isShowingDetail={showDetail && !empty && (owned.length > 0 || shared.length > 0)}
-    >
-      {empty ? (
-        <List.EmptyView
-          icon={Icon.Gift}
-          title="No wishlists yet"
-          description="Create your first wishlist at getwish.app, then come back here."
-          actions={
-            <ActionPanel>
-              <Action.OpenInBrowser title="Open Website" url={API_BASE} />
-              <Action
-                title="Refresh"
-                icon={Icon.ArrowClockwise}
-                shortcut={{ modifiers: ["cmd"], key: "r" }}
-                onAction={revalidate}
+    <List isLoading={isLoading} searchBarPlaceholder="Search wishlists" isShowingDetail={showDetail && total > 0}>
+      {sections
+        .filter(([, wishlists]) => wishlists.length > 0)
+        .map(([title, wishlists]) => (
+          <List.Section key={title} title={title}>
+            {wishlists.map((wishlist) => (
+              <WishlistRow
+                key={wishlist.id}
+                wishlist={wishlist}
+                showDetail={showDetail}
+                onToggleDetail={() => setShowDetail((shown) => !shown)}
+                onRefresh={revalidate}
+                onUnauthorized={onUnauthorized}
               />
-            </ActionPanel>
-          }
-        />
-      ) : (
-        <>
-          {owned.length > 0 && (
-            <List.Section title="My Wishlists">
-              {owned.map((w) => (
-                <WishlistRow
-                  key={w.id}
-                  wishlist={w}
-                  showDetail={showDetail}
-                  onToggleDetail={() => setShowDetail((s) => !s)}
-                  onRefresh={revalidate}
-                  onUnauthorized={onUnauthorized}
-                />
-              ))}
-            </List.Section>
-          )}
-          {shared.length > 0 && (
-            <List.Section title="Shared with Me">
-              {shared.map((w) => (
-                <WishlistRow
-                  key={w.id}
-                  wishlist={w}
-                  showDetail={showDetail}
-                  onToggleDetail={() => setShowDetail((s) => !s)}
-                  onRefresh={revalidate}
-                  onUnauthorized={onUnauthorized}
-                />
-              ))}
-            </List.Section>
-          )}
-        </>
-      )}
+            ))}
+          </List.Section>
+        ))}
     </List>
   );
 }
@@ -112,14 +61,13 @@ function WishlistRow({
 }) {
   const url = `${API_BASE}/w/${wishlist.shareUrl}`;
   const imageUrl = wishlistImageUrl(wishlist.image);
-  const itemCount = `${wishlist._count.items} item${wishlist._count.items === 1 ? "" : "s"}`;
 
   return (
     <List.Item
       icon={imageUrl}
       title={wishlist.title}
       subtitle={showDetail ? undefined : (wishlist.description ?? undefined)}
-      accessories={showDetail ? undefined : [{ text: itemCount }]}
+      accessories={showDetail ? undefined : [{ text: pluralize(wishlist._count.items, "item") }]}
       keywords={[wishlist.defaultCurrency, wishlist.shareUrl]}
       detail={<List.Item.Detail markdown={buildWishlistMarkdown(wishlist, imageUrl)} />}
       actions={
@@ -130,38 +78,33 @@ function WishlistRow({
             target={<WishlistDetail wishlistId={wishlist.id} title={wishlist.title} onUnauthorized={onUnauthorized} />}
           />
           <Action.OpenInBrowser title="Open in Browser" url={url} />
-          <Action.CopyToClipboard title="Copy Link" content={url} shortcut={{ modifiers: ["cmd"], key: "." }} />
+          <Action.CopyToClipboard title="Copy Link" content={url} shortcut={COPY_LINK} />
           <Action
             title={showDetail ? "Hide Preview" : "Show Preview"}
             icon={Icon.AppWindowSidebarRight}
-            shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
+            shortcut={TOGGLE_PREVIEW}
             onAction={onToggleDetail}
           />
-          <Action
-            title="Refresh"
-            icon={Icon.ArrowClockwise}
-            shortcut={{ modifiers: ["cmd"], key: "r" }}
-            onAction={onRefresh}
-          />
+          <Action title="Refresh" icon={Icon.ArrowClockwise} shortcut={REFRESH} onAction={onRefresh} />
         </ActionPanel>
       }
     />
   );
 }
 
+function pluralize(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
 function buildWishlistMarkdown(wishlist: Wishlist, imageUrl: string): string {
-  const parts: string[] = [`# ${wishlist.title}`];
+  const parts = [`# ${wishlist.title}`];
   if (wishlist.description) parts.push("", wishlist.description);
 
-  const chips: string[] = [];
-  const itemCount = wishlist._count.items;
-  chips.push(`${itemCount} item${itemCount === 1 ? "" : "s"}`);
-  if (wishlist._count.followers > 0) {
-    chips.push(`${wishlist._count.followers} follower${wishlist._count.followers === 1 ? "" : "s"}`);
-  }
+  const chips = [pluralize(wishlist._count.items, "item")];
+  if (wishlist._count.followers > 0) chips.push(pluralize(wishlist._count.followers, "follower"));
   chips.push(wishlist.defaultCurrency);
   parts.push("", chips.join(" · "));
 
-  parts.push("", `![${wishlist.title}](${imageUrl}?raycast-height=200)`);
+  parts.push("", imageMarkdown(wishlist.title, imageUrl));
   return parts.join("\n");
 }


### PR DESCRIPTION
## Description

Update to the existing **WishApp** extension (author `bilal_k`). No new commands, no new dependencies, no manifest changes. This is a correctness and cross-platform pass over the two existing commands.

### Windows fixes

The extension declares `"platforms": ["macOS", "Windows"]`, but several things were macOS-only in practice:

- **Shortcuts did not bind on Windows.** Every custom shortcut used the flat `{ modifiers: ["cmd"], key: "…" }` form. Per the [Keyboard docs](https://developers.raycast.com/api-reference/keyboard), `cmd` is an "ambiguous" modifier and must be declared per-platform. All shortcuts now use the `{ macOS, Windows }` form, and Refresh/Copy use `Keyboard.Shortcut.Common.Refresh` / `Common.Copy`. (Copy moves from `⌘.` to the standard `⌘⇧C`; `Ctrl+.` on Windows is Raycast's own Pin shortcut.)
- **On-screen hints showed `⌘` glyphs to Windows users.** They now render as `Ctrl+Enter` / `Ctrl+Shift+P`.
- **Image uploads silently skipped optimization for non-ASCII paths.** `runPowerShellScript` pipes the script into `powershell.exe -Command -`, and Windows PowerShell decodes stdin using the console's OEM code page rather than UTF-8, so a temp path under e.g. `C:\Users\Søren\…` arrived mangled and GDI+ threw. Paths are now base64-encoded, keeping the generated script pure ASCII.

Tested on Windows 11.

### Correctness fixes

- **Reservation privacy.** A wishlist can be set to hide reservations from its owner so gifts stay a surprise. The reservation UI respected that, but `List.Item`'s `keywords` did not — searching `reserved` filtered the list down to exactly the reserved items. The keyword is now gated on the same flag, and item previews no longer name who reserved what (matching the website and mobile app).
- **Duplicate error toasts.** `useCachedPromise` already shows a failure toast unless `onError` is passed. A separate `useEffect` was showing a second one. Now handled via `onError` + `showFailureToast`.
- **URL validation matched the server.** The scraper requires `https` via a literal `startsWith("https://")`. `new URL(x).protocol === "https:"` accepts `https:/x.com` and `HTTPS://X.COM`, which the server then rejects. The normalized `url.href` is now what gets sent and stored.
- Product images served over `http://` now load in previews; wishlist previews no longer break when the image URL already carries a query string.

### Cleanup

Deduplicated the shared empty state and the wishlist-fetching hook, collapsed the extension/MIME tables in `upload.ts` to a single source of truth, and split constants and formatting helpers out of `types.ts` / `image.ts`. Net ~100 fewer lines. No behaviour change.

## Screencast

Existing screenshots in `metadata/` are unchanged and still accurate — the UI is the same, aside from the corrected shortcut hints.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
