### PR TITLE
Update Picmal extension: Merge Audio, Combine Videos, Split PDF, Generate App Icons

### DIFF
--- a/extensions/picmal/CHANGELOG.md
+++ b/extensions/picmal/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Picmal Changelog
 
+## [New Tools] - {PR_MERGE_DATE}
+
+- Added **Merge Audio** — join two or more audio files into one. Same-format files are joined losslessly; mixed formats are re-encoded to match the first file.
+- Added **Combine Videos** — join two or more videos into one. Matching clips are joined losslessly; mismatched ones are scaled and re-encoded to match the first.
+- Added **Split PDF** — split a PDF into one document per page range (`1-3, 5, 8-`), or leave the ranges blank to split every page separately.
+- Added **Generate App Icons** — turn one image into a macOS `.icns`, a Windows `.ico`, and an iOS icon set, written to a new folder next to the source.
+- **Combine Videos**, **Split PDF**, and **Generate App Icons** also ship as AI tools, so Raycast AI can run them from a plain-English request.
+
 ## [AI Tools & Initial Release] - 2026-07-16
 
 - Added **Convert Files** and **Compress Files** AI tools, so Raycast AI can convert and compress your selection with confirmation.

--- a/extensions/picmal/CHANGELOG.md
+++ b/extensions/picmal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Picmal Changelog
 
-## [New Tools] - {PR_MERGE_DATE}
+## [New Tools] - 2026-07-16
 
 - Added **Merge Audio** — join two or more audio files into one. Same-format files are joined losslessly; mixed formats are re-encoded to match the first file.
 - Added **Combine Videos** — join two or more videos into one. Matching clips are joined losslessly; mismatched ones are scaled and re-encoded to match the first.

--- a/extensions/picmal/README.md
+++ b/extensions/picmal/README.md
@@ -11,12 +11,20 @@ Convert and compress images, audio, and video right from Raycast — powered by 
 - **Compress Files** — Compress files while keeping their format, optionally driven by
   one of Picmal's built-in or custom presets.
 - **Combine PDFs** — Merge two or more PDFs into a single PDF, in the order shown.
+- **Split PDF** — Split a PDF into one document per page range (`1-3, 5, 8-`), or one PDF
+  per page.
 - **Images to PDF** — Build a multi-page PDF from images (one image per page) with a
   page-size and quality choice and an optional open password.
+- **Merge Audio** — Join two or more audio files into one track, losslessly when they
+  share a format.
+- **Combine Videos** — Join two or more videos into one, losslessly when the clips match.
+- **Generate App Icons** — Turn one image into a macOS `.icns`, a Windows `.ico`, and an
+  iOS icon set.
 
 Every command prefills from your current Finder selection. Convert and compress write next
-to each input (compress adds a `_compressed` suffix); the PDF commands write a single new
-PDF next to the first input. A toast reports the result with a **Show in Finder** action.
+to each input (compress adds a `_compressed` suffix); the merge, combine, and PDF commands
+write a single new file next to the first input; **Generate App Icons** writes a folder of
+icons next to the source. A toast reports the result with a **Show in Finder** action.
 
 ## AI Tools
 
@@ -28,7 +36,10 @@ the output paths (and size savings for convert/compress).
 - **Convert Files** — convert files to a target format.
 - **Compress Files** — compress files (optionally with a preset) while keeping their format.
 - **Combine PDFs** — merge two or more PDFs into one.
+- **Split PDF** — split a PDF into one document per page range.
 - **Images to PDF** — create a multi-page PDF from images.
+- **Combine Videos** — join two or more videos into one.
+- **Generate App Icons** — generate macOS, Windows, and iOS app icons from one image.
 
 ## Requirements
 

