### PR TITLE
fix(deps): address CVE-2026-41907 and CVE-2026-53632 in extensions

### DIFF
--- a/extensions/bmw/package-lock.json
+++ b/extensions/bmw/package-lock.json
@@ -897,14 +897,6 @@
         "uuid": "^8.3.2"
       }
     },
-    "node_modules/bmw-connected-drive/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",

--- a/extensions/bmw/package.json
+++ b/extensions/bmw/package.json
@@ -160,5 +160,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
+  },
+  "overrides": {
+    "uuid": "^11.1.1"
   }
 }

--- a/extensions/chatgo/package-lock.json
+++ b/extensions/chatgo/package-lock.json
@@ -13,7 +13,7 @@
         "cross-fetch": "^3.1.5",
         "lodash": "^4.17.23",
         "say": "^0.16.0",
-        "uuid": "^9.0.0"
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
@@ -3554,16 +3554,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/webidl-conversions": {

--- a/extensions/chatgo/package.json
+++ b/extensions/chatgo/package.json
@@ -100,7 +100,7 @@
     "cross-fetch": "^3.1.5",
     "lodash": "^4.17.23",
     "say": "^0.16.0",
-    "uuid": "^9.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",

--- a/extensions/claude/package-lock.json
+++ b/extensions/claude/package-lock.json
@@ -14,7 +14,7 @@
         "cross-fetch": "^4.0.0",
         "csv-parse": "^5.5.3",
         "raycast": "^1.0.8",
-        "uuid": "^9.0.0"
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "@types/node": "18.8.3",
@@ -2457,15 +2457,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {

--- a/extensions/claude/package.json
+++ b/extensions/claude/package.json
@@ -108,7 +108,7 @@
     "cross-fetch": "^4.0.0",
     "csv-parse": "^5.5.3",
     "raycast": "^1.0.8",
-    "uuid": "^9.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@types/node": "18.8.3",

--- a/extensions/css-gg/package-lock.json
+++ b/extensions/css-gg/package-lock.json
@@ -12,7 +12,7 @@
         "css.gg": "^2.1.4",
         "node-fetch": "^3.1.0",
         "react": "^18.2.0",
-        "uuid": "^9.0.0"
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "@types/node": "~20.3.1",
@@ -1884,11 +1884,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -3242,9 +3247,9 @@
       }
     },
     "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
     },
     "web-streams-polyfill": {
       "version": "3.2.0",

--- a/extensions/css-gg/package.json
+++ b/extensions/css-gg/package.json
@@ -33,7 +33,7 @@
     "css.gg": "^2.1.4",
     "node-fetch": "^3.1.0",
     "react": "^18.2.0",
-    "uuid": "^9.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@types/node": "~20.3.1",

--- a/extensions/fuelx/package-lock.json
+++ b/extensions/fuelx/package-lock.json
@@ -48,6 +48,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -64,6 +65,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -80,6 +82,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -96,6 +99,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -112,6 +116,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -128,6 +133,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -144,6 +150,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -160,6 +167,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -176,6 +184,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -192,6 +201,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -208,6 +218,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -224,6 +235,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -240,6 +252,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -256,6 +269,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -272,6 +286,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -288,6 +303,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -304,6 +320,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -320,6 +337,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -336,6 +354,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -352,6 +371,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -368,6 +388,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -400,6 +421,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -416,6 +438,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -432,6 +455,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -448,6 +472,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -544,6 +569,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/abi-coder/-/abi-coder-0.96.1.tgz",
       "integrity": "sha512-czJxFPirhSO6ayshu9Cr5AmED/IprQ8h1igwlcSHFr5jR+l46bLdlsXsWiUwe7vyvZCpOnxkN/XZYkmQyNxKNg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/crypto": "0.96.1",
         "@fuel-ts/errors": "0.96.1",
@@ -562,6 +588,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -574,6 +601,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/abi-typegen/-/abi-typegen-0.96.1.tgz",
       "integrity": "sha512-vRJnAQ9sxkKuUQ2fkxntPm/679grxgwSf54O7vgDeXuXqQx/4XeylpExjH0/nZzEM5al+muw4rg9WwmKulkcZA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/errors": "0.96.1",
         "@fuel-ts/interfaces": "^0.96.1",
@@ -598,6 +626,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
       "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^10.3.7"
       },
@@ -613,6 +642,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/account/-/account-0.96.1.tgz",
       "integrity": "sha512-i9InTebg3/buKXNJZpKBhxGMBC3MKpk905Uiv2CvTmldyPVgnZV/jY/b63jlfdEWyP5yVkr5/tzo7QaPKpfnMA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/abi-coder": "0.96.1",
         "@fuel-ts/address": "0.96.1",
@@ -642,6 +672,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/address/-/address-0.96.1.tgz",
       "integrity": "sha512-PCuC8oojoWLhh0+boitaP90/Z3iSfEXZR8v1JCEfoLZIkvCq6EGKtiY0KvcNkPozHOHmmT34w/1CS6qHOoCBNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/crypto": "0.96.1",
         "@fuel-ts/errors": "0.96.1",
@@ -659,6 +690,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/contract/-/contract-0.96.1.tgz",
       "integrity": "sha512-shwNMHFZ7vr5QJsfVQ6aLd1ms88f3ZagrsNLqNz1Txhz/5KVgYyJaxfp7tUc4WZFpR67+W1zeIqx8ZNHVhck3g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/abi-coder": "0.96.1",
         "@fuel-ts/account": "0.96.1",
@@ -684,6 +716,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/crypto/-/crypto-0.96.1.tgz",
       "integrity": "sha512-OrAZPZtm8HQouzip621/ci47PeTS06QegGdz7MeN6wK4yeCbJmlRQ1WE9S3iclb3p+VLF0RtbecEbHQfsNgsnA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/errors": "0.96.1",
         "@fuel-ts/interfaces": "0.96.1",
@@ -700,6 +733,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/errors/-/errors-0.96.1.tgz",
       "integrity": "sha512-Xtso5v4a3UUvnMaOSDhMRlkb9LxLyCyC/1/RY7fZZ035ttscy6dNMuiD/iSptJ5pHklJ5R4rCPdOL5EKpgOaMA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/versions": "0.96.1"
       },
@@ -712,6 +746,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/hasher/-/hasher-0.96.1.tgz",
       "integrity": "sha512-7z4cah+5TOcCBA2Wgvje1L7wVTahiFLb9IUpRXRMVGXwaqsbV/wUNcyuc1mhPh/JKLgcOe+OqsrpcYD2dg2rpg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/crypto": "0.96.1",
         "@fuel-ts/interfaces": "^0.96.1",
@@ -727,6 +762,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/interfaces/-/interfaces-0.96.1.tgz",
       "integrity": "sha512-mZ3sDHJml5AtLRSmGWo5rbU9//3oKDhAeiFealajcPaVztAAnaKnA5a19dd4ITbjZb2q3e2lQ7zX8iAXgHUwYA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
       }
@@ -736,6 +772,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/math/-/math-0.96.1.tgz",
       "integrity": "sha512-AZUChguQmE1ILYbcc6SOTjFJIUkGzD3Z6yHgvO4tszn2QS/jVTSAZKVx653J5u9m/Xn/WthwR35l1GbwXMwB4g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/errors": "0.96.1",
         "@types/bn.js": "^5.1.6",
@@ -750,6 +787,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/merkle/-/merkle-0.96.1.tgz",
       "integrity": "sha512-7cLbxYG5berKSK+wPKrkbB9dZ6akOm7C1Ij4iwYXOxQWlmXY62mjSY5Tl1PPyDBSdRqBtqxW0xYUGIzZl2A/3g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/hasher": "^0.96.1",
         "@fuel-ts/math": "0.96.1"
@@ -763,6 +801,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/program/-/program-0.96.1.tgz",
       "integrity": "sha512-tA2YvcIdlDQLKeOOfoTyfI3LRQZiqsHi5rFaGbOsjEQvyNQBdXa92vMMFW0dFNWXqOPLjTmYNWqp0xsMuikbsA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/abi-coder": "0.96.1",
         "@fuel-ts/account": "0.96.1",
@@ -1124,7 +1163,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
       "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -1174,6 +1212,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/script/-/script-0.96.1.tgz",
       "integrity": "sha512-N/N3I3xjDI1+9XcCrYTWapF0iBbdvtBxUUUZxn5S5GuIXuTCK6UfQLrRciuCHK5QiHVwFmQjlki+ozJfI+4UbQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/abi-coder": "0.96.1",
         "@fuel-ts/account": "0.96.1",
@@ -1194,6 +1233,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/transactions/-/transactions-0.96.1.tgz",
       "integrity": "sha512-yPQBzMeFIzNBLUZigaf4q0hETO8AH8Evt6ZvpWrYhjYz2WfEpfNDpuhIHRwsMfJRbxz2vhQ51AzkRqpH0b2GMQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/abi-coder": "0.96.1",
         "@fuel-ts/address": "0.96.1",
@@ -1212,6 +1252,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/utils/-/utils-0.96.1.tgz",
       "integrity": "sha512-XXZNEUPf7qtKpVO3ak2CSroBYEKh1Gne1zlmVSNUoVPqQvglcu0I2pu/QmVnZBN4m3yVSyHUoWR2Kbo8/Dh7sA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fuel-ts/errors": "0.96.1",
         "@fuel-ts/interfaces": "0.96.1",
@@ -1228,6 +1269,7 @@
       "resolved": "https://registry.npmjs.org/@fuel-ts/versions/-/versions-0.96.1.tgz",
       "integrity": "sha512-C//ZT7U68Gksz9PzUJVzdzUARK7mfXf3MsF5ZqZaMegkE2tCy+twjy8PBdeVserY0uX6mEHRJyZJwcspk34ixg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "chalk": "4",
         "cli-table": "^0.3.11"
@@ -1243,7 +1285,8 @@
       "version": "0.58.0",
       "resolved": "https://registry.npmjs.org/@fuels/vm-asm/-/vm-asm-0.58.0.tgz",
       "integrity": "sha512-tfarairW3IAtyoAIL3I5EJiUQzKAsY4J+eLgZg58B7+itDxqF+CUEpKanmiUnt1mBgry5GwtZsPIrUJ7OgTcDA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@google/generative-ai": {
       "version": "0.24.1",
@@ -1764,7 +1807,8 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@langchain/anthropic": {
       "version": "0.3.34",
@@ -1802,12 +1846,22 @@
         }
       }
     },
+    "node_modules/@langchain/anthropic/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@langchain/core": {
       "version": "0.3.80",
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -1843,7 +1897,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1974,7 +2027,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2008,6 +2060,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -2023,6 +2076,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3026,7 +3080,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
       "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -3672,7 +3725,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -3685,7 +3739,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -3698,7 +3753,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -3711,7 +3767,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -3724,7 +3781,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -3737,7 +3795,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -3750,7 +3809,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -3763,7 +3823,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -3776,7 +3837,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -3789,7 +3851,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -3802,7 +3865,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -3815,7 +3879,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -3828,7 +3893,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -3841,7 +3907,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -3854,7 +3921,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -3867,7 +3935,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -3880,7 +3949,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -3893,7 +3963,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -3906,7 +3977,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -3919,7 +3991,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -3932,7 +4005,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -3945,7 +4019,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -3958,7 +4033,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -3971,7 +4047,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -3984,7 +4061,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.12.0",
@@ -3998,6 +4076,7 @@
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.2.0.tgz",
       "integrity": "sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4006,7 +4085,8 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -4020,7 +4100,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
       "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -4138,7 +4217,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -4428,6 +4506,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.9.tgz",
       "integrity": "sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/spy": "3.0.9",
         "@vitest/utils": "3.0.9",
@@ -4443,6 +4522,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.9.tgz",
       "integrity": "sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/spy": "3.0.9",
         "estree-walker": "^3.0.3",
@@ -4469,6 +4549,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
       "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
@@ -4481,6 +4562,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.9.tgz",
       "integrity": "sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.0.9",
         "pathe": "^2.0.3"
@@ -4494,6 +4576,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.9.tgz",
       "integrity": "sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.0.9",
         "magic-string": "^0.30.17",
@@ -4508,6 +4591,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.9.tgz",
       "integrity": "sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
@@ -4520,6 +4604,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.9.tgz",
       "integrity": "sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyspy": "^3.0.2"
       },
@@ -4532,6 +4617,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.9.tgz",
       "integrity": "sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.0.9",
         "loupe": "^3.1.3",
@@ -4546,6 +4632,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.9.tgz",
       "integrity": "sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
@@ -4581,7 +4668,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4604,6 +4690,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -4722,6 +4809,7 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4781,7 +4869,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -4799,7 +4888,8 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
       "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "2.0.3",
@@ -4842,6 +4932,7 @@
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4886,6 +4977,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
       "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -4936,6 +5028,7 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 16"
       }
@@ -5067,6 +5160,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5176,6 +5270,7 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5294,7 +5389,8 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -5383,7 +5479,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5604,6 +5699,7 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -5662,6 +5758,7 @@
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -5671,6 +5768,7 @@
       "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
       "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
       },
@@ -5893,6 +5991,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -6128,6 +6227,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -6240,6 +6340,7 @@
       "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.0.0.tgz",
       "integrity": "sha512-SpVEnIo2J5k2+Zf76cUkdvIRaq5FMZvGQYnA4lUWYbc99m+fHh4CZYRRO/Ff4tCLQ613fzCm3SiDT64ubW5Gyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "cross-fetch": "^3.1.5",
@@ -6255,6 +6356,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
       "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6355,6 +6457,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -6888,7 +6991,8 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -6901,6 +7005,7 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -7051,6 +7156,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7334,13 +7440,15 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pathval": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
       "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14.16"
       }
@@ -7368,6 +7476,7 @@
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.37.tgz",
       "integrity": "sha512-yuGIEjDAYnnOex9ddMnKZEMFE0CcGo6zbfzDklkmT1m5z734ss6JMzN9rNB3+RR7iS+F10D4/BVIaXOyh8PQKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "async": "^3.2.6",
         "debug": "^4.3.6"
@@ -7395,6 +7504,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -7420,7 +7530,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7442,6 +7551,7 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7597,6 +7707,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7703,7 +7814,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -7747,6 +7859,7 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7755,13 +7868,15 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stream-chain": {
       "version": "2.2.5",
@@ -7889,13 +8004,15 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
@@ -7935,7 +8052,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7948,6 +8064,7 @@
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
       "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
@@ -7957,6 +8074,7 @@
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
       "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -7966,6 +8084,7 @@
       "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
       "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -8079,7 +8198,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8117,22 +8235,22 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -8209,6 +8327,7 @@
       "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.9.tgz",
       "integrity": "sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.4.0",
@@ -8238,6 +8357,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8254,6 +8374,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8270,6 +8391,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8286,6 +8408,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8302,6 +8425,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8318,6 +8442,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8334,6 +8459,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8350,6 +8476,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8366,6 +8493,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8382,6 +8510,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8398,6 +8527,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8414,6 +8544,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8430,6 +8561,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8446,6 +8578,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8462,6 +8595,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8478,6 +8612,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8494,6 +8629,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8510,6 +8646,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8526,6 +8663,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8542,6 +8680,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8558,6 +8697,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8574,6 +8714,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8590,6 +8731,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8606,6 +8748,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8622,6 +8765,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8638,6 +8782,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8648,6 +8793,7 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8688,6 +8834,7 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -8828,6 +8975,7 @@
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -8914,7 +9062,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -8955,6 +9102,7 @@
       "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.0.tgz",
       "integrity": "sha512-VJce62dBd+JQvoc+fCVq+KZfPHr+hXaxCcVgotfwWvlR0Ja3ffYKaJBT8rptPOSKOGJDCUnW2C2JWpud7aRP6Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "property-expr": "^2.0.5",
         "tiny-case": "^1.0.3",
@@ -8967,6 +9115,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       },

--- a/extensions/fuelx/package.json
+++ b/extensions/fuelx/package.json
@@ -36,6 +36,10 @@
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
   },
+  "overrides": {
+    "uuid": "^11.1.1",
+    "vite": "^6.4.3"
+  },
   "preferences": [
     {
       "title": "OpenAI API Key",

--- a/extensions/klu-ai/package-lock.json
+++ b/extensions/klu-ai/package-lock.json
@@ -2421,15 +2421,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/extensions/klu-ai/package.json
+++ b/extensions/klu-ai/package.json
@@ -50,5 +50,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
+  },
+  "overrides": {
+    "uuid": "^11.1.1"
   }
 }

--- a/extensions/oci/package-lock.json
+++ b/extensions/oci/package-lock.json
@@ -10,7 +10,7 @@
         "@raycast/api": "^1.104.1",
         "@raycast/utils": "^2.2.2",
         "filesize": "^11.0.2",
-        "oci-sdk": "^2.122.2"
+        "oci-sdk": "^2.136.1"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.0.4",
@@ -1119,7 +1119,6 @@
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.10.tgz",
       "integrity": "sha512-pSbqV0aUZKAoG760DB7mMoNAFfjuyw7ok0kLHKiu6T6mkKbRZwsH2rOgVFCpl5QmvVtjOX7V5ieETZGLOHuB+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.8.4",
         "@oclif/plugin-autocomplete": "^3.2.40",
@@ -1232,18 +1231,11 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/jssha": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/jssha/-/jssha-2.0.0.tgz",
-      "integrity": "sha512-oBnY3csYnXfqZXDRBJwP1nDDJCW/+VMJ88UHT4DCy0deSXpJIQvMCwYlnmdW4M+u7PiSfQc44LmiFcUbJ8hLEw==",
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "22.13.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1274,6 +1266,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.1",
@@ -1320,7 +1318,6 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -1525,7 +1522,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1965,7 +1961,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2647,10 +2642,9 @@
       }
     },
     "node_modules/jssha": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/jssha/-/jssha-2.4.1.tgz",
-      "integrity": "sha512-77DN1YurYgh+7FPCTJ2CQ6hVDHgIWiHxm4Y5/mAdnpETKYagX22pVWMz4xfKF5fcpNfMaztgVj+/B1bt2k23Eg==",
-      "deprecated": "jsSHA versions < 3.0.0 will no longer receive feature updates",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
+      "integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
@@ -2836,1859 +2830,2038 @@
       }
     },
     "node_modules/oci-accessgovernancecp": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-accessgovernancecp/-/oci-accessgovernancecp-2.130.0.tgz",
