### PR TITLE
[WinGet] Fix empty lists on non-English Windows and upgrade failures

### DIFF
--- a/extensions/winget/CHANGELOG.md
+++ b/extensions/winget/CHANGELOG.md
@@ -1,6 +1,6 @@
 # WinGet Changelog
 
-## [Locale and Upgrade Fixes] - {PR_MERGE_DATE}
+## [Locale and Upgrade Fixes] - 2026-07-17
 
 ### Fixed
 - Installed and upgradable lists no longer come up empty on non-English Windows: table parsing is structural instead of language-based, and package details parse on all of winget's shipped display languages

--- a/extensions/winget/CHANGELOG.md
+++ b/extensions/winget/CHANGELOG.md
@@ -14,6 +14,7 @@ A full architectural rewrite of the internals, with the command set expanded fro
 - Confirmation prompts for destructive actions (Uninstall, Uninstall All, Upgrade All, Cancel)
 - Release Date in the detail pane; detail prefetch around the selection
 - Updates winget lists but cannot actually apply ("no applicable upgrade", or an installer whose reported version winget cannot match) are hidden from upgradable views until winget offers a different version
+- Operations that fail because they need administrator rights are retried with winget relaunched elevated, so the UAC prompt is the only confirmation (works during Upgrade All too)
 - Test suite covering the concurrency protocol and winget-output parsing against captured fixtures
 
 ### Changed

--- a/extensions/winget/CHANGELOG.md
+++ b/extensions/winget/CHANGELOG.md
@@ -13,11 +13,12 @@ A full architectural rewrite of the internals, with the command set expanded fro
 - A global operation lock so only one winget operation runs at a time; an in-progress operation can be cancelled, and a crashed one is recovered and reported as interrupted
 - Confirmation prompts for destructive actions (Uninstall, Uninstall All, Upgrade All, Cancel)
 - Release Date in the detail pane; detail prefetch around the selection
+- Updates winget lists but cannot actually apply ("no applicable upgrade", or an installer whose reported version winget cannot match) are hidden from upgradable views until winget offers a different version
 - Test suite covering the concurrency protocol and winget-output parsing against captured fixtures
 
 ### Changed
 - Install/upgrade outcomes (including no-ops and bulk summaries) are determined from winget's exit codes and its documented return-code table rather than matching English output text, so results no longer depend on the system language
-- Bulk upgrades report upgraded / skipped / failed separately and name the failed packages; upgrades winget immediately re-offers (installer reports an unmatchable version) are called out
+- Bulk upgrades report upgraded / skipped / failed separately and name the failed packages
 - Cold start is staged: installed and upgradable data load first and those views become usable immediately, while the full catalog (which powers Search) builds in the background
 - Installed and upgradable data refresh on open when stale and after every operation
 - Empty states explain themselves, including why Microsoft Store apps don't appear in Search

--- a/extensions/winget/CHANGELOG.md
+++ b/extensions/winget/CHANGELOG.md
@@ -1,5 +1,13 @@
 # WinGet Changelog
 
+## [Locale and Upgrade Fixes] - {PR_MERGE_DATE}
+
+### Fixed
+- Installed and upgradable lists no longer come up empty on non-English Windows: table parsing is structural instead of language-based, and package details parse on all of winget's shipped display languages
+- Updates winget lists but cannot actually apply ("no applicable upgrade", or an installer whose reported version winget cannot match) are hidden from upgradable views until winget offers a different version
+- Operations that fail because they need administrator rights are retried with winget relaunched elevated, so the UAC prompt is the only confirmation (works during Upgrade All too)
+- Installer failures with a documented Windows Installer exit code show its meaning instead of the bare number, an upgrade blocked by another running installation is retried once, and a silent installer aborted because the app is open reports "App in use, close it first"
+
 ## [Ground-Up Rewrite] - 2026-07-14
 
 A full architectural rewrite of the internals, with the command set expanded from three to six: Show Upgradable and Upgrade All Packages split out from the old Upgrade command, and Export and Import are new.
@@ -13,13 +21,11 @@ A full architectural rewrite of the internals, with the command set expanded fro
 - A global operation lock so only one winget operation runs at a time; an in-progress operation can be cancelled, and a crashed one is recovered and reported as interrupted
 - Confirmation prompts for destructive actions (Uninstall, Uninstall All, Upgrade All, Cancel)
 - Release Date in the detail pane; detail prefetch around the selection
-- Updates winget lists but cannot actually apply ("no applicable upgrade", or an installer whose reported version winget cannot match) are hidden from upgradable views until winget offers a different version
-- Operations that fail because they need administrator rights are retried with winget relaunched elevated, so the UAC prompt is the only confirmation (works during Upgrade All too)
 - Test suite covering the concurrency protocol and winget-output parsing against captured fixtures
 
 ### Changed
 - Install/upgrade outcomes (including no-ops and bulk summaries) are determined from winget's exit codes and its documented return-code table rather than matching English output text, so results no longer depend on the system language
-- Bulk upgrades report upgraded / skipped / failed separately and name the failed packages
+- Bulk upgrades report upgraded / skipped / failed separately and name the failed packages; upgrades winget immediately re-offers (installer reports an unmatchable version) are called out
 - Cold start is staged: installed and upgradable data load first and those views become usable immediately, while the full catalog (which powers Search) builds in the background
 - Installed and upgradable data refresh on open when stale and after every operation
 - Empty states explain themselves, including why Microsoft Store apps don't appear in Search

--- a/extensions/winget/CHANGELOG.md
+++ b/extensions/winget/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Updates winget lists but cannot actually apply ("no applicable upgrade", or an installer whose reported version winget cannot match) are hidden from upgradable views until winget offers a different version
 - Operations that fail because they need administrator rights are retried with winget relaunched elevated, so the UAC prompt is the only confirmation (works during Upgrade All too)
 - Installer failures with a documented Windows Installer exit code show its meaning instead of the bare number, an upgrade blocked by another running installation is retried once, and a silent installer aborted because the app is open reports "App in use, close it first"
