### PR TITLE
[Slack] Add signature to updated messages

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Changelog
 
+## [Add AI signature to updated Slack messages] - 2026-07-17
+
+- Replace the “Sent via Raycast” signature with “Updated with Raycast AI” when the `update-message` AI tool edits a message.
+
 ## [Add Slack update message AI tool] - 2026-07-16
 
 - Add an `update-message` AI tool that edits messages posted by the authenticated Slack user and returns a permalink to the updated message.

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Add AI signature to updated Slack messages] - 2026-07-17
 
-- Replace the “Sent via Raycast” signature with “Updated with Raycast AI” when the `update-message` AI tool edits a message.
+- Replace the “Sent via Raycast” signature with “Updated via Raycast” when the `update-message` AI tool edits a message.
 
 ## [Add Slack update message AI tool] - 2026-07-16
 

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Add AI signature to updated Slack messages] - {PR_MERGE_DATE}
+## [Add AI signature to updated Slack messages] - 2026-07-17
 
 - Replace the “Sent via Raycast” signature with “Updated via Raycast” when the `update-message` AI tool edits a message.
 

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Add AI signature to updated Slack messages] - 2026-07-17
+## [Add AI signature to updated Slack messages] - {PR_MERGE_DATE}
 
 - Replace the “Sent via Raycast” signature with “Updated via Raycast” when the `update-message` AI tool edits a message.
 

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -136,8 +136,8 @@
     },
     {
       "title": "AI Message Signature",
-      "label": "Add “Sent via Raycast” to messages sent with AI",
-      "description": "Show a subtle “Sent via Raycast” note below messages sent by the Send Message and Reply to Thread AI tools.",
+      "label": "Add a Raycast signature to messages written with AI",
+      "description": "Show a subtle “Sent via Raycast” or “Updated with Raycast AI” note below messages written by AI tools.",
       "name": "showAiMessageSignature",
       "type": "checkbox",
       "required": false,

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -137,7 +137,7 @@
     {
       "title": "AI Message Signature",
       "label": "Add a Raycast signature to messages written with AI",
-      "description": "Show a subtle “Sent via Raycast” or “Updated with Raycast AI” note below messages written by AI tools.",
+      "description": "Show a subtle “Sent via Raycast” or “Updated via Raycast” note below messages written by AI tools.",
       "name": "showAiMessageSignature",
       "type": "checkbox",
       "required": false,

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -137,7 +137,7 @@
     {
       "title": "AI Message Signature",
       "label": "Add a Raycast signature to messages written with AI",
-      "description": "Show a subtle “Sent via Raycast” or “Updated via Raycast” note below messages written by AI tools.",
+      "description": "Show a subtle Raycast signature below messages written by AI tools.",
       "name": "showAiMessageSignature",
       "type": "checkbox",
       "required": false,

--- a/extensions/slack/src/tools/message-signature.ts
+++ b/extensions/slack/src/tools/message-signature.ts
@@ -65,7 +65,7 @@ export function getAiMessageBlocks(text: string, action: "sent" | "updated" = "s
       elements: [
         {
           type: "mrkdwn",
-          text: action === "updated" ? "Updated with Raycast AI" : "Sent via Raycast",
+          text: action === "updated" ? "Updated via Raycast" : "Sent via Raycast",
         },
       ],
     },

--- a/extensions/slack/src/tools/message-signature.ts
+++ b/extensions/slack/src/tools/message-signature.ts
@@ -38,7 +38,7 @@ function splitTextForSectionBlocks(text: string): string[] | undefined {
   return chunks;
 }
 
-export function getAiMessageBlocks(text: string): KnownBlock[] | undefined {
+export function getAiMessageBlocks(text: string, action: "sent" | "updated" = "sent"): KnownBlock[] | undefined {
   const { showAiMessageSignature } = getPreferenceValues<Preferences>();
 
   if (!showAiMessageSignature) {
@@ -65,7 +65,7 @@ export function getAiMessageBlocks(text: string): KnownBlock[] | undefined {
       elements: [
         {
           type: "mrkdwn",
-          text: "Sent via Raycast",
+          text: action === "updated" ? "Updated with Raycast AI" : "Sent via Raycast",
         },
       ],
     },

--- a/extensions/slack/src/tools/update-message.ts
+++ b/extensions/slack/src/tools/update-message.ts
@@ -1,5 +1,6 @@
 import { getSlackWebClient } from "../shared/client/WebClient";
 import { withSlackClient } from "../shared/withSlackClient";
+import { getAiMessageBlocks } from "./message-signature";
 
 type Input = {
   /**
@@ -39,7 +40,7 @@ async function updateMessage(input: Input) {
     channel: input.channel,
     ts: input.messageTs,
     text,
-    blocks: [],
+    blocks: getAiMessageBlocks(text, "updated") ?? [],
   });
 
   if (response.error) {


### PR DESCRIPTION
## Description

Updates the Slack `update-message` AI tool to replace the existing “Sent via Raycast” footer with “Updated via Raycast”. This makes it clear that the message was updated rather than originally sent through Raycast while keeping the signature wording consistent.

The signature continues to respect the existing AI Message Signature preference. When the preference is disabled, the tool clears existing blocks and updates the message without a footer.

Also updates the preference copy and changelog.

## Checks

* `npm run lint`
* `npm run build`
* `npx tsc --noEmit`