-      "integrity": "sha512-4JNs+jRZ3BhQpN6zaj+CONmrdmidfj0BNF2zOUf3/SsJqSI9WMeUiPQMXBOeu2Kvq+hcKxiaERzovE/E78HI9A==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-accessgovernancecp/-/oci-accessgovernancecp-2.136.1.tgz",
+      "integrity": "sha512-XqlE8LXVFCgJ0JV607Si1D1cqvRk1a1f8zfGAw+9Ror1Rv4kVj6kzP6BuS9ecL+3S8EAQzpeNQXMnvLQ0gkE1Q==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-adm": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-adm/-/oci-adm-2.130.0.tgz",
-      "integrity": "sha512-psFu1diIGp4yaHMuoxj4gbNtW+76a5P/tlhLK/Uyr4K+lp8xVUhznmEzev1YeyXaU1eiJkMlHbtXf1YYBK89uA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-adm/-/oci-adm-2.136.1.tgz",
+      "integrity": "sha512-ZE4EYT2NWcKuQowP58h3ndFMg0C8LJY/W2Fjb3SQdC7p0fjFjTZVr//XMzTu1O5Dwt5DoKhu6Y+PRWCI0nWcEw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-aidataplatform": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-aidataplatform/-/oci-aidataplatform-2.130.0.tgz",
-      "integrity": "sha512-t6qZ7akZaym8FaFsCp/cdI4QIQWd0ZwQiQ3OHGIx2SN0ecmKkV2yRPE2uceANdJMmHaq6lKXPAwOiwcaxi2vVw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-aidataplatform/-/oci-aidataplatform-2.136.1.tgz",
+      "integrity": "sha512-IeenCSf4IoB85iW1ARrU2KoNZ3J7wVmO+9aUlJBZOjRfGOZ/jQeP4t8SMruvf1HnL/yQ0orc3Oh0A4vtcHeYyQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-aidocument": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-aidocument/-/oci-aidocument-2.130.0.tgz",
-      "integrity": "sha512-Bk6hzAyglxrfYE7SJqHcjAi4g3voZs2lEy6fOXWYHIPWET99UZ3mNGKRyBDpalVHcW4o7c6rMP6rtbO8SiSiiw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-aidocument/-/oci-aidocument-2.136.1.tgz",
+      "integrity": "sha512-RcAFnE5AP1VDzwoCnCB1U3WAx/ZY5XrXQVWzh5oH1peKgrRR/UzLJFGTQH2CDuo8utsGBF4O9ZMdquIzMj4QNA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-ailanguage": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-ailanguage/-/oci-ailanguage-2.130.0.tgz",
-      "integrity": "sha512-xsN9gHCgQPTVWoqbo5goNI4ynHYFdnHXIgISifVWYL17bJcpuc2xbTg+meO9+3oP8dzNgRs8IB9XFJFFh0divA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-ailanguage/-/oci-ailanguage-2.136.1.tgz",
+      "integrity": "sha512-t6/FENz29+wIW6Uu/VlprknvhA6DUe+z7k10ImFIu2aYL0/724thTrAHuMZGoYiPWalvwdM38qitHCSC8OWK8Q==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-aispeech": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-aispeech/-/oci-aispeech-2.130.0.tgz",
-      "integrity": "sha512-k5zPqk91gi6IF/5nrG1R8Ss9FEzctbWT0NHqcnmj0cwcOBRvgvpz7IH0YdPxOIjbsngT5rrh+1hPhhHDd+rzQQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-aispeech/-/oci-aispeech-2.136.1.tgz",
+      "integrity": "sha512-RFoQjJB8p5YjEUUlJHlXv0kuhA3qhmOAP5ECq2lQJ7TbJq1Rl0U4MuaBtLRh/CawSQJEzJawiYFjEbFAeIRJ5Q==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-aivision": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-aivision/-/oci-aivision-2.130.0.tgz",
-      "integrity": "sha512-65eb3msjqGUvauIl3BLx7MQoLyI9mqu+rzb1lmST9jMz1lsFaEg/SIJ9C/PWyUus7lQyivGreNnsn9gV6hiQJQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-aivision/-/oci-aivision-2.136.1.tgz",
+      "integrity": "sha512-J076jZ1bmGQKVP9WeIG4RN5edas8D7LluofSP7zZmSK4Vkk3jwnqrxvJAie1D4YVNfYNQVBUS885xKbf5J4crQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-analytics": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-analytics/-/oci-analytics-2.130.0.tgz",
-      "integrity": "sha512-w2CIr0q+NUsKZZ5U4Sxc5j11uXzY6X7+5cO6VjAcoXhifYQeQsJ7l3IQZdLekD+Bv9sebnmvQUU1zcIJZujOCA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-analytics/-/oci-analytics-2.136.1.tgz",
+      "integrity": "sha512-FLcuLMyG2tEA5Lsr14YSgvK8/YFNQ76zZSURaUcqDCIa1Ni8dlPy9NM5wTwn9/P+HDm/pwHcWPcSr/sb0Mj5iw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-announcementsservice": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-announcementsservice/-/oci-announcementsservice-2.130.0.tgz",
-      "integrity": "sha512-vHbRAY1gKY7jrRvKiGLdGjkutufwT6HKudtg2nbVPXAJw2Q4t0VP+Ftg7hOWVlbUWgSdluRPzxS37NbpSwMscQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-announcementsservice/-/oci-announcementsservice-2.136.1.tgz",
+      "integrity": "sha512-RyXiKe7rYylehdMgq4KJsbsZr+wWTJhOvmsMaKWkCEgnpuyMx6vODbZGCDQeGDIJtJSlYxUPNym1mfUp2NwzNQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-apiaccesscontrol": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-apiaccesscontrol/-/oci-apiaccesscontrol-2.130.0.tgz",
-      "integrity": "sha512-HexuAkiLeqMk9xHqSMvUxKKpYYMoXz76D5TDEkVUJDpK7rQzok9Oq62Qsyb5mctzr4Gm8nPY15Y/5FbgH5BNxQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-apiaccesscontrol/-/oci-apiaccesscontrol-2.136.1.tgz",
+      "integrity": "sha512-Z55ANkf9PFKP56PD5cER2w+C/e+z3KR2kFOBHkf6jtmaX6fqFCFxX53IDDWEKlkykoUSKQwsFYwcQQ1cFl50Lw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-apigateway": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-apigateway/-/oci-apigateway-2.130.0.tgz",
-      "integrity": "sha512-8CML4PhGpXqfxXbSfF1QnO59dnjPMZ9ZqiM15SDtFnL76qdKBYQ57OK1uKFKqU6s/1EwpXZvG8ra5szaLjD4Sg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-apigateway/-/oci-apigateway-2.136.1.tgz",
+      "integrity": "sha512-p164FNk84KJYQDED5DfvEfXFhuXoHECQe/8gDNd6AK362iF1R0OpkeOZK4BccQHNuNfI0Jy03n+ehWoel2vpPQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-apiplatform": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-apiplatform/-/oci-apiplatform-2.130.0.tgz",
-      "integrity": "sha512-ewGQyxXyxxYFouKRMC0HOrp1cpqzIiaDNhjp8wG857ETuP673V7Co4PABWJsigf/PwL1uEidpFBLc63psrnc4g==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-apiplatform/-/oci-apiplatform-2.136.1.tgz",
+      "integrity": "sha512-M9EnnhRhGiqjmEKGXtdwkVtB978fsiBSXFZmLU08HSUkwi9hjaSYOtobLyRysgCFYFllPs6vpl//2x09NMjKBw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-apmconfig": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-apmconfig/-/oci-apmconfig-2.130.0.tgz",
-      "integrity": "sha512-V1vnih8Ai/wlIu0YDXPRh+KTRPz9v2t1rsVxgXDJGHoHSTks/NETmUexadWczxkFMMEmHyRY8EX6sJnRqRhdBg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-apmconfig/-/oci-apmconfig-2.136.1.tgz",
+      "integrity": "sha512-J1XFK1lY/vE7QQpk8yibRXKv1S5m0niJUVcEoLanGehQumVtGlmXh94uZgYd75kuoCnf4WFvy40NPGKU9pFHYw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-apmcontrolplane": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-apmcontrolplane/-/oci-apmcontrolplane-2.130.0.tgz",
-      "integrity": "sha512-GntleuBImPQ2DfiEUMpoxIHZDjV45OaFbe2LgplyOtT6ktK83jAKRwwXaenFWT791EMRurOcvPiWcreueLPZ+A==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-apmcontrolplane/-/oci-apmcontrolplane-2.136.1.tgz",
+      "integrity": "sha512-V68H5mLJDKp9YZ8UL/jPu9RLLzFlcNV3ZaAVAzwFjMZ0WPGLp7EtrCt/VAnP3BpqsduCO06myC1/za/kNu7lgQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-apmsynthetics": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-apmsynthetics/-/oci-apmsynthetics-2.130.0.tgz",
-      "integrity": "sha512-RRizkkzshTU45+ZsIKhzrBRsZaMHf0KGQlLKO+a60uLqwNCyg5AMwwoYd7ZZBj8Px2nY611YFBtT1eLozUuN9g==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-apmsynthetics/-/oci-apmsynthetics-2.136.1.tgz",
+      "integrity": "sha512-a32LbAsSAK4oi6hDHY3bpHsBSkiZyuqtw7W3NANL5iSVqIIuqcnONdM+yoVWtoTyZw1mJ0+A7mW9XtnZdorKsQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-apmtraces": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-apmtraces/-/oci-apmtraces-2.130.0.tgz",
-      "integrity": "sha512-7mOUkLaVaCqPRLI+u5/EnYXD4RK83HVhvLtyjTmnyHk2nfxrp0jfKiVK+YDMEQtQdjbk376L4HbQ0xnqsnFvDA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-apmtraces/-/oci-apmtraces-2.136.1.tgz",
+      "integrity": "sha512-jOeZYsF3kfHZojGO/m7XGVjSgAEKAvH8T65m2mIFFmtZj/yhxQh6DLp2xkQGQt/D5gWwXwMJnF/MH/Ku4MoGsw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-appmgmtcontrol": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-appmgmtcontrol/-/oci-appmgmtcontrol-2.130.0.tgz",
-      "integrity": "sha512-ZROzGFcVyBWAHsCGvz/maQqVNVbfDSDyZhMhXuDadlKtEiURx8h2l2QSo7VNa+UeTH0pKi8dp3W/5q9h9e59+w==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-appmgmtcontrol/-/oci-appmgmtcontrol-2.136.1.tgz",
+      "integrity": "sha512-VlnktpGGxN0UBWPfeWi9V+G64l2i+j4k7tK2hXvBFEd3/R3jbsbC83N9J3ipYjPsYiKDslN8D8u/aPmsFY7bMQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-artifacts": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-artifacts/-/oci-artifacts-2.130.0.tgz",
-      "integrity": "sha512-nUfb4/M1ya96FK2JXadUEcSWSV1osw3rF/32vsapgWoSG+Chz3uDTFWIWZiNcrAGj4hNd1psJU3OALYmRaRhuA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-artifacts/-/oci-artifacts-2.136.1.tgz",
+      "integrity": "sha512-cyMdfCirHswytr+IRGcQMsM6CeE8YjUKvUaUxtRzc4B6eKmeb5EHDPzOxHlzsOLY6XlEhzQN9zGwIODZronoHg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-audit": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-audit/-/oci-audit-2.130.0.tgz",
-      "integrity": "sha512-ILPYCdYDYaiia1jvdjsgLV3+LLWpijIyF7dzP78LM7ZHtR0Wr2aH1lAtd+/7gBo/TFkB5E9wAqrS5sj0qIY9CA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-audit/-/oci-audit-2.136.1.tgz",
+      "integrity": "sha512-ma4Fqv7GsDv/KGvpoZlTmaBFMwTfeK1sP7pd8kZVWC6ttROLVR0UjZMLxZBEEOTfLYKbzXG0Rxel3ssK7AsMcg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-autoscaling": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-autoscaling/-/oci-autoscaling-2.130.0.tgz",
-      "integrity": "sha512-KJE+LDx1NeLzPX/44J+BUhbkfnExcYN33z1huvcr7yw/BXZGWQPx57g5MvI+9g8siKVsY7WkV3/zimzhibWXvQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-autoscaling/-/oci-autoscaling-2.136.1.tgz",
+      "integrity": "sha512-bXptG3tsJDRoB5UbWaUU5Dxxt4FRkf6jf+hrA9qwvPa/26y2TlBfKpK0/LYceNaXOVzQ6riZ+RsJtR5r6x1ZSQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-bastion": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-bastion/-/oci-bastion-2.130.0.tgz",
-      "integrity": "sha512-YPBQcrRWJCahwexSA7jmp7Vemh4X/jQHRTfe84/ZcUHzWv6LC9OVqkqPdn2pwUwRf3wFH3c3sZC6Feb/m6cfxw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-bastion/-/oci-bastion-2.136.1.tgz",
+      "integrity": "sha512-m7AAK9+STYPka1c/szyMJ/U/JZORUHRD3sfea+zhHyySI0SqlGJemdh7Qo41EQKBD9gOTyUKG7K5hubhCoE1Mw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-batch": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-batch/-/oci-batch-2.130.0.tgz",
-      "integrity": "sha512-t4c+nCwTDLJFnemGj5rfeJBqnDGePW4tPp+0FbrwT06K2zV77Xshyut8kHb7S2W9lmsxOWUhun1XFtXX37Vbqw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-batch/-/oci-batch-2.136.1.tgz",
+      "integrity": "sha512-SwZ+TYwvKyagFHx7kFTh6HGCqAZ2xYY1HoRNRrKChEBXFZrvqHB+0CG1IMYbozXBnkdSPnlXuUNRTgPmBaYttw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-bds": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-bds/-/oci-bds-2.130.0.tgz",
-      "integrity": "sha512-UQLY5RJn4ai3GvgHGqMHX5kYI7ENRmVqPqDiFJ2iU59+56gresdZqYVt1Jr6C8mrx34So6kCSxD3qus0JO3LSA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-bds/-/oci-bds-2.136.1.tgz",
+      "integrity": "sha512-bKw9T9K8pK+S0Pops4elV2HeoqbSd5gljli76L7o9xwx4+aOekhkVVszhyZ2CI3fosLkGB9sbj6VDUzXk2vBqQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-blockchain": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-blockchain/-/oci-blockchain-2.130.0.tgz",
-      "integrity": "sha512-umSSafaJGarZknc+iNnlxKMoAqPBOYm2+a04ZWyrD1qwP9HMggDwwTYlCSfcMIxAOrL07m5ldNvWJLMVX+z/Iw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-blockchain/-/oci-blockchain-2.136.1.tgz",
+      "integrity": "sha512-qOkbXcf7LprwHLAkc4iJz3MQxOVrZaLi+RPe7I8xiPNcPf8OUzUdRALuhuCRrrsby+ieGggYJTMu5RyKGe9Sfg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-budget": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-budget/-/oci-budget-2.130.0.tgz",
-      "integrity": "sha512-br2mT5S+O7xe+TrGsn7K7BXNb49ezAGz6Kzg6nlk6GFIUWz2WaSJv0MBFwRA3X+I4sqglxTQSCXVbJxNGHPeRA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-budget/-/oci-budget-2.136.1.tgz",
+      "integrity": "sha512-otvKZosPFGcMa9wytC9moMQ2ryWkIDrzvP94IpaoMLP8xLSy2isbr2V+Rs6E83luCirPJw1sEfq62PO1yavytw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-capacitymanagement": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-capacitymanagement/-/oci-capacitymanagement-2.130.0.tgz",
-      "integrity": "sha512-Ye3DM98F0s42TfZyy4jheBHcRxNSM3W5xg+aJ72d6TCWHKBwWV6EiO5+1v+xwHNO0HA8vzpZDIbCN1CjWU3SDw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-capacitymanagement/-/oci-capacitymanagement-2.136.1.tgz",
+      "integrity": "sha512-5j2I8IKNhecCB1qKYw/gNU1FKU7yDEC+iRf57nd5cVIxBdeFVBk9u3OnL+g1gyirIYU4td4iD4UNdF4QjdXhvA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-certificates": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-certificates/-/oci-certificates-2.130.0.tgz",
-      "integrity": "sha512-utVs2QBUUIBp3QxYM5qXl0qflcCXEETexFnDkYyAYqbtQzeUNLCVjW//tlR9ySmaIbTTRXBq9f/iqEMxOcdkOA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-certificates/-/oci-certificates-2.136.1.tgz",
+      "integrity": "sha512-JJ7X1I623sxTrOyGjpod311YFfEof2NHHoGccIDUER6Y/VIru0y6DQdygnngrnv0frIbcToA9paatA0iwNHp7g==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-certificatesmanagement": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-certificatesmanagement/-/oci-certificatesmanagement-2.130.0.tgz",
-      "integrity": "sha512-qB4IG2ZZSrN7wkPJslqd6l0ilfVU/rfQ2m80MhQh/n9mdjEQrg7ZtRNtp7YrlLM6o40JzZxtqVafH9xC3x7cOQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-certificatesmanagement/-/oci-certificatesmanagement-2.136.1.tgz",
+      "integrity": "sha512-mT5oOaGfSEt0r7I3DQiG/czMMFvjpcpdUM/bz0nsgsH9lpinl6c0byBMU2/dbCgo7kzZY8f1+oBkcjrNXWJfYg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-cims": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-cims/-/oci-cims-2.130.0.tgz",
-      "integrity": "sha512-CkorIr066RmouHC5Y7lKAFPIEbaB+t+bF19KlQj5MAndJTa1uWRNKr2k5OsAbfZNmpxPmoccLOsz36L95tkBkw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-cims/-/oci-cims-2.136.1.tgz",
+      "integrity": "sha512-ecW2N9a5kNT2tNSdAxiRfteCJQsaGg6OmEy0Hs07lHMu0JpjU5a/MDy0H1zczkFDxxnVuUpxtYvtfDpusaisWw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-cloudbridge": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-cloudbridge/-/oci-cloudbridge-2.130.0.tgz",
-      "integrity": "sha512-UpzC6GMDmOJT4CpMBmXtibsRMAf+aC/yBeRHzbpDIEDzJaigdYYA+ZvKMIlFa3PfBXxcIGh+cq+yPzUWKRjKbg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-cloudbridge/-/oci-cloudbridge-2.136.1.tgz",
+      "integrity": "sha512-dKPQVIPLCdLmo2/Tyt/AO8ylPvB9v9bPBF91/Md7/FcFMUM6oFnbP9l4ap/6P9rs8UttVXLDJgxm/NCb0dxr1w==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-cloudguard": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-cloudguard/-/oci-cloudguard-2.130.0.tgz",
-      "integrity": "sha512-NbYj4N+h4Ti+L8ZNqVvB/XVuWtUTW+gS1c3YskY7HPFFzlvrVOckuFYv7NfriAh3R+k2GUXRkyxX9cHNbDkAzQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-cloudguard/-/oci-cloudguard-2.136.1.tgz",
+      "integrity": "sha512-U3BC+glNhI7EVyp1HBInaOQa4tw60cLLNOXVcdx4oH1YbYxOQZDBpUHensI8KVOT2QhBlOIXGe4/bJgjwP/UIg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-cloudmigrations": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-cloudmigrations/-/oci-cloudmigrations-2.130.0.tgz",
-      "integrity": "sha512-GVMXpRxlwymBKCw1QVNnAFjCYlmQKep7c/RZM3LaQGMHKsYf2RTgykE/z+EpqxIkO+kjXelRbU3h0EGpInJAAA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-cloudmigrations/-/oci-cloudmigrations-2.136.1.tgz",
+      "integrity": "sha512-VmVtYT+G1JcztVfywphKCY49/oQQ7Q8v7nqk4J/m36vW0pJZ4Qs72FPTjvrxaBVPnnJNT7pE+BsPIiobvS94gQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-clusterplacementgroups": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-clusterplacementgroups/-/oci-clusterplacementgroups-2.130.0.tgz",
-      "integrity": "sha512-UBA+BL6RB957Lc1Lg4UjKqmXI5OiaU4H1n2nzOWYi5KHbNjMgkDeuuW4TrUq3U2RDMO6OodhN9h+AG7oHfqpWQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-clusterplacementgroups/-/oci-clusterplacementgroups-2.136.1.tgz",
+      "integrity": "sha512-8aDz0c3yacAOWmj6w7uQn8O8oq+ktiF8BzDEK9xxqjZGfIEGEqSTMzi4eNriv40d4TRS82qIedL3ManV6nRe8A==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-common": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-common/-/oci-common-2.130.0.tgz",
-      "integrity": "sha512-MkH/0Gn5GzSkG+WIhITWwn4z5QL0lCU3/55s8APfKEy6NOB3V9G+LbCSc3Dn7iGoC9V92D96rJvK02JWnHwhNQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-common/-/oci-common-2.136.1.tgz",
+      "integrity": "sha512-fiW3esdq0+WBZB53CfM66wzwRVyjPWx8HJw/+EFeUGSLMlfyJPJN4YxLHPX08Y9vjtjBe+UcBnFXbCMkLuKKGA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
         "@types/isomorphic-fetch": "0.0.35",
         "@types/jsonwebtoken": "9.0.3",
