### PR TITLE
google-chrome-profiles: spawn detached osascript before showing HUD

### DIFF
--- a/extensions/google-chrome-profiles/CHANGELOG.md
+++ b/extensions/google-chrome-profiles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Chrome Profiles Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fix profile actions still failing in the store build after the 2026-05-26 detached-spawn fix. `showHUD` was awaited *before* spawning the detached `osascript` subprocess; `showHUD` closes the main window, which starts the extension process teardown, so in the distribution build the Node process could be killed before the `spawn` call ever ran — the HUD appeared but no Chrome action happened. (Dev mode keeps the process alive, which is why this never reproduced under `npm run dev`.) Spawn the detached subprocess first, then show the HUD; skip the HUD when the spawn failed so the failure toast stays visible.
+
 ## [Fix] - 2026-05-26
 
 - Fix silent failure of all profile actions (Bring to Front, New Tab, New Window, Open URL) for users who have not previously granted Raycast `AppleEvents` permission for `System Events.app`. `@raycast/utils.runAppleScript` spawns `osascript` without `detached: true`, so it inherits the extension's Node process group. Raycast tears that group down ~40ms after the action handler returns control to React, which kills `osascript` mid-flight and also cancels the asynchronous TCC permission prompt that macOS tries to render on first run, leaving no path for the user to actually grant the permission. Run AppleScript via a detached `child_process.spawn("/usr/bin/osascript", [...], { detached: true, stdio: "ignore" })` + `child.unref()` so the subprocess survives teardown, the TCC prompt renders, and the script runs to completion.

--- a/extensions/google-chrome-profiles/CHANGELOG.md
+++ b/extensions/google-chrome-profiles/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Chrome Profiles Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-07-14
 
 - Fix profile actions still failing in the store build after the 2026-05-26 detached-spawn fix. `showHUD` was awaited *before* spawning the detached `osascript` subprocess; `showHUD` closes the main window, which starts the extension process teardown, so in the distribution build the Node process could be killed before the `spawn` call ever ran — the HUD appeared but no Chrome action happened. (Dev mode keeps the process alive, which is why this never reproduced under `npm run dev`.) Spawn the detached subprocess first, then show the HUD; skip the HUD when the spawn failed so the failure toast stays visible.
 

--- a/extensions/google-chrome-profiles/package.json
+++ b/extensions/google-chrome-profiles/package.json
@@ -9,7 +9,8 @@
     "erics118",
     "jschmidtcordeiro",
     "NirRosh",
