### PR TITLE
fix(jira-search-self-hosted): ignore stale search responses

### DIFF
--- a/extensions/jira-search-self-hosted/CHANGELOG.md
+++ b/extensions/jira-search-self-hosted/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Jira Search Self Hosted Changelog
 
+## [Fix stale search results] - {PR_MERGE_DATE}
+
+- Fixed older Jira responses overriding the latest query while typing an issue number.
+
 ## [Search issues by number] - 2026-07-16
 
 - Added the ability to find an issue by number when its project key is configured in **Default Included Projects**.

--- a/extensions/jira-search-self-hosted/CHANGELOG.md
+++ b/extensions/jira-search-self-hosted/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Jira Search Self Hosted Changelog
 
-## [Fix stale search results] - {PR_MERGE_DATE}
+## [Fix stale search results] - 2026-07-18
 
 - Fixed older Jira responses overriding the latest query while typing an issue number.
 

--- a/extensions/jira-search-self-hosted/src/command.tsx
+++ b/extensions/jira-search-self-hosted/src/command.tsx
@@ -17,14 +17,17 @@ export function SearchCommand(search: SearchFunction, searchBarPlaceholder?: str
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<ErrorText>();
   useEffect(() => {
+    let isCurrentQuery = true;
+
     setError(undefined);
     setIsLoading(true);
     search(query)
       .then((resultItems) => {
+        if (!isCurrentQuery) return;
         setItems(resultItems);
-        setIsLoading(false);
       })
       .catch((e) => {
+        if (!isCurrentQuery) return;
         setItems([]);
         console.warn(e);
         if (e instanceof Error) {
@@ -32,8 +35,12 @@ export function SearchCommand(search: SearchFunction, searchBarPlaceholder?: str
         }
       })
       .finally(() => {
-        setIsLoading(false);
+        if (isCurrentQuery) setIsLoading(false);
       });
+
+    return () => {
+      isCurrentQuery = false;
+    };
   }, [query]);
 
   const onSearchChange = (newSearch: string) => setQuery(newSearch);

--- a/extensions/jira-search-self-hosted/src/issue-key.test.mjs
+++ b/extensions/jira-search-self-hosted/src/issue-key.test.mjs
@@ -7,6 +7,10 @@ describe("buildIssueNumberJql", () => {
     assert.equal(buildIssueNumberJql("123", "ACME"), "key=ACME-123");
   });
 
+  it("supports issue numbers longer than three digits", () => {
+    assert.equal(buildIssueNumberJql("4107", "ACME"), "key=ACME-4107");
+  });
+
   it("trims the query and supports multiple unique project keys", () => {
     assert.equal(buildIssueNumberJql(" 123 ", "ACME, DEV, acme"), 'key IN ("ACME-123", "DEV-123")');
   });


### PR DESCRIPTION
## Summary

Typing longer issue numbers can start overlapping Jira requests, allowing a slower response for a partial query to overwrite the latest result. Search now ignores responses from superseded queries, so an input such as `4107` keeps the result from its exact lookup. Regression coverage also confirms that four-digit issue numbers produce the expected Jira key.

## Validation

- `npm test`
- `npm run build`
- `npm run lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
