### PR TITLE
Update `Coolify` extension - handle status is exited

### DIFF
--- a/extensions/coolify/CHANGELOG.md
+++ b/extensions/coolify/CHANGELOG.md
@@ -3,14 +3,14 @@
 ## [Resources Enhancements] - {PR_MERGE_DATE}
 
 - In `Resources`:
-    - view status tooltip
-    - handle when status is "exited" instead of "exited:..."
+    1. view status tooltip
+    2. handle when status is "exited" instead of "exited:..."
 
 ## [Delete Project + Better Error Message] - 2025-11-11
 
 - Better Error Messages are shown
 - In `Projects`:
-    - Delete Project
+    1. Delete Project
 
 ## [Add Windows Support] - 2025-11-03
 

--- a/extensions/coolify/CHANGELOG.md
+++ b/extensions/coolify/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coolify Changelog
 
-## [Resources Enhancements] - {PR_MERGE_DATE}
+## [Resources Enhancements] - 2026-07-17
 
 - In `Resources`:
     1. view status tooltip

--- a/extensions/coolify/CHANGELOG.md
+++ b/extensions/coolify/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Coolify Changelog
 
+## [Resources Enhancements] - {PR_MERGE_DATE}
+
+- In `Resources`:
+    - view status tooltip
+    - handle when status is "exited" instead of "exited:..."
+
 ## [Delete Project + Better Error Message] - 2025-11-11
 
 - Better Error Messages are shown

--- a/extensions/coolify/README.md
+++ b/extensions/coolify/README.md
@@ -10,8 +10,9 @@ This is a Raycast extension for [Coolify](https://coolify.io/) - _An open-source
 
 **Coolify** is being updated all the time so the extension might not perform well on all versions. This extension has been tested on the following:
 
-1. **v4.0.0-beta.419**
-1. **v4.0.0-beta.434**
+1. **v4.1.2**
+2. **v4.0.0-beta.434**
+3. **v4.0.0-beta.419**
 
 ## 🚀 Getting Started
 

--- a/extensions/coolify/package-lock.json
+++ b/extensions/coolify/package-lock.json
@@ -7,7 +7,7 @@
       "name": "coolify",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.103.5",
+        "@raycast/api": "^1.104.1",
         "@raycast/utils": "^2.2.2"
       },
       "devDependencies": {
@@ -1182,9 +1182,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.103.5",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.103.5.tgz",
-      "integrity": "sha512-LPI9bIr+Q6NSy+vhhn8uqy73+oKEZsiUMkW5FDNBw0ngV32atAZH7df4ZGSNba2+HTZKquYdmoEycWeRFnDWRA==",
+      "version": "1.104.1",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.1.tgz",
+      "integrity": "sha512-5v52JDzAAoCA6/JOoBfsgCXK4fzIY02lvMH0IA3ghuxZuk8i2ID2rtPkTuIAbebpkILADB7gP4yaBphkMLiCJA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.5.4",

--- a/extensions/coolify/package.json
+++ b/extensions/coolify/package.json
@@ -66,7 +66,7 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.103.5",
+    "@raycast/api": "^1.104.1",
     "@raycast/utils": "^2.2.2"
   },
   "devDependencies": {
@@ -78,7 +78,7 @@
     "typescript": "^5.8.2"
   },
   "scripts": {
-    "build": "ray build -e dist",
+    "build": "ray build",
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",

--- a/extensions/coolify/src/lib/utils.ts
+++ b/extensions/coolify/src/lib/utils.ts
@@ -18,7 +18,9 @@ export function isValidCoolifyUrl() {
 }
 
 export function getResourceColor(resource: Resource | ResourceDetails) {
-  return resource.status.startsWith("running:") ? Color.Green : Color.Red;
+  if (resource.status.startsWith("running")) return Color.Green;
+  if (resource.status.startsWith("starting")) return Color.Yellow;
+  return Color.Red;
 }
 
 export function capitalizeFirstLetter(text: string) {

--- a/extensions/coolify/src/resources.tsx
+++ b/extensions/coolify/src/resources.tsx
@@ -53,7 +53,7 @@ export default function Resources() {
         resources.map((resource) => (
           <List.Item
             key={resource.uuid}
-            icon={{ source: Icon.CircleFilled, tintColor: getResourceColor(resource) }}
+            icon={{ source: Icon.CircleFilled, tintColor: getResourceColor(resource), tooltip: resource.status }}
             title={resource.name}
             subtitle={resource.type}
             accessories={[
@@ -88,7 +88,7 @@ export default function Resources() {
                     />
                   </>
                 )}
-                {resource.status.startsWith("exited:") && (
+                {resource.status.startsWith("exited") && (
                   <Action
                     icon={{ source: Icon.Play, tintColor: Color.Yellow }}
                     title="Deploy"


### PR DESCRIPTION
## Description

- In `Resources`:
    - view status tooltip
    - handle when status is "exited" instead of "exited:..."

## Screencast

N/A - simple change.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)