### PR TITLE
Update obsidian extension

### DIFF
--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Obsidian Changelog
 
-## [Fix Delete Note Shortcut] - {PR_MERGE_DATE}
+## [Fix Delete Note Shortcut] - 2026-07-18
 
 - Update the Delete Note action to use the common `Keyboard.Shortcut.Common.Remove` shortcut
 - Drop the previous custom `opt+d` shortcut from the Delete Note action

--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Obsidian Changelog
 
+## [Fix Delete Note Shortcut] - {PR_MERGE_DATE}
+
+- Update the Delete Note action to use the common `Keyboard.Shortcut.Common.Remove` shortcut
+- Drop the previous custom `opt+d` shortcut from the Delete Note action
+
 ## [Add Open Action Shortcuts] - 2026-07-18
 
 - Add keyboard shortcut to the "Open in Default App" action

--- a/extensions/obsidian/src/utils/actions.tsx
+++ b/extensions/obsidian/src/utils/actions.tsx
@@ -213,7 +213,7 @@ export function DeleteNoteAction(props: {
   return (
     <Action
       title="Delete Note"
-      shortcut={{ modifiers: ["opt"], key: "d" }}
+      shortcut={Keyboard.Shortcut.Common.Remove}
       onAction={async () => {
         const options = {
           title: "Delete Note",


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->
### [Fix Delete Note Shortcut]

- Update the Delete Note action to use the common `Keyboard.Shortcut.Common.Remove` shortcut
- Drop the previous custom `opt+d` shortcut from the Delete Note action
## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
