### PR TITLE
[Tally] paginate submissions

### DIFF
--- a/extensions/tally/CHANGELOG.md
+++ b/extensions/tally/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Tally Changelog
 
+## [Paginate Submissions] - {PR_MERGE_DATE}
+
+- submissions are now paginated
+
 ## [Update Form + Fix for Untitled Form] - 2025-09-02
 
 - update many settings of a Form

--- a/extensions/tally/CHANGELOG.md
+++ b/extensions/tally/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tally Changelog
 
-## [Paginate Submissions] - {PR_MERGE_DATE}
+## [Paginate Submissions] - 2026-07-18
 
 - submissions are now paginated
 

--- a/extensions/tally/README.md
+++ b/extensions/tally/README.md
@@ -2,8 +2,6 @@
 
 # Tally
 
-> ⚠️ Tally’s API is currently in public beta and subject to change.
-
 This is a Raycast extension for [Tally](https://tally.so/). With this extension you can:
 - view **Forms**
     - view **Submissions**
@@ -26,15 +24,12 @@ This is a Raycast extension for [Tally](https://tally.so/). With this extension 
 
     d. `Copy` and `Paste` in Extension Preferences
 
-## 🗒️ Note
-
-> ⚠️ Tally’s API is currently in public beta and subject to change.
-
 ---
 
-Looking for more form extensions? Try this:
+Looking for more form extensions? Try these:
 
 <a title="Install jotform Raycast Extension" href="https://www.raycast.com/xmok/jotform"><img src="https://www.raycast.com/xmok/jotform/install_button@2x.png?v=1.1" height="64" alt="" style="height: 64px;"></a>
+<a title="Install youform Raycast Extension" href="https://www.raycast.com/xmok/youform"><img src="https://www.raycast.com/xmok/youform/install_button@2x.png?v=1.1" height="64" alt="" style="height: 64px;"></a>
 
 ---
 <img src="./assets/Tally Logo - White.png" height="50" />

--- a/extensions/tally/src/forms.tsx
+++ b/extensions/tally/src/forms.tsx
@@ -172,26 +172,29 @@ function Submissions({ form }: { form: tlyForm }) {
     (options: { page: number }) => API_URL + `forms/${form.id}/submissions?page=${options.page + 1}`,
     {
       headers: API_HEADERS,
-      mapResult(result) {
-        const r = result as SubmissionResult;
+      mapResult(result: SubmissionResult) {
         return {
-          data: {
-            questions: r.questions,
-            submissions: r.submissions,
-          },
-          hasMore: r.hasMore,
+          data: result.submissions.map((submission) => ({
+            id: submission.id,
+            rows: Object.values(submission.responses).map((response) => {
+              const question = result.questions.find((q) => q.id === response.questionId);
+              return {
+                question: question?.title ?? "Unknown",
+                answer: JSON.stringify(response.answer),
+              };
+            }),
+          })),
+
+          hasMore: result.hasMore,
         };
       },
-      initialData: {
-        questions: [],
-        submissions: [],
-      },
+      initialData: [],
     },
   );
 
   return (
     <List isLoading={isLoading} isShowingDetail pagination={pagination}>
-      {data.submissions.map((d) => (
+      {data.map((d) => (
         <List.Item
           key={d.id}
           title={d.id}
@@ -200,12 +203,7 @@ function Submissions({ form }: { form: tlyForm }) {
               markdown={`
 | question | answer |
 |----------|--------|
-${Object.values(d.responses)
-  .map(
-    (response) =>
-      `| ${data.questions.find((question) => question.id === response.questionId)?.title} | ${JSON.stringify(response.answer)} |`,
-  )
-  .join(`\n`)}`}
+${d.rows.map((row) => `| ${row.question} | ${row.answer} |`).join("\n")}`}
             />
           }
           actions={

--- a/extensions/tally/src/forms.tsx
+++ b/extensions/tally/src/forms.tsx
@@ -169,16 +169,17 @@ function UpdateForm({ formId }: { formId: string }) {
 
 function Submissions({ form }: { form: tlyForm }) {
   const { isLoading, data, pagination } = useFetch(
-    (options) => API_URL + `forms/${form.id}/submissions?page=${options.page + 1}`,
+    (options: { page: number }) => API_URL + `forms/${form.id}/submissions?page=${options.page + 1}`,
     {
       headers: API_HEADERS,
-      mapResult(result: SubmissionResult) {
+      mapResult(result) {
+        const r = result as SubmissionResult;
         return {
           data: {
-            questions: result.questions,
-            submissions: result.submissions,
+            questions: r.questions,
+            submissions: r.submissions,
           },
-          hasMore: result.hasMore,
+          hasMore: r.hasMore,
         };
       },
       initialData: {

--- a/extensions/tally/src/forms.tsx
+++ b/extensions/tally/src/forms.tsx
@@ -168,25 +168,28 @@ function UpdateForm({ formId }: { formId: string }) {
 }
 
 function Submissions({ form }: { form: tlyForm }) {
-  const { isLoading, data } = useFetch(API_URL + `forms/${form.id}/submissions`, {
-    headers: API_HEADERS,
-    mapResult(result: SubmissionResult) {
-      return {
-        data: {
-          questions: result.questions,
-          submissions: result.submissions,
-        },
-        hasMore: result.hasMore,
-      };
+  const { isLoading, data, pagination } = useFetch(
+    (options) => API_URL + `forms/${form.id}/submissions?page=${options.page + 1}`,
+    {
+      headers: API_HEADERS,
+      mapResult(result: SubmissionResult) {
+        return {
+          data: {
+            questions: result.questions,
+            submissions: result.submissions,
+          },
+          hasMore: result.hasMore,
+        };
+      },
+      initialData: {
+        questions: [],
+        submissions: [],
+      },
     },
-    initialData: {
-      questions: [],
-      submissions: [],
-    },
-  });
+  );
 
   return (
-    <List isLoading={isLoading} isShowingDetail>
+    <List isLoading={isLoading} isShowingDetail pagination={pagination}>
       {data.submissions.map((d) => (
         <List.Item
           key={d.id}

--- a/extensions/tally/tsconfig.json
+++ b/extensions/tally/tsconfig.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "include": ["src/**/*", "raycast-env.d.ts"],
   "compilerOptions": {
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "DOM"],
     "module": "commonjs",
     "target": "ES2023",
     "strict": true,


### PR DESCRIPTION
## Description

- submissions are now paginated

## Screencast

N/A as I am using a production form via the extension.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
