### PR TITLE
[Groq] Update Models

### DIFF
--- a/extensions/groq/CHANGELOG.md
+++ b/extensions/groq/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Groq Changelog
 
+## [Updated Models] - {PR_MERGE_DATE}
+
+- Added `Qwen 3.6 27B 131k`
+- Removed deprecated `Llama 3.1 8B 128k`, `Llama 3.3 70B 128k`, `Qwen 3 32B 128k`, `Llama 4 Scout 131k`, and `Llama 4 Maverick 131k`
+
 ## [Updated Models] - 2026-04-20
 
 - Removed deprecated `Kimi K2 0905 263k` from model selections and pricing metadata

--- a/extensions/groq/CHANGELOG.md
+++ b/extensions/groq/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Groq Changelog
 
-## [Updated Models] - {PR_MERGE_DATE}
+## [Updated Models] - 2026-07-12
 
 - Added `Qwen 3.6 27B 131k`
 - Removed deprecated `Llama 3.1 8B 128k`, `Llama 3.3 70B 128k`, `Qwen 3 32B 128k`, `Llama 4 Scout 131k`, and `Llama 4 Maverick 131k`

--- a/extensions/groq/package.json
+++ b/extensions/groq/package.json
@@ -41,6 +41,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -79,6 +83,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -117,6 +125,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -155,6 +167,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -193,6 +209,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -231,6 +251,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -285,6 +309,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -340,6 +368,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -379,6 +411,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -418,6 +454,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -457,6 +497,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -496,6 +540,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -535,6 +583,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -574,6 +626,10 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
+            },
+            {
+              "value": "qwen/qwen3.6-27b",
+              "title": "Qwen 3.6 27B 131k"
             }
           ]
         }
@@ -604,6 +660,10 @@
         {
           "value": "openai/gpt-oss-20b",
           "title": "GPT OSS 20B 131k"
+        },
+        {
+          "value": "qwen/qwen3.6-27b",
+          "title": "Qwen 3.6 27B 131k"
         }
       ]
     },

--- a/extensions/groq/package.json
+++ b/extensions/groq/package.json
@@ -41,26 +41,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -99,26 +79,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -157,26 +117,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -215,26 +155,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -273,26 +193,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -331,26 +231,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -405,26 +285,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -480,26 +340,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -539,26 +379,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -598,26 +418,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -657,26 +457,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -716,26 +496,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -775,26 +535,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -834,26 +574,6 @@
             {
               "value": "openai/gpt-oss-20b",
               "title": "GPT OSS 20B 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-              "title": "Llama 4 Maverick 131k"
-            },
-            {
-              "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-              "title": "Llama 4 Scout 131k"
-            },
-            {
-              "value": "llama-3.3-70b-versatile",
-              "title": "Llama 3.3 70B 128k"
-            },
-            {
-              "value": "llama-3.1-8b-instant",
-              "title": "Llama 3.1 8B 128k"
-            },
-            {
-              "value": "qwen/qwen3-32b",
-              "title": "Qwen 3 32B 128K"
             }
           ]
         }
@@ -884,26 +604,6 @@
         {
           "value": "openai/gpt-oss-20b",
           "title": "GPT OSS 20B 131k"
-        },
-        {
-          "value": "meta-llama/llama-4-maverick-17b-128e-instruct",
-          "title": "Llama 4 Maverick 131k"
-        },
-        {
-          "value": "meta-llama/llama-4-scout-17b-16e-instruct",
-          "title": "Llama 4 Scout 131k"
-        },
-        {
-          "value": "llama-3.3-70b-versatile",
-          "title": "Llama 3.3 70B 128k"
-        },
-        {
-          "value": "llama-3.1-8b-instant",
-          "title": "Llama 3.1 8B 128k"
-        },
-        {
-          "value": "qwen/qwen3-32b",
-          "title": "Qwen 3 32B 128K"
         }
       ]
     },

--- a/extensions/groq/src/hook/utils.ts
+++ b/extensions/groq/src/hook/utils.ts
@@ -4,24 +4,14 @@ export const allModels = [
   { name: "Follow global model", id: "global" },
   { name: "GPT OSS 120B 131k", id: "openai/gpt-oss-120b" },
   { name: "GPT OSS 20B 131k", id: "openai/gpt-oss-20b" },
-  { name: "Qwen 3 32B 128k", id: "qwen/qwen3-32b" },
-  { name: "Llama 4 Maverick 131k", id: "meta-llama/llama-4-maverick-17b-128e-instruct" },
-  { name: "Llama 4 Scout 131k", id: "meta-llama/llama-4-scout-17b-16e-instruct" },
-  { name: "Llama 3.3 70B 128k", id: "llama-3.3-70b-versatile" },
-  { name: "Llama 3.1 8B 128k", id: "llama-3.1-8b-instant" },
 ];
 
 const MODEL_RATES: Record<string, { input: number; output: number }> = {
   "openai/gpt-oss-120b": { input: 0.15, output: 0.6 },
   "openai/gpt-oss-20b": { input: 0.075, output: 0.3 },
-  "meta-llama/llama-4-scout-17b-16e-instruct": { input: 0.11, output: 0.34 },
-  "meta-llama/llama-4-maverick-17b-128e-instruct": { input: 0.2, output: 0.6 },
-  "llama-3.3-70b-versatile": { input: 0.59, output: 0.79 },
-  "llama-3.1-8b-instant": { input: 0.05, output: 0.08 },
-  "qwen/qwen3-32b": { input: 0.29, output: 0.59 },
 };
 
-export const THINKING_MODELS = ["openai/gpt-oss-120b", "openai/gpt-oss-20b", "qwen/qwen3-32b"] as const;
+export const THINKING_MODELS = ["openai/gpt-oss-120b", "openai/gpt-oss-20b"] as const;
 
 export function isThinkingModel(model: string): boolean {
   return THINKING_MODELS.includes(model as (typeof THINKING_MODELS)[number]);

--- a/extensions/groq/src/hook/utils.ts
+++ b/extensions/groq/src/hook/utils.ts
@@ -4,14 +4,16 @@ export const allModels = [
   { name: "Follow global model", id: "global" },
   { name: "GPT OSS 120B 131k", id: "openai/gpt-oss-120b" },
   { name: "GPT OSS 20B 131k", id: "openai/gpt-oss-20b" },
+  { name: "Qwen 3.6 27B 131k", id: "qwen/qwen3.6-27b" },
 ];
 
 const MODEL_RATES: Record<string, { input: number; output: number }> = {
   "openai/gpt-oss-120b": { input: 0.15, output: 0.6 },
   "openai/gpt-oss-20b": { input: 0.075, output: 0.3 },
+  "qwen/qwen3.6-27b": { input: 0.6, output: 3 },
 };
 
-export const THINKING_MODELS = ["openai/gpt-oss-120b", "openai/gpt-oss-20b"] as const;
+export const THINKING_MODELS = ["openai/gpt-oss-120b", "openai/gpt-oss-20b", "qwen/qwen3.6-27b"] as const;
 
 export function isThinkingModel(model: string): boolean {
   return THINKING_MODELS.includes(model as (typeof THINKING_MODELS)[number]);


### PR DESCRIPTION
## Description

- Added `Qwen 3.6 27B 131k`
- Removed deprecated `Llama 3.1 8B 128k`, `Llama 3.3 70B 128k`, `Qwen 3 32B 128k`, `Llama 4 Scout 131k`, and `Llama 4 Maverick 131k`
