### PR TITLE
Update agent-usage extension

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Fix MiniMax no data display] - {PR_MERGE_DATE}
+## [Fix MiniMax no data display] - 2026-07-14
 
 ### Bug Fixes
 

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Agent Usage Changelog
 
+## [Fix MiniMax no data display] - {PR_MERGE_DATE}
+
+### Bug Fixes
+
+- Fix MiniMax showing "—" (no data) for coding plan users: the upstream API now returns remaining percentages and per-window status instead of usage counts, so read `current_interval_remaining_percent` / `current_weekly_remaining_percent` when counts are 0, treat `status === 1` as an active plan window, and pick the active model first instead of matching by `MiniMax-M*` model name (new API uses `general` / `video`)
+
 ## [Fix Codex Plus plan parse error] - 2026-07-13
 
 ### Bug Fixes

--- a/extensions/agent-usage/src/minimax/fetcher.ts
+++ b/extensions/agent-usage/src/minimax/fetcher.ts
@@ -21,6 +21,10 @@ interface MiniMaxApiResponse {
     weekly_start_time: number;
     weekly_end_time: number;
     weekly_remains_time: number;
+    current_interval_status?: number;
+    current_interval_remaining_percent?: number;
+    current_weekly_status?: number;
+    current_weekly_remaining_percent?: number;
   }>;
   base_resp: {
     status_code: number;

--- a/extensions/agent-usage/src/minimax/parser.test.ts
+++ b/extensions/agent-usage/src/minimax/parser.test.ts
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getCodingModelRemain, getIntervalPercent, getWeeklyPercent } from "./parser";
+import type { MiniMaxModelRemain } from "./types";
+
+const NEW_API_RESPONSE: MiniMaxModelRemain[] = [
+  {
+    start_time: 0,
+    end_time: 0,
+    remains_time: 9963072,
+    current_interval_total_count: 0,
+    current_interval_usage_count: 0,
+    model_name: "general",
+    current_weekly_total_count: 0,
+    current_weekly_usage_count: 0,
+    weekly_start_time: 0,
+    weekly_end_time: 0,
+    weekly_remains_time: 9963072,
+    current_interval_status: 1,
+    current_interval_remaining_percent: 89,
+    current_weekly_status: 1,
+    current_weekly_remaining_percent: 78,
+  },
+  {
+    start_time: 0,
+    end_time: 0,
+    remains_time: 0,
+    current_interval_total_count: 0,
+    current_interval_usage_count: 0,
+    model_name: "video",
+    current_weekly_total_count: 0,
+    current_weekly_usage_count: 0,
+    weekly_start_time: 0,
+    weekly_end_time: 0,
+    weekly_remains_time: 0,
+    current_interval_status: 3,
+    current_interval_remaining_percent: 100,
+    current_weekly_status: 3,
+    current_weekly_remaining_percent: 100,
+  },
+];
+
+test("getCodingModelRemain picks the model with status=1 (active plan window)", () => {
+  const picked = getCodingModelRemain(NEW_API_RESPONSE);
+  assert.ok(picked);
+  assert.equal(picked!.model_name, "general");
+});
+
+test("getIntervalPercent returns the percent field when counts are 0", () => {
+  const picked = getCodingModelRemain(NEW_API_RESPONSE)!;
+  assert.equal(getIntervalPercent(picked), 89);
+});
+
+test("getWeeklyPercent returns the percent field when counts are 0", () => {
+  const picked = getCodingModelRemain(NEW_API_RESPONSE)!;
+  assert.equal(getWeeklyPercent(picked), 78);
+});
+
+test("getIntervalPercent returns null for inactive model (status=3)", () => {
+  const video = NEW_API_RESPONSE.find((r) => r.model_name === "video")!;
+  assert.equal(getIntervalPercent(video), null);
+  assert.equal(getWeeklyPercent(video), null);
+});
+
+test("getIntervalPercent falls back to counts when percent fields are missing (legacy API)", () => {
+  const legacy: MiniMaxModelRemain = {
+    start_time: 0,
+    end_time: 0,
+    remains_time: 0,
+    current_interval_total_count: 100,
+    current_interval_usage_count: 30,
+    model_name: "MiniMax-M1",
+    current_weekly_total_count: 1000,
+    current_weekly_usage_count: 200,
+    weekly_start_time: 0,
+    weekly_end_time: 0,
+    weekly_remains_time: 0,
+  };
+  assert.equal(getIntervalPercent(legacy), 70);
+  assert.equal(getWeeklyPercent(legacy), 80);
+});
+
+test("getCodingModelRemain falls back to MiniMax-M* model name (backward compat)", () => {
+  const only: MiniMaxModelRemain[] = [
+    {
+      start_time: 0,
+      end_time: 0,
+      remains_time: 0,
+      current_interval_total_count: 100,
+      current_interval_usage_count: 50,
+      model_name: "MiniMax-M1",
+      current_weekly_total_count: 0,
+      current_weekly_usage_count: 0,
+      weekly_start_time: 0,
+      weekly_end_time: 0,
+      weekly_remains_time: 0,
+    },
+  ];
+  assert.equal(getCodingModelRemain(only)!.model_name, "MiniMax-M1");
+});
+
+test("getCodingModelRemain returns null for empty list", () => {
+  assert.equal(getCodingModelRemain([]), null);
+});

