### PR TITLE
feat(claude-code-launcher): add session subcommand 

### DIFF
--- a/extensions/claude-code-launcher/CHANGELOG.md
+++ b/extensions/claude-code-launcher/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Launcher
 
-## [Claude Sessions] - {PR_MERGE_DATE}
+## [Claude Sessions] - 2026-08-10
 
 ### Added
 - New "Claude Sessions" command to manage Claude Code sessions and background agents: live status list (busy/idle/done), attach or resume background agents in your terminal, stop sessions, delete completed ones, fork interactive sessions, and dispatch new background agents (`claude --bg`) with a prompt

--- a/extensions/claude-code-launcher/CHANGELOG.md
+++ b/extensions/claude-code-launcher/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Claude Code Launcher
 
+## [Claude Sessions] - {PR_MERGE_DATE}
+
+### Added
+- New "Claude Sessions" command to manage Claude Code sessions and background agents: live status list (busy/idle/done), attach or resume background agents in your terminal, stop sessions, delete completed ones, fork interactive sessions, and dispatch new background agents (`claude --bg`) with a prompt
+- Optional "Claude CLI Path" preference on the new command for setups where the `claude` binary is not auto-detected
+
 ## [1.0.4] - 2026-03-24
 
 ### Added

--- a/extensions/claude-code-launcher/CLAUDE.md
+++ b/extensions/claude-code-launcher/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Raycast extension for quickly opening Claude Code sessions in selected directories. It allows users to save favorite project directories and launch Claude Code with a single keystroke through Raycast.
+This is a Raycast extension for working with Claude Code from Raycast. It lets users save project directories and launch Claude Code in them with a single keystroke, and manage running Claude Code sessions and background agents (list, attach, stop, delete, dispatch).
 
 ## Development Commands
 
@@ -48,35 +48,57 @@ Both TypeScript compilation and linting must pass without errors before code cha
 ## Architecture
 
 ### Core Functionality
-The extension provides a single Raycast command that:
-1. Manages a list of favorite directories stored in Raycast's LocalStorage
+The extension provides two Raycast commands:
+
+**Open Project (`open-claude-code`)**
+1. Manages a list of project directories stored in Raycast's LocalStorage
 2. Launches Claude Code in the selected directory via the terminal
 3. Tracks usage statistics (last opened, open count) for smart sorting
 
+**Claude Sessions (`claude-sessions`)**
+1. Lists all Claude Code sessions and background agents (`claude agents --all --json`) with live status, polling every few seconds
+2. Attaches/resumes background agents in the terminal (`claude attach <id>`), forks interactive sessions (`claude --resume <uuid> --fork-session`)
+3. Stops sessions (`claude stop <id>` for background agents, SIGTERM for interactive ones) and deletes completed background sessions (`claude rm <id>`)
+4. Dispatches new background agents (`claude --bg "prompt"`) and opens new interactive sessions
+
 ### Key Components
 
-**Main View (`src/open-claude-code.tsx`)**
-- `Command`: Main component that renders the favorites list
-- `AddFavoriteForm`: Form for adding new directories to favorites
-- `EditFavoriteForm`: Form for editing existing favorites
-- Directory validation, path expansion, and error handling
+**Open Project View (`src/open-claude-code.tsx`)**
+- `Command`: Main component that renders the projects list
+- `AddProjectForm` / `EditProjectForm`: Forms for adding and editing projects
+- Directory validation and error handling
+
+**Claude Sessions View (`src/claude-sessions.tsx`)**
+- Polling session list grouped into Running/Completed sections
+- Per-kind actions (attach, stop, delete, fork, jump-to-terminal) and forms for new sessions/background agents
+
+**Claude CLI Wrapper (`src/claude-cli.ts`)**
+- Resolves the `claude` binary (preference, common install locations, login-shell `which`) since Raycast does not inherit the shell PATH
+- `execFile` wrappers for `agents --all --json`, `stop`, `rm`, and `--bg`
+- Zod schemas (discriminated union on `kind`) validate the CLI's JSON output; duplicate sessionIds are merged
 
 **Terminal Adapters (`src/terminal-adapters/`)**
 - Abstraction layer for different terminal applications
 - `TerminalAdapter` interface defines the contract for terminal integrations
-- Implementations for Terminal.app and Alacritty
+- Implementations for Terminal.app, Alacritty, Ghostty, Warp, and iTerm2
 - Registry pattern for adapter management in `registry.ts`
+- `claude-command.ts` builds the `claude` invocation (with optional args like `attach <id>`) embedded into each adapter's shell command
 
