### PR TITLE
Update bitwarden extension

### DIFF
--- a/extensions/bitwarden/CHANGELOG.md
+++ b/extensions/bitwarden/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bitwarden Changelog
 
+## [Fix Authenticator TOTP] - {PR_MERGE_DATE}
+
+- Fix authenticator failing when TOTP secrets contain spaces
+
 ## [Fix sync session handling] - 2026-05-28
 
 - Fixed failed sync attempts immediately clearing the active session before cached vault data can load.

--- a/extensions/bitwarden/CHANGELOG.md
+++ b/extensions/bitwarden/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Bitwarden Changelog
 
-## [Fix Authenticator TOTP] - {PR_MERGE_DATE}
+## [Fix Authenticator TOTP] - 2026-07-13
 
 - Fix authenticator failing when TOTP secrets contain spaces
 

--- a/extensions/bitwarden/src/utils/authenticatorTotp.test.ts
+++ b/extensions/bitwarden/src/utils/authenticatorTotp.test.ts
@@ -92,6 +92,25 @@ describe("getGenerator (regular TOTP)", () => {
     expect(code).toHaveLength(6);
     expect(code).toMatch(/^\d{6}$/);
   });
+
+  it("generates the same code when a raw secret contains spaces", () => {
+    const [spacedGenerator, spacedError] = getGenerator("GEZD GNBV GY3T QOJQ GEZD GNBV GY");
+    const [plainGenerator, plainError] = getGenerator(RFC_SECRET);
+    if (spacedError) throw spacedError;
+    if (plainError) throw plainError;
+
+    expect(spacedGenerator!.generate(RFC_EPOCH_59_MS)).toBe(plainGenerator!.generate(RFC_EPOCH_59_MS));
+  });
+
+  it("generates the same code when an otpauth URI secret contains spaces", () => {
+    const spacedUri = "otpauth://totp/Test?secret=GEZD%20GNBV%20GY3T%20QOJQ%20GEZD%20GNBV%20GY&digits=8";
+    const [spacedGenerator, spacedError] = getGenerator(spacedUri);
+    const [plainGenerator, plainError] = getGenerator(RFC_URI_8_DIGITS);
+    if (spacedError) throw spacedError;
+    if (plainError) throw plainError;
+
+    expect(spacedGenerator!.generate(RFC_EPOCH_59_MS)).toBe(plainGenerator!.generate(RFC_EPOCH_59_MS));
+  });
 });
 
 describe("getGenerator (Steam Guard)", () => {

--- a/extensions/bitwarden/src/utils/authenticatorTotp.ts
+++ b/extensions/bitwarden/src/utils/authenticatorTotp.ts
@@ -12,6 +12,7 @@ const guardrails = createGuardrails({ MIN_SECRET_BYTES: 10 });
 /** Steam Guard character set (avoids 0, 1, I, L, O, S, Z for readability). */
 const STEAM_CHARS = "23456789BCDFGHJKMNPQRTVWXY";
 const STEAM_PERIOD = 30;
+const SECRET_WHITESPACE = /\s/g;
 
 type HashAlgorithm = "sha1" | "sha256" | "sha512";
 
@@ -54,6 +55,10 @@ const steamHooks = {
   },
 };
 
+function normalizeSecret(secret: string): string {
+  return secret.replace(SECRET_WHITESPACE, "");
+}
+
 /**
  * Creates a TOTP generator for regular or Steam Guard keys.
  * Steam uses HMAC-SHA1 with a custom 5-character alphanumeric encoding.
@@ -70,7 +75,7 @@ export function createTotpGenerator(opts: CreateTotpOptions): TotpGenerator {
   };
 
   if (opts.variant === "steam") {
-    const { secret } = opts;
+    const secret = normalizeSecret(opts.secret);
 
     return {
       period: STEAM_PERIOD,
@@ -90,7 +95,8 @@ export function createTotpGenerator(opts: CreateTotpOptions): TotpGenerator {
     };
   }
 
-  const { secret, period, algorithm, digits } = opts;
+  const { period, algorithm, digits } = opts;
+  const secret = normalizeSecret(opts.secret);
 
   return {
     period,


### PR DESCRIPTION
## Description

Fixes #29056

Fixes authenticator TOTP generation when secrets contain spaces. Bitwarden accepts spaced secrets, but otplib does not, so Raycast now strips whitespace before generating codes.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
