### PR TITLE
[Todoist] Fix menu bar out-of-memory crash

### DIFF
--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Todoist Changelog
 
+## [Fix menu bar out-of-memory crash] - {PR_MERGE_DATE}
+
+- Fixed the Menu Bar command crashing with "Worker terminated due to reaching memory limit" on larger accounts. Every command previously shared one cache key holding the entire sync state (all tasks, comments, and locations); the menu bar's background worker now uses its own cache key holding only the small slice of data it needs (user, projects, items, labels, collaborators), completing the sync scoping started in #28005.
+
 ## [Omit paid task fields unless requested] - 2026-06-28
 
 - **Create Task tool**: The AI tool now omits empty deadline and duration payloads, and its field descriptions clarify that those paid Todoist fields should only be sent when explicitly requested. Standard task creation with ordinary due dates remains compatible with Free plan accounts.

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Todoist Changelog
 
-## [Fix menu bar out-of-memory crash] - {PR_MERGE_DATE}
+## [Fix menu bar out-of-memory crash] - 2026-07-18
 
 - Fixed the Menu Bar command crashing with "Worker terminated due to reaching memory limit" on larger accounts. Every command previously shared one cache key holding the entire sync state (all tasks, comments, and locations); the menu bar's background worker now uses its own cache key holding only the small slice of data it needs (user, projects, items, labels, collaborators), completing the sync scoping started in #28005.
 

--- a/extensions/todoist/src/hooks/useCachedData.ts
+++ b/extensions/todoist/src/hooks/useCachedData.ts
@@ -2,6 +2,6 @@ import { useCachedState } from "@raycast/utils";
 
 import { SyncData } from "../api";
 
-export default function useCachedData() {
-  return useCachedState<SyncData>("data");
+export default function useCachedData(cacheKey = "data") {
+  return useCachedState<SyncData>(cacheKey);
 }

--- a/extensions/todoist/src/hooks/useSyncData.ts
+++ b/extensions/todoist/src/hooks/useSyncData.ts
@@ -17,7 +17,7 @@ const EMPTY_SYNC_DATA_FIELDS: Pick<
   sections: [],
 };
 
