### PR TITLE
fix(zotero): cap rendered results to prevent OOM on large libraries

### DIFF
--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zotero Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-07-17
 
 - Fix "Worker terminated due to reaching memory limit: JS heap out of memory" crash on large libraries when browsing or running broad searches: the command rendered every matching item (the whole library on an empty query, or hundreds/thousands for a broad query), and Raycast's per-item detail + action list grows the command worker's memory until it is killed. Results are now capped at 100 rendered items (the section header shows "Top 100 — refine your search to see more" when capped), which keeps the render footprint bounded. Follow-up to #29478 / #29250
 

--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Fixes] - {PR_MERGE_DATE}
 
-- Fix "Worker terminated due to reaching memory limit: JS heap out of memory" crash on large libraries when browsing or running broad searches: the command rendered every matching item (the whole library on an empty query, or hundreds/thousands for a broad query), and Raycast's per-item detail + action list grows the command worker's memory until it is killed. Results are now capped at 100 rendered items, which keeps the render footprint bounded. Follow-up to #29478 / #29250
+- Fix "Worker terminated due to reaching memory limit: JS heap out of memory" crash on large libraries when browsing or running broad searches: the command rendered every matching item (the whole library on an empty query, or hundreds/thousands for a broad query), and Raycast's per-item detail + action list grows the command worker's memory until it is killed. Results are now capped at 100 rendered items (the section header shows "Top 100 — refine your search to see more" when capped), which keeps the render footprint bounded. Follow-up to #29478 / #29250
 
 ## [Fixes] - 2026-07-16
 

--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zotero Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Fix "Worker terminated due to reaching memory limit: JS heap out of memory" crash on large libraries when browsing or running broad searches: the command rendered every matching item (the whole library on an empty query, or hundreds/thousands for a broad query), and Raycast's per-item detail + action list grows the command worker's memory until it is killed. Results are now capped at 100 rendered items, which keeps the render footprint bounded. Follow-up to #29478 / #29250
+
 ## [Fixes] - 2026-07-16
 
 - Prevent a memory spike and cache corruption when several searches run at once (e.g. fast typing right after opening the command): database opens are serialized, the data rebuild is de-duplicated so concurrent searches share one build, and the cache is written atomically (temp file + rename) so an interrupted or interleaved write can no longer leave a truncated cache that crashes on the next launch. Follow-up to #29478 / #29250

--- a/extensions/zotero/src/common/View.tsx
+++ b/extensions/zotero/src/common/View.tsx
@@ -11,7 +11,7 @@ import {
   open,
 } from "@raycast/api";
 import { dirname, join } from "path";
-import { RefData, Preferences, resolveHome } from "./zoteroApi";
+import { RefData, Preferences, resolveHome, MAX_RENDER_RESULTS } from "./zoteroApi";
 import { useVisitedUrls } from "./useVisitedUrls";
 import {
   exportRef,
@@ -241,7 +241,15 @@ export const View = ({
       searchBarAccessory={<CollectionDropdown onSelection={setCollection} collections={collections} />}
     >
       {sectionNames.map((sectionName, sectionIndex) => (
-        <List.Section key={sectionIndex} title={sectionName} subtitle={`${queryResults[sectionIndex].length}`}>
+        <List.Section
+          key={sectionIndex}
+          title={sectionName}
+          subtitle={
+            queryResults[sectionIndex].length >= MAX_RENDER_RESULTS
+              ? `Top ${MAX_RENDER_RESULTS} — refine your search to see more`
+              : `${queryResults[sectionIndex].length}`
+          }
+        >
           {queryResults[sectionIndex]
             .filter((item) => item.collection?.includes(collection) || collection == "All")
             .map((item) => {

--- a/extensions/zotero/src/common/zoteroApi.ts
+++ b/extensions/zotero/src/common/zoteroApi.ts
@@ -506,6 +506,14 @@ const parseQuery = (q: string) => {
   return { qss, tss };
 };
 
+// Cap how many results are rendered at once. Raycast renders every List item
+// with a full detail markdown and ~15-20 actions; rendering the whole library
+// (empty query) or a broad-query result of hundreds/thousands grows the
+// command worker's native render memory until it is killed ("Worker terminated
+// due to reaching memory limit: JS heap out of memory") on large libraries.
+// 100 is far more than a user scans and keeps the render footprint bounded.
+const MAX_RENDER_RESULTS = 100;
+
 export const searchResources = async (q: string): Promise<RefData[]> => {
   const preferences: Preferences = getPreferenceValues();
 
@@ -607,7 +615,7 @@ export const searchResources = async (q: string): Promise<RefData[]> => {
   const { qss, tss } = parseQuery(q);
 
   if (!qss.trim() && tss.length < 1) {
-    return ret;
+    return ret.slice(0, MAX_RENDER_RESULTS);
   }
 
   const options = {
@@ -665,5 +673,8 @@ export const searchResources = async (q: string): Promise<RefData[]> => {
     query["$and"].push({ $and: tss.map((x) => ({ tags: x.replace(/\+/gi, " ") })) });
   }
 
-  return new Fuse(ret, options).search(query).map((x) => x.item);
+  return new Fuse(ret, options)
+    .search(query)
+    .slice(0, MAX_RENDER_RESULTS)
+    .map((x) => x.item);
 };

--- a/extensions/zotero/src/common/zoteroApi.ts
+++ b/extensions/zotero/src/common/zoteroApi.ts
@@ -512,7 +512,7 @@ const parseQuery = (q: string) => {
 // command worker's native render memory until it is killed ("Worker terminated
 // due to reaching memory limit: JS heap out of memory") on large libraries.
 // 100 is far more than a user scans and keeps the render footprint bounded.
-const MAX_RENDER_RESULTS = 100;
+export const MAX_RENDER_RESULTS = 100;
 
 export const searchResources = async (q: string): Promise<RefData[]> => {
   const preferences: Preferences = getPreferenceValues();


### PR DESCRIPTION
## Description

Follow-up to #29478 / #29492 (which fixed #29250).

Those PRs stopped the extension from loading the whole SQLite database into memory and made cache rebuilds concurrency-safe. However, `Search Zotero` still crashes with:

> Worker terminated due to reaching memory limit: JS heap out of memory

on large libraries — but for a different reason: the command **renders every matching item**. On an empty query it renders the entire library (`runQuery("")` at mount + on empty), and a broad query returns hundreds/thousands of matches. Raycast renders each `List.Item` with a full `List.Item.Detail` markdown (title/authors/abstract/notes) **and ~15-20 action components**, so the render tree grows the command worker's native memory on each query until the worker is killed.

### Reproduction

On a real ~3700-item library, running the exact store code as a development extension:

- Empty query rendered **3718** items; broad queries rendered **945** ("ord"), **772** ("order"), etc.
- RSS ratcheted from ~**210 MB** up to ~**403 MB** across a couple dozen queries, then the worker was terminated.

### Fix

Cap the number of results handed to the list at **100** (both the empty-query "browse" case and query results). 100 is far more than a user scans in a result list, and it keeps the render footprint bounded.

### Verification

Same library, same stress test (browsing + broad queries like "ord"/"order"/"the" + sustained typing, ~30 queries):

- Every render is now ≤ 100 items.
- RSS stays bounded (~**230-260 MB**) instead of ratcheting to ~400 MB.
- **No crash.**

`ray build` + `ray lint` are clean. Behavior is otherwise unchanged; only the number of simultaneously-rendered rows is bounded.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I ran `npm run build` and it passed (`ray build` + `ray lint` clean)
- [x] I tested the change locally against a large (~3700-item) library
- [x] I updated the `CHANGELOG.md`