### PR TITLE
Update portfolio tracker extension

### DIFF
--- a/extensions/portfolio-tracker/CHANGELOG.md
+++ b/extensions/portfolio-tracker/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Portfolio Tracker
 
-## [Profit & Loss Tracking] - {PR_MERGE_DATE}
+## [Profit & Loss Tracking] - 2026-07-17
 
 ### Features
 

--- a/extensions/portfolio-tracker/CHANGELOG.md
+++ b/extensions/portfolio-tracker/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Portfolio Tracker
 
+## [Profit & Loss Tracking] - {PR_MERGE_DATE}
+
+### Features
+
+- Record an optional average buy price per position, set when adding an investment or later via Edit Asset, to track unrealized profit/loss (P&L)
+- P&L tag on each position showing gain/loss percentage, with amount shown on hover
+- Cost basis section in the position detail panel with average buy price, total invested, and unrealized P&L
+- Portfolio summary row totals unrealized P&L across all positions with a buy price recorded
+- "Total Value Invested" mode divides by your buy price when entered, falling back to the live price otherwise
+- Adding units with a "Price Paid per Unit" updates the average buy price using a weighted average
+- CSV import/export supports an optional "Average Cost" column, backward compatible with older files
+
 ## [Initial Version] - 2026-04-08
 
 ### Features

--- a/extensions/portfolio-tracker/README.md
+++ b/extensions/portfolio-tracker/README.md
@@ -10,6 +10,10 @@ Portfolio Tracker is built for **long-term tracking** — prices refresh daily, 
 
 Search and add any publicly traded stock, ETF, or fund via Yahoo Finance with dynamic search. Fractional shares fully supported. Prices for LSE-listed securities quoted in pence are automatically converted to pounds.
 
+### Profit & Loss
+
+Record the average price you paid for a position (when adding it, or later via Edit Asset) and the tracker shows your unrealized profit/loss — both the amount and the percentage — right next to the daily change. Buying more units with a price paid updates your average cost with a weighted average, and the portfolio summary shows total P&L across everything you've recorded a buy price for.
+
 ### Property
 
 Add properties with or without a mortgage. Mortgage positions include full principal repayment tracking, UK HPI-based appreciation by postcode, shared ownership support, and a step-by-step breakdown of every calculation — equity, principal repaid, market movement — so you always know exactly how the number was derived.

--- a/extensions/portfolio-tracker/package.json
+++ b/extensions/portfolio-tracker/package.json
@@ -5,6 +5,9 @@
   "description": "Track value of your Stocks, ETFs, Properties, Cash, Debt and Crypto with automatic price updates over time to see your net worth",
   "icon": "extension-icon.png",
   "author": "filipawaits",
+  "contributors": [
+    "ridemountainpig"
+  ],
   "platforms": [
     "macOS"
   ],

--- a/extensions/portfolio-tracker/src/__tests__/csv-portfolio.test.ts
+++ b/extensions/portfolio-tracker/src/__tests__/csv-portfolio.test.ts
@@ -225,7 +225,8 @@ describe("mapHeaders", () => {
     expect(mapping.get("Asset Name")).toBe(2);
     expect(mapping.get("Symbol")).toBe(3);
     expect(mapping.get("Units")).toBe(4);
-    expect(mapping.get("Currency")).toBe(7);
+    expect(mapping.get("Average Cost")).toBe(6);
+    expect(mapping.get("Currency")).toBe(8);
   });
 
   it("is case-insensitive", () => {
@@ -1574,8 +1575,8 @@ describe("CSV edge cases", () => {
     expect(result.rows[0].symbol).toBe("FUND.L");
   });
 
-  it("CSV_HEADERS has exactly 11 entries", () => {
-    expect(CSV_HEADERS).toHaveLength(11);
+  it("CSV_HEADERS has exactly 12 entries", () => {
+    expect(CSV_HEADERS).toHaveLength(12);
   });
 });
 
@@ -1878,5 +1879,124 @@ describe("parseAdditionalParameters", () => {
     expect(result.debtData!.totalTermMonths).toBe(24);
     expect(result.debtData!.paidOff).toBe(false);
     expect(result.debtData!.archived).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────
+// Average Cost (P&L) column
+// ──────────────────────────────────────────
+
+describe("Average Cost column", () => {
+  it("exports avgCostPrice in the Average Cost column", () => {
+    const pos = makePosition({ avgCostPrice: 65.2 });
+    const csv = exportPortfolioToCsv([makeExportData({ position: pos })]);
+    const dataLine = csv.split("\n")[1];
+    const fields = dataLine.split(",");
+
+    // Column order: Account, Account Type, Asset Name, Symbol, Units, Price, Average Cost, ...
+    expect(fields[6]).toBe("65.200000");
+  });
+
+  it("preserves 6 decimal places on export (matches the max precision accepted by validatePrice)", () => {
+    const pos = makePosition({ avgCostPrice: 3456.789012 });
+    const csv = exportPortfolioToCsv([makeExportData({ position: pos })]);
+    const dataLine = csv.split("\n")[1];
+    const fields = dataLine.split(",");
+
+    expect(fields[6]).toBe("3456.789012");
+  });
+
+  it("exports an empty Average Cost column when no cost is recorded", () => {
+    const csv = exportPortfolioToCsv([makeExportData()]);
+    const dataLine = csv.split("\n")[1];
+    const fields = dataLine.split(",");
+
+    expect(fields[6]).toBe("");
+  });
+
+  it("parses the Average Cost column into row.averageCost", () => {
+    const header =
+      "Account,Account Type,Asset Name,Symbol,Units,Price,Average Cost,Total Value,Currency,Asset Type,Last Updated,Additional Parameters";
+    const csv = [header, "Vanguard ISA,ISA,Vanguard S&P 500,VUSA.L,50,72.45,65.20,3622.50,GBP,ETF,2024-03-15,"].join(
+      "\n",
+    );
+
+    const result = parsePortfolioCsv(csv);
+    expect(result.errors).toHaveLength(0);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].averageCost).toBeCloseTo(65.2);
+  });
+
+  it("leaves averageCost undefined when the column is missing (old CSVs)", () => {
+    const csv = buildSimpleCsv(["Vanguard ISA,ISA,Vanguard S&P 500,VUSA.L,50,72.45,3622.50,GBP,ETF,2024-03-15,"]);
+
+    const result = parsePortfolioCsv(csv);
+    expect(result.errors).toHaveLength(0);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].averageCost).toBeUndefined();
+  });
+
+  it("rejects a non-numeric Average Cost value", () => {
+    const header =
+      "Account,Account Type,Asset Name,Symbol,Units,Price,Average Cost,Total Value,Currency,Asset Type,Last Updated,Additional Parameters";
+    const csv = [header, "Vanguard ISA,ISA,Vanguard S&P 500,VUSA.L,50,72.45,abc,3622.50,GBP,ETF,2024-03-15,"].join(
+      "\n",
+    );
+
+    const result = parsePortfolioCsv(csv);
+    expect(result.errors.some((e) => e.column === "Average Cost")).toBe(true);
+  });
+
+  it("builds positions with avgCostPrice for market-traded assets", () => {
+    const rows: CsvRow[] = [
+      {
+        accountName: "ISA",
+        accountType: "ISA",
+        assetName: "Vanguard S&P 500",
+        symbol: "VUSA.L",
+        units: 50,
+        price: 72.45,
+        averageCost: 65.2,
+        totalValue: 3622.5,
+        currency: "GBP",
+        assetType: "ETF",
+        lastUpdated: "2024-03-15",
+      },
+    ];
+
+    const result = buildPortfolioFromCsvRows(rows);
+    expect(result.portfolio.accounts[0].positions[0].avgCostPrice).toBeCloseTo(65.2);
+  });
+
+  it("ignores averageCost for CASH positions", () => {
+    const rows: CsvRow[] = [
+      {
+        accountName: "Savings",
+        accountType: "SAVINGS ACCOUNT",
+        assetName: "Cash (GBP)",
+        symbol: "CASH:GBP",
+        units: 500,
+        price: 1,
+        averageCost: 1,
+        totalValue: 500,
+        currency: "GBP",
+        assetType: "CASH",
+        lastUpdated: "2024-03-15",
+      },
+    ];
+
+    const result = buildPortfolioFromCsvRows(rows);
+    expect(result.portfolio.accounts[0].positions[0].avgCostPrice).toBeUndefined();
+  });
+
+  it("round-trips avgCostPrice through export → parse → build", () => {
+    const pos = makePosition({ avgCostPrice: 65.2 });
+    const csv = exportPortfolioToCsv([makeExportData({ position: pos })]);
+
+    const parsed = parsePortfolioCsv(csv);
+    expect(parsed.errors).toHaveLength(0);
+
+    const rebuilt = buildPortfolioFromCsvRows(parsed.rows);
+    expect(rebuilt.portfolio.accounts[0].positions[0].avgCostPrice).toBeCloseTo(65.2);
   });
 });

