### PR TITLE
Update gitlab extension

### DIFF
--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # GitLab Changelog
 
+## [MR todos, project search, and API logging] - 2026-07-16
+
+- Show MR todo state from the list query; add or mark todos done without loading the full todos list
+- Add searchable project dropdown with server-side search and pinned selection in Search MR and project pickers
+- Cache the selected project in Search MR instead of only the project ID
+- Fetch merge request pipeline lists via REST API
+- Log GitLab REST and GraphQL requests and improve API error diagnostics
+
 ## [GraphQL merge requests, discussions, and CI] - 2026-07-09
 
 - Migrate merge request, commit, and pipeline lists to GraphQL with cursor pagination (20 items per page)

--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitLab Changelog
 
-## [MR todos, project search, and API logging] - {PR_MERGE_DATE}
+## [MR todos, project search, and API logging] - 2026-07-17
 
 - Show MR todo state from the list query; add or mark todos done without loading the full todos list
 - Add searchable project dropdown with server-side search and pinned selection in Search MR and project pickers

--- a/extensions/gitlab/CHANGELOG.md
+++ b/extensions/gitlab/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitLab Changelog
 
-## [MR todos, project search, and API logging] - 2026-07-16
+## [MR todos, project search, and API logging] - {PR_MERGE_DATE}
 
 - Show MR todo state from the list query; add or mark todos done without loading the full todos list
 - Add searchable project dropdown with server-side search and pinned selection in Search MR and project pickers

--- a/extensions/gitlab/package-lock.json
+++ b/extensions/gitlab/package-lock.json
@@ -3337,19 +3337,6 @@
         }
       ]
     },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/extensions/gitlab/package.json
+++ b/extensions/gitlab/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "gitlab",
   "title": "GitLab",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "tonka3000",
   "license": "MIT",
   "description": "Create, search and modify issues, manage merge requests, projects and more.",

--- a/extensions/gitlab/src/common.ts
+++ b/extensions/gitlab/src/common.ts
@@ -68,15 +68,30 @@ function createGitLabGQLClient(): GitLabGQL {
     };
   });
 
