### PR TITLE
ccusage: reconcile menu bar usage readouts

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [Reconcile menu bar usage readouts] - {PR_MERGE_DATE}
+## [Reconcile menu bar usage readouts] - 2026-07-10
 
 ### Fixed
 

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [Reconcile menu bar usage readouts] - {PR_MERGE_DATE}
+
+### Fixed
+
+- The menu bar limit readouts (5-Hour, 7-Day, Highest Utilization) now show consumed usage, matching the main command and Claude's settings. The "Progress Bar Mode" preference continues to govern only the progress bars
+- The last-fetched time now persists across relaunches, so a fresh menu bar process reports the real age of its data in "Last Updated" and the stale-data warning instead of a blank timestamp
+
 ## [Honor server rate-limit backoff] - 2026-06-10
 
 ### Fixed

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Fixed
 
-- The menu bar limit readouts (5-Hour, 7-Day, Highest Utilization) now show consumed usage, matching the main command and Claude's settings. The "Progress Bar Mode" preference continues to govern only the progress bars
+- Rate-limit percentages now agree across surfaces. The menu bar title, the progress bars, and the command's Usage Limits accessory all follow one "Usage Display Mode" preference, which defaults to Consumed so they match Claude's own settings out of the box
 - The last-fetched time now persists across relaunches, so a fresh menu bar process reports the real age of its data in "Last Updated" and the stale-data warning instead of a blank timestamp
+
+### Changed
+
+- The former menu bar "Progress Bar Mode" preference is now an extension-level "Usage Display Mode" preference and defaults to Consumed. If you previously set it to Remaining, reselect it in the extension preferences
 
 ## [Honor server rate-limit backoff] - 2026-06-10
 

--- a/extensions/ccusage/package.json
+++ b/extensions/ccusage/package.json
@@ -103,24 +103,6 @@
           ]
         },
         {
-          "name": "showRemainingUsage",
-          "type": "dropdown",
-          "required": false,
-          "title": "Progress Bar Mode",
-          "description": "Whether progress bars show remaining capacity or consumed usage",
-          "default": "remaining",
-          "data": [
-            {
-              "title": "Remaining",
-              "value": "remaining"
-            },
-            {
-              "title": "Consumed",
-              "value": "consumed"
-            }
-          ]
-        },
-        {
           "name": "progressBarStyle",
           "type": "dropdown",
           "required": false,
@@ -226,6 +208,24 @@
         {
           "title": "10 minutes",
           "value": "600"
+        }
+      ]
+    },
+    {
+      "name": "showRemainingUsage",
+      "type": "dropdown",
+      "required": false,
+      "title": "Usage Display Mode",
+      "description": "Whether rate-limit percentages (menu bar title, progress bars, and the command's Usage Limits accessory) show consumed usage or remaining capacity",
+      "default": "consumed",
+      "data": [
+        {
+          "title": "Consumed",
+          "value": "consumed"
+        },
+        {
+          "title": "Remaining",
+          "value": "remaining"
         }
       ]
     },

--- a/extensions/ccusage/src/components/UsageLimits.tsx
+++ b/extensions/ccusage/src/components/UsageLimits.tsx
@@ -9,6 +9,7 @@ import {
   createProgressBar,
 } from "../utils/usage-limits-formatter";
 import { formatDuration } from "../utils/data-formatter";
+import { showRemainingUsage } from "../preferences";
 import { ErrorMetadata } from "./ErrorMetadata";
 import { STANDARD_ACCESSORIES } from "./common/accessories";
 import { ReactNode } from "react";
