### PR TITLE
Claude Code Usage (ccusage): keep rate-limit progress bars visible during backoff

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [Keep rate-limit bars visible during backoff] - {PR_MERGE_DATE}
+## [Keep rate-limit bars visible during backoff] - 2026-07-12
 
 ### Fixed
 

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [Keep rate-limit bars visible during backoff] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Rate limit progress bars no longer disappear when the menu bar restarts during a rate-limit backoff window. Restored cached limits now mark the feature available immediately, instead of waiting for a fetch that the backoff guard skips
+
 ## [Reconcile menu bar usage readouts] - 2026-07-10
 
 ### Fixed

--- a/extensions/ccusage/src/utils/usage-limits-cache.ts
+++ b/extensions/ccusage/src/utils/usage-limits-cache.ts
@@ -63,7 +63,10 @@ let cacheState: CacheState = {
   isLoading: restoredRateLimitedUntil === null && (restoredData === null || isBlobStale(restoredLastFetched)),
   isStale: restoredData !== null && isBlobStale(restoredLastFetched),
   isRateLimited: restoredRateLimitedUntil !== null,
-  isUsageLimitsAvailable: false,
+  // Restored limit data implies the token was valid last run, so the feature is
+  // available. Without this, a cold start during a rate-limit backoff early-returns
+  // from fetchUsageLimits() before availability is set, hiding the whole bars section.
+  isUsageLimitsAvailable: restoredData !== null,
   lastFetched: restoredLastFetched,
   rateLimitedUntil: restoredRateLimitedUntil,
   nextRefreshAt: null,


### PR DESCRIPTION
## Description

Fixes a regression where the menu bar's **Rate Limits** section (the progress bars) disappears intermittently.

Since the "Honor server rate-limit backoff" change, `fetchUsageLimits()` early-returns at the top when a backoff window is active (`rateLimitedUntil`, restored from cache). That early return happens _before_ the line that sets `isUsageLimitsAvailable = true`. Because the menu-bar command is a short-lived process that re-initialises module state on every tick, any cold start during a backoff window leaves `isUsageLimitsAvailable` at its initial `false` — and the whole section is gated on that flag in `menubar-ccusage.tsx`, so the bars vanish even though valid cached limit data is available.

**Fix:** seed `isUsageLimitsAvailable` from the restored cache (`restoredData !== null`) in the initial `cacheState`. If cached limit data exists, a token was valid on the previous run, so the feature is available and the (stale) bars should render immediately instead of waiting for a fetch the backoff guard will skip. The normal fetch path still corrects the flag either way once the window clears.

**Testing:** `npm run typecheck`, `ray lint`, and `ray build` all pass.

## Screencast

N/A — internal state fix; no visual change other than the bars remaining visible during a backoff window.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