-        "@types/jssha": "2.0.0",
         "@types/opossum": "4.1.1",
         "@types/sshpk": "1.10.3",
+        "@types/uuid": "8.3.4",
         "es6-promise": "4.2.6",
         "http-signature": "1.3.1",
         "isomorphic-fetch": "3.0.0",
         "jsonwebtoken": "9.0.3",
-        "jssha": "2.4.1",
+        "jssha": "3.3.1",
         "opossum": "5.0.1",
         "sshpk": "1.18.0",
-        "uuid": "3.3.3"
-      }
-    },
-    "node_modules/oci-common/node_modules/uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "11.0.2"
       }
     },
     "node_modules/oci-computecloudatcustomer": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-computecloudatcustomer/-/oci-computecloudatcustomer-2.130.0.tgz",
-      "integrity": "sha512-JpcAbyEljuErQySuHYxMZsnVUVvocNF3OP9k4q8E3dNdhg9oU/9AdNdHO7ZccmciiWODfa0C4lKmRHhnEF5Kqg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-computecloudatcustomer/-/oci-computecloudatcustomer-2.136.1.tgz",
+      "integrity": "sha512-X+yqTUCIV0oKDi1ADlfB3JpL47YAiMrDH4aMQPf4UN94HUvvEWBsXGXBNm6La5+fqs4vLdLzvaSIKv44JBV5ZA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-computeinstanceagent": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-computeinstanceagent/-/oci-computeinstanceagent-2.130.0.tgz",
-      "integrity": "sha512-brQmzTA46z2Cb9DGdTK4yLBvp6ItBnTPqKw1mRwAGeucznQ6DClTzYXlN7y+bM4lx4an9Rh8i+SJ5BkSMEXtvg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-computeinstanceagent/-/oci-computeinstanceagent-2.136.1.tgz",
+      "integrity": "sha512-hVpOWYIrlyBTUt7CdQXMdXg1L5eEPL66Wj8+462GttRWs2N3v5NyexzdNjHrhVIFXGc+BEfTuXo9JLthGqo6jQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-containerengine": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-containerengine/-/oci-containerengine-2.130.0.tgz",
-      "integrity": "sha512-+JK4fjMPknULmlgzZl0IOI4HOpwBUFnyXHdEBbgMoWqJwl3VDy6wey/6wgN/wqkWFimhUoXzoljzviDbnXiSuQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-containerengine/-/oci-containerengine-2.136.1.tgz",
+      "integrity": "sha512-tmGoGFbUJeucvFzR4B+Sz3CoJDzHnCSYUXRfajViUkXJiQHgPiIrnKmFeYA/m5bs8rGcrvhuj4TfLs08oVa4uw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-containerinstances": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-containerinstances/-/oci-containerinstances-2.130.0.tgz",
-      "integrity": "sha512-8G79cGqFZyT37wcw65NMhHCnjnwhOCitNy44L9Q2oObOX4MdHDSqOpfAMC0rc+AbofdZnriQS65S0l4SGkDdEw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-containerinstances/-/oci-containerinstances-2.136.1.tgz",
+      "integrity": "sha512-XdOQOC0j0NfIbZXcOaDVGjEqB53/rJyI+OX4XzpgFEWc2eSB3U12QymcqyKAI+U2euMOpLZnZp06VFW2OQZxZA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-containerregistry": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-containerregistry/-/oci-containerregistry-2.130.0.tgz",
-      "integrity": "sha512-aoN4ai7iVd+svceREDiaG081gKCR1hrKQlTJi1r534YG+V55YrSH02AcWIQ9Q3VMXtFp4vLslSqB31iXTFKqeQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-containerregistry/-/oci-containerregistry-2.136.1.tgz",
+      "integrity": "sha512-c4fguqNSkYzAH1o8se2pYVYOCQrDhow3EJBlR4xFR/mAiux6uVQoQNaNqaeCNZz4loxlIgWv0FdmO/tq3HjOHw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-core": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-core/-/oci-core-2.130.0.tgz",
-      "integrity": "sha512-Q0XpYR7NogqJiwZfopgwaAV0CTdDc3eN6tKXvOh705/8VoYegW/M6uh9Ht+kOkI1uC9KIAoCt/mbNybWo3Wl7g==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-core/-/oci-core-2.136.1.tgz",
+      "integrity": "sha512-B0rAXK4ioENElyaEj6qxuKpuRTpMf3eNliGB/jDLa+gctTYS9LFuL2vd+lhY4DbRkNtg2e5zxrBMsJQINLCCtg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
+      }
+    },
+    "node_modules/oci-costad": {
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-costad/-/oci-costad-2.136.1.tgz",
+      "integrity": "sha512-DvOGGbG/BOGEeHKtShdeX18ziWhHlBD/4hC3aO451vjMM/wuBB8qE0qXQCqavA60DRTw8++rfB+UAjVmon1t9w==",
+      "license": "(UPL-1.0 OR Apache-2.0)",
+      "dependencies": {
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-dashboardservice": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-dashboardservice/-/oci-dashboardservice-2.130.0.tgz",
-      "integrity": "sha512-4Axm71BAe0UpvPv0R+lGFtcd1gNrH52PkCezUgkBarKZUZXxR5ywSCHT8V0idtqkE8ZQuLyllPsRO8DekiNOFQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-dashboardservice/-/oci-dashboardservice-2.136.1.tgz",
+      "integrity": "sha512-kx5ILjgjs9tQzMAVHH9dB5r7P5nw/+Vb8fApOr8+aOKkpCslnqSjEKLeUmY6DsR1uKcRJPffqxpl/66XBlOKxQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-database": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-database/-/oci-database-2.130.0.tgz",
-      "integrity": "sha512-ii4lQq8JCVUCrqN0wh61AtSF9ygEpH78dWx49aGPvXYvS1nqdWu0fwaWAY/XdZHw1bjlKdAq0BbGUgzex4lPvw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-database/-/oci-database-2.136.1.tgz",
+      "integrity": "sha512-4U5myllCUQ+pg8TK78g4SEjhjZdCx26TNzdwuPsSJxQrL/vfQd+/hed93nIeTIoxFM1zctaa7fsapCckXbnr7Q==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-databasemanagement": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-databasemanagement/-/oci-databasemanagement-2.130.0.tgz",
-      "integrity": "sha512-yBCiJAdOhze7Uh/KRt7pZKmGFti5b6vUo0vt8iMFxcEZguXJr/T18LH0mibA6O47navGSXI1Fr/qI7uyza7a5A==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-databasemanagement/-/oci-databasemanagement-2.136.1.tgz",
+      "integrity": "sha512-UIarBTkcMWnCGW3b/gy0Ql+5HTjTRxjc5gqhbH4lLDLw6jM69YBQBn0s3DRaZFr9T08RFQnjGoTrPbYULij5MA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-databasemigration": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-databasemigration/-/oci-databasemigration-2.130.0.tgz",
-      "integrity": "sha512-HWOaBWneF9LSffiZcqUcKp1BVh1f2BDnYiw59ORvUmvAExAAXSkcYzri541XZ2LUsvYCiB1PCCbRofxh1JvM1g==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-databasemigration/-/oci-databasemigration-2.136.1.tgz",
+      "integrity": "sha512-uIUYcizf2wgQoSnaKZ8pk4moOjhThj6pv/czSk9N/AIn0sVyWoRQLcXGwm/vaDPOm98DXNXJLAirBkYkIcz8Ew==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-databasetools": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-databasetools/-/oci-databasetools-2.130.0.tgz",
-      "integrity": "sha512-rk0QOE2QPGJBJpzRJ8pzRrt3s4o+Z1ADYeSf67Dn9l1VXUSudNYI0qQu9VGjYjb4H/hrctxALtkl1E9XqCkA5Q==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-databasetools/-/oci-databasetools-2.136.1.tgz",
+      "integrity": "sha512-bIJ69DByBmV+n/WOIY0Qei2KakKcDzI8MXGukeMiOWMPko54+aSQP9jpdWG8bwXAN2V/aq5Li8/o0+qQ846cow==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
+      }
+    },
+    "node_modules/oci-databasetoolsruntime": {
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-databasetoolsruntime/-/oci-databasetoolsruntime-2.136.1.tgz",
+      "integrity": "sha512-GGC5wdyLjlp1VB3jjIbQ9wrSVIIGhSR8TNNJgMvm0Rfi0BrIhylPnI+LJujj6fuC0WD+1y1XS9HN7MAx7HsSbA==",
+      "license": "(UPL-1.0 OR Apache-2.0)",
+      "dependencies": {
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-datacatalog": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-datacatalog/-/oci-datacatalog-2.130.0.tgz",
-      "integrity": "sha512-14TSdqT2Ntvjm3KxhRxjGP3uDpfUVAueROn4l0uZLTW12qQ+F+BvQm3vMpPAzaeTsZrCoaWNnDzJAZlqdd24/A==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-datacatalog/-/oci-datacatalog-2.136.1.tgz",
+      "integrity": "sha512-017rYcd35myOl+kl+pm82MiRVr31e8CXCMiAukKY2uCr+RnythF1U1qofgzGxnlVQugh/a/eUDjINa4UYShgaw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-dataflow": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-dataflow/-/oci-dataflow-2.130.0.tgz",
-      "integrity": "sha512-2oCCfV+s1+86JD6zDT+qDKON5PtZFV3/s3RdTN9f89OzWku24tqRYD/52UrydFgiVnVJIyPMtttcPJ6nHyNYgg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-dataflow/-/oci-dataflow-2.136.1.tgz",
+      "integrity": "sha512-+XqRri38bTfHVZpsCqzfm0NfhhLQp7hWm3zjCNiFLsCcNp2+WzjL6rmW0T4DkFAJxXWD1IrJqUbcKu11gwPrbg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-dataintegration": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-dataintegration/-/oci-dataintegration-2.130.0.tgz",
-      "integrity": "sha512-14bkC+wafyH7ayJ8eWeL+DX+/dAKJ2W9klKKbrtDUPOJ3UKKiQunzlsyQDbGxWQU5gPmUXkl5iQ49y+jc3//lw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-dataintegration/-/oci-dataintegration-2.136.1.tgz",
+      "integrity": "sha512-cVXkiNCL8Yk9y1EX6JjFYJjj00lHSxgce8OwlpkuJ5/fkQ0jG/Py9dTSC44rBTqYg1dPYTDBmesPI9HnWVrh/Q==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-datalabelingservice": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-datalabelingservice/-/oci-datalabelingservice-2.130.0.tgz",
-      "integrity": "sha512-Pq8N19CdqfW9zHPTlDmlq6U0tfpfLGcu9EpaCKE9b0Pg5YKpDOOV8q/0GX1smqnE+rltrXUGRA43V/lNxAhELw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-datalabelingservice/-/oci-datalabelingservice-2.136.1.tgz",
+      "integrity": "sha512-Mvz2H64M0bqxQkKgjz2Q2Uau4qglrMxSQUCob9X+WIabN69Vaz7Ch++ofkIruegrh7WlCQDQ1lh71T1xcGLHXA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-datalabelingservicedataplane": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-datalabelingservicedataplane/-/oci-datalabelingservicedataplane-2.130.0.tgz",
-      "integrity": "sha512-cY8sztKtk24ywwZ/2BJ1rujOB1NkPk34WyTYhbHrRf6KnCDQUiy1YHC7I4q/vb9pYqHC7dkt7msnTVPu7LDh7A==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-datalabelingservicedataplane/-/oci-datalabelingservicedataplane-2.136.1.tgz",
+      "integrity": "sha512-rIvdIYKj7l1xKnXI4GNUHqDtYaaD3qS2G38Dk5Uy7k6tO0P/Bm3DKWc9OXYAW7/iZBdDVv5V/azqtiGBbghqQQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-datasafe": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-datasafe/-/oci-datasafe-2.130.0.tgz",
-      "integrity": "sha512-Fl8RPWTCFtQgumGQm2hfwA/QtwA8nrQHrq4oXxJK1hn2dcGiiVwmmIXre+WAJ3Ib0HI1CCrlHicTrS+8xQNVhw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-datasafe/-/oci-datasafe-2.136.1.tgz",
+      "integrity": "sha512-ZsR4omWD+SSoEfmzp8MnHTXoiwLf19sK1wWvpeyXGDH6ZB6gXLnOTMFsdyGe9QgxRdnJ0Q88gvrXUeNGUyBMgQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-datascience": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-datascience/-/oci-datascience-2.130.0.tgz",
-      "integrity": "sha512-1AyFk0blFLe6lOaR9alvrEQxP0YtBa9vWVX+a6Li1isLrTD64xYH1udmbgQedQRfH/Va+MfJ+aCblwfpScVR7Q==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-datascience/-/oci-datascience-2.136.1.tgz",
+      "integrity": "sha512-SBANOh0AxlnYAgZcXHQa1mDjeAt34TL31MluRCAj6MISSmD3JtVj8vvkgfdRzuC1fH+vXVN9IAP6XAh8H6STpw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-dblm": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-dblm/-/oci-dblm-2.130.0.tgz",
-      "integrity": "sha512-6D3Uu/9ddPgVnp5Q9w8XBBnAgs/AIjcaFP+d/0u0VMcx7eSt+7EcU2/QEfnJRt5XCp0CP62AFRfK4F1MsyXwjg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-dblm/-/oci-dblm-2.136.1.tgz",
+      "integrity": "sha512-J0wl17r8aD9PQPpYrjW4j5Y7i8JmECU82zhvrhBwDNxPR2MqIbDbyr52+baGRaNPBdKlrhW44UHjrOgn2Q9LJA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-dbmulticloud": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-dbmulticloud/-/oci-dbmulticloud-2.130.0.tgz",
-      "integrity": "sha512-xWbu/efcb3qC+0wv7T7aTe/FL5DcsrzqoDwcv31LnxQkbHVM4q39m3C04piYdQkU0nqVyY9yXKwm5vYagkI4Gw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-dbmulticloud/-/oci-dbmulticloud-2.136.1.tgz",
+      "integrity": "sha512-XfO0UnEI639Aa1h/pgD5Y95omXr68ClMSVSjRUVMXtxc3Jfp4ayzegm9XFbuhdQWuzC9aKK3koMM2fa+V3G0QA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-delegateaccesscontrol": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-delegateaccesscontrol/-/oci-delegateaccesscontrol-2.130.0.tgz",
-      "integrity": "sha512-fEuOnGfVNfwcUTQ2m/MkwWg8lkOvLvmj2WqmQPNDdmzD2pfFozlRmD50pkDuZlrvCnB7TT81SX6PzouTfjflZg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-delegateaccesscontrol/-/oci-delegateaccesscontrol-2.136.1.tgz",
+      "integrity": "sha512-2Ti/m8RNdSdZCSNOX7/tfzu2KXKwqxr7shEBAtn6tKwWcu/LHkBvM1i976EgF8basYEICXUVUhkuxkEg/36FNw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-demandsignal": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-demandsignal/-/oci-demandsignal-2.130.0.tgz",
-      "integrity": "sha512-DuGhBCOzummTz6eNlhq4jQoxHoCujD8I+V5mgD+Q7em82+7DzBpV59zKayS3/H3nfQj4Q6ROasiYtGzhXMTeFQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-demandsignal/-/oci-demandsignal-2.136.1.tgz",
+      "integrity": "sha512-9yZGswSnLwYhX8wc7MqmnTM3VtKcdDdcZOHKCA7niMFL4pybFKlLrpgVTRaK9KtGWD/HooyS0eJNApKDAyyvfA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-desktops": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-desktops/-/oci-desktops-2.130.0.tgz",
-      "integrity": "sha512-L69hCGcQtG8L4Hsv49tuBu3dJDueV0rUv+Szkkvrez/ZaIy31bDOeF4ny8hme4+KB5RYP8oW1zHUj+G+q0I6Yg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-desktops/-/oci-desktops-2.136.1.tgz",
+      "integrity": "sha512-1nDgfElJM76PMEfMXLS3bSPrUnIgp1CbTGJcHIVixT5ylaSBb4pM63hNOl7H04hUFbB53s7YNJLcuQOp4ET39w==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-devops": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-devops/-/oci-devops-2.130.0.tgz",
-      "integrity": "sha512-EXNgKFqtG7lkidPnpgkF8pH9y4Pq6YdcnWYjBOvhok05/FSuzhLFI+8VG/oIf/H9BV/GSW16JTylPLpBplPK5Q==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-devops/-/oci-devops-2.136.1.tgz",
+      "integrity": "sha512-nerWTCD9Xu0TdEGegYBWZUSJ8tHrCm36XXoMV1Ell/5ITBwa9+WYOMEF7+Tksv7oMIYoA1cNFXKS6hx2RH4mBQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-dif": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-dif/-/oci-dif-2.130.0.tgz",
-      "integrity": "sha512-pi5rDGII13l4hiPd348NvlHi3PtiRyHUw8SIyq+aDpwN1zStpgbc/2O+iQjncs/sgcrkcgNXXd79uU+q+1+XDA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-dif/-/oci-dif-2.136.1.tgz",
+      "integrity": "sha512-wo0ORE6xRGl/m2l5wC2YK5qXYRr1J2Ya22a/NOHjctlUWIedyaT+FQE5vOXJ8W+z8I/trgS2OiTvSP2GQ2hODw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-disasterrecovery": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-disasterrecovery/-/oci-disasterrecovery-2.130.0.tgz",
-      "integrity": "sha512-g8S7mHgWuqcRo1iYVmTXMhG2mChBCosAR82tG6Uz7tccBqKyLBzpp31zO3wGYxxYsVShRine5U+Aps0+ZlnJhA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-disasterrecovery/-/oci-disasterrecovery-2.136.1.tgz",
+      "integrity": "sha512-RMKfUfzsedQkwRnDwPtR2WVF+QdFWKDL5fJgiek4MqZSYFtwjDI/BI1eA/CKj5YB6MHdcN8A4uIYRn1EFJ24cw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-distributeddatabase": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-distributeddatabase/-/oci-distributeddatabase-2.130.0.tgz",
-      "integrity": "sha512-LLF0l0q7BdJOGeQVWDHhI7tc4TQwylW2SN5CYcWGcohkSFUjjXqukQq2jtRSdRxb8grN9zpNiFKJ77nOZFfH/A==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-distributeddatabase/-/oci-distributeddatabase-2.136.1.tgz",
+      "integrity": "sha512-ghZSUPZzEtssIFs3T4LPVt5mG4ZwwnfenInbZh7S/B5+c15DpDf0UTG9ER+n024ZRSU3XJkbavbxBF8BkI77Sw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-dns": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-dns/-/oci-dns-2.130.0.tgz",
-      "integrity": "sha512-mhN2Q3VbwGUD/CD5K1VstNHDCWj3gIg+7eR5O24w/Qz2OZxxTa/M4jI0av6V+EwuEnch7tqeezXJsAivoyQooQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-dns/-/oci-dns-2.136.1.tgz",
+      "integrity": "sha512-NgLlLNFs3gml2I9vtHSxUdoRsrNwDc5l+AzRO+w0yXENCDq17CMsSzp1HquvqnDkzgyfcuDUO9hCt4vrGUNX0w==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-email": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-email/-/oci-email-2.130.0.tgz",
-      "integrity": "sha512-RTm4xipO/IY7z1SYKZgsfQg2jTGQ70mMxmL6QAISmHeMmfS6ZLEO2+VzXicyK3L46Q5Zgptba9kMd2IlWmpkBQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-email/-/oci-email-2.136.1.tgz",
+      "integrity": "sha512-UVEloEaTFniXg8Q5xGabArTcdKXavXQrR2V0NEUxnLiRTsrZvxfefUSqSI86EBfStmsb4em9sJ1M8Aa7ByMxkw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-emaildataplane": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-emaildataplane/-/oci-emaildataplane-2.130.0.tgz",
-      "integrity": "sha512-DRyM8OcaWerbEgEbpWbfxUwzVRtJrUdEHOI4Xx8UvT5cJv+1ri1sQ8NXWb5q+2hX+WLPvT9g8lInHELuOSJmnA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-emaildataplane/-/oci-emaildataplane-2.136.1.tgz",
+      "integrity": "sha512-gcP1ZB0lkzvAfyvBMG8T06AMtT4w87Za00iRvTWngzCjfjvDpWRZGFq5y/Y6o/qZTcKjRz1kAgJrMtrlafJ5kA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-emwarehouse": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-emwarehouse/-/oci-emwarehouse-2.130.0.tgz",
-      "integrity": "sha512-/yFXfF6ZU+M8cbdkKs/ccZtiMA7RNQocpFNfH8OCHoXoTSO41TN1yKExqXHYzUKOQrDQPlEYWJONsikYgvl2HQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-emwarehouse/-/oci-emwarehouse-2.136.1.tgz",
+      "integrity": "sha512-hkbtM0Rn5j6yieNJ3BJ0avPkchkziDChEFlU1u/yDWSKMGmyvO8vLHc7J61R6tTCBS+FW08Gdyk5cWSbx+PmSg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-events": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-events/-/oci-events-2.130.0.tgz",
-      "integrity": "sha512-GTAC9PF5Ubjrmt8FaB6/sDkWwDdPb3BO/DhRFTr63jKrm+7QBTy7J6U7pQYwEGI7/ZfB2kRpjKh6MonjKYheYw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-events/-/oci-events-2.136.1.tgz",
+      "integrity": "sha512-vnUo+qEyf/NcE0qzEEz1sH3OCpBl0dDYaj5x7i3K64GE4tk2H2wtRzKosJQGy7oIkMSu1Tq//BCR9H/DVWTqpw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-filestorage": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-filestorage/-/oci-filestorage-2.130.0.tgz",
-      "integrity": "sha512-15W9hqZnoY9bmRtd4vZgleGRy+S1g461C6BTECQmnMzOsDHR41RD4L7Fh2VWSo+YkP9W+i+pWRAjliKPZE7K1w==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-filestorage/-/oci-filestorage-2.136.1.tgz",
+      "integrity": "sha512-/HG8qLSmh5xGWmgagNV0cs1quZCXKATadmSj2Vbsz8LR5YMEZhb3KhuiRawplT4cwQJiuvKS+UO2OXtb2hinmg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-fleetappsmanagement": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-fleetappsmanagement/-/oci-fleetappsmanagement-2.130.0.tgz",
-      "integrity": "sha512-X04Mlp7QEXYq4051D5Uehvsgrfi8GL1FsW39k6wDh/g2QRJodpTxsnZhxJsW9Yg5mkvBaW34fpUlvAIULtM/qA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-fleetappsmanagement/-/oci-fleetappsmanagement-2.136.1.tgz",
+      "integrity": "sha512-XPDFPE51J8uyJZwDo8zvr7d7QvcsFrrB5pZaWrMZpneh9bof/TdsxroIxq/+ze3Nhd6TXrKKG1rDZAk9rsDlmA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-fleetsoftwareupdate": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-fleetsoftwareupdate/-/oci-fleetsoftwareupdate-2.130.0.tgz",
-      "integrity": "sha512-vIj9It/UTIEzN23XgwBS0iDqUgzcwc0B/xqcsNk2at9quyu4DPuaeO8u7gu5Rte0mcyOj2Leod0o8M212AvFNw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-fleetsoftwareupdate/-/oci-fleetsoftwareupdate-2.136.1.tgz",
+      "integrity": "sha512-zCEkrXscHnXTrHuifMAkW5nynBXsY50WFAZE4aIyBrDaruoWWo76rcyvKqICyJPUxkt+mbcjcfJE+Y19NjS/uQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-functions": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-functions/-/oci-functions-2.130.0.tgz",
-      "integrity": "sha512-7PPHax/bJ9HX28wh+gP1VBgkC6GZ33SeZVIs/+vjD45Ox7euWQ1rDDGcEE21pt3HjlVsgUkT0NA/nv9Y6YbQfQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-functions/-/oci-functions-2.136.1.tgz",
+      "integrity": "sha512-GXdJzHZsSfdU94XPCTi7oTILK3xcHo8uugRVNMPo5agrH/YDzqCaQ36gIyzQtoq0jLiuCxVOvYMc8NclW6N7yA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-fusionapps": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-fusionapps/-/oci-fusionapps-2.130.0.tgz",
-      "integrity": "sha512-ajsYtd5iEZPQWkCezlvsKO9XOHPYXraM6alDNbBoz8nZcLVmGjD5C/MI3OTWFwYBDr1PGVw5pGSjm3jFCv6HmQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-fusionapps/-/oci-fusionapps-2.136.1.tgz",
+      "integrity": "sha512-RuD+z8FgbCkhVkHLzZHn98r3ZNjV+CN7PCkmyNeaJWKRv57Lj2dB9v+iyuFTcHPrPIyby2AMy97aPyvCHC5bow==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-gdp": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-gdp/-/oci-gdp-2.130.0.tgz",
-      "integrity": "sha512-M8BiqCMlxBiIToR/8CRn1GDH2Ont14Mk2azCqWj6DQyJ6iXrNApGXD9XpabD2XBNBc1tvD1umLj3dqlnqnrv9A==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-gdp/-/oci-gdp-2.136.1.tgz",
+      "integrity": "sha512-V66kbj6yOxT/Z1YNo+cMUAyLZ1myKxlZZ2JBYaWnbxgmjh2eMRekJSxIV0KtdCLb55Pg7D9VNWvaHZzd/Afxog==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-generativeai": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-generativeai/-/oci-generativeai-2.130.0.tgz",
-      "integrity": "sha512-X16wuNrBxipGK+IAz5p8oCQfULKac8wQIz1K66X9GAd3MNHKCMJK9aTnPTFFjMllsDf2ymxEjZfTdMFDIpmf/A==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-generativeai/-/oci-generativeai-2.136.1.tgz",
+      "integrity": "sha512-vDBALuqe22P/aQgklFOf5lIHbX7c2y7GMc6+4AhD+wnhvFy9vXuqTOEdOUTohyM7HoNOKGyXnhDQgxqnuu3Ulg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-generativeaiagent": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-generativeaiagent/-/oci-generativeaiagent-2.130.0.tgz",
-      "integrity": "sha512-0A6wJSUwrJT7FdC04T89RSEXPLR4P4g9I0qNtcRDC20ogHUevKYrbT4gg0cXt6zdHvUlD5R9eRlBg5XxMa2O4A==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-generativeaiagent/-/oci-generativeaiagent-2.136.1.tgz",
+      "integrity": "sha512-SkgiHSAE1Gcuc34foyke/0GIEGdAkJC8fLbm/snaNJtMT6CUcGjgkGfwAbRl1QGvCPHj6afil+ftgdiBrBIfgg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-generativeaiagentruntime": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-generativeaiagentruntime/-/oci-generativeaiagentruntime-2.130.0.tgz",
-      "integrity": "sha512-2tsnrYzLIRf8N7IXhOpw+xUeP61WMgM0eCpY99J/Z4I/y5yeWCib5pG35yrXQnUmfk7WVldo7+gR9SZvkkNdgQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-generativeaiagentruntime/-/oci-generativeaiagentruntime-2.136.1.tgz",
+      "integrity": "sha512-M9cAs8NHQVDy7DPqc6RXi9q6CO2pp7ga8xEJdy+mzjMcu52HSpdyxRc0WHhgK1ifhMCl0X6KpyZPDQMucRwpQg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-generativeaidata": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-generativeaidata/-/oci-generativeaidata-2.130.0.tgz",
-      "integrity": "sha512-Q5W+xp3kvXkfoISjG4UxdDIDIFcTd+z8TIP48jHnF73vFQZ976mx9DlL6IC4a9KJDQ9d/Ztxl+7+E295T2riUQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-generativeaidata/-/oci-generativeaidata-2.136.1.tgz",
+      "integrity": "sha512-F9qrNzCen25yx2USdeq9arvCT5p0q6mJXT9KAC6BCY8pUYfaknbF9wRmjJxjzhVyESxPkup8eF3+HYv/7m8dyg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-generativeaiinference": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-generativeaiinference/-/oci-generativeaiinference-2.130.0.tgz",
-      "integrity": "sha512-6jayvHp9frEPzPPv2ZnUAT1XU+IyXfZ3oKrB2bwFr1DLSjtuRyLWdebuO3jgJhBdpjV+72ylYO9CFFwp3pWRUQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-generativeaiinference/-/oci-generativeaiinference-2.136.1.tgz",
+      "integrity": "sha512-sNiqzbAlsKzlN5e0LYgb5OgAQXG/ebOgDPCX8EJQ9d1vowgePTEWvDPHg/NxSn2p9HPdVgSxSWOpKrzi9og97A==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-genericartifactscontent": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-genericartifactscontent/-/oci-genericartifactscontent-2.130.0.tgz",
-      "integrity": "sha512-6pG2VzMePPMiZ/oJ5k+N7wz4Eksx8F53Bg7W5kY2SlhK38Mj3iGEhtzvrjDb063ZycgSGudZZqKwiS6SPCQ8sA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-genericartifactscontent/-/oci-genericartifactscontent-2.136.1.tgz",
+      "integrity": "sha512-xa3/rIK5YsgFbnYYvyHb7Rx0Bnvya0nn0Dif3yJhseuHip2sWReCrQW+rnQ56H9aYbA/EgNFx/j9DcQ5si0nqw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-goldengate": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-goldengate/-/oci-goldengate-2.130.0.tgz",
-      "integrity": "sha512-kBzE8L9lFpLaygIAIFvip9v3tcd7px6ZZ2Hf3173eCGohugQ9a3sALAeMlEpCYghoU41CWmtEIpeZseeu2V+Pg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-goldengate/-/oci-goldengate-2.136.1.tgz",
+      "integrity": "sha512-HxQ55SagdPToEub8W8JQCAwvx5/HCWZv3QPPB09MjkzpovCSzLhC/zINnXkjP0lVyWRaK6qSXyf1FlYKSZrp8g==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-governancerulescontrolplane": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-governancerulescontrolplane/-/oci-governancerulescontrolplane-2.130.0.tgz",
-      "integrity": "sha512-k8niCYISgwlltDze3mj2pGjAg1O+RDf5sFn8OJ61Y74ARnhk14q1supx52iooF8lhNBm5qYb9R7fe6paTprphg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-governancerulescontrolplane/-/oci-governancerulescontrolplane-2.136.1.tgz",
+      "integrity": "sha512-qVRHqXVW7otCmyy8jnLK/89suK0d3h+kI9keZIEsKpjc5My9idWlR6iViDhdsvB6vFCeVKy4au+j+rPNExjOmA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-healthchecks": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-healthchecks/-/oci-healthchecks-2.130.0.tgz",
-      "integrity": "sha512-MB53lNGR/jaceAA3GtBCLIK6uLE2VbVK+NOdGEumlDCPTxlRn0SC3QpdCoZ3/zs4pf7ku6EpLKUVo0SkHiX4NA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-healthchecks/-/oci-healthchecks-2.136.1.tgz",
+      "integrity": "sha512-IcGxEkZ6byuIhtxs9QghpZRrApK4vJbiYIw/IRFm8d3ADA5vHCH2cdq4PG5U3dHwQ7M868FHzjI2dKeJVDqGcQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-identity": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-identity/-/oci-identity-2.130.0.tgz",
-      "integrity": "sha512-t6S6dXYxBPBJz+6xggL4JVpnsFuKtdfLSkfsFSMQf8npkBzk8l+NESfwGH2GDdUrcYn5eIFzQ1/k/ciRzAyJsQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-identity/-/oci-identity-2.136.1.tgz",
+      "integrity": "sha512-AIs8iTzGWUHg9hEmqAqWctFngyVtG0SO8HGCSIRvHPFNZd7llIgqaoEznJq0aorfo5ybCE0uCrZ4PL9MYvji9Q==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-identitydataplane": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-identitydataplane/-/oci-identitydataplane-2.130.0.tgz",
-      "integrity": "sha512-hFakcxGM1YxESqYTutlKljEEp3KCrCjavWTfbQSY2QW+/4Fgsn7U9uPCH37GMgp4qpQuSm/j5Ad/zn3VcvB+sA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-identitydataplane/-/oci-identitydataplane-2.136.1.tgz",
+      "integrity": "sha512-/G2HxPCXNgISPBManFRJ/SXHZSu4m7GD/wtktCZNjeLmCVfZd1nvsrQPGRagUeq04t46twm0/7liw7jE+XOsiQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-identitydomains": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-identitydomains/-/oci-identitydomains-2.130.0.tgz",
-      "integrity": "sha512-w1/7v+AdG0dxoJseAD7Gc1GoBlb7BBX0Kn6FOdNqd0xMmeSv9GnaSpKK0LqgDXBaTn7VcyMPbrNJUOrRFBt57g==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-identitydomains/-/oci-identitydomains-2.136.1.tgz",
+      "integrity": "sha512-RKR2GTbYdmZq7prbaNo22rAVC+NhkZ+Mfsl9OvA5wGO5uviWN1pOt6fGznT5bAYmd6aHN0XhqSEafUW/ZGeG+A==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-integration": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-integration/-/oci-integration-2.130.0.tgz",
-      "integrity": "sha512-kDsrJ14hyBJb3eSo0PcJXCX+v/xLfK1VoLZIH8UcZeXlSMfOoDoY39ub3fAIP8jjQguGTR2lCKpHxkrgv51Sgg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-integration/-/oci-integration-2.136.1.tgz",
+      "integrity": "sha512-rAG+lDMae3dFRqNV9/yM0QKdAYqV4eJB6cgB7P1Txq8ADuj9XuqzFyxDe8SboiuLenoRmmoX5Ydey2wzs6VvSg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-iot": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-iot/-/oci-iot-2.130.0.tgz",
-      "integrity": "sha512-14SY/72LyygKeExSfKU93IGvjs959WjrXFnBG21Fqzp+Sk3XB/e6jRMKC5T0PJSObl93CPdy6F3310TUH7kGmA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-iot/-/oci-iot-2.136.1.tgz",
+      "integrity": "sha512-DR79axBRmjFt0bGIgZcx5yRGA1JL3GR+ZStqeYcIgRCjNLOtunIlCPTLanT7VDib+awSrG02oV7zv7kEyAujoQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-jms": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-jms/-/oci-jms-2.130.0.tgz",
-      "integrity": "sha512-saEWUykXyez/RiLqzq+GLvmSpixhoJdrC2BEGo9G9yAvcEA0vasHz/SJ50UQOPEGoOWE3YqowRBOFg1EyiQq2A==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-jms/-/oci-jms-2.136.1.tgz",
+      "integrity": "sha512-gAEQI5v8bJ0ML5h516oiYfEFUPBBqRYsHxmLj/ZryPgguIyWSAaN1A7M6bjs3N7zhQNz2bIp/YgzrAsl4Tm7OQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-jmsjavadownloads": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-jmsjavadownloads/-/oci-jmsjavadownloads-2.130.0.tgz",
-      "integrity": "sha512-0Sm3NL1R84N5157GcCMmhDNAQADYcxNxuQz4r6cDY6oMnaRMd35pPCxJPPiP+G4H3yOMk9PimNhKX/VFP/z5Pg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-jmsjavadownloads/-/oci-jmsjavadownloads-2.136.1.tgz",
+      "integrity": "sha512-6Eda3uayqHmO+PQbvuHfuFR+pCPAzTDD532PeZBhQ1dZW25WuLzJ8Awmad/YswD3XvU6lm7K6SRw8Xnsy5cDeQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-jmsutils": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-jmsutils/-/oci-jmsutils-2.130.0.tgz",
-      "integrity": "sha512-SqK0cSMgjJ9FsbVi3vxiRU+K2PM1UakRli5bVfULawcZx3QSnjCkxnOe7fE7dqlYQzf04iu1WuZImPo14/XulA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-jmsutils/-/oci-jmsutils-2.136.1.tgz",
+      "integrity": "sha512-tkGblYiz0aEbQJMIQ4q7Jq7Kflih6Z0yEzjHxiypN85Cz6Y/z0fObZ3c8QGrdjssyd979kC4SoaJG0SBL/Qm0w==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-keymanagement": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-keymanagement/-/oci-keymanagement-2.130.0.tgz",
-      "integrity": "sha512-LwrLxfKAMbhdh+CpkpXjhHEywwSK/nXQGnMslZLCKqjDdUi9xoRjtvuE5fGKLdYwcP9+FNT3fNNJD6c2418FKQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-keymanagement/-/oci-keymanagement-2.136.1.tgz",
+      "integrity": "sha512-Vcv8Nb8L7uP6cGBifWBIW0N7lr2taQWBidi/Ia90b3YVEL35kblYMpX++jNHuw/YYthy8fbEMoaamlNGk6cqyg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-licensemanager": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-licensemanager/-/oci-licensemanager-2.130.0.tgz",
-      "integrity": "sha512-iMaD88nPJlfm0BNy6cnJw6pQI1RkuaSxOsAFntDp2ve6jdrjPM7r6nwnLtdS37q43hZcp41cKxSdLw7jD6V1Xg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-licensemanager/-/oci-licensemanager-2.136.1.tgz",
+      "integrity": "sha512-nzLwOqkap55yw+r0CVOa30bPXgHu23/mmP0eVMeMsUVbdPekIB2X/PbiFAxRSAkqD32Ul8zTLb3WRf1fCmpnNg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-limits": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-limits/-/oci-limits-2.130.0.tgz",
-      "integrity": "sha512-Binck0toLR7SRFEj1fHIQpZ/gS9XRGLKhEZqgWtr/BvKmzkzGgaKqml79jUuj9kRRz+OJaHnY3xJ+TTooRlZqg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-limits/-/oci-limits-2.136.1.tgz",
+      "integrity": "sha512-P44bF64mmixYm+U2nFIbr1Gh8XlpoAFByTdRegU4B8oaMkBdN7lTYcJkBaD9GFjXVE4/bOjH58OsQuTL5/39fg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-limitsincrease": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-limitsincrease/-/oci-limitsincrease-2.130.0.tgz",
-      "integrity": "sha512-+R/+nX7NPiMHrodFmIbbRUdMXL0Y/LDBcdpZbJqOsiU6HQvoMcLCfgAjgInXsUPaX3Ol17WFW8DPq0s07Fkv2g==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-limitsincrease/-/oci-limitsincrease-2.136.1.tgz",
+      "integrity": "sha512-kG1zJdM/T8hHP3F7ixRXgo1qVMJgM3ZZYMkpl7i7NW5ilb7LHjlpy4+3pehzfJ5i2z3gzgXK4KUXs28hdT5YtQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-loadbalancer": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-loadbalancer/-/oci-loadbalancer-2.130.0.tgz",
-      "integrity": "sha512-0CRM05n307G7/UD1xRifzQHkWWRQwXfWnLiTxHJhLgqNXZqwWNFTCfcGxIKPaLz0AjyzdzAI4ioMafLMOYaq1Q==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-loadbalancer/-/oci-loadbalancer-2.136.1.tgz",
+      "integrity": "sha512-KNGW//eS6reqXaFan6Hd6yEIPQjs/1E7//YfaxH+oejCQ3Uy6d11wR+XSSQgEYm4by+zjkQwcCeOy6ln+8nb4g==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-lockbox": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-lockbox/-/oci-lockbox-2.130.0.tgz",
-      "integrity": "sha512-e5/AKJ8lHbUEr2xglu+0GfIFb7lWx0s0I6MqSl5YDgxhJWytxVHqdhF5dN8dM9sUjgjDK+w/Dq5JAtasRfHNiA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-lockbox/-/oci-lockbox-2.136.1.tgz",
+      "integrity": "sha512-6cjdeSLBDAysbVE6rSQtRkoxZfq4xGbO6h2gXFP2cEbaKRp6eSA2THMlimyjFHiT+uTdd7jq64Nap9kMlt6XEg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-loganalytics": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-loganalytics/-/oci-loganalytics-2.130.0.tgz",
-      "integrity": "sha512-BNO+V6Bdb44ZYcX142d+cw+2KBZcndxejlHbun6FWnHapA8Fu21VxX1bexddk3xkp4vvn/UTW88D3CCrY6upgQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-loganalytics/-/oci-loganalytics-2.136.1.tgz",
+      "integrity": "sha512-akUG5Jm68iCmpbYYcmLaGPa336gI0XYmxOaIhHTFZjymKklnh1MyDgtGmBPX0vwmmStqber0z+wv4HwTM2r2zQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-logging": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-logging/-/oci-logging-2.130.0.tgz",
-      "integrity": "sha512-LuNEyW7P/WVJamrPJATIsYwAPYkT1qbHeQbjYIhJpO+iGAy+dvneLj5V7KQV9suO+9NjOaxBhx2PWf8q0VbqIQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-logging/-/oci-logging-2.136.1.tgz",
+      "integrity": "sha512-c8fl4RiZghr3Yjs25fawP9wFcVhLBUohZwuuVtA1jovCnvukW+P1qo//FJARQaY/hwjeY3XJyGrlGul/O5OgnQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-loggingingestion": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-loggingingestion/-/oci-loggingingestion-2.130.0.tgz",
-      "integrity": "sha512-IfTs98E/HTeZkSJErc1nKHGPu0VnifR44WoR4J3PRMmJnWZ18k9+9B0wLf+wQxpug+ZD8wCq3YoXgF4GpLAqRw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-loggingingestion/-/oci-loggingingestion-2.136.1.tgz",
+      "integrity": "sha512-7MfS025tvK449KgY/tVQzBnLGhdbJtqUrXA/UgjWCwyOadzlPaSivmrTRo/lchlhHHHqbqvDr8kUCDF1Cj6smg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-loggingsearch": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-loggingsearch/-/oci-loggingsearch-2.130.0.tgz",
-      "integrity": "sha512-ZNWiSePOFd/PNlFQk16XJmDnlsf1hrGjMgChHGE0hxCnH9JRlCs9GGU/ayIhmkaOUBOsY/bKtgx8cpHCX92Qng==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-loggingsearch/-/oci-loggingsearch-2.136.1.tgz",
+      "integrity": "sha512-emoXx4B8Gc+On9HMNH2z2yBlYuAsWCB6cD2IJ6YQ4RvXFnozeBtCDcuNeElGwwwKl7EeBLOJ2IexxaUGSK3Fkw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-lustrefilestorage": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-lustrefilestorage/-/oci-lustrefilestorage-2.130.0.tgz",
-      "integrity": "sha512-j/s+FWl13VmCMZq9hILStC8mM5kWIqfUkeGAuJT3kG3SS0+tHpcNhCXGlIxTTI0ZLK+uh9VAJZ3jNixUvS3qcw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-lustrefilestorage/-/oci-lustrefilestorage-2.136.1.tgz",
+      "integrity": "sha512-MX3/kaU98DyQOnC2M3dcberZIKtcHu8YY9I05XlL9fIXCO0F+ea68WfIkWqrB+laOEedqpm0igXYYH9PKCS1cw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-managedkafka": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-managedkafka/-/oci-managedkafka-2.130.0.tgz",
-      "integrity": "sha512-axMiG6cqJf2hnZL7kekfw/Z4+Ey1SYW9JHa9MvFTElbkEABBpYic9N/tHGxYOsKtOXHGUYvF7G5uYT4xMr7x2w==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-managedkafka/-/oci-managedkafka-2.136.1.tgz",
+      "integrity": "sha512-wcl5ylCJrXGUICNy3GK5b3f/WKHxNWWYFgOc9w/yvbOERI7kjkNjo6JW8Hhi60ru+XIQ0QKGoDSC8ka8aVjuZg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-managementagent": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-managementagent/-/oci-managementagent-2.130.0.tgz",
-      "integrity": "sha512-Cjk8A4Ct9hxjqtwNZzKXUgku/DAZ8gs3vnN0kNqP6x3R0m0p8DgLftjwbAh4m5B64o/F5FHsZ5RMmE1t+mXL0A==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-managementagent/-/oci-managementagent-2.136.1.tgz",
+      "integrity": "sha512-cuQqLtNUMzyUAPZlX1iM1gl3C4z1EH1F3yPNC3DNPIdDSxbN8mGX4ZUfSIXFxD8DvmOsgNR+ALnCsB8pIBcEeQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-managementdashboard": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-managementdashboard/-/oci-managementdashboard-2.130.0.tgz",
-      "integrity": "sha512-i2eXnSHkzlVdU+bYoN6PJcZBtzcsrITKpi2MJtayQVozDg899KUKQYnSAhI0j9XCwTN2GY+st1DADjYj9xuDjg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-managementdashboard/-/oci-managementdashboard-2.136.1.tgz",
+      "integrity": "sha512-NtecS01CckfXsGGhz3ruDGIYch66ARxx+CbfmtbhtE4By3oFQC1mJt+MGqLh27mGGoStfhB3KO0BooGDE2Y3Wg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-marketplace": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-marketplace/-/oci-marketplace-2.130.0.tgz",
-      "integrity": "sha512-DvHQHhehMVkCEC01B+Ti9kvHIR/AQkqNOexBeSnk4XcwQ3ZRQ9x+znGkw70ubmPJfAlaKl1HoPzRWBSu6fpokg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-marketplace/-/oci-marketplace-2.136.1.tgz",
+      "integrity": "sha512-vp1t1sWi3ezTZBreF/N3nkfisbSbwOPeTxYLljtYozF/uRIzkdz9ZC+VoBcW7af7XKHlu7Uqv0Sp7Wrx7QqMGw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-marketplaceprivateoffer": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-marketplaceprivateoffer/-/oci-marketplaceprivateoffer-2.130.0.tgz",
-      "integrity": "sha512-10sKhO/LR69/M52ELv0nSp4tngxZEd0wPpkZWPAmBAp6zdw9riqGdNCV9sM3OejApuwnt0v+XA6QSBe+kHl86w==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-marketplaceprivateoffer/-/oci-marketplaceprivateoffer-2.136.1.tgz",
+      "integrity": "sha512-YbrUev2hV/PKBx4X8+MsY5L/Puv3wKhtL1W1a2xqLhI5NJ2xVemKXavev3gHBjhiHlwk+9CbJW3xgOIsvZ9dYg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-marketplacepublisher": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-marketplacepublisher/-/oci-marketplacepublisher-2.130.0.tgz",
-      "integrity": "sha512-SIUmTMgYCchVlc5ocmZfjAxZCa55epPygxE83BOmpwGTricOmSBuUGq+s1kKzDsKhws5/uL9HxhRWjrFdLC+Mg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-marketplacepublisher/-/oci-marketplacepublisher-2.136.1.tgz",
+      "integrity": "sha512-UlDrzjZk1tWjDf9gwohbm7jsQ3taEGCk8QsNbr6XddUH+q/22h6z+NL9vZCdrPrTkdcQUMkyimTsTO2dECV+sw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-mediaservices": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-mediaservices/-/oci-mediaservices-2.130.0.tgz",
-      "integrity": "sha512-APq8ulvzhuh/JVhmbh5ZhunRn5BnC7cSN+tkjl5ZXGuZcJu2iwZdFXyXJ1KwVy/ud0V01BrKcQUzta65omQEOg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-mediaservices/-/oci-mediaservices-2.136.1.tgz",
+      "integrity": "sha512-g0ZLLnJCXjlE81+jbF4vQ7jYH1qb1nYf8R8bOzLCP16eNUJ/V23SuZPDzto6zord37PfGU254b2zlrLbQ2VErA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-mngdmac": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-mngdmac/-/oci-mngdmac-2.130.0.tgz",
-      "integrity": "sha512-mBcnFZ4URCve1bxaZywjvDsAeVkTwyOuWLCc5RpcQxFzhB6qEbz96pWLh1Q55Kf7vhXF9GmvYPyR7V/t6doUSg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-mngdmac/-/oci-mngdmac-2.136.1.tgz",
+      "integrity": "sha512-fHLJzF5PlXDm/jptzs8LEmKjYAGACrytAu+PvpBX+5R+YYW4Dq8RN4IhykvZA92nGfdmiNfWpd9HNMvfnDg9gw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-modeldeployment": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-modeldeployment/-/oci-modeldeployment-2.130.0.tgz",
-      "integrity": "sha512-3+yNdOVVfY/Cvs/Kq2G9VZ8WPqu/mZrGvKrhXfCYTuJDook4uzYOXQ4wX5x2hK0ffFkgzHrs9/ajZH0Bp6x8TQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-modeldeployment/-/oci-modeldeployment-2.136.1.tgz",
+      "integrity": "sha512-2QFJvC19XDz656jTG3c7I8CGdkjbfK0yw3ak9FTVZ/j0n7bQKaqSLawxVxLKQkQKJbmUHzhtEaQ+wyEJYzEn6w==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-monitoring": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-monitoring/-/oci-monitoring-2.130.0.tgz",
-      "integrity": "sha512-H1XQLctmlB5RqLhyPGeITejA4hSroo+h6j5/wIVKjm++XtoOYslJmEwkVBljhl45n99wQ+nSmI8h1HlSRm2eBQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-monitoring/-/oci-monitoring-2.136.1.tgz",
+      "integrity": "sha512-OloyjCoEKyb3NbfvNN546J+gT2eicUj8xO678Yq3nkHKo1uu8SdjXyPzJVYIFRTrO7sVuuXZLBmF0WrtRwRBQg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-multicloud": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-multicloud/-/oci-multicloud-2.130.0.tgz",
-      "integrity": "sha512-txM/7HRTnpBiCWKlCQyLb/DG7IxZgh4ZOMEguRz6qvIzjbZdV8yJ514HzPaJ3NDOB5/BXgI60ejGjjET+ImEzw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-multicloud/-/oci-multicloud-2.136.1.tgz",
+      "integrity": "sha512-iFf+H5CARsyln7e+tPTTngFcI4EEG3u8TmdzNW8i3PVkfuYtr4H9HjIOhFEFmwoRqW/RzIVftr8kvKv5fHs3NQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-mysql": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-mysql/-/oci-mysql-2.130.0.tgz",
-      "integrity": "sha512-SuWTRDH9IuxbEQc09pEtdhzVDnMRu+Pd1BAUxcClnCNi7+4V4bqDWOA9JwHtbNmmEWoAvDczkHQSvxKOy8xMvg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-mysql/-/oci-mysql-2.136.1.tgz",
+      "integrity": "sha512-DTzW9hg+C0Q8WVl6mjRIIU/F1V3e1w6mDc4ChgOszlf3yC7IfNth0hh39Jw+BHpiFJ9MGwCmGzLQSnrlsybYtg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-networkfirewall": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-networkfirewall/-/oci-networkfirewall-2.130.0.tgz",
-      "integrity": "sha512-WydHoX/9K0dQHdbEku152DtFhyVsrrFnaalvFgboeCzQ4s367njvSkDx36g4H3EG4gFcOpkZeqLbQX5lj1jycA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-networkfirewall/-/oci-networkfirewall-2.136.1.tgz",
+      "integrity": "sha512-9yZPKYENj31RWpqotRVoufv1hD8aHNkRbHMb/idD6bw9aBgSEv6Af8+Fl7QG1vA3DfidAyMLRQ6mYqiQWn6ulQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-networkloadbalancer": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-networkloadbalancer/-/oci-networkloadbalancer-2.130.0.tgz",
-      "integrity": "sha512-eD1OjoNHZUBKkHw75h0Jt0mOhA7/IB2KM9EFDarjtcGgb0Y6OLEkaMtxoqFpDV322tPUpxu6geRl5no05+4cEg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-networkloadbalancer/-/oci-networkloadbalancer-2.136.1.tgz",
+      "integrity": "sha512-Ova1sdAvPEb5CyHKO5adkJnJ0ymNvTRdnvIrtmLDQM3/WY4WJ3Af7iNSSNncC2OmL5N6I8oPedvRcCwfZNKHtQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-nosql": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-nosql/-/oci-nosql-2.130.0.tgz",
-      "integrity": "sha512-SAbK1hBy4YSmXOjwCQJ7zb0UPaoY2VYbqiSZU82wcWV5b3QRoVAmibZB+cZ8Zr73oCwrqDLqSnQo5r3M1wpR/Q==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-nosql/-/oci-nosql-2.136.1.tgz",
+      "integrity": "sha512-MEDU1nCIleptdHAz8MFInFdC993wTYK1AYF/tFTjqyO02fC4nvuYNo6HLs6hXK7ouHOJ3dAKmttf+GaIQofarg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-objectstorage": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-objectstorage/-/oci-objectstorage-2.130.0.tgz",
-      "integrity": "sha512-uNEtcRKrnfAiG6HYgoTNR8Qtp+rkSAHDSM5plGcarHg3tL4ZSt//gIGA+kSqV3T9NJGdcVdfcE8DpeJ3+Sqppw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-objectstorage/-/oci-objectstorage-2.136.1.tgz",
+      "integrity": "sha512-cV3ADHJM75Xa1EqP5BS7El83JdjofSCdgQD+MNeIEihDKeLaHE9uAp0S6AsvDRJOGBzmYiHpK9UhrQaMR8O8mg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
         "await-semaphore": "^0.1.3",
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-oce": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-oce/-/oci-oce-2.130.0.tgz",
-      "integrity": "sha512-qc54KeNpXz2nckosOvVOXMdihVsQdaS/TvgA4pZteUAN7aZIXX6VAbQB0AD/YszmojIA4A4PkECT1PUtIJ126g==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-oce/-/oci-oce-2.136.1.tgz",
+      "integrity": "sha512-Qwg0ESNS0Z14Vm97dkkRvAnx2Jnsw9kYTKH4g9/s+K0KPlUMtn42NYfzLYOXY+s/RBgaiKKlPqKkVCixmAo0qQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-ocicontrolcenter": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-ocicontrolcenter/-/oci-ocicontrolcenter-2.130.0.tgz",
-      "integrity": "sha512-Rndxs6uO6r4rYxOLUauGJekW0gZ29sZbFDDyxRhqWCCcfEKwuGrlTjxnrVZ+f/Rdqyo8OMy6zgTWKTUWC9d+oA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-ocicontrolcenter/-/oci-ocicontrolcenter-2.136.1.tgz",
+      "integrity": "sha512-KSdlKI7SXKACmEiERvVWzBGIKhIYjBMRjGNbdk9LXeXXc3kZ3CLpEhBfabp0lAQe4O5DklfTKtcT/IcMmurgNQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-ocvp": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-ocvp/-/oci-ocvp-2.130.0.tgz",
-      "integrity": "sha512-KzUK8ZZfNJ8ANVy7oS2f/+3Zb6pXAj4XJ9cC0Jr8IwMjjf+r1c67JdIGiabnHUmrg3aVPbg/bSEcorSW/601qg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-ocvp/-/oci-ocvp-2.136.1.tgz",
+      "integrity": "sha512-hOWXJVqS0B4tnGEI1kY9gqmXJBJ30kBOYqx4LNoOjkyrxg++ot98N2tmD1d/oXSQKCe7E17jTPca/HqIpzS9Zw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-oda": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-oda/-/oci-oda-2.130.0.tgz",
-      "integrity": "sha512-A6cWgB4ToXAHZI3EO8t7SFzdCFA7xT8jKPBtHQ8YQcXXQEQpRtSH0EfSpxNje40374hyVatgWYgDmNejSrjAmQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-oda/-/oci-oda-2.136.1.tgz",
+      "integrity": "sha512-YW5HdYKad0WLbFeAQqxXSVuOGbeweQckvxMUELhZ7McAcll/jVkh93DKAC8GdD4UhxG3rZ1r3iiE7ijqfLgqvA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-onesubscription": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-onesubscription/-/oci-onesubscription-2.130.0.tgz",
-      "integrity": "sha512-QmzM+r8AD9T37hcRiyIgbr20YuBqUygM0dLCR0lzLjHOSqJmUG4JwSw4zilVP9ujAFjSW4RFsKK0cQjDBahdAw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-onesubscription/-/oci-onesubscription-2.136.1.tgz",
+      "integrity": "sha512-Nj5XhQSdgy3oJD4SHK7/l5fC++7KJ94oG3yG4NbBNmW7/u9uVyT0SJxIkcya9AnurPu70Q7CHBWo+XoNw5ehHQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-ons": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-ons/-/oci-ons-2.130.0.tgz",
-      "integrity": "sha512-UL16xRmRz7HB5xhJKizCeCyX+ENZKXNxgxfUswbCzbG1PvR4bLT6W5nRt5cGDBLBUQWChdx8Z5h0DRLDqt6XkQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-ons/-/oci-ons-2.136.1.tgz",
+      "integrity": "sha512-SVaxz8AQE7whIQ1qmoxkloep796P8JJxxNmgBx817Tby2GtU0UQFwO4Mt9FUpEUCRn/kEoMQHqYE0F1rmP4+CA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-opa": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-opa/-/oci-opa-2.130.0.tgz",
-      "integrity": "sha512-Qz4z+qHosOXhWbMzdzL1zQvboy0n25Hzx26yIKDm8qych7QLTyoZkMor/C3WPOlD5G064DA+nCBnPxcNjXeCgg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-opa/-/oci-opa-2.136.1.tgz",
+      "integrity": "sha512-sCZgg9YyWGH0MvAKZjUlt46/3lJcNKeDV0fCvCSRjKcZEofo3EUVsAsLranvH01Pp7rtb4CUmB9m0l1Cpnntew==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-opensearch": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-opensearch/-/oci-opensearch-2.130.0.tgz",
-      "integrity": "sha512-ywD2n2/xfHHqEvfw3VBLTid8ccQ8gsnFRfojPLmom7oYWvtY6L+yC9s/LRYjAeWuKdRZwoxBgDCHAf8HTmcDZg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-opensearch/-/oci-opensearch-2.136.1.tgz",
+      "integrity": "sha512-ZgQcbWVXKnxgCo7Hx3aKRyxQdX45J9PB2mmCAUO1XuSgN08w8/3jaY+s/JIeYfwOqqyeVQ0tOQU0TzWf9H4Ntg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-operatoraccesscontrol": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-operatoraccesscontrol/-/oci-operatoraccesscontrol-2.130.0.tgz",
-      "integrity": "sha512-fOZOY/36wQCxXGdTC8aGaImPOY4iRTBXeLi3iSteW8cc/OlycttetbOA2VEZkt44SHWbr9o6G98rTlYY75UwqA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-operatoraccesscontrol/-/oci-operatoraccesscontrol-2.136.1.tgz",
+      "integrity": "sha512-UsZAUqZO78sMdDxJ+u3y0kLo6p8L7mUu/1c8PbRb6dw8XbCQsheqWgWxzweR553Uua/QByi+VbsdgpxcHRqRzA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-opsi": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-opsi/-/oci-opsi-2.130.0.tgz",
-      "integrity": "sha512-VVeLfJveCtFZUXGdxANd4RhiINj2Io5d9QEkuMJApQVsqTSiGS+pZZj+HXCmNg3lqXAIxZxcRml3zHtGSna6ig==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-opsi/-/oci-opsi-2.136.1.tgz",
+      "integrity": "sha512-no3ooKst59f94EVK0qINCwx6zockrF5rXE82ld7kIR+cbrR1ugDcjEXDXSrJ3NP2vjXKocBNwweCGCqI3xJesA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-optimizer": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-optimizer/-/oci-optimizer-2.130.0.tgz",
-      "integrity": "sha512-NTVm9ZRpT25FXtHC6h3vWipUEDDqNJKt641D4ahb29s48WiBsL0t/i0LdNytV7SNNd1kkWG8m2RirPQnBdcvtg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-optimizer/-/oci-optimizer-2.136.1.tgz",
+      "integrity": "sha512-ta0sMtAp5zlDg70DGVAGN5gXDqmgZezI0yh5HxFnZWyZxMuwUU/yXwl/PqCx+bFJDTQDquvGZR1RyxPCqsqh3Q==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-osmanagementhub": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-osmanagementhub/-/oci-osmanagementhub-2.130.0.tgz",
-      "integrity": "sha512-1RSnvigXFelHdDM5A3qlNjBGvVQjilZkxdK3II/5RonCfca9ScdohYcXBhlzlLHO/Xk6FVzMFE0m2EO4W/7Dyw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-osmanagementhub/-/oci-osmanagementhub-2.136.1.tgz",
+      "integrity": "sha512-SD/r0gb6I7uKZy4404fw5BLWa3gy/qZUxa18pO4IkgLAE1z8eknVfCWN0y9zdV0oFyrIvS9L+T8byri+afrLDA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-ospgateway": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-ospgateway/-/oci-ospgateway-2.130.0.tgz",
-      "integrity": "sha512-UMUFwsv5hIIseCQD0eKD7kHnIXR/VaK1+RVAGgjTQHTLKZzHQJDwp2MhOJbiXWV0X1pO6VBBE1SBmtms8/u/Qg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-ospgateway/-/oci-ospgateway-2.136.1.tgz",
+      "integrity": "sha512-KRY5s1A0ZrHEMHEb+ZTlR5lQGjpfhoamjSLj14NnhCm51I1uszSL5suUymXJ9CmRiIu3qwySZJ5xT3tOD9Vf5Q==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-osubbillingschedule": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-osubbillingschedule/-/oci-osubbillingschedule-2.130.0.tgz",
-      "integrity": "sha512-YIKSNn6fBJoxDXGZ9WO5Wh9Pwlkmhr4Y1Zz3GaiFJ7GljabFapLT1P2dUeZR711tWd7di/N1S4fNu8ooVeZDOg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-osubbillingschedule/-/oci-osubbillingschedule-2.136.1.tgz",
+      "integrity": "sha512-CnfADhtcPLH9Z25b+T3r4qVLtw804LQ/J4POZciFv/sbuPRJQxNvZdq8ykQj5Qe7DisV+helKQ/objgppL3o2A==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-osuborganizationsubscription": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-osuborganizationsubscription/-/oci-osuborganizationsubscription-2.130.0.tgz",
-      "integrity": "sha512-VuT2HSxcfahG+vg6LYqFdfzCNwQ7VHMWlZr5Ca/lQdeYoHUebOtNzuqD/QZiFtEULpdALDLQN5vPM58hDszsKA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-osuborganizationsubscription/-/oci-osuborganizationsubscription-2.136.1.tgz",
+      "integrity": "sha512-u4Dg5M1L9iuLPiuZV3h5Ps4ze1wBiAvm+2qlo2Yx8KabqztadCmiyKzM6nf57jSOsYcdv+HkDjQkrjYxXNdjZw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-osubsubscription": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-osubsubscription/-/oci-osubsubscription-2.130.0.tgz",
-      "integrity": "sha512-oy8xoOEZeLy0YuhsC4lThM2YiFcaSmIgCrmrYqRCRFF79ZnjIL2BlhnOKvYkS1aYIQnzXPj5e6sIl9WpsmivhA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-osubsubscription/-/oci-osubsubscription-2.136.1.tgz",
+      "integrity": "sha512-mJEH3TVRsyvzqXDRyFEhf/BTsdsZlKJwoUMbjh+ZGk+estaC/s7zQxKjh/vc6AP+yW5eIunyFOq4r/7KKEg+tg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-osubusage": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-osubusage/-/oci-osubusage-2.130.0.tgz",
-      "integrity": "sha512-0JvFL/ohv34DRKFyklaNn+EHraj3wNq3CJUVtGqNziRd5j2wm9TKAhYad0FpYgn97huLrhhXQol0PDAZlN9C+g==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-osubusage/-/oci-osubusage-2.136.1.tgz",
+      "integrity": "sha512-/KvviTLBEuWXFaR+c407LBQR0YegfgONFp3b+GX8v1qGqOXEuaGBpQ8GrLMV0Ev+MeaF+6r6enRm1Jp3oIs/xQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-psa": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-psa/-/oci-psa-2.130.0.tgz",
-      "integrity": "sha512-OUOcijbkKsHsT3awg/SE6KPCpAYa3nb3SNi5Q5TO0Ir6yIbHIPNbVxbcHsoc+OjpYiPqNjmNPFRlKY2XgZuSYQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-psa/-/oci-psa-2.136.1.tgz",
+      "integrity": "sha512-qQYHuGSeCX3MIW4wxwGdSxWnOX0Sa2529AlaXwP+Nj6cnzNDU8RGRBHLA6zRaCQEbDZvH8boswIpY9lrExVR4A==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-psql": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-psql/-/oci-psql-2.130.0.tgz",
-      "integrity": "sha512-9emNBGhMzKvD0mmx3eyN8vzCrQ9FAWb7W6ucefV9Mfo4qK4wM9594GWdWs4GDlCK/JAKFhI0Y/hcbVBGrXuU5g==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-psql/-/oci-psql-2.136.1.tgz",
+      "integrity": "sha512-Jhr3+cWr308ekeVPVvzNP0qxuiUIDVyaAcoYV55IjbCKa+A7odNu17y0WERaSQgcVoEpUtzWZl2uE00+n11tWg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-queue": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-queue/-/oci-queue-2.130.0.tgz",
-      "integrity": "sha512-2V5Xt53G1ilmuF+iRT28FrpqV3C7dcAzcz74mO+q+U0CiJMKlPaj6Nx1Aj8KF6iEdy5D4fHpjaDtEMmIH1GjRQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-queue/-/oci-queue-2.136.1.tgz",
+      "integrity": "sha512-bX+gF0vdk2lEO0V99ErWVXookdBgexW410Zz3gc4lbrf4baR17DF9wD3LCdUx6Bre4cYPZ3jof1CbL5yyz7wVg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-recovery": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-recovery/-/oci-recovery-2.130.0.tgz",
-      "integrity": "sha512-pWHqax4WrH59U0fTK1LV/5lTobMnHLdNmC1bu6hNpn6h4YuOn9sJJd4pVvQG+Km1/rwsrea3nAQZ6IWOVDcCIw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-recovery/-/oci-recovery-2.136.1.tgz",
+      "integrity": "sha512-Dnf9hW+jprNyxOmMcBGPc4BdShhEope78gKoETzFSNcpe3kYVgmE5Ywf/Gr4s6oTQMKe5qgsLXaTkvdG7My/jg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-redis": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-redis/-/oci-redis-2.130.0.tgz",
-      "integrity": "sha512-ISdEII8OJguorhTloqcDJJJ/C+O8/20RzaNb6VpQiXjWwo3RRj530gtV3OuzEr1PNFfv5wi9moCsf403wY/gpw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-redis/-/oci-redis-2.136.1.tgz",
+      "integrity": "sha512-CrRDfXuSZjhG1B7f4B33tirLlxvR1eZ74dQWWsGH7zwTJ7xgnq/TCaNIV1NSqlSfFGlI2+ooSvmMkLeBPfz3Ug==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-resourceanalytics": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-resourceanalytics/-/oci-resourceanalytics-2.130.0.tgz",
-      "integrity": "sha512-wN060/H3bkpZqnzytEPuat3ScKEaerTNXsBfe8STOCtV4Hl8QawACWvvhGwRfx1dfjmFZbHxJz1f2j7BuXVRKw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-resourceanalytics/-/oci-resourceanalytics-2.136.1.tgz",
+      "integrity": "sha512-kDVs9WReJL55isRQH0hxA1v3zmLQkQn5ocUvDq7lM8aRFM+gyzJuolDm7LKcXPUWyXAeNB9b38yzD5atcuo3sw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-resourcemanager": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-resourcemanager/-/oci-resourcemanager-2.130.0.tgz",
-      "integrity": "sha512-dFUzJSDvRVqMPET9q4ciYgZd0afgfknPRMikkL/yRCHCpx6YL7fzSWkv0qhM+y9xruonqox+owmT1mc6gBq1xQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-resourcemanager/-/oci-resourcemanager-2.136.1.tgz",
+      "integrity": "sha512-tJu5ZkZH37SN8cm3wcHQr5FJNHVR9TN2bs1e+eUeX5dQMj3fk0CvdaLTEbgS2OoWoWw0rJwLQGiWubti6lC1Sg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-resourcescheduler": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-resourcescheduler/-/oci-resourcescheduler-2.130.0.tgz",
-      "integrity": "sha512-KQY9H02C+3u7oPaeznH5R7EiUTqaUBI1WDKzRhUxAviIVq9DQcgYYkLy6fQSUuVN23ImS0QDMirTzKD0b8wjNg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-resourcescheduler/-/oci-resourcescheduler-2.136.1.tgz",
+      "integrity": "sha512-mrG3xPHlrlblgbvgypps/oAxWRUw65uUvLOErzFdBnwXMWVBKH8CLf9gQrfoGsE9lsZz7YTXx3E0bQDntjFQWw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-resourcesearch": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-resourcesearch/-/oci-resourcesearch-2.130.0.tgz",
-      "integrity": "sha512-CEFIqawVa2achJeDfRR39aEborQHlrxYTMlXy1GtIRLBDYLvXPtpsJE5+eZLpdsqU/WC7rKTXhAF7ipOaJaNwA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-resourcesearch/-/oci-resourcesearch-2.136.1.tgz",
+      "integrity": "sha512-YrVp9gltlAumAMKqpfOitaP6tZH/qd9qPHIcgnu5wqFziYiJS4W6FFYJaLF92ZYAUZHtmjZAwySpO3VMuGl/kQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-rover": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-rover/-/oci-rover-2.130.0.tgz",
-      "integrity": "sha512-yKlSP+eAnlRBMDrhzlJoPNLEVMxhw/fZrhaCROw88Js+gvpMeEzaxwpQdn+OsHfLbghjA4lCxIX6z7JGS9BkHg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-rover/-/oci-rover-2.136.1.tgz",
+      "integrity": "sha512-ETHhlC2DmTZVqByuZDBTAeVHCU4FN+v+qtEWxh1/pJ+sGALh8qZ5w7rXWoSUHzVKmdGTu5G7bN/Cv626D4IUnQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-sch": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-sch/-/oci-sch-2.130.0.tgz",
-      "integrity": "sha512-m5HgHEsiky3Ne445Y0cLjXGRUDjcjdDGoVvNjvZDpA+hddXM8eWSDD4toDLu1plAQlU1xL3/mkcYVM6kPajyYw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-sch/-/oci-sch-2.136.1.tgz",
+      "integrity": "sha512-1xFjDzjrVsOXzpmL7UNmTRIhWzlysX1jaHEL3Va+Jgr9K43jE+R4MQiiJNvQMCNHO2VXs1Z1gT1w9QSkc+gxcA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-sdk": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-sdk/-/oci-sdk-2.130.0.tgz",
-      "integrity": "sha512-4vJFMeTdSqNFesFwkUAF2yRqgUPYkKbUmbfRZiW8syO5eqo1Wcn6W5Zj0Eo9CvnGhTD7Lp03HS3nwB2XzbayRQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-sdk/-/oci-sdk-2.136.1.tgz",
+      "integrity": "sha512-i8XGKWY+LOowa1qmmIY9ZIY30DEbPCtRnYOIy/PXkZJ1fE7r4L33V4E+UA6wY/stu/GRCyu1KIUMoDenq3OCog==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-accessgovernancecp": "2.130.0",
-        "oci-adm": "2.130.0",
-        "oci-aidataplatform": "2.130.0",
-        "oci-aidocument": "2.130.0",
-        "oci-ailanguage": "2.130.0",
-        "oci-aispeech": "2.130.0",
-        "oci-aivision": "2.130.0",
-        "oci-analytics": "2.130.0",
-        "oci-announcementsservice": "2.130.0",
-        "oci-apiaccesscontrol": "2.130.0",
-        "oci-apigateway": "2.130.0",
-        "oci-apiplatform": "2.130.0",
-        "oci-apmconfig": "2.130.0",
-        "oci-apmcontrolplane": "2.130.0",
-        "oci-apmsynthetics": "2.130.0",
-        "oci-apmtraces": "2.130.0",
-        "oci-appmgmtcontrol": "2.130.0",
-        "oci-artifacts": "2.130.0",
-        "oci-audit": "2.130.0",
-        "oci-autoscaling": "2.130.0",
-        "oci-bastion": "2.130.0",
-        "oci-batch": "2.130.0",
-        "oci-bds": "2.130.0",
-        "oci-blockchain": "2.130.0",
-        "oci-budget": "2.130.0",
-        "oci-capacitymanagement": "2.130.0",
-        "oci-certificates": "2.130.0",
-        "oci-certificatesmanagement": "2.130.0",
-        "oci-cims": "2.130.0",
-        "oci-cloudbridge": "2.130.0",
-        "oci-cloudguard": "2.130.0",
-        "oci-cloudmigrations": "2.130.0",
-        "oci-clusterplacementgroups": "2.130.0",
-        "oci-common": "2.130.0",
-        "oci-computecloudatcustomer": "2.130.0",
-        "oci-computeinstanceagent": "2.130.0",
-        "oci-containerengine": "2.130.0",
-        "oci-containerinstances": "2.130.0",
-        "oci-containerregistry": "2.130.0",
-        "oci-core": "2.130.0",
-        "oci-dashboardservice": "2.130.0",
-        "oci-database": "2.130.0",
-        "oci-databasemanagement": "2.130.0",
-        "oci-databasemigration": "2.130.0",
-        "oci-databasetools": "2.130.0",
-        "oci-datacatalog": "2.130.0",
-        "oci-dataflow": "2.130.0",
-        "oci-dataintegration": "2.130.0",
-        "oci-datalabelingservice": "2.130.0",
-        "oci-datalabelingservicedataplane": "2.130.0",
-        "oci-datasafe": "2.130.0",
-        "oci-datascience": "2.130.0",
-        "oci-dblm": "2.130.0",
-        "oci-dbmulticloud": "2.130.0",
-        "oci-delegateaccesscontrol": "2.130.0",
-        "oci-demandsignal": "2.130.0",
-        "oci-desktops": "2.130.0",
-        "oci-devops": "2.130.0",
-        "oci-dif": "2.130.0",
-        "oci-disasterrecovery": "2.130.0",
-        "oci-distributeddatabase": "2.130.0",
-        "oci-dns": "2.130.0",
-        "oci-email": "2.130.0",
-        "oci-emaildataplane": "2.130.0",
-        "oci-emwarehouse": "2.130.0",
-        "oci-events": "2.130.0",
-        "oci-filestorage": "2.130.0",
-        "oci-fleetappsmanagement": "2.130.0",
-        "oci-fleetsoftwareupdate": "2.130.0",
-        "oci-functions": "2.130.0",
-        "oci-fusionapps": "2.130.0",
-        "oci-gdp": "2.130.0",
-        "oci-generativeai": "2.130.0",
-        "oci-generativeaiagent": "2.130.0",
-        "oci-generativeaiagentruntime": "2.130.0",
-        "oci-generativeaidata": "2.130.0",
-        "oci-generativeaiinference": "2.130.0",
-        "oci-genericartifactscontent": "2.130.0",
-        "oci-goldengate": "2.130.0",
-        "oci-governancerulescontrolplane": "2.130.0",
-        "oci-healthchecks": "2.130.0",
-        "oci-identity": "2.130.0",
-        "oci-identitydataplane": "2.130.0",
-        "oci-identitydomains": "2.130.0",
-        "oci-integration": "2.130.0",
-        "oci-iot": "2.130.0",
-        "oci-jms": "2.130.0",
-        "oci-jmsjavadownloads": "2.130.0",
-        "oci-jmsutils": "2.130.0",
-        "oci-keymanagement": "2.130.0",
-        "oci-licensemanager": "2.130.0",
-        "oci-limits": "2.130.0",
-        "oci-limitsincrease": "2.130.0",
-        "oci-loadbalancer": "2.130.0",
-        "oci-lockbox": "2.130.0",
-        "oci-loganalytics": "2.130.0",
-        "oci-logging": "2.130.0",
-        "oci-loggingingestion": "2.130.0",
-        "oci-loggingsearch": "2.130.0",
-        "oci-lustrefilestorage": "2.130.0",
-        "oci-managedkafka": "2.130.0",
-        "oci-managementagent": "2.130.0",
-        "oci-managementdashboard": "2.130.0",
-        "oci-marketplace": "2.130.0",
-        "oci-marketplaceprivateoffer": "2.130.0",
-        "oci-marketplacepublisher": "2.130.0",
-        "oci-mediaservices": "2.130.0",
-        "oci-mngdmac": "2.130.0",
-        "oci-modeldeployment": "2.130.0",
-        "oci-monitoring": "2.130.0",
-        "oci-multicloud": "2.130.0",
-        "oci-mysql": "2.130.0",
-        "oci-networkfirewall": "2.130.0",
-        "oci-networkloadbalancer": "2.130.0",
-        "oci-nosql": "2.130.0",
-        "oci-objectstorage": "2.130.0",
-        "oci-oce": "2.130.0",
-        "oci-ocicontrolcenter": "2.130.0",
-        "oci-ocvp": "2.130.0",
-        "oci-oda": "2.130.0",
-        "oci-onesubscription": "2.130.0",
-        "oci-ons": "2.130.0",
-        "oci-opa": "2.130.0",
-        "oci-opensearch": "2.130.0",
-        "oci-operatoraccesscontrol": "2.130.0",
-        "oci-opsi": "2.130.0",
-        "oci-optimizer": "2.130.0",
-        "oci-osmanagementhub": "2.130.0",
-        "oci-ospgateway": "2.130.0",
-        "oci-osubbillingschedule": "2.130.0",
-        "oci-osuborganizationsubscription": "2.130.0",
-        "oci-osubsubscription": "2.130.0",
-        "oci-osubusage": "2.130.0",
-        "oci-psa": "2.130.0",
-        "oci-psql": "2.130.0",
-        "oci-queue": "2.130.0",
-        "oci-recovery": "2.130.0",
-        "oci-redis": "2.130.0",
-        "oci-resourceanalytics": "2.130.0",
-        "oci-resourcemanager": "2.130.0",
-        "oci-resourcescheduler": "2.130.0",
-        "oci-resourcesearch": "2.130.0",
-        "oci-rover": "2.130.0",
-        "oci-sch": "2.130.0",
-        "oci-secrets": "2.130.0",
-        "oci-securityattribute": "2.130.0",
-        "oci-self": "2.130.0",
-        "oci-servicecatalog": "2.130.0",
-        "oci-servicemanagerproxy": "2.130.0",
-        "oci-stackmonitoring": "2.130.0",
-        "oci-streaming": "2.130.0",
-        "oci-tenantmanagercontrolplane": "2.130.0",
-        "oci-threatintelligence": "2.130.0",
-        "oci-usage": "2.130.0",
-        "oci-usageapi": "2.130.0",
-        "oci-vault": "2.130.0",
-        "oci-vbsinst": "2.130.0",
-        "oci-visualbuilder": "2.130.0",
-        "oci-vnmonitoring": "2.130.0",
-        "oci-vulnerabilityscanning": "2.130.0",
-        "oci-waa": "2.130.0",
-        "oci-waas": "2.130.0",
-        "oci-waf": "2.130.0",
-        "oci-wlms": "2.130.0",
-        "oci-workrequests": "2.130.0",
-        "oci-zpr": "2.130.0"
+        "oci-accessgovernancecp": "2.136.1",
+        "oci-adm": "2.136.1",
+        "oci-aidataplatform": "2.136.1",
+        "oci-aidocument": "2.136.1",
+        "oci-ailanguage": "2.136.1",
+        "oci-aispeech": "2.136.1",
+        "oci-aivision": "2.136.1",
+        "oci-analytics": "2.136.1",
+        "oci-announcementsservice": "2.136.1",
+        "oci-apiaccesscontrol": "2.136.1",
+        "oci-apigateway": "2.136.1",
+        "oci-apiplatform": "2.136.1",
+        "oci-apmconfig": "2.136.1",
+        "oci-apmcontrolplane": "2.136.1",
+        "oci-apmsynthetics": "2.136.1",
+        "oci-apmtraces": "2.136.1",
+        "oci-appmgmtcontrol": "2.136.1",
+        "oci-artifacts": "2.136.1",
+        "oci-audit": "2.136.1",
+        "oci-autoscaling": "2.136.1",
+        "oci-bastion": "2.136.1",
+        "oci-batch": "2.136.1",
+        "oci-bds": "2.136.1",
+        "oci-blockchain": "2.136.1",
+        "oci-budget": "2.136.1",
+        "oci-capacitymanagement": "2.136.1",
+        "oci-certificates": "2.136.1",
+        "oci-certificatesmanagement": "2.136.1",
+        "oci-cims": "2.136.1",
+        "oci-cloudbridge": "2.136.1",
+        "oci-cloudguard": "2.136.1",
+        "oci-cloudmigrations": "2.136.1",
+        "oci-clusterplacementgroups": "2.136.1",
+        "oci-common": "2.136.1",
+        "oci-computecloudatcustomer": "2.136.1",
+        "oci-computeinstanceagent": "2.136.1",
+        "oci-containerengine": "2.136.1",
+        "oci-containerinstances": "2.136.1",
+        "oci-containerregistry": "2.136.1",
+        "oci-core": "2.136.1",
+        "oci-costad": "2.136.1",
+        "oci-dashboardservice": "2.136.1",
+        "oci-database": "2.136.1",
+        "oci-databasemanagement": "2.136.1",
+        "oci-databasemigration": "2.136.1",
+        "oci-databasetools": "2.136.1",
+        "oci-databasetoolsruntime": "2.136.1",
+        "oci-datacatalog": "2.136.1",
+        "oci-dataflow": "2.136.1",
+        "oci-dataintegration": "2.136.1",
+        "oci-datalabelingservice": "2.136.1",
+        "oci-datalabelingservicedataplane": "2.136.1",
+        "oci-datasafe": "2.136.1",
+        "oci-datascience": "2.136.1",
+        "oci-dblm": "2.136.1",
+        "oci-dbmulticloud": "2.136.1",
+        "oci-delegateaccesscontrol": "2.136.1",
+        "oci-demandsignal": "2.136.1",
+        "oci-desktops": "2.136.1",
+        "oci-devops": "2.136.1",
+        "oci-dif": "2.136.1",
+        "oci-disasterrecovery": "2.136.1",
+        "oci-distributeddatabase": "2.136.1",
+        "oci-dns": "2.136.1",
+        "oci-email": "2.136.1",
+        "oci-emaildataplane": "2.136.1",
+        "oci-emwarehouse": "2.136.1",
+        "oci-events": "2.136.1",
+        "oci-filestorage": "2.136.1",
+        "oci-fleetappsmanagement": "2.136.1",
+        "oci-fleetsoftwareupdate": "2.136.1",
+        "oci-functions": "2.136.1",
+        "oci-fusionapps": "2.136.1",
+        "oci-gdp": "2.136.1",
+        "oci-generativeai": "2.136.1",
+        "oci-generativeaiagent": "2.136.1",
+        "oci-generativeaiagentruntime": "2.136.1",
+        "oci-generativeaidata": "2.136.1",
+        "oci-generativeaiinference": "2.136.1",
+        "oci-genericartifactscontent": "2.136.1",
+        "oci-goldengate": "2.136.1",
+        "oci-governancerulescontrolplane": "2.136.1",
+        "oci-healthchecks": "2.136.1",
+        "oci-identity": "2.136.1",
+        "oci-identitydataplane": "2.136.1",
+        "oci-identitydomains": "2.136.1",
+        "oci-integration": "2.136.1",
+        "oci-iot": "2.136.1",
+        "oci-jms": "2.136.1",
+        "oci-jmsjavadownloads": "2.136.1",
+        "oci-jmsutils": "2.136.1",
+        "oci-keymanagement": "2.136.1",
+        "oci-licensemanager": "2.136.1",
+        "oci-limits": "2.136.1",
+        "oci-limitsincrease": "2.136.1",
+        "oci-loadbalancer": "2.136.1",
+        "oci-lockbox": "2.136.1",
+        "oci-loganalytics": "2.136.1",
+        "oci-logging": "2.136.1",
+        "oci-loggingingestion": "2.136.1",
+        "oci-loggingsearch": "2.136.1",
+        "oci-lustrefilestorage": "2.136.1",
+        "oci-managedkafka": "2.136.1",
+        "oci-managementagent": "2.136.1",
+        "oci-managementdashboard": "2.136.1",
+        "oci-marketplace": "2.136.1",
+        "oci-marketplaceprivateoffer": "2.136.1",
+        "oci-marketplacepublisher": "2.136.1",
+        "oci-mediaservices": "2.136.1",
+        "oci-mngdmac": "2.136.1",
+        "oci-modeldeployment": "2.136.1",
+        "oci-monitoring": "2.136.1",
+        "oci-multicloud": "2.136.1",
+        "oci-mysql": "2.136.1",
+        "oci-networkfirewall": "2.136.1",
+        "oci-networkloadbalancer": "2.136.1",
+        "oci-nosql": "2.136.1",
+        "oci-objectstorage": "2.136.1",
+        "oci-oce": "2.136.1",
+        "oci-ocicontrolcenter": "2.136.1",
+        "oci-ocvp": "2.136.1",
+        "oci-oda": "2.136.1",
+        "oci-onesubscription": "2.136.1",
+        "oci-ons": "2.136.1",
+        "oci-opa": "2.136.1",
+        "oci-opensearch": "2.136.1",
+        "oci-operatoraccesscontrol": "2.136.1",
+        "oci-opsi": "2.136.1",
+        "oci-optimizer": "2.136.1",
+        "oci-osmanagementhub": "2.136.1",
+        "oci-ospgateway": "2.136.1",
+        "oci-osubbillingschedule": "2.136.1",
+        "oci-osuborganizationsubscription": "2.136.1",
+        "oci-osubsubscription": "2.136.1",
+        "oci-osubusage": "2.136.1",
+        "oci-psa": "2.136.1",
+        "oci-psql": "2.136.1",
+        "oci-queue": "2.136.1",
+        "oci-recovery": "2.136.1",
+        "oci-redis": "2.136.1",
+        "oci-resourceanalytics": "2.136.1",
+        "oci-resourcemanager": "2.136.1",
+        "oci-resourcescheduler": "2.136.1",
+        "oci-resourcesearch": "2.136.1",
+        "oci-rover": "2.136.1",
+        "oci-sch": "2.136.1",
+        "oci-secrets": "2.136.1",
+        "oci-securityattribute": "2.136.1",
+        "oci-self": "2.136.1",
+        "oci-servicecatalog": "2.136.1",
+        "oci-servicemanagerproxy": "2.136.1",
+        "oci-stackmonitoring": "2.136.1",
+        "oci-streaming": "2.136.1",
+        "oci-tenantmanagercontrolplane": "2.136.1",
+        "oci-threatintelligence": "2.136.1",
+        "oci-usage": "2.136.1",
+        "oci-usageapi": "2.136.1",
+        "oci-vault": "2.136.1",
+        "oci-vbsinst": "2.136.1",
+        "oci-visualbuilder": "2.136.1",
+        "oci-vnmonitoring": "2.136.1",
+        "oci-vulnerabilityscanning": "2.136.1",
+        "oci-waa": "2.136.1",
+        "oci-waas": "2.136.1",
+        "oci-waf": "2.136.1",
+        "oci-wlms": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "oci-zpr": "2.136.1"
       }
     },
     "node_modules/oci-secrets": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-secrets/-/oci-secrets-2.130.0.tgz",
