### PR TITLE
fix(clipboard-type): improve symbol typing and status feedback

### DIFF
--- a/extensions/clipboard-type/CHANGELOG.md
+++ b/extensions/clipboard-type/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added physical CoreGraphics key events for uppercase letters and symbols, improving compatibility with browser-based remote consoles.
 - Added HUD notifications with a live remaining-character count and completion state.
+- Added Auto, Chinese, and English preferences for status messages.
 
 ## [Fixed timeout for long text] - 2026-03-25
 

--- a/extensions/clipboard-type/CHANGELOG.md
+++ b/extensions/clipboard-type/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## [Improved typing reliability and feedback] - {PR_MERGE_DATE}
 
 - Added physical CoreGraphics key events for uppercase letters and symbols, improving compatibility with browser-based remote consoles.
-- Added HUD notifications with a live remaining-character count and completion state.
-- Added Auto, Chinese, and English preferences for status messages.
+- Added a non-activating progress toast with a live remaining-character count and completion state.
 
 ## [Fixed timeout for long text] - 2026-03-25
 

--- a/extensions/clipboard-type/CHANGELOG.md
+++ b/extensions/clipboard-type/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Improved typing reliability and feedback] - {PR_MERGE_DATE}
 
 - Added physical CoreGraphics key events for uppercase letters and symbols, improving compatibility with browser-based remote consoles.
-- Added HUD notifications when clipboard typing starts and finishes.
+- Added HUD notifications with a live remaining-character count and completion state.
 
 ## [Fixed timeout for long text] - 2026-03-25
 

--- a/extensions/clipboard-type/CHANGELOG.md
+++ b/extensions/clipboard-type/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Clipboard Type Changelog
 
+## [Improved typing reliability and feedback] - {PR_MERGE_DATE}
+
+- Added explicit key handling for symbols that require the Shift key.
+- Added HUD notifications when clipboard typing starts and finishes.
+
 ## [Fixed timeout for long text] - 2026-03-25
 
 - Disabled the default 10s AppleScript timeout which caused typing to fail for long clipboard content with human cadence enabled.

--- a/extensions/clipboard-type/CHANGELOG.md
+++ b/extensions/clipboard-type/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Improved typing reliability and feedback] - {PR_MERGE_DATE}
 
-- Added explicit key handling for symbols that require the Shift key.
+- Added physical CoreGraphics key events for uppercase letters and symbols, improving compatibility with browser-based remote consoles.
 - Added HUD notifications when clipboard typing starts and finishes.
 
 ## [Fixed timeout for long text] - 2026-03-25

--- a/extensions/clipboard-type/CHANGELOG.md
+++ b/extensions/clipboard-type/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clipboard Type Changelog
 
-## [Improved typing reliability and feedback] - {PR_MERGE_DATE}
+## [Improved typing reliability and feedback] - 2026-07-14
 
 - Added physical CoreGraphics key events for uppercase letters and symbols, improving compatibility with browser-based remote consoles.
 - Added a non-activating progress toast with a live remaining-character count and completion state.

--- a/extensions/clipboard-type/README.md
+++ b/extensions/clipboard-type/README.md
@@ -10,3 +10,5 @@
 - **Type Clipboard Command**: Reads the latest text from your clipboard and types it out character by character.
 - **Smart Formatting**: Correctly handles special characters like newlines and tabs by simulating the appropriate key codes.
 - **Configurable Speed**: Choose a preset typing delay (dropdown from 1s down to 0.5ms, default 2ms) to match slow remote sessions or fast local input.
+
+For reliable symbol input, use the macOS **ABC** input source. Third-party input methods can remap characters such as `$` while simulated typing is active.

--- a/extensions/clipboard-type/README.md
+++ b/extensions/clipboard-type/README.md
@@ -11,4 +11,4 @@
 - **Smart Formatting**: Correctly handles special characters like newlines and tabs by simulating the appropriate key codes.
 - **Configurable Speed**: Choose a preset typing delay (dropdown from 1s down to 0.5ms, default 2ms) to match slow remote sessions or fast local input.
 
-For reliable symbol input, use the macOS **ABC** input source. Third-party input methods can remap characters such as `$` while simulated typing is active.
+For reliable uppercase and symbol input, use the macOS **ABC** input source. Third-party input methods can remap characters such as `$` while simulated typing is active.

