### PR TITLE
pipedrive: add Copy Deal Email action for deals

### DIFF
--- a/extensions/pipedrive/CHANGELOG.md
+++ b/extensions/pipedrive/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Pipedrive Changelog
 
-## [Copy Deal Email Action] - {PR_MERGE_DATE}
+## [Copy Deal Email Action] - 2026-07-15
    - Add "Copy Deal Email" action to deal search results and deal detail view
 
 ## [Create & Edit Deals, Contacts, Organizations] - 2025-12-28

--- a/extensions/pipedrive/CHANGELOG.md
+++ b/extensions/pipedrive/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Pipedrive Changelog
 
-## [Copy Deal Email Action] - 2026-07-14
+## [Copy Deal Email Action] - {PR_MERGE_DATE}
    - Add "Copy Deal Email" action to deal search results and deal detail view
 
 ## [Create & Edit Deals, Contacts, Organizations] - 2025-12-28

--- a/extensions/pipedrive/CHANGELOG.md
+++ b/extensions/pipedrive/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Pipedrive Changelog
 
+## [Copy Deal Email Action] - 2026-07-14
+   - Add "Copy Deal Email" action to deal search results and deal detail view
+
 ## [Create & Edit Deals, Contacts, Organizations] - 2025-12-28
 
 ### New Features

--- a/extensions/pipedrive/src/deal-detail.tsx
+++ b/extensions/pipedrive/src/deal-detail.tsx
@@ -88,6 +88,11 @@ export default function DealDetail({ id }: { id: string }) {
               target={<AddDeal key={`edit-deal-${id}`} dealIdToEdit={id} onSaved={revalidate} />}
               icon="✏️"
             />
+            <Action.CopyToClipboard
+              title="Copy Deal Email"
+              content={`${preferences.domain.split(".")[0]}+deal${id}@pipedrivemail.com`}
+              shortcut={{ modifiers: ["ctrl"], key: "d" }}
+            />
             <Action.OpenInBrowser
               title="Open in Browser"
               url={itemUrl}

--- a/extensions/pipedrive/src/deal-detail.tsx
+++ b/extensions/pipedrive/src/deal-detail.tsx
@@ -90,7 +90,7 @@ export default function DealDetail({ id }: { id: string }) {
             />
             <Action.CopyToClipboard
               title="Copy Deal Email"
-              content={`${preferences.domain.split(".")[0]}+deal${id}@pipedrivemail.com`}
+              content={`${preferences.domain.replace(/^https?:\/\//, "").split(".")[0]}+deal${id}@pipedrivemail.com`}
               shortcut={{ modifiers: ["ctrl"], key: "d" }}
             />
             <Action.OpenInBrowser

--- a/extensions/pipedrive/src/index.tsx
+++ b/extensions/pipedrive/src/index.tsx
@@ -275,7 +275,7 @@ function SearchListItem({
   revalidate: () => void;
 }) {
   const itemUrl = `https://${domain}/${searchResult.type}/${searchResult.id}`;
-  const { title, subtitle, accessoryTitle, name, email, phone, organization, ccEmail } = searchResult;
+  const { title, subtitle, accessoryTitle, name, email, phone, organization } = searchResult;
   const emoji = emojiMap[searchResult.type] || "";
 
   const detailsTarget =

--- a/extensions/pipedrive/src/index.tsx
+++ b/extensions/pipedrive/src/index.tsx
@@ -387,10 +387,10 @@ function SearchListItem({
                 shortcut={Keyboard.Shortcut.Common.Open}
               />
             )}
-            {ccEmail && (
+            {searchResult.type === "deal" && (
               <Action.CopyToClipboard
-                title="Copy Deal Name"
-                content={ccEmail}
+                title="Copy Deal Email"
+                content={`${domain.split(".")[0]}+deal${searchResult.id}@pipedrivemail.com`}
                 shortcut={Keyboard.Shortcut.Common.Duplicate}
               />
             )}


### PR DESCRIPTION
## Description

Adds "Copy Deal Email" action to deal search results and deal detail view. Constructs the deal-specific email address from the domain and deal ID (e.g., company+deal123@pipedrivemail.com), no extra API calls.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
