### PR TITLE
[Is It Alive?] Fix site ID generation

### DIFF
--- a/extensions/is-it-alive/CHANGELOG.md
+++ b/extensions/is-it-alive/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Is It Alive? Changelog
 
-## [Fix Site Creation] - {PR_MERGE_DATE}
+## [Fix Site Creation] - 2026-07-10
 
 - Fix adding sites when the Web Crypto global is unavailable
 

--- a/extensions/is-it-alive/CHANGELOG.md
+++ b/extensions/is-it-alive/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Is It Alive? Changelog
 
+## [Fix Site Creation] - {PR_MERGE_DATE}
+
+- Fix adding sites when the Web Crypto global is unavailable
+
 ## [Initial Release] - 2026-06-11
 
 - Monitor status pages from a single Raycast command

--- a/extensions/is-it-alive/package.json
+++ b/extensions/is-it-alive/package.json
@@ -34,6 +34,9 @@
   ],
   "title": "Is It Alive?",
   "author": "alerix",
+  "contributors": [
+    "jchristianhall"
+  ],
   "platforms": [
     "macOS",
     "Windows"

--- a/extensions/is-it-alive/src/hooks/use-sites.ts
+++ b/extensions/is-it-alive/src/hooks/use-sites.ts
@@ -1,11 +1,12 @@
 import { useCallback } from "react";
 import { useLocalStorage } from "@raycast/utils";
+import { randomUUID } from "node:crypto";
 import type { MonitoredSite, SiteProvider } from "@/types";
 
 const STORAGE_KEY = "sites";
 
 function createId(): string {
-  return crypto.randomUUID();
+  return randomUUID();
 }
 
 export function useSites() {


### PR DESCRIPTION
## Description

Wasn't able to get this working when I installed it and Codex suggested this. Tested it out locally and the extension works!

Fixes adding monitored sites in Raycast environments where the Web Crypto global is unavailable.

## Root cause

The extension called `crypto.randomUUID()` as a global. Importing `randomUUID` from `node:crypto` explicitly uses Raycast's managed Node runtime.

## User impact

Adding any status page currently fails before the site can be saved.

## Reproduction

1. Open **Check Status Pages**.
2. Add `https://status.claude.com`.
3. Submit the form.
4. Observe `crypto is not defined`.

**Before**

![Raycast showing the crypto is not defined error](https://raw.githubusercontent.com/jchristianhall/extensions/pr-assets-is-it-alive-crypto/is-it-alive-crypto-error.png)

**After**

![Raycast showing the Claude status page working locally](https://raw.githubusercontent.com/jchristianhall/extensions/pr-assets-is-it-alive-crypto/is-it-alive-working.png)

## Validation

- Reproduced the Store build failure with `https://status.claude.com`
- Verified the local development build can add the same status page
- `npm run lint`
- `npm run build`
