### PR TITLE
Cobalt Finance: fall back to logo.dev name lookup for transaction merchant icons

### DIFF
--- a/extensions/cobalt-finance/CHANGELOG.md
+++ b/extensions/cobalt-finance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Cobalt Changelog
 
+## [Transaction Logos Fallback] - {PR_MERGE_DATE}
+
+- Resolve transaction merchant logos via the same `logoLookupName` → logo.dev name flow used by recurring streams (Cobalt's `/v1/transactions` API doesn't expose merchant `website` / `logoUrl`, so all real rows were falling through to `Icon.Coins`)
+
 ## [Merchant Logos] - 2026-07-10
 
 - Merchant, institution, and recurring-stream logos now work out of the box — no manual Brandfetch or logo.dev token required

--- a/extensions/cobalt-finance/CHANGELOG.md
+++ b/extensions/cobalt-finance/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Cobalt Changelog
 
-## [Transaction Logos Fallback] - {PR_MERGE_DATE}
+## [Transaction Logos Fallback] - 2026-07-12
 
 - Resolve transaction merchant logos via the same `logoLookupName` → logo.dev name flow used by recurring streams (Cobalt's `/v1/transactions` API doesn't expose merchant `website` / `logoUrl`, so all real rows were falling through to `Icon.Coins`)
 

--- a/extensions/cobalt-finance/src/icons.ts
+++ b/extensions/cobalt-finance/src/icons.ts
@@ -217,46 +217,33 @@ export function pickRecurringIcon(input: RecurringIconInput): string | Icon {
 }
 
 interface MerchantIconInput {
-  logoUrl: string | null;
-  website: string | null;
-  counterparties?:
-    | {
-        type?: string | null;
-        website?: string | null;
-        logo_url?: string | null;
-      }[]
-    | null;
+  /** Cobalt `Transaction.merchant` — cleaned merchant name when available. */
+  merchantName: string | null;
+  /** Cobalt `Transaction.name` — raw institution description. Fallback for logo lookup. */
+  description: string | null;
 }
 
 /**
- * Pick the best single icon source for a transaction row. Raycast only
- * accepts one source per `List.Item.icon`, so order matters:
- *   1. Brandfetch icon by `website` (or counterparty website)
- *   2. Plaid `logoUrl` from Cobalt
- *   3. Counterparty `logo_url`
- *   4. `Icon.Coins` (no merchant data — distinct from the category column)
+ * Pick the best single icon source for a transaction row. Mirrors
+ * `pickRecurringIcon`: try domain-map → logo.dev name lookup → `Icon.Coins`.
+ * Cobalt's public `/v1/transactions` API doesn't expose website/logo URLs,
+ * so all resolution is name-based.
  */
 export function pickMerchantIcon(input: MerchantIconInput): string | Icon {
-  const { counterparties, logoUrl, website } = input;
+  const { description, merchantName } = input;
+  const raw = merchantName?.trim() || description?.trim() || "";
+  if (!raw) {
+    return Icon.Coins;
+  }
 
-  const host =
-    hostFromUrl(website) ??
-    hostFromUrl(
-      counterparties?.find((c) => c.type === "merchant" && c.website)?.website ??
-        counterparties?.find((c) => c.website)?.website ??
-        null,
-    );
+  const host = domainFromName(raw);
   if (host) {
     return brandfetchIconUrl(host, BRANDFETCH_CLIENT_ID);
   }
 
-  if (logoUrl && isHttpUrl(logoUrl)) {
-    return logoUrl;
-  }
-
-  const cpLogo = counterparties?.find((c) => c.logo_url && isHttpUrl(c.logo_url))?.logo_url;
-  if (cpLogo) {
-    return cpLogo;
+  const name = logoLookupName(raw);
+  if (name) {
+    return logoDevUrlByBrandName(name, LOGO_DEV_TOKEN);
   }
 
   return Icon.Coins;

--- a/extensions/cobalt-finance/src/transactions.tsx
+++ b/extensions/cobalt-finance/src/transactions.tsx
@@ -57,9 +57,8 @@ function TransactionDetail({ tx }: { tx: Transaction }) {
   const amountStr = currency.format(Math.abs(tx.amount));
   const signedAmount = `${isCredit ? "+" : "-"}${amountStr}`;
   const merchantIcon = pickMerchantIcon({
-    counterparties: null,
-    logoUrl: null,
-    website: null,
+    description: tx.name,
+    merchantName: tx.merchant,
   });
   const title = displayName(tx) || "—";
 
@@ -165,9 +164,8 @@ export default function Command() {
         ];
 
         const merchantIcon = pickMerchantIcon({
-          counterparties: null,
-          logoUrl: null,
-          website: null,
+          description: tx.name,
+          merchantName: tx.merchant,
         });
 
         return (


### PR DESCRIPTION
### Description

Follow-up to #29334. The transaction list was still showing the generic coin icon for every row because `pickMerchantIcon` only resolved a logo when the transaction had a `website` / `logoUrl` / `counterparties[].website` field — but Cobalt's public `/v1/transactions` API doesn't expose any of those. Every real row therefore fell through to `Icon.Coins`.

Fix mirrors what `pickRecurringIcon` already does: use the merchant / description name to resolve a domain, then fall back to logo.dev's `/name/<brand>` endpoint (same publishable key already bundled in the previous PR).

Concretely:
- `pickMerchantIcon` now takes `{ merchantName, description }` and reuses `domainFromName` → `logoDevUrlByBrandName(logoLookupName(...))` → `Icon.Coins`.
- The two `transactions.tsx` call sites now pass `tx.merchant` / `tx.name`.

### Screencast

n/a — visual fix. Merchant rows in the Recent Transactions command now render brand logos instead of the coin fallback.

### Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder