### PR TITLE
Update fix-link-embeds extension

### DIFF
--- a/extensions/fix-link-embeds/CHANGELOG.md
+++ b/extensions/fix-link-embeds/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Fix Link Embeds Changelog
 
+## [Update Embed Proxies] - {PR_MERGE_DATE}
+
+- Replace the Reddit proxy with `redditez` and support Reddit share links.
+- Fix the Reddit preference toggle.
+- Add Bluesky and Instagram Reels support.
+- Refresh the TikTok proxy.
+
 ## [Update] - 2024-09-18
 
 Changed `tiktxk` to `vxtiktok` as the previous proxy service stopped working.

--- a/extensions/fix-link-embeds/CHANGELOG.md
+++ b/extensions/fix-link-embeds/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fix Link Embeds Changelog
 
-## [Update Embed Proxies] - {PR_MERGE_DATE}
+## [Update Embed Proxies] - 2026-07-16
 
 - Replace the Reddit proxy with `redditez` and support Reddit share links.
 - Fix the Reddit preference toggle.

--- a/extensions/fix-link-embeds/README.md
+++ b/extensions/fix-link-embeds/README.md
@@ -7,10 +7,11 @@ Replace links in your texts (clipboard, selected, argument) to get the shiny emb
 
 ### 🧬 Supported Services
 
-- Instagram `ddinstagram`
-- Twitter `fxtwitter`
-- Reddit `rxyddit`
-- Tiktok `tiktxk`
+- Bluesky `fxbsky`
+- Instagram `ddinstagram`, `fxig.seria.moe`
+- Reddit `redditez`
+- TikTok `tnktok`
+- Twitter/X `fxtwitter`
 
 ### 💡 Features
 

--- a/extensions/fix-link-embeds/package.json
+++ b/extensions/fix-link-embeds/package.json
@@ -65,7 +65,7 @@
       "description": "Replace Twitter URLs."
     },
     {
-      "name": "replace",
+      "name": "replaceReddit",
       "label": "Reddit Links",
       "required": false,
       "default": true,
@@ -79,6 +79,14 @@
       "default": true,
       "type": "checkbox",
       "description": "Replace TikTok URLs."
+    },
+    {
+      "name": "replaceBluesky",
+      "label": "Bluesky Links",
+      "required": false,
+      "default": true,
+      "type": "checkbox",
+      "description": "Replace Bluesky URLs."
     }
   ],
   "dependencies": {
@@ -100,5 +108,6 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "contributors": ["based"]
 }

--- a/extensions/fix-link-embeds/package.json
+++ b/extensions/fix-link-embeds/package.json
@@ -109,5 +109,10 @@
     "lint": "ray lint",
     "publish": "ray publish"
   },
-  "contributors": ["based"]
+  "contributors": [
+    "based"
+  ],
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/fix-link-embeds/src/assets/regexList.ts
+++ b/extensions/fix-link-embeds/src/assets/regexList.ts
@@ -20,7 +20,7 @@ export const regexList = [
     settingsKey: "replaceInstagram",
   },
   {
-    test: /https?:\/\/(?:www\.)?reddit\.com(?=\/)/gi,
+    test: /https?:\/\/(?:www\.)?reddit\.com(?=\/(?:r\/[^/\s]+\/(?:comments|s)\/|comments\/))/gi,
     replace: "https://redditez.com",
     settingsKey: "replaceReddit",
   },

--- a/extensions/fix-link-embeds/src/assets/regexList.ts
+++ b/extensions/fix-link-embeds/src/assets/regexList.ts
@@ -6,7 +6,7 @@ export const regexList = [
   },
   {
     test: /https?:\/\/(?:www\.|vm\.)?tiktok\.com/g,
-    replace: "https://vxtiktok.com",
+    replace: "https://tnktok.com",
     settingsKey: "replaceTiktok",
   },
   {
@@ -15,8 +15,18 @@ export const regexList = [
     settingsKey: "replaceInstagram",
   },
   {
-    test: /https?:\/\/(?:www\.)?reddit\.com(?=\/r\/\w+?\/comments\/)/g,
-    replace: "https://rxyddit.com",
+    test: /https?:\/\/(?:www\.)?instagram\.com(?=\/reels?\/)/g,
+    replace: "https://fxig.seria.moe",
+    settingsKey: "replaceInstagram",
+  },
+  {
+    test: /https?:\/\/(?:www\.)?reddit\.com(?=\/)/gi,
+    replace: "https://redditez.com",
     settingsKey: "replaceReddit",
+  },
+  {
+    test: /https?:\/\/(?:www\.)?bsky\.app(?=\/profile\/[^/\s]+\/post\/)/g,
+    replace: "https://fxbsky.app",
+    settingsKey: "replaceBluesky",
   },
 ] as const;

--- a/extensions/fix-link-embeds/src/util/linkReplacer.ts
+++ b/extensions/fix-link-embeds/src/util/linkReplacer.ts
@@ -7,6 +7,7 @@ interface Preferences {
   replaceTiktok: boolean;
   replaceInstagram: boolean;
   replaceReddit: boolean;
+  replaceBluesky: boolean;
 }
 
 export const linkReplacer = (link: string) => {


### PR DESCRIPTION
## Description

Updates the extension's embed proxy mappings and expands support for additional social link formats:

- Replace the TikTok proxy from `vxtiktok.com` to `tnktok.com`.
- Replace the Reddit proxy from `rxyddit.com` to `redditez.com`.
- Support Reddit share links such as `/r/.../s/...`, not only `/comments/` links.
- Add Instagram Reels support through `fxig.seria.moe`.
- Add Bluesky post support through `fxbsky.app`, including a corresponding preference toggle.
- Fix the Reddit preference key mismatch (`replace` → `replaceReddit`) that prevented the Reddit rule from respecting its toggle.
- Refresh the README's supported-service list and add a changelog entry.

### Validation

- `npm ci`
- `npm run lint`
- `npm run build`
- Manually verified URL transformations for Twitter/X, TikTok, Instagram posts, Instagram Reels, Reddit share links, and Bluesky posts.

## Screencast

Not included because this updates the behavior of the existing no-view commands and does not add or change any UI.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
