### PR TITLE
feat(jira-search-self-hosted): search issues by number

### DIFF
--- a/extensions/jira-search-self-hosted/CHANGELOG.md
+++ b/extensions/jira-search-self-hosted/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Jira Search Self Hosted Changelog
 
+## [Search issues by number] - 2026-07-16
+
+- Added the ability to find an issue by number when its project key is configured in **Default Included Projects**.
+
 ## [Update] - 2026-04-30
 
 Added configuration option to set default filters for projects, issue types, statuses, and assignees for inclusion and exclusion.

--- a/extensions/jira-search-self-hosted/CHANGELOG.md
+++ b/extensions/jira-search-self-hosted/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Jira Search Self Hosted Changelog
 
-## [Search issues by number] - {PR_MERGE_DATE}
+## [Search issues by number] - 2026-07-16
 
 - Added the ability to find an issue by number when its project key is configured in **Default Included Projects**.
 

--- a/extensions/jira-search-self-hosted/CHANGELOG.md
+++ b/extensions/jira-search-self-hosted/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Jira Search Self Hosted Changelog
 
-## [Search issues by number] - 2026-07-16
+## [Search issues by number] - {PR_MERGE_DATE}
 
 - Added the ability to find an issue by number when its project key is configured in **Default Included Projects**.
 

--- a/extensions/jira-search-self-hosted/README.md
+++ b/extensions/jira-search-self-hosted/README.md
@@ -17,6 +17,7 @@ search extension built by sven to work with JIRA server instances.
     - If you type a filter in the search box, it overrides the configured defaults for that field.
   - For example enter `pdf export @dev @it #bug #story` to find all issues which contain words starting with "pdf" and "export" and which are in the "DEV" or "IT" project and which are of type "Bug" or "Story."
   - Find issue directly by issue key (for example `DEV-1234`).
+  - Find an issue by number (for example `1234`) when its project key is configured in **Default Included Projects**.
 - Find projects by title.
 - Find boards by title.
 - Use the following actions on found entities:
@@ -34,6 +35,7 @@ To connect the extension to your Jira instance you need to fill the following pr
 - **Jira Domain:** The domain of your Jira instance like `mycompany.atlassian.net` or with a base URL like `mycompany.atlassian.net/baseUrl/jira`.
 - **Personal Access Token:** A personal access token created as described in [Using Personal Access Tokens](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html).
 - **Default Filters:** Optional comma-separated include and exclude defaults for projects, statuses, issue types, and assignees.
+  - Configure project keys (for example `DEV`, not a project name) in **Default Included Projects** to search for issues by number alone.
 
 ### Unsafe HTTPS
 

--- a/extensions/jira-search-self-hosted/package.json
+++ b/extensions/jira-search-self-hosted/package.json
@@ -10,7 +10,8 @@
     "koseduhemak",
     "LunaticMuch",
     "marinsokol",