--- a/extensions/picmal/package.json
+++ b/extensions/picmal/package.json
@@ -9,7 +9,7 @@
   "platforms": ["macOS"],
   "license": "MIT",
   "ai": {
-    "instructions": "Picmal converts and compresses images, audio, and video — and builds PDFs — using the locally installed Picmal app's bundled tools. When the user asks to process files, prefer their current Finder selection or explicit absolute paths. Convert is a pure format change at maximum quality by default — only pass a quality (0–100) to convert-files when the user explicitly wants to also compress the converted file. Use compress-files (not convert) when the goal is to reduce size while keeping the format. Use combine-pdfs to merge two or more PDFs into one (page order = the order of the paths). Use images-to-pdf to turn one or more images into a multi-page PDF, one image per page. Convert/compress write new files next to each input (compress adds a '_compressed' suffix); the PDF tools write a single new PDF next to the first input. Nothing overwrites existing files unless the user explicitly asks to overwrite. After running, report the output paths; report size savings only for convert and compress (not for the PDF tools, which create new documents)."
+    "instructions": "Picmal converts and compresses images, audio, and video — and builds PDFs — using the locally installed Picmal app's bundled tools. When the user asks to process files, prefer their current Finder selection or explicit absolute paths. Convert is a pure format change at maximum quality by default — only pass a quality (0–100) to convert-files when the user explicitly wants to also compress the converted file. Use compress-files (not convert) when the goal is to reduce size while keeping the format. Use combine-pdfs to merge two or more PDFs into one (page order = the order of the paths). Use split-pdf to break one PDF into a document per page range ('1-3, 5, 8-'); with no ranges it splits every page into its own PDF. Use images-to-pdf to turn one or more images into a multi-page PDF, one image per page. Use combine-videos to join two or more videos into one (order = the order of the paths). Use app-icon to generate app icons from one image — macOS (.icns), Windows (.ico), and an iOS icon set (.appiconset); it writes a new folder of icons next to the source and is not a size reduction, so don't report savings for it. Convert/compress write new files next to each input (compress adds a '_compressed' suffix); combine-pdfs, images-to-pdf, and combine-videos write a single new file next to the first input; split-pdf writes one PDF per range next to the source. Nothing overwrites existing files unless the user explicitly asks to overwrite. After running, report the output paths; report size savings only for convert and compress (not for the PDF, video, or icon tools, which create new documents)."
   },
   "preferences": [
     {
@@ -93,12 +93,44 @@
       "keywords": ["picmal", "pdf", "merge", "combine", "join", "concatenate", "document"]
     },
     {
+      "name": "merge-audio",
+      "title": "Merge Audio",
+      "subtitle": "Picmal",
+      "description": "Join two or more audio files into one.",
+      "mode": "view",
+      "keywords": ["picmal", "audio", "merge", "join", "concatenate", "combine", "mp3", "wav", "sound"]
+    },
+    {
+      "name": "combine-videos",
+      "title": "Combine Videos",
+      "subtitle": "Picmal",
+      "description": "Join two or more videos into one.",
+      "mode": "view",
+      "keywords": ["picmal", "video", "combine", "merge", "join", "concatenate", "mp4", "mov", "clip"]
+    },
+    {
+      "name": "split-pdf",
+      "title": "Split PDF",
+      "subtitle": "Picmal",
+      "description": "Split a PDF into one document per page range.",
+      "mode": "view",
+      "keywords": ["picmal", "pdf", "split", "extract", "pages", "burst", "separate", "document"]
+    },
+    {
       "name": "images-to-pdf",
       "title": "Images to PDF",
       "subtitle": "Picmal",
       "description": "Create a multi-page PDF from images, one image per page.",
       "mode": "view",
       "keywords": ["picmal", "pdf", "image", "images", "photo", "scan", "document", "convert", "create"]
+    },
+    {
+      "name": "app-icon",
+      "title": "Generate App Icons",
+      "subtitle": "Picmal",
+      "description": "Generate macOS (.icns), Windows (.ico), and iOS app icons from one image.",
+      "mode": "view",
+      "keywords": ["picmal", "icon", "app icon", "icns", "ico", "appiconset", "ios", "macos", "windows"]
     }
   ],
   "tools": [
@@ -118,9 +150,24 @@
       "description": "Merge two or more PDFs into a single PDF, in the order given, using Picmal."
     },
     {
+      "name": "combine-videos",
+      "title": "Combine Videos",
+      "description": "Join two or more videos into a single video, in the order given, using Picmal."
+    },
+    {
+      "name": "split-pdf",
+      "title": "Split PDF",
+      "description": "Split a PDF into one document per page range (or one PDF per page) using Picmal."
+    },
+    {
       "name": "images-to-pdf",
       "title": "Images to PDF",
       "description": "Create a multi-page PDF from images (one image per page) using Picmal."
+    },
+    {
+      "name": "app-icon",
+      "title": "Generate App Icons",
+      "description": "Generate macOS (.icns), Windows (.ico), and iOS app icons from one image using Picmal."
     }
   ],
   "dependencies": {

--- a/extensions/picmal/src/app-icon.tsx
+++ b/extensions/picmal/src/app-icon.tsx
@@ -1,0 +1,78 @@
+import { Action, ActionPanel, Detail, Form, Icon, popToRoot, showToast, Toast } from "@raycast/api";
+import { useForm, usePromise } from "@raycast/utils";
+import { useEffect } from "react";
+import { NotInstalled } from "./components/NotInstalled";
+import { isPicmalInstalled } from "./lib/cli";
+import { runAndReport } from "./lib/feedback";
+import { selectedFinderPaths } from "./lib/finder";
+import { categorize, FormatGroups, loadFormats } from "./lib/formats";
+
+interface AppIconFormValues {
+  input: string[];
+  macos: boolean;
+  windows: boolean;
+  ios: boolean;
+  overwrite: boolean;
+}
+
+/** Keep only image files, per Picmal's known formats. */
+function imagesOnly(paths: string[], formats: FormatGroups | undefined): string[] {
+  if (!formats || formats.image.length === 0) return paths;
+  return paths.filter((path) => categorize(path, formats) === "image");
+}
+
+export default function AppIcon() {
+  const { data: installed } = usePromise(async () => isPicmalInstalled());
+  const { data: formats, isLoading: loadingFormats } = usePromise(loadFormats);
+  const { data: finderPaths, isLoading: loadingFinder } = usePromise(selectedFinderPaths);
+
+  const { handleSubmit, itemProps, setValue } = useForm<AppIconFormValues>({
+    async onSubmit(values) {
+      if (!values.macos && !values.windows && !values.ios) {
+        await showToast({ style: Toast.Style.Failure, title: "Choose at least one format" });
+        return;
+      }
+      await runAndReport("app-icon", {
+        // app-icon works on one source; take the first image.
+        input: imagesOnly(values.input, formats).slice(0, 1),
+        macos: values.macos,
+        windows: values.windows,
+        ios: values.ios,
+        overwrite: values.overwrite,
+      });
+      await popToRoot();
+    },
+    initialValues: { input: [], macos: true, windows: true, ios: true, overwrite: false },
+    validation: {
+      input: (value) => (imagesOnly(value ?? [], formats).length === 0 ? "Select an image" : undefined),
+    },
+  });
+
+  useEffect(() => {
+    const images = imagesOnly(finderPaths ?? [], formats);
+    if (images.length > 0) setValue("input", [images[0]]);
+  }, [finderPaths, formats]);
+
+  if (installed === undefined) return <Detail isLoading />;
+  if (!installed) return <NotInstalled />;
+
+  return (
+    <Form
+      isLoading={loadingFormats || loadingFinder}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Generate Icons" icon={Icon.AppWindow} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.FilePicker {...itemProps.input} title="Image" allowMultipleSelection={false} />
+      <Form.Description title="Source" text="Use a square image at least 1024 × 1024 for crisp icons." />
+      <Form.Separator />
+      <Form.Checkbox {...itemProps.macos} label="macOS (.icns)" />
+      <Form.Checkbox {...itemProps.windows} label="Windows (.ico)" />
+      <Form.Checkbox {...itemProps.ios} label="iOS icon set (.appiconset)" />
+      <Form.Separator />
+      <Form.Checkbox {...itemProps.overwrite} label="Overwrite existing files" />
+    </Form>
+  );
+}

--- a/extensions/picmal/src/combine-videos.tsx
+++ b/extensions/picmal/src/combine-videos.tsx
@@ -1,0 +1,118 @@
+import { Action, ActionPanel, Detail, Form, Icon, popToRoot } from "@raycast/api";
+import { useForm, usePromise } from "@raycast/utils";
+import { useEffect } from "react";
+import { NotInstalled } from "./components/NotInstalled";
+import { isPicmalInstalled } from "./lib/cli";
+import { runAndReport } from "./lib/feedback";
+import { selectedFinderPaths } from "./lib/finder";
+
+interface CombineVideosFormValues {
+  input: string[];
+  overwrite: boolean;
+}
+
+/** Video extensions picmal-cli accepts as combine inputs (mirrors Constants.videoFormats). */
+const VIDEO_EXTENSIONS = [
+  ".mp4",
+  ".mov",
+  ".avi",
+  ".mkv",
+  ".webm",
+  ".flv",
+  ".wmv",
+  ".m4v",
+  ".mpg",
+  ".mpeg",
+  ".3gp",
+  ".3g2",
+  ".m2ts",
+  ".mts",
+  ".vob",
+  ".asf",
+  ".ogv",
+  ".wtv",
+  ".ts",
+  ".mjpeg",
+  ".m2v",
+  ".hevc",
+  ".f4v",
+  ".mxf",
+  ".mod",
+  ".rm",
+  ".rmvb",
+  ".bik",
+  ".fli",
+  ".flc",
+  ".nsv",
+  ".dav",
+];
+
+/** Keep only the video files from a list of paths (case-insensitive extension match). */
+function videoOnly(paths: string[]): string[] {
+  return paths.filter((path) => VIDEO_EXTENSIONS.some((ext) => path.toLowerCase().endsWith(ext)));
+}
+
+export default function CombineVideos() {
+  // Deferred so Spotlight (mdfind) never runs on the synchronous render path.
+  const { data: installed } = usePromise(async () => isPicmalInstalled());
+  const { data: finderPaths, isLoading: loadingFinder } = usePromise(selectedFinderPaths);
+
+  const { handleSubmit, itemProps, setValue, values } = useForm<CombineVideosFormValues>({
+    async onSubmit(values) {
+      await runAndReport("combine-videos", {
+        input: videoOnly(values.input),
+        overwrite: values.overwrite,
+      });
+      await popToRoot();
+    },
+    initialValues: { input: [], overwrite: false },
+    validation: {
+      input: (value) => {
+        const videos = videoOnly(value ?? []);
+        if (videos.length < 2) return "Select at least two videos";
+        return undefined;
+      },
+    },
+  });
+
+  // Prefill the file picker with the videos in the current Finder selection.
+  useEffect(() => {
+    const videos = videoOnly(finderPaths ?? []);
+    if (videos.length > 0) setValue("input", videos);
+  }, [finderPaths]);
+
+  if (installed === undefined) return <Detail isLoading />;
+  if (!installed) return <NotInstalled />;
+
+  const selectedVideos = videoOnly(values.input ?? []);
+  const prefilledCount = videoOnly(finderPaths ?? []).length;
+
+  return (
+    <Form
+      isLoading={loadingFinder}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Combine Videos" icon={Icon.Video} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.FilePicker {...itemProps.input} title="Videos" allowMultipleSelection />
+      <Form.Description
+        title="Order"
+        text={
+          selectedVideos.length >= 2
+            ? `Joined top-to-bottom into one file — ${selectedVideos.length} videos in this order.`
+            : "Pick two or more videos. They join in the order shown, top to bottom."
+        }
+      />
+      {prefilledCount > 0 && (
+        <Form.Description
+          title="From Finder"
+          text={`Prefilled ${prefilledCount} video${prefilledCount === 1 ? "" : "s"}`}
+        />
+      )}
+      <Form.Separator />
+      <Form.Checkbox {...itemProps.overwrite} label="Overwrite existing files" />
+    </Form>
+  );
+}

--- a/extensions/picmal/src/lib/cli.ts
+++ b/extensions/picmal/src/lib/cli.ts
@@ -52,7 +52,15 @@ export interface RunResult {
   exitCode: number;
 }
 
-export type Command = "convert" | "compress" | "combine" | "images-to-pdf";
+export type Command =
+  | "convert"
+  | "compress"
+  | "combine"
+  | "combine-videos"
+  | "merge-audio"
+  | "split-pdf"
+  | "images-to-pdf"
+  | "app-icon";
 
 export interface ConvertArgs {
   input: string[];
@@ -78,6 +86,32 @@ export interface CombineArgs {
   overwrite?: boolean;
 }
 
+/** Combine two or more videos into one, in order (at least two inputs). */
+export interface CombineVideosArgs {
+  input: string[];
+  /** Output file or directory. Default: `<first> (combined).<ext>` next to the first input. */
+  output?: string;
+  overwrite?: boolean;
+}
+
+/** Merge two or more audio files into one, in order (at least two inputs). */
+export interface MergeAudioArgs {
+  input: string[];
+  /** Output file or directory. Default: `<first> (merged).<ext>` next to the first input. */
+  output?: string;
+  overwrite?: boolean;
+}
+
+/** Split a PDF into one document per page range (one input). */
+export interface SplitPdfArgs {
+  input: string[];
+  /** Page ranges like `1-3,5,8-`. Omit for one PDF per page. */
+  pages?: string;
+  /** Output directory. Default: next to each input. */
+  output?: string;
+  overwrite?: boolean;
+}
+
 /** Build a multi-page PDF from images, one image per page (at least one input). */
 export interface ImagesToPDFArgs {
   input: string[];
@@ -92,8 +126,30 @@ export interface ImagesToPDFArgs {
   overwrite?: boolean;
 }
 
+/** Generate app icons (.icns / .ico / iOS set) from one image. */
+export interface AppIconArgs {
+  input: string[];
+  /** Generate macOS .icns. Omit all three flags to generate every format. */
+  macos?: boolean;
+  /** Generate Windows .ico. */
+  windows?: boolean;
+  /** Generate an iOS .appiconset. */
+  ios?: boolean;
+  /** Output directory. Default: `<name> App Icons` next to the source. */
+  output?: string;
+  overwrite?: boolean;
+}
+
 /** Any argument shape accepted by {@link run}. */
-export type RunArgs = ConvertArgs | CompressArgs | CombineArgs | ImagesToPDFArgs;
+export type RunArgs =
+  | ConvertArgs
+  | CompressArgs
+  | CombineArgs
+  | CombineVideosArgs
+  | MergeAudioArgs
+  | SplitPdfArgs
+  | ImagesToPDFArgs
+  | AppIconArgs;
 
 /** Progress callback for long audio/video transcodes (percent is 0–100). */
 export type ProgressHandler = (input: string, percent: number) => void;
@@ -161,15 +217,25 @@ function buildArgs(command: Command, args: RunArgs): string[] {
     if (typeof quality === "number") out.push("--quality", String(quality));
     if ((args as ConvertArgs | CompressArgs).stripMetadata) out.push("--strip-metadata");
   } else {
-    // combine/images-to-pdf: positional inputs, a single PDF output.
+    // combine/split-pdf/images-to-pdf: positional inputs.
     for (const path of args.input) out.push(path);
     if (command === "images-to-pdf") {
       const a = args as ImagesToPDFArgs;
       if (a.pageSize) out.push("--page-size", a.pageSize);
       if (typeof a.quality === "number") out.push("--quality", String(a.quality));
       if (a.password) out.push("--password", a.password);
+    } else if (command === "split-pdf") {
+      const pages = (args as SplitPdfArgs).pages?.trim();
+      if (pages) out.push("--pages", pages);
+    } else if (command === "app-icon") {
+      const a = args as AppIconArgs;
+      if (a.macos) out.push("--macos");
+      if (a.windows) out.push("--windows");
+      if (a.ios) out.push("--ios");
     }
-    const output = (args as CombineArgs | ImagesToPDFArgs).output;
+    const output = (
+      args as CombineArgs | CombineVideosArgs | MergeAudioArgs | SplitPdfArgs | ImagesToPDFArgs | AppIconArgs
+    ).output;
     if (output) out.push("--output", output);
   }
 

--- a/extensions/picmal/src/lib/feedback.ts
+++ b/extensions/picmal/src/lib/feedback.ts
@@ -2,9 +2,9 @@ import { open, showInFinder, showToast, Toast } from "@raycast/api";
 import { basename } from "path";
 import { Command, describeResult, PICMAL_WEBSITE, PicmalNotInstalledError, run, RunArgs } from "./cli";
 
-/** PDF-building commands produce one new PDF, so a "saved %" figure doesn't apply. */
-function isPdfBuilder(command: Command): boolean {
-  return command === "combine" || command === "images-to-pdf";
+/** Merge/build commands produce one new file, so a "saved %" figure doesn't apply. */
+function isBuilder(command: Command): boolean {
+  return command === "combine" || command === "images-to-pdf" || command === "merge-audio" || command === "app-icon";
 }
 
 /**
@@ -14,7 +14,7 @@ function isPdfBuilder(command: Command): boolean {
  * produced files, Open Picmal when licensing or tooling is the problem).
  */
 export async function runAndReport(command: Command, args: RunArgs): Promise<void> {
-  const buildsPdf = isPdfBuilder(command);
+  const builds = isBuilder(command);
   const toast = await showToast({
     style: Toast.Style.Animated,
     title: args.input.length > 1 ? `Processing ${args.input.length} files…` : "Processing…",
@@ -26,8 +26,9 @@ export async function runAndReport(command: Command, args: RunArgs): Promise<voi
     });
 
     const described = describeResult(result, {
-      showSavings: !buildsPdf,
-      outputNoun: buildsPdf ? "PDF" : "file",
+      showSavings: !builds,
+      outputNoun:
+        command === "combine" || command === "images-to-pdf" ? "PDF" : command === "app-icon" ? "icon" : "file",
     });
     // Raycast has no "warning" toast — partial batches use Failure so they read as
     // needing attention, while the title still surfaces how many succeeded.

--- a/extensions/picmal/src/lib/feedback.ts
+++ b/extensions/picmal/src/lib/feedback.ts
@@ -4,7 +4,14 @@ import { Command, describeResult, PICMAL_WEBSITE, PicmalNotInstalledError, run, 
 
 /** Merge/build commands produce one new file, so a "saved %" figure doesn't apply. */
 function isBuilder(command: Command): boolean {
-  return command === "combine" || command === "images-to-pdf" || command === "merge-audio" || command === "app-icon";
+  return (
+    command === "combine" ||
+    command === "images-to-pdf" ||
+    command === "merge-audio" ||
+    command === "combine-videos" ||
+    command === "split-pdf" ||
+    command === "app-icon"
+  );
 }
 
 /**

--- a/extensions/picmal/src/merge-audio.tsx
+++ b/extensions/picmal/src/merge-audio.tsx
@@ -1,0 +1,127 @@
+import { Action, ActionPanel, Detail, Form, Icon, popToRoot } from "@raycast/api";
+import { useForm, usePromise } from "@raycast/utils";
+import { useEffect } from "react";
+import { NotInstalled } from "./components/NotInstalled";
+import { isPicmalInstalled } from "./lib/cli";
+import { runAndReport } from "./lib/feedback";
+import { selectedFinderPaths } from "./lib/finder";
+
+interface MergeAudioFormValues {
+  input: string[];
+  overwrite: boolean;
+}
+
+/** Audio extensions picmal-cli accepts as merge inputs (mirrors Constants.audioFormats). */
+const AUDIO_EXTENSIONS = [
+  ".mp3",
+  ".wav",
+  ".aac",
+  ".m4a",
+  ".flac",
+  ".ogg",
+  ".oga",
+  ".opus",
+  ".m4r",
+  ".ac3",
+  ".wv",
+  ".au",
+  ".caf",
+  ".spx",
+  ".ircam",
+  ".snd",
+  ".voc",
+  ".dts",
+  ".tta",
+  ".w64",
+  ".sln",
+  ".hcom",
+  ".paf",
+  ".mp2",
+  ".wve",
+  ".nist",
+  ".aiff",
+  ".aif",
+  ".aifc",
+  ".avr",
+  ".pvf",
+  ".wma",
+  ".eac3",
+  ".mka",
+  ".ape",
+  ".mpc",
+  ".tak",
+  ".dsf",
+  ".shn",
+  ".amr",
+  ".gsm",
+];
+
+/** Keep only the audio files from a list of paths (case-insensitive extension match). */
+function audioOnly(paths: string[]): string[] {
+  return paths.filter((path) => AUDIO_EXTENSIONS.some((ext) => path.toLowerCase().endsWith(ext)));
+}
+
+export default function MergeAudio() {
+  // Deferred so Spotlight (mdfind) never runs on the synchronous render path.
+  const { data: installed } = usePromise(async () => isPicmalInstalled());
+  const { data: finderPaths, isLoading: loadingFinder } = usePromise(selectedFinderPaths);
+
+  const { handleSubmit, itemProps, setValue, values } = useForm<MergeAudioFormValues>({
+    async onSubmit(values) {
+      await runAndReport("merge-audio", {
+        input: audioOnly(values.input),
+        overwrite: values.overwrite,
+      });
+      await popToRoot();
+    },
+    initialValues: { input: [], overwrite: false },
+    validation: {
+      input: (value) => {
+        const audio = audioOnly(value ?? []);
+        if (audio.length < 2) return "Select at least two audio files";
+        return undefined;
+      },
+    },
+  });
+
+  // Prefill the file picker with the audio files in the current Finder selection.
+  useEffect(() => {
+    const audio = audioOnly(finderPaths ?? []);
+    if (audio.length > 0) setValue("input", audio);
+  }, [finderPaths]);
+
+  if (installed === undefined) return <Detail isLoading />;
+  if (!installed) return <NotInstalled />;
+
+  const selectedAudio = audioOnly(values.input ?? []);
+  const prefilledCount = audioOnly(finderPaths ?? []).length;
+
+  return (
+    <Form
+      isLoading={loadingFinder}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Merge Audio" icon={Icon.Music} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.FilePicker {...itemProps.input} title="Audio Files" allowMultipleSelection />
+      <Form.Description
+        title="Order"
+        text={
+          selectedAudio.length >= 2
+            ? `Joined top-to-bottom into one file — ${selectedAudio.length} files in this order.`
+            : "Pick two or more audio files. They join in the order shown, top to bottom."
+        }
+      />
+      {prefilledCount > 0 && (
+        <Form.Description
+          title="From Finder"
+          text={`Prefilled ${prefilledCount} audio file${prefilledCount === 1 ? "" : "s"}`}
+        />
+      )}
+      <Form.Separator />
+      <Form.Checkbox {...itemProps.overwrite} label="Overwrite existing files" />
+    </Form>
+  );
+}

--- a/extensions/picmal/src/split-pdf.tsx
+++ b/extensions/picmal/src/split-pdf.tsx
@@ -1,0 +1,78 @@
+import { Action, ActionPanel, Detail, Form, Icon, popToRoot } from "@raycast/api";
+import { useForm, usePromise } from "@raycast/utils";
+import { useEffect } from "react";
+import { NotInstalled } from "./components/NotInstalled";
+import { isPicmalInstalled } from "./lib/cli";
+import { runAndReport } from "./lib/feedback";
+import { selectedFinderPaths } from "./lib/finder";
+
+interface SplitFormValues {
+  input: string[];
+  pages: string;
+  overwrite: boolean;
+}
+
+/** Keep only the PDFs from a list of paths (case-insensitive extension match). */
+function pdfsOnly(paths: string[]): string[] {
+  return paths.filter((path) => path.toLowerCase().endsWith(".pdf"));
+}
+
+export default function SplitPdf() {
+  // Deferred so Spotlight (mdfind) never runs on the synchronous render path.
+  const { data: installed } = usePromise(async () => isPicmalInstalled());
+  const { data: finderPaths, isLoading: loadingFinder } = usePromise(selectedFinderPaths);
+
+  const { handleSubmit, itemProps, setValue, values } = useForm<SplitFormValues>({
+    async onSubmit(values) {
+      await runAndReport("split-pdf", {
+        input: pdfsOnly(values.input),
+        pages: values.pages.trim() || undefined,
+        overwrite: values.overwrite,
+      });
+      await popToRoot();
+    },
+    initialValues: { input: [], pages: "", overwrite: false },
+    validation: {
+      input: (value) => {
+        const pdfs = pdfsOnly(value ?? []);
+        if (pdfs.length < 1) return "Select at least one PDF";
+        return undefined;
+      },
+    },
+  });
+
+  // Prefill the file picker with the PDFs in the current Finder selection.
+  useEffect(() => {
+    const pdfs = pdfsOnly(finderPaths ?? []);
+    if (pdfs.length > 0) setValue("input", pdfs);
+  }, [finderPaths]);
+
+  if (installed === undefined) return <Detail isLoading />;
+  if (!installed) return <NotInstalled />;
+
+  const hasRanges = values.pages.trim().length > 0;
+
+  return (
+    <Form
+      isLoading={loadingFinder}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Split PDF" icon={Icon.NewDocument} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.FilePicker {...itemProps.input} title="PDFs" allowMultipleSelection />
+      <Form.TextField {...itemProps.pages} title="Page ranges" placeholder="1-3, 5, 8-" />
+      <Form.Description
+        title="Result"
+        text={
+          hasRanges
+            ? `One PDF per range (${values.pages.trim()}), saved next to each input.`
+            : "Leave blank to split every page into its own PDF."
+        }
+      />
+      <Form.Separator />
+      <Form.Checkbox {...itemProps.overwrite} label="Overwrite existing files" />
+    </Form>
+  );
+}

--- a/extensions/picmal/src/tools/app-icon.ts
+++ b/extensions/picmal/src/tools/app-icon.ts
@@ -1,0 +1,45 @@
+import { Tool } from "@raycast/api";
+import { run, summarizeRun } from "../lib/cli";
+
+type Input = {
+  /** Absolute path of the source image to generate icons from. */
+  path: string;
+  /** Generate a macOS .icns. Omit all three format flags to generate every format. */
+  macos?: boolean;
+  /** Generate a Windows .ico. */
+  windows?: boolean;
+  /** Generate an iOS .appiconset. */
+  ios?: boolean;
+  /** Output directory. Omit to write a "<name> App Icons" folder next to the source. */
+  output?: string;
+  /** Overwrite existing output files. Defaults to false. */
+  overwrite?: boolean;
+};
+
+/**
+ * Generate app icons (.icns / .ico / iOS icon set) from one image. Returns the
+ * produced output paths and any error.
+ */
+export default async function (input: Input) {
+  const result = await run("app-icon", {
+    input: [input.path],
+    macos: input.macos,
+    windows: input.windows,
+    ios: input.ios,
+    output: input.output?.trim() || undefined,
+    overwrite: input.overwrite,
+  });
+  // Icons aren't a size reduction — don't report "saved %".
+  return summarizeRun(result, { showSavings: false, outputNoun: "icon" });
+}
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => {
+  const formats = [input.macos && "macOS", input.windows && "Windows", input.ios && "iOS"].filter(Boolean);
+  return {
+    message: `Generate app icons from ${input.path.split("/").pop()}?`,
+    info: [
+      { name: "Formats", value: formats.length ? formats.join(", ") : "All" },
+      ...(input.overwrite ? [{ name: "Overwrite", value: "Yes" }] : []),
+    ],
+  };
+};

--- a/extensions/picmal/src/tools/combine-videos.ts
+++ b/extensions/picmal/src/tools/combine-videos.ts
@@ -1,0 +1,37 @@
+import { Tool } from "@raycast/api";
+import { run, summarizeRun } from "../lib/cli";
+
+type Input = {
+  /** Absolute paths of the videos to combine, in play order. At least two. */
+  paths: string[];
+  /**
+   * Output file or directory for the combined video. Omit to write
+   * `<first> (combined).<ext>` next to the first input.
+   */
+  output?: string;
+  /** Overwrite the output file if it already exists. Defaults to false. */
+  overwrite?: boolean;
+};
+
+/**
+ * Combine two or more videos into a single video, in the order given. Returns
+ * the produced output path and any error.
+ */
+export default async function (input: Input) {
+  const result = await run("combine-videos", {
+    input: input.paths,
+    output: input.output?.trim() || undefined,
+    overwrite: input.overwrite,
+  });
+  // A combined video isn't a size reduction — don't report "saved %".
+  return summarizeRun(result, { showSavings: false, outputNoun: "video" });
+}
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: `Combine ${input.paths.length} videos into one?`,
+  info: [
+    { name: "Videos", value: String(input.paths.length) },
+    ...(input.output ? [{ name: "Output", value: input.output }] : []),
+    ...(input.overwrite ? [{ name: "Overwrite", value: "Yes" }] : []),
+  ],
+});

--- a/extensions/picmal/src/tools/split-pdf.ts
+++ b/extensions/picmal/src/tools/split-pdf.ts
@@ -1,0 +1,40 @@
+import { Tool } from "@raycast/api";
+import { run, summarizeRun } from "../lib/cli";
+
+type Input = {
+  /** Absolute paths of the PDFs to split. */
+  paths: string[];
+  /** Page ranges like `1-3,5,8-`. Omit to split every page into its own PDF. */
+  pages?: string;
+  /** Output directory for the split PDFs. Omit to write next to each input. */
+  output?: string;
+  /** Overwrite existing output files. Defaults to false. */
+  overwrite?: boolean;
+};
+
+/**
+ * Split each PDF into one document per page range. Returns the produced output
+ * paths and any error.
+ */
+export default async function (input: Input) {
+  const result = await run("split-pdf", {
+    input: input.paths,
+    pages: input.pages?.trim() || undefined,
+    output: input.output?.trim() || undefined,
+    overwrite: input.overwrite,
+  });
+  // Splitting isn't a size reduction — don't report "saved %".
+  return summarizeRun(result, { showSavings: false, outputNoun: "PDF" });
+}
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: input.pages?.trim()
+    ? `Split ${input.paths.length} PDF(s) by pages ${input.pages.trim()}?`
+    : `Split ${input.paths.length} PDF(s) into one file per page?`,
+  info: [
+    { name: "PDFs", value: String(input.paths.length) },
+    ...(input.pages?.trim() ? [{ name: "Pages", value: input.pages.trim() }] : []),
+    ...(input.output ? [{ name: "Output", value: input.output }] : []),
+    ...(input.overwrite ? [{ name: "Overwrite", value: "Yes" }] : []),
+  ],
+});


### PR DESCRIPTION
## Description

Adds four commands to the Picmal extension, each backed by a tool that already ships in the Picmal app and its bundled CLI:

- **Merge Audio** — join two or more audio files into one. Same-format inputs are joined losslessly; mixed formats are re-encoded to match the first file.
- **Combine Videos** — join two or more videos into one. Matching clips are joined losslessly; mismatched ones are scaled and re-encoded to match the first.
- **Split PDF** — split a PDF into one document per page range (`1-3, 5, 8-`), or one PDF per page when the ranges are left blank.
- **Generate App Icons** — turn one image into a macOS `.icns`, a Windows `.ico`, and an iOS icon set, written to a new folder next to the source.

**Combine Videos**, **Split PDF**, and **Generate App Icons** also ship as AI tools. The AI instructions have been extended to cover them, including which tools report size savings (convert/compress only) and where each writes its output.

Like the existing commands, all four prefill from the current Finder selection and shell out to the `picmal-cli` binary bundled inside the locally installed `Picmal.app` — no API key, no separate download, and everything runs locally.

## Screencast

<!-- Screenshots in `metadata/` cover the existing commands. -->

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