-      "integrity": "sha512-fkrE2h7aGKeCVdpsbUmHZ2RXrdVS3zYnkU8m9+dR9WAkpqknW6RVkqjjS8jeLbW9PmiA1OMYk42/uepKS70krw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-secrets/-/oci-secrets-2.136.1.tgz",
+      "integrity": "sha512-dH2bOJhkc8Smbc8iFZmdH3KAqoC3S8QQJwPPevHzgf3Gg6nrZGPBU3AMD96xJphdXyK9N/iNidt0pBaH0oXrUw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-securityattribute": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-securityattribute/-/oci-securityattribute-2.130.0.tgz",
-      "integrity": "sha512-Nbd3USThaM3LXSl92oFpNPrtUFAG7YpSKPLf2e2shtbDHI95hbsRNrYr/8MKuJsi/fTsrkQrUVxd9A6otxf/sA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-securityattribute/-/oci-securityattribute-2.136.1.tgz",
+      "integrity": "sha512-yl1orbZN1yZA1eimR/QQ29dcUtyy3vv0cnyncxdOkCjP5Rc0ieAUSeqwNw2z1wTwWt4KAftLb9ZAwZryVWwfdw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-self": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-self/-/oci-self-2.130.0.tgz",
-      "integrity": "sha512-JxiV0gYP3vJPC9cVOQhNpH0b+JYLxdr/YbcPSMH4odFqX4ey0zilHpy0+MqmMflVRLfMWPWl0kdx2B+w90do0w==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-self/-/oci-self-2.136.1.tgz",
+      "integrity": "sha512-dN9/Iys+ELgK5hYEhO08d7nQtOTKDUj4hGkVszAPKuVMo2OtBnG5NP9AaMmoKg8CwePilmEYa21RMIpfnmuUsQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-servicecatalog": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-servicecatalog/-/oci-servicecatalog-2.130.0.tgz",
-      "integrity": "sha512-RFfpsdrgvPQ+QvUofBIwLjNcwIyWW828B3Tm7sXcxYvm9IXbUROw6EkSdUgkRDCNhlG5umM73DwVW5HWaZdIuw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-servicecatalog/-/oci-servicecatalog-2.136.1.tgz",
+      "integrity": "sha512-pwavFYBfq2WOT6HgUmhn3VCe1J6Di2dQwZglD1nJX8at0s6GA1TSKJtJOgFpIMJuA+6lh4RKFtsUHpgg6/m2cA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-servicemanagerproxy": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-servicemanagerproxy/-/oci-servicemanagerproxy-2.130.0.tgz",
-      "integrity": "sha512-68atat55cD+kYbYip6kaxQoqa6U1lJneGJeICOozQaU/fwXZRptL89/E5Q75IDm93xxryZp9eV3zK3dq6Esx8A==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-servicemanagerproxy/-/oci-servicemanagerproxy-2.136.1.tgz",
+      "integrity": "sha512-CAGDLG2tYiWGSSWoEoEM4yO+yyHc1aP6RgD0pKh3V0Elzoey6SOQTUTnUvff/ByLDYLuPNRFHCb7n2hOxOb35A==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-stackmonitoring": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-stackmonitoring/-/oci-stackmonitoring-2.130.0.tgz",
-      "integrity": "sha512-zvkrYIA/Bi1/Vw50aXreI7pDmGfh6G5XvfQR3YvK/70tEtjZbqgC1KN7gxUb+RY74MDcaQesWSF4jrKpuX59aw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-stackmonitoring/-/oci-stackmonitoring-2.136.1.tgz",
+      "integrity": "sha512-6RczZU9Z1vuTVgKb22ORu6xWuI/PRo0z7rn2Lx4MUh/wpH/GgzEgZyxczxwLH+GPP3H+w6sTOYLJ2ZA3/gmXVw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-streaming": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-streaming/-/oci-streaming-2.130.0.tgz",
-      "integrity": "sha512-gZO9QaoEdw0xZwyvLkuNu+92DhYvWKmT9z3dWCFeANFWyqrHoecD9fQYieTNsrxPthbboNkgbbEZ03CJfKVlPw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-streaming/-/oci-streaming-2.136.1.tgz",
+      "integrity": "sha512-+g0hyTjBaF2754j5JNQGVwIYsmgC0Gu8gWqEZBMbg8Q2W8LIGRlYKJvvyO1orUxqG7WG4iYC1//QG5msk7JUJg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-tenantmanagercontrolplane": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-tenantmanagercontrolplane/-/oci-tenantmanagercontrolplane-2.130.0.tgz",
-      "integrity": "sha512-7ikF57w4dZj4EywxdzFrUnrwx2S48v0vf6TOunVbVx1WjcTXFgHMiB/tpikMp4etR4AswBjcMGOeBACEczUL7g==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-tenantmanagercontrolplane/-/oci-tenantmanagercontrolplane-2.136.1.tgz",
+      "integrity": "sha512-GSREc1xONeajnJj/a3BsaIpkpxLc//Sq+14Kk1BxVLItMEeGS92rS/gVUpLQPlw7NM6N1o+JhZRDB6EtT75riQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-threatintelligence": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-threatintelligence/-/oci-threatintelligence-2.130.0.tgz",
-      "integrity": "sha512-mDQ/AAG70a2xlZX95fBvd46Ffzfo45tzk2mCADm54/YIBgNiQJxnQhFXMubbM903J7ATPSmkp3nvZRQimrsNtg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-threatintelligence/-/oci-threatintelligence-2.136.1.tgz",
+      "integrity": "sha512-OwYQCnL0SOf98Yo6NR5CZF4r4esKszYId+iufBYDx/FNLb0MtuqqDb74tMz3JIZHbfKsHL+XfAfoqnX77oiTfA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-usage": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-usage/-/oci-usage-2.130.0.tgz",
-      "integrity": "sha512-HxzZD8pawVtnUX49fbcm+uNSMG6mKa1pC1mf8++HFm6M1OSgoEQs6IgpN6+r8vj/KLVI/Ngeb+dAZCCoJCWFPA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-usage/-/oci-usage-2.136.1.tgz",
+      "integrity": "sha512-a8Rcn6Kxv51nH6GP6kmwH7jqE6303hWu98AwflJavQmgEBEPzZdeyjdH4LkWus0ngO/RL6lY6rSAYaueJOi+7w==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-usageapi": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-usageapi/-/oci-usageapi-2.130.0.tgz",
-      "integrity": "sha512-+AeiBDgZv7PfD3ptjJo/aB8zM8+jz8hD7GyNn0Qv8kS/8ZVT5PZbqZJ+UF61hgQTXzZT4BzG4FajuT+7coBGoA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-usageapi/-/oci-usageapi-2.136.1.tgz",
+      "integrity": "sha512-kdivqsa6280zT30bPD1hHZD8SjP3wsErryP4jS0BiImErUvndnbbR2gt/QlQXb5VJIBQoaaFu7bC0XUAhJc9OQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-vault": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-vault/-/oci-vault-2.130.0.tgz",
-      "integrity": "sha512-xLeG0OMW0WpvnUiBNmZ6al5rTqHRf+0wkCXWzlvn+00Ptr2h7FJVAdIVCm1dMSsWsuJRwGMahu66USg+po6m0Q==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-vault/-/oci-vault-2.136.1.tgz",
+      "integrity": "sha512-9REQxVWiC1pcsHXE4MhqaPtjTOfOMQ+oskM1oBfwl3sr0Oici1HotRnBUNngxBuyE0TbZj8R6pvftWsUCTN3OQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-vbsinst": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-vbsinst/-/oci-vbsinst-2.130.0.tgz",
-      "integrity": "sha512-DPkc23jHb2VjbfwOjKBmBmIGokrmdI72jR54/KwH6385UIn9f+Qc5ZPeNfZZZWtkqFzjzGCfqbu/JRWscrfMTQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-vbsinst/-/oci-vbsinst-2.136.1.tgz",
+      "integrity": "sha512-e5oLlPqvV3SLIsHJdNRI7Ho8guHOHgnLIV93y5sIm/k0Bmr9NC2AFcO/LOIMK4ccYo8U3tKxYHsauBLl4WlfCw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-visualbuilder": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-visualbuilder/-/oci-visualbuilder-2.130.0.tgz",
-      "integrity": "sha512-5gFivnhELE4k/9cDwOcrwrxCD5evbPPCOlvSE/iUCOVAZjJvf6wIoTgQolDUprIlCu4zD2yK/gOT7RmeTrkDyA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-visualbuilder/-/oci-visualbuilder-2.136.1.tgz",
+      "integrity": "sha512-5ORm6wV247nZQhQNLDGP6yv7Pwor9eNb/ucw7XC9R3IMJ4HDt5eA9kIeIKx5jQACqF1OOn1kI+VNLz7aISmFig==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-vnmonitoring": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-vnmonitoring/-/oci-vnmonitoring-2.130.0.tgz",
-      "integrity": "sha512-DGLFR8CuPUMLSMcrQV8s9F7fhNL+1y5Uv8QN0VK7JAJPxDMp+sR0W0VVpSvzxf3JhI+bmeE2WrEJ4ZR7k5FMtQ==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-vnmonitoring/-/oci-vnmonitoring-2.136.1.tgz",
+      "integrity": "sha512-tJqslOwFSij2cj0bfy2dE23Z8zoBB0QwDXIJzzBoVUeBb+UhMkpyreHBnJGUUvxWe3mjS73b6sbJYKkaNOguyA==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-vulnerabilityscanning": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-vulnerabilityscanning/-/oci-vulnerabilityscanning-2.130.0.tgz",
-      "integrity": "sha512-Nbe0BArPUACPUcgUtAnPlvziGatsuoEW2ndF5qjsSm8abmkOUFnaiNHCMyfXptJSyonT5R0BvNkOTx8LoFieDA==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-vulnerabilityscanning/-/oci-vulnerabilityscanning-2.136.1.tgz",
+      "integrity": "sha512-PMVvMn0qji4z+qk8IdViQzBBlm6j7KmUXgw8IVNUNQ0uvKPzmrzLDcQLH5AEzpEvSBcqOPhSGE8wub3OnSjNAw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-waa": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-waa/-/oci-waa-2.130.0.tgz",
-      "integrity": "sha512-iEjkNfH5jiFvuP9GK7h67a5keBrNUv9RSYONMg8Oq99z/N44ujhGmWnuL3mw3PMaPOrNxqsi/hu0VsbdgBjeZw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-waa/-/oci-waa-2.136.1.tgz",
+      "integrity": "sha512-ePvC3/NEr2D/hWxMrl/RTvUrA/zgWV3Jk7Z847Mo0cMxDsHfK1C8NjPIiQM7IUx4i47Ujn3m+0z4iELe8y/y+A==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-waas": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-waas/-/oci-waas-2.130.0.tgz",
-      "integrity": "sha512-j5ivtgqof/Wcvki0u2yJvrtU6yG2IlsAWm9IK1gqzziog5a4nOIZnSIf+IC5osiyQ1f4thpR8ESVD5sMaq8Pkg==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-waas/-/oci-waas-2.136.1.tgz",
+      "integrity": "sha512-pbskEvMFSWetTgVhBSGNGJD4B3ZK2WfzJol4WW+IESlsbULjk9mMbfAJnFhDrKFofneV/zRnKKQ4aoqrZEeQTQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-waf": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-waf/-/oci-waf-2.130.0.tgz",
-      "integrity": "sha512-2CNH40e3UVJfjruVUofwGhFkQvmtMV5mcgQmpJKpWTnKLOC6pyDMO3OAhqwzeizby6HWg1r1KABvH4MyXxqaMw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-waf/-/oci-waf-2.136.1.tgz",
+      "integrity": "sha512-t1iWQczry56llWFAfm3PVsglG/DV7Dvu7oeQjjC3ow7dibjCorNFmbtSloSMIc8/OsLTY5ZVqNuGVtuof634sw==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-wlms": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-wlms/-/oci-wlms-2.130.0.tgz",
-      "integrity": "sha512-Q+VTjm1HGrqOxd7234W2ZE/8vfH5I+s46SPCcAljERSb6UgmyX74dCVlnyYY6D5JOFnZLv1YZe2dRXNOl1WsWw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-wlms/-/oci-wlms-2.136.1.tgz",
+      "integrity": "sha512-cMX4HTQd4U1rCjwPsb5oPdfRV7XFLtZRg4XLXYZLVfPxqo6UPxQ2jP9/D9XaQRjodmCJB5zQMSZ++PT8RYBesg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-workrequests": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-workrequests/-/oci-workrequests-2.130.0.tgz",
-      "integrity": "sha512-f1f86BLqe78MBJZlQZPCC9eFudn6mpULjtOPMH9MDtqJ6/Pqeyf0ATs6Q1z/Qwn0FKaKLkp25e3DnGCnpeyB0w==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-workrequests/-/oci-workrequests-2.136.1.tgz",
+      "integrity": "sha512-L7ZO4QEXHLJcy6KbdfXQ0cDAOErLe3yfuZoOIyt1jNf2F0XTBR+RoAGaz2InSo0Q092l23umwn2tENgQaJTIxQ==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/oci-zpr": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/oci-zpr/-/oci-zpr-2.130.0.tgz",
-      "integrity": "sha512-vSfAKbToY/F0QxNZfPUGZlzsz8hPENmpoQ9wRgio2CXhAIFlm/sOC45z25eMSaqtSnOFbi6Jo1ml+al/c78tRw==",
+      "version": "2.136.1",
+      "resolved": "https://registry.npmjs.org/oci-zpr/-/oci-zpr-2.136.1.tgz",
+      "integrity": "sha512-1JE3qCPJs9tvpnoMg6u14AC83uSDXzqi74IbQ9WRk9BM+tq+FfSAvaTqA2o16wqawckoXZ1BSe2puFHOZAdKeg==",
       "license": "(UPL-1.0 OR Apache-2.0)",
       "dependencies": {
-        "oci-common": "2.130.0",
-        "oci-workrequests": "2.130.0"
+        "oci-common": "2.136.1",
+        "oci-workrequests": "2.136.1",
+        "opossum": "5.0.1"
       }
     },
     "node_modules/opossum": {
@@ -4801,7 +4974,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4825,7 +4997,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5089,7 +5260,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5136,6 +5306,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/verror": {

--- a/extensions/oci/package.json
+++ b/extensions/oci/package.json
@@ -46,7 +46,7 @@
     "@raycast/api": "^1.104.1",
     "@raycast/utils": "^2.2.2",
     "filesize": "^11.0.2",
-    "oci-sdk": "^2.122.2"
+    "oci-sdk": "^2.136.1"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.0.4",
@@ -63,5 +63,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
+  },
+  "overrides": {
+    "uuid": "^11.1.1"
   }
 }

