### PR TITLE
Update gh-pr-tracker Extension

### DIFF
--- a/extensions/gh-pr-tracker/CHANGELOG.md
+++ b/extensions/gh-pr-tracker/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the **GitHub Pull Requests** Raycast extension are docume
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.0] - {PR_MERGE_DATE}
+
+### Added
+
+- **Unread PR Alert** menu bar command (macOS) — shows how many pull requests have unread changes as a menu bar badge, refreshing automatically every 5 minutes and hiding when you are all caught up.
+- The menu bar dropdown lists the 5 most recently updated PRs with unread changes; when there are more, a **Show all …** item opens the full list.
+- Selecting a PR in the dropdown opens **View Pull Requests** with that PR expanded and the rest collapsed.
+
+### Changed
+
+- **View Pull Requests** and **Unread PR Alert** now share the same cached PR data, so opening either command benefits from data already fetched by the other.
+
 ## [1.0.1] - 2026-07-09
 
 ### Changed

--- a/extensions/gh-pr-tracker/CHANGELOG.md
+++ b/extensions/gh-pr-tracker/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the **GitHub Pull Requests** Raycast extension are docume
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.1.0] - {PR_MERGE_DATE}
+## [1.1.0] - 2026-07-18
 
 ### Added
 

--- a/extensions/gh-pr-tracker/README.md
+++ b/extensions/gh-pr-tracker/README.md
@@ -1,4 +1,5 @@
 # GitHub Pull Requests
