### PR TITLE
[Linear] Add attachments to comment AI tools

### DIFF
--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Linear Changelog
 
+## [AI Comment Attachments] - 2026-07-14
+
+- Add local file attachments to the AI tools for creating and updating comments. Images are embedded in the comment, while other files are added as links.
+
 ## [Templates, Copy Title as Link, and Auth Fix] - 2026-06-17
 
 - Add template support to the Create Issue command. Let users pick a Linear issue template to auto-populate the title, description, labels, project, status, priority, assignee, estimate, due date, and cycle. See https://github.com/raycast/extensions/issues/27138

--- a/extensions/linear/src/api/attachments.ts
+++ b/extensions/linear/src/api/attachments.ts
@@ -86,7 +86,10 @@ export async function appendFileAttachments(markdown: string, attachmentPaths?: 
     return markdown;
   }
 
-  const files = await Promise.all(attachmentPaths.map(uploadFile));
+  const files: UploadedFile[] = [];
+  for (const filePath of attachmentPaths) {
+    files.push(await uploadFile(filePath));
+  }
   const attachments = files.map(({ assetUrl, contentType, name }) => {
     const label = escapeMarkdownLabel(name);
     return contentType.startsWith("image/") ? `![${label}](${assetUrl})` : `[${label}](${assetUrl})`;

--- a/extensions/linear/src/api/attachments.ts
+++ b/extensions/linear/src/api/attachments.ts
@@ -6,23 +6,38 @@ import { fileTypeFromFile } from "file-type";
 
 import { getLinearClient } from "./linearClient";
 
-export async function uploadFile(filePath: string) {
+const DEFAULT_CONTENT_TYPE = "application/octet-stream";
+
+type FileUploadVariables = {
+  size: number;
+  contentType: string;
+  filename: string;
+};
+
+export type UploadedFile = {
+  assetUrl: string;
+  contentType: string;
+  name: string;
+};
+
+export async function uploadFile(filePath: string): Promise<UploadedFile> {
   const { graphQLClient } = getLinearClient();
 
   const buffer = await readFile(filePath);
   const type = await fileTypeFromFile(filePath);
-  const file = new Blob([buffer], { type: type?.mime });
+  const contentType = type?.mime ?? DEFAULT_CONTENT_TYPE;
   const name = path.basename(filePath);
 
   const { data } = await graphQLClient.rawRequest<
     {
-      fileUpload: { uploadFile: UploadFile };
+      fileUpload: { success: boolean; uploadFile?: UploadFile };
     },
-    Record<string, unknown>
+    FileUploadVariables
   >(
     `
-      mutation {
-        fileUpload(size: ${file.size}, contentType: "${file.type}", filename: "${name}") {
+      mutation FileUpload($size: Int!, $contentType: String!, $filename: String!) {
+        fileUpload(size: $size, contentType: $contentType, filename: $filename) {
+          success
           uploadFile {
             headers {
               key
@@ -34,27 +49,50 @@ export async function uploadFile(filePath: string) {
         }
       }
     `,
+    { size: buffer.byteLength, contentType, filename: name },
   );
 
-  const uploadFile = data?.fileUpload.uploadFile;
+  const upload = data?.fileUpload.uploadFile;
 
-  const authHeader = uploadFile?.headers[0];
-  const uploadUrl = uploadFile?.uploadUrl;
-
-  if (uploadUrl && authHeader?.key && authHeader?.value) {
-    const options = {
-      method: "PUT",
-      headers: {
-        [authHeader?.key]: authHeader?.value,
-        "Content-Type": file.type,
-      },
-      body: buffer,
-    };
-
-    await fetch(uploadUrl, options);
-
-    return { assetUrl: uploadFile?.assetUrl, name };
+  if (!data?.fileUpload.success || !upload) {
+    throw new Error(`Failed to request an upload URL for "${name}"`);
   }
+
+  const headers = new Headers({
+    "Content-Type": contentType,
+    "Cache-Control": "public, max-age=31536000",
+  });
+  upload.headers.forEach(({ key, value }) => headers.set(key, value));
+
+  const response = await fetch(upload.uploadUrl, {
+    method: "PUT",
+    headers,
+    body: buffer,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to upload "${name}": ${response.status} ${response.statusText}`);
+  }
+
+  return { assetUrl: upload.assetUrl, contentType, name };
+}
+
+function escapeMarkdownLabel(value: string) {
+  return value.replaceAll("\\", "\\\\").replaceAll("[", "\\[").replaceAll("]", "\\]");
+}
+
+export async function appendFileAttachments(markdown: string, attachmentPaths?: string[]) {
+  if (!attachmentPaths?.length) {
+    return markdown;
+  }
+
+  const files = await Promise.all(attachmentPaths.map(uploadFile));
+  const attachments = files.map(({ assetUrl, contentType, name }) => {
+    const label = escapeMarkdownLabel(name);
+    return contentType.startsWith("image/") ? `![${label}](${assetUrl})` : `[${label}](${assetUrl})`;
+  });
+
+  return [markdown.trimEnd(), ...attachments].filter(Boolean).join("\n\n");
 }
 
 export type CreateAttachmentPayload = {
@@ -66,10 +104,6 @@ export async function createAttachment(payload: CreateAttachmentPayload) {
   const { graphQLClient } = getLinearClient();
 
   const file = await uploadFile(payload.url);
-
-  if (!file) {
-    throw new Error("Unable to upload file");
-  }
 
   const attachmentInput = `issueId: "${payload.issueId}", title: "${file.name}", url: "${file.assetUrl}"`;
 

--- a/extensions/linear/src/tools/create-comment.ts
+++ b/extensions/linear/src/tools/create-comment.ts
@@ -1,5 +1,8 @@
+import path from "path";
+
 import { withAccessToken } from "@raycast/utils";
 
+import { appendFileAttachments } from "../api/attachments";
 import { getLinearClient, linear } from "../api/linearClient";
 
 type Input = {
@@ -14,11 +17,20 @@ type Input = {
 
   /** The comment content in markdown format */
   body: string;
+
+  /** A list of absolute local file paths to upload and append to the comment */
+  attachmentPaths?: string[];
 };
 
 export default withAccessToken(linear)(async (inputs: Input) => {
   const { linearClient } = getLinearClient();
-  const result = await linearClient.createComment(inputs);
+  const body = await appendFileAttachments(inputs.body, inputs.attachmentPaths);
+  const result = await linearClient.createComment({
+    issueId: inputs.issueId,
+    parentId: inputs.parentId,
+    projectUpdateId: inputs.projectUpdateId,
+    body,
+  });
 
   if (!result.success) {
     throw new Error("Failed to create comment");
@@ -27,7 +39,13 @@ export default withAccessToken(linear)(async (inputs: Input) => {
   return result.comment;
 });
 
-export const confirmation = withAccessToken(linear)(async ({ issueId, parentId, projectUpdateId, body }: Input) => {
+export const confirmation = withAccessToken(linear)(async ({
+  issueId,
+  parentId,
+  projectUpdateId,
+  body,
+  attachmentPaths,
+}: Input) => {
   const { linearClient } = getLinearClient();
 
   let title: string = "";
@@ -46,6 +64,9 @@ export const confirmation = withAccessToken(linear)(async ({ issueId, parentId, 
     info: [
       { name: "Title", value: title },
       { name: "Comment", value: body },
+      ...(attachmentPaths?.length
+        ? [{ name: "Attachments", value: attachmentPaths.map((filePath) => path.basename(filePath)).join(", ") }]
+        : []),
     ],
   };
 });

--- a/extensions/linear/src/tools/update-comment.ts
+++ b/extensions/linear/src/tools/update-comment.ts
@@ -1,10 +1,16 @@
+import path from "path";
+
 import { withAccessToken } from "@raycast/utils";
 
+import { appendFileAttachments } from "../api/attachments";
 import { getLinearClient, linear } from "../api/linearClient";
 
 type Input = {
   /** The comment content in markdown format */
   body: string;
+
+  /** A list of absolute local file paths to upload and append to the comment */
+  attachmentPaths?: string[];
 
   /** The ID of the comment to update */
   id: string;
@@ -12,7 +18,8 @@ type Input = {
 
 export default withAccessToken(linear)(async (inputs: Input) => {
   const { linearClient } = getLinearClient();
-  const result = await linearClient.updateComment(inputs.id, { body: inputs.body });
+  const body = await appendFileAttachments(inputs.body, inputs.attachmentPaths);
+  const result = await linearClient.updateComment(inputs.id, { body });
 
   if (!result.success) {
     throw new Error("Failed to update comment");
@@ -20,13 +27,18 @@ export default withAccessToken(linear)(async (inputs: Input) => {
   return result.comment;
 });
 
-export const confirmation = withAccessToken(linear)(async ({ id, body }: Input) => {
+export const confirmation = withAccessToken(linear)(async ({ id, body, attachmentPaths }: Input) => {
   const { linearClient } = getLinearClient();
 
   const comment = await linearClient.comment({ id });
 
   return {
     message: `Are you sure you want to update the [comment](${comment.url})?`,
-    info: [{ name: "Comment", value: body }],
+    info: [
+      { name: "Comment", value: body },
+      ...(attachmentPaths?.length
+        ? [{ name: "Attachments", value: attachmentPaths.map((filePath) => path.basename(filePath)).join(", ") }]
+        : []),
+    ],
   };
 });


### PR DESCRIPTION
## Description

Adds local file attachment support to the Linear AI extension’s create and update comment tools.

* accepts absolute local file paths through `attachmentPaths`
* follows Linear’s documented upload flow using a parameterized `fileUpload` mutation and a PUT to the pre-signed URL
* forwards every upload header returned by Linear
* appends images as Markdown images and other files as Markdown links
* shows attachment names in the confirmation UI
* improves MIME fallback and upload error handling for the existing attachment uploader

## Validation

* `npm run lint`
* `npm run build`