### PR TITLE
fix(keka): await AppleScript operations

### DIFF
--- a/extensions/keka/CHANGELOG.md
+++ b/extensions/keka/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Keka Changelog
 
+## [Fixed asynchronous Keka commands] - 2026-07-14
+
+- Wait for compression, extraction, and open operations to finish before closing the command
+
 ## [Added Keka] - 2025-05-22
 
 Initial version code

--- a/extensions/keka/CHANGELOG.md
+++ b/extensions/keka/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Keka Changelog
 
-## [Fixed asynchronous Keka commands] - 2026-07-14
+## [Fixed asynchronous Keka commands] - {PR_MERGE_DATE}
 
 - Wait for compression, extraction, and open operations to finish before closing the command
 

--- a/extensions/keka/CHANGELOG.md
+++ b/extensions/keka/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Keka Changelog
 
-## [Fixed asynchronous Keka commands] - {PR_MERGE_DATE}
+## [Fixed asynchronous Keka commands] - 2026-07-14
 
 - Wait for compression, extraction, and open operations to finish before closing the command
 

--- a/extensions/keka/package.json
+++ b/extensions/keka/package.json
@@ -51,6 +51,7 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
+    "test": "node --disable-warning=ExperimentalWarning --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-test-module-mocks --experimental-strip-types --test tests/*.test.mts",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
   },

--- a/extensions/keka/src/utils/applescript-utils.ts
+++ b/extensions/keka/src/utils/applescript-utils.ts
@@ -1,15 +1,15 @@
 import { showFailureToast, runAppleScript } from "@raycast/utils";
 
-export const scriptCompressFiles = async (filePaths: string[]) => {
-  scriptExecuteFiles("compress", filePaths);
+export const scriptCompressFiles = (filePaths: string[]) => {
+  return scriptExecuteFiles("compress", filePaths);
 };
 
-export const scriptExtractFiles = async (filePaths: string[]) => {
-  scriptExecuteFiles("extract", filePaths);
+export const scriptExtractFiles = (filePaths: string[]) => {
+  return scriptExecuteFiles("extract", filePaths);
 };
 
-export const scriptSendFiles = async (filePaths: string[]) => {
-  scriptExecuteFiles("send", filePaths);
+export const scriptSendFiles = (filePaths: string[]) => {
+  return scriptExecuteFiles("send", filePaths);
 };
 
 export const scriptExecuteFiles = async (

--- a/extensions/keka/tests/applescript-utils.test.mts
+++ b/extensions/keka/tests/applescript-utils.test.mts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+
+let resolveAppleScript: (() => void) | undefined;
+
+const runAppleScript = mock.fn(
+  () =>
+    new Promise<void>((resolve) => {
+      resolveAppleScript = resolve;
+    }),
+);
+
+mock.module("@raycast/utils", {
+  exports: {
+    runAppleScript,
+    showFailureToast: mock.fn(async () => undefined),
+  },
+});
+
+const {
+  scriptCompressFiles,
+  scriptExtractFiles,
+  scriptSendFiles,
+} = await import("../src/utils/applescript-utils.ts");
+
+const actions = [
+  ["compress", scriptCompressFiles],
+  ["extract", scriptExtractFiles],
+  ["send", scriptSendFiles],
+] as const;
+
+for (const [action, execute] of actions) {
+  test(`${action} waits for AppleScript execution`, async () => {
+    let settled = false;
+    const execution = execute(["/tmp/example.txt"]);
+    void execution.then(() => {
+      settled = true;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(settled, false);
+    assert.ok(resolveAppleScript);
+
+    resolveAppleScript();
+    await execution;
+
+    assert.equal(settled, true);
+  });
+}


### PR DESCRIPTION
## Description

- return the delegated AppleScript Promise from all Keka action wrappers
- keep Raycast commands alive until compression, extraction, or open operations settle
- add regression coverage for all three wrappers

## Root cause

The async wrappers started `scriptExecuteFiles` without returning or awaiting its Promise, so Raycast could unload the command runtime before the AppleScript call completed.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
