### PR TITLE
[Slack] Improve AI messaging and conversation tools

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Add optional AI message signature] - {PR_MERGE_DATE}
+## [Add optional AI message signature] - 2026-07-15
 
 - Add an enabled-by-default extension preference that shows a subtle “Sent via Raycast” Block Kit context below messages sent by the `send-message` and `reply-thread` AI tools. Messages sent with the Send Message command are unchanged.
 

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Changelog
 
+## [Add optional AI message signature] - 2026-07-14
+
+- Add an enabled-by-default extension preference that shows a subtle “Sent via Raycast” Block Kit context below messages sent by the `send-message` and `reply-thread` AI tools. Messages sent with the Send Message command are unchanged.
+
 ## [Add Slack send message AI tool] - 2026-07-14
 
 - Add a `send-message` AI tool that sends messages to channels, group DMs, existing DMs, or users. User IDs are resolved to a direct-message conversation before posting.

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Add optional AI message signature] - 2026-07-14
+## [Add optional AI message signature] - {PR_MERGE_DATE}
 
 - Add an enabled-by-default extension preference that shows a subtle “Sent via Raycast” Block Kit context below messages sent by the `send-message` and `reply-thread` AI tools. Messages sent with the Send Message command are unchanged.
 

--- a/extensions/slack/README.md
+++ b/extensions/slack/README.md
@@ -38,31 +38,32 @@ If you don't want to log in through OAuth, you can use an access token instead. 
 4. Select a workspace to which you want to grant the extension access.
 5. Copy and paste the following manifest (Select `YAML`):
    _Feel free to exclude permission scope groups - see comments - if you don't want to have the full experience of this extension._
+
    ```
    display_information:
      name: Raycast - Slack
-   
+
    oauth_config:
      scopes:
        user:
          # Command: Search & Unread Messages & Set Presence
          - users:read
-   
+
          # Command: Search & Unread Messages
          - channels:read
          - groups:read
          - im:read
          - mpim:read
-   
+
          # Command: Search
          - search:read
-   
+
          # Command: Unread Messages
          - channels:history
          - groups:history
          - im:history
          - mpim:history
-   
+
          # Command: Unread Messages (optional - needed for marking conversations as read)
          - channels:write
          - groups:write
@@ -71,35 +72,34 @@ If you don't want to log in through OAuth, you can use an access token instead. 
          # AI Tool: Send Message (needed to open a DM from a user ID)
          - im:write
          - mpim:write
-   
+
          # Command: Set Presence
          - users:write
-   
+
          # Command: Set Snooze
          - dnd:read
          - dnd:write
-   
+
          # Command & AI Tool: Send Message
          - chat:write
-   
+
          # Command: Search Emojis
          - emoji:read
-   
+
          # Command: Set Status
          - users.profile:write
          - users.profile:read
-   
+
    settings:
      org_deploy_enabled: false
      socket_mode_enabled: false
      token_rotation_enabled: false
    ```
 
-
 6. Confirm creation of app
 7. Press `Install to Workspace`
 8. Get your personal access token from `Features -> OAuth & Permissions` (section `OAuth Tokens for Your Workspace`).
-Your personal access token will start with `xoxp-`.
+   Your personal access token will start with `xoxp-`.
 
 ## Proxy Support
 