+  const requestLogLink = new ApolloLink((operation, forward) => {
+    console.log(
+      `GitLab GraphQL → ${operation.operationName ?? "anonymous"}`,
+      operation.variables && Object.keys(operation.variables).length > 0 ? operation.variables : "",
+    );
+    return forward(operation);
+  });
+
   const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) => {
     if (graphQLErrors) {
       for (const error of graphQLErrors) {
-        console.warn(`GitLab GraphQL: ${error.message}`);
+        console.warn(
+          `GitLab GraphQL ${operation.operationName ?? "anonymous"}: ${error.message}`,
+          error.path ? { path: error.path, extensions: error.extensions } : error.extensions,
+        );
       }
     }
     if (networkError) {
       const statusCode = "statusCode" in networkError ? networkError.statusCode : undefined;
-      console.warn(`GitLab GraphQL network error${statusCode ? ` ${statusCode}` : ""}: ${networkError.message}`);
+      const result = "result" in networkError ? networkError.result : undefined;
+      console.warn(
+        `GitLab GraphQL network error${statusCode ? ` ${statusCode}` : ""} (${operation.operationName ?? "anonymous"}): ${networkError.message}`,
+        result ?? "",
+      );
       if (statusCode === 401 && isOAuthEnabled() && !operation.getContext().gitlabAuthRetried && forward) {
         operation.setContext({ gitlabAuthRetried: true });
         return fromPromise(refreshToken()).flatMap(() => forward(operation));
@@ -85,7 +100,7 @@ function createGitLabGQLClient(): GitLabGQL {
   });
 
   const client = new ApolloClient({
-    link: ApolloLink.from([errorLink, authLink, httpLink]),
+    link: ApolloLink.from([errorLink, requestLogLink, authLink, httpLink]),
     cache: new InMemoryCache(),
     defaultOptions: {
       query: {

--- a/extensions/gitlab/src/components/mr_actions.tsx
+++ b/extensions/gitlab/src/components/mr_actions.tsx
@@ -8,7 +8,6 @@ import { MRCommitList } from "./commits/list";
 import { MREditForm } from "./mr_create";
 import { MRDiscussionList } from "./mr_discussion_list";
 import { MRPipelineList } from "./mr_pipelines";
-import { findTodoForMR, useTodos } from "./todo/utils";
 import { showFailureToast } from "@raycast/utils";
 
 async function createNote(mr: MergeRequest, body: string): Promise<void> {
@@ -201,20 +200,16 @@ function MRTodoAction(props: {
   shortcut?: Keyboard.Shortcut;
   finished?: () => void;
 }): React.ReactElement | null {
-  const { todos, performRefetch } = useTodos();
-  const existingTodo = findTodoForMR(todos, props.mr);
-
-  if (props.mr.state !== "opened" && !existingTodo) {
+  if (props.mr.state !== "opened" && !props.mr.todo_id) {
     return null;
   }
 
-  if (existingTodo) {
+  if (props.mr.todo_id) {
     async function markAsDone() {
       try {
         await showToast({ style: Toast.Style.Animated, title: "Marking Todo as done..." });
-        await gitlab.post(`todos/${existingTodo!.id}/mark_as_done`);
+        await gitlab.post(`todos/${props.mr.todo_id}/mark_as_done`);
         showToast(Toast.Style.Success, "Done", "Todo is now marked as done");
-        performRefetch();
         props.finished?.();
       } catch (error) {
         showFailureToast(error, { title: "Failed to mark Todo as done" });
@@ -235,7 +230,6 @@ function MRTodoAction(props: {
       await showToast({ style: Toast.Style.Animated, title: "Adding To-Do..." });
       await gitlab.post(`projects/${props.mr.project_id}/merge_requests/${props.mr.iid}/todo`);
       showToast(Toast.Style.Success, "To do created");
-      performRefetch();
       props.finished?.();
     } catch (error) {
       showFailureToast(error, { title: "Failed to add to do" });

--- a/extensions/gitlab/src/components/mr_gql.ts
+++ b/extensions/gitlab/src/components/mr_gql.ts
@@ -71,16 +71,6 @@ const MERGE_REQUEST_LIST_FIELDS = gql`
         name
       }
     }
-    pipelines(first: 1) {
-      nodes {
-        id
-        status
-        detailedStatus {
-          label
-          name
-        }
-      }
-    }
     userPermissions {
       canMerge
       updateMergeRequest
@@ -88,6 +78,11 @@ const MERGE_REQUEST_LIST_FIELDS = gql`
     approvedBy {
       nodes {
         username
+      }
+    }
+    currentUserTodos(state: pending, first: 1) {
+      nodes {
+        id
       }
     }
     description
@@ -398,9 +393,9 @@ interface GqlMRListNode {
   };
   milestone?: { id: string; title: string } | null;
   headPipeline?: GqlPipelineNode | null;
-  pipelines?: { nodes: GqlPipelineNode[] };
   userPermissions?: { canMerge: boolean; updateMergeRequest: boolean };
   approvedBy?: { nodes: { username: string }[] };
+  currentUserTodos?: { nodes: { id: string }[] } | null;
 }
 
 interface GqlMRConnection {
@@ -490,16 +485,11 @@ function pipelineStatusFromGql(pipeline: GqlPipelineNode | null | undefined): st
   return undefined;
 }
 
-function mergeRequestListPipeline(node: GqlMRListNode): GqlPipelineNode | null | undefined {
-  return node.headPipeline ?? node.pipelines?.nodes?.[0];
-}
-
 export function gqlNodeToMergeRequest(node: GqlMRListNode, currentUsername?: string): MergeRequest {
   const approvedByCurrentUser = currentUsername
     ? (node.approvedBy?.nodes?.some((user) => user.username === currentUsername) ?? false)
     : undefined;
-  const listPipeline = mergeRequestListPipeline(node);
-  const headStatus = pipelineStatusFromGql(listPipeline);
+  const headStatus = pipelineStatusFromGql(node.headPipeline);
   return {
     title: node.title,
     web_url: node.webUrl,
@@ -543,6 +533,7 @@ export function gqlNodeToMergeRequest(node: GqlMRListNode, currentUsername?: str
     resolved_discussions_count: node.resolvedDiscussionsCount ?? undefined,
     resolvable_discussions_count: node.resolvableDiscussionsCount ?? undefined,
     approvals_count: node.approvedBy?.nodes?.length,
+    todo_id: node.currentUserTodos?.nodes[0]?.id ? getIdFromGqlId(node.currentUserTodos.nodes[0].id) : undefined,
     user:
       node.userPermissions || approvedByCurrentUser !== undefined
         ? {
@@ -553,7 +544,7 @@ export function gqlNodeToMergeRequest(node: GqlMRListNode, currentUsername?: str
         : undefined,
     head_pipeline: headStatus
       ? {
-          id: listPipeline?.id ? getIdFromGqlId(listPipeline.id) : 0,
+          id: node.headPipeline?.id ? getIdFromGqlId(node.headPipeline.id) : 0,
           status: headStatus,
         }
       : undefined,

--- a/extensions/gitlab/src/components/mr_pipelines.tsx
+++ b/extensions/gitlab/src/components/mr_pipelines.tsx
@@ -6,8 +6,7 @@ import { usePaginatedMRPipelines } from "./pipelines_data";
 
 export function MRPipelineList(props: { mr: MergeRequest }) {
   const { pipelines, isLoading, performRefetch, pagination } = usePaginatedMRPipelines({
-    cacheKey: `mr_pipelines_${props.mr.project_id}_${props.mr.iid}`,
-    projectFullPath: props.mr.project_full_path,
+    projectId: props.mr.project_id,
     mrIID: props.mr.iid,
   });
 

--- a/extensions/gitlab/src/components/mr_search.tsx
+++ b/extensions/gitlab/src/components/mr_search.tsx
@@ -1,7 +1,6 @@
-import { ActionPanel, Color, List } from "@raycast/api";
+import { ActionPanel, List } from "@raycast/api";
 import { useCachedState } from "@raycast/utils";
 import { useEffect, useMemo, useState } from "react";
-import { GitLabIcons } from "../icons";
 import { hashRecord } from "../utils";
 import { Project } from "../gitlabapi";
 import {
@@ -138,8 +137,11 @@ function SearchMergeRequestsEmptyView(props: {
 }
 
 export function SearchMyMergeRequests(props: { project?: Project } = {}) {
-  const [projectId, setProjectId] = useCachedState<string | undefined>("mr-search-project-id", undefined);
-  const { projects: myprojects, isLoading: projectsLoading } = useMyProjects();
+  const [project, setProject] = props.project
+    ? useState<Project | undefined>(props.project)
+    : useCachedState<Project | undefined>("mr-search-project", undefined);
+
+  const { projects: myprojects } = useMyProjects("", !props.project);
   const [mrState, setMrState] = useCachedState<MRState>("mr-search-state", MRState.opened);
   const [scope, setScope] = useCachedState<MRScope>("mr-search-scope", MRScope.all);
   const [orderBy, setOrderBy] = useCachedState<MRSearchOrderBy>("mr-search-order-by", MR_DEFAULT_ORDER_BY);
@@ -149,23 +151,11 @@ export function SearchMyMergeRequests(props: { project?: Project } = {}) {
   const toggleDraftOnly = () => setDraftOnly((current) => !current);
 
   useEffect(() => {
-    if (props.project) {
-      setProjectId(`${props.project.id}`);
-    }
-  }, [props.project?.id, setProjectId]);
-
-  const project = useMemo(
-    () => myprojects.find((candidate) => `${candidate.id}` === projectId),
-    [myprojects, projectId],
-  );
-  const hasProjects = myprojects.length > 0;
-
-  useEffect(() => {
-    if (!myprojects.length || projectId !== undefined) {
+    if (!myprojects.length || project !== undefined) {
       return;
     }
-    setProjectId(`${myprojects[0].id}`);
-  }, [myprojects, projectId, setProjectId]);
+    setProject(myprojects[0]);
+  }, [myprojects, project, setProject]);
 
   const params = useMemo(() => {
     const requestParams = buildMRListParams(search, scope, mrState);
@@ -183,7 +173,7 @@ export function SearchMyMergeRequests(props: { project?: Project } = {}) {
   } = usePaginatedMergeRequests({
     cacheKey: `mymrssearch_${project?.id ?? "none"}_${hashRecord(params)}`,
     buildParams: () => params,
-    project,
+    project: project,
     execute: !!project,
     keepPreviousData: true,
   });
@@ -194,7 +184,7 @@ export function SearchMyMergeRequests(props: { project?: Project } = {}) {
 
   return (
     <List
-      isLoading={projectsLoading || isLoading || (hasProjects && !project)}
+      isLoading={isLoading}
       pagination={pagination}
       searchText={search}
       onSearchTextChange={setSearch}
@@ -203,14 +193,11 @@ export function SearchMyMergeRequests(props: { project?: Project } = {}) {
       throttle
       searchBarAccessory={
         <MyProjectsDropdown
-          projects={myprojects}
-          value={projectId}
+          value={project ? `${project.id}` : undefined}
           includeAllItem={false}
-          onChange={(project) => {
-            const nextId = project ? `${project.id}` : undefined;
-            setProjectId((current) => (current === nextId ? current : nextId));
+          onChange={(nextProject) => {
+            setProject((current) => (current?.id === nextProject?.id ? current : nextProject));
           }}
-          storeValue
         />
       }
       actions={
@@ -233,53 +220,43 @@ export function SearchMyMergeRequests(props: { project?: Project } = {}) {
         </ActionPanel>
       }
     >
-      {!projectsLoading && !hasProjects ? (
-        <List.EmptyView
-          title="No Projects"
-          description="You have no GitLab projects with membership."
-          icon={{ source: GitLabIcons.project, tintColor: Color.PrimaryText }}
-        />
-      ) : (
-        <>
-          <List.Section title={sectionTitle}>
-            {data.map((mergeRequest) => (
-              <MRListItem
-                key={mergeRequest.id}
-                mr={mergeRequest}
-                refreshData={performRefetch}
-                showCIStatus={true}
-                isShowingDetail={isShowingDetail}
-                onToggleListDetails={toggleListDetails}
-                filterAction={
-                  <MergeRequestFilterSubmenu
-                    scope={scope}
-                    onSelectScope={setScope}
-                    state={mrState}
-                    onSelectState={setMrState}
-                    draftOnly={draftOnly}
-                    onToggleDraftOnly={toggleDraftOnly}
-                  />
-                }
-                sortAction={<MergeRequestSortSubmenu orderBy={orderBy} onSelect={setOrderBy} />}
-                refreshAction={<RefreshMergeRequestsAction onRefresh={performRefetch} />}
-              />
-            ))}
-          </List.Section>
-          <SearchMergeRequestsEmptyView
-            mrState={mrState}
-            onSelectState={setMrState}
-            scope={scope}
-            onSelectScope={setScope}
-            draftOnly={draftOnly}
-            onToggleDraftOnly={toggleDraftOnly}
-            orderBy={orderBy}
-            onSelectOrderBy={setOrderBy}
-            onRefresh={performRefetch}
+      <List.Section title={sectionTitle}>
+        {data.map((mergeRequest) => (
+          <MRListItem
+            key={mergeRequest.id}
+            mr={mergeRequest}
+            refreshData={performRefetch}
+            showCIStatus={true}
             isShowingDetail={isShowingDetail}
             onToggleListDetails={toggleListDetails}
+            filterAction={
+              <MergeRequestFilterSubmenu
+                scope={scope}
+                onSelectScope={setScope}
+                state={mrState}
+                onSelectState={setMrState}
+                draftOnly={draftOnly}
+                onToggleDraftOnly={toggleDraftOnly}
+              />
+            }
+            sortAction={<MergeRequestSortSubmenu orderBy={orderBy} onSelect={setOrderBy} />}
+            refreshAction={<RefreshMergeRequestsAction onRefresh={performRefetch} />}
           />
-        </>
-      )}
+        ))}
+      </List.Section>
+      <SearchMergeRequestsEmptyView
+        mrState={mrState}
+        onSelectState={setMrState}
+        scope={scope}
+        onSelectScope={setScope}
+        draftOnly={draftOnly}
+        onToggleDraftOnly={toggleDraftOnly}
+        orderBy={orderBy}
+        onSelectOrderBy={setOrderBy}
+        onRefresh={performRefetch}
+        isShowingDetail={isShowingDetail}
+        onToggleListDetails={toggleListDetails}
+      />
     </List>
   );
 }

--- a/extensions/gitlab/src/components/pipelines_data.ts
+++ b/extensions/gitlab/src/components/pipelines_data.ts
@@ -2,7 +2,7 @@ import { List } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { useRef } from "react";
 import { Pipeline } from "../gitlabapi";
-import { fetchMRPipelinesGqlPage, fetchProjectPipelinesGqlPage } from "./pipelines_gql";
+import { fetchMRPipelinesPage, fetchProjectPipelinesGqlPage } from "./pipelines_gql";
 
 export type ListPagination = List.Props["pagination"];
 
@@ -46,8 +46,7 @@ export function usePaginatedProjectPipelines(options: {
 }
 
 export function usePaginatedMRPipelines(options: {
-  cacheKey: string;
-  projectFullPath: string;
+  projectId: number;
   mrIID: number;
   execute?: boolean;
   keepPreviousData?: boolean;
@@ -57,22 +56,16 @@ export function usePaginatedMRPipelines(options: {
   performRefetch: () => void;
   pagination: ListPagination;
 } {
-  const projectFullPathRef = useRef(options.projectFullPath);
-  projectFullPathRef.current = options.projectFullPath;
-  const mrIIDRef = useRef(options.mrIID);
-  mrIIDRef.current = options.mrIID;
-
   const { data, isLoading, revalidate, pagination } = useCachedPromise(
-    (cacheKey: string) => async (paginationOptions: { page: number }) => {
-      const { pipelines, hasMore } = await fetchMRPipelinesGqlPage({
-        cacheKey,
+    (projectId: number, mrIID: number) => async (paginationOptions: { page: number }) => {
+      const { pipelines, hasMore } = await fetchMRPipelinesPage({
         page: paginationOptions.page,
-        projectFullPath: projectFullPathRef.current,
-        mrIID: mrIIDRef.current,
+        projectId,
+        mrIID,
       });
       return { data: pipelines, hasMore };
     },
-    [options.cacheKey],
+    [options.projectId, options.mrIID],
     {
       execute: options.execute,
       keepPreviousData: options.keepPreviousData,

--- a/extensions/gitlab/src/components/pipelines_gql.ts
+++ b/extensions/gitlab/src/components/pipelines_gql.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { getGitLabGQL } from "../common";
+import { getGitLabGQL, gitlab } from "../common";
 import { Pipeline, User } from "../gitlabapi";
 import { getIdFromGqlId } from "../utils";
 
@@ -21,7 +21,7 @@ export function normalizePipelineForList(data: Record<string, any>): Pipeline {
   pipeline.started_at = data.started_at ?? data.startedAt ?? "";
   pipeline.finished_at = data.finished_at ?? data.finishedAt ?? "";
   pipeline.duration = data.duration ?? 0;
-  pipeline.commit_title = data.commit_title ?? data.commitTitle ?? "";
+  pipeline.commit_title = data.commit_title ?? data.commitTitle ?? data.name ?? "";
   if (data.user?.name || data.user?.username) {
     const user = new User();
     user.name = data.user.name ?? "";
@@ -41,15 +41,10 @@ const PIPELINE_LIST_FIELDS = gql`
     status
     path
     ref
-    sha
+    name
     startedAt
-    duration
     createdAt
-    updatedAt
     finishedAt
-    commit {
-      title
-    }
     user {
       name
       username
@@ -68,25 +63,6 @@ const PROJECT_PIPELINES = gql`
         pageInfo {
           hasNextPage
           endCursor
-        }
-      }
-    }
-  }
-`;
-
-const MR_PIPELINES = gql`
-  ${PIPELINE_LIST_FIELDS}
-  query MergeRequestPipelines($fullPath: ID!, $iid: String!, $first: Int!, $after: String) {
-    project(fullPath: $fullPath) {
-      mergeRequest(iid: $iid) {
-        pipelines(first: $first, after: $after) {
-          nodes {
-            ...PipelineListFields
-          }
-          pageInfo {
-            hasNextPage
-            endCursor
-          }
         }
       }
     }
@@ -112,13 +88,10 @@ interface GqlPipelineNode {
   status: string;
   path: string;
   ref: string;
-  sha: string;
+  name?: string | null;
   startedAt?: string;
-  duration?: number;
   createdAt: string;
-  updatedAt: string;
   finishedAt?: string;
-  commit?: { title?: string | null } | null;
   user?: { name?: string | null; username?: string | null } | null;
 }
 
@@ -145,12 +118,9 @@ function gqlPipelineToPipeline(node: GqlPipelineNode): Pipeline {
     ref: node.ref,
     web_url: `${getGitLabGQL().url}${node.path}`,
     created_at: node.createdAt,
-    updated_at: node.updatedAt,
     started_at: node.startedAt,
-    duration: node.duration,
     finished_at: node.finishedAt,
-    sha: node.sha,
-    commit_title: node.commit?.title ?? "",
+    name: node.name,
     user: node.user,
   });
 }
@@ -170,27 +140,6 @@ async function queryProjectPipelinesConnection(
   const connection = response.data?.project?.pipelines as GqlPipelineConnection | undefined;
   if (!connection) {
     throw new Error("Could not load pipelines");
-  }
-  return connection;
-}
-
-async function queryMRPipelinesConnection(
-  projectFullPath: string,
-  mrIID: number,
-  variables: { first: number; after?: string },
-): Promise<GqlPipelineConnection> {
-  const response = await getGitLabGQL().client.query({
-    query: MR_PIPELINES,
-    variables: {
-      fullPath: projectFullPath,
-      iid: `${mrIID}`,
-      first: variables.first,
-      after: variables.after,
-    },
-  });
-  const connection = response.data?.project?.mergeRequest?.pipelines as GqlPipelineConnection | undefined;
-  if (!connection) {
-    throw new Error("Could not load merge request pipelines");
   }
   return connection;
 }
@@ -251,18 +200,43 @@ export async function fetchProjectPipelinesGqlPage(options: {
   });
 }
 
-export async function fetchMRPipelinesGqlPage(options: {
-  cacheKey: string;
+interface RestMrPipelineJson {
+  id: number;
+  iid: number;
+  project_id: number;
+  sha?: string;
+  ref: string;
+  status: string;
+  web_url: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export async function fetchMRPipelinesPage(options: {
   page: number;
-  projectFullPath: string;
+  projectId: number;
   mrIID: number;
 }): Promise<{ pipelines: Pipeline[]; hasMore: boolean }> {
-  const { cacheKey, page, projectFullPath, mrIID } = options;
-  return fetchPipelineGqlPage({
-    cacheKey,
-    page,
-    queryConnection: (variables) => queryMRPipelinesConnection(projectFullPath, mrIID, variables),
-  });
+  const { data, hasMore } = await gitlab.fetchPaged(
+    `projects/${options.projectId}/merge_requests/${options.mrIID}/pipelines`,
+    {},
+    options.page + 1,
+    PIPELINE_LIST_PAGE_SIZE,
+  );
+  const pipelines = ((data as RestMrPipelineJson[]) ?? []).map((pipeline) =>
+    normalizePipelineForList({
+      id: pipeline.id,
+      iid: pipeline.iid,
+      project_id: pipeline.project_id,
+      status: pipeline.status,
+      ref: pipeline.ref,
+      sha: pipeline.sha,
+      web_url: pipeline.web_url,
+      created_at: pipeline.created_at,
+      updated_at: pipeline.updated_at,
+    }),
+  );
+  return { pipelines, hasMore };
 }
 
 export async function fetchLatestPipelineIidByCommitShaGql(

--- a/extensions/gitlab/src/components/project.tsx
+++ b/extensions/gitlab/src/components/project.tsx
@@ -127,13 +127,21 @@ export function ProjectList() {
   );
 }
 
-export function useMyProjects(): {
+const MY_PROJECTS_PAGE_SIZE = 20;
+
+export function useMyProjects(
+  search = "",
+  execute = true,
+): {
   projects: Project[];
   isLoading?: boolean;
 } {
-  const { data, isLoading } = useCachedPromise(() => gitlab.getUserProjects({ search: "" }, true), [], {
-    initialData: [],
-  });
+  const { data, isLoading } = useCachedPromise(
+    async (query: string): Promise<Project[]> =>
+      gitlab.getUserProjects({ search: query, per_page: `${MY_PROJECTS_PAGE_SIZE}` }, false),
+    [search],
+    { initialData: [], keepPreviousData: true, execute },
+  );
   return {
     projects: data,
     isLoading,
@@ -142,26 +150,50 @@ export function useMyProjects(): {
 
 export function MyProjectsDropdown(props: {
   onChange: (project: Project | undefined) => void;
-  projects?: Project[];
   value?: string;
   storeValue?: boolean;
   includeAllItem?: boolean;
 }): React.ReactNode {
-  const { projects: hookProjects } = useMyProjects();
-  const myprojects = props.projects ?? hookProjects;
+  const [search, setSearch] = useState("");
+  const [selected, setSelected] = useState<Project>();
+  const { projects, isLoading } = useMyProjects(search);
   const includeAllItem = props.includeAllItem !== false;
+  const selectedId = props.value ?? (selected ? `${selected.id}` : undefined);
+  const { data: fetchedSelected } = useCachedPromise(
+    async (id: string): Promise<Project> => gitlab.getProject(Number(id)),
+    [selectedId ?? ""],
+    {
+      execute:
+        !!selectedId &&
+        selectedId !== "-" &&
+        !projects.some((project) => `${project.id}` === selectedId) &&
+        (!selected || `${selected.id}` !== selectedId),
+    },
+  );
+  const pinnedProject = selected && `${selected.id}` === selectedId ? selected : fetchedSelected;
+  const myprojects =
+    pinnedProject && !projects.some((project) => project.id === pinnedProject.id)
+      ? [pinnedProject, ...projects]
+      : projects;
+
   return (
     <List.Dropdown
       tooltip="Select Project"
+      placeholder="Search Projects..."
       value={props.value}
       storeValue={props.storeValue}
+      isLoading={isLoading}
+      throttle={true}
+      onSearchTextChange={setSearch}
       onChange={(newValue) => {
         if (includeAllItem && newValue === "-") {
+          setSelected(undefined);
           props.onChange(undefined);
           return;
         }
-        const selectedProject = myprojects.find((project) => `${project.id}` === newValue);
-        props.onChange(selectedProject);
+        const nextProject = myprojects.find((project) => `${project.id}` === newValue);
+        setSelected(nextProject);
+        props.onChange(nextProject);
       }}
     >
       {includeAllItem && (

--- a/extensions/gitlab/src/components/todo/utils.ts
+++ b/extensions/gitlab/src/components/todo/utils.ts
@@ -1,15 +1,7 @@
 import { useCachedPromise } from "@raycast/utils";
 import { getExcludeTodoAuthorUsernamesPreference, gitlab } from "../../common";
-import { MergeRequest, Project, Todo } from "../../gitlabapi";
+import { Project, Todo } from "../../gitlabapi";
 import { getErrorMessage } from "../../utils";
-
-export function findTodoForMR(todos: Todo[], mr: MergeRequest): Todo | undefined {
-  return todos.find(
-    (todo) =>
-      todo.target_type === "MergeRequest" &&
-      (todo.target?.id === mr.id || (todo.target?.iid === mr.iid && todo.target?.project_id === mr.project_id)),
-  );
-}
 
 export function useTodos(
   search?: string,

--- a/extensions/gitlab/src/components/todo_actions.tsx
+++ b/extensions/gitlab/src/components/todo_actions.tsx
@@ -11,7 +11,7 @@ export function ShowTodoDetailsAction(props: { todo: Todo }): React.ReactNode | 
     return (
       <Action.Push
         title="Show Details"
-        target={<MRDetail mr={jsonDataToMergeRequest(props.todo.target)} />}
+        target={<MRDetail mr={{ ...jsonDataToMergeRequest(props.todo.target), todo_id: props.todo.id }} />}
         icon={{ source: Icon.ArrowRight, tintColor: Color.PrimaryText }}
       />
     );

--- a/extensions/gitlab/src/gitlabapi.ts
+++ b/extensions/gitlab/src/gitlabapi.ts
@@ -517,6 +517,7 @@ export class MergeRequest {
   public resolved_discussions_count?: number;
   public resolvable_discussions_count?: number;
   public approvals_count?: number;
+  public todo_id?: number;
 }
 
 export class Pipeline {
@@ -662,16 +663,22 @@ function gitLabApiErrorDescription(json: GitLabApiErrorBody, statusCode: number)
   return `http status ${statusCode}`;
 }
 
-async function warnGitLabApiErrorResponse(response: Response, url: string): Promise<void> {
+async function warnGitLabApiErrorResponse(response: Response, url: string, method?: string): Promise<void> {
   const statusCode = response.status;
   let description = response.statusText || `http status ${statusCode}`;
+  let body: unknown;
   try {
-    const json = (await response.clone().json()) as GitLabApiErrorBody;
-    description = gitLabApiErrorDescription(json, statusCode);
+    body = await response.clone().json();
+    description = gitLabApiErrorDescription(body as GitLabApiErrorBody, statusCode);
   } catch {
-    // non-JSON error body
+    try {
+      body = await response.clone().text();
+    } catch {
+      // unreadable error body
+    }
   }
-  console.warn(`GitLab API ${statusCode}: ${description} (${url})`);
+  const verb = method?.toUpperCase() || "GET";
+  console.warn(`GitLab API ${verb} ${statusCode}: ${description} (${url})`, body ?? "");
 }
 
 /**
@@ -684,6 +691,17 @@ function isReplayableBody(body: unknown): boolean {
   if (typeof requestBody.pipe === "function" || typeof requestBody.read === "function") return false;
   if (typeof requestBody.getBuffer === "function" && typeof requestBody.getBoundary === "function") return false;
   return true;
+}
+
+function logGitLabApiRequest(url: string, method?: string, body?: unknown): void {
+  const verb = method?.toUpperCase() || "GET";
+  if (body != null && typeof body === "string") {
+    console.log(`GitLab API → ${verb} ${url}`, body);
+  } else if (body != null && isReplayableBody(body)) {
+    console.log(`GitLab API → ${verb} ${url}`, body);
+  } else {
+    console.log(`GitLab API → ${verb} ${url}`);
+  }
 }
 
 async function toJsonOrError(response: Response): Promise<any> {
@@ -741,6 +759,10 @@ export class GitLab {
     return async (...args: Parameters<typeof fetch>) => {
       const [fullUrl, options] = args;
       const agent = getHttpAgent();
+      const requestUrl = typeof fullUrl === "string" ? fullUrl : fullUrl.toString();
+      const requestMethod = typeof options?.method === "string" ? options.method : "GET";
+      logGitLabApiRequest(requestUrl, requestMethod, options?.body);
+
       const send = async (token: string) =>
         fetch(fullUrl, {
           ...options,
@@ -764,19 +786,20 @@ export class GitLab {
       ) {
         try {
           const fresh = await this.resolveToken(true);
+          logGitLabApiRequest(`${requestUrl} (oauth retry)`, requestMethod);
           const retryResponse = await send(fresh);
           if (!retryResponse.ok) {
-            await warnGitLabApiErrorResponse(retryResponse, typeof fullUrl === "string" ? fullUrl : fullUrl.toString());
+            await warnGitLabApiErrorResponse(retryResponse, requestUrl, requestMethod);
           }
           return retryResponse;
         } catch {
-          await warnGitLabApiErrorResponse(response, typeof fullUrl === "string" ? fullUrl : fullUrl.toString());
+          await warnGitLabApiErrorResponse(response, requestUrl, requestMethod);
           return response;
         }
       }
 
       if (!response.ok) {
-        await warnGitLabApiErrorResponse(response, typeof fullUrl === "string" ? fullUrl : fullUrl.toString());
+        await warnGitLabApiErrorResponse(response, requestUrl, requestMethod);
       }
       return response;
     };


### PR DESCRIPTION
## Description

GitLab extension v1.2.1 — MR todos, project search, and API logging improvements.

- Show MR todo state from the list query; add or mark todos done without loading the full todos list
- Add searchable project dropdown with server-side search and pinned selection in Search MR and project pickers
- Cache the selected project in Search MR instead of only the project ID
- Fetch merge request pipeline lists via REST API
- Log GitLab REST and GraphQL requests and improve API error diagnostics

## Screencast

Not applicable — incremental improvements to existing commands; no new UI surfaces or registration flows.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)