### PR TITLE
Update filezilla extension

### DIFF
--- a/extensions/filezilla/CHANGELOG.md
+++ b/extensions/filezilla/CHANGELOG.md
@@ -1,5 +1,9 @@
 # FileZilla Changelog
 
+## [Bug Fixes] - 2026-07-14
+
+- Fix issue with connecting to servers that have spaces in their names
+
 ## [FileZilla Pro Support] - 2026-05-25
 
 - Add support for FileZilla Pro (Mac App Store version) alongside standard FileZilla

--- a/extensions/filezilla/CHANGELOG.md
+++ b/extensions/filezilla/CHANGELOG.md
@@ -1,6 +1,6 @@
 # FileZilla Changelog
 
-## [Bug Fixes] - 2026-07-14
+## [Bug Fixes] - {PR_MERGE_DATE}
 
 - Fix issue with connecting to servers that have spaces in their names
 

--- a/extensions/filezilla/CHANGELOG.md
+++ b/extensions/filezilla/CHANGELOG.md
@@ -1,6 +1,6 @@
 # FileZilla Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-07-14
 
 - Fix issue with connecting to servers that have spaces in their names
 

--- a/extensions/filezilla/package.json
+++ b/extensions/filezilla/package.json
@@ -6,7 +6,8 @@
   "icon": "icon.png",
   "author": "naqet",
   "contributors": [
-    "xmok"
+    "xmok",
+    "uaustudio"
   ],
   "categories": [
     "Developer Tools",

--- a/extensions/filezilla/src/utils.tsx
+++ b/extensions/filezilla/src/utils.tsx
@@ -207,5 +207,5 @@ export async function connectToTheServer(server: Server): Promise<void> {
   if (!variant) return;
   // Unfortunatelly FileZilla does not provide a way to change connections inside a currently working app via it's API.
   // Hence we need to reopen the app every time we want to perform some action in FileZilla via Raycast
-  exec(`(pkill -x filezilla; open -a "${variant.appName}" --args --site=${server.Path})`);
+  exec(`(pkill -x filezilla; open -a "${variant.appName}" --args --site="${server.Path}")`);
 }

--- a/extensions/filezilla/src/utils.tsx
+++ b/extensions/filezilla/src/utils.tsx
@@ -1,5 +1,5 @@
 import { getApplications, showToast, Toast } from "@raycast/api";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { XMLParser } from "fast-xml-parser";
 import { homedir } from "os";
 import { readFile } from "fs/promises";
@@ -25,6 +25,24 @@ const VARIANTS: FileZillaVariant[] = [
 ];
 
 let installedVariantPromise: Promise<FileZillaVariant | null> | null = null;
+
+/**
+ * Restarts FileZilla and passes its command-line arguments without a shell.
+ */
+async function reopenFileZilla(variant: FileZillaVariant, args: string[]): Promise<void> {
+  // Continue when FileZilla is not already running: pkill exits with a non-zero status in that case.
+  await new Promise<void>((resolve) => {
+    execFile("/usr/bin/pkill", ["-x", "filezilla"], () => resolve());
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    execFile("/usr/bin/open", ["-a", variant.appName, "--args", ...args], (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
 /**
  * Finds the installed FileZilla variant (standard or Pro from the Mac App Store)
  * @returns The installed variant, or null if neither is installed
@@ -63,7 +81,7 @@ export async function openSiteManager(): Promise<void> {
   if (!variant) return;
   // Unfortunatelly FileZilla does not provide a way to change current state of the working app via it's API.
   // Hence we need to reopen the app every time we want to perform some action in FileZilla via Raycast
-  exec(`(pkill -x filezilla; open -a "${variant.appName}" --args -s)`);
+  await reopenFileZilla(variant, ["-s"]);
 }
 
 /**
@@ -207,5 +225,5 @@ export async function connectToTheServer(server: Server): Promise<void> {
   if (!variant) return;
   // Unfortunatelly FileZilla does not provide a way to change connections inside a currently working app via it's API.
   // Hence we need to reopen the app every time we want to perform some action in FileZilla via Raycast
-  exec(`(pkill -x filezilla; open -a "${variant.appName}" --args --site="${server.Path}")`);
+  await reopenFileZilla(variant, [`--site=${server.Path}`]);
 }


### PR DESCRIPTION
## Description

Using List Saved Servers, selecting a site containing a space in its name would trigger:

**Syntax error in command line**
-c cannot be used together with an FTP URL.

Adding quotes to ${server.Path} (i.e. --site="${server.Path}") solves the issue.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
