### PR TITLE
Put.io: Clearer setup documentation and preferences help

### DIFF
--- a/extensions/putio/CHANGELOG.md
+++ b/extensions/putio/CHANGELOG.md
@@ -1,5 +1,10 @@
 # put.io Changelog
 
+## [Clearer setup documentation] - {PR_MERGE_DATE}
+
+- Rewrote the README with a step-by-step guide for obtaining the app-specific password and a summary of the available commands
+- Clarified the app-specific password field description in the extension preferences
+
 ## [Security Maintenance] - 2026-05-21
 
 - Updated the extension to address security advisories.

--- a/extensions/putio/CHANGELOG.md
+++ b/extensions/putio/CHANGELOG.md
@@ -1,6 +1,6 @@
 # put.io Changelog
 
-## [Clearer setup documentation] - {PR_MERGE_DATE}
+## [Clearer setup documentation] - 2026-07-12
 
 - Rewrote the README with a step-by-step guide for obtaining the app-specific password and a summary of the available commands
 - Clarified the app-specific password field description in the extension preferences

--- a/extensions/putio/README.md
+++ b/extensions/putio/README.md
@@ -17,3 +17,30 @@
     <a title="Install putio Raycast Extension" href="https://www.raycast.com/putio/putio"><img src="https://www.raycast.com/putio/putio/install_button@2x.png" height="64" alt="" style="height: 64px;"></a>
   </p>
 </div>
+
+## Setup
+
+The first time you run a command, the extension asks for an **app-specific password**. This is **not** your put.io account password — it's a separate credential, scoped to this extension, that you can revoke at any time without changing your login.
+
+To get one:
+
+1. Open **[put.io/raycast](https://put.io/raycast)** in your browser and sign in to put.io.
+2. That page creates an app-specific password for Raycast — confirm to generate it.
+3. Copy the generated password.
+4. Paste it into the **App-specific password** field in Raycast.
+
+You can revoke this password later from your put.io account settings, and your login is unaffected.
+
+## Commands
+
+| Command              | What it does                                       |
+| -------------------- | -------------------------------------------------- |
+| **View Your Files**  | Browse the files in your put.io account.           |
+| **Search in put.io** | Search across your put.io files.                   |
+| **New Transfer**     | Add a transfer from a magnet link, torrent or URL. |
+| **View Transfers**   | Track in-progress and completed transfers.         |
+| **View History**     | Browse your account's history events.              |
+
+## Feedback
+
+Found a bug or have a suggestion? Open an issue on the [Raycast extensions repository](https://github.com/raycast/extensions).

--- a/extensions/putio/package.json
+++ b/extensions/putio/package.json
@@ -7,6 +7,9 @@
   "owner": "putio",
   "access": "public",
   "author": "altaywtf",
+  "contributors": [
+    "kud"
+  ],
   "categories": [
     "Applications",
     "Media"

--- a/extensions/putio/package.json
+++ b/extensions/putio/package.json
@@ -88,7 +88,7 @@
       "title": "App-specific password",
       "type": "password",
       "placeholder": "Get this from put.io/raycast",
-      "description": "App-specific password used for authenticating with put.io API.",
+      "description": "Create one at put.io/raycast (sign in first), then paste it here. This is a revocable app-specific password — not your put.io account password.",
       "required": true
     }
   ],

--- a/extensions/putio/package.json
+++ b/extensions/putio/package.json
@@ -121,5 +121,8 @@
     "axios": "^1.8.4",
     "minimatch": "^10.0.1",
     "picomatch": "^4.0.4"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }


### PR DESCRIPTION
## Description

The extension's store page and setup dialog gave almost no guidance, so new users hit the **App-specific password** field with no idea what to enter or where to get it. This PR fixes the documentation without touching any extension code:

- **README** — added a **Setup** section with the exact step-by-step flow for obtaining an app-specific password (`put.io/raycast` → generate → copy → paste), a note that it's a revocable credential rather than the account password, and a **Commands** table describing what each command does. The original README was just a logo, a one-line description and an install button.
- **Preferences** — clarified the `token` preference `description` so the setup dialog itself explains where the password comes from and that it isn't the account password.
- **CHANGELOG** — added an entry using the `{PR_MERGE_DATE}` token.

## Screencast

Documentation/metadata-only change — no UI behaviour changes. The confusing field this addresses:

> **App-specific password** — previously described only as _"App-specific password used for authenticating with put.io API."_ with no indication of where to obtain it.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration) — _this change only touches the README, the CHANGELOG and one preference `description` string (no code), so no distribution build was run; CI validation covers the manifest._
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