--- a/extensions/slack/package-lock.json
+++ b/extensions/slack/package-lock.json
@@ -1338,7 +1338,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1404,7 +1403,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -1609,7 +1607,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1939,7 +1936,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -2141,7 +2137,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3175,7 +3170,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3199,7 +3193,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3436,7 +3429,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -165,9 +165,19 @@
       "description": "Fetches a channel's history of messages and events."
     },
     {
+      "title": "Read Conversation",
+      "name": "read-conversation",
+      "description": "Read messages from a Slack channel, DM, group DM, user DM, or pasted Slack message permalink. A permalink returns the referenced message and its thread."
+    },
+    {
       "title": "Get Users",
       "name": "get-users",
       "description": "List all users in the Slack team"
+    },
+    {
+      "title": "Find Users",
+      "name": "find-users",
+      "description": "Find Slack users by name, username, display name, or email address. Use this to resolve a person to a user ID before sending a direct message."
     },
     {
       "title": "Set Status",

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -135,6 +135,15 @@
       "type": "textfield"
     },
     {
+      "title": "AI Message Signature",
+      "label": "Add “Sent via Raycast” to messages sent with AI",
+      "description": "Show a subtle “Sent via Raycast” note below messages sent by the Send Message and Reply to Thread AI tools.",
+      "name": "showAiMessageSignature",
+      "type": "checkbox",
+      "required": false,
+      "default": true
+    },
+    {
       "title": "Navigation",
       "label": "Close Slack right sidebar",
       "description": "Automatically close Slack right sidebar after navigating to a user chat",

--- a/extensions/slack/src/shared/client/WebClient.ts
+++ b/extensions/slack/src/shared/client/WebClient.ts
@@ -56,7 +56,7 @@ function getProxyAgent(): HttpsProxyAgent<string> | undefined {
 
 export const slack = OAuthService.slack({
   scope:
-    "users:read channels:read groups:read im:read mpim:read chat:write channels:history groups:history im:history mpim:history channels:write groups:write im:write mpim:write users:write dnd:read dnd:write search:read users.profile:write emoji:read users.profile:read",
+    "users:read users:read.email channels:read groups:read im:read mpim:read chat:write channels:history groups:history im:history mpim:history channels:write groups:write im:write mpim:write users:write dnd:read dnd:write search:read users.profile:write emoji:read users.profile:read",
   personalAccessToken: accessToken,
   onAuthorize({ token }) {
     const agent = getProxyAgent();

--- a/extensions/slack/src/tools/find-users.ts
+++ b/extensions/slack/src/tools/find-users.ts
@@ -1,0 +1,60 @@
+import { getSlackWebClient } from "../shared/client/WebClient";
+import { withSlackClient } from "../shared/withSlackClient";
+
+type Input = {
+  /**
+   * A name, display name, username, or email address to search for.
+   */
+  query: string;
+};
+
+async function findUsers(input: Input) {
+  const query = input.query.trim().toLocaleLowerCase();
+  if (!query) {
+    throw new Error("Search query cannot be empty");
+  }
+
+  const slackWebClient = getSlackWebClient();
+  const matches = [];
+  let cursor: string | undefined;
+
+  do {
+    const response = await slackWebClient.users.list({ limit: 200, cursor });
+
+    if (response.error) {
+      throw new Error(response.error);
+    }
+
+    for (const user of response.members ?? []) {
+      if (!user.id || user.deleted || user.is_bot || user.is_workflow_bot || user.id === "USLACKBOT") {
+        continue;
+      }
+
+      const searchableValues = [
+        user.name,
+        user.real_name,
+        user.profile?.display_name,
+        user.profile?.real_name,
+        user.profile?.email,
+      ].filter((value): value is string => Boolean(value));
+
+      if (searchableValues.some((value) => value.toLocaleLowerCase().includes(query))) {
+        matches.push({
+          id: user.id,
+          username: user.name,
+          displayName: user.profile?.display_name,
+          realName: user.profile?.real_name ?? user.real_name,
+          email: user.profile?.email,
+          status: user.profile?.status_text,
+          timezone: user.tz_label,
+        });
+      }
+    }
+
+    cursor = response.response_metadata?.next_cursor || undefined;
+  } while (cursor);
+
+  return matches;
+}
+
+export default withSlackClient(findUsers);

--- a/extensions/slack/src/tools/message-signature.ts
+++ b/extensions/slack/src/tools/message-signature.ts
@@ -1,0 +1,29 @@
+import { getPreferenceValues } from "@raycast/api";
+import { KnownBlock } from "@slack/types";
+
+export function getAiMessageBlocks(text: string): KnownBlock[] | undefined {
+  const { showAiMessageSignature } = getPreferenceValues<Preferences>();
+
+  if (!showAiMessageSignature) {
+    return undefined;
+  }
+
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text,
+      },
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "Sent via Raycast",
+        },
+      ],
+    },
+  ];
+}

--- a/extensions/slack/src/tools/message-signature.ts
+++ b/extensions/slack/src/tools/message-signature.ts
@@ -1,6 +1,43 @@
 import { getPreferenceValues } from "@raycast/api";
 import { KnownBlock } from "@slack/types";
 
