### PR TITLE
[Slack] Add update message AI tool

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Changelog
 
+## [Add Slack update message AI tool] - 2026-07-16
+
+- Add an `update-message` AI tool that edits messages posted by the authenticated Slack user and returns a permalink to the updated message.
+
 ## [Add optional AI message signature] - 2026-07-15
 
 - Add an enabled-by-default extension preference that shows a subtle “Sent via Raycast” Block Kit context below messages sent by the `send-message` and `reply-thread` AI tools. Messages sent with the Send Message command are unchanged.

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -205,6 +205,11 @@
       "description": "Send a Slack message to a channel, group DM, existing DM, or user. Pass a conversation ID or user ID and the message text. When given a user ID, the tool opens or finds the DM first."
     },
     {
+      "title": "Update Message",
+      "name": "update-message",
+      "description": "Edit a Slack message posted by the authenticated user. Requires the channel ID, message timestamp, and complete replacement text. Use the permalink or a read/search tool to resolve the message first when needed."
+    },
+    {
       "title": "Reply to Thread",
       "name": "reply-thread",
       "description": "Post a reply to a Slack thread. Requires the channel ID, the parent message timestamp, and the reply text. Use Read Thread first when context is needed."
@@ -280,6 +285,26 @@
         ],
         "mocks": {
           "reply-thread": "success"
+        }
+      },
+      {
+        "input": "@slack edit this message to say \"Updated copy\": https://example.slack.com/archives/C12345678/p1718899200000100",
+        "expected": [
+          {
+            "callsTool": {
+              "name": "update-message",
+              "arguments": {
+                "channel": "C12345678",
+                "messageTs": "1718899200.000100",
+                "text": {
+                  "includes": "Updated copy"
+                }
+              }
+            }
+          }
+        ],
+        "mocks": {
+          "update-message": "success"
         }
       }
     ]

--- a/extensions/slack/src/tools/update-message.ts
+++ b/extensions/slack/src/tools/update-message.ts
@@ -1,0 +1,62 @@
+import { getSlackWebClient } from "../shared/client/WebClient";
+import { withSlackClient } from "../shared/withSlackClient";
+
+type Input = {
+  /**
+   * The Slack channel ID containing the message. Use a Slack permalink, Get Channels, Read Conversation, Get Channel History, or Search Messages to find it.
+   *
+   * @example "C12345678"
+   */
+  channel: string;
+  /**
+   * The timestamp of the message to edit. This is the `ts` value from a Slack permalink or a read/search tool.
+   *
+   * @example "1718899200.000100"
+   */
+  messageTs: string;
+  /**
+   * The complete replacement text for the message. Slack mrkdwn is supported.
+   */
+  text: string;
+};
+
+async function updateMessage(input: Input) {
+  if (!/^[CDG][A-Z0-9]{8,}$/.test(input.channel)) {
+    throw new Error("Invalid Slack conversation ID");
+  }
+
+  if (!/^\d+\.\d+$/.test(input.messageTs)) {
+    throw new Error("Invalid Slack message timestamp");
+  }
+
+  const text = input.text.trim();
+  if (!text) {
+    throw new Error("Message text cannot be empty");
+  }
+
+  const slackWebClient = getSlackWebClient();
+  const response = await slackWebClient.chat.update({
+    channel: input.channel,
+    ts: input.messageTs,
+    text,
+    blocks: [],
+  });
+
+  if (response.error) {
+    throw new Error(response.error);
+  }
+
+  const permalinkResponse = await slackWebClient.chat.getPermalink({
+    channel: input.channel,
+    message_ts: input.messageTs,
+  });
+
+  return {
+    channel: response.channel ?? input.channel,
+    ts: response.ts ?? input.messageTs,
+    text: response.text ?? text,
+    permalink: permalinkResponse.ok ? permalinkResponse.permalink : undefined,
+  };
+}
+
+export default withSlackClient(updateMessage);


### PR DESCRIPTION
## Description

Adds an `update-message` AI tool backed by Slack's `chat.update` API. The tool edits a message posted by the authenticated user, removes any existing Block Kit blocks when replacing the text, and returns a permalink to the updated message.

Also adds an AI eval and changelog entry.

## Checks

* `npm run lint`
* `npm run build`
* `npx tsc --noEmit`