### PR TITLE
[Brave] Fix history search database lock error

### DIFF
--- a/extensions/brave/CHANGELOG.md
+++ b/extensions/brave/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Brave Changelog
 
-## [Fix History Search] - {PR_MERGE_DATE}
+## [Fix History Search] - 2026-07-19
 
 - Fixed history search failing with a "database is locked" error while Brave is running.
 

--- a/extensions/brave/CHANGELOG.md
+++ b/extensions/brave/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Brave Changelog
 
+## [Fix History Search] - {PR_MERGE_DATE}
+
+- Fixed history search failing with a "database is locked" error while Brave is running.
+
 ## [Bookmark Folder Search] - 2026-01-05
 
 - Added support for searching bookmark folders.

--- a/extensions/brave/package-lock.json
+++ b/extensions/brave/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.103.0",
-        "@raycast/utils": "^2.2.2"
+        "@raycast/utils": "^2.2.7"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
@@ -1209,9 +1209,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.2.tgz",
-      "integrity": "sha512-tZcyWCHZvz4L/i1CGEnSZkBoK6wwX1pzlTKjcWWugbrQyG0QCMOxjKJfRC/iNkD+hHaqhMWUj4Y0LNo/NknvFw==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.7.tgz",
+      "integrity": "sha512-1jV9tKLluP0Av/ICcl/yvVzCj7mY6F3wnKsh8SJpy/Fsqq/LCFXcI6TgMabIJ45AaDVhEV+JH9jS1lJSwBgiMw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -3717,9 +3717,9 @@
       }
     },
     "@raycast/utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.2.tgz",
-      "integrity": "sha512-tZcyWCHZvz4L/i1CGEnSZkBoK6wwX1pzlTKjcWWugbrQyG0QCMOxjKJfRC/iNkD+hHaqhMWUj4Y0LNo/NknvFw==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.7.tgz",
+      "integrity": "sha512-1jV9tKLluP0Av/ICcl/yvVzCj7mY6F3wnKsh8SJpy/Fsqq/LCFXcI6TgMabIJ45AaDVhEV+JH9jS1lJSwBgiMw==",
       "requires": {
         "dequal": "^2.0.3"
       }

--- a/extensions/brave/package.json
+++ b/extensions/brave/package.json
@@ -111,7 +111,7 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.103.0",
-    "@raycast/utils": "^2.2.2"
+    "@raycast/utils": "^2.2.7"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",


### PR DESCRIPTION
## Description

- Update `@raycast/utils` from 2.2.2 to 2.2.7.
- Bundle the upstream `useSQL` fix that handles `SQLITE_BUSY` errors raised while preparing or executing a query, not only while opening the database.
- Add a changelog entry for the history search fix.

This allows history search to use the existing copy-on-lock fallback while Brave keeps its History database in exclusive locking mode.

Fixes #27619.

## Screencast

Not applicable; this is a dependency-only fix for the SQLite lock handling path.

## Validation

- `npm run lint`
- `npm run build`

## Checklist

- [x] I read the extension guidelines.
- [x] I read the documentation about publishing.
- [x] I ran lint and a distribution build.
- [x] No assets were changed.