--- a/extensions/agent-usage/src/minimax/parser.ts
+++ b/extensions/agent-usage/src/minimax/parser.ts
@@ -1,0 +1,31 @@
+import type { MiniMaxModelRemain } from "./types";
+
+export function getCodingModelRemain(remains: MiniMaxModelRemain[]): MiniMaxModelRemain | null {
+  const active = remains.find((r) => r.current_interval_status === 1 || r.current_weekly_status === 1);
+  return active || remains.find((r) => r.model_name.startsWith("MiniMax-M")) || remains[0] || null;
+}
+
+export function getIntervalPercent(model: MiniMaxModelRemain): number | null {
+  if (model.current_interval_total_count > 0) {
+    return getRemainingPercent(model.current_interval_usage_count, model.current_interval_total_count);
+  }
+  if (model.current_interval_status === 1 && typeof model.current_interval_remaining_percent === "number") {
+    return model.current_interval_remaining_percent;
+  }
+  return null;
+}
+
+export function getWeeklyPercent(model: MiniMaxModelRemain): number | null {
+  if (model.current_weekly_total_count > 0) {
+    return getRemainingPercent(model.current_weekly_usage_count, model.current_weekly_total_count);
+  }
+  if (model.current_weekly_status === 1 && typeof model.current_weekly_remaining_percent === "number") {
+    return model.current_weekly_remaining_percent;
+  }
+  return null;
+}
+
+function getRemainingPercent(remaining: number, total: number): number {
+  if (total === 0) return 100;
+  return Math.round((remaining / total) * 100);
+}

