### PR TITLE
Add Nika MCP server to model-context-protocol-registry

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add Nika MCP Server] - {PR_MERGE_DATE}
+## [Add Nika MCP Server] - 2026-07-12
 
 Add Nika to the community registry — a workflow language for AI (one file, four verbs, one Rust binary). Its MCP server is a read-only oracle: agents validate .nika.yaml workflows (nika_check, nika_explain) and learn the language (schema, templates, examples, catalogs) without executing anything; execution stays on the CLI, budget-capped and trace-verified. Local binary via Homebrew/cargo-binstall/Nix; no env vars, no API key.
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Add Nika MCP Server] - {PR_MERGE_DATE}
+
+Add Nika to the community registry — a workflow language for AI (one file, four verbs, one Rust binary). Its MCP server is a read-only oracle: agents validate .nika.yaml workflows (nika_check, nika_explain) and learn the language (schema, templates, examples, catalogs) without executing anything; execution stays on the CLI, budget-capped and trace-verified. Local binary via Homebrew/cargo-binstall/Nix; no env vars, no API key.
+
 ## [Update Circleback MCP Server URL] - 2026-07-10
 
 Update the Circleback MCP server endpoint from app.circleback.ai to circleback.ai to reflect our domain migration.

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -942,6 +942,18 @@ export const COMMUNITY_ENTRIES: RegistryEntry[] = [
     },
   },
   {
+    name: "nika",
+    title: "Nika",
+    description:
+      "Nika is a workflow language for AI — one file, four verbs, one Rust binary. Its MCP server is a read-only oracle: agents validate workflows (nika_check, nika_explain) and learn the language (schema, templates, examples, catalogs) without executing anything. Running stays on the CLI, budget-capped and trace-verified — inspect freely, execute deliberately.",
+    icon: "https://github.com/supernovae-st.png",
+    homepage: "https://github.com/supernovae-st/nika",
+    configuration: {
+      command: "nika",
+      args: ["mcp"],
+    },
+  },
+  {
     name: "optionsahoy",
     title: "OptionsAhoy",
     description:


### PR DESCRIPTION
## Description

Adds **Nika** to `COMMUNITY_ENTRIES` of the Model Context Protocol Registry extension (data-only change to `entries.ts`, alphabetical slot).

Nika (github.com/supernovae-st/nika · AGPL, Rust) ships a read-only MCP oracle over stdio: `nika mcp`. Agents validate `.nika.yaml` workflows (`nika_check`, `nika_explain`) and learn the language (schema, templates, examples, catalogs) without executing anything — execution stays on the CLI, budget-capped and trace-verified. The configuration is the simplest shape in the file: `command: nika, args: ["mcp"]`, no env vars, no API key.

The binary installs via Homebrew (`brew install supernovae-st/tap/nika`), cargo-binstall, or Nix — install runbook: https://github.com/supernovae-st/nika/blob/main/llms-install.md

Disclosure: I am the Nika author (first-party submission).

## Screencast

N/A — data-only registry entry (no UI/code change). The entry renders like every other `RegistryEntry` in the list.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` — not run in my submission environment (single data entry in `entries.ts`, TypeScript shape mirrors the adjacent entries); happy to iterate if CI flags anything
- [x] I checked that files in the `assets` folder are used by the extension itself (no asset added — icon is a remote URL like other community entries)
- [x] I checked that assets used in the `README` are located outside the metadata folder (README untouched)
