### PR TITLE
Update Amphetamine extension: add Quick Start Session command

### DIFF
--- a/extensions/amphetamine/CHANGELOG.md
+++ b/extensions/amphetamine/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Quick Start Session command] - {PR_MERGE_DATE}
+
+- Add a Quick Start Session command: type hours, minutes, and seconds inline to start a session
+  without opening a form. Leave the fields empty for a session with no time limit.
+- New preference on the command to allow the display to sleep during the session.
+
 ## [Require a fresh until-time on each launch] - 2026-06-15
 
 - The configurable session command no longer restores a past until-time. The Until Time mode

--- a/extensions/amphetamine/CHANGELOG.md
+++ b/extensions/amphetamine/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Quick Start Session command] - {PR_MERGE_DATE}
+## [Quick Start Session command] - 2026-07-14
 
 - Add a Quick Start Session command: type hours, minutes, and seconds inline to start a session
   without opening a form. Leave the fields empty for a session with no time limit.

--- a/extensions/amphetamine/package-lock.json
+++ b/extensions/amphetamine/package-lock.json
@@ -1150,7 +1150,6 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1200,7 +1199,6 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -1405,7 +1403,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1700,7 +1697,6 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2405,7 +2401,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2429,7 +2424,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2625,7 +2619,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/amphetamine/package.json
+++ b/extensions/amphetamine/package.json
@@ -10,7 +10,8 @@
     "System"
   ],
   "contributors": [
-    "mike_dloss"
+    "mike_dloss",
+    "ceyhuncicek"
   ],
   "license": "MIT",
   "commands": [
@@ -26,6 +27,52 @@
         "amp start",
         "amphetamine",
         "ampstart"
+      ]
+    },
+    {
+      "name": "quick-start",
+      "title": "Quick Start Session",
+      "subtitle": "Amphetamine",
+      "description": "Start a keep-awake session by typing the duration inline; leave all fields empty for a session with no time limit",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "hours",
+          "type": "text",
+          "placeholder": "Hours (empty = no limit)",
+          "required": false
+        },
+        {
+          "name": "minutes",
+          "type": "text",
+          "placeholder": "Minutes",
+          "required": false
+        },
+        {
+          "name": "seconds",
+          "type": "text",
+          "placeholder": "Seconds",
+          "required": false
+        }
+      ],
+      "preferences": [
+        {
+          "name": "displaySleepAllowed",
+          "type": "checkbox",
+          "required": false,
+          "default": false,
+          "title": "Display Sleep",
+          "label": "Allow the display to sleep during the session",
+          "description": "When enabled, the session keeps the Mac awake but lets the display turn off."
+        }
+      ],
+      "keywords": [
+        "quick",
+        "amp",
+        "amp quick",
+        "amphetamine",
+        "start",
+        "duration"
       ]
     },
     {

--- a/extensions/amphetamine/src/quick-start.ts
+++ b/extensions/amphetamine/src/quick-start.ts
@@ -70,15 +70,14 @@ export default async function Command(props: LaunchProps<{ arguments: QuickStart
 
   const { displaySleepAllowed } = getPreferenceValues<QuickStartPreferences>();
 
-  // Per Amphetamine's scripting dictionary, an infinite session uses 0 for both duration and interval.
-  const options =
+  const startSessionScript =
     durationMinutes === 0
-      ? `{duration: 0, interval: 0, displaySleepAllowed: ${displaySleepAllowed}}`
-      : `{duration: ${durationMinutes}, interval: minutes, displaySleepAllowed: ${displaySleepAllowed}}`;
+      ? "start new session"
+      : `start new session with options {duration: ${durationMinutes}, interval: minutes, displaySleepAllowed: ${displaySleepAllowed}}`;
 
   await runAppleScript(`
     tell application "Amphetamine"
-        start new session with options ${options}
+        ${startSessionScript}
     end tell
   `);
 

--- a/extensions/amphetamine/src/quick-start.ts
+++ b/extensions/amphetamine/src/quick-start.ts
@@ -1,0 +1,85 @@
+import { LaunchProps, Toast, getPreferenceValues, open, showHUD } from "@raycast/api";
+import { runAppleScript } from "run-applescript";
+
+import { AMPHETAMINE_DOWNLOAD_URL, checkIfAmphetamineInstalled } from "./utils";
+
+interface QuickStartArguments {
+  hours?: string;
+  minutes?: string;
+  seconds?: string;
+}
+
+interface QuickStartPreferences {
+  displaySleepAllowed: boolean;
+}
+
+/** Parse a duration argument: empty means 0, anything that isn't a whole number is invalid (null). */
+function parseArgument(value: string | undefined): number | null {
+  const trimmed = (value ?? "").trim();
+  if (trimmed === "") return 0;
+  if (!/^\d+$/.test(trimmed)) return null;
+  return parseInt(trimmed, 10);
+}
+
+function formatMinutes(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (h && m) return `${h}h ${m}m`;
+  if (h) return `${h}h`;
+  return `${m}m`;
+}
+
+export default async function Command(props: LaunchProps<{ arguments: QuickStartArguments }>) {
+  const toast = new Toast({
+    title: "Starting a new session",
+    style: Toast.Style.Animated,
+  });
+
+  toast.show();
+
+  const amphetamineAvailable = await checkIfAmphetamineInstalled();
+  if (!amphetamineAvailable) {
+    toast.title = "Amphetamine is not installed";
+    toast.message = "Press Command + D to download";
+    toast.primaryAction = {
+      title: "Download",
+      shortcut: {
+        modifiers: ["cmd"],
+        key: "d",
+      },
+      onAction: async () => await open(AMPHETAMINE_DOWNLOAD_URL),
+    };
+    toast.style = Toast.Style.Failure;
+    return;
+  }
+
+  const hours = parseArgument(props.arguments.hours);
+  const minutes = parseArgument(props.arguments.minutes);
+  const seconds = parseArgument(props.arguments.seconds);
+  if (hours === null || minutes === null || seconds === null) {
+    toast.title = "Invalid duration";
+    toast.message = "Enter whole numbers only, or leave all fields empty for no time limit";
+    toast.style = Toast.Style.Failure;
+    return;
+  }
+
+  const totalSeconds = hours * 3600 + minutes * 60 + seconds;
+
+  // Amphetamine's granularity is whole minutes; round any leftover seconds up. 0 means no time limit.
+  const durationMinutes = Math.ceil(totalSeconds / 60);
+
+  const { displaySleepAllowed } = getPreferenceValues<QuickStartPreferences>();
+
+  await runAppleScript(`
+    tell application "Amphetamine"
+        start new session with options {duration: ${durationMinutes}, interval: minutes, displaySleepAllowed: ${displaySleepAllowed}}
+    end tell
+  `);
+
+  if (durationMinutes === 0) {
+    await showHUD("Session started with no time limit");
+  } else {
+    const rounded = totalSeconds % 60 !== 0 ? " (rounded up)" : "";
+    await showHUD(`Session started for ${formatMinutes(durationMinutes)}${rounded}`);
+  }
+}

--- a/extensions/amphetamine/src/quick-start.ts
+++ b/extensions/amphetamine/src/quick-start.ts
@@ -70,9 +70,15 @@ export default async function Command(props: LaunchProps<{ arguments: QuickStart
 
   const { displaySleepAllowed } = getPreferenceValues<QuickStartPreferences>();
 
+  // Per Amphetamine's scripting dictionary, an infinite session uses 0 for both duration and interval.
+  const options =
+    durationMinutes === 0
+      ? `{duration: 0, interval: 0, displaySleepAllowed: ${displaySleepAllowed}}`
+      : `{duration: ${durationMinutes}, interval: minutes, displaySleepAllowed: ${displaySleepAllowed}}`;
+
   await runAppleScript(`
     tell application "Amphetamine"
-        start new session with options {duration: ${durationMinutes}, interval: minutes, displaySleepAllowed: ${displaySleepAllowed}}
+        start new session with options ${options}
     end tell
   `);
 

--- a/extensions/amphetamine/src/quick-start.ts
+++ b/extensions/amphetamine/src/quick-start.ts
@@ -72,7 +72,7 @@ export default async function Command(props: LaunchProps<{ arguments: QuickStart
 
   const startSessionScript =
     durationMinutes === 0
-      ? "start new session"
+      ? `start new session with options {duration: 0, interval: 0, displaySleepAllowed: ${displaySleepAllowed}}`
       : `start new session with options {duration: ${durationMinutes}, interval: minutes, displaySleepAllowed: ${displaySleepAllowed}}`;
 
   await runAppleScript(`


### PR DESCRIPTION
## Description

This adds a Quick Start Session command to the Amphetamine extension, following @pernielsentikaer's suggestion in #29304 to fold my separate extension into this one instead.

- Quick Start Session takes hours, minutes and seconds as inline arguments, so you can start a timed session without opening the form. Leave all fields empty for a session with no time limit. Amphetamine works in whole minutes, so leftover seconds get rounded up. There's a command preference to let the display sleep during the session.
- The command is self-contained in `src/quick-start.ts` and reuses the existing install check from `utils.ts`. No existing source files are changed.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the assets folder are used by the extension itself
- [x] I checked that assets used by the README are placed outside of the metadata folder