-**Icon System (`src/favorite-icons.ts`)**
-- Provides Raycast icons for favorites with Claude brand tinting
+**Shared Modules**
+- `src/launch-terminal.ts`: opens the preferred terminal in a directory running `claude` (optionally with args)
+- `src/focus-terminal/`: focuses the terminal window already hosting an interactive session; `index.ts` resolves pid → tty → hosting app and dispatches to per-terminal adapters in `adapters/` (AppleScript tab targeting for Terminal.app/iTerm2, tty title-marker matching via Ghostty's AppleScript API for Ghostty 1.3+), falling back to NSRunningApplication pid activation (`activate-app.ts`)
+- `src/projects.ts`: `Project` type, LocalStorage key, read-only loader
+- `src/utils.ts`: `expandTilde`, `collapseTilde`, `getDirectoryName`
+
+**Icon System (`src/project-icons.ts`)**
 - Maps icon names to Raycast Icon components
 - Supports customizable default icon via preferences
 
 ### Data Model
 
-Favorites are stored in LocalStorage with this structure:
+Projects are stored in LocalStorage with this structure:
 ```typescript
-interface Favorite {
+interface Project {
   id: string;          // UUID
   path: string;        // Absolute directory path
   name?: string;       // Optional display name
@@ -87,15 +109,18 @@ interface Favorite {
 }
 ```
 
+Sessions are not persisted by the extension; they are read live from the Claude CLI (never from `~/.claude/sessions/*` or `~/.claude/jobs/*`, which are undocumented and unstable).
+
 ### User Preferences
 Configurable via Raycast preferences:
-- `claudeBinaryPath`: Path to Claude executable (default: `~/.claude/local/claude`)
-- `terminalApp`: Terminal choice (Terminal or Alacritty)
-- `defaultFavoriteIcon`: Default icon for new favorites
+- `terminalApp`: Terminal choice (Terminal, Alacritty, Ghostty, Warp, iTerm2)
+- `ghosttyOpenBehavior`: Window vs. tab behavior when Ghostty is selected
+- `defaultProjectIcon`: Default icon for new projects
+- `claudeBinaryPath` (Claude Sessions command only): Path to the Claude executable when auto-detection fails
 
 ### Error Handling
-- Validates Claude binary exists and is executable
 - Validates directories exist before attempting to open
+- Surfaces actionable errors when the Claude binary cannot be found (with recovery via command preferences)
 - Provides actionable error messages with recovery options
 - Handles corrupted LocalStorage data gracefully
 

--- a/extensions/claude-code-launcher/package-lock.json
+++ b/extensions/claude-code-launcher/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.102.3",
-        "@raycast/utils": "^1.17.0"
+        "@raycast/utils": "^1.17.0",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.0.4",
@@ -3052,6 +3053,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/extensions/claude-code-launcher/package.json
+++ b/extensions/claude-code-launcher/package.json
@@ -7,7 +7,8 @@
   "author": "stephendolan",
   "contributors": [
     "ridemountainpig",
-    "tim_gailey"
+    "tim_gailey",
+    "secustor"
   ],
   "categories": [
     "Developer Tools",
@@ -22,6 +23,23 @@
       "subtitle": "Claude Code Launcher",
       "description": "Launch Claude Code in project directories.",
       "mode": "view"
+    },
+    {
+      "name": "claude-sessions",
+      "title": "Claude Sessions",
+      "subtitle": "Claude Code Launcher",
+      "description": "List, attach, stop, and delete Claude Code sessions and background agents.",
+      "mode": "view",
+      "preferences": [
+        {
+          "name": "claudeBinaryPath",
+          "title": "Claude CLI Path",
+          "description": "Absolute path to the claude binary. Leave empty to auto-detect (Homebrew, ~/.claude/local, ~/.local/bin, ~/.bun/bin).",
+          "type": "textfield",
+          "required": false,
+          "placeholder": "/opt/homebrew/bin/claude"
+        }
+      ]
     }
   ],
   "preferences": [
@@ -118,7 +136,8 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.102.3",
-    "@raycast/utils": "^1.17.0"
+    "@raycast/utils": "^1.17.0",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.0.4",

--- a/extensions/claude-code-launcher/src/claude-cli.ts
+++ b/extensions/claude-code-launcher/src/claude-cli.ts
@@ -1,0 +1,200 @@
+import { getPreferenceValues } from "@raycast/api";
+import { execFile, spawn } from "child_process";
+import { promisify } from "util";
+import { access, constants } from "fs/promises";
+import { z } from "zod";
+import { expandTilde } from "./utils";
+
+const execFileAsync = promisify(execFile);
+
+const sessionBase = z.object({
+  sessionId: z.string(),
+  cwd: z.string(),
+  name: z.string().optional(),
+  startedAt: z.number().optional(),
+  // Present when status is "waiting", e.g. "permission prompt" (also covers plan-mode acceptance)
+  waitingFor: z.string().optional(),
+});
+
+const interactiveSessionSchema = sessionBase.extend({
+  kind: z.literal("interactive"),
+  pid: z.number(),
+  // "busy" | "idle" | "waiting" today; deliberately open so unknown future values still render
+  status: z.string(),
+});
+
+const backgroundSessionSchema = sessionBase.extend({
+  kind: z.literal("background"),
+  // Short job id — the target for `claude stop|rm|attach`
+  id: z.string(),
+  // "done" today; deliberately open
+  state: z.string(),
+  pid: z.number().optional(),
+  status: z.string().optional(),
+});
+
+const sessionSchema = z.discriminatedUnion("kind", [interactiveSessionSchema, backgroundSessionSchema]);
+
+export type BackgroundSession = z.infer<typeof backgroundSessionSchema>;
+// Merged dedupe rows (live interactive resume of a background job) carry the job's short id
+export type InteractiveSession = z.infer<typeof interactiveSessionSchema> & { jobId?: string };
+export type ClaudeSession = InteractiveSession | BackgroundSession;
+
+export function isRunning(session: ClaudeSession): boolean {
+  return session.kind === "interactive" || session.pid !== undefined;
+}
+
+export class ClaudeBinaryNotFoundError extends Error {
+  constructor(searchedPaths: string[]) {
+    super(
+      `Claude CLI not found. Searched: ${searchedPaths.join(", ")}. ` +
+        "Set 'Claude CLI Path' in the command preferences.",
+    );
+    this.name = "ClaudeBinaryNotFoundError";
+  }
+}
+
+const BINARY_CANDIDATES = [
+  "/opt/homebrew/bin/claude",
+  "/usr/local/bin/claude",
+  "~/.claude/local/claude",
+  "~/.local/bin/claude",
+  "~/.bun/bin/claude",
+];
+
+let cachedBinaryPath: string | undefined;
+
+async function isExecutable(filepath: string): Promise<boolean> {
+  try {
+    await access(filepath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveClaudeBinary(): Promise<string> {
+  if (cachedBinaryPath) return cachedBinaryPath;
+
+  const { claudeBinaryPath } = getPreferenceValues<{ claudeBinaryPath?: string }>();
+  const candidates = [...(claudeBinaryPath ? [claudeBinaryPath] : []), ...BINARY_CANDIDATES].map(expandTilde);
+
+  for (const candidate of candidates) {
+    if (await isExecutable(candidate)) {
+      cachedBinaryPath = candidate;
+      return candidate;
+    }
+  }
+
+  // Raycast does not inherit the shell PATH, but a login shell knows it
+  try {
+    const { stdout } = await execFileAsync("/bin/zsh", ["-lic", "which claude"], { timeout: 5000 });
+    const found = stdout.trim().split("\n").pop()?.trim();
+    if (found && (await isExecutable(found))) {
+      cachedBinaryPath = found;
+      return found;
+    }
+  } catch {
+    // fall through to the not-found error
+  }
+
+  throw new ClaudeBinaryNotFoundError(candidates);
+}
+
+async function execClaude(args: string[], options?: { cwd?: string; timeout?: number }): Promise<string> {
+  const binary = await resolveClaudeBinary();
+  try {
+    const { stdout } = await execFileAsync(binary, args, {
+      timeout: options?.timeout ?? 10_000,
+      cwd: options?.cwd,
+    });
+    return stdout;
+  } catch (error) {
+    // execFile buries the useful message in stderr
+    const stderr = (error as { stderr?: string }).stderr?.trim();
+    throw stderr ? new Error(stderr) : error;
+  }
+}
+
+/**
+ * The same sessionId can appear twice: once as a completed background job and
+ * once as a live interactive resume of it. Collapse those into a single
+ * interactive row that keeps the background job id for `claude rm`.
+ */
+function mergeDuplicate(a: ClaudeSession, b: ClaudeSession): ClaudeSession {
+  if (a.kind === "interactive" && b.kind === "background") return { ...a, jobId: b.id };
+  if (a.kind === "background" && b.kind === "interactive") return { ...b, jobId: a.id };
+  if (a.kind === "background" && b.kind === "background") return a.pid !== undefined ? a : b;
+  return a;
+}
+
+export async function listSessions(): Promise<ClaudeSession[]> {
+  const stdout = await execClaude(["agents", "--all", "--json"]);
+  const entries = z.array(z.unknown()).parse(JSON.parse(stdout));
+
+  const bySessionId = new Map<string, ClaudeSession>();
+  for (const entry of entries) {
+    // Validate per element so one malformed entry does not reject the whole list
+    const parsed = sessionSchema.safeParse(entry);
+    if (!parsed.success) continue;
+
+    const existing = bySessionId.get(parsed.data.sessionId);
+    bySessionId.set(parsed.data.sessionId, existing ? mergeDuplicate(existing, parsed.data) : parsed.data);
+  }
+
+  return [...bySessionId.values()];
+}
+
+// `claude stop|rm` refuse to act when they cannot confirm the job's worker is
+// dead, and print this message. That check needs the on-demand background
+// daemon, which those commands never start themselves — once it idle-exits,
+// they fail deterministically until the daemon runs again.
+function isKillUnconfirmedError(error: unknown): boolean {
+  return error instanceof Error && /couldn't confirm .* was stopped/.test(error.message);
+}
+
+// Start the background daemon supervisor detached. It exits by itself ~5s
+// after the last client disconnects, and bails when one is already running,
+// so there is nothing to clean up or guard against.
+async function startDaemon(): Promise<void> {
+  const binary = await resolveClaudeBinary();
+  spawn(binary, ["daemon", "run"], { detached: true, stdio: "ignore" }).unref();
+}
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function execClaudeWithDaemonRetry(args: string[]): Promise<void> {
+  try {
+    await execClaude(args, { timeout: 15_000 });
+    return;
+  } catch (error) {
+    if (!isKillUnconfirmedError(error)) throw error;
+  }
+
+  await startDaemon();
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    await delay(500);
+    try {
+      await execClaude(args, { timeout: 15_000 });
+      return;
+    } catch (error) {
+      if (!isKillUnconfirmedError(error) || Date.now() >= deadline) throw error;
+    }
+  }
+}
+
+export async function stopSession(id: string): Promise<void> {
+  await execClaudeWithDaemonRetry(["stop", id]);
+}
+
+export async function removeSession(id: string): Promise<void> {
+  await execClaudeWithDaemonRetry(["rm", id]);
+}
+
+export async function dispatchBackgroundAgent(directory: string, prompt: string, name?: string): Promise<void> {
+  await execClaude(["--bg", prompt, ...(name ? ["-n", name] : [])], {
+    cwd: expandTilde(directory),
+    timeout: 30_000,
+  });
+}

--- a/extensions/claude-code-launcher/src/claude-cli.ts
+++ b/extensions/claude-code-launcher/src/claude-cli.ts
@@ -146,11 +146,17 @@ export async function listSessions(): Promise<ClaudeSession[]> {
 }
 
 // `claude stop|rm` refuse to act when they cannot confirm the job's worker is
-// dead, and print this message. That check needs the on-demand background
-// daemon, which those commands never start themselves — once it idle-exits,
-// they fail deterministically until the daemon runs again.
-function isKillUnconfirmedError(error: unknown): boolean {
-  return error instanceof Error && /couldn't confirm .* was stopped/.test(error.message);
+// dead. That check needs the on-demand background daemon, which those commands
+// never start themselves — once it idle-exits, they fail deterministically
+// until the daemon runs again. Depending on command and CLI version the
+// message is "couldn't confirm <id> was stopped — …" or
+// "couldn't remove <id> — the background service may be restarting …".
+function isDaemonUnreachableError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    /couldn't confirm .* was stopped/.test(error.message) ||
+    error.message.includes("background service may be restarting")
+  );
 }
 
 // Start the background daemon supervisor detached. It exits by itself ~5s
@@ -168,7 +174,7 @@ async function execClaudeWithDaemonRetry(args: string[]): Promise<void> {
     await execClaude(args, { timeout: 15_000 });
     return;
   } catch (error) {
-    if (!isKillUnconfirmedError(error)) throw error;
+    if (!isDaemonUnreachableError(error)) throw error;
   }
 
   await startDaemon();
@@ -179,7 +185,7 @@ async function execClaudeWithDaemonRetry(args: string[]): Promise<void> {
       await execClaude(args, { timeout: 15_000 });
       return;
     } catch (error) {
-      if (!isKillUnconfirmedError(error) || Date.now() >= deadline) throw error;
+      if (!isDaemonUnreachableError(error) || Date.now() >= deadline) throw error;
     }
   }
 }