+- Operations no longer fail when the Upgrade All Packages command is disabled ([#29525](https://github.com/raycast/extensions/issues/29525)): they run inside the view that started them instead — the in-flight package finishes even if the view closes, at the cost of live progress toasts
 
 ## [Ground-Up Rewrite] - 2026-07-14
 

--- a/extensions/winget/README.md
+++ b/extensions/winget/README.md
@@ -42,4 +42,5 @@ How long the cached package catalog stays valid before it is refreshed. Search o
 ## Notes
 
 - **Microsoft Store packages can't be searched** — winget only enumerates the `winget` source. Store packages you already have remain manageable from Show Installed and Show Upgradable.
-- **Some packages reappear in Show Upgradable after upgrading** — their installer reports a version winget can't match against the catalog (self-updating apps, or `< version` entries), so winget keeps offering the upgrade. Pin the package to stop the repeated offer.
+- **A Windows UAC prompt may appear during operations** — packages that can only be installed with administrator rights are retried with winget elevated. Declining the prompt fails just that package; the rest of a bulk upgrade continues.
+- **Some listed updates are hidden** — when winget offers an update it then refuses to apply ("no applicable upgrade"), or keeps re-offering one that already succeeded (self-updating apps report versions winget can't match), the row is hidden from upgradable views until winget offers a different version.

--- a/extensions/winget/README.md
+++ b/extensions/winget/README.md
@@ -20,7 +20,7 @@ Winget comes pre-installed on Windows 11 and recent Windows 10 builds. If it is 
 | **Export Packages**      | Save installed packages to a winget JSON manifest                   |
 | **Import Packages**      | Install packages from a winget JSON manifest                        |
 
-> **Keep _Upgrade All Packages_ enabled.** Besides upgrading everything, it runs this extension's package operations in the background. Disabling it breaks those operations.
+> **Keep _Upgrade All Packages_ enabled** for the best experience: besides upgrading everything, it runs this extension's package operations in the background. With it disabled, operations run inside the view that started them — they still complete if you leave, but progress toasts stop, and an interrupted bulk run continues only when relaunched.
 
 ## Preferences
 

--- a/extensions/winget/src/cli/commands.test.ts
+++ b/extensions/winget/src/cli/commands.test.ts
@@ -80,6 +80,30 @@ describe("isElevationFailure", () => {
     ).toBe(false);
   });
 
+  it("matches the machine-scope MSIX error 0x80073D28 as exit code and in messages", () => {
+    expect(
+      isElevationFailure({
+        success: false,
+        exitCode: -2147009240, // 0x80073D28 signed
+        message: "Localized message on non-English Windows",
+      }),
+    ).toBe(true);
+    expect(
+      isElevationFailure({
+        success: false,
+        exitCode: 1,
+        message: "Installer failed with exit code 0x80073D28",
+      }),
+    ).toBe(true);
+    // Must be the whole code, not a prefix of a longer one.
+    expect(
+      isElevationFailure({
+        success: false,
+        message: "Installer failed with exit code 0x80073D280",
+      }),
+    ).toBe(false);
+  });
+
   it("does not match the run-unelevated failure (opposite direction)", () => {
     expect(
       isElevationFailure({

--- a/extensions/winget/src/cli/commands.test.ts
+++ b/extensions/winget/src/cli/commands.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { isElevationFailure, isModifiedPortableFailure, remapUpgradeNotFound } from "./commands";
+import {
+  isElevationFailure,
+  isInstallerBusyFailure,
+  isModifiedPortableFailure,
+  remapUpgradeNotFound,
+} from "./commands";
 
 describe("remapUpgradeNotFound", () => {
   it("remaps NO_APPLICATIONS_FOUND to a no-op for upgrades (source-filter quirk)", () => {
@@ -133,6 +138,26 @@ describe("isElevationFailure", () => {
       }),
     ).toBe(false);
     expect(isElevationFailure({ success: false, message: "Disk full" })).toBe(false);
+  });
+});
+
+describe("isInstallerBusyFailure", () => {
+  it("matches installer exit code 1618 (ERROR_INSTALL_ALREADY_RUNNING)", () => {
+    expect(
+      isInstallerBusyFailure({
+        success: false,
+        exitCode: 1,
+        errorCode: "1618",
+        message: "Another installation is already in progress, retry later",
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores successes, cancellations, and other codes", () => {
+    expect(isInstallerBusyFailure({ success: true, errorCode: "1618" })).toBe(false);
+    expect(isInstallerBusyFailure({ success: false, cancelled: true, errorCode: "1618" })).toBe(false);
+    expect(isInstallerBusyFailure({ success: false, errorCode: "1603" })).toBe(false);
+    expect(isInstallerBusyFailure({ success: false, message: "Disk full" })).toBe(false);
   });
 });
 

--- a/extensions/winget/src/cli/commands.ts
+++ b/extensions/winget/src/cli/commands.ts
@@ -14,6 +14,9 @@
  * - upgrade: retried once WITH --force when a modified portable package
  *   refuses removal (winget's own printed remedy; an upgrade replaces the
  *   package either way)
+ * - install/upgrade/uninstall/repair: when every unelevated attempt fails
+ *   with the requires-administrator class, winget itself is relaunched
+ *   elevated (the UAC prompt is the user's confirmation)
  * - download/import: + --accept-package-agreements, no --silent
  * - Every targeted operation: --exact --id <id> --source <source>
  */
@@ -37,7 +40,7 @@ import {
   type TableParseResult,
 } from "./parser";
 import { WingetProgressDetector } from "./progress";
-import { runWinget, withQuerySlot } from "./spawn";
+import { runWinget, runWingetElevated, UAC_DECLINED_EXIT_CODE, withQuerySlot } from "./spawn";
 import {
   type WingetExecutorOptions,
   type WingetInstalledPackage,
@@ -128,6 +131,38 @@ async function enrichFailureMessage(
 // ---------------------------------------------------------------------------
 // Core executors
 // ---------------------------------------------------------------------------
+
+/**
+ * Elevated execution: no output crosses the elevation boundary, so the result
+ * comes from the exit code alone (locale-independent, same interpretation
+ * table as normal runs). Failure enrichment still applies — `winget error`
+ * runs unelevated.
+ */
+async function executeElevatedOperation(
+  args: string[],
+  options: WingetExecutorOptions,
+): Promise<WingetOperationResult> {
+  options.onElevated?.();
+  try {
+    const execResult = await runWingetElevated(args, { onSpawn: options.onSpawn });
+    if (execResult.exitCode === UAC_DECLINED_EXIT_CODE) {
+      // The same failure class as INSTALL_CANCELLED_BY_USER — a decline is a
+      // per-package failure, not a caller cancellation.
+      return {
+        success: false,
+        message: "Cancelled in the UAC prompt",
+        exitCode: execResult.exitCode,
+      };
+    }
+    const result = interpretOperationResult(execResult.exitCode, "");
+    return enrichFailureMessage(result, options.signal);
+  } catch (error) {
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
 
 async function executeOperation(args: string[], options: WingetExecutorOptions = {}): Promise<WingetOperationResult> {
   const detector = new WingetProgressDetector((state) => options.onProgress?.(state));
@@ -293,27 +328,63 @@ async function showPackageVersions(
 // ---------------------------------------------------------------------------
 
 /**
+ * Windows deployment error ERROR_PACKAGED_SERVICE_REQUIRES_ADMIN_PRIVILEGES:
+ * a machine-scope MSIX package can only be installed by an elevated winget.
+ * winget relays it as the installer's exit code, so it appears both as a
+ * process exit code and inside "Installer failed with exit code" messages.
+ */
+const PACKAGED_SERVICE_REQUIRES_ADMIN = 0x80073d28;
+
+/**
  * The requires-administrator failure class: winget's silent mode blocks the
  * installer's UAC prompt for some packages (the root cause behind upgrade's
- * no---silent policy). Anchored to locale-independent signals: the winget
- * exit code, the curated message from the failure-pattern catalog (matched as
- * a prefix — enrichment appends the installer-log path), or installer exit
- * code 740 (ERROR_ELEVATION_REQUIRED). A free-text scan would over-trigger on
- * enriched content such as log paths under C:\Users\Administrator.
+ * no---silent policy), and machine-scope MSIX packages need winget itself
+ * elevated. Anchored to locale-independent signals: the winget exit code, the
+ * curated message from the failure-pattern catalog (matched as a prefix —
+ * enrichment appends the installer-log path), or installer exit codes 740
+ * (ERROR_ELEVATION_REQUIRED) and 0x80073D28. A free-text scan would
+ * over-trigger on enriched content such as log paths under
+ * C:\Users\Administrator.
  */
 function isElevationFailure(result: WingetOperationResult): boolean {
   if (result.success || result.cancelled) return false;
-  if (result.exitCode !== undefined && toUnsignedHResult(result.exitCode) === COMMAND_REQUIRES_ADMIN) {
-    return true;
+  if (result.exitCode !== undefined) {
+    const code = toUnsignedHResult(result.exitCode);
+    if (code === COMMAND_REQUIRES_ADMIN || code === PACKAGED_SERVICE_REQUIRES_ADMIN) {
+      return true;
+    }
   }
   const message = result.message ?? "";
-  return message.startsWith("Requires administrator") || /exit code:?\s*740\b/i.test(message);
+  return (
+    message.startsWith("Requires administrator") ||
+    /exit code:?\s*740\b/i.test(message) ||
+    /0x80073d28\b/i.test(message)
+  );
+}
+
+/**
+ * Last-resort retry for the requires-administrator class: relaunch winget
+ * itself elevated. The UAC prompt is the confirmation — no dialog precedes
+ * it — and a decline surfaces as a normal per-package failure, so bulk runs
+ * carry on with the next package.
+ */
+async function executeWithElevatedFallback(
+  run: () => Promise<WingetOperationResult>,
+  elevatedArgs: string[],
+  options: WingetExecutorOptions,
+): Promise<WingetOperationResult> {
+  const result = await run();
+  if (!isElevationFailure(result)) {
+    return result;
+  }
+  return executeElevatedOperation(elevatedArgs, options);
 }
 
 /**
  * Run an install/repair invocation silent-first; when it fails with the
  * requires-administrator class, retry once without --silent so the installer
- * can raise its UAC prompt.
+ * can raise its own UAC prompt, then fall back to relaunching winget itself
+ * elevated (machine-scope MSIX packages accept nothing less).
  */
 async function executeWithElevationRetry(
   argsFor: (flags: string[]) => string[],
@@ -324,7 +395,11 @@ async function executeWithElevationRetry(
   if (!isElevationFailure(result)) {
     return result;
   }
-  return executeOperation(argsFor(ELEVATION_RETRY_FLAGS), options);
+  return executeWithElevatedFallback(
+    () => executeOperation(argsFor(ELEVATION_RETRY_FLAGS), options),
+    argsFor(silentFlags),
+    options,
+  );
 }
 
 async function installPackage(
@@ -456,10 +531,9 @@ async function upgradePackage(
   source: WingetSource,
   options: WingetExecutorOptions = {},
 ): Promise<WingetOperationResult> {
-  const result = await executeWithForceRetry(
-    (extra) => withSource(["upgrade", ...EXACT_ID_FLAGS, id, ...UPGRADE_FLAGS, ...extra], source),
-    options,
-  );
+  const argsFor = (extra: string[]) =>
+    withSource(["upgrade", ...EXACT_ID_FLAGS, id, ...UPGRADE_FLAGS, ...extra], source);
+  const result = await executeWithElevatedFallback(() => executeWithForceRetry(argsFor, options), argsFor([]), options);
   return remapUpgradeNotFound(result);
 }
 
@@ -479,10 +553,11 @@ async function uninstallPackage(
 ): Promise<WingetOperationResult> {
   const versionFlags = version ? ["--version", version] : [];
   const forceFlags = force ? ["--force"] : [];
-  return executeOperation(
-    withSource(["uninstall", ...EXACT_ID_FLAGS, id, ...versionFlags, ...UNINSTALL_FLAGS, ...forceFlags], source),
-    options,
+  const args = withSource(
+    ["uninstall", ...EXACT_ID_FLAGS, id, ...versionFlags, ...UNINSTALL_FLAGS, ...forceFlags],
+    source,
   );
+  return executeWithElevatedFallback(() => executeOperation(args, options), args, options);
 }
 
 async function repairPackage(

--- a/extensions/winget/src/cli/commands.ts
+++ b/extensions/winget/src/cli/commands.ts
@@ -17,9 +17,14 @@
  * - install/upgrade/uninstall/repair: when every unelevated attempt fails
  *   with the requires-administrator class, winget itself is relaunched
  *   elevated (the UAC prompt is the user's confirmation)
+ * - install/upgrade/uninstall/repair: installer exit code 1618 (Windows
+ *   Installer mutex busy — an earlier install still finishing in the
+ *   background) is retried once after a wait
  * - download/import: + --accept-package-agreements, no --silent
  * - Every targeted operation: --exact --id <id> --source <source>
  */
+
+import { closeSync, fstatSync, openSync, readSync } from "node:fs";
 
 import {
   CancelledError,
@@ -107,6 +112,40 @@ async function resolveErrorDescriptionViaCli(errorCode: string, signal?: AbortSi
   }
 }
 
+/**
+ * Silent-mode markers of "the app is open" aborts. Inno Setup suppresses its
+ * "close all instances" prompt under /SILENT, auto-answers Cancel, and exits
+ * with a generic code — the real cause is only in the installer log.
+ */
+const APP_RUNNING_LOG_MARKERS = [/is currently running/i, /close all instances/i];
+
+/**
+ * Bounded read of an installer log's tail. MSI logs are UTF-16LE (BOM at the
+ * start of the file, checked separately from the tail read); Inno logs are
+ * plain text.
+ */
+function readInstallerLogTail(filePath: string, maxBytes = 256 * 1024): string | null {
+  try {
+    const fd = openSync(filePath, "r");
+    try {
+      const bom = Buffer.alloc(2);
+      const utf16 = readSync(fd, bom, 0, 2, 0) === 2 && bom[0] === 0xff && bom[1] === 0xfe;
+      const size = fstatSync(fd).size;
+      let length = Math.min(size, maxBytes);
+      if (utf16 && (size - length) % 2 !== 0) {
+        length -= 1; // keep the read aligned to whole UTF-16 code units
+      }
+      const buffer = Buffer.alloc(length);
+      readSync(fd, buffer, 0, length, size - length);
+      return buffer.toString(utf16 ? "utf16le" : "utf8");
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return null;
+  }
+}
+
 /** Append installer-log location and a CLI-resolved description where useful. */
 async function enrichFailureMessage(
   result: WingetOperationResult,
@@ -120,6 +159,14 @@ async function enrichFailureMessage(
     const description = await resolveErrorDescriptionViaCli(result.errorCode, signal);
     if (description) {
       message = description;
+    }
+  }
+  // A generic installer exit code with a log: check the log for the
+  // app-is-open abort, which silent mode reports no other way.
+  if (result.installerLogPath && message && /^Installer failed with exit code/.test(message)) {
+    const tail = readInstallerLogTail(result.installerLogPath);
+    if (tail && APP_RUNNING_LOG_MARKERS.some((marker) => marker.test(tail))) {
+      message = "App in use, close it first";
     }
   }
   if (message && result.installerLogPath) {
@@ -363,6 +410,57 @@ function isElevationFailure(result: WingetOperationResult): boolean {
 }
 
 /**
+ * ERROR_INSTALL_ALREADY_RUNNING: the Windows Installer mutex was held by
+ * another installation when this one started. Common mid-bulk — an earlier
+ * package's installer can leave a background msiexec finishing after winget
+ * already reported success.
+ */
+const INSTALLER_BUSY_EXIT_CODE = "1618";
+const INSTALLER_BUSY_RETRY_DELAY_MS = 30_000;
+
+function isInstallerBusyFailure(result: WingetOperationResult): boolean {
+  return !result.success && !result.cancelled && result.errorCode === INSTALLER_BUSY_EXIT_CODE;
+}
+
+/** Resolves "elapsed" after `ms`, or "aborted" as soon as the signal fires. */
+function delay(ms: number, signal?: AbortSignal): Promise<"elapsed" | "aborted"> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve("aborted");
+      return;
+    }
+    const finish = (outcome: "elapsed" | "aborted") => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      resolve(outcome);
+    };
+    const onAbort = () => finish("aborted");
+    const timer = setTimeout(() => finish("elapsed"), ms);
+    signal?.addEventListener("abort", onAbort);
+  });
+}
+
+/**
+ * Retry once when the installer failed only because the Windows Installer
+ * mutex was busy — a transient collision, not a package problem. The wait
+ * gives the other installation time to finish; a cancel during the wait
+ * returns the original failure immediately.
+ */
+async function executeWithBusyRetry(
+  run: () => Promise<WingetOperationResult>,
+  options: WingetExecutorOptions,
+): Promise<WingetOperationResult> {
+  const result = await run();
+  if (!isInstallerBusyFailure(result)) {
+    return result;
+  }
+  if ((await delay(INSTALLER_BUSY_RETRY_DELAY_MS, options.signal)) === "aborted") {
+    return result;
+  }
+  return run();
+}
+
+/**
  * Last-resort retry for the requires-administrator class: relaunch winget
  * itself elevated. The UAC prompt is the confirmation — no dialog precedes
  * it — and a decline surfaces as a normal per-package failure, so bulk runs
@@ -407,9 +505,13 @@ async function installPackage(
   source: WingetSource,
   options: WingetExecutorOptions = {},
 ): Promise<WingetOperationResult> {
-  return executeWithElevationRetry(
-    (flags) => withSource(["install", ...EXACT_ID_FLAGS, id, ...flags], source),
-    INSTALL_FLAGS,
+  return executeWithBusyRetry(
+    () =>
+      executeWithElevationRetry(
+        (flags) => withSource(["install", ...EXACT_ID_FLAGS, id, ...flags], source),
+        INSTALL_FLAGS,
+        options,
+      ),
     options,
   );
 }
@@ -425,9 +527,13 @@ async function installPackageVersion(
   source: WingetSource,
   options: WingetExecutorOptions = {},
 ): Promise<WingetOperationResult> {
-  const result = await executeWithElevationRetry(
-    (flags) => withSource(["install", ...EXACT_ID_FLAGS, id, "--version", version, ...flags], source),
-    INSTALL_FLAGS,
+  const result = await executeWithBusyRetry(
+    () =>
+      executeWithElevationRetry(
+        (flags) => withSource(["install", ...EXACT_ID_FLAGS, id, "--version", version, ...flags], source),
+        INSTALL_FLAGS,
+        options,
+      ),
     options,
   );
   if (!result.success) {
@@ -533,7 +639,10 @@ async function upgradePackage(
 ): Promise<WingetOperationResult> {
   const argsFor = (extra: string[]) =>
     withSource(["upgrade", ...EXACT_ID_FLAGS, id, ...UPGRADE_FLAGS, ...extra], source);
-  const result = await executeWithElevatedFallback(() => executeWithForceRetry(argsFor, options), argsFor([]), options);
+  const result = await executeWithBusyRetry(
+    () => executeWithElevatedFallback(() => executeWithForceRetry(argsFor, options), argsFor([]), options),
+    options,
+  );
   return remapUpgradeNotFound(result);
 }
 
@@ -557,7 +666,10 @@ async function uninstallPackage(
     ["uninstall", ...EXACT_ID_FLAGS, id, ...versionFlags, ...UNINSTALL_FLAGS, ...forceFlags],
     source,
   );
-  return executeWithElevatedFallback(() => executeOperation(args, options), args, options);
+  return executeWithBusyRetry(
+    () => executeWithElevatedFallback(() => executeOperation(args, options), args, options),
+    options,
+  );
 }
 
 async function repairPackage(
@@ -565,9 +677,13 @@ async function repairPackage(
   source: WingetSource,
   options: WingetExecutorOptions = {},
 ): Promise<WingetOperationResult> {
-  return executeWithElevationRetry(
-    (flags) => withSource(["repair", ...EXACT_ID_FLAGS, id, ...flags], source),
-    REPAIR_FLAGS,
+  return executeWithBusyRetry(
+    () =>
+      executeWithElevationRetry(
+        (flags) => withSource(["repair", ...EXACT_ID_FLAGS, id, ...flags], source),
+        REPAIR_FLAGS,
+        options,
+      ),
     options,
   );
 }
@@ -628,6 +744,7 @@ async function importPackages(
 
 export {
   isElevationFailure,
+  isInstallerBusyFailure,
   isModifiedPortableFailure,
   remapUpgradeNotFound,
   downloadInstaller,

--- a/extensions/winget/src/cli/commands.ts
+++ b/extensions/winget/src/cli/commands.ts
@@ -464,18 +464,20 @@ async function executeWithBusyRetry(
  * Last-resort retry for the requires-administrator class: relaunch winget
  * itself elevated. The UAC prompt is the confirmation — no dialog precedes
  * it — and a decline surfaces as a normal per-package failure, so bulk runs
- * carry on with the next package.
+ * carry on with the next package. `elevatedArgs` is a thunk resolved after
+ * `run` settles, so retry chains can elevate with the arguments of whichever
+ * attempt ran last (e.g. upgrade's --force retry).
  */
 async function executeWithElevatedFallback(
   run: () => Promise<WingetOperationResult>,
-  elevatedArgs: string[],
+  elevatedArgs: () => string[],
   options: WingetExecutorOptions,
 ): Promise<WingetOperationResult> {
   const result = await run();
   if (!isElevationFailure(result)) {
     return result;
   }
-  return executeElevatedOperation(elevatedArgs, options);
+  return executeElevatedOperation(elevatedArgs(), options);
 }
 
 /**
@@ -495,7 +497,7 @@ async function executeWithElevationRetry(
   }
   return executeWithElevatedFallback(
     () => executeOperation(argsFor(ELEVATION_RETRY_FLAGS), options),
-    argsFor(silentFlags),
+    () => argsFor(silentFlags),
     options,
   );
 }
@@ -637,10 +639,18 @@ async function upgradePackage(
   source: WingetSource,
   options: WingetExecutorOptions = {},
 ): Promise<WingetOperationResult> {
+  // Track the last attempt's arguments so an elevated retry keeps the
+  // --force flag when the force retry is what hit the administrator wall.
+  let lastAttemptArgs = withSource(["upgrade", ...EXACT_ID_FLAGS, id, ...UPGRADE_FLAGS], source);
   const argsFor = (extra: string[]) =>
-    withSource(["upgrade", ...EXACT_ID_FLAGS, id, ...UPGRADE_FLAGS, ...extra], source);
+    (lastAttemptArgs = withSource(["upgrade", ...EXACT_ID_FLAGS, id, ...UPGRADE_FLAGS, ...extra], source));
   const result = await executeWithBusyRetry(
-    () => executeWithElevatedFallback(() => executeWithForceRetry(argsFor, options), argsFor([]), options),
+    () =>
+      executeWithElevatedFallback(
+        () => executeWithForceRetry(argsFor, options),
+        () => lastAttemptArgs,
+        options,
+      ),
     options,
   );
   return remapUpgradeNotFound(result);
@@ -667,7 +677,12 @@ async function uninstallPackage(
     source,
   );
   return executeWithBusyRetry(
-    () => executeWithElevatedFallback(() => executeOperation(args, options), args, options),
+    () =>
+      executeWithElevatedFallback(
+        () => executeOperation(args, options),
+        () => args,
+        options,
+      ),
     options,
   );
 }

--- a/extensions/winget/src/cli/failure-patterns.test.ts
+++ b/extensions/winget/src/cli/failure-patterns.test.ts
@@ -187,6 +187,17 @@ Installer log is available at: C:\\Users\\user\\AppData\\Local\\Packages\\...\\G
     expect(result.installerLogPath).toContain("Git.Git.log");
   });
 
+  it("maps well-known Windows Installer exit codes to their documented meaning", () => {
+    const output = `Starting package install...
+Installer failed with exit code: 1618
+Installer log is available at: C:\\Users\\user\\AppData\\Local\\Packages\\...\\EpicGames.log
+`;
+    const result = interpretOperationResult(1, output);
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Another installation is already in progress, retry later");
+    expect(result.errorCode).toBe("1618");
+  });
+
   it("extracts winget error code and message", () => {
     const output = `An unexpected error occurred while executing the command:
 0x8a15000f : Data required by the source is missing

--- a/extensions/winget/src/cli/parser.test.ts
+++ b/extensions/winget/src/cli/parser.test.ts
@@ -147,6 +147,65 @@ Git               Git.Git            2.52.0    winget
       },
     ]);
   });
+
+  it("resolves single-space column boundaries in localized headers from the rows", () => {
+    // winget pads each column to max(widest value, header name width) + 1:
+    // when the localized header name is wider than every value beneath it,
+    // adjacent header names are separated by a SINGLE space. Here "Version"
+    // and "Disponible" are wider than their values, so the header reads
+    // "Version Disponible Source" with single spaces (real French layout).
+    const output = `
+Nom               ID                  Version Disponible Source
+---------------------------------------------------------------
+Stardock Curtains Stardock.Curtains   1.2     1.19.1     winget
+Notepad++         Notepad++.Notepad++ 8.5.8   8.6.0      winget
+2 mises à niveau disponibles.
+`;
+
+    const { items } = parseUpgradePackages(output);
+    expect(items).toEqual([
+      {
+        name: "Stardock Curtains",
+        id: "Stardock.Curtains",
+        version: "1.2",
+        available: "1.19.1",
+        source: "winget",
+        truncatedFields: undefined,
+      },
+      {
+        name: "Notepad++",
+        id: "Notepad++.Notepad++",
+        version: "8.5.8",
+        available: "8.6.0",
+        source: "winget",
+        truncatedFields: undefined,
+      },
+    ]);
+  });
+
+  it("rejects partially-English localized headers instead of dropping the localized columns", () => {
+    // German headers contain the English words Name, ID, and Version next to
+    // Verfügbar and Quelle. Trusting the English keywords alone would build a
+    // 3-column table whose rows all fail source validation.
+    const output = `
+Name              ID                  Version    Verfügbar  Quelle
+-------------------------------------------------------------------
+Stardock Curtains Stardock.Curtains   1.2        1.19.1     winget
+2 Aktualisierungen verfügbar.
+`;
+
+    const { items } = parseUpgradePackages(output);
+    expect(items).toEqual([
+      {
+        name: "Stardock Curtains",
+        id: "Stardock.Curtains",
+        version: "1.2",
+        available: "1.19.1",
+        source: "winget",
+        truncatedFields: undefined,
+      },
+    ]);
+  });
 });
 
 describe("parseInstalledPackages", () => {
@@ -313,6 +372,52 @@ Tags:
     expect(result?.name).toContain("115");
     expect(result?.version).toBeTruthy();
   });
+
+  it("parses localized labels (French, space before the colon)", () => {
+    const output = `Trouvé Git [Git.Git]
+Version : 2.52.0
+Publisher : The Git Development Community
+Auteur : Johannes Schindelin
+Page d’accueil : https://gitforwindows.org
+Licence : GPL-2.0
+Date de version : 2025-11-24
+Description : Git for Windows
+Mots-clés :
+    vcs
+`;
+
+    expect(parsePackageDetails(output)).toEqual({
+      id: "Git.Git",
+      name: "Git",
+      version: "2.52.0",
+      publisher: "The Git Development Community",
+      author: "Johannes Schindelin",
+      homepage: "https://gitforwindows.org",
+      license: "GPL-2.0",
+      releaseDate: "2025-11-24",
+      description: "Git for Windows",
+      tags: ["vcs"],
+    });
+  });
+
+  it("parses localized labels (Korean colonless homepage, fullwidth colons)", () => {
+    const output = `찾음 Git [Git.Git]
+버전: 2.52.0
+게시자: The Git Development Community
+홈페이지 https://gitforwindows.org
+标记：
+    vcs
+`;
+
+    expect(parsePackageDetails(output)).toEqual({
+      id: "Git.Git",
+      name: "Git",
+      version: "2.52.0",
+      publisher: "The Git Development Community",
+      homepage: "https://gitforwindows.org",
+      tags: ["vcs"],
+    });
+  });
 });
 
 describe("parseVersionList", () => {
@@ -340,6 +445,22 @@ Version
     const result = parseVersionList(fixture("show-versions.raw.txt"));
     expect(result?.id).toBe("Git.Git");
     expect(result!.versions.length).toBeGreaterThan(3);
+  });
+
+  it("parses a localized identity line (the Found verb is translated)", () => {
+    const output = `
+Trouvé GIMP [GIMP.GIMP.3]
+Version
+-------
+3.0.6.1
+3.0.6.0
+`;
+
+    expect(parseVersionList(output)).toEqual({
+      id: "GIMP.GIMP.3",
+      name: "GIMP",
+      versions: ["3.0.6.1", "3.0.6.0"],
+    });
   });
 });
 
@@ -376,6 +497,24 @@ Git               Git.Git            2.52.0    winget
   it("parses the real pin list format with Pin type column and solid separator", () => {
     const { items } = parsePinnedPackages(fixture("pin-list.raw.txt"));
     expect(items).toEqual([{ id: "jqlang.jq", version: "1.8.1", source: "winget" }]);
+  });
+
+  it("merges multi-word localized headers whose later words overhang the values", () => {
+    // Spanish pin list: single space between Origen and Tipo (equal-width
+    // values), and "anclaje" starts beyond "Pinning"/"Gating" so no row has
+    // content beneath it — it must not open a phantom column.
+    const output = `
+Nombre Id               Versión     Origen Tipo de anclaje
+----------------------------------------------------------
+Git    Git.Git          2.52.0      winget Pinning
+Claude Anthropic.Claude 1.20186.0.0 winget Gating
+`;
+
+    const { items } = parsePinnedPackages(output);
+    expect(items).toEqual([
+      { id: "Git.Git", version: "2.52.0", source: "winget" },
+      { id: "Anthropic.Claude", version: "1.20186.0.0", source: "winget" },
+    ]);
   });
 });
 

--- a/extensions/winget/src/cli/parser.ts
+++ b/extensions/winget/src/cli/parser.ts
@@ -855,6 +855,19 @@ function extractFailureMessage(buffer: string): string | undefined {
   return m?.[0]?.trim();
 }
 
+/**
+ * Installer exit codes with a fixed, documented meaning (Windows Installer
+ * error codes — MSI installers relay them verbatim). Only codes that are
+ * unambiguous across installer technologies belong here; generic codes like
+ * 1 or 2 mean different things per installer and stay unmapped.
+ */
+const WELL_KNOWN_INSTALLER_EXIT_CODES: Record<string, string> = {
+  "1602": "Cancelled by the user",
+  "1603": "Installer reported a fatal error",
+  "1618": "Another installation is already in progress, retry later",
+  "1638": "Another version of this product is already installed",
+};
+
 function extractFailureInfo(buffer: string): FailureInfo | null {
   const installerLogPath = buffer.match(/Installer log is available at:\s*([^\r\n]+)/i)?.[1]?.trim();
 
@@ -873,7 +886,7 @@ function extractFailureInfo(buffer: string): FailureInfo | null {
   if (exitCodeMatch?.[1]) {
     const code = normalizeErrorCode(exitCodeMatch[1]);
     return {
-      message: `Installer failed with exit code ${code}`,
+      message: WELL_KNOWN_INSTALLER_EXIT_CODES[code] ?? `Installer failed with exit code ${code}`,
       errorCode: code,
       installerLogPath,
     };

--- a/extensions/winget/src/cli/parser.ts
+++ b/extensions/winget/src/cli/parser.ts
@@ -11,10 +11,14 @@
  *   truncates cells with "…" (U+2026). Verified live: names truncate often,
  *   versions sometimes (list/upgrade), IDs almost never. Cells are tagged; rows
  *   with truncated IDs are excluded (operations on them can never match).
- * - Localized headers: header detection prefers English column names; when the
- *   header has no recognizable English names, columns map to canonical keys BY
- *   POSITION using the calling command's expected shapes.
- * - Key-value output (`show`, `show --versions`).
+ * - Localized headers: column detection is structural, not linguistic — one
+ *   column per header token, boundaries validated against the data rows, then
+ *   mapped to canonical keys BY POSITION using the calling command's expected
+ *   shapes. English is just another locale. Row validation matters because
+ *   winget separates columns by a SINGLE space when a localized header name is
+ *   wider than the column's widest value (French "Disponible" vs "1.19.1").
+ * - Key-value output (`show`, `show --versions`): labels are localized; they
+ *   map to canonical keys via winget's own string tables (10 shipped locales).
  * - Operation result interpretation: EXIT-CODE-FIRST (exit codes are
  *   locale-independent HRESULTs; winget localizes all prose). English text
  *   patterns only refine messages and detect no-ops on exit 0.
@@ -157,6 +161,11 @@ interface ParseStats {
   droppedTruncatedIds: number;
 }
 
+// Section markers are English prose. On localized systems they simply don't
+// match: the sections still parse (each has its own header/separator), the
+// rows just carry the default "main" tag. That costs nothing functionally —
+// the explicit-targeting tag is informational, and the unknown-version table
+// only appears under --include-unknown, which no command here passes.
 const EXPLICIT_TARGETING_MARKER = /require explicit targeting/i;
 const UNKNOWN_VERSION_MARKER = /version numbers that cannot be determined/i;
 /** Footer/summary lines that are not data rows. */
@@ -169,14 +178,24 @@ function isSeparatorLine(line: string): boolean {
   return trimmed.length >= 10 && /^[-\s]+$/.test(trimmed) && trimmed.includes("-");
 }
 
+/** True when the display cell `cell` of `line` is blank or past the end. */
+function cellIsBlank(line: string, cell: number): boolean {
+  return sliceByDisplayCells(line, cell, cell + 1).trim() === "";
+}
+
 /**
- * Detect column boundaries. Primary: dash-run boundaries in the separator
- * (works when the separator has gaps). Fallback 1: positions of known English
- * keywords in the header (pin list's solid separator). Fallback 2 (localized
- * headers): split the header on runs of 2+ spaces and map names by position
- * using `canonicalByCount`.
+ * Detect column boundaries, without depending on the header's language.
+ * Primary: dash-run boundaries in the separator (exact, but winget's
+ * separators are usually one solid run). Otherwise: one column per header
+ * token, boundaries validated against the data rows, mapped to canonical keys
+ * by position using `canonicalByCount`.
  */
-function detectColumns(header: string, separator: string, canonicalByCount: Record<number, string[]>): TableColumn[] {
+function detectColumns(
+  header: string,
+  separator: string,
+  rowLines: string[],
+  canonicalByCount: Record<number, string[]>,
+): TableColumn[] {
   // Primary: gaps in the dashes give exact boundaries.
   const dashColumns: TableColumn[] = [];
   let i = 0;
@@ -194,60 +213,42 @@ function detectColumns(header: string, separator: string, canonicalByCount: Reco
     return canonicalizeColumns(dashColumns, canonicalByCount);
   }
 
-  // Fallback 1: English keyword positions (solid separator, e.g. pin list).
-  // Word-boundary matches only ("Identifiant" must not match "id"), and the
-  // result is only trusted when it found the columns the row mappers need.
-  const lower = header.toLowerCase();
-  const keywordColumns: TableColumn[] = [];
-  for (const word of ENGLISH_COLUMN_KEYWORDS) {
-    const match = new RegExp(`\\b${word.replace(" ", "\\s")}\\b`).exec(lower);
-    if (match && !keywordColumns.some((c) => match.index >= c.start && match.index < c.start + c.name.length)) {
-      keywordColumns.push({ name: word, start: match.index, end: -1 });
-    }
-  }
-  keywordColumns.sort((a, b) => a.start - b.start);
-  const keywordNames = new Set(keywordColumns.map((c) => c.name));
-  if (keywordColumns.length >= 2 && keywordNames.has("name") && keywordNames.has("id")) {
-    for (let j = 0; j < keywordColumns.length; j++) {
-      keywordColumns[j]!.end = keywordColumns[j + 1]?.start ?? Math.max(header.length, separator.length);
-    }
-    return remapColumnsToCells(keywordColumns, header);
-  }
-
-  // Fallback 2: localized header — positions from runs of 2+ spaces.
+  // Positional detection: every header token opens a column when either
+  // criterion holds.
+  // - A run of 2+ spaces before the token. Column names never contain double
+  //   spaces, so this is always a boundary — but winget separates columns by
+  //   a SINGLE space when the header name is wider than the column's widest
+  //   value (French "Disponible" vs "1.19.1"), so its absence proves nothing.
+  // - The rows confirm it: the display cell before the token is blank in
+  //   every row (true boundaries are padded in every row) AND some row has
+  //   content starting at the token (winget left-aligns values at the column
+  //   start, and drops columns with no values at all). Both checks are
+  //   needed: "Pin type"'s second word usually has row content beneath it,
+  //   but "Tipo de anclaje"'s third word starts beyond the widest value, so
+  //   only the content-at-start check rules it out. Prose lines (localized
+  //   "2 upgrades available.") never align to columns, so only lines with a
+  //   2+ space run get a vote.
+  const voters = rowLines.filter((line) => /\S\s{2,}\S/.test(line));
   const positional: TableColumn[] = [];
-  const matches = [...header.matchAll(/\S+(?:\s\S+)*?(?=\s{2,}|$)/g)];
-  for (const match of matches) {
-    if (match.index !== undefined && match[0].trim()) {
-      positional.push({
-        name: match[0].trim().toLowerCase(),
-        start: match.index,
-        end: -1,
-      });
+  for (const token of header.matchAll(/\S+/g)) {
+    const cellStart = codeUnitToCellOffset(header, token.index);
+    const isBoundary =
+      positional.length === 0 ||
+      /\s{2,}$/.test(header.slice(0, token.index)) ||
+      (voters.length > 0 &&
+        voters.every((line) => cellIsBlank(line, cellStart - 1)) &&
+        voters.some((line) => !cellIsBlank(line, cellStart)));
+    if (isBoundary) {
+      positional.push({ name: token[0].toLowerCase(), start: cellStart, end: -1 });
+    } else {
+      const previous = positional[positional.length - 1]!;
+      previous.name = `${previous.name} ${token[0].toLowerCase()}`;
     }
   }
   for (let j = 0; j < positional.length; j++) {
-    positional[j]!.end = positional[j + 1]?.start ?? Math.max(header.length, separator.length);
+    positional[j]!.end = positional[j + 1]?.start ?? Number.MAX_SAFE_INTEGER;
   }
-  return canonicalizeColumns(remapColumnsToCells(positional, header), canonicalByCount, true);
-}
-
-/**
- * Header-derived offsets are code-unit indices, but rows are sliced by display
- * cells. For localized headers containing wide (CJK) characters the two
- * diverge — remap. Identity for ASCII headers.
- */
-function remapColumnsToCells(columns: TableColumn[], header: string): TableColumn[] {
-  if (!MAYBE_WIDE.test(header)) {
-    return columns;
-  }
-  return columns.map((column, index) => ({
-    ...column,
-    start: codeUnitToCellOffset(header, column.start),
-    // The header's display width understates how far row content may extend;
-    // the last column always runs to the end of each row.
-    end: index === columns.length - 1 ? Number.MAX_SAFE_INTEGER : codeUnitToCellOffset(header, column.end),
-  }));
+  return canonicalizeColumns(positional, canonicalByCount, true);
 }
 
 /** Map detected columns to canonical names by position when names aren't English. */
@@ -274,12 +275,21 @@ function canonicalizeColumns(
  * Split output into table sections. A section starts at a header line followed
  * by a separator line; its tag comes from marker text seen since the previous
  * section. Lines before the first header and summary/marker lines are skipped.
+ * Row lines are collected BEFORE column detection: localized headers need the
+ * rows to resolve single-space column boundaries.
  */
 function parseTableSections(output: string, canonicalByCount: Record<number, string[]>): TableSection[] {
+  interface RawSection {
+    tag: SectionTag;
+    header: string;
+    separator: string;
+    rowLines: string[];
+  }
+
   const lines = output.split(/\r?\n/);
-  const sections: TableSection[] = [];
+  const rawSections: RawSection[] = [];
   let nextTag: SectionTag = "main";
-  let current: { columns: TableColumn[]; section: TableSection } | null = null;
+  let current: RawSection | null = null;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
@@ -303,28 +313,32 @@ function parseTableSections(output: string, canonicalByCount: Record<number, str
     // A new section begins wherever a line is followed by a separator.
     const next = lines[i + 1];
     if (next !== undefined && isSeparatorLine(next) && !isSeparatorLine(line)) {
-      const columns = detectColumns(line, next, canonicalByCount);
-      if (columns.length >= 2) {
-        const section: TableSection = { tag: nextTag, rows: [] };
-        sections.push(section);
-        current = { columns, section };
-        i++; // skip separator
-        continue;
-      }
+      current = { tag: nextTag, header: line, separator: next, rowLines: [] };
+      rawSections.push(current);
+      i++; // skip separator
+      continue;
     }
 
     if (!current || isSeparatorLine(line)) {
       continue;
     }
-
-    const row: Record<string, string> = {};
-    for (const col of current.columns) {
-      row[col.name] = sliceByDisplayCells(line, col.start, col.end).trim();
-    }
-    current.section.rows.push(row);
+    current.rowLines.push(line);
   }
 
-  return sections;
+  return rawSections.map(({ tag, header, separator, rowLines }) => {
+    const section: TableSection = { tag, rows: [] };
+    const columns = detectColumns(header, separator, rowLines, canonicalByCount);
+    if (columns.length >= 2) {
+      for (const line of rowLines) {
+        const row: Record<string, string> = {};
+        for (const col of columns) {
+          row[col.name] = sliceByDisplayCells(line, col.start, col.end).trim();
+        }
+        section.rows.push(row);
+      }
+    }
+    return section;
+  });
 }
 
 /** Collect truncated-field tags for a row. */
@@ -441,16 +455,151 @@ function parsePinnedPackages(output: string): TableParseResult<WingetPinnedPacka
 // Key-value parsing (show, show --versions)
 // ============================================================================
 
+/**
+ * The identity line opening every `show` output is `<verb> <name> [<id>]`.
+ * The verb is localized ("Found", "Trouvé", "Gefunden", "已找到", …) but the
+ * shape is not: winget prints its localized label, a space, then `name [id]`.
+ * IDs never contain whitespace, which keeps prose lines from matching.
+ */
+const IDENTITY_LINE = /^(\S+)\s+(.+?)\s+\[(\S+)\]/;
+
+type DetailField =
+  | "version"
+  | "publisher"
+  | "author"
+  | "moniker"
+  | "homepage"
+  | "license"
+  | "releasedate"
+  | "description"
+  | "tags";
+
+/** Lowercase, collapse whitespace, drop a trailing colon (half- or fullwidth). */
+function normalizeShowLabel(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[:：]\s*$/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * `winget show` localizes its field labels (the colon is part of the label
+ * string, and can be fullwidth or, for Korean's homepage, absent). This maps
+ * the labels of winget's 10 shipped locales, taken from its own string
+ * tables, to canonical fields; unknown labels are ignored.
+ */
+const SHOW_LABELS = new Map<string, DetailField>();
+for (const [field, labels] of Object.entries({
+  version: ["Version", "Versión", "Versione", "Versão", "バージョン", "버전", "Версия", "版本"],
+  publisher: [
+    "Publisher",
+    "Herausgeber",
+    "Editor",
+    "Editore",
+    "Fornecedor",
+    "公開元",
+    "게시자",
+    "Издатель",
+    "发布者",
+    "發行者",
+  ],
+  author: ["Author", "Auteur", "Autor", "Autore", "作成者", "만든 이", "Автор", "作者"],
+  moniker: ["Moniker", "モニカー", "모니커", "Моникер", "绰号", "綽號"],
+  homepage: [
+    "Homepage",
+    "Page d’accueil",
+    "Startseite",
+    "Página principal",
+    "Home page",
+    "ホーム ページ",
+    "홈페이지",
+    "Página inicial",
+    "Домашняя страница",
+    "主页",
+    "首頁",
+  ],
+  license: [
+    "License",
+    "Licence",
+    "Lizenz",
+    "Licencia",
+    "Licenza",
+    "ライセンス",
+    "라이선스",
+    "Licença",
+    "Лицензия",
+    "许可证",
+    "授权",
+  ],
+  releasedate: [
+    "Release Date",
+    "Date de version",
+    "Freigabedatum",
+    "Fecha de lanzamiento",
+    "Data di rilascio",
+    "リリース日",
+    "릴리스 날짜",
+    "Data do Lançamento",
+    "Дата выпуска",
+    "发布日期",
+    "發行日期",
+  ],
+  description: [
+    "Description",
+    "Beschreibung",
+    "Descripción",
+    "Descrizione",
+    "説明",
+    "설명",
+    "Descrição",
+    "Описание",
+    "描述",
+  ],
+  tags: ["Tags", "Mots-clés", "Markierungen", "Etiquetas", "Tag", "タグ", "태그", "Marcas", "标记", "標記"],
+} satisfies Record<DetailField, string[]>)) {
+  for (const label of labels) {
+    SHOW_LABELS.set(normalizeShowLabel(label), field as DetailField);
+  }
+}
+
+/**
+ * Korean's homepage label carries no colon at all ("홈페이지 https://…"). Only
+ * these labels may match without one; matching any known label as a bare
+ * prefix would let "Publisher Support Url: …" swallow the publisher field.
+ */
+const COLONLESS_SHOW_LABELS = new Map<string, DetailField>([["홈페이지", "homepage"]]);
+
+/** Match a top-level `Label: value` line against the known localized labels. */
+function matchShowLabel(line: string): { field: DetailField; value: string } | null {
+  if (/^\s/.test(line)) return null;
+  const colonIndex = line.search(/[:：]/);
+  if (colonIndex !== -1) {
+    const field = SHOW_LABELS.get(normalizeShowLabel(line.slice(0, colonIndex)));
+    if (field) {
+      return { field, value: line.slice(colonIndex + 1).trim() };
+    }
+  }
+  const firstSpace = line.indexOf(" ");
+  if (firstSpace !== -1) {
+    const field = COLONLESS_SHOW_LABELS.get(line.slice(0, firstSpace));
+    if (field) {
+      return { field, value: line.slice(firstSpace + 1).trim() };
+    }
+  }
+  return null;
+}
+
 function parsePackageDetails(output: string): WingetPackageDetails | null {
   const lines = output.split(/\r?\n/);
-  const foundIndex = lines.findIndex((line) => /^Found\s+.+\[.+\]/.test(line));
+  const foundIndex = lines.findIndex((line) => IDENTITY_LINE.test(line));
   if (foundIndex === -1) return null;
-  const headerMatch = lines[foundIndex]!.match(/^Found\s+(.+?)\s+\[(.+?)\]/);
-  if (!headerMatch?.[1] || !headerMatch[2]) return null;
+  const headerMatch = lines[foundIndex]!.match(IDENTITY_LINE);
+  if (!headerMatch?.[2] || !headerMatch[3]) return null;
 
   const result: WingetPackageDetails = {
-    id: headerMatch[2],
-    name: headerMatch[1],
+    id: headerMatch[3],
+    name: headerMatch[2],
     version: "",
   };
   let collecting: "description" | "tags" | null = null;
@@ -480,36 +629,33 @@ function parsePackageDetails(output: string): WingetPackageDetails | null {
       collecting = null;
     }
 
-    const kv = line.match(/^([A-Za-z][A-Za-z\s]*?):\s*(.*)$/);
-    if (!kv?.[1] || kv[2] === undefined) continue;
+    const kv = matchShowLabel(line);
+    if (!kv) continue;
 
-    const key = kv[1].toLowerCase().replace(/\s+/g, "");
-    const value = kv[2].trim();
-
-    switch (key) {
+    switch (kv.field) {
       case "version":
-        result.version = value;
+        result.version = kv.value;
         break;
       case "publisher":
-        result.publisher = value;
+        result.publisher = kv.value;
         break;
       case "author":
-        result.author = value;
+        result.author = kv.value;
         break;
       case "moniker":
-        result.moniker = value;
+        result.moniker = kv.value;
         break;
       case "homepage":
-        result.homepage = value;
+        result.homepage = kv.value;
         break;
       case "license":
-        result.license = value;
+        result.license = kv.value;
         break;
       case "releasedate":
-        result.releaseDate = value;
+        result.releaseDate = kv.value;
         break;
       case "description":
-        if (value) descriptionLines.push(value);
+        if (kv.value) descriptionLines.push(kv.value);
         collecting = "description";
         break;
       case "tags":
@@ -525,17 +671,17 @@ function parsePackageDetails(output: string): WingetPackageDetails | null {
 
 function parseVersionList(output: string): WingetVersionList | null {
   const lines = output.split(/\r?\n/).filter((l) => l.trim());
-  const foundIndex = lines.findIndex((line) => /^Found\s+.+\[.+\]/.test(line));
+  const foundIndex = lines.findIndex((line) => IDENTITY_LINE.test(line));
   if (foundIndex === -1) return null;
-  const headerMatch = lines[foundIndex]!.match(/^Found\s+(.+?)\s+\[(.+?)\]/);
-  if (!headerMatch?.[1] || !headerMatch[2]) return null;
+  const headerMatch = lines[foundIndex]!.match(IDENTITY_LINE);
+  if (!headerMatch?.[2] || !headerMatch[3]) return null;
 
   const separatorIndex = lines.findIndex((l, i) => i > foundIndex && /^-+$/.test(l.trim()));
   if (separatorIndex === -1) return null;
 
   return {
-    id: headerMatch[2],
-    name: headerMatch[1],
+    id: headerMatch[3],
+    name: headerMatch[2],
     versions: lines
       .slice(separatorIndex + 1)
       .map((l) => l.trim())

--- a/extensions/winget/src/cli/spawn.ts
+++ b/extensions/winget/src/cli/spawn.ts
@@ -194,6 +194,83 @@ async function runWinget(args: string[], options: SpawnWingetOptions = {}): Prom
   });
 }
 
+/** ERROR_CANCELLED: the user declined the UAC prompt. */
+const UAC_DECLINED_EXIT_CODE = 1223;
+
+/**
+ * Run winget elevated via ShellExecute's RunAs verb (UAC prompt), through a
+ * PowerShell Start-Process wrapper. The elevation boundary makes the child's
+ * stdio unreachable, so there is no output, no progress, and no cancellation —
+ * only the exit code, forwarded by the wrapper. The elevated PID is echoed
+ * before waiting so the lock's orphan detection still covers the child. A
+ * declined UAC prompt exits with UAC_DECLINED_EXIT_CODE.
+ */
+async function runWingetElevated(
+  args: string[],
+  options: { onSpawn?: (pid: number) => void } = {},
+): Promise<ExecutorResult> {
+  // Escape element-wise for PowerShell's single-quoted strings; arguments
+  // with whitespace additionally get embedded double quotes because
+  // Start-Process joins -ArgumentList with plain spaces.
+  const psArgs = args
+    .map((arg) => {
+      const escaped = arg.replace(/'/g, "''");
+      return /\s/.test(arg) ? `'"${escaped}"'` : `'${escaped}'`;
+    })
+    .join(", ");
+  const executable = wingetExecutable().replace(/'/g, "''");
+  const script = [
+    "$ErrorActionPreference = 'Stop'",
+    `try { $p = Start-Process -FilePath '${executable}' -ArgumentList @(${psArgs}) -Verb RunAs -WindowStyle Hidden -PassThru } catch { exit ${UAC_DECLINED_EXIT_CODE} }`,
+    "Write-Output ('ELEVATED_PID=' + $p.Id)",
+    "$p.WaitForExit()",
+    "exit $p.ExitCode",
+  ].join("; ");
+
+  // Absolute path: the worker's PATH cannot be relied on for System32 tools.
+  const env = repairedChildEnv();
+  const powershell = join(env.SystemRoot!, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+  const child = spawn(powershell, ["-NoProfile", "-NonInteractive", "-Command", script], {
+    windowsHide: true,
+    env,
+  });
+
+  return new Promise<ExecutorResult>((resolve, reject) => {
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let pidReported = false;
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdoutChunks.push(chunk);
+      if (!pidReported) {
+        const match = Buffer.concat(stdoutChunks)
+          .toString("utf-8")
+          .match(/ELEVATED_PID=(\d+)/);
+        if (match) {
+          pidReported = true;
+          options.onSpawn?.(Number.parseInt(match[1]!, 10));
+        }
+      }
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+    });
+
+    child.on("close", (code) => {
+      // Wrapper stdout is only the PID echo — winget's output never crosses
+      // the elevation boundary, so the interpreter sees an empty transcript.
+      resolve({
+        stdout: "",
+        stderr: Buffer.concat(stderrChunks).toString("utf-8"),
+        exitCode: code ?? 1,
+      });
+    });
+    child.on("error", (error) => {
+      reject(error);
+    });
+  });
+}
+
 /**
  * Filter WinGet loading-animation noise from final output. Every rule here
  * corresponds to a real output artifact:
@@ -261,4 +338,12 @@ function filterLoadingAnimation(output: string): string {
   return filtered.join("\n");
 }
 
-export { configureWingetPath, filterLoadingAnimation, repairedChildEnv, runWinget, withQuerySlot };
+export {
+  configureWingetPath,
+  filterLoadingAnimation,
+  repairedChildEnv,
+  runWinget,
+  runWingetElevated,
+  UAC_DECLINED_EXIT_CODE,
+  withQuerySlot,
+};

--- a/extensions/winget/src/cli/types.ts
+++ b/extensions/winget/src/cli/types.ts
@@ -100,6 +100,13 @@ interface WingetExecutorOptions {
   signal?: AbortSignal;
   /** Receives the spawned winget PID (lock orphan-detection registers it). */
   onSpawn?: (pid: number) => void;
+  /**
+   * Called when execution falls back to an elevated winget relaunch (UAC
+   * prompt). Output is not observable across the elevation boundary — no
+   * progress, and the child cannot be killed from this unelevated process, so
+   * the caller must stop honouring cancellation for the rest of the run.
+   */
+  onElevated?: () => void;
 }
 
 /** Internal spawn options. */

--- a/extensions/winget/src/core/feedback.ts
+++ b/extensions/winget/src/core/feedback.ts
@@ -211,9 +211,11 @@ async function finalizeOperationToast(toast: Toast, state: OperationState): Prom
       toast.message = state.kind === "download" ? state.downloadPath : state.message;
       break;
     case "noop":
+      // The runner clears redundant noop messages; one that survives adds
+      // information (e.g. a not-applicable update that is now hidden).
       toast.style = Toast.Style.Success;
       toast.title = noopTitle(state);
-      toast.message = undefined;
+      toast.message = state.message;
       break;
     case "cancelled":
       toast.style = Toast.Style.Failure;

--- a/extensions/winget/src/core/index-store.test.ts
+++ b/extensions/winget/src/core/index-store.test.ts
@@ -12,6 +12,7 @@ import {
   currentMutationEpoch,
   isCatalogFresh,
   loadIndex,
+  markUpdateNotApplicable,
   migrateLegacyIndex,
   patchMutable,
   type IndexPaths,
@@ -87,6 +88,48 @@ describe("patchMutable", () => {
 
     expect(outcome).toBe("fenced");
     expect(loadIndex(paths)!.upgradable).toHaveLength(0); // foo not resurrected
+  });
+});
+
+describe("not-applicable markers", () => {
+  it("marks a version and keeps the marker while winget offers the same version", () => {
+    patchMutable(paths, env, {}, (s) => ({ ...s, upgradable: [upgradable("zed")] }));
+    markUpdateNotApplicable(paths, env, { id: "zed", source: "winget" }, "2.0");
+    expect(loadIndex(paths)!.notApplicable).toEqual({ "winget|zed": "2.0" });
+
+    // An authoritative refresh that still lists 2.0 keeps the marker.
+    patchMutable(paths, env, { stampMutableAt: true }, (s) => ({ ...s, upgradable: [upgradable("zed")] }));
+    expect(loadIndex(paths)!.notApplicable).toEqual({ "winget|zed": "2.0" });
+  });
+
+  it("clears the marker when winget offers a different version", () => {
+    patchMutable(paths, env, {}, (s) => ({ ...s, upgradable: [upgradable("zed")] }));
+    markUpdateNotApplicable(paths, env, { id: "zed", source: "winget" }, "2.0");
+
+    patchMutable(paths, env, {}, (s) => ({
+      ...s,
+      upgradable: [{ ...upgradable("zed"), available: "2.1" }],
+    }));
+
+    expect(loadIndex(paths)!.notApplicable).toEqual({});
+  });
+
+  it("clears the marker when the row leaves the upgradable list", () => {
+    patchMutable(paths, env, {}, (s) => ({ ...s, upgradable: [upgradable("zed")] }));
+    markUpdateNotApplicable(paths, env, { id: "zed", source: "winget" }, "2.0");
+
+    patchMutable(paths, env, {}, (s) => ({ ...s, upgradable: [] }));
+
+    expect(loadIndex(paths)!.notApplicable).toEqual({});
+  });
+
+  it("defaults the field when loading an index written before markers existed", () => {
+    commitCatalog(paths, env, catalog(1));
+    const raw = loadIndex(paths)! as unknown as Record<string, unknown>;
+    delete raw.notApplicable;
+    writeFileSync(paths.indexPath, JSON.stringify(raw));
+
+    expect(loadIndex(paths)!.notApplicable).toEqual({});
   });
 });
 

--- a/extensions/winget/src/core/index-store.ts
+++ b/extensions/winget/src/core/index-store.ts
@@ -51,6 +51,14 @@ interface PackageIndex extends MutableSlices {
   /** When the mutable slices were last refreshed from winget. */
   mutableAt: number | null;
   packages: WingetSearchPackage[];
+  /**
+   * Updates winget lists but refuses to apply ("no applicable upgrade" — the
+   * listed installer does not match this system). Keyed by `source|id`, value
+   * is the available version that was refused; the marker hides the row from
+   * upgradable views until winget offers a DIFFERENT version (reconciled on
+   * every mutable commit).
+   */
+  notApplicable: Record<string, string>;
 }
 
 interface IndexPaths {
@@ -68,7 +76,13 @@ const EMPTY_INDEX: PackageIndex = {
   installed: [],
   upgradable: [],
   pinned: [],
+  notApplicable: {},
 };
+
+/** Canonical `source|id` key for cross-slice and marker lookups. */
+function packageKey(pkg: { id: string; source: string }): string {
+  return `${pkg.source}|${pkg.id}`;
+}
 
 function sleepSync(ms: number): void {
   const buffer = new SharedArrayBuffer(4);
@@ -80,6 +94,8 @@ function loadIndex(paths: IndexPaths): PackageIndex | null {
   if (!data || data.schemaVersion !== SCHEMA_VERSION || !Array.isArray(data.packages)) {
     return null;
   }
+  // Additive field: files written before markers existed lack it.
+  data.notApplicable ??= {};
   return data;
 }
 
@@ -145,6 +161,23 @@ function currentMutationEpoch(paths: IndexPaths): number {
 type CommitOutcome = "committed" | "fenced" | "rejected-shrink";
 
 /**
+ * Drop not-applicable markers the new upgradable slice no longer supports:
+ * the row is gone (upgraded or uninstalled elsewhere) or winget now offers a
+ * different version (which must be re-tried, not silently hidden).
+ */
+function reconcileNotApplicable(
+  markers: Record<string, string>,
+  upgradable: WingetUpgradePackage[],
+): Record<string, string> {
+  const entries = Object.entries(markers);
+  if (entries.length === 0) {
+    return markers;
+  }
+  const availableByKey = new Map(upgradable.map((pkg) => [packageKey(pkg), pkg.available]));
+  return Object.fromEntries(entries.filter(([key, version]) => availableByKey.get(key) === version));
+}
+
+/**
  * Apply a surgical change to the mutable slices (post-operation optimistic
  * patches and authoritative refreshes). Never touches `packages`.
  */
@@ -171,11 +204,28 @@ function patchMutable(
       next: {
         ...current,
         ...slices,
+        notApplicable: reconcileNotApplicable(current.notApplicable, slices.upgradable),
         mutableAt: options.stampMutableAt ? env.now() : current.mutableAt,
       },
       result: "committed" as const,
     };
   });
+}
+
+/** Record that the listed update for a package does not apply to this system. */
+function markUpdateNotApplicable(
+  paths: IndexPaths,
+  env: LockEnvironment,
+  target: { id: string; source: string },
+  availableVersion: string,
+): void {
+  withIndexWrite(paths, env, (current) => ({
+    next: {
+      ...current,
+      notApplicable: { ...current.notApplicable, [packageKey(target)]: availableVersion },
+    },
+    result: undefined,
+  }));
 }
 
 /** Commit only the catalog slice (stage 1 of the staged cold build). */
@@ -238,7 +288,9 @@ export {
   indexMtime,
   isCatalogFresh,
   loadIndex,
+  markUpdateNotApplicable,
   migrateLegacyIndex,
+  packageKey,
   patchMutable,
   SCHEMA_VERSION,
   type CommitOutcome,

--- a/extensions/winget/src/core/runner.ts
+++ b/extensions/winget/src/core/runner.ts
@@ -275,7 +275,15 @@ async function runOperation(request: OperationRequest): Promise<OperationState |
     }
   }, HEARTBEAT_MS);
 
+  // Set when execution falls back to an elevated relaunch: the elevated child
+  // cannot be killed from this unelevated process, so honouring a cancel would
+  // only orphan it while releasing the lock.
+  let elevatedPhase = false;
+
   const cancelTimer = setInterval(() => {
+    if (elevatedPhase) {
+      return;
+    }
     if (!fenced && !cancelling && isCancelRequested(opId)) {
       cancelling = true;
       if (toast) {
@@ -292,22 +300,31 @@ async function runOperation(request: OperationRequest): Promise<OperationState |
     writeOperationState(state);
     toast = await showOperationToast(request.title);
 
-    const cliOptions = (targetName?: string): WingetExecutorOptions => ({
-      signal: controller.signal,
-      onSpawn: (pid) => {
-        registerWingetPid(lockPath, opId, pid);
-      },
-      onProgress: (progress) => {
-        const message = progressMessage(progress);
-        publish({
-          stage: progress.type,
-          message:
-            state.bulk && targetName
-              ? `${targetName} (${state.bulk.index + 1}/${state.bulk.total})${message ? ` • ${message}` : ""}`
-              : message,
-        });
-      },
-    });
+    const cliOptions = (targetName?: string): WingetExecutorOptions => {
+      // Called once per package (bulk runs re-invoke it), so each package's
+      // retry chain starts unelevated; the guard re-arms only if the chain
+      // falls back to an elevated relaunch.
+      elevatedPhase = false;
+      return {
+        signal: controller.signal,
+        onElevated: () => {
+          elevatedPhase = true;
+        },
+        onSpawn: (pid) => {
+          registerWingetPid(lockPath, opId, pid);
+        },
+        onProgress: (progress) => {
+          const message = progressMessage(progress);
+          publish({
+            stage: progress.type,
+            message:
+              state.bulk && targetName
+                ? `${targetName} (${state.bulk.index + 1}/${state.bulk.total})${message ? ` • ${message}` : ""}`
+                : message,
+          });
+        },
+      };
+    };
 
     let result: WingetOperationResult;
     // Successfully upgraded/installed targets, re-checked against the

--- a/extensions/winget/src/core/runner.ts
+++ b/extensions/winget/src/core/runner.ts
@@ -49,7 +49,15 @@ import { type WingetExecutorOptions, type WingetOperationResult } from "../cli/t
 import { finalizeOperationToast, operationTitle, progressMessage, showBusyToast, showOperationToast } from "./feedback";
 import { cleanupOrphanTempFiles } from "./files";
 import { applyOperationPatch } from "./index-patches";
-import { bumpMutationEpoch, currentMutationEpoch, patchMutable, type IndexPaths } from "./index-store";
+import {
+  bumpMutationEpoch,
+  currentMutationEpoch,
+  loadIndex,
+  markUpdateNotApplicable,
+  packageKey,
+  patchMutable,
+  type IndexPaths,
+} from "./index-store";
 import {
   acquireLock,
   DEFAULT_ENV,
@@ -135,6 +143,24 @@ function statusFromResult(result: WingetOperationResult): OperationStatus {
   if (result.cancelled) return "cancelled";
   if (!result.success) return "failed";
   return result.noop ? "noop" : "succeeded";
+}
+
+/**
+ * A targeted upgrade that no-ops while winget's own upgrade list still offers
+ * a version is the "no applicable upgrade" contradiction: winget's list is a
+ * naive version comparison, but the actual install found no installer
+ * matching this system. Record the refused version so the row stops showing
+ * as upgradable; the marker clears itself when a different version appears
+ * (reconciled on every mutable commit). Returns the hidden version, or null
+ * when the package was simply up to date.
+ */
+function markNotApplicableIfListed(indexPaths: IndexPaths, target: PackageTarget): string | null {
+  const row = loadIndex(indexPaths)?.upgradable.find((u) => packageKey(u) === packageKey(target));
+  if (!row) {
+    return null;
+  }
+  markUpdateNotApplicable(indexPaths, DEFAULT_ENV, target, row.available);
+  return row.available;
 }
 
 /**
@@ -284,6 +310,10 @@ async function runOperation(request: OperationRequest): Promise<OperationState |
     });
 
     let result: WingetOperationResult;
+    // Successfully upgraded/installed targets, re-checked against the
+    // post-operation refresh: any that winget immediately re-offers get
+    // hidden as not-applicable.
+    const succeededTargets: PackageTarget[] = [];
     try {
       switch (request.kind) {
         case "upgrade-all":
@@ -297,6 +327,7 @@ async function runOperation(request: OperationRequest): Promise<OperationState |
             lockPath,
             opId,
             () => fenced || cancelling,
+            request.kind === "upgrade-all" ? succeededTargets : undefined,
           );
           break;
         case "import":
@@ -323,6 +354,9 @@ async function runOperation(request: OperationRequest): Promise<OperationState |
             request.force,
           );
           registerWingetPid(lockPath, opId, null); // child exited
+          if (result.success && !result.noop && (request.kind === "upgrade" || request.kind === "install")) {
+            succeededTargets.push(request.target);
+          }
           if (!fenced && PATCHABLE_KINDS.has(request.kind)) {
             // Optimistic patch: open views update on their next tick.
             patchMutable(
@@ -359,6 +393,17 @@ async function runOperation(request: OperationRequest): Promise<OperationState |
     }
 
     const status = statusFromResult(result);
+    if (status === "noop") {
+      // Noop titles are self-explanatory; a message only adds information
+      // when the noop revealed a not-applicable update that is now hidden.
+      result.message = undefined;
+      if (request.kind === "upgrade" && request.target) {
+        const hidden = markNotApplicableIfListed(indexPaths, request.target);
+        if (hidden) {
+          result.message = `Version ${hidden} does not apply to this system and is hidden until a newer version appears`;
+        }
+      }
+    }
     publish(
       {
         status,
@@ -403,17 +448,20 @@ async function runOperation(request: OperationRequest): Promise<OperationState |
         });
         if (refreshed.outcome === "fenced") {
           fenced = true;
-        } else if (
+        } else if (succeededTargets.length > 0) {
           // Some installers report a version winget cannot match against the
           // catalog (e.g. self-updating apps), so winget offers the same
-          // upgrade again immediately after a successful one. State that in
-          // the terminal toast instead of letting the row silently reappear.
-          state.status === "succeeded" &&
-          request.target &&
-          (request.kind === "upgrade" || request.kind === "install") &&
-          refreshed.upgradable.some((u) => u.id === request.target!.id && u.source === request.target!.source)
-        ) {
-          state.message = `The package was ${request.kind === "install" ? "installed" : "upgraded"}, but winget still reports an update available`;
+          // upgrade again immediately after a successful one. Hide those rows
+          // exactly like refused upgrades — the row would otherwise reappear
+          // after every upgrade forever.
+          for (const target of succeededTargets) {
+            const hidden = markNotApplicableIfListed(indexPaths, target);
+            // Single operations surface the hiding in the toast; bulk runs
+            // keep their upgraded/skipped/failed summary.
+            if (hidden && request.target) {
+              state.message = `winget still lists version ${hidden}, so it is hidden until a newer version appears`;
+            }
+          }
         } else if (
           // Some uninstallers only launch their own confirmation GUI and
           // exit; winget reports success regardless. The spawned window opens
@@ -470,6 +518,7 @@ async function runBulkOperation(
   lockPath: string,
   opId: string,
   shouldStop: () => boolean,
+  succeededTargets?: PackageTarget[],
 ): Promise<WingetOperationResult> {
   const targets = request.targets ?? [];
   const perPackageKind: SingleOperationKind = request.kind === "uninstall-all" ? "uninstall" : "upgrade";
@@ -517,8 +566,14 @@ async function runBulkOperation(
       // cannot determine. Counting these as successes would make "N succeeded"
       // include packages that remain in the upgradable list.
       skipped++;
+      if (perPackageKind === "upgrade" && !shouldStop()) {
+        // Bulk targets come from the upgradable list, so a skip means the
+        // listed version is not applicable — hide it from future runs.
+        markNotApplicableIfListed(indexPaths, target);
+      }
     } else if (result.success) {
       succeeded++;
+      succeededTargets?.push(target);
       // Per-package optimistic patch: a mid-bulk interruption preserves the
       // rows that were already truthfully mutated.
       if (!shouldStop()) {
@@ -611,9 +666,11 @@ async function runDirectUpgradeAll(): Promise<void> {
       return;
     }
 
-    const pinnedKeys = new Set(data.pinned.map((p) => `${p.source}|${p.id}`));
+    // Markers were reconciled against this snapshot by the commit above.
+    const notApplicable = loadIndex(indexPaths)?.notApplicable ?? {};
+    const pinnedKeys = new Set(data.pinned.map((p) => packageKey(p)));
     targets = data.upgradable
-      .filter((u) => !pinnedKeys.has(`${u.source}|${u.id}`))
+      .filter((u) => !pinnedKeys.has(packageKey(u)) && notApplicable[packageKey(u)] !== u.available)
       .map((u) => ({ id: u.id, name: u.name, source: u.source }));
   } catch (error) {
     toast.style = Toast.Style.Failure;

--- a/extensions/winget/src/hooks/useOperation.ts
+++ b/extensions/winget/src/hooks/useOperation.ts
@@ -31,7 +31,7 @@ import {
   requestCancel,
   writeOperationRequest,
 } from "../core/operations";
-import { runOperation } from "../core/runner";
+import { runOperation, runOperationWithFollowUp } from "../core/runner";
 
 const TICK_MS = 1_000;
 /** The runner command name (also the user-visible Upgrade All command). */
@@ -115,15 +115,18 @@ function useOperation(): UseOperationResult {
       // The runner never launched, so nothing will consume the request;
       // remove it so it cannot be executed by a later launch.
       discardOperationRequest(request.requestId);
+      if (error instanceof Error && /disabled|no enabled command/i.test(error.message)) {
+        // The runner command is disabled: run the same engine in THIS view's
+        // worker. The operation completes even if the worker dies (winget is
+        // a separate process; the interrupted-op machinery recovers state) —
+        // the user only loses live toast updates after leaving.
+        const state = await runOperationWithFollowUp(request);
+        return state !== null;
+      }
       await showToast({
         style: Toast.Style.Failure,
         title: "Could not start the operation",
-        message:
-          error instanceof Error && /disabled/i.test(error.message)
-            ? "Enable the 'Upgrade All Packages' command in Raycast settings. It runs this extension's operations"
-            : error instanceof Error
-              ? error.message
-              : undefined,
+        message: error instanceof Error ? error.message : undefined,
       });
       return false;
     }

--- a/extensions/winget/src/utils/packages.ts
+++ b/extensions/winget/src/utils/packages.ts
@@ -4,7 +4,7 @@
  */
 
 import { type WingetSource } from "../cli/types";
-import { type PackageIndex } from "../core/index-store";
+import { packageKey, type PackageIndex } from "../core/index-store";
 import { getCachedDetails } from "../hooks/useDetails";
 
 import { calculateRelevanceScore } from "./ranking";
@@ -34,7 +34,7 @@ interface PackageInfo {
  * reset the detail pane) after every upgrade.
  */
 function makeItemId(pkg: { id: string; source: string }): string {
-  return `${pkg.source}|${pkg.id}`;
+  return packageKey(pkg);
 }
 
 interface IndexLookups {
@@ -55,7 +55,13 @@ function buildLookups(index: PackageIndex): IndexLookups {
   }
   const upgradeByKey = new Map<string, { available: string; version: string; requiresExplicitTargeting?: boolean }>();
   for (const pkg of index.upgradable) {
-    upgradeByKey.set(makeItemId(pkg), {
+    const key = makeItemId(pkg);
+    if (index.notApplicable[key] === pkg.available) {
+      // winget refused this exact version ("no applicable upgrade"); hide it
+      // until a different version appears.
+      continue;
+    }
+    upgradeByKey.set(key, {
       available: pkg.available,
       version: pkg.version,
       requiresExplicitTargeting: pkg.requiresExplicitTargeting,
@@ -173,7 +179,7 @@ function upgradableRows(index: PackageIndex, lookups: IndexLookups): PackageInfo
   const rows: PackageInfo[] = [];
   for (const pkg of index.upgradable) {
     const key = makeItemId(pkg);
-    if (seen.has(key)) {
+    if (seen.has(key) || index.notApplicable[key] === pkg.available) {
       continue;
     }
     seen.add(key);


### PR DESCRIPTION
## Description

Follow-up fixes for the WinGet extension, addressing a locale regression reported in #29501, operations breaking when the Upgrade All Packages command is disabled (#29525), plus three upgrade-reliability issues found while running bulk upgrades.

**Fixed: package lists coming up empty on non-English Windows** (fixes #29501)

winget separates table columns by a single space whenever a localized header name is wider than the column's widest value (French `Disponible` over `1.19.1`), which the previous parsing missed, and headers mixing English with localized words (German `Name ID Version Verfügbar Quelle`) built tables that dropped the remaining columns. Column detection is now structural instead of linguistic: one column per header token, boundaries validated against the actual data rows, mapped to canonical keys by position. Package details (`winget show`) match the identity line by shape and map field labels through winget's own translation tables for its ten shipped display languages. Verified live on a French-locale system (the reported case) and against captured French, German, Spanish, Russian, Italian, Portuguese, Korean, and CJK fixtures in the test suite.

**Fixed: phantom rows in upgradable views**

`winget upgrade` can list an update it then refuses to apply ("No applicable upgrade found"), and some installers report versions winget cannot match against the catalog, so a successful upgrade is immediately re-offered. Both left permanent rows in Show Upgradable. The refused version is now recorded in the index and the row hidden until winget offers a different version.

**Fixed: packages that require administrator rights failing permanently**

Machine-scope MSIX packages (error 0x80073D28) cannot be installed by an unelevated winget at all. When every unelevated attempt fails with the requires-administrator class, winget is relaunched elevated the UAC prompt is the only confirmation, a declined prompt fails just that package, and bulk upgrades carry on with the next one.

**Fixed: unhelpful installer failure messages**

Documented Windows Installer exit codes (1602/1603/1618/1638) now show their meaning instead of the bare number; exit 1618 (another installation already in progress a transient mid-bulk collision) is retried once after a wait; and a silent installer that aborted because the app is open (which Inno Setup reports only in its log) now says "App in use, close it first" instead of a generic exit code.

**Fixed: every operation failing when the Upgrade All Packages command is disabled** (fixes #29525)

All long operations execute inside the Upgrade All Packages command, the only worker the platform keeps alive after the window closes, so disabling that command failed every install/upgrade/uninstall with "No enabled command". The launch failure now falls back to running the operation inside the view that started it: same engine, same global lock, same feedback. The in-flight winget call finishes even if the view closes (it is a separate process, guarded by the lock's orphan detection); the cost is that live progress toasts stop and an interrupted bulk run continues only when relaunched, which the README now explains.

The CHANGELOG has a new entry for these fixes, and the README notes are updated to match the new behavior.

## Screencast

_Screenshot below: Show Upgradable on a French-locale system next to `winget upgrade`. Note EA app: winget lists it as upgradable but refuses to act on it (second terminal command) the extension deliberately hides such rows until winget offers a different version, per the phantom-rows fix._


<img width="2431" height="976" alt="image" src="https://github.com/user-attachments/assets/2af52e2e-baa2-484e-8dd1-478a523e194c" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

Made with [Cursor](https://cursor.com)