-    "josh_carty"
+    "josh_carty",
+    "smpeotn"
   ],
   "license": "MIT",
   "commands": [

--- a/extensions/google-chrome-profiles/src/index.tsx
+++ b/extensions/google-chrome-profiles/src/index.tsx
@@ -362,7 +362,9 @@ function ActionPanelForTarget(props: { profile: Profile; target: ChromeTarget; b
   const context = encodeURIComponent(
     JSON.stringify({ directory: props.profile.directory, name: props.profile.name, ...props.target }),
   );
-  const deeplink = `${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/frouo/${environment.extensionName}/open-profile?context=${context}`;
+  const deeplink = `${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/frouo/${
+    environment.extensionName
+  }/open-profile?context=${context}`;
 
   const targetUrl = props.target.action === "openUrl" ? props.target.url : "";
 

--- a/extensions/google-chrome-profiles/src/util/util.ts
+++ b/extensions/google-chrome-profiles/src/util/util.ts
@@ -206,8 +206,11 @@ export const escapeAppleScriptString = (str: string): string => {
  * The temp script file is removed on the child's `exit` event when the
  * parent is still alive; if the parent dies first, macOS cleans `/tmp`
  * during normal maintenance.
+ *
+ * @returns `true` when the subprocess was spawned, `false` otherwise
+ *   (a failure toast has already been shown).
  */
-const runDetachedAppleScript = (script: string): void => {
+const runDetachedAppleScript = (script: string): boolean => {
   const scriptPath = join(tmpdir(), `raycast-google-chrome-profiles-${randomUUID()}.applescript`);
   try {
     writeFileSync(scriptPath, script);
@@ -217,7 +220,7 @@ const runDetachedAppleScript = (script: string): void => {
       title: "Could not write script file",
       message: String(writeError),
     });
-    return;
+    return false;
   }
 
   let child;
@@ -237,7 +240,7 @@ const runDetachedAppleScript = (script: string): void => {
       title: "Could not start osascript",
       message: String(spawnError),
     });
-    return;
+    return false;
   }
 
   child.on("exit", () => {
@@ -256,6 +259,7 @@ const runDetachedAppleScript = (script: string): void => {
   });
 
   child.unref();
+  return true;
 };
 
 /**
@@ -268,18 +272,21 @@ const runDetachedAppleScript = (script: string): void => {
  *
  * @param profile The Chrome profile to open
  * @param target The action to perform
- * @param willOpen Function to run before opening Google Chrome
+ * @param didSpawn Function to run after the detached osascript has been
+ *   spawned (e.g. `showHUD`). It must run *after* the spawn: `showHUD`
+ *   closes the main window, which starts the extension process teardown,
+ *   and in the store build the process can be killed before a later
+ *   `spawn` call ever runs — the HUD shows but nothing happens. Not called
+ *   when the spawn failed, so the failure toast stays visible.
  */
 export const openGoogleChrome = async (
   profile: { name: string; directory: string },
   target: ChromeTarget,
-  willOpen: () => Promise<void>,
+  didSpawn: () => Promise<void>,
   browser: BrowserConfig,
 ) => {
   const action = target.action;
   const url = action === "openUrl" ? target.url : undefined;
-
-  await willOpen();
 
   const escapedProfileDirectory = escapeAppleScriptString(profile.directory);
   const escapedBinaryPath = escapeAppleScriptString(browser.binaryPath);
@@ -290,7 +297,9 @@ export const openGoogleChrome = async (
       set theProfile to quoted form of "${escapedProfileDirectory}"
       do shell script theAppPath & " --profile-directory=" & theProfile & " --new-window"
     `;
-    runDetachedAppleScript(newWindowScript);
+    if (runDetachedAppleScript(newWindowScript)) {
+      await didSpawn();
+    }
     return;
   }
 
@@ -367,5 +376,7 @@ export const openGoogleChrome = async (
     }
   `;
 
-  runDetachedAppleScript(script);
+  if (runDetachedAppleScript(script)) {
+    await didSpawn();
+  }
 };


### PR DESCRIPTION
## Description

Fixes profile actions (Bring to Front, New Tab, New Window, Open URL) still silently failing in the store build after the detached-spawn fix (#27615): the HUD appears but no Chrome action happens.

**Root cause:** `openGoogleChrome` awaited `showHUD` *before* spawning the detached `osascript` subprocess. `showHUD` closes the main window, which starts the extension process teardown, so in the distribution build the Node process could be killed before the `spawn` call ever ran. Dev mode keeps the extension process alive, which is why this never reproduces under `npm run dev` — only with the distribution build (and thus in the store version).

**Fix:** spawn the detached subprocess first (synchronously, before any `await`), then show the HUD. `runDetachedAppleScript` now returns whether the spawn succeeded, and the HUD is skipped on failure so the failure toast stays visible.

**Verification (distribution build, no dev server):**
- Before: invoking an action left no temp script file behind — the process died before `writeFileSync`/`spawn` ran. The generated AppleScript itself runs fine (~0.9s) when executed manually.
- After: with temporary debug logging in the dist build, the temp script is written, `osascript` is spawned detached, and exits with code 0 in ~600ms; the profile actually switches. Also verified by replacing the store-installed extension's files with this build and exercising the actions through the store install path.

## Screencast

Straightforward ordering fix; happy to add one if needed.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)