--- a/extensions/agent-usage/src/minimax/parser.ts
+++ b/extensions/agent-usage/src/minimax/parser.ts
@@ -7,7 +7,7 @@ export function getCodingModelRemain(remains: MiniMaxModelRemain[]): MiniMaxMode
 
 export function getIntervalPercent(model: MiniMaxModelRemain): number | null {
   if (model.current_interval_total_count > 0) {
-    return getRemainingPercent(model.current_interval_usage_count, model.current_interval_total_count);
+    return getRemainingPercentFromCounts(model.current_interval_usage_count, model.current_interval_total_count);
   }
   if (model.current_interval_status === 1 && typeof model.current_interval_remaining_percent === "number") {
     return model.current_interval_remaining_percent;
@@ -17,7 +17,7 @@ export function getIntervalPercent(model: MiniMaxModelRemain): number | null {
 
 export function getWeeklyPercent(model: MiniMaxModelRemain): number | null {
   if (model.current_weekly_total_count > 0) {
-    return getRemainingPercent(model.current_weekly_usage_count, model.current_weekly_total_count);
+    return getRemainingPercentFromCounts(model.current_weekly_usage_count, model.current_weekly_total_count);
   }
   if (model.current_weekly_status === 1 && typeof model.current_weekly_remaining_percent === "number") {
     return model.current_weekly_remaining_percent;
@@ -25,7 +25,7 @@ export function getWeeklyPercent(model: MiniMaxModelRemain): number | null {
   return null;
 }
 
-function getRemainingPercent(remaining: number, total: number): number {
+function getRemainingPercentFromCounts(usage: number, total: number): number {
   if (total === 0) return 100;
-  return Math.round((remaining / total) * 100);
+  return Math.round(((total - usage) / total) * 100);
 }

--- a/extensions/agent-usage/src/minimax/renderer.tsx
+++ b/extensions/agent-usage/src/minimax/renderer.tsx
@@ -1,5 +1,5 @@
 import { List } from "@raycast/api";
-import { MiniMaxUsage, MiniMaxError, MiniMaxModelRemain } from "./types";
+import { MiniMaxUsage, MiniMaxError } from "./types";
 import type { Accessory } from "../agents/types";
 import { formatDuration } from "../agents/format";
 import {
@@ -10,15 +10,7 @@ import {
   generatePieIcon,
   generateAsciiBar,
 } from "../agents/ui";
-
-function getCodingModelRemain(remains: MiniMaxModelRemain[]): MiniMaxModelRemain | null {
-  return remains.find((r) => r.model_name.startsWith("MiniMax-M")) || remains[0] || null;
-}
-
-function getRemainingPercent(remaining: number, total: number): number {
-  if (total === 0) return 100;
-  return Math.round((remaining / total) * 100);
-}
+import { getCodingModelRemain, getIntervalPercent, getWeeklyPercent } from "./parser";
 
 export function formatMiniMaxUsageText(usage: MiniMaxUsage | null, error: MiniMaxError | null): string {
   const fallback = formatErrorOrNoData("MiniMax", usage, error);
@@ -31,25 +23,19 @@ export function formatMiniMaxUsageText(usage: MiniMaxUsage | null, error: MiniMa
   if (codingModel) {
     text += `\n\nCoding Model (${codingModel.model_name}):`;
 
-    if (codingModel.current_interval_total_count > 0) {
-      const percent = getRemainingPercent(
-        codingModel.current_interval_usage_count,
-        codingModel.current_interval_total_count,
-      );
+    const intervalPercent = getIntervalPercent(codingModel);
+    if (intervalPercent !== null) {
       text += `\n\n5h Limit (${formatDuration(codingModel.remains_time / 1000)}):`;
-      text += `\n${generateAsciiBar(percent)}`;
-      text += `\n${percent}% remaining`;
+      text += `\n${generateAsciiBar(intervalPercent)}`;
+      text += `\n${intervalPercent}% remaining`;
       text += `\nResets In: ${formatDuration(codingModel.remains_time / 1000)}`;
     }
 
-    if (codingModel.current_weekly_total_count > 0) {
-      const percent = getRemainingPercent(
-        codingModel.current_weekly_usage_count,
-        codingModel.current_weekly_total_count,
-      );
+    const weeklyPercent = getWeeklyPercent(codingModel);
+    if (weeklyPercent !== null) {
       text += `\n\nWeekly Limit (${formatDuration(codingModel.weekly_remains_time / 1000)}):`;
-      text += `\n${generateAsciiBar(percent)}`;
-      text += `\n${percent}% remaining`;
+      text += `\n${generateAsciiBar(weeklyPercent)}`;
+      text += `\n${weeklyPercent}% remaining`;
       text += `\nResets In: ${formatDuration(codingModel.weekly_remains_time / 1000)}`;
     }
   }
@@ -70,33 +56,41 @@ export function renderMiniMaxDetail(usage: MiniMaxUsage | null, error: MiniMaxEr
         <>
           <List.Item.Detail.Metadata.Label title="Coding Model" text={codingModel.model_name} />
 
-          {codingModel.current_interval_total_count > 0 && (
-            <>
-              <List.Item.Detail.Metadata.Separator />
-              <List.Item.Detail.Metadata.Label
-                title="5h Limit"
-                text={`${generateAsciiBar(getRemainingPercent(codingModel.current_interval_usage_count, codingModel.current_interval_total_count))} ${getRemainingPercent(codingModel.current_interval_usage_count, codingModel.current_interval_total_count)}% remaining`}
-              />
-              <List.Item.Detail.Metadata.Label
-                title="Resets In"
-                text={formatDuration(codingModel.remains_time / 1000)}
-              />
-            </>
-          )}
+          {(() => {
+            const percent = getIntervalPercent(codingModel);
+            if (percent === null) return null;
+            return (
+              <>
+                <List.Item.Detail.Metadata.Separator />
+                <List.Item.Detail.Metadata.Label
+                  title="5h Limit"
+                  text={`${generateAsciiBar(percent)} ${percent}% remaining`}
+                />
+                <List.Item.Detail.Metadata.Label
+                  title="Resets In"
+                  text={formatDuration(codingModel.remains_time / 1000)}
+                />
+              </>
+            );
+          })()}
 
-          {codingModel.current_weekly_total_count > 0 && (
-            <>
-              <List.Item.Detail.Metadata.Separator />
-              <List.Item.Detail.Metadata.Label
-                title="Weekly Limit"
-                text={`${generateAsciiBar(getRemainingPercent(codingModel.current_weekly_usage_count, codingModel.current_weekly_total_count))} ${getRemainingPercent(codingModel.current_weekly_usage_count, codingModel.current_weekly_total_count)}% remaining`}
-              />
-              <List.Item.Detail.Metadata.Label
-                title="Resets In"
-                text={formatDuration(codingModel.weekly_remains_time / 1000)}
-              />
-            </>
-          )}
+          {(() => {
+            const percent = getWeeklyPercent(codingModel);
+            if (percent === null) return null;
+            return (
+              <>
+                <List.Item.Detail.Metadata.Separator />
+                <List.Item.Detail.Metadata.Label
+                  title="Weekly Limit"
+                  text={`${generateAsciiBar(percent)} ${percent}% remaining`}
+                />
+                <List.Item.Detail.Metadata.Label
+                  title="Resets In"
+                  text={formatDuration(codingModel.weekly_remains_time / 1000)}
+                />
+              </>
+            );
+          })()}
         </>
       )}
     </List.Item.Detail.Metadata>
@@ -134,18 +128,20 @@ export function getMiniMaxAccessory(
     return getNoDataAccessory();
   }
 
-  if (codingModel.current_interval_total_count === 0 && codingModel.current_weekly_total_count === 0) {
+  const intervalPercent = getIntervalPercent(codingModel);
+  const weeklyPercent = getWeeklyPercent(codingModel);
+  if (intervalPercent === null && weeklyPercent === null) {
     return getNoDataAccessory();
   }
 
-  const percent = getRemainingPercent(
-    codingModel.current_interval_usage_count,
-    codingModel.current_interval_total_count,
-  );
+  const percent = intervalPercent ?? weeklyPercent ?? 0;
+  const parts: string[] = [];
+  if (intervalPercent !== null) parts.push(`5h: ${intervalPercent}%`);
+  if (weeklyPercent !== null) parts.push(`Weekly: ${weeklyPercent}%`);
 
   return {
     icon: generatePieIcon(percent),
     text: `${percent}%`,
-    tooltip: `5h: ${percent}% | Weekly: ${getRemainingPercent(codingModel.current_weekly_usage_count, codingModel.current_weekly_total_count)}%`,
+    tooltip: parts.join(" | "),
   };
 }

--- a/extensions/agent-usage/src/minimax/types.ts
+++ b/extensions/agent-usage/src/minimax/types.ts
@@ -10,6 +10,10 @@ export interface MiniMaxModelRemain {
   weekly_start_time: number;
   weekly_end_time: number;
   weekly_remains_time: number;
+  current_interval_status?: number;
+  current_interval_remaining_percent?: number;
+  current_weekly_status?: number;
+  current_weekly_remaining_percent?: number;
 }
 
 export interface MiniMaxUsage {


### PR DESCRIPTION
## Description

Fix MiniMax showing "—" (no data) for coding plan users.

**Problem**

The `https://www.minimax.io/v1/api/openplatform/coding_plan/remains` endpoint changed shape: it no longer reports usage counts (`current_interval_total_count`, `current_interval_usage_count`, `current_weekly_total_count`, `current_weekly_usage_count`) — those all come back as `0`. Instead it returns the remaining percentage and a per-window status directly:

```json
{
  "model_remains": [
    {
      "model_name": "general",
      "current_interval_total_count": 0,
      "current_interval_usage_count": 0,
      "current_interval_status": 1,
      "current_interval_remaining_percent": 89,
      "current_weekly_total_count": 0,
      "current_weekly_usage_count": 0,
      "current_weekly_status": 1,
      "current_weekly_remaining_percent": 78
    },
    {
      "model_name": "video",
      "current_interval_status": 3,
      "current_interval_remaining_percent": 100,
      "current_weekly_status": 3,
      "current_weekly_remaining_percent": 100
    }
  ],
  "base_resp": { "status_code": 0, "status_msg": "success" }
}
```
The existing parser only rendered a window when total_count > 0, so every MiniMax coding plan user saw a dash in the list and an empty detail view.
Fix
- Extend MiniMaxModelRemain with optional current_interval_status, current_interval_remaining_percent, current_weekly_status, current_weekly_remaining_percent
- When total_count > 0, keep the legacy usage / total calculation
- When total_count === 0, fall back to the new percent field — but only if status === 1 (active plan window). Status 3 means the model is not on this plan and should be hidden
- getCodingModelRemain now picks the model with status === 1 first, then falls back to the legacy MiniMax-M* name match, then the first model
- Split pure helpers into src/minimax/parser.ts so they're unit-testable without React, matching the cursor / opencode-go pattern in this repo
- getMiniMaxAccessory no longer returns getNoDataAccessory() when both counts are 0 but percent data is available
Verification
- npm run lint and npm run build pass
- Parser exercised against the captured real response — general model selected, 5h: 89%, Weekly: 78%, video correctly filtered out
- Manual check in Raycast with MiniMax coding plan: list now shows percentage instead of —, detail renders both 5h and weekly limits
- Added src/minimax/parser.test.ts covering new API shape, legacy shape (counts), inactive status, backward-compat model name, and empty list

## Screencast

<img width="767" height="324" alt="file-4d5de202471c24063502813ae32f695f" src="https://github.com/user-attachments/assets/0fd9f2d4-2a49-4eaf-87dc-eb66dc590e36" />

<img width="1500" height="948" alt="image" src="https://github.com/user-attachments/assets/030f0f0f-a676-43e2-8f9e-1b750d717665" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
