### PR TITLE
Add Find MCP to MCP registry (community)

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Add Find MCP Server] - {PR_MERGE_DATE}
+
+Add Find MCP to the community registry: search 17,000+ MCP servers synced from the official MCP registry (registry.modelcontextprotocol.io) via the agentage MCP Catalog. Stdio server; also available as a remote Streamable HTTP endpoint at catalog.agentage.io/mcp with no auth required for search.
+
 ## [Add Agentcard MCP Server] - 2026-07-15
 
 Add Agentcard to the official registry: prepaid virtual cards for AI agents. Fund a wallet, set spend caps and human approvals, and your agent mints a one-time virtual card for each purchase that works at any merchant. Remote streamable HTTP MCP server with OAuth 2.0 sign-in via mcp-remote; no API key required.

--- a/extensions/model-context-protocol-registry/README.md
+++ b/extensions/model-context-protocol-registry/README.md
@@ -99,6 +99,7 @@ To add a new MCP registry to the registry, you need to create a new entry in the
 | [Monday](https://github.com/sakce/mcp-server-monday) | MCP Server for monday.com, enabling MCP clients to interact with Monday.com boards, items, updates, and documents. |
 | [Paperless-NGX](https://github.com/baruchiro/paperless-mcp) | An MCP server for interacting with a Paperless-NGX API server. Manage documents, tags, correspondents, and document types in your Paperless-NGX instance. |
 | [VC Deal Flow Signal](https://github.com/kindrat86/vc-deal-flow-signal) | GitHub-derived engineering acceleration signals for ~400 venture-backed startups across 20 sectors. Five read-only tools for VC sourcing — trending startups, sector lookup, individual signal, dataset summary, methodology. No API key required. |
+| [Find MCP](https://catalog.agentage.io/mcp) | Search 17,000+ MCP servers synced from the official MCP registry (registry.modelcontextprotocol.io). Tools to search, get server details, and browse categories. Also available as a remote Streamable HTTP server at catalog.agentage.io/mcp, no auth required for search. |
 
 
 <!-- MCP_SERVERS_END -->

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -1017,4 +1017,16 @@ export const COMMUNITY_ENTRIES: RegistryEntry[] = [
       args: ["-y", "@gitdealflow/mcp-signal@latest"],
     },
   },
+  {
+    name: "find-mcp",
+    title: "Find MCP",
+    description:
+      "Search 17,000+ MCP servers synced from the official MCP registry (registry.modelcontextprotocol.io). Tools to search, get server details, and browse categories. Also available as a remote Streamable HTTP server at catalog.agentage.io/mcp, no auth required for search.",
+    icon: "https://github.com/agentage.png",
+    homepage: "https://catalog.agentage.io/mcp",
+    configuration: {
+      command: "npx",
+      args: ["-y", "@agentage/find-mcp"],
+    },
+  },
 ];


### PR DESCRIPTION
## Description

Adds Find MCP to the extension's community MCP server registry (`COMMUNITY_ENTRIES`).

Find MCP is a stdio MCP server for discovering other MCP servers. It searches the agentage MCP Catalog, 17,000+ servers synced from the official MCP registry (registry.modelcontextprotocol.io), and exposes `mcp_search`, `mcp_get`, and `mcp_categories` tools.

The configured install is the native stdio entry (`npx -y @agentage/find-mcp`), so no `mcp-remote` wrapper is needed. The same catalog is also reachable as a remote Streamable HTTP server at `https://catalog.agentage.io/mcp` (no auth required for search), used here as the registry entry's homepage.

- GitHub: https://github.com/agentage/find-mcp
- npm: `@agentage/find-mcp`
- Official registry entry: `io.agentage/find-mcp`
- Web UI / homepage used in the entry: https://catalog.agentage.io/mcp

## Changes

- `src/registries/builtin/entries.ts`: new `COMMUNITY_ENTRIES` entry (`npx -y @agentage/find-mcp`)
- `README.md`: registry table row under Community MCP Servers
- `CHANGELOG.md`: changelog entry with `{PR_MERGE_DATE}` placeholder, matching existing convention

## Notes

- Only the `model-context-protocol-registry` extension is modified; no code changes, data-only diff.
- Icon: `https://github.com/agentage.png`.
- Disclosure: I maintain Find MCP.