+
 A [Raycast](https://raycast.com) extension that tracks unread pull request activity across your GitHub or GitHub Enterprise repositories. Never miss a review, comment, or push again.
 
 ## Features
@@ -10,6 +11,7 @@ A [Raycast](https://raycast.com) extension that tracks unread pull request activ
 - **Event filters** — Toggle which activity types appear (reviews, comments, commits, labels, force pushes, etc.).
 - **Local caching** — Cached data displays instantly while a background refresh runs.
 - **Demo mode** — Built-in sample data for trying out the extension without a real token.
+- **Menu bar alert** — A background command refreshes every 5 minutes and shows how many PRs have unread changes in the macOS menu bar (macOS only). Click a PR to jump straight into it in **View Pull Requests**.
 
 ## Setup
 
@@ -30,6 +32,10 @@ Open Raycast and run **View Pull Requests**. The command shows a list of open PR
 - **Select an activity item** to view full detail (diff hunks, conversation threads, review verdicts).
 - **Mark as Read** — Use `CMD`/`CTRL` + `D` to mark a single item as read, `CMD`/`CTRL` + `S` to mark an entire PR as read, or mark all PRs as read with `CMD`/`CTRL` + `Shift` + `S`.
 - **Toggle Event Filters** — show/hide specific activity types.
+
+### Unread PR Alert (menu bar)
+
+Enable the **Unread PR Alert** command on MacOS to show a menu bar item with the number of PRs that have unread changes. It refreshes automatically every 5 minutes and shares its data with **View Pull Requests**, so opening the main command shows already-cached data. Clicking a PR in the dropdown opens **View Pull Requests** on that PR. The menu bar item disappears if there are no new unread changes.
 
 ## License
 

--- a/extensions/gh-pr-tracker/package-lock.json
+++ b/extensions/gh-pr-tracker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gh-pr-tracker",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gh-pr-tracker",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.21",
@@ -1191,7 +1191,6 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1251,7 +1250,6 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -1456,7 +1454,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1760,7 +1757,6 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -2426,7 +2422,6 @@
       "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2453,7 +2448,6 @@
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2590,7 +2584,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2642,7 +2635,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/gh-pr-tracker/package.json
+++ b/extensions/gh-pr-tracker/package.json
@@ -9,7 +9,7 @@
     "Developer Tools"
   ],
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "commands": [
     {
       "name": "unread-updates",
@@ -17,6 +17,14 @@
       "subtitle": "GitHub Pull Requests",
       "description": "Shows unread pull request activity",
       "mode": "view"
+    },
+    {
+      "name": "unread-menu-bar",
+      "title": "Unread PR Alert",
+      "subtitle": "GitHub Pull Requests",
+      "description": "Menu bar alert showing how many pull requests have unread changes",
+      "mode": "menu-bar",
+      "interval": "5m"
     }
   ],
   "preferences": [

--- a/extensions/gh-pr-tracker/src/unread-menu-bar.tsx
+++ b/extensions/gh-pr-tracker/src/unread-menu-bar.tsx
@@ -1,0 +1,117 @@
+import { MenuBarExtra, Icon, launchCommand, LaunchType, type LaunchProps } from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import { useEffect, useState } from "react";
+import { fetchPRsWithActivity } from "./api";
+import { loadCachedPRs, saveCachedPRs } from "./cache";
+import { loadSeen, saveSeen } from "./seen";
+import { loadEventFilters } from "./event-filters";
+import { computePrsWithUnseen, type PRWithUnseen } from "./utils";
+import { prKey, type PRWithActivity } from "./types";
+
+const MENU_ICON = Icon.Bell;
+
+type MenuBarContext = { source?: string };
+
+function truncateTitle(title: string, max = 40): string {
+  const clean = title.replace(/\s+/g, " ").trim();
+  return clean.length > max ? clean.slice(0, max - 1) + "…" : clean;
+}
+
+/** Compute the unread-PR list from the shared cache without hitting the network. */
+async function loadFromCache(): Promise<PRWithUnseen[]> {
+  const [prs, seen, filters] = await Promise.all([loadCachedPRs(), loadSeen(), loadEventFilters()]);
+  if (!prs) return [];
+  return computePrsWithUnseen(prs, seen, filters);
+}
+
+/** Fetch fresh data, update the shared cache/seen, and compute the unread-PR list. */
+async function fetchAndCompute(): Promise<PRWithUnseen[]> {
+  const prs = await fetchPRsWithActivity();
+  const seen = await loadSeen();
+  const activePrKeys = new Set(prs.map((pr) => prKey(pr)));
+  await saveSeen(seen, activePrKeys); // prune seen entries for closed PRs
+  await saveCachedPRs(prs); // shared cache — benefits the main command
+  const filters = await loadEventFilters();
+  return computePrsWithUnseen(prs, seen, filters);
+}
+
+/** Open the main command with this PR expanded and all others collapsed. */
+async function openFocused(pr: PRWithActivity): Promise<void> {
+  try {
+    await launchCommand({
+      name: "unread-updates",
+      type: LaunchType.UserInitiated,
+      context: { focusPrKey: prKey(pr) },
+    });
+  } catch {
+    // main command may be unavailable; ignore
+  }
+}
+
+/** Open the main command normally — all PRs collapsed, default selection. */
+async function openAll(): Promise<void> {
+  try {
+    await launchCommand({ name: "unread-updates", type: LaunchType.UserInitiated });
+  } catch {
+    // main command may be unavailable; ignore
+  }
+}
+
+export default function Command(props: LaunchProps<{ launchContext?: MenuBarContext }>) {
+  const skipFetch = props.launchContext?.source === "view-refresh";
+  const [cached, setCached] = useState<PRWithUnseen[] | undefined>(undefined);
+
+  // Seed instant render from the shared cache.
+  useEffect(() => {
+    loadFromCache().then(setCached);
+  }, []);
+
+  const { data, isLoading } = usePromise(
+    async (skip: boolean) => (skip ? loadFromCache() : fetchAndCompute()),
+    [skipFetch],
+    {
+      onError: () => {
+        // Background command: no toast UI. Keep any stale cached data; retry next interval.
+      },
+    },
+  );
+
+  const list = data ?? cached;
+
+  // Nothing to show yet: while a fetch is in flight, keep the command alive with a bare
+  // loading item (never a "0" badge or empty menu); once settled, hide the item entirely
+  // (zero unread, or error with no cache — retry on the next interval).
+  if (!list || list.length === 0) {
+    return isLoading ? <MenuBarExtra isLoading icon={MENU_ICON} /> : null;
+  }
+
+  const count = list.length;
+
+  return (
+    <MenuBarExtra
+      isLoading={isLoading}
+      icon={MENU_ICON}
+      title={String(count)}
+      tooltip={`${count} pull request${count !== 1 ? "s" : ""} with unread changes`}
+    >
+      <MenuBarExtra.Section title={`${count} PR${count !== 1 ? "s" : ""} with unread changes`}>
+        {list.slice(0, 5).map(({ pr, unseen }) => (
+          <MenuBarExtra.Item
+            key={prKey(pr)}
+            title={`#${pr.number} — ${truncateTitle(pr.title)}`}
+            subtitle={`${pr.repo.split("/").pop() ?? pr.repo} · ${unseen.length} update${unseen.length !== 1 ? "s" : ""}`}
+            onAction={() => openFocused(pr)}
+          />
+        ))}
+        {count > 5 && (
+          <MenuBarExtra.Item
+            key="show-all"
+            icon={Icon.Ellipsis}
+            title={`Show all ${count} unread PRs…`}
+            onAction={openAll}
+          />
+        )}
+      </MenuBarExtra.Section>
+    </MenuBarExtra>
+  );
+}

--- a/extensions/gh-pr-tracker/src/unread-updates.tsx
+++ b/extensions/gh-pr-tracker/src/unread-updates.tsx
@@ -1,4 +1,17 @@
-import { List, Detail, Action, ActionPanel, Icon, Color, showToast, Toast, Keyboard } from "@raycast/api";
+import {
+  List,
+  Detail,
+  Action,
+  ActionPanel,
+  Icon,
+  Color,
+  showToast,
+  Toast,
+  Keyboard,
+  launchCommand,
+  LaunchType,
+  type LaunchProps,
+} from "@raycast/api";
 import { usePromise } from "@raycast/utils";
 import { useState, useEffect } from "react";
 import { fetchPRsWithActivity } from "./api";
@@ -12,7 +25,13 @@ import {
   ALL_ACTIVITY_TYPES,
   type EventFilters,
 } from "./event-filters";
-import { getUnseenActivity, getAllActivity, renderActivityMarkdown, renderPRSummaryMarkdown } from "./utils";
+import {
+  getUnseenActivity,
+  getAllActivity,
+  renderActivityMarkdown,
+  renderPRSummaryMarkdown,
+  computePrsWithUnseen,
+} from "./utils";
 import type { ActivityItem, PRWithActivity, SeenMap } from "./types";
 import { prKey } from "./types";
 
@@ -60,7 +79,29 @@ function isReplyComment(item: ActivityItem, pr: PRWithActivity): boolean {
 
 // ─── Main command ────────────────────────────────────────────────────────────
 
-export default function UnreadUpdates() {
+/**
+ * Nudge the menu-bar command to recompute from the shared cache/seen (no network fetch).
+ * Called only on data fetches (view open / revalidate) — NOT on mark-as-read, which stays a
+ * purely local update so rapid marking isn't blocked by the launchCommand spawn cost. The
+ * badge otherwise refreshes on the menu bar's own interval and whenever the user clicks it
+ * (a click re-reads the cache+seen, so it reflects marks immediately).
+ */
+async function refreshMenuBar(): Promise<void> {
+  try {
+    await launchCommand({
+      name: "unread-menu-bar",
+      type: LaunchType.Background,
+      context: { source: "view-refresh" },
+    });
+  } catch {
+    // menu-bar command may be disabled; ignore
+  }
+}
+
+type FocusContext = { focusPrKey?: string };
+
+export default function UnreadUpdates(props: LaunchProps<{ launchContext?: FocusContext }>) {
+  const focusPrKey = props.launchContext?.focusPrKey;
   const [seenMap, setSeenMap] = useState<SeenMap>({});
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const [displayPrs, setDisplayPrs] = useState<PRWithActivity[] | undefined>(undefined);
@@ -76,7 +117,7 @@ export default function UnreadUpdates() {
       if (cached) {
         setDisplayPrs(cached);
         const allCollapsed: Record<string, boolean> = {};
-        for (const pr of cached) allCollapsed[prKey(pr)] = true;
+        for (const pr of cached) allCollapsed[prKey(pr)] = prKey(pr) !== focusPrKey;
         setCollapsed(allCollapsed);
       }
     });
@@ -94,6 +135,8 @@ export default function UnreadUpdates() {
     await saveSeen(fetchedSeen);
     setSeenMap(fetchedSeen);
     await saveCachedPRs(fetchedPrs);
+    // Nudge the menu-bar command to re-render from the fresh shared cache.
+    await refreshMenuBar();
 
     setDisplayPrs(fetchedPrs);
     // Preserve existing collapsed state; default new PRs to collapsed
@@ -101,7 +144,7 @@ export default function UnreadUpdates() {
       const updated: Record<string, boolean> = {};
       for (const pr of fetchedPrs) {
         const key = prKey(pr);
-        updated[key] = prev[key] !== undefined ? prev[key] : true;
+        updated[key] = prev[key] !== undefined ? prev[key] : key !== focusPrKey;
       }
       return updated;
     });
@@ -120,17 +163,7 @@ export default function UnreadUpdates() {
   const activePrs = demoMode ? getDemoPRs() : displayPrs;
   const activeSeenMap = demoMode ? demoSeenMap : seenMap;
 
-  const prsWithUnseen = (activePrs ?? [])
-    .map((pr) => ({
-      pr,
-      unseen: getUnseenActivity(pr, activeSeenMap[prKey(pr)]).filter((item) => eventFilters[item.type]),
-    }))
-    .filter(({ unseen }) => unseen.length > 0)
-    .sort((a, b) => {
-      const aDate = a.unseen[0]?.date ?? "";
-      const bDate = b.unseen[0]?.date ?? "";
-      return new Date(bDate).getTime() - new Date(aDate).getTime();
-    });
+  const prsWithUnseen = computePrsWithUnseen(activePrs ?? [], activeSeenMap, eventFilters);
 
   const toggleCollapse = (pr: PRWithActivity) => {
     const key = prKey(pr);

--- a/extensions/gh-pr-tracker/src/unread-updates.tsx
+++ b/extensions/gh-pr-tracker/src/unread-updates.tsx
@@ -144,7 +144,7 @@ export default function UnreadUpdates(props: LaunchProps<{ launchContext?: Focus
       const updated: Record<string, boolean> = {};
       for (const pr of fetchedPrs) {
         const key = prKey(pr);
-        updated[key] = prev[key] !== undefined ? prev[key] : key !== focusPrKey;
+        updated[key] = key === focusPrKey ? false : prev[key] !== undefined ? prev[key] : true;
       }
       return updated;
     });
@@ -335,10 +335,7 @@ export default function UnreadUpdates(props: LaunchProps<{ launchContext?: Focus
                   <Action
                     title="Mark All as Caught up"
                     icon={Icon.CheckCircle}
-                    shortcut={{
-                      macOS: { modifiers: ["cmd", "shift"], key: "s" },
-                      Windows: { modifiers: ["ctrl", "shift"], key: "s" },
-                    }}
+                    shortcut={Keyboard.Shortcut.Common.Duplicate}
                     onAction={handleMarkAllSeen}
                   />
                   <Action
@@ -563,10 +560,7 @@ function ActivityListItem({
           <Action
             title="Mark All as Caught up"
             icon={Icon.CheckCircle}
-            shortcut={{
-              macOS: { modifiers: ["cmd", "shift"], key: "s" },
-              Windows: { modifiers: ["ctrl", "shift"], key: "s" },
-            }}
+            shortcut={Keyboard.Shortcut.Common.Duplicate}
             onAction={onMarkAllSeen}
           />
           <Action.Push title="View PR Summary" icon={Icon.List} target={<PRSummaryDetail pr={pr} />} />

--- a/extensions/gh-pr-tracker/src/utils.ts
+++ b/extensions/gh-pr-tracker/src/utils.ts
@@ -1,4 +1,6 @@
-import type { ActivityItem, GHReviewComment, PRWithActivity, SeenState } from "./types";
+import type { ActivityItem, GHReviewComment, PRWithActivity, SeenState, SeenMap } from "./types";
+import { prKey } from "./types";
+import type { EventFilters } from "./event-filters";
 
 // ─── Build all activity items for a PR (used for seen-tracking) ─────────────
 
@@ -125,6 +127,33 @@ export function getUnseenActivity(pr: PRWithActivity, seen: SeenState | undefine
 
   const seenSet = new Set(seen.seenItemIds ?? []);
   return allItems.filter((item) => !seenSet.has(item.itemKey));
+}
+
+// ─── Compute PRs with unseen activity (shared by both commands) ─────────────
+
+export interface PRWithUnseen {
+  pr: PRWithActivity;
+  unseen: ActivityItem[];
+}
+
+/**
+ * Returns the PRs that have at least one unseen activity item after applying
+ * event filters, sorted by most-recent unseen activity first. This is the
+ * single source of truth for the "unread PR" count shown in both the list
+ * command and the menu-bar command.
+ */
+export function computePrsWithUnseen(prs: PRWithActivity[], seenMap: SeenMap, filters: EventFilters): PRWithUnseen[] {
+  return prs
+    .map((pr) => ({
+      pr,
+      unseen: getUnseenActivity(pr, seenMap[prKey(pr)]).filter((item) => filters[item.type]),
+    }))
+    .filter(({ unseen }) => unseen.length > 0)
+    .sort((a, b) => {
+      const aDate = a.unseen[0]?.date ?? "";
+      const bDate = b.unseen[0]?.date ?? "";
+      return new Date(bDate).getTime() - new Date(aDate).getTime();
+    });
 }
 
 // ─── Build the conversation thread for a review comment ─────────────────────


### PR DESCRIPTION
## Description

### Added

- **Unread PR Alert** menu bar command (macOS) — shows how many pull requests have unread changes as a menu bar badge, refreshing automatically every 5 minutes and hiding when you are all caught up.
- The menu bar dropdown lists the 5 most recently updated PRs with unread changes; when there are more, a **Show all …** item opens the full list.
- Selecting a PR in the dropdown opens **View Pull Requests** with that PR expanded and the rest collapsed.

### Changed

- **View Pull Requests** and **Unread PR Alert** now share the same cached PR data, so opening either command benefits from data already fetched by the other.

## Screencast

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [X] I checked that files in the `assets` folder are used by the extension itself
- [X] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