--- a/extensions/clipboard-type/README.md
+++ b/extensions/clipboard-type/README.md
@@ -7,6 +7,7 @@
 - **Legacy Applications**: Input text into older applications that may not support standard system paste commands.
 
 **Features:**
+
 - **Type Clipboard Command**: Reads the latest text from your clipboard and types it out character by character.
 - **Smart Formatting**: Correctly handles special characters like newlines and tabs by simulating the appropriate key codes.
 - **Configurable Speed**: Choose a preset typing delay (dropdown from 1s down to 0.5ms, default 2ms) to match slow remote sessions or fast local input.

--- a/extensions/clipboard-type/package.json
+++ b/extensions/clipboard-type/package.json
@@ -6,7 +6,8 @@
   "icon": "extension-icon.png",
   "author": "krishna_bhanushali",
   "contributors": [
-    "itninja04"
+    "itninja04",
+    "yemor"
   ],
   "platforms": [
     "macOS"

--- a/extensions/clipboard-type/package.json
+++ b/extensions/clipboard-type/package.json
@@ -28,28 +28,6 @@
   ],
   "preferences": [
     {
-      "name": "language",
-      "type": "dropdown",
-      "title": "Language",
-      "required": false,
-      "description": "Choose the language for status messages. Auto follows the system locale.",
-      "default": "auto",
-      "data": [
-        {
-          "title": "Auto",
-          "value": "auto"
-        },
-        {
-          "title": "中文",
-          "value": "zh"
-        },
-        {
-          "title": "English",
-          "value": "en"
-        }
-      ]
-    },
-    {
       "name": "humanCadence",
       "type": "checkbox",
       "label": "Human Cadence",

--- a/extensions/clipboard-type/package.json
+++ b/extensions/clipboard-type/package.json
@@ -28,6 +28,28 @@
   ],
   "preferences": [
     {
+      "name": "language",
+      "type": "dropdown",
+      "title": "Language",
+      "required": false,
+      "description": "Choose the language for status messages. Auto follows the system locale.",
+      "default": "auto",
+      "data": [
+        {
+          "title": "Auto",
+          "value": "auto"
+        },
+        {
+          "title": "中文",
+          "value": "zh"
+        },
+        {
+          "title": "English",
+          "value": "en"
+        }
+      ]
+    },
+    {
       "name": "humanCadence",
       "type": "checkbox",
       "label": "Human Cadence",

--- a/extensions/clipboard-type/src/type-clipboard.ts
+++ b/extensions/clipboard-type/src/type-clipboard.ts
@@ -1,47 +1,141 @@
+import { execFile } from "node:child_process";
 import { Clipboard, getPreferenceValues, showHUD } from "@raycast/api";
-import { runAppleScript, showFailureToast } from "@raycast/utils";
+import { showFailureToast } from "@raycast/utils";
 
-const shiftedKeyCodes = [
-  ["!", 18],
-  ["@", 19],
-  ["#", 20],
-  ["$", 21],
-  ["%", 23],
-  ["^", 22],
-  ["&", 26],
-  ["*", 28],
-  ["(", 25],
-  [")", 29],
-  ["_", 27],
-  ["+", 24],
-  ["{", 33],
-  ["}", 30],
-  ["|", 42],
-  [":", 41],
-  ['"', 39],
-  ["<", 43],
-  [">", 47],
-  ["?", 44],
-  ["~", 50],
-] as const;
+const keyCodes = {
+  a: 0,
+  b: 11,
+  c: 8,
+  d: 2,
+  e: 14,
+  f: 3,
+  g: 5,
+  h: 4,
+  i: 34,
+  j: 38,
+  k: 40,
+  l: 37,
+  m: 46,
+  n: 45,
+  o: 31,
+  p: 35,
+  q: 12,
+  r: 15,
+  s: 1,
+  t: 17,
+  u: 32,
+  v: 9,
+  w: 13,
+  x: 7,
+  y: 16,
+  z: 6,
+  "1": 18,
+  "2": 19,
+  "3": 20,
+  "4": 21,
+  "5": 23,
+  "6": 22,
+  "7": 26,
+  "8": 28,
+  "9": 25,
+  "0": 29,
+  "-": 27,
+  "=": 24,
+  "[": 33,
+  "]": 30,
+  "\\": 42,
+  ";": 41,
+  "'": 39,
+  ",": 43,
+  ".": 47,
+  "/": 44,
+  "`": 50,
+  " ": 49,
+} as const;
 
-function buildShiftedCharacterBranches() {
-  return shiftedKeyCodes
-    .map(([character, keyCode]) => {
-      const condition = character === '"' ? "quote" : `"${character}"`;
-      return `    else if c is ${condition} then\n      key code ${keyCode} using shift down`;
-    })
-    .join("\n");
+const shiftedKeyCodes = {
+  A: 0,
+  B: 11,
+  C: 8,
+  D: 2,
+  E: 14,
+  F: 3,
+  G: 5,
+  H: 4,
+  I: 34,
+  J: 38,
+  K: 40,
+  L: 37,
+  M: 46,
+  N: 45,
+  O: 31,
+  P: 35,
+  Q: 12,
+  R: 15,
+  S: 1,
+  T: 17,
+  U: 32,
+  V: 9,
+  W: 13,
+  X: 7,
+  Y: 16,
+  Z: 6,
+  "!": 18,
+  "@": 19,
+  "#": 20,
+  $: 21,
+  "%": 23,
+  "^": 22,
+  "&": 26,
+  "*": 28,
+  "(": 25,
+  ")": 29,
+  _: 27,
+  "+": 24,
+  "{": 33,
+  "}": 30,
+  "|": 42,
+  ":": 41,
+  '"': 39,
+  "<": 43,
+  ">": 47,
+  "?": 44,
+  "~": 50,
+} as const;
+
+const shiftKeyCode = 56;
+const returnKeyCode = 36;
+const tabKeyCode = 48;
+const keyEventDelaySeconds = 0.05;
+
+function runJavaScriptForAutomation(script: string) {
+  return new Promise<void>((resolve, reject) => {
+    execFile("/usr/bin/osascript", ["-l", "JavaScript", "-e", script], (error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function buildReleaseShiftScript() {
+  return `
+ObjC.import("CoreGraphics");
+const shiftUpEvent = $.CGEventCreateKeyboardEvent(null, ${shiftKeyCode}, false);
+$.CGEventPost($.kCGHIDEventTap, shiftUpEvent);
+`;
 }
 
 export default async function Command() {
   const latestClipboardItem = await Clipboard.readText();
 
-  // If clipboard is empty show Toast and return
   if (!latestClipboardItem) {
     await showFailureToast("Clipboard is empty");
     return;
   }
+
   await showHUD("Typing Clipboard...");
   const { humanCadence, humanCadenceSpeed, softNewlines } = getPreferenceValues<Preferences>();
 
@@ -51,40 +145,88 @@ export default async function Command() {
     average: { min: 0.02, max: 0.1 },
     fast: { min: 0.01, max: 0.05 },
     "very-fast": { min: 0.005, max: 0.02 },
-    "super-human": { min: 0.001, max: 0.0 },
+    "super-human": { min: 0, max: 0 },
   };
 
   const humanCadenceRange = humanCadenceSpeeds[humanCadenceSpeed];
+  const automationScript = `
+ObjC.import("AppKit");
+ObjC.import("CoreGraphics");
 
-  const delayString = `(random number from ${humanCadenceRange.min} to ${humanCadenceRange.max})`;
-  const shiftedCharacterBranches = buildShiftedCharacterBranches();
+const systemEvents = Application("System Events");
+const keyCodes = ${JSON.stringify(keyCodes)};
+const shiftedKeyCodes = ${JSON.stringify(shiftedKeyCodes)};
+const shiftKeyCode = ${shiftKeyCode};
+const returnKeyCode = ${returnKeyCode};
+const tabKeyCode = ${tabKeyCode};
+const keyEventDelay = ${keyEventDelaySeconds};
+const humanCadence = ${humanCadence};
+const cadenceMin = ${humanCadenceRange.min};
+const cadenceMax = ${humanCadenceRange.max};
+const softNewlines = ${softNewlines};
 
-  const appleScriptContent = `
-set theText to the clipboard as text
-delay 0.2
-tell application "System Events"
-  repeat with ch in characters of theText
-    set c to contents of ch
-    if c is return or c is linefeed then
-      key code 36${softNewlines ? " using shift down" : ""}
-    else if c is tab then
-      key code 48
-${shiftedCharacterBranches}
-    else
-      keystroke c
-    end if
-    ${humanCadence ? `delay ${delayString}` : ""}
-  end repeat
-end tell
+function postKey(keyCode, keyDown) {
+  const event = $.CGEventCreateKeyboardEvent(null, keyCode, keyDown);
+  $.CGEventPost($.kCGHIDEventTap, event);
+}
+
+function pressKey(keyCode, withShift) {
+  if (withShift) {
+    postKey(shiftKeyCode, true);
+    delay(keyEventDelay);
+  }
+
+  try {
+    postKey(keyCode, true);
+    delay(keyEventDelay);
+    postKey(keyCode, false);
+  } finally {
+    if (withShift) {
+      delay(keyEventDelay);
+      postKey(shiftKeyCode, false);
+    }
+  }
+
+  delay(keyEventDelay);
+}
+
+function applyCadence() {
+  if (!humanCadence) return;
+  delay(cadenceMin + Math.random() * (cadenceMax - cadenceMin));
+}
+
+const clipboardValue = $.NSPasteboard.generalPasteboard.stringForType($.NSPasteboardTypeString);
+const text = ObjC.unwrap(clipboardValue) || "";
+
+delay(0.3);
+postKey(shiftKeyCode, false);
+
+try {
+  for (const character of text) {
+    if (character === "\\r" || character === "\\n") {
+      pressKey(returnKeyCode, softNewlines);
+    } else if (character === "\\t") {
+      pressKey(tabKeyCode, false);
+    } else if (Object.prototype.hasOwnProperty.call(shiftedKeyCodes, character)) {
+      pressKey(shiftedKeyCodes[character], true);
+    } else if (Object.prototype.hasOwnProperty.call(keyCodes, character)) {
+      pressKey(keyCodes[character], false);
+    } else {
+      systemEvents.keystroke(character);
+    }
+    applyCadence();
+  }
+} finally {
+  postKey(shiftKeyCode, false);
+}
 `;
 
-  // Execute the AppleScript using osascript directly
   try {
-    await runAppleScript(appleScriptContent, {
-      timeout: 0, // runAppleScript defaults to 10s: typing long text + human cadence can exceed that
-    });
+    await runJavaScriptForAutomation(automationScript);
     await showHUD("Finished Typing Clipboard");
   } catch (error) {
     await showFailureToast(error);
+  } finally {
+    await runJavaScriptForAutomation(buildReleaseShiftScript()).catch(() => undefined);
   }
 }

--- a/extensions/clipboard-type/src/type-clipboard.ts
+++ b/extensions/clipboard-type/src/type-clipboard.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { spawn } from "node:child_process";
 import { Clipboard, getPreferenceValues, showHUD } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 
@@ -107,17 +107,80 @@ const shiftKeyCode = 56;
 const returnKeyCode = 36;
 const tabKeyCode = 48;
 const keyEventDelaySeconds = 0.05;
+const progressPrefix = "__RAYCAST_CLIPBOARD_PROGRESS__:";
 
-function runJavaScriptForAutomation(script: string) {
+function runJavaScriptForAutomation(script: string, onProgress?: (remaining: number) => void) {
   return new Promise<void>((resolve, reject) => {
-    execFile("/usr/bin/osascript", ["-l", "JavaScript", "-e", script], (error) => {
-      if (error) {
-        reject(error);
+    const child = spawn("/usr/bin/osascript", ["-l", "JavaScript", "-e", script]);
+    let errorOutput = "";
+    let errorBuffer = "";
+
+    const processErrorLine = (line: string) => {
+      if (line.startsWith(progressPrefix)) {
+        const remaining = Number.parseInt(line.slice(progressPrefix.length), 10);
+        if (Number.isFinite(remaining)) onProgress?.(remaining);
       } else {
+        errorOutput += `${line}\n`;
+      }
+    };
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      errorBuffer += chunk.toString();
+      const lines = errorBuffer.split("\n");
+      errorBuffer = lines.pop() ?? "";
+      lines.forEach(processErrorLine);
+    });
+
+    child.on("error", reject);
+    child.on("close", (exitCode) => {
+      if (errorBuffer) processErrorLine(errorBuffer);
+      if (exitCode === 0) {
         resolve();
+      } else {
+        reject(new Error(errorOutput.trim() || `osascript exited with code ${exitCode}`));
       }
     });
   });
+}
+
+function formatClipboardPreview(characters: string[], remaining: number) {
+  const nextCharacters = characters.slice(characters.length - remaining);
+  const preview = nextCharacters
+    .slice(0, 20)
+    .map((character) =>
+      character === "\n" ? "\\n" : character === "\r" ? "\\r" : character === "\t" ? "\\t" : character,
+    )
+    .join("");
+  return `${preview}${nextCharacters.length > 20 ? "…" : ""}`;
+}
+
+function createProgressHUD(characters: string[]) {
+  let latestRemaining = 0;
+  let updateTimer: ReturnType<typeof setTimeout> | undefined;
+  let updatePromise = Promise.resolve();
+
+  const flush = () => {
+    updateTimer = undefined;
+    const remaining = latestRemaining;
+    const preview = formatClipboardPreview(characters, remaining);
+    updatePromise = updatePromise
+      .then(() => showHUD(`正在粘贴 ${preview}，还剩 ${remaining} 个字符`))
+      .catch(() => undefined);
+  };
+
+  return {
+    update(remaining: number) {
+      latestRemaining = remaining;
+      updateTimer ??= setTimeout(flush, 100);
+    },
+    async finish() {
+      if (updateTimer) {
+        clearTimeout(updateTimer);
+        flush();
+      }
+      await updatePromise;
+    },
+  };
 }
 
 function buildReleaseShiftScript() {
@@ -136,7 +199,12 @@ export default async function Command() {
     return;
   }
 
-  await showHUD("Typing Clipboard...");
+  const clipboardCharacters = Array.from(latestClipboardItem);
+  const characterCount = clipboardCharacters.length;
+  const progressHUD = createProgressHUD(clipboardCharacters);
+  await showHUD(
+    `正在粘贴 ${formatClipboardPreview(clipboardCharacters, characterCount)}，还剩 ${characterCount} 个字符`,
+  );
   const { humanCadence, humanCadenceSpeed, softNewlines } = getPreferenceValues<Preferences>();
 
   const humanCadenceSpeeds = {
@@ -164,6 +232,7 @@ const humanCadence = ${humanCadence};
 const cadenceMin = ${humanCadenceRange.min};
 const cadenceMax = ${humanCadenceRange.max};
 const softNewlines = ${softNewlines};
+const progressPrefix = ${JSON.stringify(progressPrefix)};
 
 function postKey(keyCode, keyDown) {
   const event = $.CGEventCreateKeyboardEvent(null, keyCode, keyDown);
@@ -197,12 +266,14 @@ function applyCadence() {
 
 const clipboardValue = $.NSPasteboard.generalPasteboard.stringForType($.NSPasteboardTypeString);
 const text = ObjC.unwrap(clipboardValue) || "";
+const characters = Array.from(text);
 
 delay(0.3);
 postKey(shiftKeyCode, false);
 
 try {
-  for (const character of text) {
+  for (let index = 0; index < characters.length; index++) {
+    const character = characters[index];
     if (character === "\\r" || character === "\\n") {
       pressKey(returnKeyCode, softNewlines);
     } else if (character === "\\t") {
@@ -214,6 +285,7 @@ try {
     } else {
       systemEvents.keystroke(character);
     }
+    console.log(progressPrefix + (characters.length - index - 1));
     applyCadence();
   }
 } finally {
@@ -222,9 +294,11 @@ try {
 `;
 
   try {
-    await runJavaScriptForAutomation(automationScript);
-    await showHUD("Finished Typing Clipboard");
+    await runJavaScriptForAutomation(automationScript, progressHUD.update);
+    await progressHUD.finish();
+    await showHUD("粘贴结束");
   } catch (error) {
+    await progressHUD.finish();
     await showFailureToast(error);
   } finally {
     await runJavaScriptForAutomation(buildReleaseShiftScript()).catch(() => undefined);

--- a/extensions/clipboard-type/src/type-clipboard.ts
+++ b/extensions/clipboard-type/src/type-clipboard.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { Clipboard, getPreferenceValues, showHUD } from "@raycast/api";
+import { Clipboard, closeMainWindow, getPreferenceValues, showToast, Toast } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 
 const keyCodes = {
@@ -109,32 +109,6 @@ const tabKeyCode = 48;
 const keyEventDelaySeconds = 0.05;
 const progressPrefix = "__RAYCAST_CLIPBOARD_PROGRESS__:";
 
-type Messages = {
-  clipboardEmpty: string;
-  typing: (preview: string, remaining: number) => string;
-  finished: string;
-};
-
-function getMessages(languagePreference: string): Messages {
-  const systemLocale = Intl.DateTimeFormat().resolvedOptions().locale.toLowerCase();
-  const language = languagePreference === "auto" ? (systemLocale.startsWith("zh") ? "zh" : "en") : languagePreference;
-
-  if (language === "zh") {
-    return {
-      clipboardEmpty: "剪贴板为空",
-      typing: (preview, remaining) => `正在粘贴 ${preview}，还剩 ${remaining} 个字符`,
-      finished: "粘贴结束",
-    };
-  }
-
-  return {
-    clipboardEmpty: "Clipboard is empty",
-    typing: (preview, remaining) =>
-      `Pasting ${preview}, ${remaining} ${remaining === 1 ? "character" : "characters"} remaining`,
-    finished: "Pasting complete",
-  };
-}
-
 function runJavaScriptForAutomation(script: string, onProgress?: (remaining: number) => void) {
   return new Promise<void>((resolve, reject) => {
     const child = spawn("/usr/bin/osascript", ["-l", "JavaScript", "-e", script]);
@@ -180,16 +154,18 @@ function formatClipboardPreview(characters: string[], remaining: number) {
   return `${preview}${nextCharacters.length > 20 ? "…" : ""}`;
 }
 
-function createProgressHUD(characters: string[], messages: Messages) {
+function formatProgressTitle(characters: string[], remaining: number) {
+  const preview = formatClipboardPreview(characters, remaining);
+  return `Pasting ${preview}, ${remaining} ${remaining === 1 ? "character" : "characters"} remaining`;
+}
+
+function createProgressToast(characters: string[], toast: Toast) {
   let latestRemaining = 0;
   let updateTimer: ReturnType<typeof setTimeout> | undefined;
-  let updatePromise = Promise.resolve();
 
   const flush = () => {
     updateTimer = undefined;
-    const remaining = latestRemaining;
-    const preview = formatClipboardPreview(characters, remaining);
-    updatePromise = updatePromise.then(() => showHUD(messages.typing(preview, remaining))).catch(() => undefined);
+    toast.title = formatProgressTitle(characters, latestRemaining);
   };
 
   return {
@@ -197,12 +173,11 @@ function createProgressHUD(characters: string[], messages: Messages) {
       latestRemaining = remaining;
       updateTimer ??= setTimeout(flush, 100);
     },
-    async finish() {
+    finish() {
       if (updateTimer) {
         clearTimeout(updateTimer);
         flush();
       }
-      await updatePromise;
     },
   };
 }
@@ -216,20 +191,22 @@ $.CGEventPost($.kCGHIDEventTap, shiftUpEvent);
 }
 
 export default async function Command() {
-  const preferences = getPreferenceValues<Preferences>();
-  const messages = getMessages(preferences.language);
   const latestClipboardItem = await Clipboard.readText();
 
   if (!latestClipboardItem) {
-    await showFailureToast(messages.clipboardEmpty);
+    await showFailureToast("Clipboard is empty");
     return;
   }
 
   const clipboardCharacters = Array.from(latestClipboardItem);
   const characterCount = clipboardCharacters.length;
-  const progressHUD = createProgressHUD(clipboardCharacters, messages);
-  await showHUD(messages.typing(formatClipboardPreview(clipboardCharacters, characterCount), characterCount));
-  const { humanCadence, humanCadenceSpeed, softNewlines } = preferences;
+  await closeMainWindow();
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: formatProgressTitle(clipboardCharacters, characterCount),
+  });
+  const progressToast = createProgressToast(clipboardCharacters, toast);
+  const { humanCadence, humanCadenceSpeed, softNewlines } = getPreferenceValues<Preferences>();
 
   const humanCadenceSpeeds = {
     "very-slow": { min: 0.1, max: 0.3 },
@@ -318,11 +295,12 @@ try {
 `;
 
   try {
-    await runJavaScriptForAutomation(automationScript, progressHUD.update);
-    await progressHUD.finish();
-    await showHUD(messages.finished);
+    await runJavaScriptForAutomation(automationScript, progressToast.update);
+    progressToast.finish();
+    toast.style = Toast.Style.Success;
+    toast.title = "Pasting complete";
   } catch (error) {
-    await progressHUD.finish();
+    progressToast.finish();
     await showFailureToast(error);
   } finally {
     await runJavaScriptForAutomation(buildReleaseShiftScript()).catch(() => undefined);

--- a/extensions/clipboard-type/src/type-clipboard.ts
+++ b/extensions/clipboard-type/src/type-clipboard.ts
@@ -109,6 +109,32 @@ const tabKeyCode = 48;
 const keyEventDelaySeconds = 0.05;
 const progressPrefix = "__RAYCAST_CLIPBOARD_PROGRESS__:";
 
+type Messages = {
+  clipboardEmpty: string;
+  typing: (preview: string, remaining: number) => string;
+  finished: string;
+};
+
+function getMessages(languagePreference: string): Messages {
+  const systemLocale = Intl.DateTimeFormat().resolvedOptions().locale.toLowerCase();
+  const language = languagePreference === "auto" ? (systemLocale.startsWith("zh") ? "zh" : "en") : languagePreference;
+
+  if (language === "zh") {
+    return {
+      clipboardEmpty: "剪贴板为空",
+      typing: (preview, remaining) => `正在粘贴 ${preview}，还剩 ${remaining} 个字符`,
+      finished: "粘贴结束",
+    };
+  }
+
+  return {
+    clipboardEmpty: "Clipboard is empty",
+    typing: (preview, remaining) =>
+      `Pasting ${preview}, ${remaining} ${remaining === 1 ? "character" : "characters"} remaining`,
+    finished: "Pasting complete",
+  };
+}
+
 function runJavaScriptForAutomation(script: string, onProgress?: (remaining: number) => void) {
   return new Promise<void>((resolve, reject) => {
     const child = spawn("/usr/bin/osascript", ["-l", "JavaScript", "-e", script]);
@@ -154,7 +180,7 @@ function formatClipboardPreview(characters: string[], remaining: number) {
   return `${preview}${nextCharacters.length > 20 ? "…" : ""}`;
 }
 
-function createProgressHUD(characters: string[]) {
+function createProgressHUD(characters: string[], messages: Messages) {
   let latestRemaining = 0;
   let updateTimer: ReturnType<typeof setTimeout> | undefined;
   let updatePromise = Promise.resolve();
@@ -163,9 +189,7 @@ function createProgressHUD(characters: string[]) {
     updateTimer = undefined;
     const remaining = latestRemaining;
     const preview = formatClipboardPreview(characters, remaining);
-    updatePromise = updatePromise
-      .then(() => showHUD(`正在粘贴 ${preview}，还剩 ${remaining} 个字符`))
-      .catch(() => undefined);
+    updatePromise = updatePromise.then(() => showHUD(messages.typing(preview, remaining))).catch(() => undefined);
   };
 
   return {
@@ -192,20 +216,20 @@ $.CGEventPost($.kCGHIDEventTap, shiftUpEvent);
 }
 
 export default async function Command() {
+  const preferences = getPreferenceValues<Preferences>();
+  const messages = getMessages(preferences.language);
   const latestClipboardItem = await Clipboard.readText();
 
   if (!latestClipboardItem) {
-    await showFailureToast("Clipboard is empty");
+    await showFailureToast(messages.clipboardEmpty);
     return;
   }
 
   const clipboardCharacters = Array.from(latestClipboardItem);
   const characterCount = clipboardCharacters.length;
-  const progressHUD = createProgressHUD(clipboardCharacters);
-  await showHUD(
-    `正在粘贴 ${formatClipboardPreview(clipboardCharacters, characterCount)}，还剩 ${characterCount} 个字符`,
-  );
-  const { humanCadence, humanCadenceSpeed, softNewlines } = getPreferenceValues<Preferences>();
+  const progressHUD = createProgressHUD(clipboardCharacters, messages);
+  await showHUD(messages.typing(formatClipboardPreview(clipboardCharacters, characterCount), characterCount));
+  const { humanCadence, humanCadenceSpeed, softNewlines } = preferences;
 
   const humanCadenceSpeeds = {
     "very-slow": { min: 0.1, max: 0.3 },
@@ -296,7 +320,7 @@ try {
   try {
     await runJavaScriptForAutomation(automationScript, progressHUD.update);
     await progressHUD.finish();
-    await showHUD("粘贴结束");
+    await showHUD(messages.finished);
   } catch (error) {
     await progressHUD.finish();
     await showFailureToast(error);

--- a/extensions/clipboard-type/src/type-clipboard.ts
+++ b/extensions/clipboard-type/src/type-clipboard.ts
@@ -1,5 +1,38 @@
-import { Clipboard, closeMainWindow, getPreferenceValues } from "@raycast/api";
+import { Clipboard, getPreferenceValues, showHUD } from "@raycast/api";
 import { runAppleScript, showFailureToast } from "@raycast/utils";
+
+const shiftedKeyCodes = [
+  ["!", 18],
+  ["@", 19],
+  ["#", 20],
+  ["$", 21],
+  ["%", 23],
+  ["^", 22],
+  ["&", 26],
+  ["*", 28],
+  ["(", 25],
+  [")", 29],
+  ["_", 27],
+  ["+", 24],
+  ["{", 33],
+  ["}", 30],
+  ["|", 42],
+  [":", 41],
+  ['"', 39],
+  ["<", 43],
+  [">", 47],
+  ["?", 44],
+  ["~", 50],
+] as const;
+
+function buildShiftedCharacterBranches() {
+  return shiftedKeyCodes
+    .map(([character, keyCode]) => {
+      const condition = character === '"' ? "quote" : `"${character}"`;
+      return `    else if c is ${condition} then\n      key code ${keyCode} using shift down`;
+    })
+    .join("\n");
+}
 
 export default async function Command() {
   const latestClipboardItem = await Clipboard.readText();
@@ -9,7 +42,7 @@ export default async function Command() {
     await showFailureToast("Clipboard is empty");
     return;
   }
-  await closeMainWindow();
+  await showHUD("Typing Clipboard...");
   const { humanCadence, humanCadenceSpeed, softNewlines } = getPreferenceValues<Preferences>();
 
   const humanCadenceSpeeds = {
@@ -24,6 +57,7 @@ export default async function Command() {
   const humanCadenceRange = humanCadenceSpeeds[humanCadenceSpeed];
 
   const delayString = `(random number from ${humanCadenceRange.min} to ${humanCadenceRange.max})`;
+  const shiftedCharacterBranches = buildShiftedCharacterBranches();
 
   const appleScriptContent = `
 set theText to the clipboard as text
@@ -35,6 +69,7 @@ tell application "System Events"
       key code 36${softNewlines ? " using shift down" : ""}
     else if c is tab then
       key code 48
+${shiftedCharacterBranches}
     else
       keystroke c
     end if
@@ -48,6 +83,7 @@ end tell
     await runAppleScript(appleScriptContent, {
       timeout: 0, // runAppleScript defaults to 10s: typing long text + human cadence can exceed that
     });
+    await showHUD("Finished Typing Clipboard");
   } catch (error) {
     await showFailureToast(error);
   }

--- a/extensions/clipboard-type/src/type-clipboard.ts
+++ b/extensions/clipboard-type/src/type-clipboard.ts
@@ -301,6 +301,7 @@ try {
     toast.title = "Pasting complete";
   } catch (error) {
     progressToast.finish();
+    toast.style = Toast.Style.Failure;
     await showFailureToast(error);
   } finally {
     await runJavaScriptForAutomation(buildReleaseShiftScript()).catch(() => undefined);


### PR DESCRIPTION
## Description

- Type symbols that require Shift with explicit macOS key codes, preventing characters such as `$` from being reduced to their base key.
- Show a HUD when clipboard typing starts and finishes.
- Document the ABC input source requirement for reliable symbol typing.

## Screencast

Not included; this updates an existing no-view command.

## Verification

- `npm run lint`
- `npm run build`
- Manually tested in Raycast with the ABC input source using letters, numbers, all supported Shift symbols, unshifted punctuation, spaces, a tab, and newlines. The resulting file matched the expected 67-byte fixture exactly.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