--- a/extensions/spaces/package-lock.json
+++ b/extensions/spaces/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@raycast/api": "^1.36.1",
         "open": "^8.4.0",
-        "uuid": "^8.3.2"
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "@types/node": "~16.10.0",
@@ -301,7 +301,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
       "integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.29.0",
         "@typescript-eslint/types": "5.29.0",
@@ -453,7 +452,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -737,7 +735,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -1363,6 +1360,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -1422,6 +1420,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1694,6 +1693,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -1923,7 +1923,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1942,11 +1941,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -2209,7 +2213,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
       "integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.29.0",
         "@typescript-eslint/types": "5.29.0",
@@ -2287,8 +2290,7 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -2494,7 +2496,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -2961,6 +2962,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -3005,7 +3007,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "peer": true
     },
     "once": {
       "version": "1.4.0",
@@ -3170,6 +3173,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -3336,8 +3340,7 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",
@@ -3349,9 +3352,9 @@
       }
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/extensions/spaces/package.json
+++ b/extensions/spaces/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@raycast/api": "^1.36.1",
     "open": "^8.4.0",
-    "uuid": "^8.3.2"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@types/node": "~16.10.0",

--- a/extensions/zerion/package-lock.json
+++ b/extensions/zerion/package-lock.json
@@ -13,7 +13,7 @@
         "bignumber.js": "^9.1.2",
         "dayjs": "^1.11.13",
         "lodash": "^4.17.23",
