### PR TITLE
Is It Alive: Add new adapters

### DIFF
--- a/extensions/is-it-alive/CHANGELOG.md
+++ b/extensions/is-it-alive/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Is It Alive? Changelog
 
+## [Instatus, Checkly, AWS, Salesforce Trust, Uptime.com, and RSS Support] - 2026-07-10
+
+- Add support for Instatus status pages via the public `/summary.json` API, including per-component uptime and 90-day history
+- Add support for Checkly status pages (e.g. status.mistral.ai) with per-service uptime and 90-day history
+- Add support for the AWS Health Dashboard (health.aws.amazon.com) with per-service-region events and history
+- Add support for Salesforce Trust product pages (status.salesforce.com/products/…) via the public Trust API; status.heroku.com maps to the Heroku product since its own status site is deprecated
+- Add support for Uptime.com status pages (hosted and custom-domain) with per-component uptime, 90-day history, and incident details
+- Add a generic RSS feed fallback for status pages that block their APIs (e.g. status.x.ai)
+
 ## [Fix Site Creation] - 2026-07-10
 
 - Fix adding sites when the Web Crypto global is unavailable

--- a/extensions/is-it-alive/CHANGELOG.md
+++ b/extensions/is-it-alive/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Is It Alive? Changelog
 
-## [Instatus, Checkly, AWS, Salesforce Trust, Uptime.com, and RSS Support] - {PR_MERGE_DATE}
+## [Instatus, Checkly, AWS, Salesforce Trust, Uptime.com, and RSS Support] - 2026-07-10
 
 - Add support for Instatus status pages via the public `/summary.json` API, including per-component uptime and 90-day history
 - Add support for Checkly status pages (e.g. status.mistral.ai) with per-service uptime and 90-day history

--- a/extensions/is-it-alive/CHANGELOG.md
+++ b/extensions/is-it-alive/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Is It Alive? Changelog
 
-## [Instatus, Checkly, AWS, Salesforce Trust, Uptime.com, and RSS Support] - 2026-07-10
+## [Instatus, Checkly, AWS, Salesforce Trust, Uptime.com, and RSS Support] - {PR_MERGE_DATE}
 
 - Add support for Instatus status pages via the public `/summary.json` API, including per-component uptime and 90-day history
 - Add support for Checkly status pages (e.g. status.mistral.ai) with per-service uptime and 90-day history

--- a/extensions/is-it-alive/README.md
+++ b/extensions/is-it-alive/README.md
@@ -32,16 +32,34 @@
 
 ## Supported status pages
 