--- a/extensions/claude-code-launcher/src/claude-sessions.tsx
+++ b/extensions/claude-code-launcher/src/claude-sessions.tsx
@@ -1,0 +1,559 @@
+import {
+  Action,
+  ActionPanel,
+  Alert,
+  Color,
+  Form,
+  Icon,
+  Image,
+  Keyboard,
+  List,
+  Toast,
+  confirmAlert,
+  getPreferenceValues,
+  openCommandPreferences,
+  showHUD,
+  showToast,
+  useNavigation,
+} from "@raycast/api";
+import { showFailureToast, useCachedPromise } from "@raycast/utils";
+import { useEffect, useMemo, useState } from "react";
+import { access, constants } from "fs/promises";
+import {
+  BackgroundSession,
+  ClaudeBinaryNotFoundError,
+  ClaudeSession,
+  InteractiveSession,
+  dispatchBackgroundAgent,
+  isRunning,
+  listSessions,
+  removeSession,
+  stopSession,
+} from "./claude-cli";
+import { focusSessionTerminal } from "./focus-terminal";
+import { launchClaudeInTerminal } from "./launch-terminal";
+import { getIcon } from "./project-icons";
+import { loadStoredProjects } from "./projects";
+import { collapseTilde, expandTilde, getDirectoryName } from "./utils";
+
+const REFRESH_INTERVAL_MS = 3000;
+const CUSTOM_DIRECTORY = "__custom__";
+
+const STATUS_COLORS: Record<string, Color> = {
+  busy: Color.Orange,
+  idle: Color.Blue,
+  waiting: Color.Red,
+  done: Color.Green,
+};
+
+const STATUS_ICONS: Record<string, Image.ImageLike> = {
+  busy: { source: Icon.PlayFilled, tintColor: Color.Orange },
+  idle: { source: Icon.PauseFilled, tintColor: Color.Blue },
+  waiting: { source: Icon.Bell, tintColor: Color.Red },
+  done: { source: Icon.CheckCircle, tintColor: Color.Green },
+};
+
+function sessionTitle(session: ClaudeSession): string {
+  return session.name || getDirectoryName(session.cwd);
+}
+
+// Live process status first (busy/idle), else the background job state (done)
+function statusLabel(session: ClaudeSession): string {
+  return session.status ?? (session.kind === "background" ? session.state : "unknown");
+}
+
+function sessionIcon(session: ClaudeSession): { value: Image.ImageLike; tooltip: string } {
+  const label = statusLabel(session);
+  const icon = STATUS_ICONS[label] ?? { source: Icon.QuestionMarkCircle, tintColor: Color.SecondaryText };
+  const detail = session.waitingFor ? ` (${session.waitingFor})` : "";
+  return { value: icon, tooltip: `Status: ${label}${detail}` };
+}
+
+function sessionAccessories(session: ClaudeSession): List.Item.Accessory[] {
+  const accessories: List.Item.Accessory[] = [];
+  const label = statusLabel(session);
+  // The left icon shows the status; keep text tags only for what it cannot
+  // show: raw values of unknown statuses, and the done state of an agent
+  // whose process is still alive and attachable (idle + done)
+  if (!(label in STATUS_ICONS)) {
+    accessories.push({ tag: { value: label, color: STATUS_COLORS[label] ?? Color.SecondaryText } });
+  }
+  // What the session is waiting on (e.g. "permission prompt") — the icon alone cannot show it
+  if (session.waitingFor) {
+    accessories.push({ tag: { value: session.waitingFor, color: Color.Red } });
+  }
+  if (session.kind === "background" && session.status && session.state !== session.status) {
+    accessories.push({ tag: { value: session.state, color: STATUS_COLORS[session.state] ?? Color.SecondaryText } });
+  }
+  accessories.push({ tag: { value: session.kind, color: Color.SecondaryText } });
+  if (session.startedAt) {
+    const startedAt = new Date(session.startedAt);
+    accessories.push({ date: startedAt, tooltip: `Started: ${startedAt.toLocaleString()}` });
+  }
+  return accessories;
+}
+
+async function openSessionInTerminal(
+  session: ClaudeSession,
+  preferences: Preferences.ClaudeSessions,
+  claudeArgs: string[],
+  successTitle: string,
+): Promise<void> {
+  try {
+    await launchClaudeInTerminal(session.cwd, preferences, claudeArgs);
+    showToast({ style: Toast.Style.Success, title: successTitle, message: sessionTitle(session) });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "An unknown error occurred";
+    await showFailureToast(errorMessage, { title: "Failed to open terminal" });
+  }
+}
+
+function CopySessionActions({ session }: { session: ClaudeSession }) {
+  const jobId = session.kind === "background" ? session.id : session.jobId;
+  return (
+    <ActionPanel.Section>
+      <Action.CopyToClipboard title="Copy Session ID" content={session.sessionId} />
+      {jobId && <Action.CopyToClipboard title="Copy Job ID" content={jobId} />}
+      <Action.CopyToClipboard
+        title="Copy Path"
+        content={session.cwd}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+      />
+      <Action.ShowInFinder
+        title="Show in Finder"
+        path={expandTilde(session.cwd)}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
+      />
+    </ActionPanel.Section>
+  );
+}
+
+function InteractiveSessionActions({
+  session,
+  preferences,
+  revalidate,
+}: {
+  session: InteractiveSession;
+  preferences: Preferences.ClaudeSessions;
+  revalidate: () => void;
+}) {
+  return (
+    <>
+      <Action
+        title="Jump to Terminal"
+        icon={Icon.Window}
+        onAction={async () => {
+          try {
+            const result = await focusSessionTerminal(session.pid);
+            await showHUD(
+              result.kind === "window"
+                ? "Jumped to Terminal"
+                : `Activated ${result.appName} — exact window not targetable`,
+            );
+          } catch (error) {
+            await showFailureToast(error, { title: "Could not jump to terminal" });
+          }
+        }}
+      />
+      <Action
+        title={`Fork to New ${preferences.terminalApp} Window`}
+        icon={Icon.Terminal}
+        onAction={() =>
+          openSessionInTerminal(
+            session,
+            preferences,
+            ["--resume", session.sessionId, "--fork-session"],
+            "Forked Session",
+          )
+        }
+      />
+      <Action
+        title="Stop Session"
+        icon={Icon.Stop}
+        style={Action.Style.Destructive}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "x" }}
+        onAction={async () => {
+          await confirmAlert({
+            title: "Stop Session",
+            message: `Send SIGTERM to the Claude process of "${sessionTitle(session)}" running in your terminal?`,
+            primaryAction: {
+              title: "Stop",
+              style: Alert.ActionStyle.Destructive,
+              onAction: () => {
+                try {
+                  process.kill(session.pid, "SIGTERM");
+                  showToast({ style: Toast.Style.Success, title: "Stopped Session", message: sessionTitle(session) });
+                } catch (error) {
+                  if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+                    showToast({ style: Toast.Style.Success, title: "Session Already Exited" });
+                  } else {
+                    showFailureToast(error, { title: "Failed to stop session" });
+                  }
+                }
+                revalidate();
+              },
+            },
+          });
+        }}
+      />
+    </>
+  );
+}
+
+function BackgroundSessionActions({
+  session,
+  preferences,
+  revalidate,
+}: {
+  session: BackgroundSession;
+  preferences: Preferences.ClaudeSessions;
+  revalidate: () => void;
+}) {
+  const running = isRunning(session);
+  return (
+    <>
+      <Action
+        title={`${running ? "Attach" : "Resume"} in ${preferences.terminalApp}`}
+        icon={Icon.Terminal}
+        onAction={() =>
+          openSessionInTerminal(session, preferences, ["attach", session.id], running ? "Attached" : "Resumed")
+        }
+      />
+      {running ? (
+        <Action
+          title="Stop Session"
+          icon={Icon.Stop}
+          shortcut={{ modifiers: ["cmd", "shift"], key: "x" }}
+          onAction={async () => {
+            await confirmAlert({
+              title: "Stop Background Agent",
+              message: `Stop "${sessionTitle(session)}"? Its conversation is kept and can be resumed later.`,
+              primaryAction: {
+                title: "Stop",
+                onAction: async () => {
+                  try {
+                    await stopSession(session.id);
+                    showToast({ style: Toast.Style.Success, title: "Stopped Session", message: sessionTitle(session) });
+                  } catch (error) {
+                    await showFailureToast(error, { title: "Failed to stop session" });
+                  }
+                  revalidate();
+                },
+              },
+            });
+          }}
+        />
+      ) : (
+        <Action
+          title="Delete Session"
+          icon={Icon.Trash}
+          style={Action.Style.Destructive}
+          shortcut={Keyboard.Shortcut.Common.Remove}
+          onAction={async () => {
+            await confirmAlert({
+              title: "Delete Session",
+              message: `Delete "${sessionTitle(session)}"? This removes the session and its worktree.`,
+              primaryAction: {
+                title: "Delete",
+                style: Alert.ActionStyle.Destructive,
+                onAction: async () => {
+                  try {
+                    await removeSession(session.id);
+                    showToast({ style: Toast.Style.Success, title: "Deleted Session", message: sessionTitle(session) });
+                  } catch (error) {
+                    await showFailureToast(error, { title: "Failed to delete session" });
+                  }
+                  revalidate();
+                },
+              },
+            });
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+function GlobalActions({
+  preferences,
+  revalidate,
+}: {
+  preferences: Preferences.ClaudeSessions;
+  revalidate: () => void;
+}) {
+  return (
+    <ActionPanel.Section>
+      <Action.Push
+        title="New Session"
+        icon={Icon.Plus}
+        target={<NewSessionForm preferences={preferences} />}
+        shortcut={{ modifiers: ["cmd"], key: "n" }}
+      />
+      <Action.Push
+        title="New Background Agent"
+        icon={Icon.Bolt}
+        target={<NewBackgroundAgentForm onDispatched={revalidate} />}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "n" }}
+      />
+      <Action
+        title="Refresh"
+        icon={Icon.ArrowClockwise}
+        onAction={revalidate}
+        shortcut={{ modifiers: ["cmd"], key: "r" }}
+      />
+    </ActionPanel.Section>
+  );
+}
+
+function useDirectoryField() {
+  const { data: projects } = useCachedPromise(loadStoredProjects, []);
+  const [directoryChoice, setDirectoryChoice] = useState<string | undefined>();
+  const [customDirectory, setCustomDirectory] = useState<string[]>([]);
+  const [directoryError, setDirectoryError] = useState<string | undefined>();
+
+  const resolveDirectory = async (): Promise<string | undefined> => {
+    const directory = directoryChoice === CUSTOM_DIRECTORY ? customDirectory[0] : directoryChoice;
+    if (!directory) {
+      setDirectoryError("Please select a directory");
+      return undefined;
+    }
+
+    try {
+      const expandedPath = expandTilde(directory);
+      await access(expandedPath, constants.R_OK);
+      const stats = await import("fs/promises").then((fs) => fs.stat(expandedPath));
+      if (!stats.isDirectory()) {
+        setDirectoryError("Path must be a directory");
+        return undefined;
+      }
+    } catch {
+      setDirectoryError("Directory does not exist or is not accessible");
+      return undefined;
+    }
+
+    setDirectoryError(undefined);
+    return directory;
+  };
+
+  const fields = (
+    <>
+      <Form.Dropdown
+        id="directory"
+        title="Directory"
+        value={directoryChoice ?? (projects && projects.length > 0 ? projects[0].path : CUSTOM_DIRECTORY)}
+        onChange={(value) => {
+          setDirectoryChoice(value);
+          setDirectoryError(undefined);
+        }}
+        error={directoryError}
+      >
+        {(projects ?? []).map((project) => (
+          <Form.Dropdown.Item
+            key={project.id}
+            value={project.path}
+            title={project.name || getDirectoryName(project.path)}
+            icon={getIcon(project.icon || "Folder")}
+          />
+        ))}
+        <Form.Dropdown.Item value={CUSTOM_DIRECTORY} title="Choose Directory…" icon={Icon.Folder} />
+      </Form.Dropdown>
+      {(directoryChoice ?? (projects && projects.length > 0 ? projects[0].path : CUSTOM_DIRECTORY)) ===
+        CUSTOM_DIRECTORY && (
+        <Form.FilePicker
+          id="customDirectory"
+          title="Custom Directory"
+          allowMultipleSelection={false}
+          canChooseDirectories={true}
+          canChooseFiles={false}
+          value={customDirectory}
+          onChange={(paths) => {
+            setCustomDirectory(paths);
+            setDirectoryError(undefined);
+          }}
+        />
+      )}
+    </>
+  );
+
+  return { fields, resolveDirectory };
+}
+
+function NewSessionForm({ preferences }: { preferences: Preferences.ClaudeSessions }) {
+  const { pop } = useNavigation();
+  const { fields, resolveDirectory } = useDirectoryField();
+
+  const handleSubmit = async () => {
+    const directory = await resolveDirectory();
+    if (!directory) return;
+
+    try {
+      await launchClaudeInTerminal(directory, preferences);
+      showToast({ style: Toast.Style.Success, title: "Opened in Terminal", message: getDirectoryName(directory) });
+      pop();
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "An unknown error occurred";
+      await showFailureToast(errorMessage, { title: "Failed to open terminal" });
+    }
+  };
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title={`Open in ${preferences.terminalApp}`} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      {fields}
+    </Form>
+  );
+}
+
+function NewBackgroundAgentForm({ onDispatched }: { onDispatched: () => void }) {
+  const { pop } = useNavigation();
+  const { fields, resolveDirectory } = useDirectoryField();
+  const [promptError, setPromptError] = useState<string | undefined>();
+
+  const handleSubmit = async (values: { prompt: string; name: string }) => {
+    if (!values.prompt.trim()) {
+      setPromptError("Please enter a prompt");
+      return;
+    }
+
+    const directory = await resolveDirectory();
+    if (!directory) return;
+
+    try {
+      await showToast({ style: Toast.Style.Animated, title: "Dispatching background agent…" });
+      await dispatchBackgroundAgent(directory, values.prompt.trim(), values.name.trim() || undefined);
+      showToast({ style: Toast.Style.Success, title: "Dispatched Background Agent" });
+      onDispatched();
+      pop();
+    } catch (error) {
+      await showFailureToast(error, { title: "Failed to dispatch background agent" });
+    }
+  };
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Dispatch Background Agent" onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      {fields}
+      <Form.TextArea
+        id="prompt"
+        title="Prompt"
+        placeholder="What should the agent do?"
+        error={promptError}
+        onChange={() => setPromptError(undefined)}
+      />
+      <Form.TextField id="name" title="Name (Optional)" placeholder="my-agent" />
+    </Form>
+  );
+}
+
+export default function Command() {
+  const preferences = getPreferenceValues<Preferences.ClaudeSessions>();
+  const {
+    data: sessions,
+    isLoading,
+    error,
+    revalidate,
+  } = useCachedPromise(listSessions, [], {
+    keepPreviousData: true,
+  });
+
+  useEffect(() => {
+    // Pause polling while in an error state; the Retry action revalidates
+    if (error) return;
+    const timer = setInterval(revalidate, REFRESH_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [error, revalidate]);
+
+  const { running, completed } = useMemo(() => {
+    const all = sessions ?? [];
+    // Waiting sessions need the user's attention, so they outrank busy ones
+    const statusRank = (session: ClaudeSession) =>
+      session.status === "waiting" ? 0 : session.status === "busy" ? 1 : 2;
+    const byStartedAt = (a: ClaudeSession, b: ClaudeSession) => (b.startedAt ?? 0) - (a.startedAt ?? 0);
+    return {
+      running: all.filter(isRunning).sort((a, b) => statusRank(a) - statusRank(b) || byStartedAt(a, b)),
+      completed: all.filter((session) => !isRunning(session)).sort(byStartedAt),
+    };
+  }, [sessions]);
+
+  const renderItem = (session: ClaudeSession) => (
+    <List.Item
+      key={session.sessionId}
+      icon={sessionIcon(session)}
+      title={sessionTitle(session)}
+      subtitle={collapseTilde(session.cwd)}
+      keywords={[session.cwd, session.sessionId]}
+      accessories={sessionAccessories(session)}
+      actions={
+        <ActionPanel>
+          {session.kind === "interactive" ? (
+            <InteractiveSessionActions session={session} preferences={preferences} revalidate={revalidate} />
+          ) : (
+            <BackgroundSessionActions session={session} preferences={preferences} revalidate={revalidate} />
+          )}
+          <CopySessionActions session={session} />
+          <GlobalActions preferences={preferences} revalidate={revalidate} />
+        </ActionPanel>
+      }
+    />
+  );
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Search sessions...">
+      {error instanceof ClaudeBinaryNotFoundError ? (
+        <List.EmptyView
+          icon={Icon.ExclamationMark}
+          title="Claude CLI Not Found"
+          description={error.message}
+          actions={
+            <ActionPanel>
+              <Action title="Open Command Preferences" icon={Icon.Gear} onAction={openCommandPreferences} />
+              <Action title="Retry" icon={Icon.ArrowClockwise} onAction={revalidate} />
+            </ActionPanel>
+          }
+        />
+      ) : error ? (
+        <List.EmptyView
+          icon={Icon.ExclamationMark}
+          title="Failed to Load Sessions"
+          description={error instanceof Error ? error.message : "An unknown error occurred"}
+          actions={
+            <ActionPanel>
+              <Action title="Retry" icon={Icon.ArrowClockwise} onAction={revalidate} />
+              <GlobalActions preferences={preferences} revalidate={revalidate} />
+            </ActionPanel>
+          }
+        />
+      ) : (sessions ?? []).length === 0 ? (
+        <List.EmptyView
+          icon={Icon.Terminal}
+          title="No Claude Sessions"
+          description="Press ⌘N to start a session or ⌘⇧N to dispatch a background agent"
+          actions={
+            <ActionPanel>
+              <GlobalActions preferences={preferences} revalidate={revalidate} />
+            </ActionPanel>
+          }
+        />
+      ) : (
+        <>
+          <List.Section title="Running" subtitle={`${running.length} items`}>
+            {running.map(renderItem)}
+          </List.Section>
+          <List.Section title="Completed" subtitle={`${completed.length} items`}>
+            {completed.map(renderItem)}
+          </List.Section>
+        </>
+      )}
+    </List>
+  );
+}

--- a/extensions/claude-code-launcher/src/claude-sessions.tsx
+++ b/extensions/claude-code-launcher/src/claude-sessions.tsx
@@ -311,8 +311,12 @@ function useDirectoryField() {
   const [customDirectory, setCustomDirectory] = useState<string[]>([]);
   const [directoryError, setDirectoryError] = useState<string | undefined>();
 
+  // The dropdown shows the first project before any onChange fires, so submit
+  // must resolve against the same fallback the user sees, not the raw state
+  const effectiveChoice = directoryChoice ?? (projects && projects.length > 0 ? projects[0].path : CUSTOM_DIRECTORY);
+
   const resolveDirectory = async (): Promise<string | undefined> => {
-    const directory = directoryChoice === CUSTOM_DIRECTORY ? customDirectory[0] : directoryChoice;
+    const directory = effectiveChoice === CUSTOM_DIRECTORY ? customDirectory[0] : effectiveChoice;
     if (!directory) {
       setDirectoryError("Please select a directory");
       return undefined;
@@ -340,7 +344,7 @@ function useDirectoryField() {
       <Form.Dropdown
         id="directory"
         title="Directory"
-        value={directoryChoice ?? (projects && projects.length > 0 ? projects[0].path : CUSTOM_DIRECTORY)}
+        value={effectiveChoice}
         onChange={(value) => {
           setDirectoryChoice(value);
           setDirectoryError(undefined);
@@ -357,8 +361,7 @@ function useDirectoryField() {
         ))}
         <Form.Dropdown.Item value={CUSTOM_DIRECTORY} title="Choose Directory…" icon={Icon.Folder} />
       </Form.Dropdown>
-      {(directoryChoice ?? (projects && projects.length > 0 ? projects[0].path : CUSTOM_DIRECTORY)) ===
-        CUSTOM_DIRECTORY && (
+      {effectiveChoice === CUSTOM_DIRECTORY && (
         <Form.FilePicker
           id="customDirectory"
           title="Custom Directory"

--- a/extensions/claude-code-launcher/src/focus-terminal/activate-app.ts
+++ b/extensions/claude-code-launcher/src/focus-terminal/activate-app.ts
@@ -1,0 +1,27 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+// Bring the app instance owning the pid to the front via NSRunningApplication.
+// Unlike System Events' frontmost, this is a real activation that switches Spaces
+// (including into fullscreen ones) and targets the exact instance when several
+// share a bundle (Alacritty, Ghostty in window mode). For a single instance with
+// several windows, macOS activates its most-recently-focused window. Throws when
+// the pid does not belong to a GUI process (e.g. a session inside tmux or over ssh).
+export async function activateProcess(pid: number): Promise<void> {
+  const script = `
+    ObjC.import("AppKit");
+    function run(argv) {
+      const app = $.NSRunningApplication.runningApplicationWithProcessIdentifier(parseInt(argv[0], 10));
+      if (app.isNil()) throw new Error("no GUI app with pid " + argv[0]);
+      app.activateWithOptions($.NSApplicationActivateIgnoringOtherApps);
+    }
+  `;
+  await execFileAsync("osascript", ["-l", "JavaScript", "-e", script, String(pid)]);
+}
+
+// App-level activation via LaunchServices (same as a Dock-icon click).
+export async function openAppBundle(bundlePath: string): Promise<void> {
+  await execFileAsync("open", [bundlePath]);
+}

--- a/extensions/claude-code-launcher/src/focus-terminal/adapters/ghostty.ts
+++ b/extensions/claude-code-launcher/src/focus-terminal/adapters/ghostty.ts
@@ -1,0 +1,102 @@
+import { execFile } from "child_process";
+import { randomUUID } from "crypto";
+import { promisify } from "util";
+import { FocusAdapter } from "../types";
+
+const execFileAsync = promisify(execFile);
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export class GhosttyFocusAdapter implements FocusAdapter {
+  name = "Ghostty";
+
+  matches(command: string): boolean {
+    return /Ghostty/i.test(command);
+  }
+
+  // Focus the Ghostty surface attached to the given tty. Ghostty's AppleScript API
+  // (1.3+) exposes no tty, so the surface is identified by briefly setting a unique
+  // title marker through the tty itself, then restored. Handled inside Ghostty (not
+  // the Accessibility API), `focus` reaches windows on other Spaces, fullscreen
+  // included. Returns false when the marker never shows up (session hosted by
+  // another Ghostty instance, AppleScript disabled, or Ghostty < 1.3).
+  async focusSession(ttyPath: string): Promise<boolean> {
+    try {
+      const titlesBefore = await this.listTerminals();
+      const marker = `claude-code-launcher-${randomUUID()}`;
+      await this.writeTerminalTitle(ttyPath, marker);
+      let focusedId: string | undefined;
+      try {
+        for (let attempt = 0; attempt < 5 && !focusedId; attempt++) {
+          focusedId = await this.focusTerminalByName(marker);
+          if (!focusedId) await delay(150);
+        }
+      } finally {
+        // Claude repaints its title on activity, but restore the pre-marker title
+        // anyway so idle sessions don't keep the marker (blank when unknown).
+        await this.writeTerminalTitle(ttyPath, (focusedId && titlesBefore.get(focusedId)) || "").catch(() => undefined);
+      }
+      return focusedId !== undefined;
+    } catch {
+      return false;
+    }
+  }
+
+  // Set the terminal title by writing an OSC 2 escape straight to the session's
+  // tty device. The hosting emulator applies it to whichever surface owns the tty.
+  private async writeTerminalTitle(ttyPath: string, title: string): Promise<void> {
+    await execFileAsync("/bin/sh", ["-c", 'printf "\\033]2;%s\\007" "$1" > "$2"', "_", title, ttyPath]);
+  }
+
+  private async listTerminals(): Promise<Map<string, string>> {
+    const script = `
+      -- Bind the separator before the tell block: inside it, "tab" is Ghostty's tab class
+      set sep to tab
+      set out to ""
+      tell application "Ghostty"
+        repeat with w in windows
+          repeat with t in tabs of w
+            repeat with s in terminals of t
+              set out to out & (id of s) & sep & (name of s) & linefeed
+            end repeat
+          end repeat
+        end repeat
+      end tell
+      return out
+    `;
+    const { stdout } = await execFileAsync("osascript", ["-e", script]);
+    const terminals = new Map<string, string>();
+    for (const line of stdout.split("\n")) {
+      const tabIndex = line.indexOf("\t");
+      if (tabIndex > 0) terminals.set(line.slice(0, tabIndex), line.slice(tabIndex + 1));
+    }
+    return terminals;
+  }
+
+  // Focus the terminal whose current title matches. Returns the terminal's id,
+  // or undefined when no title matches.
+  private async focusTerminalByName(name: string): Promise<string | undefined> {
+    const script = `
+      on run argv
+        set targetName to item 1 of argv
+        tell application "Ghostty"
+          repeat with w in windows
+            repeat with t in tabs of w
+              repeat with s in terminals of t
+                if name of s is targetName then
+                  focus s
+                  activate
+                  return id of s
+                end if
+              end repeat
+            end repeat
+          end repeat
+        end tell
+        return ""
+      end run
+    `;
+    const { stdout } = await execFileAsync("osascript", ["-e", script, name]);
+    const id = stdout.trim();
+    return id || undefined;
+  }
+}

--- a/extensions/claude-code-launcher/src/focus-terminal/adapters/iterm2.ts
+++ b/extensions/claude-code-launcher/src/focus-terminal/adapters/iterm2.ts
@@ -1,0 +1,40 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { FocusAdapter } from "../types";
+
+const execFileAsync = promisify(execFile);
+
+export class ITerm2FocusAdapter implements FocusAdapter {
+  name = "iTerm2";
+
+  matches(command: string): boolean {
+    return /iTerm/i.test(command);
+  }
+
+  // Focus the iTerm2 session attached to the given tty.
+  async focusSession(ttyPath: string): Promise<boolean> {
+    const script = `
+      on run argv
+        set targetTty to item 1 of argv
+        tell application "iTerm2"
+          repeat with w in windows
+            repeat with t in tabs of w
+              repeat with s in sessions of t
+                if tty of s is targetTty then
+                  select w
+                  select t
+                  select s
+                  activate
+                  return "found"
+                end if
+              end repeat
+            end repeat
+          end repeat
+        end tell
+        return "missing"
+      end run
+    `;
+    const { stdout } = await execFileAsync("osascript", ["-e", script, ttyPath]);
+    return stdout.trim() === "found";
+  }
+}

--- a/extensions/claude-code-launcher/src/focus-terminal/adapters/terminal-app.ts
+++ b/extensions/claude-code-launcher/src/focus-terminal/adapters/terminal-app.ts
@@ -1,0 +1,37 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { FocusAdapter } from "../types";
+
+const execFileAsync = promisify(execFile);
+
+export class TerminalAppFocusAdapter implements FocusAdapter {
+  name = "Terminal";
+
+  matches(command: string): boolean {
+    return /Terminal\.app\//.test(command);
+  }
+
+  // Focus the Terminal.app tab attached to the given tty.
+  async focusSession(ttyPath: string): Promise<boolean> {
+    const script = `
+      on run argv
+        set targetTty to item 1 of argv
+        tell application "Terminal"
+          repeat with w in windows
+            repeat with t in tabs of w
+              if tty of t is targetTty then
+                set selected of t to true
+                set index of w to 1
+                activate
+                return "found"
+              end if
+            end repeat
+          end repeat
+        end tell
+        return "missing"
+      end run
+    `;
+    const { stdout } = await execFileAsync("osascript", ["-e", script, ttyPath]);
+    return stdout.trim() === "found";
+  }
+}

--- a/extensions/claude-code-launcher/src/focus-terminal/index.ts
+++ b/extensions/claude-code-launcher/src/focus-terminal/index.ts
@@ -1,0 +1,45 @@
+import { activateProcess, openAppBundle } from "./activate-app";
+import { appNameOf, bundlePathOf, getAncestors, getTtyPath, isTerminalProcess } from "./process";
+import { getFocusAdapter } from "./registry";
+import { FocusResult } from "./types";
+
+export type { FocusAdapter, FocusResult } from "./types";
+
+/**
+ * Focus the terminal window that hosts the Claude process with the given pid,
+ * instead of opening a new one. Throws when the hosting terminal cannot be
+ * located (e.g. the session runs inside tmux, over ssh, or in an editor pane
+ * that System Events cannot target).
+ */
+export async function focusSessionTerminal(pid: number): Promise<FocusResult> {
+  const [ttyPath, ancestors] = await Promise.all([getTtyPath(pid), getAncestors(pid)]);
+
+  const terminalAncestor = ancestors.find(isTerminalProcess);
+
+  if (ttyPath && terminalAncestor) {
+    // Window/tab-level targeting for scriptable terminals; adapters are matched
+    // against the app found in the ancestry, since `tell application` would
+    // launch an app that is not running.
+    const adapter = getFocusAdapter(terminalAncestor.command);
+    if (adapter && (await adapter.focusSession(ttyPath))) {
+      return { kind: "window" };
+    }
+  }
+
+  // Fall back to activating the hosting app process. Prefer the recognized
+  // terminal ancestor; otherwise try the top-level ancestor spawned by launchd.
+  const candidate = terminalAncestor ?? ancestors.find((p) => p.ppid === 1);
+  if (!candidate) {
+    throw new Error("Could not locate the terminal hosting this session");
+  }
+  try {
+    await activateProcess(candidate.pid);
+  } catch {
+    const bundlePath = bundlePathOf(candidate.command);
+    if (!bundlePath) {
+      throw new Error("Could not locate the terminal hosting this session");
+    }
+    await openAppBundle(bundlePath);
+  }
+  return { kind: "app", appName: appNameOf(candidate.command) };
+}

--- a/extensions/claude-code-launcher/src/focus-terminal/process.ts
+++ b/extensions/claude-code-launcher/src/focus-terminal/process.ts
@@ -1,0 +1,54 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+export interface ProcessInfo {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+export async function getTtyPath(pid: number): Promise<string | undefined> {
+  const { stdout } = await execFileAsync("ps", ["-o", "tty=", "-p", String(pid)]);
+  const tty = stdout.trim();
+  return tty && tty !== "??" ? `/dev/${tty}` : undefined;
+}
+
+export async function getAncestors(pid: number): Promise<ProcessInfo[]> {
+  const ancestors: ProcessInfo[] = [];
+  let current = pid;
+  for (let depth = 0; depth < 20 && current > 1; depth++) {
+    let stdout: string;
+    try {
+      ({ stdout } = await execFileAsync("ps", ["-o", "ppid=,comm=", "-p", String(current)]));
+    } catch {
+      break; // process exited mid-walk
+    }
+    const match = stdout.trim().match(/^(\d+)\s+(.*)$/);
+    if (!match) break;
+    const ppid = Number(match[1]);
+    ancestors.push({ pid: current, ppid, command: match[2] });
+    current = ppid;
+  }
+  return ancestors;
+}
+
+// Whether a process looks like a GUI terminal app hosting a session: anything
+// inside an .app bundle, plus bare binaries of known terminals (e.g. Homebrew
+// installs). Broader than the focus adapters on purpose — terminals without
+// window-level scripting still get app-level activation.
+export function isTerminalProcess(process: ProcessInfo): boolean {
+  return /\.app\//.test(process.command) || /alacritty|ghostty|kitty|wezterm/i.test(process.command);
+}
+
+export function appNameOf(command: string): string {
+  const bundle = command.match(/\/([^/]+)\.app\//);
+  if (bundle) return bundle[1];
+  return command.split("/").pop() ?? command;
+}
+
+export function bundlePathOf(command: string): string | undefined {
+  const match = command.match(/^(.*?\.app)\//);
+  return match ? match[1] : undefined;
+}

--- a/extensions/claude-code-launcher/src/focus-terminal/registry.ts
+++ b/extensions/claude-code-launcher/src/focus-terminal/registry.ts
@@ -1,0 +1,10 @@
+import { GhosttyFocusAdapter } from "./adapters/ghostty";
+import { ITerm2FocusAdapter } from "./adapters/iterm2";
+import { TerminalAppFocusAdapter } from "./adapters/terminal-app";
+import { FocusAdapter } from "./types";
+
+const adapters: FocusAdapter[] = [new TerminalAppFocusAdapter(), new ITerm2FocusAdapter(), new GhosttyFocusAdapter()];
+
+export function getFocusAdapter(command: string): FocusAdapter | undefined {
+  return adapters.find((adapter) => adapter.matches(command));
+}

--- a/extensions/claude-code-launcher/src/focus-terminal/types.ts
+++ b/extensions/claude-code-launcher/src/focus-terminal/types.ts
@@ -1,0 +1,12 @@
+export type FocusResult =
+  | { kind: "window" } // the exact window/tab hosting the session was focused
+  | { kind: "app"; appName: string }; // only the hosting terminal app was brought to front
+
+/** Focuses the existing window/tab hosting a session, identified by its tty. */
+export interface FocusAdapter {
+  name: string;
+  /** Whether this adapter handles the terminal with the given executable path. */
+  matches(command: string): boolean;
+  /** Focus the window/tab attached to the tty. Returns false when the session cannot be found. */
+  focusSession(ttyPath: string): Promise<boolean>;
+}

--- a/extensions/claude-code-launcher/src/launch-terminal.ts
+++ b/extensions/claude-code-launcher/src/launch-terminal.ts
@@ -1,0 +1,46 @@
+import { closeMainWindow } from "@raycast/api";
+import { access, constants } from "fs/promises";
+import { getTerminalAdapter } from "./terminal-adapters";
+import { expandTilde } from "./utils";
+
+export interface TerminalLaunchPreferences {
+  terminalApp: string;
+  ghosttyOpenBehavior?: string;
+}
+
+/**
+ * Opens the user's preferred terminal in the given directory running
+ * `claude` with the given arguments (plain `claude` when omitted).
+ * Throws on inaccessible directories or unsupported terminals; callers
+ * are responsible for toasts.
+ */
+export async function launchClaudeInTerminal(
+  directory: string,
+  preferences: TerminalLaunchPreferences,
+  claudeArgs?: string[],
+): Promise<void> {
+  const expandedPath = expandTilde(directory);
+
+  try {
+    await access(expandedPath, constants.R_OK);
+  } catch {
+    throw new Error(`Cannot access directory: ${expandedPath}. It may have been moved or deleted.`);
+  }
+
+  const adapter = getTerminalAdapter(preferences.terminalApp);
+
+  if (!adapter) {
+    throw new Error(`Unsupported terminal: ${preferences.terminalApp}`);
+  }
+
+  const options = {
+    ghosttyOpenBehavior: preferences.ghosttyOpenBehavior as "window" | "tab" | undefined,
+    claudeArgs,
+  };
+
+  if (preferences.terminalApp === "Ghostty" && options.ghosttyOpenBehavior === "tab") {
+    await closeMainWindow();
+  }
+
+  await adapter.open(expandedPath, options);
+}

--- a/extensions/claude-code-launcher/src/open-claude-code.tsx
+++ b/extensions/claude-code-launcher/src/open-claude-code.tsx
@@ -12,34 +12,16 @@ import {
   confirmAlert,
   Keyboard,
   Alert,
-  closeMainWindow,
 } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { PROJECT_ICON_NAMES, getIcon } from "./project-icons";
 import { getTerminalAdapter } from "./terminal-adapters";
+import { launchClaudeInTerminal } from "./launch-terminal";
+import { Project, ProjectsState, PROJECTS_STORAGE_KEY, PROJECTS_CURRENT_VERSION } from "./projects";
+import { expandTilde, getDirectoryName } from "./utils";
 import { useState, useEffect, useMemo } from "react";
 import { randomUUID } from "crypto";
-import { homedir } from "os";
-import path from "path";
 import { access, constants } from "fs/promises";
-
-const STORAGE_KEY = "claude-code-projects";
-const CURRENT_VERSION = 1;
-
-interface Project {
-  id: string;
-  path: string;
-  name?: string;
-  icon?: string;
-  addedAt: Date;
-  lastOpened?: Date;
-  openCount: number;
-}
-
-interface ProjectsState {
-  projects: Project[];
-  version: number;
-}
 
 function showSuccessToast(title: string, message?: string) {
   showToast({
@@ -83,40 +65,9 @@ function getRelativeTime(date: Date | undefined): string {
   return `${years} ${years === 1 ? "year" : "years"} ago`;
 }
 
-function expandTilde(filepath: string): string {
-  if (filepath.startsWith("~/")) {
-    return path.join(homedir(), filepath.slice(2));
-  }
-  return filepath;
-}
-
-function getDirectoryName(dirPath: string): string {
-  return path.basename(dirPath) || path.dirname(dirPath);
-}
-
 async function openInTerminal(project: Project, preferences: Preferences, onSuccess: () => void): Promise<void> {
-  const expandedPath = expandTilde(project.path);
-
   try {
-    try {
-      await access(expandedPath, constants.R_OK);
-    } catch {
-      throw new Error(`Cannot access directory: ${expandedPath}. It may have been moved or deleted.`);
-    }
-
-    const adapter = getTerminalAdapter(preferences.terminalApp);
-
-    if (!adapter) {
-      throw new Error(`Unsupported terminal: ${preferences.terminalApp}`);
-    }
-
-    const options = { ghosttyOpenBehavior: preferences.ghosttyOpenBehavior as "window" | "tab" | undefined };
-
-    if (preferences.terminalApp === "Ghostty" && options.ghosttyOpenBehavior === "tab") {
-      await closeMainWindow();
-    }
-
-    await adapter.open(expandedPath, options);
+    await launchClaudeInTerminal(project.path, preferences);
     onSuccess();
     showSuccessToast("Opened in Terminal", project.name || getDirectoryName(project.path));
   } catch (error) {
@@ -365,7 +316,7 @@ export default function Command() {
 
   const loadProjects = async () => {
     try {
-      const stored = await LocalStorage.getItem<string>(STORAGE_KEY);
+      const stored = await LocalStorage.getItem<string>(PROJECTS_STORAGE_KEY);
       if (stored) {
         let state: ProjectsState;
         try {
@@ -376,7 +327,7 @@ export default function Command() {
             title: "Corrupted Data",
             message: "Your projects data was corrupted and has been reset.",
           });
-          await LocalStorage.removeItem(STORAGE_KEY);
+          await LocalStorage.removeItem(PROJECTS_STORAGE_KEY);
           setProjects([]);
           return;
         }
@@ -387,7 +338,7 @@ export default function Command() {
             title: "Invalid Data",
             message: "Your projects data structure was invalid and has been reset.",
           });
-          await LocalStorage.removeItem(STORAGE_KEY);
+          await LocalStorage.removeItem(PROJECTS_STORAGE_KEY);
           setProjects([]);
           return;
         }
@@ -419,9 +370,9 @@ export default function Command() {
     try {
       const state: ProjectsState = {
         projects: newProjects,
-        version: CURRENT_VERSION,
+        version: PROJECTS_CURRENT_VERSION,
       };
-      await LocalStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      await LocalStorage.setItem(PROJECTS_STORAGE_KEY, JSON.stringify(state));
       setProjects(newProjects);
     } catch (error) {
       console.error("Failed to save projects:", error);

--- a/extensions/claude-code-launcher/src/projects.ts
+++ b/extensions/claude-code-launcher/src/projects.ts
@@ -1,0 +1,38 @@
+import { LocalStorage } from "@raycast/api";
+
+export const PROJECTS_STORAGE_KEY = "claude-code-projects";
+export const PROJECTS_CURRENT_VERSION = 1;
+
+export interface Project {
+  id: string;
+  path: string;
+  name?: string;
+  icon?: string;
+  addedAt: Date;
+  lastOpened?: Date;
+  openCount: number;
+}
+
+export interface ProjectsState {
+  projects: Project[];
+  version: number;
+}
+
+/**
+ * Read-only project loader for commands that only need the saved directories.
+ * Returns an empty list on missing or corrupted data without side effects;
+ * corruption recovery stays in the Open Project command.
+ */
+export async function loadStoredProjects(): Promise<Project[]> {
+  try {
+    const stored = await LocalStorage.getItem<string>(PROJECTS_STORAGE_KEY);
+    if (!stored) return [];
+
+    const state: ProjectsState = JSON.parse(stored);
+    if (!state.projects || !Array.isArray(state.projects)) return [];
+
+    return state.projects.filter((proj) => proj && proj.id && proj.path);
+  } catch {
+    return [];
+  }
+}

--- a/extensions/claude-code-launcher/src/terminal-adapters/adapters/alacritty.ts
+++ b/extensions/claude-code-launcher/src/terminal-adapters/adapters/alacritty.ts
@@ -1,6 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
-import { TerminalAdapter } from "../types";
+import { TerminalAdapter, TerminalOpenOptions } from "../types";
+import { buildClaudeCommand } from "../claude-command";
 
 const execFileAsync = promisify(execFile);
 
@@ -8,10 +9,10 @@ export class AlacrittyAdapter implements TerminalAdapter {
   name = "Alacritty";
   bundleId = "org.alacritty";
 
-  async open(directory: string): Promise<void> {
+  async open(directory: string, options?: TerminalOpenOptions): Promise<void> {
     const userShell = process.env.SHELL || "/bin/zsh";
 
-    const command = `cd ${this.shellEscape(directory)} && clear && claude ; exec ${userShell} -l`;
+    const command = `cd ${this.shellEscape(directory)} && clear && ${buildClaudeCommand(options)} ; exec ${userShell} -l`;
 
     await execFileAsync("open", ["-n", "-a", "Alacritty", "--args", "-e", userShell, "-l", "-i", "-c", command]);
   }

--- a/extensions/claude-code-launcher/src/terminal-adapters/adapters/ghostty.ts
+++ b/extensions/claude-code-launcher/src/terminal-adapters/adapters/ghostty.ts
@@ -1,8 +1,12 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { TerminalAdapter, TerminalOpenOptions } from "../types";
+import { buildClaudeCommand } from "../claude-command";
 
 const execFileAsync = promisify(execFile);
+
+// Ghostty's AppleScript API (new window / new tab / focus) was introduced in 1.3.
+const MIN_APPLESCRIPT_VERSION = { major: 1, minor: 3 };
 
 /**
  * Ghostty terminal adapter
@@ -19,28 +23,92 @@ export class GhosttyAdapter implements TerminalAdapter {
 
   async open(directory: string, options?: TerminalOpenOptions): Promise<void> {
     const userShell = process.env.SHELL || "/bin/zsh";
-    const command = `cd ${this.shellEscape(directory)} && clear && claude ; exec ${userShell} -l`;
+    const command = `cd ${this.shellEscape(directory)} && clear && ${buildClaudeCommand(options)} ; exec ${userShell} -l`;
+    const asTab = options?.ghosttyOpenBehavior === "tab";
 
-    if (options?.ghosttyOpenBehavior === "tab") {
-      await this.openInTab(command);
+    // Prefer Ghostty's own AppleScript API (1.3+) whenever it is available: it opens
+    // windows/tabs inside the already-running instance. The `open -na` window fallback
+    // instead spawns a SECOND Ghostty instance that macOS merges with existing
+    // (fullscreen) windows into one tabbed window, and the tab fallback is brittle GUI
+    // keystroke scripting. Fall back only when scripting is unavailable (Ghostty < 1.3,
+    // `macos-applescript = false`, or the app is not running yet).
+    if (await this.supportsAppleScript()) {
+      try {
+        await this.openViaAppleScript(userShell, command, asTab);
+        return;
+      } catch {
+        // Scripting failed at runtime (e.g. disabled) — fall through to legacy paths.
+      }
+    }
+
+    if (asTab) {
+      await this.openTabViaKeystroke(command);
     } else {
-      await this.openInNewWindow(userShell, command);
+      await this.openWindowViaOpen(userShell, command);
     }
   }
 
-  private async openInNewWindow(shell: string, command: string): Promise<void> {
-    // Launch Ghostty using macOS 'open' command
-    // -na: open a new instance of the application
-    // --args: pass arguments to the application
-    // -e: execute command flag for Ghostty
-    // -l: login shell
-    // -c: command to execute
+  // Whether the running Ghostty exposes its AppleScript API (1.3+). Probing the
+  // version is guarded by `is running` so a cold start never launches the app just to
+  // check — cold starts use the fallbacks anyway (a fresh window has nothing to merge
+  // with, and the keystroke path launches Ghostty itself).
+  private async supportsAppleScript(): Promise<boolean> {
+    const version = await this.runningVersion();
+    if (!version) return false;
+    const [major, minor] = version.split(".").map((part) => parseInt(part, 10));
+    if (!Number.isFinite(major) || !Number.isFinite(minor)) return false;
+    return (
+      major > MIN_APPLESCRIPT_VERSION.major ||
+      (major === MIN_APPLESCRIPT_VERSION.major && minor >= MIN_APPLESCRIPT_VERSION.minor)
+    );
+  }
+
+  // Version of the running Ghostty (e.g. "1.3.1"), or undefined when it is not running
+  // or scripting is unavailable. The `is running` check comes first so the query never
+  // launches the app.
+  private async runningVersion(): Promise<string | undefined> {
+    const script = `if application "Ghostty" is not running then return ""
+return version of application "Ghostty"`;
+    try {
+      const { stdout } = await execFileAsync("osascript", ["-e", script]);
+      return stdout.trim() || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async openViaAppleScript(shell: string, command: string, asTab: boolean): Promise<void> {
+    // Ghostty runs a surface configuration's `command` under /bin/sh with a bare
+    // default PATH, so run it through a login shell so `claude` resolves — the same
+    // login shell the `open ... ${shell} -l -c` fallback relies on.
+    const loginShellCommand = `${shell} -l -c ${this.shellEscape(command)}`;
+    const config = `{command:${this.appleScriptEscape(loginShellCommand)}}`;
+    // `new tab` must target a window (front window); `new window` creates its own.
+    const create = asTab
+      ? `set newSurface to new tab in front window with configuration ${config}
+          set target to focused terminal of newSurface`
+      : `set newSurface to new window with configuration ${config}
+          set target to focused terminal of selected tab of newSurface`;
+    const script = `
+      tell application "Ghostty"
+        ${create}
+        activate
+        try
+          focus target
+        end try
+      end tell
+    `;
+    await execFileAsync("osascript", ["-e", script]);
+  }
+
+  private async openWindowViaOpen(shell: string, command: string): Promise<void> {
+    // Fallback for Ghostty < 1.3 / disabled scripting / cold start.
+    // -na: new instance, --args: pass to Ghostty, -e: execute, -l login shell, -c command
     await execFileAsync("open", ["-na", "Ghostty.app", "--args", "-e", shell, "-l", "-c", command]);
   }
 
-  private async openInTab(command: string): Promise<void> {
-    // Ghostty on macOS has no native AppleScript/IPC for tab creation,
-    // so we use GUI scripting via System Events:
+  private async openTabViaKeystroke(command: string): Promise<void> {
+    // Fallback for Ghostty < 1.3 (no `new tab` AppleScript command): drive the GUI.
     // 1. Set clipboard to the command
     // 2. Activate Ghostty and wait for it to be frontmost
     // 3. Cmd+T to open a new tab

--- a/extensions/claude-code-launcher/src/terminal-adapters/adapters/iterm2.ts
+++ b/extensions/claude-code-launcher/src/terminal-adapters/adapters/iterm2.ts
@@ -1,6 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
-import { TerminalAdapter } from "../types";
+import { TerminalAdapter, TerminalOpenOptions } from "../types";
+import { buildClaudeCommand } from "../claude-command";
 
 const execFileAsync = promisify(execFile);
 
@@ -8,9 +9,9 @@ export class ITerm2Adapter implements TerminalAdapter {
   name = "iTerm2";
   bundleId = "com.googlecode.iterm2";
 
-  async open(directory: string): Promise<void> {
+  async open(directory: string, options?: TerminalOpenOptions): Promise<void> {
     const userShell = process.env.SHELL || "/bin/zsh";
-    const command = `clear && claude ; exec ${userShell} -l`;
+    const command = `clear && ${buildClaudeCommand(options)} ; exec ${userShell} -l`;
 
     await execFileAsync("open", ["-a", "iTerm", directory]);
 

--- a/extensions/claude-code-launcher/src/terminal-adapters/adapters/terminal-app.ts
+++ b/extensions/claude-code-launcher/src/terminal-adapters/adapters/terminal-app.ts
@@ -1,6 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
-import { TerminalAdapter } from "../types";
+import { TerminalAdapter, TerminalOpenOptions } from "../types";
+import { buildClaudeCommand } from "../claude-command";
 
 const execFileAsync = promisify(execFile);
 
@@ -8,21 +9,22 @@ export class TerminalAppAdapter implements TerminalAdapter {
   name = "Terminal";
   bundleId = "com.apple.Terminal";
 
-  async open(directory: string): Promise<void> {
+  async open(directory: string, options?: TerminalOpenOptions): Promise<void> {
     const userShell = process.env.SHELL || "/bin/zsh";
 
     const script = `
       on run argv
         set targetDir to item 1 of argv
         set shellPath to item 2 of argv
-        
+        set claudeCmd to item 3 of argv
+
         tell application "Terminal"
-          do script "cd " & quoted form of targetDir & " && clear && claude ; exec " & quoted form of shellPath
+          do script "cd " & quoted form of targetDir & " && clear && " & claudeCmd & " ; exec " & quoted form of shellPath
           activate
         end tell
       end run
     `;
 
-    await execFileAsync("osascript", ["-e", script, directory, userShell]);
+    await execFileAsync("osascript", ["-e", script, directory, userShell, buildClaudeCommand(options)]);
   }
 }

--- a/extensions/claude-code-launcher/src/terminal-adapters/adapters/warp.ts
+++ b/extensions/claude-code-launcher/src/terminal-adapters/adapters/warp.ts
@@ -4,7 +4,8 @@ import { writeFile, mkdir, unlink } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import { randomUUID } from "crypto";
-import { TerminalAdapter } from "../types";
+import { TerminalAdapter, TerminalOpenOptions } from "../types";
+import { buildClaudeCommand } from "../claude-command";
 
 const execFileAsync = promisify(execFile);
 
@@ -14,9 +15,10 @@ export class WarpAdapter implements TerminalAdapter {
 
   private readonly launchConfigDir = join(homedir(), ".warp", "launch_configurations");
 
-  async open(directory: string): Promise<void> {
+  async open(directory: string, options?: TerminalOpenOptions): Promise<void> {
     const configName = `claude-code-${randomUUID()}`;
     const configPath = join(this.launchConfigDir, `${configName}.yaml`);
+    const claudeCommand = buildClaudeCommand(options);
 
     const yamlContent = `
 name: ${configName}
@@ -26,7 +28,7 @@ windows:
         layout:
           cwd: "${directory.replace(/"/g, '\\"')}"
           commands:
-            - exec: claude
+            - exec: "${claudeCommand.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"
 `;
 
     try {

--- a/extensions/claude-code-launcher/src/terminal-adapters/claude-command.ts
+++ b/extensions/claude-code-launcher/src/terminal-adapters/claude-command.ts
@@ -1,0 +1,17 @@
+import { TerminalOpenOptions } from "./types";
+
+const SAFE_ARG_PATTERN = /^[A-Za-z0-9@%_+=:,./-]+$/;
+
+function shellQuoteArg(arg: string): string {
+  return SAFE_ARG_PATTERN.test(arg) ? arg : `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Builds the claude invocation embedded in each adapter's shell command.
+ * Session ids and flags match the safe pattern, so the common results are
+ * plain `claude`, `claude attach <id>`, or `claude --resume <uuid> --fork-session`.
+ */
+export function buildClaudeCommand(options?: TerminalOpenOptions): string {
+  const args = options?.claudeArgs ?? [];
+  return ["claude", ...args.map(shellQuoteArg)].join(" ");
+}

--- a/extensions/claude-code-launcher/src/terminal-adapters/types.ts
+++ b/extensions/claude-code-launcher/src/terminal-adapters/types.ts
@@ -1,5 +1,7 @@
 export interface TerminalOpenOptions {
   ghosttyOpenBehavior?: "window" | "tab";
+  /** Arguments appended to the `claude` invocation, e.g. ["attach", "b0da874e"]. Omit to launch plain `claude`. */
+  claudeArgs?: string[];
 }
 
 export interface TerminalAdapter {

--- a/extensions/claude-code-launcher/src/utils.ts
+++ b/extensions/claude-code-launcher/src/utils.ts
@@ -1,0 +1,22 @@
+import { homedir } from "os";
+import path from "path";
+
+export function expandTilde(filepath: string): string {
+  if (filepath.startsWith("~/")) {
+    return path.join(homedir(), filepath.slice(2));
+  }
+  return filepath;
+}
+
+export function collapseTilde(filepath: string): string {
+  const home = homedir();
+  if (filepath === home) return "~";
+  if (filepath.startsWith(home + path.sep)) {
+    return "~" + filepath.slice(home.length);
+  }
+  return filepath;
+}
+
+export function getDirectoryName(dirPath: string): string {
+  return path.basename(dirPath) || path.dirname(dirPath);
+}


### PR DESCRIPTION
## Description

Adds an additional sub command `Clause Sessions` which shows all interactive and background sessions of Claude Code.

Which allows: 
- To see which session needs attention ( no manual registering of sessions needed ) 
- Attach background tasks to a new terminal session if necessary 
- Delete / Stop background agents 
- Fork an existing session to a new tab / window
- Start new sessions in the front or background


## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

<img width="1000" height="625" alt="Raycast 2026-08-10 at 12 55 26" src="https://github.com/user-attachments/assets/fbcf60e8-5d7c-4d49-9c37-c4fa711209d9" />
<img width="1000" height="625" alt="Raycast 2026-08-10 at 12 55 36" src="https://github.com/user-attachments/assets/6645b13c-8c15-4794-9cb9-f362235287e0" />
<img width="1000" height="625" alt="Raycast 2026-08-10 at 12 55 46" src="https://github.com/user-attachments/assets/e1991864-eddf-4e32-9534-7cf356a2ae03" />
<img width="1000" height="625" alt="Raycast 2026-08-10 at 12 55 54" src="https://github.com/user-attachments/assets/ac6e1455-5796-42f3-afb0-c5ca5a6de65d" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