--- a/extensions/portfolio-tracker/src/__tests__/pnl.test.ts
+++ b/extensions/portfolio-tracker/src/__tests__/pnl.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for unrealized P&L calculations (utils/pnl.ts).
+ */
+
+import { computePnl, computeWeightedAvgCost } from "../utils/pnl";
+
+// ──────────────────────────────────────────
+// computePnl
+// ──────────────────────────────────────────
+
+describe("computePnl", () => {
+  it("computes a loss when the price drops below the average cost", () => {
+    // The motivating example: $100 invested in ETH at $4,000 (0.025 units),
+    // ETH drops 50% to $2,000 → position is worth $50, a $50 (−50%) loss.
+    const result = computePnl(0.025, 4000, 2000);
+
+    expect(result).toBeDefined();
+    expect(result!.costBasis).toBeCloseTo(100);
+    expect(result!.pnl).toBeCloseTo(-50);
+    expect(result!.pnlPercent).toBeCloseTo(-50);
+  });
+
+  it("computes a gain when the price rises above the average cost", () => {
+    const result = computePnl(10, 100, 150);
+
+    expect(result).toBeDefined();
+    expect(result!.costBasis).toBeCloseTo(1000);
+    expect(result!.pnl).toBeCloseTo(500);
+    expect(result!.pnlPercent).toBeCloseTo(50);
+  });
+
+  it("returns zero P&L when the price equals the average cost", () => {
+    const result = computePnl(5, 80, 80);
+
+    expect(result).toBeDefined();
+    expect(result!.pnl).toBeCloseTo(0);
+    expect(result!.pnlPercent).toBeCloseTo(0);
+  });
+
+  it("returns undefined when no average cost is recorded", () => {
+    expect(computePnl(10, undefined, 100)).toBeUndefined();
+  });
+
+  it("returns undefined for non-positive average cost", () => {
+    expect(computePnl(10, 0, 100)).toBeUndefined();
+    expect(computePnl(10, -5, 100)).toBeUndefined();
+  });
+
+  it("returns undefined when the current price is unavailable (zero)", () => {
+    expect(computePnl(10, 100, 0)).toBeUndefined();
+  });
+
+  it("returns undefined for non-positive units", () => {
+    expect(computePnl(0, 100, 120)).toBeUndefined();
+    expect(computePnl(-1, 100, 120)).toBeUndefined();
+  });
+
+  it("handles fractional units (crypto-style holdings)", () => {
+    const result = computePnl(0.5, 60000, 90000);
+
+    expect(result).toBeDefined();
+    expect(result!.costBasis).toBeCloseTo(30000);
+    expect(result!.pnl).toBeCloseTo(15000);
+    expect(result!.pnlPercent).toBeCloseTo(50);
+  });
+});
+
+// ──────────────────────────────────────────
+// computeWeightedAvgCost
+// ──────────────────────────────────────────
+
+describe("computeWeightedAvgCost", () => {
+  it("computes the weighted average when buying more at a different price", () => {
+    // 10 units at 100, buy 10 more at 200 → 20 units at 150
+    expect(computeWeightedAvgCost(10, 100, 10, 200)).toBeCloseTo(150);
+  });
+
+  it("weights by units, not by purchase count", () => {
+    // 30 units at 10, buy 10 more at 50 → (300 + 500) / 40 = 20
+    expect(computeWeightedAvgCost(30, 10, 10, 50)).toBeCloseTo(20);
+  });
+
+  it("keeps the average unchanged when buying at the same price", () => {
+    expect(computeWeightedAvgCost(10, 75, 5, 75)).toBeCloseTo(75);
+  });
+
+  it("uses the price paid when no existing average is recorded", () => {
+    expect(computeWeightedAvgCost(10, undefined, 5, 80)).toBeCloseTo(80);
+  });
+
+  it("uses the price paid when the position previously had zero units", () => {
+    expect(computeWeightedAvgCost(0, 100, 5, 80)).toBeCloseTo(80);
+  });
+
+  it("returns undefined for invalid added units or price", () => {
+    expect(computeWeightedAvgCost(10, 100, 0, 80)).toBeUndefined();
+    expect(computeWeightedAvgCost(10, 100, -5, 80)).toBeUndefined();
+    expect(computeWeightedAvgCost(10, 100, 5, 0)).toBeUndefined();
+  });
+
+  it("handles fractional units", () => {
+    // 0.025 units at 4000, buy 0.025 more at 2000 → 0.05 units at 3000
+    expect(computeWeightedAvgCost(0.025, 4000, 0.025, 2000)).toBeCloseTo(3000);
+  });
+});

--- a/extensions/portfolio-tracker/src/components/AddUnitsForm.tsx
+++ b/extensions/portfolio-tracker/src/components/AddUnitsForm.tsx
@@ -23,8 +23,8 @@
  *   position={position}
  *   accountId={account.id}
  *   accountName={account.name}