-The extension auto-detects the provider when you add a URL. Detection order: **Railway → incident.io → Better Stack → Statuspage**.
+The extension auto-detects the provider when you add a URL. Detection order: **Railway → AWS → Salesforce Trust → incident.io → Better Stack → Instatus → Statuspage → Checkly → Uptime.com → RSS**.
 
 | Provider          | Examples                                                       | Detection                             |
 | ----------------- | -------------------------------------------------------------- | ------------------------------------- |
 | **Railway**       | [status.railway.com](https://status.railway.com)               | Hostname match                        |
+| **AWS**           | [health.aws.amazon.com](https://health.aws.amazon.com/health/status) | Hostname match                 |
+| **Salesforce Trust** | [status.salesforce.com/products/Heroku](https://status.salesforce.com/products/Heroku), [status.heroku.com](https://status.heroku.com) | Hostname match |
 | **incident.io**   | [status.openai.com](https://status.openai.com)                 | `/proxy/{host}/component_impacts` API |
 | **Better Stack**  | [status.yachtway.com](https://status.yachtway.com)             | `/index.json` JSON:API                |
+| **Instatus**      | [instat.us](https://instat.us)                                 | `/summary.json`                       |
 | **Statuspage.io** | [status.claude.com](https://status.claude.com), GitHub, Vercel | `/api/v2/summary.json`                |
+| **Checkly**       | [status.mistral.ai](https://status.mistral.ai)                 | `__NUXT_DATA__` payload in page HTML  |
+| **Uptime.com**    | [status.uptime.com](https://status.uptime.com), [uptime.com/statuspage/hackerrank](https://uptime.com/statuspage/hackerrank) | React props payload in page HTML |
+| **RSS fallback**  | [status.x.ai](https://status.x.ai)                             | `/feed.xml` (and common feed paths)   |
 
 incident.io is checked before Statuspage because some Statuspage hosts expose proxy-style URLs that look similar but lack incident.io-only endpoints like `component_impacts`.
+
+Instatus must also be checked before Statuspage: Instatus pages serve a Statuspage-compatible `/api/v2/summary.json` shim, so the Statuspage detector matches them even though the payload lacks Statuspage-only fields.
+
+Checkly has no public JSON API for status pages, so its adapter parses the Nuxt (`__NUXT_DATA__`) payload embedded in the page HTML. It is checked late because its detection requires downloading the full page.
+
+Uptime.com status pages embed their full state as React props in the page HTML; the adapter parses that payload and also calls the page's `/history` JSON endpoint for 90-day uptime and past incidents. Like Checkly, it is checked late because detection requires downloading the page. Both hosted (`uptime.com/statuspage/{slug}`) and custom-domain pages work.
+
+The RSS fallback is checked last and covers pages whose APIs and HTML are blocked (e.g. status.x.ai sits behind a Cloudflare challenge but keeps `/feed.xml` reachable). It is incident-only: components are derived from incident titles, day history marks incident days, and no uptime percentage is available.
+
+The AWS adapter reads the Health Dashboard's public `currentevents` endpoint (UTF-16 JSON) plus the 12-month `historyevents.json` S3 export. Components cover service–region pairs that have reported events; services with no events in the window don't appear.
+
+The Salesforce Trust adapter uses the public `api.status.salesforce.com/v1` API and covers any product page on [status.salesforce.com](https://status.salesforce.com) (Heroku, Tableau, Mulesoft, Slack, …). Add `https://status.salesforce.com/products/{Product}` to monitor one product; the bare domain maps to the core Salesforce Services product. `status.heroku.com` is deprecated in favor of Salesforce Trust, so it maps to the Heroku product automatically.
 
 ## Features
 
@@ -75,9 +93,15 @@ src/
   adapters/
     index.ts             # provider detection + registry
     statuspage.ts        # Statuspage.io v2 API
+    aws.ts               # AWS Health Dashboard public events
     betterstack.ts       # Better Stack /index.json API
+    checkly.ts           # Checkly __NUXT_DATA__ HTML payload
     incident-io.ts       # incident.io proxy API
+    instatus.ts          # Instatus public /summary.json API
     railway.ts           # Railway status API
+    rss.ts               # generic RSS feed fallback (e.g. status.x.ai)
+    salesforce.ts        # Salesforce Trust API (also covers status.heroku.com)
+    uptimecom.ts         # Uptime.com React props payload + /history JSON
   components/
     site-form.tsx        # add / edit form
     site-detail.tsx      # preview with uptime charts

--- a/extensions/is-it-alive/package-lock.json
+++ b/extensions/is-it-alive/package-lock.json
@@ -7,7 +7,7 @@
       "name": "is-it-alive",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.19",
+        "@raycast/api": "^1.104.22",
         "@raycast/utils": "^2.2.6"
       },
       "devDependencies": {
@@ -1028,9 +1028,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.19",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.19.tgz",
-      "integrity": "sha512-SAVg56BAzxZGy/OPQ0jekUG3pJaoX5pCqleALvFo9JRE7P2tvKoglWnYRcIJArRhLlvV8FtFNMDafd+NNwXXCw==",
+      "version": "1.104.22",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.22.tgz",
+      "integrity": "sha512-t4HwubTb1qpbaxdP8mu62Ugd1qYgcOM4Lc4+7EsxPPm7g3g5xlarH+MG+/kQEGrUukctGwrNL8S6VCVnuGIutw==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
@@ -1166,7 +1166,6 @@
       "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1226,7 +1225,6 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -1431,7 +1429,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1735,7 +1732,6 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2430,7 +2426,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2454,7 +2449,6 @@
       "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2638,7 +2632,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/is-it-alive/package.json
+++ b/extensions/is-it-alive/package.json
@@ -12,7 +12,7 @@
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1"
   },
   "dependencies": {
-    "@raycast/api": "^1.104.19",
+    "@raycast/api": "^1.104.22",
     "@raycast/utils": "^2.2.6"
   },
   "devDependencies": {

--- a/extensions/is-it-alive/src/adapters/aws.ts
+++ b/extensions/is-it-alive/src/adapters/aws.ts
@@ -1,0 +1,346 @@
+import type {
+  ComponentStatus,
+  ComponentStatusValue,
+  DayStatus,
+  StatusAdapter,
+  StatusIncident,
+  StatusIndicator,
+  StatusSnapshot,
+} from "@/types";
+import { normalizeSiteUrl } from "@/lib/url";
+import { overallDescription } from "@/lib/snapshot-text";
+import { buildPageHistoryFromComponents } from "@/lib/uptime-chart";
+import {
+  AwsCurrentEvent,
+  AwsEventLogEntry,
+  AwsHistoryEvent,
+  AwsHistoryEvents,
+} from "@/types/aws";
+
+const AWS_HOSTS = new Set(["health.aws.amazon.com", "status.aws.amazon.com"]);
+const AWS_PAGE = "https://health.aws.amazon.com/health/status";
+const CURRENT_EVENTS_URL = "https://health.aws.amazon.com/public/currentevents";
+const HISTORY_EVENTS_URL =
+  "https://history-events-eu-west-1-prod.s3.amazonaws.com/historyevents.json";
+
+/** The currentevents endpoint serves UTF-16 JSON (BOM decides endianness). */
+async function fetchAwsJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const bytes = new Uint8Array(await response.arrayBuffer());
+
+  let text: string;
+  if (bytes[0] === 0xfe && bytes[1] === 0xff) {
+    const swapped = new Uint8Array(bytes.length - 2);
+    for (let i = 2; i + 1 < bytes.length; i += 2) {
+      swapped[i - 2] = bytes[i + 1];
+      swapped[i - 1] = bytes[i];
+    }
+    text = new TextDecoder("utf-16le").decode(swapped);
+  } else if (bytes[0] === 0xff && bytes[1] === 0xfe) {
+    text = new TextDecoder("utf-16le").decode(bytes.subarray(2));
+  } else {
+    text = new TextDecoder("utf-8").decode(bytes);
+  }
+
+  return JSON.parse(text.replace(/^\uFEFF/, "")) as T;
+}
+
+function isAwsHost(siteUrl: string): boolean {
+  try {
+    return AWS_HOSTS.has(new URL(normalizeSiteUrl(siteUrl)).hostname);
+  } catch {
+    return false;
+  }
+}
+
+function lastLog(
+  event: AwsCurrentEvent | AwsHistoryEvent,
+): AwsEventLogEntry | undefined {
+  const log = event.event_log;
+  return log && log.length > 0 ? log[log.length - 1] : undefined;
+}
+
+function isEventActive(event: AwsCurrentEvent | AwsHistoryEvent): boolean {
+  const last = lastLog(event);
+  if (last !== undefined) {
+    return String(last.status) !== "0";
+  }
+  return String(event.status) !== "0";
+}
+
+/** arn:aws:health:us-east-1::event/EC2/... -> { service: "EC2", region: "us-east-1" } */
+function parseArn(arn: string): { service?: string; region?: string } {
+  const parts = arn.split(":");
+  const region = parts[3] || undefined;
+  const service = parts[5]?.split("/")[1];
+  return { service, region };
+}
+
+function componentKey(event: AwsCurrentEvent | AwsHistoryEvent): string {
+  if ("service" in event && event.service) {
+    return event.service;
+  }
+  const { service, region } = parseArn(event.arn);
+  const name = (service ?? "unknown").toLowerCase().replace(/_/g, "");
+  return region ? `${name}-${region}` : name;
+}
+
+function componentName(
+  key: string,
+  events: Array<AwsCurrentEvent | AwsHistoryEvent>,
+): string {
+  const current = events.find(
+    (event): event is AwsCurrentEvent =>
+      "service_name" in event && Boolean(event.service_name),
+  );
+  const { service, region } = parseArn(events[0].arn);
+
+  const base =
+    current?.service_name ??
+    (service ? service.replace(/_/g, " ") : key.toUpperCase());
+  const regionLabel =
+    (current && "region_name" in current && current.region_name) || region;
+
+  return regionLabel ? `${base} (${regionLabel})` : base;
+}
+
+function severityToComponentStatus(status: string): ComponentStatusValue {
+  switch (status) {
+    case "2":
+      return "partial_outage";
+    case "3":
+      return "major_outage";
+    default:
+      return "degraded_performance";
+  }
+}
+
+function severityToDayLevel(status: string): DayStatus["level"] {
+  switch (status) {
+    case "2":
+      return "partial";
+    case "3":
+      return "major";
+    default:
+      return "degraded";
+  }
+}
+
+function severityToIndicator(status: string): StatusIndicator {
+  switch (status) {
+    case "2":
+      return "major";
+    case "3":
+      return "critical";
+    default:
+      return "minor";
+  }
+}
+
+function severityToImpact(status: string): string {
+  switch (status) {
+    case "2":
+      return "major";
+    case "3":
+      return "critical";
+    default:
+      return "minor";
+  }
+}
+
+function severityLabel(status: string): string {
+  switch (status) {
+    case "2":
+      return "degraded";
+    case "3":
+      return "disrupted";
+    default:
+      return "impacted";
+  }
+}
+
+const DAY_LEVEL_SEVERITY: Record<DayStatus["level"], number> = {
+  operational: 0,
+  degraded: 1,
+  partial: 2,
+  major: 3,
+  unknown: 0,
+};
+
+interface TrackedEvent {
+  event: AwsCurrentEvent | AwsHistoryEvent;
+  /** Only events from the currentevents endpoint may be ongoing; history
+   * events sometimes lack a final "resolved" log entry. */
+  canBeActive: boolean;
+}
+
+function isActive(tracked: TrackedEvent): boolean {
+  return tracked.canBeActive && isEventActive(tracked.event);
+}
+
+function buildHistory(events: TrackedEvent[], days = 90): DayStatus[] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const dayMap = new Map<string, DayStatus["level"]>();
+  for (let i = 0; i < days; i++) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - (days - 1 - i));
+    dayMap.set(d.toISOString().slice(0, 10), "operational");
+  }
+
+  for (const tracked of events) {
+    const { event } = tracked;
+    const start = new Date(parseInt(event.date, 10) * 1000);
+    const last = lastLog(event);
+    const end = isActive(tracked)
+      ? today
+      : new Date((last?.timestamp ?? parseInt(event.date, 10)) * 1000);
+    const level = severityToDayLevel(String(event.status));
+
+    const cursor = new Date(start);
+    cursor.setHours(0, 0, 0, 0);
+    const endDay = new Date(end);
+    endDay.setHours(0, 0, 0, 0);
+
+    while (cursor <= endDay) {
+      const key = cursor.toISOString().slice(0, 10);
+      const existing = dayMap.get(key);
+      if (
+        existing !== undefined &&
+        DAY_LEVEL_SEVERITY[level] > DAY_LEVEL_SEVERITY[existing]
+      ) {
+        dayMap.set(key, level);
+      }
+      cursor.setDate(cursor.getDate() + 1);
+    }
+  }
+
+  return Array.from(dayMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, level]) => ({ date, level }));
+}
+
+function buildComponents(
+  currentEvents: AwsCurrentEvent[],
+  history: AwsHistoryEvents,
+): ComponentStatus[] {
+  const byKey = new Map<string, TrackedEvent[]>();
+
+  for (const [key, events] of Object.entries(history)) {
+    byKey.set(
+      key,
+      events.map((event) => ({ event, canBeActive: false })),
+    );
+  }
+  for (const event of currentEvents) {
+    const key = componentKey(event);
+    byKey.set(key, [...(byKey.get(key) ?? []), { event, canBeActive: true }]);
+  }
+
+  return Array.from(byKey.entries())
+    .filter(([, events]) => events.length > 0)
+    .map(([key, events]) => {
+      const worst = events
+        .filter(isActive)
+        .map((tracked) => String(tracked.event.status))
+        .sort()
+        .pop();
+
+      return {
+        id: key,
+        name: componentName(
+          key,
+          events.map((tracked) => tracked.event),
+        ),
+        status: worst
+          ? severityToComponentStatus(worst)
+          : ("operational" as const),
+        historyDays: buildHistory(events),
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function mapIncidents(currentEvents: AwsCurrentEvent[]): StatusIncident[] {
+  return currentEvents.filter(isEventActive).map((event) => {
+    const last = lastLog(event);
+    const scope = [event.service_name, event.region_name]
+      .filter(Boolean)
+      .join(" — ");
+
+    return {
+      id: event.arn,
+      name: scope ? `${scope}: ${event.summary}` : event.summary,
+      status: severityLabel(String(event.status)),
+      impact: severityToImpact(String(event.status)),
+      updatedAt: new Date(
+        (last?.timestamp ?? parseInt(event.date, 10)) * 1000,
+      ).toISOString(),
+      body: last?.message,
+      affectedComponentIds: [componentKey(event)],
+    };
+  });
+}
+
+export const awsAdapter: StatusAdapter = {
+  async detect(siteUrl: string): Promise<boolean> {
+    return isAwsHost(siteUrl);
+  },
+
+  async fetchSnapshot(): Promise<StatusSnapshot> {
+    const fetchedAt = new Date().toISOString();
+
+    try {
+      const [currentEvents, history] = await Promise.all([
+        fetchAwsJson<AwsCurrentEvent[]>(CURRENT_EVENTS_URL),
+        fetchAwsJson<AwsHistoryEvents>(HISTORY_EVENTS_URL).catch(
+          () => ({}) as AwsHistoryEvents,
+        ),
+      ]);
+
+      const components = buildComponents(currentEvents ?? [], history);
+      const incidents = mapIncidents(currentEvents ?? []);
+
+      const indicator: StatusIndicator =
+        incidents.length > 0
+          ? severityToIndicator(
+              incidents.some((incident) => incident.impact === "critical")
+                ? "3"
+                : incidents.some((incident) => incident.impact === "major")
+                  ? "2"
+                  : "1",
+            )
+          : "none";
+
+      return {
+        pageName: "AWS",
+        pageUrl: AWS_PAGE,
+        overallDescription: overallDescription(indicator, incidents.length),
+        indicator,
+        components,
+        incidents,
+        historyDays: buildPageHistoryFromComponents(components),
+        fetchedAt,
+      };
+    } catch (error) {
+      return {
+        pageName: "AWS",
+        pageUrl: AWS_PAGE,
+        overallDescription: "Failed to fetch",
+        indicator: "none",
+        components: [],
+        incidents: [],
+        fetchedAt,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+};

--- a/extensions/is-it-alive/src/adapters/checkly.ts
+++ b/extensions/is-it-alive/src/adapters/checkly.ts
@@ -32,37 +32,49 @@ const REF_TAGS = new Set(["ShallowReactive", "Reactive", "Ref", "ShallowRef"]);
  * embedded in the HTML as a devalue-encoded `__NUXT_DATA__` payload (a flat
  * array where objects/arrays reference other entries by index).
  */
-function hydrateNuxtData(values: unknown[], index: unknown): unknown {
+function hydrateNuxtData(
+  values: unknown[],
+  index: unknown,
+  // Indices on the current recursion path; a repeat means a cycle in a
+  // malformed payload. Entries are removed on exit so devalue's legitimate
+  // shared references (same index reachable via multiple paths) still resolve.
+  visiting: Set<number> = new Set(),
+): unknown {
   if (typeof index !== "number") {
     return index;
   }
-  if (index < 0) {
+  if (index < 0 || visiting.has(index)) {
     return undefined;
   }
 
   const value = values[index];
+  visiting.add(index);
 
-  if (Array.isArray(value)) {
-    if (value.length === 2 && typeof value[0] === "string") {
-      if (REF_TAGS.has(value[0])) {
-        return hydrateNuxtData(values, value[1]);
+  try {
+    if (Array.isArray(value)) {
+      if (value.length === 2 && typeof value[0] === "string") {
+        if (REF_TAGS.has(value[0])) {
+          return hydrateNuxtData(values, value[1], visiting);
+        }
+        if (value[0] === "Date") {
+          return value[1];
+        }
       }
-      if (value[0] === "Date") {
-        return value[1];
+      return value.map((item) => hydrateNuxtData(values, item, visiting));
+    }
+
+    if (value !== null && typeof value === "object") {
+      const result: Record<string, unknown> = {};
+      for (const [key, item] of Object.entries(value)) {
+        result[key] = hydrateNuxtData(values, item, visiting);
       }
+      return result;
     }
-    return value.map((item) => hydrateNuxtData(values, item));
-  }
 
-  if (value !== null && typeof value === "object") {
-    const result: Record<string, unknown> = {};
-    for (const [key, item] of Object.entries(value)) {
-      result[key] = hydrateNuxtData(values, item);
-    }
-    return result;
+    return value;
+  } finally {
+    visiting.delete(index);
   }
-
-  return value;
 }
 
 function parseNuxtPayload(html: string): ChecklyPayload | null {

--- a/extensions/is-it-alive/src/adapters/checkly.ts
+++ b/extensions/is-it-alive/src/adapters/checkly.ts
@@ -1,0 +1,341 @@
+import type {
+  ComponentStatus,
+  ComponentStatusValue,
+  DayStatus,
+  StatusAdapter,
+  StatusIncident,
+  StatusIndicator,
+  StatusSnapshot,
+} from "@/types";
+import { getOrigin, normalizeSiteUrl } from "@/lib/url";
+import { overallDescription } from "@/lib/snapshot-text";
+import {
+  averageComponentUptime,
+  buildPageHistoryFromComponents,
+} from "@/lib/uptime-chart";
+import {
+  ChecklyDayEvent,
+  ChecklyIncident,
+  ChecklyPayload,
+  ChecklyService,
+  ChecklyStatusPageInfo,
+  ChecklyUptimeCard,
+} from "@/types/checkly";
+
+const NUXT_DATA_PATTERN =
+  /<script[^>]*id="__NUXT_DATA__"[^>]*>([\s\S]*?)<\/script>/;
+
+const REF_TAGS = new Set(["ShallowReactive", "Reactive", "Ref", "ShallowRef"]);
+
+/**
+ * Checkly status pages are Nuxt apps with no public JSON API; all data is
+ * embedded in the HTML as a devalue-encoded `__NUXT_DATA__` payload (a flat
+ * array where objects/arrays reference other entries by index).
+ */
+function hydrateNuxtData(values: unknown[], index: unknown): unknown {
+  if (typeof index !== "number") {
+    return index;
+  }
+  if (index < 0) {
+    return undefined;
+  }
+
+  const value = values[index];
+
+  if (Array.isArray(value)) {
+    if (value.length === 2 && typeof value[0] === "string") {
+      if (REF_TAGS.has(value[0])) {
+        return hydrateNuxtData(values, value[1]);
+      }
+      if (value[0] === "Date") {
+        return value[1];
+      }
+    }
+    return value.map((item) => hydrateNuxtData(values, item));
+  }
+
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      result[key] = hydrateNuxtData(values, item);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+function parseNuxtPayload(html: string): ChecklyPayload | null {
+  const match = html.match(NUXT_DATA_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  let values: unknown[];
+  try {
+    values = JSON.parse(match[1]) as unknown[];
+  } catch {
+    return null;
+  }
+
+  const root = hydrateNuxtData(values, 0) as
+    | { data?: Record<string, unknown> }
+    | undefined;
+  const data = root?.data;
+  if (!data) {
+    return null;
+  }
+
+  const resolverKey = Object.keys(data).find((key) =>
+    key.startsWith("status-page-resolver-"),
+  );
+  if (!resolverKey) {
+    return null;
+  }
+
+  const resolver = data[resolverKey] as
+    | { statusPage?: ChecklyStatusPageInfo }
+    | undefined;
+
+  const incidentsEntry = Object.entries(data).find(([key]) =>
+    key.startsWith("unresolved-incidents-"),
+  )?.[1] as { incidents?: ChecklyIncident[] } | undefined;
+
+  const uptimeEntry = Object.entries(data).find(([key]) =>
+    key.startsWith("uptime-"),
+  )?.[1] as { uptime?: ChecklyUptimeCard[] } | undefined;
+
+  return {
+    statusPage: resolver?.statusPage,
+    incidents: incidentsEntry?.incidents ?? [],
+    cards: uptimeEntry?.uptime ?? [],
+  };
+}
+
+async function fetchPayload(siteUrl: string): Promise<ChecklyPayload | null> {
+  const response = await fetch(siteUrl, {
+    headers: { Accept: "text/html" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  return parseNuxtPayload(await response.text());
+}
+
+const SEVERITY_RANK: Record<string, number> = {
+  MINOR: 1,
+  MEDIUM: 2,
+  MAJOR: 3,
+};
+
+function severityToDayLevel(severity: string | undefined): DayStatus["level"] {
+  switch (severity) {
+    case "MINOR":
+      return "degraded";
+    case "MEDIUM":
+      return "partial";
+    case "MAJOR":
+      return "major";
+    default:
+      return "degraded";
+  }
+}
+
+function severityToComponentStatus(
+  severity: string | undefined,
+): ComponentStatusValue {
+  switch (severity) {
+    case "MINOR":
+      return "degraded_performance";
+    case "MEDIUM":
+      return "partial_outage";
+    case "MAJOR":
+      return "major_outage";
+    default:
+      return "degraded_performance";
+  }
+}
+
+function severityToIndicator(severity: string | undefined): StatusIndicator {
+  switch (severity) {
+    case "MINOR":
+      return "minor";
+    case "MEDIUM":
+      return "major";
+    case "MAJOR":
+      return "critical";
+    default:
+      return "minor";
+  }
+}
+
+function severityToImpact(severity: string | undefined): string {
+  switch (severity) {
+    case "MINOR":
+      return "minor";
+    case "MEDIUM":
+      return "major";
+    case "MAJOR":
+      return "critical";
+    default:
+      return "minor";
+  }
+}
+
+function isUnresolved(event: ChecklyDayEvent): boolean {
+  return event.lastUpdateStatus !== "RESOLVED";
+}
+
+function worstSeverity(events: ChecklyDayEvent[]): string | undefined {
+  let worst: string | undefined;
+  for (const event of events) {
+    const rank = SEVERITY_RANK[event.severity ?? ""] ?? 1;
+    if (worst === undefined || rank > (SEVERITY_RANK[worst] ?? 1)) {
+      worst = event.severity;
+    }
+  }
+  return worst;
+}
+
+function unresolvedEvents(service: ChecklyService): ChecklyDayEvent[] {
+  return (service.days ?? []).flatMap((day) => day.events).filter(isUnresolved);
+}
+
+function buildServiceHistory(service: ChecklyService): DayStatus[] {
+  return (service.days ?? []).map((day) => ({
+    date: day.date.slice(0, 10),
+    level:
+      day.events.length > 0
+        ? severityToDayLevel(worstSeverity(day.events))
+        : ("operational" as const),
+  }));
+}
+
+function mapComponents(cards: ChecklyUptimeCard[]): {
+  components: ComponentStatus[];
+  activeSeverities: string[];
+} {
+  const components: ComponentStatus[] = [];
+  const activeSeverities: string[] = [];
+
+  for (const card of cards) {
+    for (const service of card.services ?? []) {
+      const active = unresolvedEvents(service);
+      if (active.length > 0) {
+        activeSeverities.push(worstSeverity(active) ?? "MINOR");
+      }
+
+      components.push({
+        id: service.id,
+        name: service.name,
+        status:
+          active.length > 0
+            ? severityToComponentStatus(worstSeverity(active))
+            : "operational",
+        uptimePercent: service.uptime,
+        historyDays: buildServiceHistory(service),
+      });
+    }
+  }
+
+  return { components, activeSeverities };
+}
+
+function mapIncidents(incidents: ChecklyIncident[]): StatusIncident[] {
+  return incidents.map((incident, index) => ({
+    id: incident.id ?? `incident-${index}`,
+    name: incident.name ?? "Incident",
+    status: (
+      incident.lastUpdateStatus ??
+      incident.status ??
+      "investigating"
+    ).toLowerCase(),
+    impact: severityToImpact(incident.severity),
+    updatedAt:
+      incident.updatedAt ??
+      incident.created_at ??
+      incident.createdAt ??
+      new Date().toISOString(),
+    body: incident.description,
+  }));
+}
+
+function computeIndicator(
+  incidents: ChecklyIncident[],
+  activeSeverities: string[],
+): StatusIndicator {
+  const severities = [
+    ...incidents.map((incident) => incident.severity),
+    ...activeSeverities,
+  ].filter((severity): severity is string => Boolean(severity));
+
+  if (severities.length === 0 && incidents.length === 0) {
+    return "none";
+  }
+  if (severities.length === 0) {
+    return "minor";
+  }
+
+  let worst = severities[0];
+  for (const severity of severities) {
+    if ((SEVERITY_RANK[severity] ?? 1) > (SEVERITY_RANK[worst] ?? 1)) {
+      worst = severity;
+    }
+  }
+
+  return severityToIndicator(worst);
+}
+
+export const checklyAdapter: StatusAdapter = {
+  async detect(siteUrl: string): Promise<boolean> {
+    try {
+      const origin = getOrigin(normalizeSiteUrl(siteUrl));
+      const payload = await fetchPayload(origin);
+      return payload !== null;
+    } catch {
+      return false;
+    }
+  },
+
+  async fetchSnapshot(siteUrl: string): Promise<StatusSnapshot> {
+    const normalized = normalizeSiteUrl(siteUrl);
+    const origin = getOrigin(normalized);
+    const fetchedAt = new Date().toISOString();
+
+    try {
+      const payload = await fetchPayload(origin);
+      if (!payload) {
+        throw new Error("Not a Checkly status page");
+      }
+
+      const { components, activeSeverities } = mapComponents(payload.cards);
+      const incidents = mapIncidents(payload.incidents);
+      const indicator = computeIndicator(payload.incidents, activeSeverities);
+
+      return {
+        pageName: payload.statusPage?.name ?? new URL(normalized).hostname,
+        pageUrl: normalized,
+        overallDescription: overallDescription(indicator, incidents.length),
+        indicator,
+        components,
+        incidents,
+        historyDays: buildPageHistoryFromComponents(components),
+        uptimePercent: averageComponentUptime(components),
+        fetchedAt,
+      };
+    } catch (error) {
+      return {
+        pageName: new URL(normalized).hostname,
+        pageUrl: normalized,
+        overallDescription: "Failed to fetch",
+        indicator: "none",
+        components: [],
+        incidents: [],
+        fetchedAt,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+};

--- a/extensions/is-it-alive/src/adapters/index.ts
+++ b/extensions/is-it-alive/src/adapters/index.ts
@@ -1,15 +1,29 @@
 import type { SiteProvider, StatusAdapter, StatusSnapshot } from "@/types";
 import { isRailwayHost, normalizeSiteUrl } from "@/lib/url";
+import { awsAdapter } from "@/adapters/aws";
 import { betterstackAdapter } from "@/adapters/betterstack";
+import { checklyAdapter } from "@/adapters/checkly";
 import { incidentIoAdapter } from "@/adapters/incident-io";
+import { instatusAdapter } from "@/adapters/instatus";
 import { railwayAdapter } from "@/adapters/railway";
+import { rssAdapter } from "@/adapters/rss";
+import { salesforceAdapter } from "@/adapters/salesforce";
 import { statuspageAdapter } from "@/adapters/statuspage";
+import { uptimecomAdapter } from "@/adapters/uptimecom";
 
 const adapters: Record<SiteProvider, StatusAdapter> = {
   statuspage: statuspageAdapter,
   railway: railwayAdapter,
   incidentio: incidentIoAdapter,
   betterstack: betterstackAdapter,
+  instatus: instatusAdapter,
+  checkly: checklyAdapter,
+  rss: rssAdapter,
+  aws: awsAdapter,
+  // status.heroku.com moved to Salesforce Trust; legacy sites keep working.
+  heroku: salesforceAdapter,
+  salesforce: salesforceAdapter,
+  uptimecom: uptimecomAdapter,
 };
 
 export function getAdapter(provider: SiteProvider): StatusAdapter {
@@ -23,6 +37,16 @@ export async function detectProvider(siteUrl: string): Promise<SiteProvider> {
     return "railway";
   }
 
+  const isAws = await awsAdapter.detect?.(normalized);
+  if (isAws) {
+    return "aws";
+  }
+
+  const isSalesforce = await salesforceAdapter.detect?.(normalized);
+  if (isSalesforce) {
+    return "salesforce";
+  }
+
   const isIncidentIo = await incidentIoAdapter.detect?.(normalized);
   if (isIncidentIo) {
     return "incidentio";
@@ -33,13 +57,33 @@ export async function detectProvider(siteUrl: string): Promise<SiteProvider> {
     return "betterstack";
   }
 
+  const isInstatus = await instatusAdapter.detect?.(normalized);
+  if (isInstatus) {
+    return "instatus";
+  }
+
   const isStatuspage = await statuspageAdapter.detect?.(normalized);
   if (isStatuspage) {
     return "statuspage";
   }
 
+  const isCheckly = await checklyAdapter.detect?.(normalized);
+  if (isCheckly) {
+    return "checkly";
+  }
+
+  const isUptimeCom = await uptimecomAdapter.detect?.(normalized);
+  if (isUptimeCom) {
+    return "uptimecom";
+  }
+
+  const isRss = await rssAdapter.detect?.(normalized);
+  if (isRss) {
+    return "rss";
+  }
+
   throw new Error(
-    "Unsupported status page. Try Statuspage, Better Stack, incident.io, or status.railway.app",
+    "Unsupported status page. Try Statuspage, Better Stack, incident.io, Instatus, Checkly, an RSS status feed, or status.railway.app",
   );
 }
 

--- a/extensions/is-it-alive/src/adapters/instatus.ts
+++ b/extensions/is-it-alive/src/adapters/instatus.ts
@@ -1,0 +1,445 @@
+import type {
+  ComponentStatus,
+  ComponentStatusValue,
+  DayStatus,
+  StatusAdapter,
+  StatusIncident,
+  StatusIndicator,
+  StatusSnapshot,
+} from "@/types";
+import { getOrigin, normalizeSiteUrl } from "@/lib/url";
+import { fetchJson } from "@/lib/fetch-json";
+import { overallDescription } from "@/lib/snapshot-text";
+import {
+  averageComponentUptime,
+  buildPageHistoryFromComponents,
+} from "@/lib/uptime-chart";
+import {
+  InstatusComponent,
+  InstatusComponentsResponse,
+  InstatusComponentsUptime,
+  InstatusOutage,
+  InstatusSummary,
+  InstatusSummaryIncident,
+} from "@/types/instatus";
+
+function summaryUrl(siteUrl: string): string {
+  return `${getOrigin(normalizeSiteUrl(siteUrl))}/summary.json`;
+}
+
+function componentsUrl(siteUrl: string): string {
+  return `${getOrigin(normalizeSiteUrl(siteUrl))}/v2/components.json`;
+}
+
+function isInstatusSummary(data: unknown): data is InstatusSummary {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "page" in data &&
+    typeof data.page === "object" &&
+    data.page !== null &&
+    "status" in data.page &&
+    typeof data.page.status === "string" &&
+    "name" in data.page
+  );
+}
+
+function componentStatusValue(status: string): ComponentStatusValue | string {
+  switch (status) {
+    case "OPERATIONAL":
+      return "operational";
+    case "DEGRADEDPERFORMANCE":
+      return "degraded_performance";
+    case "PARTIALOUTAGE":
+      return "partial_outage";
+    case "MINOROUTAGE":
+      return "partial_outage";
+    case "MAJOROUTAGE":
+      return "major_outage";
+    case "UNDERMAINTENANCE":
+      return "under_maintenance";
+    default:
+      return status.toLowerCase();
+  }
+}
+
+function impactToIndicator(impact: string): StatusIndicator {
+  switch (impact) {
+    case "MAJOROUTAGE":
+      return "critical";
+    case "PARTIALOUTAGE":
+      return "major";
+    case "MINOROUTAGE":
+    case "DEGRADEDPERFORMANCE":
+      return "minor";
+    default:
+      return "minor";
+  }
+}
+
+function impactToIncidentImpact(impact: string): string {
+  switch (impact) {
+    case "MAJOROUTAGE":
+      return "critical";
+    case "PARTIALOUTAGE":
+      return "major";
+    case "MINOROUTAGE":
+    case "DEGRADEDPERFORMANCE":
+      return "minor";
+    default:
+      return "minor";
+  }
+}
+
+const INDICATOR_SEVERITY: Record<StatusIndicator, number> = {
+  none: 0,
+  minor: 1,
+  major: 2,
+  critical: 3,
+};
+
+function worstIndicator(indicators: StatusIndicator[]): StatusIndicator {
+  return indicators.reduce<StatusIndicator>(
+    (worst, indicator) =>
+      INDICATOR_SEVERITY[indicator] > INDICATOR_SEVERITY[worst]
+        ? indicator
+        : worst,
+    "none",
+  );
+}
+
+function componentStatusToIndicator(status: string): StatusIndicator {
+  switch (status) {
+    case "OPERATIONAL":
+      return "none";
+    case "DEGRADEDPERFORMANCE":
+    case "UNDERMAINTENANCE":
+      return "minor";
+    case "PARTIALOUTAGE":
+    case "MINOROUTAGE":
+      return "major";
+    case "MAJOROUTAGE":
+      return "critical";
+    default:
+      return "minor";
+  }
+}
+
+/**
+ * Instatus lists group containers alongside regular components (children
+ * reference them via `group.id`), so drop any entry acting as a group.
+ */
+function leafComponents(components: InstatusComponent[]): InstatusComponent[] {
+  const groupIds = new Set(
+    components
+      .map((component) => component.group?.id)
+      .filter((id): id is string => Boolean(id)),
+  );
+
+  return components.filter((component) => !groupIds.has(component.id));
+}
+
+const DAY_LEVEL_SEVERITY: Record<DayStatus["level"], number> = {
+  operational: 0,
+  degraded: 1,
+  partial: 2,
+  major: 3,
+  unknown: 0,
+};
+
+function outageStatusToDayLevel(status: string): DayStatus["level"] | null {
+  switch (status) {
+    case "DEGRADEDPERFORMANCE":
+    case "UNDERMAINTENANCE":
+      return "degraded";
+    case "MINOROUTAGE":
+    case "PARTIALOUTAGE":
+      return "partial";
+    case "MAJOROUTAGE":
+      return "major";
+    default:
+      // OPERATIONAL entries mark recovery windows, not downtime.
+      return null;
+  }
+}
+
+function buildHistoryFromOutages(
+  outages: InstatusOutage[],
+  days = 90,
+): DayStatus[] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const dayMap = new Map<string, DayStatus["level"]>();
+
+  for (let i = 0; i < days; i++) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - (days - 1 - i));
+    dayMap.set(d.toISOString().slice(0, 10), "operational");
+  }
+
+  for (const outage of outages) {
+    const level = outageStatusToDayLevel(outage.status);
+    if (!level) {
+      continue;
+    }
+
+    const start = new Date(outage.from);
+    const end = outage.to ? new Date(outage.to) : today;
+
+    const cursor = new Date(start);
+    cursor.setHours(0, 0, 0, 0);
+    const endDay = new Date(end);
+    endDay.setHours(0, 0, 0, 0);
+
+    while (cursor <= endDay) {
+      const key = cursor.toISOString().slice(0, 10);
+      const existing = dayMap.get(key);
+      if (
+        existing !== undefined &&
+        DAY_LEVEL_SEVERITY[level] > DAY_LEVEL_SEVERITY[existing]
+      ) {
+        dayMap.set(key, level);
+      }
+      cursor.setDate(cursor.getDate() + 1);
+    }
+  }
+
+  return Array.from(dayMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, level]) => ({ date, level }));
+}
+
+function extractBalancedObject(text: string, openIndex: number): string | null {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = openIndex; i < text.length; i++) {
+    const char = text[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) {
+      continue;
+    }
+    if (char === "{") {
+      depth++;
+    } else if (char === "}") {
+      depth--;
+      if (depth === 0) {
+        return text.slice(openIndex, i + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Instatus has no public endpoint for uptime history; the data is embedded in
+ * the status page HTML as Next.js flight data (`self.__next_f.push` chunks)
+ * under a `componentsUptime` key. Best effort: returns {} when unavailable.
+ */
+async function fetchComponentsUptime(
+  siteUrl: string,
+): Promise<InstatusComponentsUptime> {
+  try {
+    const response = await fetch(siteUrl, {
+      headers: { Accept: "text/html" },
+    });
+
+    if (!response.ok) {
+      return {};
+    }
+
+    const html = await response.text();
+    const chunks = html.matchAll(
+      /self\.__next_f\.push\(\[1,\s*"((?:[^"\\]|\\.)*)"\]\)/g,
+    );
+
+    let payload = "";
+    for (const match of chunks) {
+      try {
+        payload += JSON.parse(`"${match[1]}"`);
+      } catch {
+        // Skip chunks that fail to unescape.
+      }
+    }
+
+    const marker = '"componentsUptime":';
+    const markerIndex = payload.indexOf(marker);
+    if (markerIndex === -1) {
+      return {};
+    }
+
+    const openIndex = payload.indexOf("{", markerIndex + marker.length);
+    if (openIndex === -1) {
+      return {};
+    }
+
+    const objectText = extractBalancedObject(payload, openIndex);
+    if (!objectText) {
+      return {};
+    }
+
+    return JSON.parse(objectText) as InstatusComponentsUptime;
+  } catch {
+    return {};
+  }
+}
+
+function incidentKey(incident: InstatusSummaryIncident): string {
+  return incident.id ?? incident.url ?? incident.name;
+}
+
+function affectedComponentIds(
+  incident: InstatusSummaryIncident,
+  components: InstatusComponent[],
+): string[] | undefined {
+  const key = incidentKey(incident);
+  const ids = components
+    .filter((component) =>
+      component.activeIncidents?.some((active) => incidentKey(active) === key),
+    )
+    .map((component) => component.id);
+
+  return ids.length > 0 ? ids : undefined;
+}
+
+function mapIncidents(
+  summary: InstatusSummary,
+  components: InstatusComponent[],
+): StatusIncident[] {
+  const incidents = (summary.activeIncidents ?? []).map((incident) => ({
+    id: incidentKey(incident),
+    name: incident.name,
+    status: incident.status.toLowerCase(),
+    impact: impactToIncidentImpact(incident.impact),
+    updatedAt: incident.updatedAt ?? incident.started,
+    affectedComponentIds: affectedComponentIds(incident, components),
+  }));
+
+  const maintenances = (summary.activeMaintenances ?? [])
+    .filter((maintenance) => maintenance.status === "INPROGRESS")
+    .map((maintenance) => ({
+      id: maintenance.id ?? maintenance.url ?? maintenance.name,
+      name: maintenance.name,
+      status: "maintenance",
+      impact: "minor",
+      updatedAt: maintenance.updatedAt ?? maintenance.start,
+    }));
+
+  return [...incidents, ...maintenances];
+}
+
+function computeIndicator(
+  summary: InstatusSummary,
+  components: InstatusComponent[],
+): StatusIndicator {
+  if (summary.page.status === "UP") {
+    return "none";
+  }
+
+  const fromIncidents = (summary.activeIncidents ?? []).map((incident) =>
+    impactToIndicator(incident.impact),
+  );
+  const fromComponents = components.map((component) =>
+    componentStatusToIndicator(component.status),
+  );
+  const worst = worstIndicator([...fromIncidents, ...fromComponents]);
+
+  return worst === "none" ? "minor" : worst;
+}
+
+export const instatusAdapter: StatusAdapter = {
+  async detect(siteUrl: string): Promise<boolean> {
+    try {
+      const data = await fetchJson<unknown>(summaryUrl(siteUrl));
+      return isInstatusSummary(data);
+    } catch {
+      return false;
+    }
+  },
+
+  async fetchSnapshot(siteUrl: string): Promise<StatusSnapshot> {
+    const normalized = normalizeSiteUrl(siteUrl);
+    const fetchedAt = new Date().toISOString();
+
+    try {
+      const [summary, componentsResponse, componentsUptime] = await Promise.all(
+        [
+          fetchJson<InstatusSummary>(summaryUrl(normalized)),
+          fetchJson<InstatusComponentsResponse>(
+            componentsUrl(normalized),
+          ).catch(() => ({ components: [] as InstatusComponent[] })),
+          fetchComponentsUptime(normalized),
+        ],
+      );
+
+      const allComponents = componentsResponse.components ?? [];
+      const components: ComponentStatus[] = leafComponents(allComponents).map(
+        (component) => {
+          const uptimeInfo = componentsUptime[component.id];
+          const uptime = uptimeInfo?.uptime
+            ? parseFloat(uptimeInfo.uptime)
+            : undefined;
+
+          return {
+            id: component.id,
+            name: component.name,
+            status: componentStatusValue(component.status),
+            uptimePercent:
+              uptime !== undefined && !Number.isNaN(uptime)
+                ? uptime
+                : undefined,
+            historyDays: uptimeInfo
+              ? buildHistoryFromOutages(uptimeInfo.outages ?? [])
+              : undefined,
+          };
+        },
+      );
+
+      const incidents = mapIncidents(summary, allComponents);
+      const indicator = computeIndicator(summary, allComponents);
+
+      const overall =
+        summary.page.status === "UNDERMAINTENANCE" && incidents.length === 0
+          ? "Under Maintenance"
+          : overallDescription(indicator, incidents.length);
+
+      return {
+        pageName: summary.page.name,
+        pageUrl: summary.page.url || normalized,
+        overallDescription: overall,
+        indicator,
+        components,
+        incidents,
+        historyDays: buildPageHistoryFromComponents(components),
+        uptimePercent: averageComponentUptime(components),
+        fetchedAt,
+      };
+    } catch (error) {
+      return {
+        pageName: new URL(normalized).hostname,
+        pageUrl: normalized,
+        overallDescription: "Failed to fetch",
+        indicator: "none",
+        components: [],
+        incidents: [],
+        fetchedAt,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+};

--- a/extensions/is-it-alive/src/adapters/rss.ts
+++ b/extensions/is-it-alive/src/adapters/rss.ts
@@ -1,0 +1,284 @@
+import type {
+  ComponentStatus,
+  DayStatus,
+  StatusAdapter,
+  StatusIncident,
+  StatusIndicator,
+  StatusSnapshot,
+} from "@/types";
+import { getOrigin, normalizeSiteUrl } from "@/lib/url";
+import { overallDescription } from "@/lib/snapshot-text";
+import { buildPageHistoryFromComponents } from "@/lib/uptime-chart";
+import { RssFeed, RssFeedItem } from "@/types/rss";
+
+/**
+ * Generic RSS fallback for status pages that block their JSON APIs but keep
+ * an RSS feed reachable (e.g. status.x.ai behind Cloudflare). Incident-only:
+ * the feed lists notices, so components are derived from incident titles and
+ * uptime is approximated from incident days.
+ */
+const FEED_PATHS = ["feed.xml", "rss.xml", "history.rss", "feed", "rss"];
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function stripCdata(text: string): string {
+  return text.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1");
+}
+
+function tagContent(xml: string, tag: string): string | undefined {
+  const match = xml.match(
+    new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)</${tag}>`, "i"),
+  );
+  return match ? stripCdata(match[1]).trim() : undefined;
+}
+
+function toIso(date: string | undefined): string | undefined {
+  if (!date) {
+    return undefined;
+  }
+  const parsed = new Date(date);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+}
+
+function parseItem(itemXml: string): RssFeedItem | null {
+  const rawTitle = tagContent(itemXml, "title");
+  if (!rawTitle) {
+    return null;
+  }
+
+  const title = decodeEntities(rawTitle.replace(/\s+/g, " ").trim());
+  const serviceMatch = title.match(/^\[(.+?)\]\s*(.*)$/);
+
+  const description = tagContent(itemXml, "description") ?? "";
+  const status = description.match(/Status:\s*([A-Za-z_ -]+)</)?.[1]?.trim();
+  const resolvedAt = description.match(/Resolved:\s*([^<]+)</)?.[1]?.trim();
+
+  // Update blocks follow "<p><strong>{date}</strong></p><h3>{status}</h3><p>{message}</p>";
+  // the newest update comes first.
+  const update = description.match(
+    /<p><strong>([^<]+)<\/strong><\/p>\s*<h3>[^<]*<\/h3>\s*<p>([\s\S]*?)<\/p>/,
+  );
+
+  return {
+    service: serviceMatch?.[1],
+    title: serviceMatch?.[2] || title,
+    guid: tagContent(itemXml, "guid"),
+    pubDate: toIso(tagContent(itemXml, "pubDate")),
+    status,
+    resolvedAt: toIso(resolvedAt),
+    latestUpdateAt: toIso(update?.[1]),
+    latestUpdate: update
+      ? decodeEntities(update[2].replace(/<[^>]+>/g, " ").trim())
+      : undefined,
+  };
+}
+
+function parseFeed(xml: string): RssFeed | null {
+  if (!/<rss[\s>]/i.test(xml)) {
+    return null;
+  }
+
+  const channel = xml.match(/<channel(?:\s[^>]*)?>([\s\S]*?)<\/channel>/i)?.[1];
+  if (!channel) {
+    return null;
+  }
+
+  const header = channel.slice(0, channel.indexOf("<item") + 1 || undefined);
+  const title = tagContent(header, "title");
+  if (!title) {
+    return null;
+  }
+
+  const items = [...channel.matchAll(/<item(?:\s[^>]*)?>([\s\S]*?)<\/item>/gi)]
+    .map((match) => parseItem(match[1]))
+    .filter((item): item is RssFeedItem => item !== null);
+
+  return {
+    title: decodeEntities(title),
+    link: tagContent(header, "link"),
+    items,
+  };
+}
+
+async function fetchFeed(siteUrl: string): Promise<RssFeed | null> {
+  const normalized = normalizeSiteUrl(siteUrl);
+  const origin = getOrigin(normalized);
+
+  const candidates = /\.(xml|rss)$/i.test(normalized)
+    ? [normalized]
+    : FEED_PATHS.map((path) => `${origin}/${path}`);
+
+  for (const url of candidates) {
+    try {
+      const response = await fetch(url, {
+        headers: { Accept: "application/rss+xml, application/xml, text/xml" },
+      });
+      if (!response.ok) {
+        continue;
+      }
+
+      const feed = parseFeed(await response.text());
+      if (feed) {
+        return feed;
+      }
+    } catch {
+      // Try the next candidate path.
+    }
+  }
+
+  return null;
+}
+
+function isResolved(item: RssFeedItem): boolean {
+  if (item.status) {
+    return item.status.toUpperCase() === "RESOLVED";
+  }
+  return Boolean(item.resolvedAt);
+}
+
+function markDays(
+  dayMap: Map<string, DayStatus["level"]>,
+  from: string | undefined,
+  to: string | undefined,
+): void {
+  if (!from) {
+    return;
+  }
+
+  const today = new Date();
+  const cursor = new Date(from);
+  cursor.setHours(0, 0, 0, 0);
+  const endDay = new Date(to ?? today);
+  endDay.setHours(0, 0, 0, 0);
+
+  while (cursor <= endDay) {
+    const key = cursor.toISOString().slice(0, 10);
+    if (dayMap.has(key)) {
+      dayMap.set(key, "degraded");
+    }
+    cursor.setDate(cursor.getDate() + 1);
+  }
+}
+
+function emptyDayMap(days = 90): Map<string, DayStatus["level"]> {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const dayMap = new Map<string, DayStatus["level"]>();
+  for (let i = 0; i < days; i++) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - (days - 1 - i));
+    dayMap.set(d.toISOString().slice(0, 10), "operational");
+  }
+  return dayMap;
+}
+
+function toHistory(dayMap: Map<string, DayStatus["level"]>): DayStatus[] {
+  return Array.from(dayMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, level]) => ({ date, level }));
+}
+
+function buildComponents(items: RssFeedItem[]): ComponentStatus[] {
+  const services = new Map<string, RssFeedItem[]>();
+  for (const item of items) {
+    if (!item.service) {
+      continue;
+    }
+    services.set(item.service, [...(services.get(item.service) ?? []), item]);
+  }
+
+  return Array.from(services.entries())
+    .map(([name, serviceItems]) => {
+      const dayMap = emptyDayMap();
+      for (const item of serviceItems) {
+        // Resolved items without an explicit end date only affect their start
+        // day; open-ended ranges are reserved for ongoing incidents.
+        const end =
+          item.resolvedAt ?? (isResolved(item) ? item.pubDate : undefined);
+        markDays(dayMap, item.pubDate, end);
+      }
+
+      const hasActive = serviceItems.some((item) => !isResolved(item));
+
+      return {
+        id: name,
+        name,
+        status: hasActive ? "degraded_performance" : "operational",
+        historyDays: toHistory(dayMap),
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function mapIncidents(items: RssFeedItem[]): StatusIncident[] {
+  return items
+    .filter((item) => !isResolved(item))
+    .map((item, index) => ({
+      id: item.guid ?? `rss-${index}`,
+      name: item.service ? `[${item.service}] ${item.title}` : item.title,
+      status: (item.status ?? "investigating").toLowerCase(),
+      impact: "minor",
+      updatedAt:
+        item.latestUpdateAt ?? item.pubDate ?? new Date().toISOString(),
+      body: item.latestUpdate,
+      affectedComponentIds: item.service ? [item.service] : undefined,
+    }));
+}
+
+export const rssAdapter: StatusAdapter = {
+  async detect(siteUrl: string): Promise<boolean> {
+    try {
+      return (await fetchFeed(siteUrl)) !== null;
+    } catch {
+      return false;
+    }
+  },
+
+  async fetchSnapshot(siteUrl: string): Promise<StatusSnapshot> {
+    const normalized = normalizeSiteUrl(siteUrl);
+    const fetchedAt = new Date().toISOString();
+
+    try {
+      const feed = await fetchFeed(normalized);
+      if (!feed) {
+        throw new Error("No RSS status feed found");
+      }
+
+      const components = buildComponents(feed.items);
+      const incidents = mapIncidents(feed.items);
+      const indicator: StatusIndicator =
+        incidents.length > 0 ? "minor" : "none";
+
+      return {
+        pageName:
+          feed.title.replace(/\s*(System\s+)?Status\s*$/i, "") || feed.title,
+        pageUrl: feed.link ?? getOrigin(normalized),
+        overallDescription: overallDescription(indicator, incidents.length),
+        indicator,
+        components,
+        incidents,
+        historyDays: buildPageHistoryFromComponents(components),
+        fetchedAt,
+      };
+    } catch (error) {
+      return {
+        pageName: new URL(normalized).hostname,
+        pageUrl: normalized,
+        overallDescription: "Failed to fetch",
+        indicator: "none",
+        components: [],
+        incidents: [],
+        fetchedAt,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+};

--- a/extensions/is-it-alive/src/adapters/salesforce.ts
+++ b/extensions/is-it-alive/src/adapters/salesforce.ts
@@ -1,0 +1,319 @@
+import type {
+  ComponentStatus,
+  ComponentStatusValue,
+  DayStatus,
+  StatusAdapter,
+  StatusIncident,
+  StatusIndicator,
+  StatusSnapshot,
+} from "@/types";
+import { normalizeSiteUrl } from "@/lib/url";
+import { fetchJson } from "@/lib/fetch-json";
+import { overallDescription } from "@/lib/snapshot-text";
+import { buildPageHistoryFromComponents } from "@/lib/uptime-chart";
+import type {
+  SalesforceIncident,
+  SalesforceInstance,
+  SalesforceProduct,
+} from "@/types/salesforce";
+
+const TRUST_HOST = "status.salesforce.com";
+/** status.heroku.com is deprecated; Heroku status now lives on Salesforce Trust. */
+const HEROKU_HOST = "status.heroku.com";
+const API_BASE = "https://api.status.salesforce.com/v1";
+const DEFAULT_PRODUCT = "Salesforce_Services";
+const HISTORY_DAYS = 90;
+const INCIDENTS_PAGE_SIZE = 200;
+const MAX_INCIDENT_PAGES = 5;
+
+function productKeyFromUrl(siteUrl: string): string {
+  const url = new URL(normalizeSiteUrl(siteUrl));
+
+  if (url.hostname === HEROKU_HOST) {
+    return "Heroku";
+  }
+
+  const match = url.pathname.match(/^\/products\/([^/]+)/);
+  return match ? decodeURIComponent(match[1]) : DEFAULT_PRODUCT;
+}
+
+function instanceStatusToComponentStatus(status: string): ComponentStatusValue {
+  if (status === "OK") {
+    return "operational";
+  }
+  if (status.startsWith("MAJOR_INCIDENT")) {
+    return "major_outage";
+  }
+  if (status.startsWith("MINOR_INCIDENT")) {
+    return "degraded_performance";
+  }
+  if (status.startsWith("MAINTENANCE")) {
+    return "under_maintenance";
+  }
+  return "operational";
+}
+
+function instanceStatusToIndicator(status: string): StatusIndicator {
+  if (status.startsWith("MAJOR_INCIDENT")) {
+    return "critical";
+  }
+  if (status.startsWith("MINOR_INCIDENT") || status.startsWith("MAINTENANCE")) {
+    return "minor";
+  }
+  return "none";
+}
+
+const INDICATOR_SEVERITY: Record<StatusIndicator, number> = {
+  none: 0,
+  minor: 1,
+  major: 2,
+  critical: 3,
+};
+
+function worstIndicator(indicators: StatusIndicator[]): StatusIndicator {
+  return indicators.reduce<StatusIndicator>(
+    (worst, indicator) =>
+      INDICATOR_SEVERITY[indicator] > INDICATOR_SEVERITY[worst]
+        ? indicator
+        : worst,
+    "none",
+  );
+}
+
+/** "HEROKUVIRGINIA" with product "Heroku" becomes "Virginia (NA)". */
+function instanceDisplayName(
+  instance: SalesforceInstance,
+  productKey: string,
+): string {
+  const productPrefix = productKey.replace(/[^a-z0-9]/gi, "").toUpperCase();
+  const key = instance.key.toUpperCase();
+
+  let label = instance.key;
+  if (productPrefix && key.startsWith(productPrefix)) {
+    const rest = instance.key.slice(productPrefix.length);
+    if (rest.length > 1) {
+      label = rest.charAt(0).toUpperCase() + rest.slice(1).toLowerCase();
+    }
+  }
+
+  return instance.location ? `${label} (${instance.location})` : label;
+}
+
+async function fetchIncidentsSince(
+  startTime: string,
+): Promise<SalesforceIncident[]> {
+  const incidents: SalesforceIncident[] = [];
+
+  for (let page = 0; page < MAX_INCIDENT_PAGES; page++) {
+    const batch = await fetchJson<SalesforceIncident[]>(
+      `${API_BASE}/incidents?startTime=${encodeURIComponent(startTime)}&limit=${INCIDENTS_PAGE_SIZE}&offset=${page * INCIDENTS_PAGE_SIZE}`,
+    );
+
+    incidents.push(...batch);
+
+    if (batch.length < INCIDENTS_PAGE_SIZE) {
+      break;
+    }
+  }
+
+  return incidents;
+}
+
+function incidentSeverity(incident: SalesforceIncident): "minor" | "major" {
+  const severities = (incident.IncidentImpacts ?? []).map(
+    (impact) => impact.severity,
+  );
+  return severities.includes("major") ? "major" : "minor";
+}
+
+function incidentWindow(incident: SalesforceIncident): {
+  start: Date;
+  end: Date;
+} {
+  const impacts = incident.IncidentImpacts ?? [];
+
+  const startTimes = impacts
+    .map((impact) => impact.startTime)
+    .filter((time): time is string => Boolean(time));
+  const start = startTimes.length
+    ? new Date(Math.min(...startTimes.map((time) => new Date(time).getTime())))
+    : new Date(incident.createdAt);
+
+  if (incident.status === "Active") {
+    return { start, end: new Date() };
+  }
+
+  const endTimes = impacts
+    .map((impact) => impact.endTime)
+    .filter((time): time is string => Boolean(time));
+  const end = endTimes.length
+    ? new Date(Math.max(...endTimes.map((time) => new Date(time).getTime())))
+    : new Date(incident.updatedAt ?? incident.createdAt);
+
+  return { start, end };
+}
+
+function buildInstanceHistory(
+  instanceKey: string,
+  incidents: SalesforceIncident[],
+): DayStatus[] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const dayMap = new Map<string, DayStatus["level"]>();
+  for (let i = 0; i < HISTORY_DAYS; i++) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - (HISTORY_DAYS - 1 - i));
+    dayMap.set(d.toISOString().slice(0, 10), "operational");
+  }
+
+  for (const incident of incidents) {
+    if (!incident.affectsAll && !incident.instanceKeys.includes(instanceKey)) {
+      continue;
+    }
+
+    const level: DayStatus["level"] =
+      incidentSeverity(incident) === "major" ? "major" : "degraded";
+    const { start, end } = incidentWindow(incident);
+
+    const cursor = new Date(start);
+    cursor.setHours(0, 0, 0, 0);
+    const endDay = new Date(end);
+    endDay.setHours(0, 0, 0, 0);
+
+    while (cursor <= endDay) {
+      const key = cursor.toISOString().slice(0, 10);
+      const existing = dayMap.get(key);
+      if (existing && (existing === "operational" || level === "major")) {
+        dayMap.set(key, level);
+      }
+      cursor.setDate(cursor.getDate() + 1);
+    }
+  }
+
+  return Array.from(dayMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, level]) => ({ date, level }));
+}
+
+function incidentName(incident: SalesforceIncident): string {
+  const type = incident.type ?? "Incident";
+  const services = incident.serviceKeys ?? [];
+  return services.length ? `${type}: ${services.join(", ")}` : type;
+}
+
+function latestEventMessage(incident: SalesforceIncident): string | undefined {
+  const events = [...(incident.IncidentEvents ?? [])].sort((a, b) =>
+    (b.createdAt ?? "").localeCompare(a.createdAt ?? ""),
+  );
+  return events[0]?.message;
+}
+
+function mapActiveIncidents(
+  incidents: SalesforceIncident[],
+  instanceKeys: Set<string>,
+): StatusIncident[] {
+  return incidents
+    .filter((incident) => incident.status === "Active")
+    .map((incident) => ({
+      id: String(incident.id),
+      name: incidentName(incident),
+      status: incident.status.toLowerCase(),
+      impact: incidentSeverity(incident) === "major" ? "major" : "minor",
+      updatedAt: incident.updatedAt ?? incident.createdAt,
+      body: latestEventMessage(incident),
+      affectedComponentIds: incident.instanceKeys.filter((key) =>
+        instanceKeys.has(key),
+      ),
+    }));
+}
+
+export const salesforceAdapter: StatusAdapter = {
+  async detect(siteUrl: string): Promise<boolean> {
+    try {
+      const hostname = new URL(normalizeSiteUrl(siteUrl)).hostname;
+      return hostname === TRUST_HOST || hostname === HEROKU_HOST;
+    } catch {
+      return false;
+    }
+  },
+
+  async fetchSnapshot(siteUrl: string): Promise<StatusSnapshot> {
+    const fetchedAt = new Date().toISOString();
+    const pageUrl = normalizeSiteUrl(siteUrl);
+
+    let productKey = DEFAULT_PRODUCT;
+    try {
+      productKey = productKeyFromUrl(siteUrl);
+
+      const historyStart = new Date();
+      historyStart.setDate(historyStart.getDate() - HISTORY_DAYS);
+      historyStart.setHours(0, 0, 0, 0);
+
+      const [product, instances, allIncidents] = await Promise.all([
+        fetchJson<SalesforceProduct>(
+          `${API_BASE}/products/${encodeURIComponent(productKey)}`,
+        ).catch(() => null),
+        fetchJson<SalesforceInstance[]>(
+          `${API_BASE}/instances?products=${encodeURIComponent(productKey)}`,
+        ),
+        fetchIncidentsSince(historyStart.toISOString()),
+      ]);
+
+      const activeInstances = instances.filter((instance) => instance.isActive);
+      if (activeInstances.length === 0) {
+        throw new Error(`No instances found for product "${productKey}"`);
+      }
+
+      const instanceKeys = new Set(
+        activeInstances.map((instance) => instance.key),
+      );
+      const productIncidents = allIncidents.filter(
+        (incident) =>
+          incident.affectsAll ||
+          incident.instanceKeys.some((key) => instanceKeys.has(key)),
+      );
+
+      const components: ComponentStatus[] = activeInstances.map((instance) => ({
+        id: instance.key,
+        name: instanceDisplayName(instance, productKey),
+        status: instanceStatusToComponentStatus(instance.status),
+        historyDays: buildInstanceHistory(instance.key, productIncidents),
+      }));
+
+      const incidents = mapActiveIncidents(productIncidents, instanceKeys);
+      const indicator = worstIndicator(
+        activeInstances.map((instance) =>
+          instanceStatusToIndicator(instance.status),
+        ),
+      );
+
+      const pageName =
+        product?.altDisplayName ??
+        product?.name ??
+        productKey.replace(/_/g, " ");
+
+      return {
+        pageName,
+        pageUrl,
+        overallDescription: overallDescription(indicator, incidents.length),
+        indicator,
+        components,
+        incidents,
+        historyDays: buildPageHistoryFromComponents(components),
+        fetchedAt,
+      };
+    } catch (error) {
+      return {
+        pageName: productKey.replace(/_/g, " "),
+        pageUrl,
+        overallDescription: "Failed to fetch",
+        indicator: "none",
+        components: [],
+        incidents: [],
+        fetchedAt,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+};

--- a/extensions/is-it-alive/src/adapters/uptimecom.ts
+++ b/extensions/is-it-alive/src/adapters/uptimecom.ts
@@ -1,0 +1,411 @@
+import type {
+  ComponentStatus,
+  ComponentStatusValue,
+  DayStatus,
+  StatusAdapter,
+  StatusIncident,
+  StatusIndicator,
+  StatusSnapshot,
+} from "@/types";
+import { normalizeSiteUrl } from "@/lib/url";
+import { overallDescription } from "@/lib/snapshot-text";
+import { buildPageHistoryFromComponents } from "@/lib/uptime-chart";
+import type {
+  UptimeComComponent,
+  UptimeComHistoryResponse,
+  UptimeComIncident,
+  UptimeComPageProps,
+} from "@/types/uptimecom";
+
+const PROPS_MARKER = "createElement(StatusPageDisplayController,";
+const HISTORY_DAYS = 90;
+
+/**
+ * Uptime.com status pages render server-side and embed the full page state as
+ * React props in an inline script: createElement(StatusPageDisplayController,
+ * {...}). The props JSON also carries per-page AJAX URLs (e.g. the history
+ * endpoint used for the 90-day view).
+ */
+function extractPageProps(html: string): UptimeComPageProps | null {
+  const marker = html.indexOf(PROPS_MARKER);
+  if (marker === -1) {
+    return null;
+  }
+
+  const start = html.indexOf("{", marker);
+  if (start === -1) {
+    return null;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let end = -1;
+
+  for (let i = start; i < html.length; i++) {
+    const char = html[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+    } else if (char === "{") {
+      depth++;
+    } else if (char === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+
+  if (end === -1) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(html.slice(start, end + 1)) as UptimeComPageProps;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchPageProps(
+  siteUrl: string,
+): Promise<UptimeComPageProps | null> {
+  const response = await fetch(siteUrl, {
+    headers: { Accept: "text/html" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  return extractPageProps(await response.text());
+}
+
+function componentStatusValue(status: string): ComponentStatusValue | string {
+  switch (status) {
+    case "operational":
+      return "operational";
+    case "degraded-performance":
+      return "degraded_performance";
+    case "partial-outage":
+      return "partial_outage";
+    case "major-outage":
+      return "major_outage";
+    case "under-maintenance":
+      return "under_maintenance";
+    default:
+      return status;
+  }
+}
+
+function statusToDayLevel(status: string): DayStatus["level"] {
+  switch (status) {
+    case "major-outage":
+      return "major";
+    case "partial-outage":
+      return "partial";
+    case "degraded-performance":
+    case "under-maintenance":
+      return "degraded";
+    default:
+      return "operational";
+  }
+}
+
+function statusToIndicator(status: string): StatusIndicator {
+  switch (status) {
+    case "major-outage":
+      return "critical";
+    case "partial-outage":
+      return "major";
+    case "degraded-performance":
+    case "under-maintenance":
+      return "minor";
+    default:
+      return "none";
+  }
+}
+
+const INDICATOR_SEVERITY: Record<StatusIndicator, number> = {
+  none: 0,
+  minor: 1,
+  major: 2,
+  critical: 3,
+};
+
+const DAY_LEVEL_SEVERITY: Record<DayStatus["level"], number> = {
+  operational: 0,
+  unknown: 0,
+  degraded: 1,
+  partial: 2,
+  major: 3,
+};
+
+function worstIndicator(indicators: StatusIndicator[]): StatusIndicator {
+  return indicators.reduce<StatusIndicator>(
+    (worst, indicator) =>
+      INDICATOR_SEVERITY[indicator] > INDICATOR_SEVERITY[worst]
+        ? indicator
+        : worst,
+    "none",
+  );
+}
+
+/** Flatten component groups into "Group / Component" leaf entries. */
+function flattenComponents(
+  components: UptimeComComponent[],
+  prefix = "",
+): Array<{ id: number; name: string; status: string }> {
+  const result: Array<{ id: number; name: string; status: string }> = [];
+
+  for (const component of components) {
+    const name = prefix ? `${prefix} / ${component.name}` : component.name;
+    if (component.is_group && component.subcomponents?.length) {
+      result.push(...flattenComponents(component.subcomponents, name));
+    } else {
+      result.push({ id: component.id, name, status: component.status });
+    }
+  }
+
+  return result;
+}
+
+function isMaintenance(incident: UptimeComIncident): boolean {
+  return incident.incident_type === "SCHEDULED_MAINTENANCE";
+}
+
+function incidentWindow(incident: UptimeComIncident): {
+  start: Date;
+  end: Date;
+} {
+  const start = incident.starts_at ? new Date(incident.starts_at) : new Date();
+  const end = incident.ends_at ? new Date(incident.ends_at) : new Date();
+  return { start, end };
+}
+
+function incidentDayLevel(
+  incident: UptimeComIncident,
+  componentId?: number,
+): DayStatus["level"] {
+  const affected = (incident.affected_components ?? []).filter(
+    (component) => componentId === undefined || component.id === componentId,
+  );
+
+  let worst: DayStatus["level"] = "degraded";
+  for (const component of affected) {
+    const level = statusToDayLevel(component.status);
+    if (DAY_LEVEL_SEVERITY[level] > DAY_LEVEL_SEVERITY[worst]) {
+      worst = level;
+    }
+  }
+  return worst;
+}
+
+function emptyHistory(): Map<string, DayStatus["level"]> {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const dayMap = new Map<string, DayStatus["level"]>();
+  for (let i = 0; i < HISTORY_DAYS; i++) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - (HISTORY_DAYS - 1 - i));
+    dayMap.set(d.toISOString().slice(0, 10), "operational");
+  }
+  return dayMap;
+}
+
+function toDayStatuses(dayMap: Map<string, DayStatus["level"]>): DayStatus[] {
+  return Array.from(dayMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, level]) => ({ date, level }));
+}
+
+function buildComponentHistory(
+  componentId: number,
+  incidents: UptimeComIncident[],
+): DayStatus[] {
+  const dayMap = emptyHistory();
+
+  for (const incident of incidents) {
+    if (isMaintenance(incident)) {
+      continue;
+    }
+    const affectsComponent = (incident.affected_components ?? []).some(
+      (component) => component.id === componentId,
+    );
+    if (!affectsComponent) {
+      continue;
+    }
+
+    const level = incidentDayLevel(incident, componentId);
+    const { start, end } = incidentWindow(incident);
+
+    const cursor = new Date(start);
+    cursor.setHours(0, 0, 0, 0);
+    const endDay = new Date(end);
+    endDay.setHours(0, 0, 0, 0);
+
+    while (cursor <= endDay) {
+      const key = cursor.toISOString().slice(0, 10);
+      const existing = dayMap.get(key);
+      if (
+        existing !== undefined &&
+        DAY_LEVEL_SEVERITY[level] > DAY_LEVEL_SEVERITY[existing]
+      ) {
+        dayMap.set(key, level);
+      }
+      cursor.setDate(cursor.getDate() + 1);
+    }
+  }
+
+  return toDayStatuses(dayMap);
+}
+
+function isIncidentActive(incident: UptimeComIncident): boolean {
+  const state =
+    incident.latest_update_incident_state ??
+    incident.updates?.[0]?.incident_state;
+  if (state === "resolved") {
+    return false;
+  }
+  return !incident.ends_at || new Date(incident.ends_at) > new Date();
+}
+
+function mapIncidents(incidents: UptimeComIncident[]): StatusIncident[] {
+  return incidents.map((incident) => {
+    const update = incident.updates?.[0];
+    return {
+      id: String(incident.id),
+      name: incident.name,
+      status:
+        incident.latest_update_incident_state ??
+        update?.incident_state ??
+        (isMaintenance(incident) ? "maintenance" : "investigating"),
+      impact: worstIndicator(
+        (incident.affected_components ?? []).map((component) =>
+          statusToIndicator(component.status),
+        ),
+      ),
+      updatedAt: update?.updated_at ?? incident.starts_at ?? "",
+      body: incident.latest_update_description ?? update?.description,
+      affectedComponentIds: (incident.affected_components ?? []).map(
+        (component) => String(component.id),
+      ),
+    };
+  });
+}
+
+function historyRangeQuery(): string {
+  const end = new Date();
+  const start = new Date();
+  start.setDate(start.getDate() - (HISTORY_DAYS - 1));
+
+  const format = (d: Date) => d.toISOString().slice(0, 10).replace(/-/g, "");
+  return `?start=${format(start)}&end=${format(end)}`;
+}
+
+export const uptimecomAdapter: StatusAdapter = {
+  async detect(siteUrl: string): Promise<boolean> {
+    try {
+      const normalized = normalizeSiteUrl(siteUrl);
+      const props = await fetchPageProps(normalized);
+      return props?.statuspage !== undefined;
+    } catch {
+      return false;
+    }
+  },
+
+  async fetchSnapshot(siteUrl: string): Promise<StatusSnapshot> {
+    const normalized = normalizeSiteUrl(siteUrl);
+    const fetchedAt = new Date().toISOString();
+
+    try {
+      const props = await fetchPageProps(normalized);
+      const statuspage = props?.statuspage;
+      if (!statuspage) {
+        throw new Error("Not an Uptime.com status page");
+      }
+
+      let history: UptimeComHistoryResponse["data"];
+      if (props.updateHistoryURL) {
+        const historyUrl = new URL(props.updateHistoryURL, normalized);
+        history = await fetch(`${historyUrl.href}${historyRangeQuery()}`, {
+          headers: { Accept: "application/json" },
+        })
+          .then((response) =>
+            response.ok
+              ? (response.json() as Promise<UptimeComHistoryResponse>)
+              : Promise.resolve({} as UptimeComHistoryResponse),
+          )
+          .then((body) => body.data)
+          .catch(() => undefined);
+      }
+
+      const pastIncidents = history?.past_incidents ?? [];
+      const componentUptime = history?.component_history ?? {};
+
+      const components: ComponentStatus[] = flattenComponents(
+        statuspage.components ?? [],
+      ).map((component) => {
+        const uptimePct = componentUptime[String(component.id)]?.uptime_pct;
+        return {
+          id: String(component.id),
+          name: component.name,
+          status: componentStatusValue(component.status),
+          uptimePercent:
+            typeof uptimePct === "number" ? uptimePct * 100 : undefined,
+          historyDays: buildComponentHistory(component.id, pastIncidents),
+        };
+      });
+
+      const activeIncidents = (statuspage.active_incidents ?? []).filter(
+        isIncidentActive,
+      );
+      const incidents = mapIncidents(activeIncidents);
+
+      const indicator = worstIndicator(
+        flattenComponents(statuspage.components ?? []).map((component) =>
+          statusToIndicator(component.status),
+        ),
+      );
+
+      const globalUptime = history?.global_metrics?.uptime_pct;
+
+      return {
+        pageName: statuspage.name,
+        pageUrl: normalized,
+        overallDescription: overallDescription(indicator, incidents.length),
+        indicator,
+        components,
+        incidents,
+        historyDays: buildPageHistoryFromComponents(components),
+        uptimePercent:
+          typeof globalUptime === "number" ? globalUptime * 100 : undefined,
+        fetchedAt,
+      };
+    } catch (error) {
+      return {
+        pageName: new URL(normalized).hostname,
+        pageUrl: normalized,
+        overallDescription: "Failed to fetch",
+        indicator: "none",
+        components: [],
+        incidents: [],
+        fetchedAt,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+};

--- a/extensions/is-it-alive/src/types/aws.ts
+++ b/extensions/is-it-alive/src/types/aws.ts
@@ -1,0 +1,35 @@
+/**
+ * AWS Health Dashboard event status codes (shared by events and log entries):
+ * "0" = resolved, "1" = impacted/informational, "2" = degraded, "3" = disrupted.
+ */
+export type AwsEventStatus = "0" | "1" | "2" | "3";
+
+export interface AwsEventLogEntry {
+  summary?: string;
+  message: string;
+  status: AwsEventStatus | string | number;
+  timestamp: number;
+}
+
+export interface AwsCurrentEvent {
+  date: string;
+  arn: string;
+  region_name?: string;
+  status: AwsEventStatus | string;
+  /** Service-region key, e.g. "ec2-us-east-1". */
+  service?: string;
+  service_name?: string;
+  summary: string;
+  event_log?: AwsEventLogEntry[];
+}
+
+export interface AwsHistoryEvent {
+  summary: string;
+  arn: string;
+  status: AwsEventStatus | string;
+  date: string;
+  event_log?: AwsEventLogEntry[];
+}
+
+/** Keyed by service-region, e.g. "ec2-us-east-1" or "route53". */
+export type AwsHistoryEvents = Record<string, AwsHistoryEvent[]>;

--- a/extensions/is-it-alive/src/types/checkly.ts
+++ b/extensions/is-it-alive/src/types/checkly.ts
@@ -1,0 +1,53 @@
+export type ChecklySeverity = "MINOR" | "MEDIUM" | "MAJOR";
+
+export interface ChecklyDayEvent {
+  id?: string;
+  name?: string;
+  duration?: number;
+  severity?: ChecklySeverity | string;
+  lastUpdateStatus?: string;
+  created_at?: string;
+}
+
+export interface ChecklyServiceDay {
+  date: string;
+  events: ChecklyDayEvent[];
+}
+
+export interface ChecklyService {
+  id: string;
+  name: string;
+  uptime?: number;
+  days?: ChecklyServiceDay[];
+}
+
+export interface ChecklyUptimeCard {
+  id: string;
+  name: string;
+  services?: ChecklyService[];
+}
+
+export interface ChecklyStatusPageInfo {
+  id?: string;
+  name?: string;
+  customDomain?: string;
+  url?: string;
+}
+
+export interface ChecklyIncident {
+  id?: string;
+  name?: string;
+  severity?: ChecklySeverity | string;
+  lastUpdateStatus?: string;
+  status?: string;
+  updatedAt?: string;
+  created_at?: string;
+  createdAt?: string;
+  description?: string;
+}
+
+export interface ChecklyPayload {
+  statusPage?: ChecklyStatusPageInfo;
+  incidents: ChecklyIncident[];
+  cards: ChecklyUptimeCard[];
+}

--- a/extensions/is-it-alive/src/types/index.ts
+++ b/extensions/is-it-alive/src/types/index.ts
@@ -2,7 +2,14 @@ export type SiteProvider =
   | "statuspage"
   | "railway"
   | "incidentio"
-  | "betterstack";
+  | "betterstack"
+  | "instatus"
+  | "checkly"
+  | "rss"
+  | "aws"
+  | "heroku"
+  | "salesforce"
+  | "uptimecom";
 
 export type StatusIndicator = "none" | "minor" | "major" | "critical";
 

--- a/extensions/is-it-alive/src/types/instatus.ts
+++ b/extensions/is-it-alive/src/types/instatus.ts
@@ -1,0 +1,68 @@
+export type InstatusPageStatus = "UP" | "HASISSUES" | "UNDERMAINTENANCE";
+
+export type InstatusComponentStatus =
+  | "OPERATIONAL"
+  | "UNDERMAINTENANCE"
+  | "DEGRADEDPERFORMANCE"
+  | "PARTIALOUTAGE"
+  | "MAJOROUTAGE";
+
+export interface InstatusSummaryIncident {
+  id?: string;
+  name: string;
+  started: string;
+  status: string;
+  impact: string;
+  url?: string;
+  updatedAt?: string;
+}
+
+export interface InstatusSummaryMaintenance {
+  id?: string;
+  name: string;
+  start: string;
+  status: string;
+  duration?: string;
+  url?: string;
+  updatedAt?: string;
+}
+
+export interface InstatusSummary {
+  page: {
+    name: string;
+    url?: string;
+    status: InstatusPageStatus | string;
+  };
+  activeIncidents?: InstatusSummaryIncident[];
+  activeMaintenances?: InstatusSummaryMaintenance[];
+}
+
+export interface InstatusComponent {
+  id: string;
+  name: string;
+  description?: string;
+  status: InstatusComponentStatus | string;
+  group: { id: string; name: string; description?: string } | null;
+  activeIncidents?: InstatusSummaryIncident[];
+}
+
+export interface InstatusComponentsResponse {
+  components: InstatusComponent[];
+}
+
+export interface InstatusOutage {
+  from: string;
+  to?: string | null;
+  status: InstatusComponentStatus | string;
+  noticeId?: string;
+}
+
+export interface InstatusComponentUptime {
+  uptime?: string;
+  outages?: InstatusOutage[];
+}
+
+export type InstatusComponentsUptime = Record<
+  string,
+  InstatusComponentUptime | undefined
+>;

--- a/extensions/is-it-alive/src/types/rss.ts
+++ b/extensions/is-it-alive/src/types/rss.ts
@@ -1,0 +1,17 @@
+export interface RssFeedItem {
+  /** Service name when the title uses the "[Service] Incident title" convention. */
+  service?: string;
+  title: string;
+  guid?: string;
+  pubDate?: string;
+  status?: string;
+  resolvedAt?: string;
+  latestUpdate?: string;
+  latestUpdateAt?: string;
+}
+
+export interface RssFeed {
+  title: string;
+  link?: string;
+  items: RssFeedItem[];
+}

--- a/extensions/is-it-alive/src/types/salesforce.ts
+++ b/extensions/is-it-alive/src/types/salesforce.ts
@@ -1,0 +1,47 @@
+export interface SalesforceInstance {
+  key: string;
+  location?: string;
+  environment?: string;
+  /** e.g. "OK", "MINOR_INCIDENT_CORE", "MAJOR_INCIDENT_NONCORE", "MAINTENANCE_CORE" */
+  status: string;
+  isActive: boolean;
+  Services?: Array<{ key: string }>;
+}
+
+export interface SalesforceProduct {
+  key: string;
+  name?: string;
+  altDisplayName?: string;
+  isActive?: boolean;
+}
+
+export interface SalesforceIncidentImpact {
+  id: number;
+  startTime?: string | null;
+  endTime?: string | null;
+  type?: string;
+  /** "minor" | "major" */
+  severity?: string;
+}
+
+export interface SalesforceIncidentEvent {
+  id: number;
+  type?: string;
+  message?: string;
+  createdAt?: string;
+}
+
+export interface SalesforceIncident {
+  id: number;
+  /** "Active" | "Resolved" */
+  status: string;
+  /** e.g. "Degradation" | "Disruption" */
+  type?: string;
+  createdAt: string;
+  updatedAt?: string;
+  affectsAll?: boolean;
+  instanceKeys: string[];
+  serviceKeys?: string[];
+  IncidentImpacts?: SalesforceIncidentImpact[];
+  IncidentEvents?: SalesforceIncidentEvent[];
+}

--- a/extensions/is-it-alive/src/types/uptimecom.ts
+++ b/extensions/is-it-alive/src/types/uptimecom.ts
@@ -1,0 +1,81 @@
+/** Status values: "operational", "degraded-performance", "partial-outage", "major-outage", "under-maintenance". */
+export interface UptimeComComponent {
+  id: number;
+  is_group: boolean;
+  name: string;
+  status: string;
+  status_display?: string;
+  subcomponents?: UptimeComComponent[];
+}
+
+export interface UptimeComAffectedComponent {
+  id: number;
+  name: string;
+  status: string;
+  status_display?: string;
+}
+
+export interface UptimeComIncidentUpdate {
+  id: number;
+  updated_at: string;
+  description?: string;
+  incident_state?: string;
+}
+
+export interface UptimeComIncident {
+  id: number;
+  name: string;
+  /** "INCIDENT" | "SCHEDULED_MAINTENANCE" */
+  incident_type?: string;
+  starts_at?: string;
+  ends_at?: string | null;
+  affected_components?: UptimeComAffectedComponent[];
+  updates?: UptimeComIncidentUpdate[];
+  latest_update_description?: string;
+  latest_update_incident_state?: string;
+}
+
+export interface UptimeComStatusPage {
+  name: string;
+  global_is_operational?: boolean;
+  has_components_under_maintenance_state?: boolean;
+  has_components_under_critical_state?: boolean;
+  components?: UptimeComComponent[];
+  active_incidents?: UptimeComIncident[];
+}
+
+/** React props embedded in the page HTML for StatusPageDisplayController. */
+export interface UptimeComPageProps {
+  siteURL?: string;
+  updateHistoryURL?: string;
+  statuspage?: UptimeComStatusPage;
+}
+
+export interface UptimeComComponentHistory {
+  uptime_pct?: number | null;
+  outages?: number;
+  downtime_secs?: number;
+  major_outage?: number;
+  partial_outage?: number;
+  degraded_performance?: number;
+}
+
+export interface UptimeComDayHistory {
+  uptime_pct?: number | null;
+  outages?: number;
+  downtime_secs?: number;
+  affected_components?: UptimeComAffectedComponent[];
+}
+
+export interface UptimeComHistoryData {
+  global_metrics?: { uptime_pct?: number | null };
+  component_history?: Record<string, UptimeComComponentHistory>;
+  date_history?: Record<string, UptimeComDayHistory>;
+  past_incidents?: UptimeComIncident[];
+  active_incidents?: UptimeComIncident[];
+}
+
+export interface UptimeComHistoryResponse {
+  error?: string | null;
+  data?: UptimeComHistoryData;
+}


### PR DESCRIPTION
## Description
- Add support for Instatus status pages via the public `/summary.json` API, including per-component uptime and 90-day history
- Add support for Checkly status pages (e.g. status.mistral.ai) with per-service uptime and 90-day history
- Add support for the AWS Health Dashboard (health.aws.amazon.com) with per-service-region events and history
- Add support for Salesforce Trust product pages (status.salesforce.com/products/…) via the public Trust API; status.heroku.com maps to the Heroku product since its own status site is deprecated
- Add support for Uptime.com status pages (hosted and custom-domain) with per-component uptime, 90-day history, and incident details
- Add a generic RSS feed fallback for status pages that block their APIs (e.g. status.x.ai)
