### PR TITLE
[Slack] Add thread reply AI tool

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Add Slack thread reply AI tool] - {PR_MERGE_DATE}
+## [Add Slack thread reply AI tool] - 2026-07-14
 
 - Add a `reply-thread` AI tool that posts a message to an existing Slack thread using its channel ID and parent message timestamp.
 

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Changelog
 
+## [Add Slack thread reply AI tool] - {PR_MERGE_DATE}
+
+- Add a `reply-thread` AI tool that posts a message to an existing Slack thread using its channel ID and parent message timestamp.
+
 ## [Fix YAML codeblock in README] - 2026-07-09
 
 ## [Add Slack thread reader AI tool, fix missing webhook author] - 2026-06-17

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -179,6 +179,11 @@
       "title": "Read Thread",
       "name": "read-thread",
       "description": "Read a bounded page of messages in a Slack thread. Use this when the user asks to summarize, inspect, or answer questions about a specific threaded conversation. Requires the channel ID and the parent message timestamp, which can come from Get Channel History or Search Messages. The response includes hasMore and nextCursor so more messages can be fetched when needed."
+    },
+    {
+      "title": "Reply to Thread",
+      "name": "reply-thread",
+      "description": "Post a reply to a Slack thread. Requires the channel ID, the parent message timestamp, and the reply text. Use Read Thread first when context is needed."
     }
   ],
   "ai": {
@@ -232,6 +237,26 @@
             }
           }
         ]
+      },
+      {
+        "input": "@slack reply \"I will take a look\" to this thread: https://example.slack.com/archives/C12345678/p1718899200000100",
+        "expected": [
+          {
+            "callsTool": {
+              "name": "reply-thread",
+              "arguments": {
+                "channel": "C12345678",
+                "threadTs": "1718899200.000100",
+                "text": {
+                  "includes": "I will take a look"
+                }
+              }
+            }
+          }
+        ],
+        "mocks": {
+          "reply-thread": "success"
+        }
       }
     ]
   },

--- a/extensions/slack/src/tools/reply-thread.ts
+++ b/extensions/slack/src/tools/reply-thread.ts
@@ -1,0 +1,56 @@
+import { getSlackWebClient } from "../shared/client/WebClient";
+import { withSlackClient } from "../shared/withSlackClient";
+
+type Input = {
+  /**
+   * The Slack channel ID that contains the thread. Use Get Channels, Get Channel History, or Search Messages to find it.
+   *
+   * @example "C12345678"
+   */
+  channel: string;
+  /**
+   * The timestamp of the parent message to reply to. This is the `ts` value from Get Channel History, Search Messages, or Read Thread.
+   *
+   * @example "1718899200.000100"
+   */
+  threadTs: string;
+  /**
+   * The text to post as a reply in the thread.
+   */
+  text: string;
+};
+
+async function replyThread(input: Input) {
+  if (!/^[CDG][A-Z0-9]{8,}$/.test(input.channel)) {
+    throw new Error("Invalid Slack conversation ID");
+  }
+
+  if (!/^\d+\.\d+$/.test(input.threadTs)) {
+    throw new Error("Invalid Slack thread timestamp");
+  }
+
+  const text = input.text.trim();
+  if (!text) {
+    throw new Error("Reply text cannot be empty");
+  }
+
+  const slackWebClient = getSlackWebClient();
+  const response = await slackWebClient.chat.postMessage({
+    channel: input.channel,
+    thread_ts: input.threadTs,
+    text,
+  });
+
+  if (response.error) {
+    throw new Error(response.error);
+  }
+
+  return {
+    channel: response.channel,
+    threadTs: input.threadTs,
+    ts: response.ts,
+    text: response.message?.text ?? text,
+  };
+}
+
+export default withSlackClient(replyThread);


### PR DESCRIPTION
## Description

Adds a `reply-thread` AI tool to the Slack extension. It posts a reply with `chat.postMessage` using the channel ID and parent message timestamp.

The extension already requests `chat:write` for its Send Message command, so no additional Slack scope is required.

## Checks

- `npm run build`
- `npm run lint`