@@ -35,6 +36,7 @@ export function UsageLimits() {
 
   const fiveHourUtil = data?.five_hour?.utilization ?? 0;
   const sevenDayUtil = data?.seven_day?.utilization ?? 0;
+  const preferRemaining = showRemainingUsage();
 
   const accessories: List.Item.Accessory[] =
     error && !data
@@ -53,8 +55,8 @@ export function UsageLimits() {
             : [
                 {
                   icon: Icon.Gauge,
-                  text: `${fiveHourUtil.toFixed(0)}%`,
-                  tooltip: "5-Hour Limit (higher priority)",
+                  text: `${(preferRemaining ? 100 - fiveHourUtil : fiveHourUtil).toFixed(0)}%`,
+                  tooltip: `5-Hour Limit · ${preferRemaining ? "Remaining" : "Consumed"} (higher priority)`,
                 },
               ];
 

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -116,17 +116,11 @@ export default function MenuBarccusage() {
     if (menuBarTitlePref === "monthlyCost") return monthlyUsage ? formatCost(monthlyUsage.totalCost) : undefined;
     if (menuBarTitlePref === "todayTokens") return todayUsage ? formatTokensAsMTok(todayUsage.totalTokens) : undefined;
     if (menuBarTitlePref === "fiveHour")
-      return effectiveLimitsData
-        ? `${(preferRemaining ? 100 - effectiveLimitsData.five_hour.utilization : effectiveLimitsData.five_hour.utilization).toFixed(0)}%`
-        : undefined;
+      return effectiveLimitsData ? `${effectiveLimitsData.five_hour.utilization.toFixed(0)}%` : undefined;
     if (menuBarTitlePref === "sevenDay")
-      return effectiveLimitsData
-        ? `${(preferRemaining ? 100 - effectiveLimitsData.seven_day.utilization : effectiveLimitsData.seven_day.utilization).toFixed(0)}%`
-        : undefined;
+      return effectiveLimitsData ? `${effectiveLimitsData.seven_day.utilization.toFixed(0)}%` : undefined;
     if (menuBarTitlePref === "utilization")
-      return highestUtilization !== null
-        ? `${(preferRemaining ? 100 - highestUtilization : highestUtilization).toFixed(0)}%`
-        : undefined;
+      return highestUtilization !== null ? `${highestUtilization.toFixed(0)}%` : undefined;
     if (menuBarTitlePref === "blockProjection") {
       const block = workingTime.activeBlock;
       return block ? formatCost(block.projection?.totalCost ?? block.costUSD) : undefined;

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -171,7 +171,9 @@ export default function MenuBarccusage() {
                   title="Unable to fetch limits"
                   subtitle="Check Claude Code authentication"
                   icon={Icon.ExclamationMark}
-                  onAction={() => open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)}
+                  onAction={() =>
+                    open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)
+                  }
                 />
               )}
               {effectiveLimitsData && (
@@ -296,7 +298,9 @@ export default function MenuBarccusage() {
                   .filter(Boolean)
                   .join(" · ")}
                 icon={Icon.Gauge}
-                onAction={() => open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)}
+                onAction={() =>
+                  open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)
+                }
               />
             </MenuBarExtra.Section>
           )}

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -84,15 +84,14 @@ export default function MenuBarccusage() {
   const preferRemaining = showRemainingUsage();
   const progressBarStyle = getProgressBarStyle();
 
+  const displayUtil = (utilization: number): number => (preferRemaining ? 100 - utilization : utilization);
+
   const rateLimitsSectionTitle = `Rate Limits · ${preferRemaining ? "Remaining" : "Consumed"}`;
 
-  const limitInfo = (utilization: number, resetsAt: string | null): string => {
-    const value = preferRemaining ? 100 - utilization : utilization;
-    return `${value.toFixed(0)}%  ↻ ${resetsAt ? formatTimeRemaining(resetsAt) : "N/A"}`;
-  };
+  const limitInfo = (utilization: number, resetsAt: string | null): string =>
+    `${displayUtil(utilization).toFixed(0)}%  ↻ ${resetsAt ? formatTimeRemaining(resetsAt) : "N/A"}`;
 
-  const limitBar = (utilization: number): string =>
-    createProgressBar(preferRemaining ? 100 - utilization : utilization, 22, progressBarStyle);
+  const limitBar = (utilization: number): string => createProgressBar(displayUtil(utilization), 22, progressBarStyle);
 
   const limitTitle = (label: string, utilization: number): string => `${label.padEnd(6)}  ${limitBar(utilization)}`;
 
@@ -116,11 +115,11 @@ export default function MenuBarccusage() {
     if (menuBarTitlePref === "monthlyCost") return monthlyUsage ? formatCost(monthlyUsage.totalCost) : undefined;
     if (menuBarTitlePref === "todayTokens") return todayUsage ? formatTokensAsMTok(todayUsage.totalTokens) : undefined;
     if (menuBarTitlePref === "fiveHour")
-      return effectiveLimitsData ? `${effectiveLimitsData.five_hour.utilization.toFixed(0)}%` : undefined;
+      return effectiveLimitsData ? `${displayUtil(effectiveLimitsData.five_hour.utilization).toFixed(0)}%` : undefined;
     if (menuBarTitlePref === "sevenDay")
-      return effectiveLimitsData ? `${effectiveLimitsData.seven_day.utilization.toFixed(0)}%` : undefined;
+      return effectiveLimitsData ? `${displayUtil(effectiveLimitsData.seven_day.utilization).toFixed(0)}%` : undefined;
     if (menuBarTitlePref === "utilization")
-      return highestUtilization !== null ? `${highestUtilization.toFixed(0)}%` : undefined;
+      return highestUtilization !== null ? `${displayUtil(highestUtilization).toFixed(0)}%` : undefined;
     if (menuBarTitlePref === "blockProjection") {
       const block = workingTime.activeBlock;
       return block ? formatCost(block.projection?.totalCost ?? block.costUSD) : undefined;

--- a/extensions/ccusage/src/preferences.ts
+++ b/extensions/ccusage/src/preferences.ts
@@ -8,7 +8,7 @@ import type { ProgressBarStyle } from "./utils/usage-limits-formatter";
 export const preferences = getPreferenceValues<Preferences>();
 const menuBarPreferences = getPreferenceValues<Preferences.MenubarCcusage>();
 
-export const showRemainingUsage = (): boolean => (menuBarPreferences.showRemainingUsage as string) !== "consumed";
+export const showRemainingUsage = (): boolean => (preferences.showRemainingUsage as string) === "remaining";
 
 type MenuBarTitleMode =
   | "todayUsage"

--- a/extensions/ccusage/src/utils/usage-limits-cache.ts
+++ b/extensions/ccusage/src/utils/usage-limits-cache.ts
@@ -60,7 +60,7 @@ const restoredRateLimitedUntil = ((): number | null => {
 let cacheState: CacheState = {
   data: restoredData,
   error: null,
-  isLoading: restoredRateLimitedUntil === null,
+  isLoading: restoredRateLimitedUntil === null && (restoredData === null || isBlobStale(restoredLastFetched)),
   isStale: restoredData !== null && isBlobStale(restoredLastFetched),
   isRateLimited: restoredRateLimitedUntil !== null,
   isUsageLimitsAvailable: false,

--- a/extensions/ccusage/src/utils/usage-limits-cache.ts
+++ b/extensions/ccusage/src/utils/usage-limits-cache.ts
@@ -21,6 +21,15 @@ type Listener = (state: CacheState) => void;
 const raycastCache = new Cache();
 const LIMITS_CACHE_KEY = "usage-limits-data";
 const RATE_LIMITED_UNTIL_KEY = "usage-limits-rate-limited-until";
+const LAST_FETCHED_KEY = "usage-limits-last-fetched";
+
+const FETCH_INTERVAL_MS = ((): number => {
+  const seconds = parseInt(getPreferenceValues<Preferences>().usageLimitsRefreshInterval || "60", 10);
+  return Number.isNaN(seconds) ? 60 * 1000 : seconds * 1000;
+})();
+
+const isBlobStale = (lastFetched: Date | null): boolean =>
+  lastFetched === null || Date.now() - lastFetched.getTime() >= FETCH_INTERVAL_MS;
 
 const restoredData = ((): UsageLimitData | null => {
   const cached = raycastCache.get(LIMITS_CACHE_KEY);
@@ -30,6 +39,14 @@ const restoredData = ((): UsageLimitData | null => {
   } catch {
     return null;
   }
+})();
+
+const restoredLastFetched = ((): Date | null => {
+  const cached = raycastCache.get(LAST_FETCHED_KEY);
+  if (!cached) return null;
+  const parsed = parseInt(cached, 10);
+  if (Number.isNaN(parsed)) return null;
+  return new Date(parsed);
 })();
 
 const restoredRateLimitedUntil = ((): number | null => {
@@ -44,10 +61,10 @@ let cacheState: CacheState = {
   data: restoredData,
   error: null,
   isLoading: restoredRateLimitedUntil === null,
-  isStale: restoredData !== null,
+  isStale: restoredData !== null && isBlobStale(restoredLastFetched),
   isRateLimited: restoredRateLimitedUntil !== null,
   isUsageLimitsAvailable: false,
-  lastFetched: null,
+  lastFetched: restoredLastFetched,
   rateLimitedUntil: restoredRateLimitedUntil,
   nextRefreshAt: null,
 };
@@ -64,7 +81,6 @@ const listeners = new Set<Listener>();
 let fetchInterval: NodeJS.Timeout | null = null;
 let isFetching = false;
 let rateLimitedUntil: number | null = restoredRateLimitedUntil;
-let fetchIntervalMs = 60 * 1000;
 
 const notifyListeners = (): void => {
   listeners.forEach((listener) => listener(cacheState));
@@ -100,9 +116,11 @@ const fetchUsageLimits = async (): Promise<void> => {
     const result: UsageLimitsResult = await fetchClaudeUsageLimits(token);
 
     if (result.status === "ok") {
+      const fetchedAt = new Date();
       rateLimitedUntil = null;
       raycastCache.remove(RATE_LIMITED_UNTIL_KEY);
       raycastCache.set(LIMITS_CACHE_KEY, JSON.stringify(result.data));
+      raycastCache.set(LAST_FETCHED_KEY, String(fetchedAt.getTime()));
       cacheState = {
         data: result.data,
         error: null,
@@ -110,9 +128,9 @@ const fetchUsageLimits = async (): Promise<void> => {
         isRateLimited: false,
         isUsageLimitsAvailable: true,
         isStale: false,
-        lastFetched: new Date(),
+        lastFetched: fetchedAt,
         rateLimitedUntil: null,
-        nextRefreshAt: Date.now() + fetchIntervalMs,
+        nextRefreshAt: Date.now() + FETCH_INTERVAL_MS,
       };
     } else if (result.status === "rate_limited") {
       rateLimitedUntil = Date.now() + clampBackoff(result.retryAfterMs);
@@ -157,25 +175,11 @@ const fetchUsageLimits = async (): Promise<void> => {
 const startFetching = (): void => {
   if (fetchInterval) return;
 
-  const preferences = getPreferenceValues<Preferences>();
-  const intervalSeconds = parseInt(preferences.usageLimitsRefreshInterval || "60", 10);
-  const intervalMs = intervalSeconds * 1000;
-  fetchIntervalMs = intervalMs;
-
-  const shouldFetchImmediately = (): boolean => {
-    if (!cacheState.data || !cacheState.lastFetched) {
-      return true;
-    }
-
-    const timeSinceLastFetch = Date.now() - cacheState.lastFetched.getTime();
-    return timeSinceLastFetch >= intervalMs;
-  };
-
-  if (shouldFetchImmediately()) {
+  if (!cacheState.data || isBlobStale(cacheState.lastFetched)) {
     fetchUsageLimits();
   }
 
-  fetchInterval = setInterval(fetchUsageLimits, intervalMs);
+  fetchInterval = setInterval(fetchUsageLimits, FETCH_INTERVAL_MS);
 };
 
 const stopFetching = (): void => {


### PR DESCRIPTION
## Description

The menu bar and the main command disagreed about Claude usage: the reporter saw the menu bar read 2% while the command read 11% and Claude's own settings read 12% for the same day. Both surfaces already draw from one source (`useClaudeUsageLimits` → the `usage-limits-cache` singleton → Claude's OAuth usage API), so this was framing and freshness, not two calculations of one number.

Two fixes:

- **Framing.** `showRemainingUsage` is now a single extension-level "Usage Display Mode" preference that governs the menu bar title, the progress bars, and the command's Usage Limits accessory together. It defaults to Consumed, so every rate-limit percentage matches Claude's settings out of the box, and flipping to Remaining flips all of them. Previously the preference was menu-bar-scoped, titled "Progress Bar Mode", and defaulted to Remaining, so the numeric title showed `100 − util` while the command accessory and Claude showed `util`.
- **Freshness.** `lastFetched` was only set on a successful in-process fetch and never written to the cache, so every menu bar relaunch restored it to `null` and flagged the restored blob stale, and the command's "Last Updated" read blank on a fresh process. It now persists alongside the data blob and restores on load, and staleness is derived from real blob age against the user's configured refresh interval.

### Decisions

- Rejected the narrower fix of hardcoding the title to consumed while the preference governed only the bars: that left the title and bars able to disagree within the same menu. One toggle now covers every at-a-glance readout.
- Rejected making the preference diverge from Claude by default. Consumed is the default so the out-of-the-box reading matches Claude's settings, which is what the reporter compared against.
- The command's expanded detail metadata keeps its precise "Utilization" (consumed) labels. Those rows are a consumption analytics panel, and relabeling them as remaining would be wrong.

### Migration

`showRemainingUsage` moved from the menu bar command's preferences to an extension-level preference, so an existing Remaining setting resets to the new Consumed default. Noted in the changelog.

Verified with the extension's built-in mock (`five_hour.utilization = 28`): default Consumed shows `28%` in both the menu bar title and the command accessory (matching Claude), and Remaining shows `72%` in both.

Reported in #29320.

## Screencast

Not applicable. There is no new command or view. The change is a percentage that flips framing (5-Hour utilization renders the same value the command and Claude already show) and a freshness timestamp that was previously blank on a fresh process. Behavior is verified with the extension's built-in mock, as described above.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