- *   onSubmit={async (newTotalUnits) => {
- *     await updatePosition(account.id, position.id, newTotalUnits);
+ *   onSubmit={async (newTotalUnits, newAvgCostPrice) => {
+ *     await updatePosition(account.id, position.id, { units: newTotalUnits, avgCostPrice: newAvgCostPrice });
  *   }}
  * />
  * ```
@@ -41,10 +41,13 @@ import {
   validateTotalValue,
   parseTotalValue,
   computeUnitsFromTotalValue,
+  validatePrice,
 } from "../utils/validation";
 import { formatUnits, formatCurrency, getDisplayName } from "../utils/formatting";
+import { computeWeightedAvgCost } from "../utils/pnl";
 import { useAssetPrice } from "../hooks/useAssetPrice";
 import { useFxRate } from "../hooks/useFxRate";
+import { useOptionalPrice } from "../hooks/useOptionalPrice";
 
 // ──────────────────────────────────────────
 // Input Mode
@@ -76,8 +79,10 @@ interface AddUnitsFormProps {
    * Receives the NEW TOTAL units (currentUnits + addedUnits), already computed.
    *
    * @param newTotalUnits - The updated total number of units
+   * @param newAvgCostPrice - The updated average buy price (weighted), or
+   *   undefined when the user didn't enter a price paid (cost stays unchanged)
    */
-  onSubmit: (newTotalUnits: number) => Promise<void>;
+  onSubmit: (newTotalUnits: number, newAvgCostPrice?: number) => Promise<void>;
 }
 
 // ──────────────────────────────────────────
@@ -137,7 +142,15 @@ export function AddUnitsForm({
   const [unitsError, setUnitsError] = useState<string | undefined>(undefined);
   const [totalValueInput, setTotalValueInput] = useState<string>("");
   const [totalValueError, setTotalValueError] = useState<string | undefined>(undefined);
+  const [pricePaidInput, setPricePaidInput] = useState<string>("");
+  const [pricePaidError, setPricePaidError] = useState<string | undefined>(undefined);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // When a price paid is entered, value mode divides by it instead of the
+  // current price — "amount invested ÷ price paid" recovers the units bought.
+  const enteredPricePaid = useOptionalPrice(pricePaidInput);
+
+  const valueModeUnitPrice = enteredPricePaid ?? referencePrice;
 
   const needsFxConversion = valueCurrency !== position.currency;
 
@@ -177,13 +190,13 @@ export function AddUnitsForm({
 
   const computedUnitsFromValue = useMemo(() => {
     const trimmed = totalValueInput.trim();
-    if (!trimmed || !referencePrice) return null;
+    if (!trimmed || !valueModeUnitPrice) return null;
     const parsed = Number(trimmed);
     if (isNaN(parsed) || parsed <= 0) return null;
     const valueInAssetCurrency = needsFxConversion && fxRate ? parsed * fxRate : parsed;
     if (needsFxConversion && !fxRate) return null;
-    return computeUnitsFromTotalValue(valueInAssetCurrency, referencePrice);
-  }, [totalValueInput, referencePrice, needsFxConversion, fxRate]);
+    return computeUnitsFromTotalValue(valueInAssetCurrency, valueModeUnitPrice);
+  }, [totalValueInput, valueModeUnitPrice, needsFxConversion, fxRate]);
 
   const newTotalFromValue = useMemo(() => {
     if (computedUnitsFromValue === null) return null;
@@ -195,19 +208,27 @@ export function AddUnitsForm({
       return "Loading FX rate...";
     }
     if (computedUnitsFromValue === null || newTotalFromValue === null) {
+      const priceHint = enteredPricePaid
+        ? `your price paid (${formatCurrency(enteredPricePaid, position.currency)})`
+        : `${formatCurrency(referencePrice, position.currency)}/unit`;
       return needsFxConversion
-        ? `Enter the total amount to invest in ${valueCurrency}. Will be converted to ${position.currency} then divided by ${formatCurrency(referencePrice, position.currency)}/unit.`
-        : `Enter the total amount to invest in ${valueCurrency}. Units will be calculated at ${formatCurrency(referencePrice, position.currency)}/unit.`;
+        ? `Enter the total amount to invest in ${valueCurrency}. Will be converted to ${position.currency} then divided by ${priceHint}.`
+        : `Enter the total amount to invest in ${valueCurrency}. Units will be calculated at ${priceHint}.`;
     }
-    const nativeAdded = computedUnitsFromValue * referencePrice;
+    const priceLabel = enteredPricePaid
+      ? `${formatCurrency(enteredPricePaid, position.currency)} paid`
+      : formatCurrency(referencePrice, position.currency);
+    const nativeAdded = computedUnitsFromValue * valueModeUnitPrice;
     if (needsFxConversion && fxRate) {
-      return `→ ${formatUnits(computedUnitsFromValue)} units × ${formatCurrency(referencePrice, position.currency)} = ${formatCurrency(nativeAdded, position.currency)} (${formatCurrency(Number(totalValueInput.trim()), valueCurrency)} at ${fxRate.toFixed(4)} ${valueCurrency}/${position.currency})\n${currentUnitsDisplay} + ${formatUnits(computedUnitsFromValue)} = ${formatUnits(newTotalFromValue)} units`;
+      return `→ ${formatUnits(computedUnitsFromValue)} units × ${priceLabel} = ${formatCurrency(nativeAdded, position.currency)} (${formatCurrency(Number(totalValueInput.trim()), valueCurrency)} at ${fxRate.toFixed(4)} ${valueCurrency}/${position.currency})\n${currentUnitsDisplay} + ${formatUnits(computedUnitsFromValue)} = ${formatUnits(newTotalFromValue)} units`;
     }
-    return `→ ${formatUnits(computedUnitsFromValue)} units × ${formatCurrency(referencePrice, position.currency)} = ${formatCurrency(nativeAdded, position.currency)}\n${currentUnitsDisplay} + ${formatUnits(computedUnitsFromValue)} = ${formatUnits(newTotalFromValue)} units`;
+    return `→ ${formatUnits(computedUnitsFromValue)} units × ${priceLabel} = ${formatCurrency(nativeAdded, position.currency)}\n${currentUnitsDisplay} + ${formatUnits(computedUnitsFromValue)} = ${formatUnits(newTotalFromValue)} units`;
   }, [
     computedUnitsFromValue,
     newTotalFromValue,
     referencePrice,
+    enteredPricePaid,
+    valueModeUnitPrice,
     position.currency,
     currentUnitsDisplay,
     needsFxConversion,
@@ -251,6 +272,17 @@ export function AddUnitsForm({
     setTotalValueError(undefined);
   }
 
+  function handlePricePaidBlur(event: Form.Event<string>) {
+    if (event.target.value && event.target.value.trim().length > 0) {
+      setPricePaidError(validatePrice(event.target.value));
+    }
+  }
+
+  function handlePricePaidChange(value: string) {
+    setPricePaidInput(value);
+    if (pricePaidError) setPricePaidError(undefined);
+  }
+
   // ── Submission ──
 
   async function handleSubmit(values: {
@@ -258,8 +290,19 @@ export function AddUnitsForm({
     totalValueToAdd?: string;
     inputMode?: string;
     valueCurrency?: string;
+    pricePaid?: string;
   }) {
     let addedUnits: number;
+
+    // Validate the optional price paid (native currency)
+    const trimmedPricePaid = values.pricePaid?.trim() ?? "";
+    if (!isCash && trimmedPricePaid) {
+      const priceValidation = validatePrice(trimmedPricePaid);
+      if (priceValidation) {
+        setPricePaidError(priceValidation);
+        return;
+      }
+    }
 
     if (!isCash && inputMode === "value") {
       const tvValidation = validateTotalValue(values.totalValueToAdd);
@@ -275,7 +318,10 @@ export function AddUnitsForm({
 
       const totalValue = parseTotalValue(values.totalValueToAdd!);
       const totalValueInAssetCurrency = needsFxConversion && fxRate ? totalValue * fxRate : totalValue;
-      addedUnits = computeUnitsFromTotalValue(totalValueInAssetCurrency, referencePrice);
+      // Divide by the price paid when entered ("amount invested ÷ price paid"),
+      // otherwise by the current price ("buying at today's price").
+      const paidPrice = trimmedPricePaid ? Number(trimmedPricePaid) : undefined;
+      addedUnits = computeUnitsFromTotalValue(totalValueInAssetCurrency, paidPrice ?? referencePrice);
       if (addedUnits <= 0) {
         setTotalValueError("Computed units would be zero — check the price and total value.");
         return;
@@ -291,10 +337,16 @@ export function AddUnitsForm({
 
     const computedTotal = position.units + addedUnits;
 
+    // Update the average buy price (weighted) when a price paid is provided
+    const newAvgCostPrice =
+      !isCash && trimmedPricePaid
+        ? computeWeightedAvgCost(position.units, position.avgCostPrice, addedUnits, Number(trimmedPricePaid))
+        : undefined;
+
     setIsSubmitting(true);
 
     try {
-      await onSubmit(computedTotal);
+      await onSubmit(computedTotal, newAvgCostPrice);
       pop();
     } catch (error) {
       console.error("AddUnitsForm submission failed:", error);
@@ -386,6 +438,35 @@ export function AddUnitsForm({
           />
 
           <Form.Description title="" text={valuePreviewText} />
+        </>
+      )}
+
+      {/* ── Price Paid (optional, non-cash — updates average buy price) ── */}
+      {!isCash && (
+        <>
+          <Form.Separator />
+
+          <Form.TextField
+            id="pricePaid"
+            title="Price Paid per Unit"
+            placeholder={
+              referencePrice > 0
+                ? `e.g. ${formatCurrency(referencePrice, position.currency)} (optional)`
+                : `e.g. 72.50 (${position.currency}, optional)`
+            }
+            error={pricePaidError}
+            onChange={handlePricePaidChange}
+            onBlur={handlePricePaidBlur}
+          />
+
+          <Form.Description
+            title=""
+            text={
+              position.avgCostPrice !== undefined
+                ? `Optional. Updates your average buy price (currently ${formatCurrency(position.avgCostPrice, position.currency)}) using a weighted average. Leave empty to keep it unchanged.`
+                : `Optional. Applies this price as the average buy price for your ENTIRE holding — including the ${formatUnits(position.units)} units you already hold, not just the ones added now — and enables profit/loss tracking.`
+            }
+          />
         </>
       )}
     </Form>

--- a/extensions/portfolio-tracker/src/components/AssetConfirmation.tsx
+++ b/extensions/portfolio-tracker/src/components/AssetConfirmation.tsx
@@ -39,6 +39,7 @@ import { useFxRate } from "../hooks/useFxRate";
 import { useState, useMemo } from "react";
 import { AssetSearchResult, AssetType } from "../utils/types";
 import { useAssetPrice } from "../hooks/useAssetPrice";
+import { useOptionalPrice } from "../hooks/useOptionalPrice";
 import {
   validateUnits,
   parseUnits,
@@ -77,6 +78,7 @@ interface AssetConfirmationProps {
     currency: string;
     assetType: AssetType;
     priceOverride?: number;
+    avgCostPrice?: number;
   }) => Promise<void>;
 }
 
@@ -289,13 +291,26 @@ export function AssetConfirmationForm({
   const [totalValueError, setTotalValueError] = useState<string | undefined>(undefined);
   const [totalValueInput, setTotalValueInput] = useState<string>("");
   const [nameError, setNameError] = useState<string | undefined>(undefined);
+  const [priceOverrideInput, setPriceOverrideInput] = useState<string>("");
   const [priceOverrideError, setPriceOverrideError] = useState<string | undefined>(undefined);
+  const [avgCostInput, setAvgCostInput] = useState<string>("");
+  const [avgCostError, setAvgCostError] = useState<string | undefined>(undefined);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // ── Computed values for total-value mode ──
 
   const effectivePrice = useMemo(() => price?.price ?? 0, [price]);
   const assetCurrency = price?.currency ?? "";
+
+  // When a buy price is entered, total-value mode divides by it instead of the
+  // live price — "amount invested ÷ price paid" recovers the units actually
+  // bought, even when the position is being recorded long after the purchase.
+  const enteredBuyPrice = useOptionalPrice(avgCostInput);
+
+  // A manual price override also affects the value-mode divisor at submit
+  // time (see resolvedPrice in handleSubmit) — mirror that here so the live
+  // preview matches what actually gets saved.
+  const enteredPriceOverride = useOptionalPrice(priceOverrideInput);
 
   const valueCurrencyOptions = useMemo(() => {
     const options: Array<{ value: string; title: string }> = [];
@@ -314,27 +329,48 @@ export function AssetConfirmationForm({
     needsFxConversion ? assetCurrency : undefined,
   );
 
+  // Units in total-value mode are derived from the buy price when entered,
+  // then the price override (matches resolvedPrice in handleSubmit), falling
+  // back to the live price for "buying right now" entries.
+  const valueModeUnitPrice = enteredBuyPrice ?? enteredPriceOverride ?? effectivePrice;
+
   const computedUnitsFromValue = useMemo(() => {
     const trimmed = totalValueInput.trim();
-    if (!trimmed || !effectivePrice) return null;
+    if (!trimmed || !valueModeUnitPrice) return null;
     const parsed = Number(trimmed);
     if (isNaN(parsed) || parsed <= 0) return null;
     const valueInAssetCurrency = needsFxConversion && fxRate ? parsed * fxRate : parsed;
     if (needsFxConversion && !fxRate) return null;
-    return computeUnitsFromTotalValue(valueInAssetCurrency, effectivePrice);
-  }, [totalValueInput, effectivePrice, needsFxConversion, fxRate]);
+    return computeUnitsFromTotalValue(valueInAssetCurrency, valueModeUnitPrice);
+  }, [totalValueInput, valueModeUnitPrice, needsFxConversion, fxRate]);
 
   const computedTotalDisplay = useMemo(() => {
     if (needsFxConversion && !fxRate && totalValueInput.trim()) {
       return "Loading FX rate...";
     }
     if (computedUnitsFromValue === null || !price) return null;
-    const nativeTotal = computedUnitsFromValue * price.price;
+    const priceLabel = enteredBuyPrice
+      ? `${formatCurrency(enteredBuyPrice, price.currency)} buy price`
+      : enteredPriceOverride
+        ? `${formatCurrency(enteredPriceOverride, price.currency)} price override`
+        : formatCurrency(price.price, price.currency);
+    const total = computedUnitsFromValue * valueModeUnitPrice;
     if (needsFxConversion && fxRate) {
-      return `${formatUnits(computedUnitsFromValue)} units × ${formatCurrency(price.price, price.currency)} = ${formatCurrency(nativeTotal, price.currency)} (${formatCurrency(Number(totalValueInput.trim()), valueCurrency)} at ${fxRate.toFixed(4)} ${valueCurrency}/${assetCurrency})`;
+      return `${formatUnits(computedUnitsFromValue)} units × ${priceLabel} = ${formatCurrency(total, price.currency)} (${formatCurrency(Number(totalValueInput.trim()), valueCurrency)} at ${fxRate.toFixed(4)} ${valueCurrency}/${assetCurrency})`;
     }
-    return `${formatUnits(computedUnitsFromValue)} units × ${formatCurrency(price.price, price.currency)} = ${formatCurrency(nativeTotal, price.currency)}`;
-  }, [computedUnitsFromValue, price, needsFxConversion, fxRate, totalValueInput, valueCurrency, assetCurrency]);
+    return `${formatUnits(computedUnitsFromValue)} units × ${priceLabel} = ${formatCurrency(total, price.currency)}`;
+  }, [
+    computedUnitsFromValue,
+    price,
+    enteredBuyPrice,
+    enteredPriceOverride,
+    valueModeUnitPrice,
+    needsFxConversion,
+    fxRate,
+    totalValueInput,
+    valueCurrency,
+    assetCurrency,
+  ]);
 
   // ── Handlers ──
 
@@ -381,9 +417,23 @@ export function AssetConfirmationForm({
     }
   }
 
-  function handlePriceChange() {
+  function handlePriceChange(value: string) {
+    setPriceOverrideInput(value);
     if (priceOverrideError) {
       setPriceOverrideError(undefined);
+    }
+  }
+
+  function handleAvgCostBlur(event: Form.Event<string>) {
+    if (event.target.value && event.target.value.trim().length > 0) {
+      setAvgCostError(validatePrice(event.target.value));
+    }
+  }
+
+  function handleAvgCostChange(value: string) {
+    setAvgCostInput(value);
+    if (avgCostError) {
+      setAvgCostError(undefined);
     }
   }
 
@@ -398,6 +448,7 @@ export function AssetConfirmationForm({
     units?: string;
     totalValue?: string;
     priceOverride?: string;
+    avgCostPrice?: string;
     inputMode: string;
     valueCurrency?: string;
   }) {
@@ -412,6 +463,15 @@ export function AssetConfirmationForm({
       const priceValidation = validatePrice(priceOverrideValue);
       if (priceValidation) {
         setPriceOverrideError(priceValidation);
+        return;
+      }
+    }
+
+    const avgCostValue = values.avgCostPrice?.trim();
+    if (avgCostValue) {
+      const avgCostValidation = validatePrice(avgCostValue);
+      if (avgCostValidation) {
+        setAvgCostError(avgCostValidation);
         return;
       }
     }
@@ -442,7 +502,10 @@ export function AssetConfirmationForm({
 
       const rawTotalValue = parseTotalValue(values.totalValue!);
       const totalValueInAssetCurrency = needsFxConversion && fxRate ? rawTotalValue * fxRate : rawTotalValue;
-      finalUnits = computeUnitsFromTotalValue(totalValueInAssetCurrency, resolvedPrice);
+      // Divide by the buy price when entered ("amount invested ÷ price paid"),
+      // otherwise by the current/override price ("buying at today's price").
+      const buyPrice = avgCostValue ? Number(avgCostValue) : undefined;
+      finalUnits = computeUnitsFromTotalValue(totalValueInAssetCurrency, buyPrice ?? resolvedPrice);
       if (finalUnits <= 0) {
         setTotalValueError("Computed units would be zero — check the price and total value.");
         return;
@@ -466,6 +529,7 @@ export function AssetConfirmationForm({
         currency: price.currency,
         assetType: result.type,
         priceOverride: priceOverrideValue ? parseUnits(priceOverrideValue) : undefined,
+        avgCostPrice: avgCostValue ? Number(avgCostValue) : undefined,
       });
       pop();
     } catch (error) {
@@ -541,6 +605,20 @@ export function AssetConfirmationForm({
         }
       />
 
+      <Form.TextField
+        id="avgCostPrice"
+        title="Average Buy Price"
+        placeholder={price ? `e.g. ${formatCurrency(price.price, price.currency)} (optional)` : "e.g. 72.50 (optional)"}
+        error={avgCostError}
+        onChange={handleAvgCostChange}
+        onBlur={handleAvgCostBlur}
+      />
+
+      <Form.Description
+        title=""
+        text={`Optional. The average price per unit you paid${price ? ` in ${price.currency}` : ""}. Enables profit/loss tracking.`}
+      />
+
       {/* ── Input Mode Toggle ── */}
       <Form.Description title="Account" text={accountName} />
 
@@ -601,10 +679,17 @@ export function AssetConfirmationForm({
               computedTotalDisplay
                 ? `→ ${computedTotalDisplay}`
                 : price
-                  ? needsFxConversion
-                    ? `Enter total amount in ${valueCurrency}. Will be converted to ${assetCurrency} then divided by ${formatCurrency(price.price, price.currency)}/unit.`
-                    : `Enter total amount invested in ${valueCurrency}. Units will be auto-calculated at ${formatCurrency(price.price, price.currency)} per unit.`
-                  : "Enter total amount invested. Units will be calculated from the current price."
+                  ? (() => {
+                      const divisorLabel = enteredBuyPrice
+                        ? `your buy price (${formatCurrency(enteredBuyPrice, price.currency)})`
+                        : enteredPriceOverride
+                          ? `your price override (${formatCurrency(enteredPriceOverride, price.currency)})`
+                          : `${formatCurrency(price.price, price.currency)}/unit`;
+                      return needsFxConversion
+                        ? `Enter total amount in ${valueCurrency}. Will be converted to ${assetCurrency} then divided by ${divisorLabel}.`
+                        : `Enter total amount invested in ${valueCurrency}. Units will be auto-calculated at ${divisorLabel} per unit.`;
+                    })()
+                  : "Enter total amount invested. Units will be calculated from your buy price (if entered), your price override (if entered), or the current price."
             }
           />
         </>

--- a/extensions/portfolio-tracker/src/components/EditPositionForm.tsx
+++ b/extensions/portfolio-tracker/src/components/EditPositionForm.tsx
@@ -49,6 +49,7 @@ import {
   validateTotalValue,
   parseTotalValue,
   computeUnitsFromTotalValue,
+  validatePrice,
 } from "../utils/validation";
 import { formatUnits, formatCurrency, getDisplayName, hasCustomName } from "../utils/formatting";
 import { BatchRenameMatch } from "./BatchRenameForm";
@@ -73,11 +74,23 @@ export interface EditPositionUpdates {
    */
   customName: string | undefined;
 
+  /**
+   * The new average buy price per unit (native currency).
+   *
+   * - A number means "set this as the average cost"
+   * - `null` means "the user cleared the field" (remove the recorded cost)
+   * - `undefined` means "no change"
+   */
+  avgCostPrice: number | null | undefined;
+
   /** Whether the units value changed from the original */
   unitsChanged: boolean;
 
   /** Whether the custom name changed from the original */
   nameChanged: boolean;
+
+  /** Whether the average buy price changed from the original */
+  costChanged: boolean;
 }
 
 interface EditPositionFormProps {
@@ -240,7 +253,11 @@ function EditPhaseForm({
   const [totalValueInput, setTotalValueInput] = useState<string>("");
   const [valueCurrency, setValueCurrency] = useState<string>(baseCurrency);
   const [nameError, setNameError] = useState<string | undefined>(undefined);
+  const [avgCostError, setAvgCostError] = useState<string | undefined>(undefined);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Average buy price is only meaningful for traded securities
+  const showAvgCostField = !isCash && !isProperty && !isDebt;
 
   // ── Display Values ──
 
@@ -333,6 +350,19 @@ function EditPhaseForm({
     setTotalValueError(undefined);
   }
 
+  function handleAvgCostBlur(event: Form.Event<string>) {
+    const value = event.target.value;
+    if (value && value.trim().length > 0) {
+      setAvgCostError(validatePrice(value));
+    }
+  }
+
+  function handleAvgCostChange() {
+    if (avgCostError) {
+      setAvgCostError(undefined);
+    }
+  }
+
   function handleNameBlur(event: Form.Event<string>) {
     const value = event.target.value?.trim();
     if (value && value === position.name) {
@@ -356,6 +386,7 @@ function EditPhaseForm({
     inputMode?: string;
     valueCurrency?: string;
     displayName?: string;
+    avgCostPrice?: string;
   }) {
     // Validate name (if provided)
     const trimmedName = values.displayName?.trim() ?? "";
@@ -363,6 +394,26 @@ function EditPhaseForm({
       setNameError("Same as original name — clear the field to use the original, or enter a different name");
       return;
     }
+
+    // Validate and resolve the average buy price (optional field)
+    // - number: set as the new average cost
+    // - null: user cleared a previously recorded cost
+    // - undefined: no change
+    let newAvgCost: number | null | undefined = undefined;
+    if (showAvgCostField) {
+      const trimmedCost = values.avgCostPrice?.trim() ?? "";
+      if (trimmedCost) {
+        const costValidation = validatePrice(trimmedCost);
+        if (costValidation) {
+          setAvgCostError(costValidation);
+          return;
+        }
+        newAvgCost = Number(trimmedCost);
+      } else if (position.avgCostPrice !== undefined) {
+        newAvgCost = null;
+      }
+    }
+    const costChanged = newAvgCost !== undefined && (newAvgCost === null || newAvgCost !== position.avgCostPrice);
 
     let newUnits: number;
 
@@ -399,7 +450,7 @@ function EditPhaseForm({
     const nameChanged = trimmedName !== oldCustomName;
 
     // Skip if nothing changed
-    if (!unitsChanged && !nameChanged) {
+    if (!unitsChanged && !nameChanged && !costChanged) {
       onDone();
       return;
     }
@@ -411,8 +462,10 @@ function EditPhaseForm({
       const matches = await onSave({
         units: newUnits,
         customName: trimmedName || undefined,
+        avgCostPrice: newAvgCost,
         unitsChanged,
         nameChanged,
+        costChanged,
       });
 
       // If batch candidates found, transition to phase 2
@@ -526,6 +579,26 @@ function EditPhaseForm({
           />
 
           <Form.Description title="" text={unitsHelpText} />
+        </>
+      )}
+
+      {/* ── Average Buy Price (traded securities only) ── */}
+      {showAvgCostField && (
+        <>
+          <Form.TextField
+            id="avgCostPrice"
+            title="Average Buy Price"
+            placeholder={`e.g. 72.50 (${position.currency}, optional)`}
+            defaultValue={position.avgCostPrice !== undefined ? String(position.avgCostPrice) : ""}
+            error={avgCostError}
+            onChange={handleAvgCostChange}
+            onBlur={handleAvgCostBlur}
+          />
+
+          <Form.Description
+            title=""
+            text={`Optional. The average price per unit you paid, in ${position.currency}. Enables profit/loss tracking. Clear the field to remove it.`}
+          />
         </>
       )}
 

--- a/extensions/portfolio-tracker/src/components/PortfolioList.tsx
+++ b/extensions/portfolio-tracker/src/components/PortfolioList.tsx
@@ -41,7 +41,13 @@ import {
   isPropertyAssetType,
   isDebtAssetType,
 } from "../utils/types";
-import { formatCurrency, formatCurrencyCompact, formatRelativeTime, getDisplayName } from "../utils/formatting";
+import {
+  formatCurrency,
+  formatCurrencyCompact,
+  formatPercent,
+  formatRelativeTime,
+  getDisplayName,
+} from "../utils/formatting";
 import { isDebtAccountType } from "../utils/types";
 import {
   ACCOUNT_TYPE_LABELS,
@@ -397,6 +403,20 @@ export function PortfolioList({
                         color: portfolioTotals.liabilities < 0 ? COLOR_NEGATIVE : COLOR_NEUTRAL,
                       },
                     },
+                    ...(valuation.pnl
+                      ? [
+                          {
+                            tag: {
+                              value: `P&L: ${formatCurrency(valuation.pnl.pnl, valuation.baseCurrency, { showSign: true })}`,
+                              color: valuation.pnl.pnl >= 0 ? COLOR_POSITIVE : COLOR_NEGATIVE,
+                            },
+                            tooltip:
+                              valuation.pnl.costBasis > 0
+                                ? `Unrealized P&L across positions with a buy price recorded (${formatPercent((valuation.pnl.pnl / valuation.pnl.costBasis) * 100)} of ${formatCurrency(valuation.pnl.costBasis, valuation.baseCurrency)} invested)`
+                                : undefined,
+                          },
+                        ]
+                      : []),
                     {
                       tag: {
                         value: `Net: ${formatCurrency(portfolioTotals.net, valuation.baseCurrency)}`,
@@ -419,6 +439,21 @@ export function PortfolioList({
                         color={portfolioTotals.liabilities < 0 ? COLOR_NEGATIVE : COLOR_NEUTRAL}
                       />
                     </List.Item.Detail.Metadata.TagList>
+                    {valuation.pnl && (
+                      <>
+                        <List.Item.Detail.Metadata.Separator />
+                        <List.Item.Detail.Metadata.Label
+                          title="Total Invested"
+                          text={formatCurrency(valuation.pnl.costBasis, valuation.baseCurrency)}
+                        />
+                        <List.Item.Detail.Metadata.TagList title="Unrealized P&L">
+                          <List.Item.Detail.Metadata.TagList.Item
+                            text={`${formatCurrency(valuation.pnl.pnl, valuation.baseCurrency, { showSign: true })}${valuation.pnl.costBasis > 0 ? ` (${formatPercent((valuation.pnl.pnl / valuation.pnl.costBasis) * 100)})` : ""}`}
+                            color={valuation.pnl.pnl >= 0 ? COLOR_POSITIVE : COLOR_NEGATIVE}
+                          />
+                        </List.Item.Detail.Metadata.TagList>
+                      </>
+                    )}
                     <List.Item.Detail.Metadata.Separator />
                     <List.Item.Detail.Metadata.TagList title="Net Worth">
                       <List.Item.Detail.Metadata.TagList.Item

--- a/extensions/portfolio-tracker/src/components/PositionListItem.tsx
+++ b/extensions/portfolio-tracker/src/components/PositionListItem.tsx
@@ -45,7 +45,14 @@
 
 import React from "react";
 import { Color, Icon, List } from "@raycast/api";
-import { PositionValuation, AssetType, isPropertyAssetType, isDebtAssetType, isDebtPaidOff } from "../utils/types";
+import {
+  PositionValuation,
+  PositionPnl,
+  AssetType,
+  isPropertyAssetType,
+  isDebtAssetType,
+  isDebtPaidOff,
+} from "../utils/types";
 import {
   formatCurrency,
   formatCurrencyCompact,
@@ -124,8 +131,17 @@ export function PositionListItem({
   isShowingDetail,
   actions,
 }: PositionListItemProps): React.JSX.Element {
-  const { position, currentPrice, totalNativeValue, totalBaseValue, change, changePercent, fxRate, hpiChangePercent } =
-    valuation;
+  const {
+    position,
+    currentPrice,
+    totalNativeValue,
+    totalBaseValue,
+    change,
+    changePercent,
+    fxRate,
+    hpiChangePercent,
+    pnl,
+  } = valuation;
 
   // ── Computed Display Values ──
 
@@ -197,6 +213,7 @@ export function PositionListItem({
       displayName,
       isRenamed,
       hpiChangePercent,
+      pnl,
       keywords,
       actions,
     });
@@ -219,6 +236,7 @@ export function PositionListItem({
     displayName,
     isRenamed,
     hpiChangePercent,
+    pnl,
     keywords,
     actions,
   });
@@ -245,6 +263,7 @@ interface ListModeProps {
   displayName: string;
   isRenamed: boolean;
   hpiChangePercent?: number;
+  pnl?: PositionPnl;
   keywords: string[];
   actions: React.JSX.Element;
 }
@@ -285,6 +304,7 @@ function renderListMode({
   displayName,
   isRenamed,
   hpiChangePercent,
+  pnl,
   keywords,
   actions,
 }: ListModeProps): React.JSX.Element {
@@ -374,6 +394,17 @@ function renderListMode({
       });
     }
 
+    // Unrealized P&L tag (only when an average buy price is recorded)
+    if (pnl) {
+      accessories.push({
+        tag: {
+          value: formatPercent(pnl.pnlPercent),
+          color: pnl.pnlPercent > 0 ? COLOR_POSITIVE : pnl.pnlPercent < 0 ? COLOR_NEGATIVE : COLOR_NEUTRAL,
+        },
+        tooltip: `Unrealized P&L: ${formatCurrency(pnl.pnl, position.currency, { showSign: true })} (${formatPercent(pnl.pnlPercent)})`,
+      });
+    }
+
     // Total value / equity in base currency (rightmost = most prominent)
     accessories.push({
       text: { value: formatCurrencyCompact(totalBaseValue, baseCurrency), color: COLOR_PRIMARY },
@@ -436,6 +467,7 @@ interface DetailModeProps {
   displayName: string;
   isRenamed: boolean;
   hpiChangePercent?: number;
+  pnl?: PositionPnl;
   keywords: string[];
   actions: React.JSX.Element;
 }
@@ -481,6 +513,7 @@ function renderDetailMode({
   displayName,
   isRenamed,
   hpiChangePercent,
+  pnl,
   keywords,
   actions,
 }: DetailModeProps): React.JSX.Element {
@@ -559,6 +592,7 @@ function renderDetailMode({
             baseCurrency,
             displayName,
             isRenamed,
+            pnl,
           });
 
   return (
@@ -971,6 +1005,7 @@ function buildSecuritiesDetail({
   baseCurrency,
   displayName,
   isRenamed,
+  pnl,
 }: {
   position: PositionValuation["position"];
   typeLabel: string;
@@ -986,7 +1021,10 @@ function buildSecuritiesDetail({
   baseCurrency: string;
   displayName: string;
   isRenamed: boolean;
+  pnl?: PositionPnl;
 }): React.JSX.Element {
+  const pnlColor = pnl ? (pnl.pnl > 0 ? COLOR_POSITIVE : pnl.pnl < 0 ? COLOR_NEGATIVE : COLOR_NEUTRAL) : COLOR_NEUTRAL;
+
   return (
     <List.Item.Detail
       metadata={
@@ -1023,6 +1061,27 @@ function buildSecuritiesDetail({
             <List.Item.Detail.Metadata.TagList title="Price">
               <List.Item.Detail.Metadata.TagList.Item text="Unavailable" color={COLOR_MUTED} />
             </List.Item.Detail.Metadata.TagList>
+          )}
+
+          {/* ── Cost Basis & Unrealized P&L (when an average buy price is recorded) ── */}
+          {pnl && (
+            <>
+              <List.Item.Detail.Metadata.Separator />
+              <List.Item.Detail.Metadata.Label
+                title="Avg Buy Price"
+                text={formatCurrency(pnl.avgCostPrice, position.currency)}
+              />
+              <List.Item.Detail.Metadata.Label
+                title="Total Invested"
+                text={formatCurrency(pnl.costBasis, position.currency)}
+              />
+              <List.Item.Detail.Metadata.TagList title="Unrealized P&L">
+                <List.Item.Detail.Metadata.TagList.Item
+                  text={`${formatCurrency(pnl.pnl, position.currency, { showSign: true })} (${formatPercent(pnl.pnlPercent)})`}
+                  color={pnlColor}
+                />
+              </List.Item.Detail.Metadata.TagList>
+            </>
           )}
 
           <List.Item.Detail.Metadata.Separator />

--- a/extensions/portfolio-tracker/src/components/SearchInvestmentsFlow.tsx
+++ b/extensions/portfolio-tracker/src/components/SearchInvestmentsFlow.tsx
@@ -19,6 +19,7 @@ import { AccountForm } from "./AccountForm";
 import { useAssetPrice } from "../hooks/useAssetPrice";
 import { useFxRate } from "../hooks/useFxRate";
 import { usePortfolio } from "../hooks/usePortfolio";
+import { useOptionalPrice } from "../hooks/useOptionalPrice";
 import {
   validateAssetName,
   validatePrice,
@@ -100,6 +101,7 @@ export function SearchInvestmentsFlow({ onDone }: SearchInvestmentsFlowProps): R
     currency: string;
     assetType: AssetType;
     priceOverride?: number;
+    avgCostPrice?: number;
   }): Promise<void> {
     if (!selectedAccount) return;
 
@@ -163,6 +165,7 @@ interface ConfirmInvestmentFormProps {
     currency: string;
     assetType: AssetType;
     priceOverride?: number;
+    avgCostPrice?: number;
   }) => Promise<void>;
 }
 
@@ -183,7 +186,10 @@ function ConfirmInvestmentForm({ result, account, onBack, onConfirm }: ConfirmIn
   const [unitsError, setUnitsError] = useState<string | undefined>(undefined);
   const [totalValueError, setTotalValueError] = useState<string | undefined>(undefined);
   const [totalValueInput, setTotalValueInput] = useState<string>("");
+  const [priceOverrideInput, setPriceOverrideInput] = useState<string>("");
   const [priceOverrideError, setPriceOverrideError] = useState<string | undefined>(undefined);
+  const [avgCostInput, setAvgCostInput] = useState<string>("");
+  const [avgCostError, setAvgCostError] = useState<string | undefined>(undefined);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const typeLabel = ASSET_TYPE_LABELS[result.type] ?? "Unknown";
@@ -193,6 +199,18 @@ function ConfirmInvestmentForm({ result, account, onBack, onConfirm }: ConfirmIn
   }, [price]);
 
   const assetCurrency = price?.currency ?? "";
+
+  // When a buy price is entered, total-value mode divides by it instead of the
+  // live price — "amount invested ÷ price paid" recovers the units actually
+  // bought, even when the position is being recorded long after the purchase.
+  const enteredBuyPrice = useOptionalPrice(avgCostInput);
+
+  // A manual price override also affects the value-mode divisor at submit
+  // time (see resolvedPrice in handleSubmit) — mirror that here so the live
+  // preview matches what actually gets saved.
+  const enteredPriceOverride = useOptionalPrice(priceOverrideInput);
+
+  const valueModeUnitPrice = enteredBuyPrice ?? enteredPriceOverride ?? effectivePrice;
 
   const valueCurrencyOptions = useMemo(() => {
     const options: Array<{ value: string; title: string }> = [];
@@ -213,26 +231,42 @@ function ConfirmInvestmentForm({ result, account, onBack, onConfirm }: ConfirmIn
 
   const computedUnitsFromValue = useMemo(() => {
     const trimmed = totalValueInput.trim();
-    if (!trimmed || !effectivePrice) return null;
+    if (!trimmed || !valueModeUnitPrice) return null;
     const parsed = Number(trimmed);
     if (isNaN(parsed) || parsed <= 0) return null;
     // Convert entered value to asset currency if needed
     const valueInAssetCurrency = needsFxConversion && fxRate ? parsed * fxRate : parsed;
     if (needsFxConversion && !fxRate) return null; // FX rate not yet loaded
-    return computeUnitsFromTotalValue(valueInAssetCurrency, effectivePrice);
-  }, [totalValueInput, effectivePrice, needsFxConversion, fxRate]);
+    return computeUnitsFromTotalValue(valueInAssetCurrency, valueModeUnitPrice);
+  }, [totalValueInput, valueModeUnitPrice, needsFxConversion, fxRate]);
 
   const computedTotalDisplay = useMemo(() => {
     if (needsFxConversion && !fxRate && totalValueInput.trim()) {
       return "Loading FX rate...";
     }
     if (computedUnitsFromValue === null || !price) return null;
-    const nativeTotal = computedUnitsFromValue * price.price;
+    const priceLabel = enteredBuyPrice
+      ? `${formatCurrency(enteredBuyPrice, price.currency)} buy price`
+      : enteredPriceOverride
+        ? `${formatCurrency(enteredPriceOverride, price.currency)} price override`
+        : formatCurrency(price.price, price.currency);
+    const total = computedUnitsFromValue * valueModeUnitPrice;
     if (needsFxConversion && fxRate) {
-      return `${formatUnits(computedUnitsFromValue)} units × ${formatCurrency(price.price, price.currency)} = ${formatCurrency(nativeTotal, price.currency)} (${formatCurrency(Number(totalValueInput.trim()), valueCurrency)} at ${fxRate.toFixed(4)} ${valueCurrency}/${assetCurrency})`;
+      return `${formatUnits(computedUnitsFromValue)} units × ${priceLabel} = ${formatCurrency(total, price.currency)} (${formatCurrency(Number(totalValueInput.trim()), valueCurrency)} at ${fxRate.toFixed(4)} ${valueCurrency}/${assetCurrency})`;
     }
-    return `${formatUnits(computedUnitsFromValue)} units × ${formatCurrency(price.price, price.currency)} = ${formatCurrency(nativeTotal, price.currency)}`;
-  }, [computedUnitsFromValue, price, needsFxConversion, fxRate, totalValueInput, valueCurrency, assetCurrency]);
+    return `${formatUnits(computedUnitsFromValue)} units × ${priceLabel} = ${formatCurrency(total, price.currency)}`;
+  }, [
+    computedUnitsFromValue,
+    price,
+    enteredBuyPrice,
+    enteredPriceOverride,
+    valueModeUnitPrice,
+    needsFxConversion,
+    fxRate,
+    totalValueInput,
+    valueCurrency,
+    assetCurrency,
+  ]);
 
   function handleNameBlur(event: Form.Event<string>) {
     const error = validateAssetName(event.target.value);
@@ -273,8 +307,20 @@ function ConfirmInvestmentForm({ result, account, onBack, onConfirm }: ConfirmIn
     }
   }
 
-  function handlePriceChange() {
+  function handlePriceChange(value: string) {
+    setPriceOverrideInput(value);
     if (priceOverrideError) setPriceOverrideError(undefined);
+  }
+
+  function handleAvgCostBlur(event: Form.Event<string>) {
+    if (event.target.value && event.target.value.trim().length > 0) {
+      setAvgCostError(validatePrice(event.target.value));
+    }
+  }
+
+  function handleAvgCostChange(value: string) {
+    setAvgCostInput(value);
+    if (avgCostError) setAvgCostError(undefined);
   }
 
   function handleInputModeChange(value: string) {
@@ -288,6 +334,7 @@ function ConfirmInvestmentForm({ result, account, onBack, onConfirm }: ConfirmIn
     units?: string;
     totalValue?: string;
     priceOverride?: string;
+    avgCostPrice?: string;
     inputMode: string;
     valueCurrency?: string;
   }) {
@@ -302,6 +349,15 @@ function ConfirmInvestmentForm({ result, account, onBack, onConfirm }: ConfirmIn
       const priceValidation = validatePrice(priceOverrideValue);
       if (priceValidation) {
         setPriceOverrideError(priceValidation);
+        return;
+      }
+    }
+
+    const avgCostValue = values.avgCostPrice?.trim();
+    if (avgCostValue) {
+      const avgCostValidation = validatePrice(avgCostValue);
+      if (avgCostValidation) {
+        setAvgCostError(avgCostValidation);
         return;
       }
     }
@@ -332,7 +388,10 @@ function ConfirmInvestmentForm({ result, account, onBack, onConfirm }: ConfirmIn
 
       const rawTotalValue = parseTotalValue(values.totalValue!);
       const totalValueInAssetCurrency = needsFxConversion && fxRate ? rawTotalValue * fxRate : rawTotalValue;
-      finalUnits = computeUnitsFromTotalValue(totalValueInAssetCurrency, resolvedPrice);
+      // Divide by the buy price when entered ("amount invested ÷ price paid"),
+      // otherwise by the current/override price ("buying at today's price").
+      const buyPrice = avgCostValue ? Number(avgCostValue) : undefined;
+      finalUnits = computeUnitsFromTotalValue(totalValueInAssetCurrency, buyPrice ?? resolvedPrice);
       if (finalUnits <= 0) {
         setTotalValueError("Computed units would be zero — check the price and total value.");
         return;
@@ -356,6 +415,7 @@ function ConfirmInvestmentForm({ result, account, onBack, onConfirm }: ConfirmIn
         currency: price.currency,
         assetType: result.type,
         priceOverride: priceOverrideValue ? parseUnits(priceOverrideValue) : undefined,
+        avgCostPrice: avgCostValue ? Number(avgCostValue) : undefined,
       });
     } finally {
       setIsSubmitting(false);
@@ -423,6 +483,20 @@ function ConfirmInvestmentForm({ result, account, onBack, onConfirm }: ConfirmIn
         }
       />
 
+      <Form.TextField
+        id="avgCostPrice"
+        title="Average Buy Price"
+        placeholder={price ? `e.g. ${formatCurrency(price.price, price.currency)} (optional)` : "e.g. 72.50 (optional)"}
+        error={avgCostError}
+        onChange={handleAvgCostChange}
+        onBlur={handleAvgCostBlur}
+      />
+
+      <Form.Description
+        title=""
+        text={`Optional. The average price per unit you paid${price ? ` in ${price.currency}` : ""}. Enables profit/loss tracking.`}
+      />
+
       {/* ── Input Mode Toggle ── */}
       <Form.Description title="Account" text={account.name} />
 
@@ -479,10 +553,17 @@ function ConfirmInvestmentForm({ result, account, onBack, onConfirm }: ConfirmIn
               computedTotalDisplay
                 ? `→ ${computedTotalDisplay}`
                 : price
-                  ? needsFxConversion
-                    ? `Enter total amount in ${valueCurrency}. Will be converted to ${assetCurrency} then divided by ${formatCurrency(price.price, price.currency)}/unit.`
-                    : `Enter total amount invested in ${valueCurrency}. Units will be auto-calculated at ${formatCurrency(price.price, price.currency)} per unit.`
-                  : "Enter total amount invested. Units will be calculated from the current price."
+                  ? (() => {
+                      const divisorLabel = enteredBuyPrice
+                        ? `your buy price (${formatCurrency(enteredBuyPrice, price.currency)})`
+                        : enteredPriceOverride
+                          ? `your price override (${formatCurrency(enteredPriceOverride, price.currency)})`
+                          : `${formatCurrency(price.price, price.currency)}/unit`;
+                      return needsFxConversion
+                        ? `Enter total amount in ${valueCurrency}. Will be converted to ${assetCurrency} then divided by ${divisorLabel}.`
+                        : `Enter total amount invested in ${valueCurrency}. Units will be auto-calculated at ${divisorLabel} per unit.`;
+                    })()
+                  : "Enter total amount invested. Units will be calculated from your buy price (if entered), your price override (if entered), or the current price."
             }
           />
         </>

--- a/extensions/portfolio-tracker/src/components/SearchInvestmentsView.tsx
+++ b/extensions/portfolio-tracker/src/components/SearchInvestmentsView.tsx
@@ -85,6 +85,8 @@ export interface SearchInvestmentsViewProps {
     units: number;
     currency: string;
     assetType: AssetType;
+    priceOverride?: number;
+    avgCostPrice?: number;
   }) => Promise<void>;
 
   /**

--- a/extensions/portfolio-tracker/src/hooks/useOptionalPrice.ts
+++ b/extensions/portfolio-tracker/src/hooks/useOptionalPrice.ts
@@ -1,0 +1,22 @@
+/**
+ * Parses an optional price-like form input into a positive number.
+ *
+ * Used by forms that let the user optionally enter a price (buy price,
+ * price paid, price override) which, when present, should override a
+ * default price (live quote, current price) used elsewhere in the form —
+ * e.g. as the divisor for a "total value invested" calculation.
+ *
+ * @param input - Raw string from a Form.TextField
+ * @returns The parsed positive number, or null when empty, non-numeric, or ≤ 0
+ */
+
+import { useMemo } from "react";
+
+export function useOptionalPrice(input: string): number | null {
+  return useMemo(() => {
+    const trimmed = input.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return !isNaN(parsed) && parsed > 0 ? parsed : null;
+  }, [input]);
+}

--- a/extensions/portfolio-tracker/src/hooks/usePortfolio.ts
+++ b/extensions/portfolio-tracker/src/hooks/usePortfolio.ts
@@ -85,12 +85,20 @@ export interface UsePortfolioReturn {
       units: number;
       currency: string;
       assetType: AssetType;
+      avgCostPrice?: number;
       debtData?: DebtData;
     },
   ) => Promise<Position>;
 
-  /** Updates the units of an existing position */
-  updatePosition: (accountId: string, positionId: string, units: number) => Promise<void>;
+  /**
+   * Updates the units and/or average cost of an existing position.
+   * `avgCostPrice: null` clears the recorded average cost; `undefined` leaves it unchanged.
+   */
+  updatePosition: (
+    accountId: string,
+    positionId: string,
+    updates: { units?: number; avgCostPrice?: number | null },
+  ) => Promise<void>;
 
   /**
    * Updates a property position's mortgage data, asset type, and/or name.
@@ -325,6 +333,7 @@ export function usePortfolio(): UsePortfolioReturn {
         currency: string;
         assetType: AssetType;
         priceOverride?: number;
+        avgCostPrice?: number;
         mortgageData?: MortgageData;
         debtData?: DebtData;
       },
@@ -337,6 +346,7 @@ export function usePortfolio(): UsePortfolioReturn {
         currency: params.currency,
         assetType: params.assetType,
         priceOverride: params.priceOverride,
+        ...(params.avgCostPrice && params.avgCostPrice > 0 && { avgCostPrice: params.avgCostPrice }),
         ...(params.mortgageData && { mortgageData: params.mortgageData }),
         ...(params.debtData && { debtData: params.debtData }),
         addedAt: new Date().toISOString(),
@@ -381,19 +391,31 @@ export function usePortfolio(): UsePortfolioReturn {
   );
 
   const updatePosition = useCallback(
-    async (accountId: string, positionId: string, units: number): Promise<void> => {
+    async (
+      accountId: string,
+      positionId: string,
+      updates: { units?: number; avgCostPrice?: number | null },
+    ): Promise<void> => {
+      const applyUpdates = (pos: Position): Position => {
+        if (pos.id !== positionId) return pos;
+        const next = {
+          ...pos,
+          ...(updates.units !== undefined && { units: updates.units }),
+          ...(typeof updates.avgCostPrice === "number" && { avgCostPrice: updates.avgCostPrice }),
+        };
+        if (updates.avgCostPrice === null) {
+          delete next.avgCostPrice;
+        }
+        return next;
+      };
+
       await mutate(
         (async () => {
           const current = await loadPortfolio();
           const updated: Portfolio = {
             ...current,
             accounts: current.accounts.map((account) =>
-              account.id === accountId
-                ? {
-                    ...account,
-                    positions: account.positions.map((pos) => (pos.id === positionId ? { ...pos, units } : pos)),
-                  }
-                : account,
+              account.id === accountId ? { ...account, positions: account.positions.map(applyUpdates) } : account,
             ),
             updatedAt: new Date().toISOString(),
           };
@@ -406,12 +428,7 @@ export function usePortfolio(): UsePortfolioReturn {
             return {
               ...currentData,
               accounts: currentData.accounts.map((account) =>
-                account.id === accountId
-                  ? {
-                      ...account,
-                      positions: account.positions.map((pos) => (pos.id === positionId ? { ...pos, units } : pos)),
-                    }
-                  : account,
+                account.id === accountId ? { ...account, positions: account.positions.map(applyUpdates) } : account,
               ),
               updatedAt: new Date().toISOString(),
             };
@@ -419,10 +436,14 @@ export function usePortfolio(): UsePortfolioReturn {
         },
       );
 
+      const messageParts: string[] = [];
+      if (updates.units !== undefined) messageParts.push(`Units set to ${updates.units}`);
+      if (updates.avgCostPrice !== undefined) messageParts.push("average buy price updated");
+
       await showToast({
         style: Toast.Style.Success,
         title: "Position Updated",
-        message: `Units set to ${units}`,
+        message: messageParts.join(" and ") || "Position updated",
       });
     },
     [mutate],

--- a/extensions/portfolio-tracker/src/hooks/usePortfolioValue.ts
+++ b/extensions/portfolio-tracker/src/hooks/usePortfolioValue.ts
@@ -56,6 +56,7 @@ import {
   isDebtPaidOff,
 } from "../utils/types";
 import { getCachedPrices, getCachedFxRates } from "../services/price-cache";
+import { computePnl } from "../utils/pnl";
 import { getTodayDateKey } from "../utils/formatting";
 import { createPortfolioError } from "../utils/errors";
 import { PropertyPriceChange, getPropertyPriceChange, getPropertyPriceChangeSync } from "../services/property-price";
@@ -443,6 +444,12 @@ export function usePortfolioValue(portfolio: Portfolio | undefined): UsePortfoli
         const change = hasPriceOverride ? 0 : (priceData?.change ?? 0);
         const changePercent = hasPriceOverride ? 0 : (priceData?.changePercent ?? 0);
 
+        // Unrealized P&L (native currency) — only when an average cost is recorded.
+        // computePnl only returns a result when avgCostPrice is a valid positive
+        // number, so the assertion below is safe and centralises the one place
+        // that needs to know this invariant — consumers just check `pnl`.
+        const pnlResult = computePnl(position.units, position.avgCostPrice, currentPrice);
+
         return {
           position,
           currentPrice,
@@ -451,6 +458,7 @@ export function usePortfolioValue(portfolio: Portfolio | undefined): UsePortfoli
           change,
           changePercent,
           fxRate,
+          ...(pnlResult && { pnl: { ...pnlResult, avgCostPrice: position.avgCostPrice! } }),
         };
       });
 
@@ -464,6 +472,19 @@ export function usePortfolioValue(portfolio: Portfolio | undefined): UsePortfoli
     });
 
     const grandTotal = accountValuations.reduce((sum, av) => sum + av.totalBaseValue, 0);
+
+    // Portfolio-level P&L totals (base currency) across positions with cost data
+    let totalCostBasis = 0;
+    let totalPnl = 0;
+    let hasAnyCostData = false;
+    for (const av of accountValuations) {
+      for (const pv of av.positions) {
+        if (pv.pnl === undefined) continue;
+        hasAnyCostData = true;
+        totalCostBasis += pv.pnl.costBasis * pv.fxRate;
+        totalPnl += pv.pnl.pnl * pv.fxRate;
+      }
+    }
 
     // Determine the most recent fetch timestamp across all prices
     let latestFetch = "";
@@ -484,6 +505,7 @@ export function usePortfolioValue(portfolio: Portfolio | undefined): UsePortfoli
       totalValue: grandTotal,
       baseCurrency,
       lastUpdated: latestFetch || new Date().toISOString(),
+      ...(hasAnyCostData && { pnl: { costBasis: totalCostBasis, pnl: totalPnl } }),
     };
   }, [portfolio, prices, fxRates, hpiData, debtSyncResults, baseCurrency]);
 

--- a/extensions/portfolio-tracker/src/portfolio.tsx
+++ b/extensions/portfolio-tracker/src/portfolio.tsx
@@ -237,8 +237,11 @@ export default function PortfolioCommand(): React.JSX.Element {
         accountName={account.name}
         onSave={async (updates) => {
           // ── 1. Save changes to the ORIGINAL asset ──
-          if (updates.unitsChanged) {
-            await updatePosition(account.id, position.id, updates.units);
+          if (updates.unitsChanged || updates.costChanged) {
+            await updatePosition(account.id, position.id, {
+              ...(updates.unitsChanged && { units: updates.units }),
+              ...(updates.costChanged && { avgCostPrice: updates.avgCostPrice }),
+            });
           }
 
           let didRename = false;
@@ -278,8 +281,11 @@ export default function PortfolioCommand(): React.JSX.Element {
         position={position}
         accountId={account.id}
         accountName={account.name}
-        onSubmit={async (newTotalUnits: number) => {
-          await updatePosition(account.id, position.id, newTotalUnits);
+        onSubmit={async (newTotalUnits: number, newAvgCostPrice?: number) => {
+          await updatePosition(account.id, position.id, {
+            units: newTotalUnits,
+            ...(newAvgCostPrice !== undefined && { avgCostPrice: newAvgCostPrice }),
+          });
         }}
       />,
     );

--- a/extensions/portfolio-tracker/src/utils/csv-portfolio.ts
+++ b/extensions/portfolio-tracker/src/utils/csv-portfolio.ts
@@ -751,11 +751,11 @@ export function parsePortfolioCsv(csvContent: string): CsvParseResult {
     }
 
     const averageCost = averageCostStr ? parseFloat(averageCostStr) : 0;
-    if (averageCostStr && isNaN(averageCost)) {
+    if (averageCostStr && (isNaN(averageCost) || averageCost < 0)) {
       rowErrors.push({
         row: rowNum,
         column: "Average Cost",
-        message: "Average Cost must be a number",
+        message: "Average Cost must be a positive number",
         rawValue: averageCostStr,
       });
     }

--- a/extensions/portfolio-tracker/src/utils/csv-portfolio.ts
+++ b/extensions/portfolio-tracker/src/utils/csv-portfolio.ts
@@ -17,8 +17,8 @@
  *   - Encoding: UTF-8.
  *
  * Supported columns:
- *   Account, Account Type, Asset Name, Symbol, Units, Price, Total Value,
- *   Currency, Asset Type, Last Updated, Additional Parameters
+ *   Account, Account Type, Asset Name, Symbol, Units, Price, Average Cost,
+ *   Total Value, Currency, Asset Type, Last Updated, Additional Parameters
  *
  * The "Additional Parameters" column contains a JSON object with non-standard
  * settings for specialised position types (mortgage, property, debt). This
@@ -55,6 +55,7 @@ export const CSV_HEADERS = [
   "Symbol",
   "Units",
   "Price",
+  "Average Cost",
   "Total Value",
   "Currency",
   "Asset Type",
@@ -82,6 +83,8 @@ export interface CsvRow {
   units: number;
   /** Price per unit at export time */
   price: number;
+  /** Average purchase price per unit (undefined when not recorded) */
+  averageCost?: number;
   /** Total value (units × price) */
   totalValue: number;
   /** Currency code (e.g. "GBP") */
@@ -273,6 +276,8 @@ export function exportPortfolioToCsv(positions: ExportPositionData[]): string {
       escapeCsvField(position.symbol),
       formatCsvNumber(position.units, 4),
       formatCsvNumber(currentPrice, 2),
+      // 6 decimals to match validatePrice's max precision for the buy-price input fields
+      position.avgCostPrice !== undefined ? formatCsvNumber(position.avgCostPrice, 6) : "",
       formatCsvNumber(totalValue, 2),
       escapeCsvField(position.currency),
       escapeCsvField(assetTypeLabel),
@@ -591,6 +596,11 @@ export function mapHeaders(headers: string[]): { mapping: Map<CsvHeader, number>
     SHARES: "Units",
     PRICE: "Price",
     "PRICE PER UNIT": "Price",
+    "AVERAGE COST": "Average Cost",
+    "AVG COST": "Average Cost",
+    "AVERAGE BUY PRICE": "Average Cost",
+    "BUY PRICE": "Average Cost",
+    "COST BASIS": "Average Cost",
     "TOTAL VALUE": "Total Value",
     VALUE: "Total Value",
     TOTAL: "Total Value",
@@ -728,6 +738,7 @@ export function parsePortfolioCsv(csvContent: string): CsvParseResult {
     // ── Extract optional fields ──
     const accountType = getValue("Account Type") || "OTHER";
     const priceStr = getValue("Price");
+    const averageCostStr = getValue("Average Cost");
     const totalValueStr = getValue("Total Value");
     const assetTypeStr = getValue("Asset Type") || "UNKNOWN";
     const lastUpdated = getValue("Last Updated") || new Date().toISOString();
@@ -737,6 +748,16 @@ export function parsePortfolioCsv(csvContent: string): CsvParseResult {
     const price = priceStr ? parseFloat(priceStr) : 0;
     if (priceStr && isNaN(price)) {
       rowErrors.push({ row: rowNum, column: "Price", message: "Price must be a number", rawValue: priceStr });
+    }
+
+    const averageCost = averageCostStr ? parseFloat(averageCostStr) : 0;
+    if (averageCostStr && isNaN(averageCost)) {
+      rowErrors.push({
+        row: rowNum,
+        column: "Average Cost",
+        message: "Average Cost must be a number",
+        rawValue: averageCostStr,
+      });
     }
 
     const totalValue = totalValueStr ? parseFloat(totalValueStr) : units * price;
@@ -772,6 +793,7 @@ export function parsePortfolioCsv(csvContent: string): CsvParseResult {
       symbol,
       units,
       price,
+      averageCost: averageCost > 0 ? averageCost : undefined,
       totalValue,
       currency: currency.toUpperCase(),
       assetType: assetTypeStr.toUpperCase(),
@@ -830,6 +852,9 @@ export function buildPortfolioFromCsvRows(rows: CsvRow[]): CsvImportResult {
       !isPropertyAssetType(assetType) && !isDebtAssetType(assetType) && assetType !== AssetType.CASH;
     const priceOverride = !isMarketTraded && row.price > 0 ? row.price : undefined;
 
+    // Average cost only applies to market-traded assets (enables P&L tracking)
+    const avgCostPrice = isMarketTraded && row.averageCost && row.averageCost > 0 ? row.averageCost : undefined;
+
     const position: Position = {
       id: generateId(),
       symbol: row.symbol,
@@ -839,6 +864,7 @@ export function buildPortfolioFromCsvRows(rows: CsvRow[]): CsvImportResult {
       assetType,
       priceOverride,
       addedAt: row.lastUpdated || new Date().toISOString(),
+      ...(avgCostPrice ? { avgCostPrice } : {}),
       ...(mortgageData ? { mortgageData } : {}),
       ...(debtData ? { debtData } : {}),
     };

--- a/extensions/portfolio-tracker/src/utils/pnl.ts
+++ b/extensions/portfolio-tracker/src/utils/pnl.ts
@@ -1,0 +1,97 @@
+/**
+ * Unrealized profit/loss (P&L) calculations.
+ *
+ * Pure functions with zero side effects and zero Raycast imports.
+ * All calculations happen in the position's native currency — callers
+ * convert to the base currency via the position's FX rate.
+ *
+ * Cost basis model: each position stores a single average purchase price
+ * (`Position.avgCostPrice`). Buying more units updates the average via
+ * `computeWeightedAvgCost`. Positions without an average cost recorded
+ * simply have no P&L data.
+ */
+
+// ──────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────
+
+/** Result of a P&L calculation for a single position */
+export interface PnlResult {
+  /** Total invested: units × avgCostPrice */
+  costBasis: number;
+  /** Unrealized profit/loss: currentValue − costBasis */
+  pnl: number;
+  /** Unrealized profit/loss as a percentage of costBasis */
+  pnlPercent: number;
+}
+
+// ──────────────────────────────────────────
+// Calculations
+// ──────────────────────────────────────────
+
+/**
+ * Computes unrealized P&L for a position from its average purchase price.
+ *
+ * Returns undefined when the inputs cannot produce a meaningful result
+ * (no cost recorded, non-positive units, or no current price available).
+ *
+ * @param units - Number of units held
+ * @param avgCostPrice - Average purchase price per unit (native currency)
+ * @param currentPrice - Current market price per unit (native currency)
+ * @returns P&L result in the position's native currency, or undefined
+ *
+ * @example
+ * // Invested $100 in ETH at $4,000 (0.025 units), ETH now at $2,000:
+ * computePnl(0.025, 4000, 2000)
+ * // { costBasis: 100, pnl: -50, pnlPercent: -50 }
+ */
+export function computePnl(
+  units: number,
+  avgCostPrice: number | undefined,
+  currentPrice: number,
+): PnlResult | undefined {
+  if (avgCostPrice === undefined || avgCostPrice <= 0) return undefined;
+  if (units <= 0 || currentPrice <= 0) return undefined;
+
+  const costBasis = units * avgCostPrice;
+  const currentValue = units * currentPrice;
+  const pnl = currentValue - costBasis;
+  const pnlPercent = (pnl / costBasis) * 100;
+
+  return { costBasis, pnl, pnlPercent };
+}
+
+/**
+ * Computes the new average cost after buying additional units.
+ *
+ * Standard weighted average:
+ *   newAvg = (existingUnits × existingAvg + addedUnits × pricePaid) / totalUnits
+ *
+ * When no existing average is recorded, the price paid for the new units
+ * becomes the average for the WHOLE position — callers should only do this
+ * when that assumption is acceptable (the AddUnitsForm explains it to the user).
+ *
+ * @param existingUnits - Units held before the purchase
+ * @param existingAvgCost - Average cost of those units, or undefined if never recorded
+ * @param addedUnits - Units being added (must be > 0)
+ * @param pricePaid - Price paid per new unit (native currency)
+ * @returns The new average cost per unit, or undefined if inputs are invalid
+ *
+ * @example
+ * computeWeightedAvgCost(10, 100, 10, 200) // 150
+ * computeWeightedAvgCost(10, undefined, 5, 80) // 80
+ */
+export function computeWeightedAvgCost(
+  existingUnits: number,
+  existingAvgCost: number | undefined,
+  addedUnits: number,
+  pricePaid: number,
+): number | undefined {
+  if (addedUnits <= 0 || pricePaid <= 0) return undefined;
+
+  const hasExistingCost = existingAvgCost !== undefined && existingAvgCost > 0 && existingUnits > 0;
+  if (!hasExistingCost) return pricePaid;
+
+  const totalUnits = existingUnits + addedUnits;
+  return (existingUnits * existingAvgCost + addedUnits * pricePaid) / totalUnits;
+}

--- a/extensions/portfolio-tracker/src/utils/types.ts
+++ b/extensions/portfolio-tracker/src/utils/types.ts
@@ -5,6 +5,8 @@
  * No runtime logic lives here — only interfaces, enums, and type aliases.
  */
 
+import type { PnlResult } from "./pnl";
+
 // ──────────────────────────────────────────
 // Sorting
 // ──────────────────────────────────────────
@@ -361,6 +363,13 @@ export interface Position {
    */
   priceOverride?: number;
   /**
+   * Average purchase price per unit, in the asset's native currency.
+   * When set, enables unrealized profit/loss (P&L) display for this position.
+   * Undefined for positions without cost data and for CASH / property / debt
+   * positions (which have their own valuation models).
+   */
+  avgCostPrice?: number;
+  /**
    * Additional data for MORTGAGE and OWNED_PROPERTY positions.
    * Undefined for all other asset types.
    */
@@ -467,6 +476,18 @@ export interface AssetQuote {
 // Computed / Display Types (never persisted)
 // ──────────────────────────────────────────
 
+/**
+ * Unrealized P&L for a position, bundled with the average cost that produced
+ * it. Present only when the position has an `avgCostPrice` recorded and a
+ * usable current price — consumers can gate an entire "cost basis" section
+ * on a single `if (valuation.pnl)` check instead of testing several optional
+ * fields independently.
+ */
+export interface PositionPnl extends PnlResult {
+  /** Average buy price per unit used to compute this P&L (native currency) */
+  avgCostPrice: number;
+}
+
 /** Valuation of a single position at current prices */
 export interface PositionValuation {
   position: Position;
@@ -488,6 +509,8 @@ export interface PositionValuation {
    * display the HPI change separately from the equity-relative changePercent.
    */
   hpiChangePercent?: number;
+  /** Unrealized P&L (native currency). Only set for traded positions with avgCostPrice recorded. */
+  pnl?: PositionPnl;
 }
 
 /** Valuation of an account (sum of its positions) */
@@ -496,6 +519,14 @@ export interface AccountValuation {
   positions: PositionValuation[];
   /** Sum of all position values in base currency */
   totalBaseValue: number;
+}
+
+/** Aggregated cost basis and P&L totals across positions with a recorded avgCostPrice */
+export interface PortfolioPnlTotals {
+  /** Total invested, in base currency */
+  costBasis: number;
+  /** Total unrealized P&L, in base currency */
+  pnl: number;
 }
 
 /** Valuation of the entire portfolio */
@@ -507,6 +538,8 @@ export interface PortfolioValuation {
   baseCurrency: string;
   /** ISO 8601 timestamp of the most recent price fetch */
   lastUpdated: string;
+  /** P&L totals across positions with avgCostPrice recorded. Undefined when no position has cost data. */
+  pnl?: PortfolioPnlTotals;
 }
 
 // ──────────────────────────────────────────


### PR DESCRIPTION
## Description
- Record an optional average buy price per position, set when adding an investment or later via Edit Asset, to track unrealized profit/loss (P&L)
- P&L tag on each position showing gain/loss percentage, with amount shown on hover
- Cost basis section in the position detail panel with average buy price, total invested, and unrealized P&L
- Portfolio summary row totals unrealized P&L across all positions with a buy price recorded
- "Total Value Invested" mode divides by your buy price when entered, falling back to the live price otherwise
- Adding units with a "Price Paid per Unit" updates the average buy price using a weighted average
- CSV import/export supports an optional "Average Cost" column, backward compatible with older files
- Close #28712.
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1000" height="625" alt="portfolio-tracker 2026-07-16 at 23 28 54" src="https://github.com/user-attachments/assets/4fa7b75a-f656-45d6-8631-5be067baf6e1" />
<img width="1000" height="625" alt="portfolio-tracker 2026-07-16 at 23 26 44" src="https://github.com/user-attachments/assets/b5994467-4ef2-469f-a7db-f5508d64e50c" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