-    "limonkufu"
+    "limonkufu",
+    "thezaff"
   ],
   "pastContributors": [
     "ryanp",
@@ -77,7 +78,7 @@
       "type": "textfield",
       "required": false,
       "title": "Default Included Projects",
-      "description": "Comma-separated project keys or names to include when no @project filter is typed.",
+      "description": "Comma-separated project keys or names to include when no @project filter is typed. Project keys also enable search by issue number.",
       "placeholder": "DEV, IT"
     },
     {
@@ -154,6 +155,7 @@
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test src/*.test.mjs",
     "lint": "ray lint",
     "fix-lint": "ray lint --fix",
     "publish": "npx @raycast/api@latest publish"

--- a/extensions/jira-search-self-hosted/src/issue-key.test.mjs
+++ b/extensions/jira-search-self-hosted/src/issue-key.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildIssueNumberJql } from "./issue-key.ts";
+
+describe("buildIssueNumberJql", () => {
+  it("builds an exact key from a number and one default project", () => {
+    assert.equal(buildIssueNumberJql("123", "ACME"), "key=ACME-123");
+  });
+
+  it("trims the query and supports multiple unique project keys", () => {
+    assert.equal(buildIssueNumberJql(" 123 ", "ACME, DEV, acme"), 'key IN ("ACME-123", "DEV-123")');
+  });
+
+  it("ignores default project values that cannot be issue-key prefixes", () => {
+    assert.equal(buildIssueNumberJql("123", "My Project, ACME, OPS_TEAM"), "key=ACME-123");
+    assert.equal(buildIssueNumberJql("123", "My Project, OPS_TEAM"), undefined);
+  });
+
+  it("does not resolve non-numeric searches", () => {
+    for (const query of ["", "ACME-123", "123a", "-123", "1.23", "@ACME 123"]) {
+      assert.equal(buildIssueNumberJql(query, "ACME"), undefined);
+    }
+  });
+
+  it("does not resolve a number without a default project key", () => {
+    assert.equal(buildIssueNumberJql("123", undefined), undefined);
+    assert.equal(buildIssueNumberJql("123", ""), undefined);
+  });
+});

--- a/extensions/jira-search-self-hosted/src/issue-key.ts
+++ b/extensions/jira-search-self-hosted/src/issue-key.ts
@@ -1,0 +1,24 @@
+const ISSUE_NUMBER_PATTERN = /^\d+$/;
+const PROJECT_KEY_PATTERN = /^[A-Z][A-Z0-9]+$/i;
+
+export function buildIssueNumberJql(query: string, defaultIncludeProjects?: string): string | undefined {
+  const issueNumber = query.trim();
+  if (!ISSUE_NUMBER_PATTERN.test(issueNumber)) return undefined;
+
+  const projectKeys = [
+    ...new Set(
+      (defaultIncludeProjects ?? "")
+        .split(",")
+        .map((project) => project.trim())
+        .filter((project) => PROJECT_KEY_PATTERN.test(project))
+        .map((project) => project.toUpperCase()),
+    ),
+  ];
+
+  if (projectKeys.length === 0) return undefined;
+
+  const issueKeys = projectKeys.map((projectKey) => `${projectKey}-${issueNumber}`);
+  if (issueKeys.length === 1) return `key=${issueKeys[0]}`;
+
+  return `key IN (${issueKeys.map((issueKey) => `"${issueKey}"`).join(", ")})`;
+}

--- a/extensions/jira-search-self-hosted/src/issue.ts
+++ b/extensions/jira-search-self-hosted/src/issue.ts
@@ -4,6 +4,8 @@ import { ResultItem, SearchCommand } from "./command";
 import { Color, Icon, Image } from "@raycast/api";
 import { ErrorText } from "./exception";
 import { buildIssueSearchJql } from "./issue-search";
+import { buildIssueNumberJql } from "./issue-key";
+import { prefs } from "./preferences";
 
 interface IssueType {
   id: string;
@@ -88,7 +90,8 @@ function buildJql(query: string): string {
 
 function jqlFor(query: string): string {
   const trimmedQuery = query.trim();
-  return isIssueKey(trimmedQuery) ? `key=${trimmedQuery}` : buildJql(query);
+  if (isIssueKey(trimmedQuery)) return `key=${trimmedQuery}`;
+  return buildIssueNumberJql(trimmedQuery, prefs.defaultIncludeProjects) ?? buildJql(query);
 }
 
 export async function searchIssues(query: string): Promise<ResultItem[]> {

--- a/extensions/jira-search-self-hosted/src/open-issues.ts
+++ b/extensions/jira-search-self-hosted/src/open-issues.ts
@@ -4,6 +4,8 @@ import { ResultItem, SearchCommand } from "./command";
 import { Color, Icon, Image } from "@raycast/api";
 import { ErrorText } from "./exception";
 import { buildIssueSearchJql } from "./issue-search";
+import { buildIssueNumberJql } from "./issue-key";
+import { prefs } from "./preferences";
 
 interface IssueType {
   id: string;
@@ -83,7 +85,8 @@ function buildJql(query: string, assignee: string): string {
 
 function jqlFor(query: string, assignee: string): string {
   const trimmedQuery = query.trim();
-  return isIssueKey(trimmedQuery) ? `key=${trimmedQuery}` : buildJql(query, assignee);
+  if (isIssueKey(trimmedQuery)) return `key=${trimmedQuery}`;
+  return buildIssueNumberJql(trimmedQuery, prefs.defaultIncludeProjects) ?? buildJql(query, assignee);
 }
 
 export async function searchIssues(query: string): Promise<ResultItem[]> {


### PR DESCRIPTION
## Summary

Jira Search (Self-Hosted) users can now type an issue number such as `1234` to find the exact issue in projects configured under **Default Included Projects**. Multiple configured project keys produce exact candidates for each project, while existing full-key, text, and filter searches keep their current behavior.

The shortcut is documented in the extension preferences, README, and changelog.

## Testing

- `npm test` — 5 focused query-resolution tests pass
- `npm run build` — Raycast TypeScript build passes
- `npm run lint` — no linting issues

## Post-Deploy Monitoring & Validation

No additional centralized operational monitoring is required because this change only constructs client-side JQL and does not persist state or add a service. During the release smoke test, the extension maintainer should enter a numeric query with one configured default project key and confirm the generated JQL in the Raycast extension console is an exact key lookup; an invalid query error or no matching result for a known issue is the rollback trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
