### PR TITLE
Update spotify player extension

### DIFF
--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Spotify Player Changelog
 
-## [Copy Embed Code Action] - {PR_MERGE_DATE}
+## [Copy Embed Code Action] - 2026-07-10
 
 - Add a "Copy Embed Code" action to the action panel and the menu bar
 

--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Spotify Player Changelog
 
+## [Copy Embed Code Action] - {PR_MERGE_DATE}
+
+- Add a "Copy Embed Code" action to the action panel and the menu bar
+
 ## [Fix Find Lyrics] - 2026-07-09
 
 - Fixed the Find Lyrics command by replacing the broken Genius package integration with LRCLIB lyrics lookup.

--- a/extensions/spotify-player/package.json
+++ b/extensions/spotify-player/package.json
@@ -44,7 +44,8 @@
     "xmok",
     "hugodemenez",
     "alexi.build",
-    "shivraj-roy"
+    "shivraj-roy",
+    "ridemountainpig"
   ],
   "pastContributors": [
     "bkeys818",

--- a/extensions/spotify-player/src/components/FooterAction.tsx
+++ b/extensions/spotify-player/src/components/FooterAction.tsx
@@ -1,5 +1,6 @@
 import { Action, ActionPanel, Icon, Keyboard } from "@raycast/api";
 import { isSpotifyInstalled } from "../helpers/isSpotifyInstalled";
+import { getEmbedCode } from "../helpers/getEmbedCode";
 
 type FooterActionProps = {
   url?: string;
@@ -18,6 +19,15 @@ export function FooterAction({ url, uri, title }: FooterActionProps) {
           html: `<a href="${url}" title="${title}">${title}</a>`,
           text: url,
         }}
+      />
+      <Action.CopyToClipboard
+        icon={Icon.Code}
+        title="Copy Embed Code"
+        shortcut={{
+          macOS: { modifiers: ["cmd", "shift"], key: "e" },
+          Windows: { modifiers: ["ctrl", "shift"], key: "e" },
+        }}
+        content={getEmbedCode(url)}
       />
       <Action.CopyToClipboard
         icon={Icon.CopyClipboard}

--- a/extensions/spotify-player/src/components/FooterAction.tsx
+++ b/extensions/spotify-player/src/components/FooterAction.tsx
@@ -9,6 +9,8 @@ type FooterActionProps = {
 };
 
 export function FooterAction({ url, uri, title }: FooterActionProps) {
+  const embedCode = getEmbedCode(url);
+
   return (
     <ActionPanel.Section>
       <Action.CopyToClipboard
@@ -20,15 +22,17 @@ export function FooterAction({ url, uri, title }: FooterActionProps) {
           text: url,
         }}
       />
-      <Action.CopyToClipboard
-        icon={Icon.Code}
-        title="Copy Embed Code"
-        shortcut={{
-          macOS: { modifiers: ["cmd", "shift"], key: "e" },
-          Windows: { modifiers: ["ctrl", "shift"], key: "e" },
-        }}
-        content={getEmbedCode(url)}
-      />
+      {embedCode && (
+        <Action.CopyToClipboard
+          icon={Icon.Code}
+          title="Copy Embed Code"
+          shortcut={{
+            macOS: { modifiers: ["cmd", "shift"], key: "e" },
+            Windows: { modifiers: ["ctrl", "shift"], key: "e" },
+          }}
+          content={embedCode}
+        />
+      )}
       <Action.CopyToClipboard
         icon={Icon.CopyClipboard}
         title="Copy Artist and Title"

--- a/extensions/spotify-player/src/copyEmbed.ts
+++ b/extensions/spotify-player/src/copyEmbed.ts
@@ -1,6 +1,7 @@
 import { Clipboard, showHUD } from "@raycast/api";
 import { setSpotifyClient } from "./helpers/withSpotifyClient";
 import { getCurrentlyPlaying } from "./api/getCurrentlyPlaying";
+import { getEmbedCode } from "./helpers/getEmbedCode";
 
 export default async function Command() {
   await setSpotifyClient();
@@ -15,9 +16,7 @@ export default async function Command() {
   const external_urls = currentlyPlayingData.item.external_urls;
   const spotifyUrl = external_urls?.spotify;
 
-  const embedUrl = spotifyUrl?.replace("open.spotify.com/", "open.spotify.com/embed/");
-
-  const embedCode = `<iframe style="border-radius:12px" src="${embedUrl}?utm_source=generator" width="100%" height="352" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>`;
+  const embedCode = getEmbedCode(spotifyUrl);
 
   await Clipboard.copy(embedCode);
   return showHUD("Copied embed code to clipboard");

--- a/extensions/spotify-player/src/copyEmbed.ts
+++ b/extensions/spotify-player/src/copyEmbed.ts
@@ -18,6 +18,10 @@ export default async function Command() {
 
   const embedCode = getEmbedCode(spotifyUrl);
 
+  if (!embedCode) {
+    return await showHUD("Nothing is currently playing");
+  }
+
   await Clipboard.copy(embedCode);
   return showHUD("Copied embed code to clipboard");
 }

--- a/extensions/spotify-player/src/helpers/getEmbedCode.ts
+++ b/extensions/spotify-player/src/helpers/getEmbedCode.ts
@@ -1,4 +1,5 @@
-export function getEmbedCode(spotifyUrl?: string) {
-  const embedUrl = spotifyUrl?.replace("open.spotify.com/", "open.spotify.com/embed/");
+export function getEmbedCode(spotifyUrl?: string): string | undefined {
+  if (!spotifyUrl) return undefined;
+  const embedUrl = spotifyUrl.replace("open.spotify.com/", "open.spotify.com/embed/");
   return `<iframe style="border-radius:12px" src="${embedUrl}?utm_source=generator" width="100%" height="352" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>`;
 }

--- a/extensions/spotify-player/src/helpers/getEmbedCode.ts
+++ b/extensions/spotify-player/src/helpers/getEmbedCode.ts
@@ -1,0 +1,4 @@
+export function getEmbedCode(spotifyUrl?: string) {
+  const embedUrl = spotifyUrl?.replace("open.spotify.com/", "open.spotify.com/embed/");
+  return `<iframe style="border-radius:12px" src="${embedUrl}?utm_source=generator" width="100%" height="352" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>`;
+}

--- a/extensions/spotify-player/src/nowPlayingMenuBar.tsx
+++ b/extensions/spotify-player/src/nowPlayingMenuBar.tsx
@@ -397,7 +397,12 @@ function NowPlayingMenuBarCommand({ launchType }: LaunchProps) {
             Windows: { modifiers: ["ctrl", "shift"], key: "e" },
           }}
           onAction={async () => {
-            await Clipboard.copy(getEmbedCode(external_urls?.spotify));
+            const embedCode = getEmbedCode(external_urls?.spotify);
+            if (!embedCode) {
+              showHUD("Unable to copy embed code");
+              return;
+            }
+            await Clipboard.copy(embedCode);
             showHUD("Copied embed code to clipboard");
           }}
         />

--- a/extensions/spotify-player/src/nowPlayingMenuBar.tsx
+++ b/extensions/spotify-player/src/nowPlayingMenuBar.tsx
@@ -37,6 +37,7 @@ import { useContainsMyLikedTracks } from "./hooks/useContainsMyLikedTracks";
 import { usePlaylistsContainingTrack } from "./hooks/usePlaylistsContainingTrack";
 import { useMe } from "./hooks/useMe";
 import { formatTitle } from "./helpers/formatTitle";
+import { getEmbedCode } from "./helpers/getEmbedCode";
 import { getErrorMessage } from "./helpers/getError";
 
 import { useSpotifyAppData } from "./hooks/useSpotifyAppData";
@@ -386,6 +387,18 @@ function NowPlayingMenuBarCommand({ launchType }: LaunchProps) {
               text: external_urls?.spotify,
             });
             showHUD("Copied URL to clipboard");
+          }}
+        />
+        <MenuBarExtra.Item
+          title="Copy Embed Code"
+          icon={Icon.Code}
+          shortcut={{
+            macOS: { modifiers: ["cmd", "shift"], key: "e" },
+            Windows: { modifiers: ["ctrl", "shift"], key: "e" },
+          }}
+          onAction={async () => {
+            await Clipboard.copy(getEmbedCode(external_urls?.spotify));
+            showHUD("Copied embed code to clipboard");
           }}
         />
         <MenuBarExtra.Item


### PR DESCRIPTION
## Description
Add a "Copy Embed Code" action to the action panel and the menu bar. Close #29183.
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1000" height="625" alt="spotify-player 2026-07-10 at 09 20 52" src="https://github.com/user-attachments/assets/6e1c9668-38f5-4c8f-9ace-20d8509566e5" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