-export default function useSyncData(shouldSync = true, resourceTypes?: SyncResourceType[]) {
+export default function useSyncData(shouldSync = true, resourceTypes?: SyncResourceType[], cacheKey?: string) {
   const { data: syncData, ...rest } = usePromise(
     async (resourceTypes?: SyncResourceType[]) => {
       if (shouldSync) {
@@ -29,7 +29,7 @@ export default function useSyncData(shouldSync = true, resourceTypes?: SyncResou
     { failureToastOptions: { title: "Unable to get Todoist data" } },
   );
 
-  const [cachedData, setCachedData] = useCachedData();
+  const [cachedData, setCachedData] = useCachedData(cacheKey);
 
   useEffect(() => {
     if (syncData) {

--- a/extensions/todoist/src/menu-bar.tsx
+++ b/extensions/todoist/src/menu-bar.tsx
@@ -27,15 +27,9 @@ const byPriorityThenDefault = (a: Task, b: Task) => sortByPriority(a, b) || sort
 
 const MENU_BAR_RESOURCE_TYPES: SyncResourceType[] = ["user", "projects", "items", "labels", "collaborators"];
 
-// Isolate the menu bar's cache from the full-sync blob the UI commands share under "data". The menu
-// bar runs in a background worker with a tight JS heap, so it must never load or re-serialise the
-// comment-heavy shared cache — doing so is what crashes it with "Worker terminated due to reaching
-// memory limit". Its own key holds only the small slice above (no notes/locations).
 const MENU_BAR_CACHE_KEY = "menu-bar-data";
 
 function MenuBar() {
-  // Always sync the small slice: with an isolated cache, background refreshes triggered after a
-  // mutation (refreshMenuBarCommand) can no longer rely on another command having freshened "data".
   const { data, setData, isLoading } = useSyncData(true, MENU_BAR_RESOURCE_TYPES, MENU_BAR_CACHE_KEY);
   const { focusedTask, unfocusTask } = useFocusedTask();
   const {

--- a/extensions/todoist/src/menu-bar.tsx
+++ b/extensions/todoist/src/menu-bar.tsx
@@ -2,7 +2,6 @@ import {
   MenuBarExtra,
   openCommandPreferences,
   getPreferenceValues,
-  LaunchProps,
   LaunchType,
   launchCommand,
   Icon,
@@ -24,16 +23,20 @@ import useFilterTasks from "./hooks/useFilterData";
 import { useFocusedTask } from "./hooks/useFocusedTask";
 import useSyncData from "./hooks/useSyncData";
 
-type MenuBarProps = LaunchProps<{ launchContext: { fromCommand: boolean } }>;
-
 const byPriorityThenDefault = (a: Task, b: Task) => sortByPriority(a, b) || sortByDefault(a, b);
 
 const MENU_BAR_RESOURCE_TYPES: SyncResourceType[] = ["user", "projects", "items", "labels", "collaborators"];
 
-function MenuBar(props: MenuBarProps) {
-  const launchedFromWithinCommand = props.launchContext?.fromCommand ?? false;
-  // Don't perform a full sync if the command was launched from within another commands
-  const { data, setData, isLoading } = useSyncData(!launchedFromWithinCommand, MENU_BAR_RESOURCE_TYPES);
+// Isolate the menu bar's cache from the full-sync blob the UI commands share under "data". The menu
+// bar runs in a background worker with a tight JS heap, so it must never load or re-serialise the
+// comment-heavy shared cache — doing so is what crashes it with "Worker terminated due to reaching
+// memory limit". Its own key holds only the small slice above (no notes/locations).
+const MENU_BAR_CACHE_KEY = "menu-bar-data";
+
+function MenuBar() {
+  // Always sync the small slice: with an isolated cache, background refreshes triggered after a
+  // mutation (refreshMenuBarCommand) can no longer rely on another command having freshened "data".
+  const { data, setData, isLoading } = useSyncData(true, MENU_BAR_RESOURCE_TYPES, MENU_BAR_CACHE_KEY);
   const { focusedTask, unfocusTask } = useFocusedTask();
   const {
     view,


### PR DESCRIPTION
## Description

Fixes the Todoist Menu Bar command crashing with:

> Worker terminated due to reaching memory limit: JS heap out of memory (Code: 6, Worker Error)

**Root cause:** every Todoist command (My Tasks, Menu Bar, etc.) shared a single `useCachedState` cache key `"data"` holding the _entire_ sync state — every task, plus every comment (`notes`) and every location. The Menu Bar command runs in a background worker with a tight JS heap. On each refresh it loaded that whole shared blob off disk, merged new sync data into it, and re-serialised the whole thing back to disk — on larger accounts (lots of comments) this exceeded the worker's heap limit and crashed.

A prior PR, #28005 ("[Todoist] Reduce Menu Bar Tasks sync size"), narrowed what the menu bar _fetched_ from the Todoist Sync API, but left the shared cache key in place — so the full blob (including comments/locations from other commands) was still pulled back into memory on every merge. This PR completes that intent by scoping the _cache_ too, not just the fetch.

**The fix (3 source files + CHANGELOG):**

- `src/hooks/useCachedData.ts`: now accepts an optional `cacheKey` parameter, defaulting to `"data"` — every existing caller that doesn't pass a key is unaffected.
- `src/hooks/useSyncData.ts`: threads that optional `cacheKey` through to `useCachedData`.
- `src/menu-bar.tsx`: now passes its own dedicated cache key, `"menu-bar-data"`, which holds only the 5 resource types the menu bar actually needs (`user`, `projects`, `items`, `labels`, `collaborators`) — no `notes` (comments) or locations. The background worker never touches the heavy shared blob anymore. The command also always performs the sync now (previously it conditionally skipped syncing when launched from within another command, relying on that other command having freshened the shared `"data"` cache — that assumption no longer holds now the cache is isolated, so it always syncs its own small slice).

No UI or behavioural changes for other commands — the default cache key is unchanged, so `My Tasks` and the rest keep sharing `"data"` exactly as before.

## Screencast

No visual changes — this is an internal caching fix with no UI impact.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