+const SECTION_TEXT_MAX_LENGTH = 3000;
+const MAX_SECTION_BLOCKS = 49;
+
+function splitTextForSectionBlocks(text: string): string[] | undefined {
+  if (text.length <= SECTION_TEXT_MAX_LENGTH) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (chunks.length >= MAX_SECTION_BLOCKS) {
+      return undefined;
+    }
+
+    if (remaining.length <= SECTION_TEXT_MAX_LENGTH) {
+      chunks.push(remaining);
+      break;
+    }
+
+    const chunk = remaining.slice(0, SECTION_TEXT_MAX_LENGTH);
+    const newlineIndex = chunk.lastIndexOf("\n");
+
+    if (newlineIndex > 0) {
+      chunks.push(remaining.slice(0, newlineIndex));
+      remaining = remaining.slice(newlineIndex + 1);
+      continue;
+    }
+
+    chunks.push(chunk);
+    remaining = remaining.slice(SECTION_TEXT_MAX_LENGTH);
+  }
+
+  return chunks;
+}
+
 export function getAiMessageBlocks(text: string): KnownBlock[] | undefined {
   const { showAiMessageSignature } = getPreferenceValues<Preferences>();
 
@@ -8,14 +45,21 @@ export function getAiMessageBlocks(text: string): KnownBlock[] | undefined {
     return undefined;
   }
 
-  return [
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text,
-      },
+  const textChunks = splitTextForSectionBlocks(text);
+  if (!textChunks) {
+    return undefined;
+  }
+
+  const sectionBlocks: KnownBlock[] = textChunks.map((chunk) => ({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: chunk,
     },
+  }));
+
+  return [
+    ...sectionBlocks,
     {
       type: "context",
       elements: [

--- a/extensions/slack/src/tools/read-conversation.ts
+++ b/extensions/slack/src/tools/read-conversation.ts
@@ -1,0 +1,144 @@
+import { getSlackWebClient } from "../shared/client/WebClient";
+import { withSlackClient } from "../shared/withSlackClient";
+
+type Input = {
+  /**
+   * A Slack conversation ID, user ID, or message permalink. Conversation IDs start with C, D, or G. User IDs start with U or W.
+   */
+  conversation: string;
+  /**
+   * Maximum number of messages to return. Defaults to 30 and is capped at 100.
+   */
+  limit?: number;
+  /**
+   * Only messages after this ISO 8601 timestamp will be returned.
+   */
+  after?: string;
+};
+
+const CONVERSATION_ID_PATTERN = /^[CDG][A-Z0-9]{8,}$/;
+const USER_ID_PATTERN = /^[UW][A-Z0-9]{8,}$/;
+
+function parseSlackPermalink(value: string) {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return undefined;
+  }
+
+  if (!url.hostname.endsWith("slack.com")) {
+    return undefined;
+  }
+
+  const match = url.pathname.match(/\/archives\/([CDG][A-Z0-9]+)(?:\/p(\d+))?/i);
+  if (!match) {
+    return undefined;
+  }
+
+  const compactTimestamp = match[2];
+  const messageTs = compactTimestamp ? `${compactTimestamp.slice(0, -6)}.${compactTimestamp.slice(-6)}` : undefined;
+
+  return { channel: match[1].toUpperCase(), messageTs };
+}
+
+async function resolveConversation(value: string): Promise<{ channel: string; messageTs?: string }> {
+  const permalink = parseSlackPermalink(value);
+  if (permalink) {
+    return permalink;
+  }
+
+  if (CONVERSATION_ID_PATTERN.test(value)) {
+    return { channel: value };
+  }
+
+  if (USER_ID_PATTERN.test(value)) {
+    const slackWebClient = getSlackWebClient();
+    const response = await slackWebClient.conversations.open({ users: value });
+
+    if (response.error) {
+      throw new Error(response.error);
+    }
+    if (!response.channel?.id) {
+      throw new Error("Slack did not return a direct message conversation ID");
+    }
+
+    return { channel: response.channel.id };
+  }
+
+  throw new Error("Conversation must be a Slack conversation ID, user ID, or message permalink");
+}
+
+async function readConversation(input: Input) {
+  const value = input.conversation.trim();
+  const limit = Math.min(Math.max(input.limit ?? 30, 1), 100);
+  const oldest = input.after ? Date.parse(input.after) / 1000 : undefined;
+
+  if (input.after && Number.isNaN(oldest)) {
+    throw new Error("After must be a valid ISO 8601 timestamp");
+  }
+
+  const slackWebClient = getSlackWebClient();
+  const { channel, messageTs } = await resolveConversation(value);
+
+  if (messageTs) {
+    const response = await slackWebClient.conversations.replies({
+      channel,
+      ts: messageTs,
+      limit,
+      oldest: oldest?.toString(),
+      inclusive: true,
+    });
+
+    if (response.error) {
+      throw new Error(response.error);
+    }
+
+    return {
+      channel,
+      messageTs,
+      messages: response.messages?.map(formatMessage),
+      hasMore: response.has_more ?? false,
+      nextCursor: response.response_metadata?.next_cursor || undefined,
+    };
+  }
+
+  const response = await slackWebClient.conversations.history({
+    channel,
+    limit,
+    oldest: oldest?.toString(),
+  });
+
+  if (response.error) {
+    throw new Error(response.error);
+  }
+
+  return {
+    channel,
+    messages: response.messages?.map(formatMessage),
+    hasMore: response.has_more ?? false,
+    nextCursor: response.response_metadata?.next_cursor || undefined,
+  };
+}
+
+function formatMessage(message: {
+  text?: string;
+  user?: string;
+  bot_id?: string;
+  bot_profile?: { name?: string };
+  username?: string;
+  ts?: string;
+  thread_ts?: string;
+  reply_count?: number;
+}) {
+  return {
+    text: message.text,
+    user: message.user ?? message.bot_profile?.name ?? message.username ?? message.bot_id,
+    ts: message.ts,
+    threadTs: message.thread_ts,
+    replyCount: message.reply_count,
+    date: message.ts ? new Date(Number.parseFloat(message.ts) * 1000).toISOString() : undefined,
+  };
+}
+
+export default withSlackClient(readConversation);

--- a/extensions/slack/src/tools/reply-thread.ts
+++ b/extensions/slack/src/tools/reply-thread.ts
@@ -1,5 +1,6 @@
 import { getSlackWebClient } from "../shared/client/WebClient";
 import { withSlackClient } from "../shared/withSlackClient";
+import { getAiMessageBlocks } from "./message-signature";
 
 type Input = {
   /**
@@ -39,6 +40,7 @@ async function replyThread(input: Input) {
     channel: input.channel,
     thread_ts: input.threadTs,
     text,
+    blocks: getAiMessageBlocks(text),
   });
 
   if (response.error) {

--- a/extensions/slack/src/tools/send-message.ts
+++ b/extensions/slack/src/tools/send-message.ts
@@ -1,5 +1,6 @@
 import { getSlackWebClient } from "../shared/client/WebClient";
 import { withSlackClient } from "../shared/withSlackClient";
+import { getAiMessageBlocks } from "./message-signature";
 
 type Input = {
   /**
@@ -51,7 +52,11 @@ async function sendMessage(input: Input) {
 
   const slackWebClient = getSlackWebClient();
   const channel = await getConversationId(recipient);
-  const response = await slackWebClient.chat.postMessage({ channel, text });
+  const response = await slackWebClient.chat.postMessage({
+    channel,
+    text,
+    blocks: getAiMessageBlocks(text),
+  });
 
   if (response.error) {
     throw new Error(response.error);

--- a/extensions/slack/src/tools/set-status.ts
+++ b/extensions/slack/src/tools/set-status.ts
@@ -3,48 +3,89 @@ import { withSlackClient } from "../shared/withSlackClient";
 
 type Input = {
   /**
-   * A string value for status text, should be short and sweet, with no punctuation, e.g. "Working out", "Listening to Drake's new album", "Coffe break". It should not include the status duration for example "Working out" instead of "Working out for 2 hours" or "Working out until tomorrow".
-   *
-   * To unset the status, provide an empty string.
+   * Status text. Keep it short and omit the duration. Provide an empty string together with an empty emoji to clear the status. Omit both text and emoji when only changing snooze.
    */
-  text: string;
+  text?: string;
   /**
-   * A Slack-compatible string for single emoji matching the text of the status. Emojis should be in the form: :<emoji identifier>:. If the user doesn't specify an emoji, come up with one that matches the text.
-   *
-   * You can call the `get-emojis` tool to get a list of all custom emojis in the workspace. Do this only if you think the user is using a custom emoji.
-   *
-   * To unset the status, provide an empty string.
+   * A Slack-compatible emoji in the form :emoji:. Provide an empty string together with empty text to clear the status. Omit both text and emoji when only changing snooze.
    */
-  emoji: string;
+  emoji?: string;
   /**
-   * An integer representing the duration of the status in seconds. Only provide it if the user has specified a time or the end of status
+   * Status duration in seconds. Only provide it when the user specifies when the status should expire.
    */
   duration?: number;
+  /**
+   * Do Not Disturb duration in minutes. A positive integer starts or changes snooze. Use 0 to end the current snooze. Omit it to leave snooze unchanged.
+   */
+  snoozeMinutes?: number;
 };
 
 let retried = false;
 
 async function setStatus(input: Input) {
+  const hasStatusInput = input.text !== undefined || input.emoji !== undefined || input.duration !== undefined;
+  const hasSnoozeInput = input.snoozeMinutes !== undefined;
+
+  if (!hasStatusInput && !hasSnoozeInput) {
+    throw new Error("Provide a status or snooze duration");
+  }
+
+  if (hasStatusInput && (input.text === undefined || input.emoji === undefined)) {
+    throw new Error("Status text and emoji must be provided together");
+  }
+
+  if (input.duration !== undefined && (!Number.isInteger(input.duration) || input.duration < 0)) {
+    throw new Error("Status duration must be a non-negative integer number of seconds");
+  }
+
+  if (input.snoozeMinutes !== undefined && (!Number.isInteger(input.snoozeMinutes) || input.snoozeMinutes < 0)) {
+    throw new Error("Snooze duration must be a non-negative integer number of minutes");
+  }
+
   const slackWebClient = getSlackWebClient();
 
-  const res = await slackWebClient.users.profile.set({
-    profile: {
-      status_text: input.text,
-      status_emoji: input.emoji,
-      status_expiration: typeof input.duration === "number" ? new Date().getTime() / 1000 + input.duration : 0,
-    },
-  });
+  try {
+    const [statusResponse, snoozeResponse] = await Promise.all([
+      hasStatusInput
+        ? slackWebClient.users.profile.set({
+            profile: {
+              status_text: input.text,
+              status_emoji: input.emoji,
+              status_expiration: input.duration ? Math.floor(Date.now() / 1000) + input.duration : 0,
+            },
+          })
+        : undefined,
+      input.snoozeMinutes === undefined
+        ? undefined
+        : input.snoozeMinutes === 0
+          ? slackWebClient.dnd.endSnooze()
+          : slackWebClient.dnd.setSnooze({ num_minutes: input.snoozeMinutes }),
+    ]);
 
-  if (res.error) {
-    if (res.error?.includes("missing_scope") && !retried) {
+    if (statusResponse?.error) {
+      throw new Error(statusResponse.error);
+    }
+    if (snoozeResponse?.error) {
+      throw new Error(snoozeResponse.error);
+    }
+
+    return {
+      profile: statusResponse?.profile,
+      snooze: hasSnoozeInput
+        ? {
+            enabled: input.snoozeMinutes !== 0,
+            minutes: input.snoozeMinutes,
+          }
+        : undefined,
+    };
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("missing_scope") && !retried) {
       retried = true;
       await slack.client.removeTokens();
       return withSlackClient(setStatus)(input);
     }
-    throw new Error(res.error);
+    throw error;
   }
-
-  return res.profile;
 }
 
 export default withSlackClient(setStatus);


### PR DESCRIPTION
## Description

Adds and improves Slack AI tools:

- Adds `find-users` to resolve people by name, username, display name, or email
- Adds `read-conversation` for channels, DMs, group DMs, user IDs, and Slack permalinks
- Adds optional snooze management to `set-status`
- Keeps message sending as a single-message tool
- Adds an optional "Sent via Raycast" signature to AI-sent messages
- Handles long signed messages by splitting them into valid Slack section blocks

Unread-message retrieval is intentionally excluded because Slack does not provide a reliable workspace-wide unread endpoint.

## Validation

- `npm run lint --prefix extensions/slack`
- `npm run build --prefix extensions/slack`
