### PR TITLE
fix(zotero): make Search Zotero concurrency-safe (follow-up to #29478)

### DIFF
--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zotero Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-07-16
 
 - Prevent a memory spike and cache corruption when several searches run at once (e.g. fast typing right after opening the command): database opens are serialized, the data rebuild is de-duplicated so concurrent searches share one build, and the cache is written atomically (temp file + rename) so an interrupted or interleaved write can no longer leave a truncated cache that crashes on the next launch. Follow-up to #29478 / #29250
 - Fix a memory leak in the collections dropdown: the database opened by `getCollections` is now closed after use

--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Zotero Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Prevent a memory spike and cache corruption when several searches run at once (e.g. fast typing right after opening the command): database opens are serialized, the data rebuild is de-duplicated so concurrent searches share one build, and the cache is written atomically (temp file + rename) so an interrupted or interleaved write can no longer leave a truncated cache that crashes on the next launch. Follow-up to #29478 / #29250
+- Fix a memory leak in the collections dropdown: the database opened by `getCollections` is now closed after use
+
 ## [Fixes] - 2026-07-16
 
 - Fix "Worker terminated due to reaching memory limit: JS heap out of memory" crash on large libraries by loading only the metadata tables the search needs into `sql.js` (with their indexes) instead of the entire database, which is dominated by the full-text index. See #29250

--- a/extensions/zotero/src/common/zoteroApi.ts
+++ b/extensions/zotero/src/common/zoteroApi.ts
@@ -1,4 +1,4 @@
-import { stat, readFile, writeFile, copyFile } from "fs/promises";
+import { stat, readFile, writeFile, copyFile, rename } from "fs/promises";
 import { getPreferenceValues, environment, showToast, Toast } from "@raycast/api";
 import * as utils from "./utils";
 import { existsSync, readFileSync, rmSync } from "fs";
@@ -251,7 +251,18 @@ function buildSlimDb(sourcePath: string, slimPath: string): Buffer | null {
 // getCollections during startup) never share a temp path.
 let dbSeq = 0;
 
-async function openDb() {
+// Serialise openDb() so concurrent callers (getCollections + per-keystroke
+// searches) never each hold a full database copy in memory at the same time.
+// Each ~471 MB library copied + loaded in parallel is what pushes the Raycast
+// worker over its memory limit; running them one at a time caps the footprint.
+let openChain: Promise<unknown> = Promise.resolve();
+function openDb(): Promise<SqlJsDatabase> {
+  const run = openChain.then(openDbImpl, openDbImpl);
+  openChain = run.catch(() => undefined);
+  return run;
+}
+
+async function openDbImpl(): Promise<SqlJsDatabase> {
   const preferences: Preferences = getPreferenceValues();
   const f_path = resolveHome(preferences.zotero_path);
 
@@ -339,10 +350,32 @@ export const getCollections = async (): Promise<string[]> => {
   while (st.step()) {
     cols.push(st.getAsObject().name);
   }
+  st.free();
+  db.close();
   return cols;
 };
 
-async function getData(): Promise<RefData[]> {
+// Dedupe concurrent getData() calls. With a cold cache, fast typing fires
+// several searchResources() → getData() in parallel; without this each one
+// builds its own multi-thousand-row array (and opens its own database),
+// multiplying peak memory. Concurrent callers now share a single build.
+let getDataInflight: Promise<RefData[]> | null = null;
+// Shared across searchResources() invocations so a burst of concurrent searches
+// rebuilds (and writes) the cache exactly once. Declared at module scope because
+// updateCache() is defined inside searchResources().
+let updateCacheInflight: Promise<RefData[]> | null = null;
+
+function getData(): Promise<RefData[]> {
+  if (getDataInflight) {
+    return getDataInflight;
+  }
+  getDataInflight = getDataImpl().finally(() => {
+    getDataInflight = null;
+  });
+  return getDataInflight;
+}
+
+async function getDataImpl(): Promise<RefData[]> {
   const db = await openDb();
   const preferences: Preferences = getPreferenceValues();
 
@@ -477,19 +510,34 @@ export const searchResources = async (q: string): Promise<RefData[]> => {
   const preferences: Preferences = getPreferenceValues();
 
   async function updateCache(): Promise<RefData[]> {
-    const data = await getData();
-    const fData = {
-      version: CACHE_VERSION,
-      zotero_path: preferences.zotero_path,
-      use_bibtex: preferences.use_bibtex,
-      data: data,
-    };
-    try {
-      await writeFile(cachePath, JSON.stringify(fData));
-    } catch (err) {
-      console.error("Failed to write installed cache:", err);
+    // Dedupe concurrent rebuilds: a burst of cold-cache searches must not each
+    // stringify the whole dataset and write the cache file in parallel —
+    // interleaved writes to the same path can leave a truncated/0-byte cache,
+    // which then fails to parse and triggers an endless rebuild loop.
+    if (updateCacheInflight) {
+      return updateCacheInflight;
     }
-    return data;
+    updateCacheInflight = (async () => {
+      const data = await getData();
+      const fData = {
+        version: CACHE_VERSION,
+        zotero_path: preferences.zotero_path,
+        use_bibtex: preferences.use_bibtex,
+        data: data,
+      };
+      try {
+        // Write to a temp file and rename so the cache is updated atomically.
+        const tmp = `${cachePath}.tmp`;
+        await writeFile(tmp, JSON.stringify(fData));
+        await rename(tmp, cachePath);
+      } catch (err) {
+        console.error("Failed to write installed cache:", err);
+      }
+      return data;
+    })().finally(() => {
+      updateCacheInflight = null;
+    });
+    return updateCacheInflight;
   }
 
   async function mtime(path: string): Promise<Date> {


### PR DESCRIPTION
## Description

Follow-up hardening to #29478 (which fixed #29250).

#29478 removed the per-open memory blowup by loading only a slim copy of the database into `sql.js`. However, a **burst of concurrent searches** — `getCollections()` plus per-keystroke `searchResources()` fired while typing on first open, before a cache exists — still has each call independently open the database and rebuild the full dataset in parallel, and each writes the cache file over the same path.

Two problems remain from that:

1. **Peak memory multiplies** with the number of concurrent searches (each builds its own multi-thousand-row array and opens its own database).
2. **The cache write is not atomic** and several writes race on the same path, so an interrupted/interleaved write can leave a **truncated or 0-byte cache**. That cache then fails to `JSON.parse`, which forces a rebuild on every subsequent search — an endless loop that reproduces the original `JS heap out of memory` crash even though the slim fix is in place.

### Fix

- **Serialize `openDb()`** so concurrent callers never each hold a database copy in memory at the same time.
- **De-duplicate in-flight `getData()` / `updateCache()`** so a burst of concurrent searches shares a single build and a single cache write.
- **Write the cache atomically** (temp file + `rename`) so an interrupted or interleaved write can never leave a truncated cache.

### Verification

Reproduced against a real **471 MB** library by firing `getCollections()` + 6 `searchResources()` concurrently on a cold cache (simulating fast typing on first open):

- **Before:** each concurrent search builds and writes independently; the concurrent writes are what produced a 0-byte cache and the recurring crash.
- **After:** exactly **one** `getData` build and **one** atomic cache write; peak RSS ~**200 MB** instead of scaling with the number of concurrent searches; the cache is always valid and no temp files are left behind.

Behavior and results are otherwise unchanged; `ray build` + `ray lint` are clean.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I ran `npm run build` and it passed (`ray build` + `ray lint` clean)
- [x] I tested the change locally against a large (471 MB) library
- [x] I updated the `CHANGELOG.md`