### PR TITLE
Add Agentcard MCP server to model-context-protocol-registry

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Add Agentcard MCP Server] - {PR_MERGE_DATE}
+
+Add Agentcard to the official registry: prepaid virtual cards for AI agents. Fund a wallet, set spend caps and human approvals, and your agent mints a one-time virtual card for each purchase that works at any merchant. Remote streamable HTTP MCP server with OAuth 2.0 sign-in via mcp-remote; no API key required.
+
 ## [Add Appwrite MCP Server] - 2026-07-13
 
 Add the official Appwrite MCP server to the registry, enabling AI assistants to securely inspect and manage Appwrite projects and resources through Appwrite's API using OAuth authentication.

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add Agentcard MCP Server] - {PR_MERGE_DATE}
+## [Add Agentcard MCP Server] - 2026-07-15
 
 Add Agentcard to the official registry: prepaid virtual cards for AI agents. Fund a wallet, set spend caps and human approvals, and your agent mints a one-time virtual card for each purchase that works at any merchant. Remote streamable HTTP MCP server with OAuth 2.0 sign-in via mcp-remote; no API key required.
 

--- a/extensions/model-context-protocol-registry/README.md
+++ b/extensions/model-context-protocol-registry/README.md
@@ -78,6 +78,7 @@ To add a new MCP registry to the registry, you need to create a new entry in the
 | [Jellypod](https://www.jellypod.com/mcp) | Jellypod's Model Context Protocol server lets AI assistants create, edit, and publish conversational AI podcasts and video episodes. |
 | [plori](https://plori.ai/mcp) | Give your AI agent its own cloud computer. plori hosts agents on persistent machines with a real disk, tools, and memory that survives between sessions; idle agents scale to zero. This server creates and drives those agents: invoke an agent and read its reply, answer human-in-the-loop questions, and schedule deferred runs. Sign-in happens in the browser on first use (OAuth), or use an API key for headless setups. |
 | [Appwrite](https://github.com/appwrite/mcp) | The official Appwrite MCP server lets AI assistants securely inspect and manage Appwrite projects and resources through Appwrite's API. |
+| [Agentcard](https://agentcard.sh) | Prepaid virtual cards for AI agents. Fund a wallet, set spend caps and human approvals, and your agent mints a one-time virtual card for each purchase that works at any merchant. Connects to the remote Agentcard MCP server over OAuth 2.0. |
 
 ### Community MCP Servers
 

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -739,6 +739,18 @@ export const OFFICIAL_ENTRIES: RegistryEntry[] = [
       args: ["-y", "mcp-remote", "https://mcp.appwrite.io/"],
     },
   },
+  {
+    name: "agentcard",
+    title: "Agentcard",
+    description:
+      "Prepaid virtual cards for AI agents. Fund a wallet, set spend caps and human approvals, and your agent mints a one-time virtual card for each purchase that works at any merchant. Connects to the remote Agentcard MCP server over OAuth 2.0.",
+    icon: "https://www.agentcard.sh/logo-icon.png",
+    homepage: "https://agentcard.sh",
+    configuration: {
+      command: "npx",
+      args: ["-y", "mcp-remote", "https://mcp.agentcard.sh/mcp"],
+    },
+  },
 ];
 
 export const COMMUNITY_ENTRIES: RegistryEntry[] = [


### PR DESCRIPTION
## Description

Adds Agentcard to the extension's official MCP server registry (`OFFICIAL_ENTRIES`).

Agentcard issues prepaid virtual cards for AI agents. Users fund a wallet, set spend caps and human approval rules, and the agent mints a one-time virtual card for each purchase that works at any merchant that accepts cards. A leaked number is worthless and spend never exceeds the cap.

The server is Agentcard's remote MCP endpoint (`https://mcp.agentcard.sh/mcp`), reached over OAuth 2.0 through `mcp-remote`, so there is no API key to configure. This matches the existing remote entries in the registry.

## Changes

- `src/registries/builtin/entries.ts`: new `OFFICIAL_ENTRIES` entry (`npx mcp-remote https://mcp.agentcard.sh/mcp`)
- `README.md`: registry table row under Official MCP Servers
- `CHANGELOG.md`: changelog entry

## Notes

- Only the `model-context-protocol-registry` extension is modified.
- The icon is served over HTTPS: `https://www.agentcard.sh/logo-icon.png`.
