### PR TITLE
[Slack] Add send message AI tool

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Slack Changelog
 
+## [Add Slack send message AI tool] - 2026-07-14
+
+- Add a `send-message` AI tool that sends messages to channels, group DMs, existing DMs, or users. User IDs are resolved to a direct-message conversation before posting.
+- Return the sent message permalink so AI can link directly to it.
+- Use the existing `chat:write` and `im:write` OAuth scopes required to post messages and open DMs.
+
 ## [Add Slack thread reply AI tool] - 2026-07-14
 
 - Add a `reply-thread` AI tool that posts a message to an existing Slack thread using its channel ID and parent message timestamp.

--- a/extensions/slack/README.md
+++ b/extensions/slack/README.md
@@ -66,6 +66,9 @@ If you don't want to log in through OAuth, you can use an access token instead. 
          # Command: Unread Messages (optional - needed for marking conversations as read)
          - channels:write
          - groups:write
+
+         # Command: Unread Messages (optional - needed for marking conversations as read)
+         # AI Tool: Send Message (needed to open a DM from a user ID)
          - im:write
          - mpim:write
    
@@ -76,7 +79,7 @@ If you don't want to log in through OAuth, you can use an access token instead. 
          - dnd:read
          - dnd:write
    
-         # Command: Send Message
+         # Command & AI Tool: Send Message
          - chat:write
    
          # Command: Search Emojis

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -181,6 +181,11 @@
       "description": "Read a bounded page of messages in a Slack thread. Use this when the user asks to summarize, inspect, or answer questions about a specific threaded conversation. Requires the channel ID and the parent message timestamp, which can come from Get Channel History or Search Messages. The response includes hasMore and nextCursor so more messages can be fetched when needed."
     },
     {
+      "title": "Send Message",
+      "name": "send-message",
+      "description": "Send a Slack message to a channel, group DM, existing DM, or user. Pass a conversation ID or user ID and the message text. When given a user ID, the tool opens or finds the DM first."
+    },
+    {
       "title": "Reply to Thread",
       "name": "reply-thread",
       "description": "Post a reply to a Slack thread. Requires the channel ID, the parent message timestamp, and the reply text. Use Read Thread first when context is needed."

--- a/extensions/slack/src/tools/send-message.ts
+++ b/extensions/slack/src/tools/send-message.ts
@@ -1,0 +1,77 @@
+import { getSlackWebClient } from "../shared/client/WebClient";
+import { withSlackClient } from "../shared/withSlackClient";
+
+type Input = {
+  /**
+   * The recipient's Slack conversation ID or user ID. Conversation IDs start with C, D, or G. User IDs start with U or W.
+   * Use Get Channels or Get Users to find the ID. When a user ID is provided, the tool opens or finds the direct message first.
+   *
+   * @example "C12345678"
+   */
+  recipient: string;
+  /**
+   * The message text to send. Slack mrkdwn is supported.
+   */
+  text: string;
+};
+
+const CONVERSATION_ID_PATTERN = /^[CDG][A-Z0-9]{8,}$/;
+const USER_ID_PATTERN = /^[UW][A-Z0-9]{8,}$/;
+
+async function getConversationId(recipient: string) {
+  if (CONVERSATION_ID_PATTERN.test(recipient)) {
+    return recipient;
+  }
+
+  if (!USER_ID_PATTERN.test(recipient)) {
+    throw new Error("Recipient must be a Slack conversation ID or user ID");
+  }
+
+  const slackWebClient = getSlackWebClient();
+  const response = await slackWebClient.conversations.open({ users: recipient });
+
+  if (response.error) {
+    throw new Error(response.error);
+  }
+
+  if (!response.channel?.id) {
+    throw new Error("Slack did not return a direct message conversation ID");
+  }
+
+  return response.channel.id;
+}
+
+async function sendMessage(input: Input) {
+  const recipient = input.recipient.trim();
+  const text = input.text.trim();
+
+  if (!text) {
+    throw new Error("Message text cannot be empty");
+  }
+
+  const slackWebClient = getSlackWebClient();
+  const channel = await getConversationId(recipient);
+  const response = await slackWebClient.chat.postMessage({ channel, text });
+
+  if (response.error) {
+    throw new Error(response.error);
+  }
+
+  if (!response.channel || !response.ts) {
+    throw new Error("Slack did not return the sent message");
+  }
+
+  const permalinkResponse = await slackWebClient.chat.getPermalink({
+    channel: response.channel,
+    message_ts: response.ts,
+  });
+
+  return {
+    channel: response.channel,
+    ts: response.ts,
+    text: response.message?.text ?? text,
+    permalink: permalinkResponse.ok ? permalinkResponse.permalink : undefined,
+  };
+}
+
+export default withSlackClient(sendMessage);


### PR DESCRIPTION
## Description

Adds a `send-message` AI tool to the Slack extension.

The tool can send a message to:

* Public or private channels
* Existing DMs and group DMs
* A Slack user ID, opening or resolving the DM before posting

It returns the message timestamp and permalink so AI can link directly to the sent message.

The existing OAuth configuration already includes the required scopes:

* `chat:write` to post the message
* `im:write` to open or resolve a DM from a user ID

The README scope comments now document the AI tool requirements.

## Testing

* `npm run lint`
* `npm run build`
