### PR TITLE
Update Circleback MCP server URL to circleback.ai

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Update Circleback MCP Server URL] - {PR_MERGE_DATE}
+## [Update Circleback MCP Server URL] - 2026-07-10
 
 Update the Circleback MCP server endpoint from app.circleback.ai to circleback.ai to reflect our domain migration.
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Update Circleback MCP Server URL] - 2026-07-09
+## [Update Circleback MCP Server URL] - {PR_MERGE_DATE}
 
 Update the Circleback MCP server endpoint from app.circleback.ai to circleback.ai to reflect our domain migration.
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Update Circleback MCP Server URL] - 2026-07-09
+
+Update the Circleback MCP server endpoint from app.circleback.ai to circleback.ai to reflect our domain migration.
+
 ## [Add plori MCP Server] - 2026-07-06
 
 Add official plori MCP server to registry: give your AI agent its own cloud computer. Create and drive hosted plori agents (persistent disk, real tools, memory that survives between sessions), read their replies, answer human-in-the-loop questions, and schedule deferred runs. Remote endpoint via mcp-remote; OAuth sign-in or API key.

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -68,7 +68,7 @@ export const OFFICIAL_ENTRIES: RegistryEntry[] = [
     homepage: "https://circleback.ai",
     configuration: {
       command: "npx",
-      args: ["-y", "mcp-remote", "https://app.circleback.ai/api/mcp"],
+      args: ["-y", "mcp-remote", "https://circleback.ai/api/mcp"],
     },
   },
   {


### PR DESCRIPTION
## Summary
- Updates the Circleback MCP server endpoint in the registry from `https://app.circleback.ai/api/mcp` to `https://circleback.ai/api/mcp`.
- We moved our app from `app.circleback.ai` to `circleback.ai`, so this points the registry entry at the canonical host.

## Checklist
- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)