-        "uuid": "^9.0.1"
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^1.0.6",
@@ -1152,7 +1152,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
       "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1244,7 +1243,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.0.tgz",
       "integrity": "sha512-1DyBLG5SH7PYCd00QlroiW60YJ4rWMuUGa/JBV0iZuqi4l4IK3twKPq5ZkEebmGqRjXWVgsUzfd3+nZveewgow==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.19.0",
         "@typescript-eslint/types": "6.19.0",
@@ -1506,7 +1504,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1905,7 +1902,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2795,7 +2791,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2817,7 +2812,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
       "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3181,7 +3175,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3206,16 +3199,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/webidl-conversions": {

--- a/extensions/zerion/package.json
+++ b/extensions/zerion/package.json
@@ -287,7 +287,7 @@
     "bignumber.js": "^9.1.2",
     "dayjs": "^1.11.13",
     "lodash": "^4.17.23",
-    "uuid": "^9.0.1"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^1.0.6",
@@ -308,6 +308,7 @@
   },
   "overrides": {
     "minimatch": "^10.0.1",
-    "picomatch": "^4.0.4"
+    "picomatch": "^4.0.4",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## Summary Table

| Extension | Package(s) Addressed | CVEs / Advisories | Method Used | Details / Notes |
|-----------|----------------------|-------------------|-------------|-----------------|
| BMW | uuid | CVE-2026-41907 | Override | `overrides.uuid ^11.1.1` (transitive via `bmw-connected-drive`; direct was already `^11.1.1`) |
| Chatgo | uuid | CVE-2026-41907 | Direct bump | `"uuid": "^11.1.1"` (was `^9.0.0`) |
| Claude | uuid | CVE-2026-41907 | Direct bump | `"uuid": "^11.1.1"` (was `^9.0.0`) |
| css-gg | uuid | CVE-2026-41907 | Direct bump | `"uuid": "^11.1.1"` (was `^9.0.0`) |
| FuelX | vite, uuid | CVE-2026-53632, CVE-2026-41907 | Overrides | `overrides.vite ^6.4.3`, `overrides.uuid ^11.1.1` (vite via vitest; uuid via langchain) |
| Klu (`klu-ai`) | uuid | CVE-2026-41907 | Override | `overrides.uuid ^11.1.1` (transitive via `@kluai/core`) |
| Oracle Cloud (`oci`) | uuid | CVE-2026-41907 | SDK bump + override | `oci-sdk` `^2.122.2` → `^2.136.1`; `overrides.uuid ^11.1.1` |
| Spaces | uuid | CVE-2026-41907 | Direct bump | `"uuid": "^11.1.1"` (was `^8.3.2`) |
| Zerion | uuid | CVE-2026-41907 | Direct bump + override | `"uuid": "^11.1.1"` (was `^9.0.1`); `overrides.uuid ^11.1.1` |

## Screencast

N/A

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
