### PR TITLE
chore(copymoveto): Transfer ownership from Mehdi_Hp to kumamaki

### DIFF
--- a/extensions/copymoveto/CHANGELOG.md
+++ b/extensions/copymoveto/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CopyMoveTo Changelog
 
+## [Changed Extension Author] - {PR_MERGE_DATE}
+
 ## [Enhancement] - 2025-04-14
 
 - Add a preference to show hidden folders in directory picker.

--- a/extensions/copymoveto/CHANGELOG.md
+++ b/extensions/copymoveto/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CopyMoveTo Changelog
 
-## [Changed Extension Author] - {PR_MERGE_DATE}
+## [Changed Extension Author] - 2026-08-03
 
 ## [Enhancement] - 2025-04-14
 

--- a/extensions/copymoveto/package.json
+++ b/extensions/copymoveto/package.json
@@ -102,5 +102,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/copymoveto/package.json
+++ b/extensions/copymoveto/package.json
@@ -4,7 +4,7 @@
   "title": "CopyMoveTo",
   "description": "Save time moving files between folders. Define destinations once, use quick commands to copy or move files effortlessly",
   "icon": "extension-icon.png",
-  "author": "Mehdi_Hp",
+  "author": "kumamaki",
   "contributors": [
     "pernielsentikaer",
     "snuki",


### PR DESCRIPTION
Transfer CopyMoveTo ownership from `Mehdi_Hp` to `kumamaki` (GitHub username rename).

As discussed with @pernielsentikaer — ready for the handle transfer.