### PR TITLE
Remo: infinite scroll in folders and trash, clearer search

### DIFF
--- a/extensions/remo-notes/CHANGELOG.md
+++ b/extensions/remo-notes/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Folders and Trash now load more notes as you scroll, instead of stopping at the first batch
 - Search shows your 20 most recent notes by default, then searches note titles and content as you type
+- Removed the Inbox and Quick Capture shortcuts from the Folders view
 
 ## [Pinned notes & improved rendering] - 2026-06-30
 

--- a/extensions/remo-notes/CHANGELOG.md
+++ b/extensions/remo-notes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Remo Changelog
 
+## [Infinite scroll and clearer search] - {PR_MERGE_DATE}
+
+- Folders and Trash now load more notes as you scroll, instead of stopping at the first batch
+- Search shows your 20 most recent notes by default, then searches note titles and content as you type
+
 ## [Pinned notes & improved rendering] - 2026-06-30
 
 - Pinned notes now appear in a dedicated "Pinned" section in search and folders, with a count

--- a/extensions/remo-notes/CHANGELOG.md
+++ b/extensions/remo-notes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Remo Changelog
 
-## [Infinite scroll and clearer search] - {PR_MERGE_DATE}
+## [Infinite scroll and clearer search] - 2026-07-21
 
 - Folders and Trash now load more notes as you scroll, instead of stopping at the first batch
 - Search shows your 20 most recent notes by default, then searches note titles and content as you type

--- a/extensions/remo-notes/src/components/NoteListItem.tsx
+++ b/extensions/remo-notes/src/components/NoteListItem.tsx
@@ -12,7 +12,7 @@ interface NoteListItemProps {
   onRefresh: () => void;
   isShowingDetail: boolean;
   onToggleDetail: () => void;
-  mutate?: MutatePromise<Note[] | undefined>;
+  mutate?: MutatePromise<Note[]> | MutatePromise<Note[] | undefined>;
   folders?: Folder[];
 }
 
@@ -24,7 +24,7 @@ export function NoteListItem({ note, onRefresh, isShowingDetail, onToggleDetail,
     try {
       if (mutate) {
         await mutate(remoApi.togglePin(note._id), {
-          optimisticUpdate: (data) =>
+          optimisticUpdate: (data: Note[] | undefined) =>
             (data ?? []).map((n) => (n._id === note._id ? { ...n, isPinned: !n.isPinned } : n)),
         });
       } else {
@@ -61,7 +61,7 @@ export function NoteListItem({ note, onRefresh, isShowingDetail, onToggleDetail,
     try {
       if (mutate) {
         await mutate(remoApi.softDeleteNote(note._id), {
-          optimisticUpdate: (data) => (data ?? []).filter((n) => n._id !== note._id),
+          optimisticUpdate: (data: Note[] | undefined) => (data ?? []).filter((n) => n._id !== note._id),
         });
       } else {
         await remoApi.softDeleteNote(note._id);

--- a/extensions/remo-notes/src/components/NoteSections.tsx
+++ b/extensions/remo-notes/src/components/NoteSections.tsx
@@ -8,13 +8,20 @@ interface NoteSectionsProps {
   onRefresh: () => void;
   isShowingDetail: boolean;
   onToggleDetail: () => void;
-  mutate?: MutatePromise<Note[] | undefined>;
+  mutate?: MutatePromise<Note[]> | MutatePromise<Note[] | undefined>;
   folders?: Folder[];
   othersTitle?: string;
+  othersSubtitle?: string;
   groupPinned?: boolean;
 }
 
-export function NoteSections({ notes, othersTitle = "Notes", groupPinned = true, ...itemProps }: NoteSectionsProps) {
+export function NoteSections({
+  notes,
+  othersTitle = "Notes",
+  othersSubtitle,
+  groupPinned = true,
+  ...itemProps
+}: NoteSectionsProps) {
   const renderItem = (note: Note) => <NoteListItem key={note._id} note={note} {...itemProps} />;
 
   if (!groupPinned) {
@@ -32,7 +39,7 @@ export function NoteSections({ notes, othersTitle = "Notes", groupPinned = true,
         </List.Section>
       )}
       {others.length > 0 && (
-        <List.Section title={othersTitle} subtitle={`${others.length}`}>
+        <List.Section title={othersTitle} subtitle={othersSubtitle ?? `${others.length}`}>
           {others.map(renderItem)}
         </List.Section>
       )}

--- a/extensions/remo-notes/src/daily-note.tsx
+++ b/extensions/remo-notes/src/daily-note.tsx
@@ -21,7 +21,6 @@ export default async function DailyNote() {
     let noteId = existingNote?._id;
 
     if (!noteId) {
-      // Create new note
       noteId = await remoApi.createNote({
         title: title,
         content: `# ${title}\n\n`,

--- a/extensions/remo-notes/src/pinned-notes.tsx
+++ b/extensions/remo-notes/src/pinned-notes.tsx
@@ -1,7 +1,6 @@
 import { Icon, MenuBarExtra, open } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { buildAppUrl, buildWebUrl } from "./config";
-import type { Note } from "./types";
 import { remoApi } from "./utils/api";
 import { notePlainText, truncate } from "./utils/noteDisplay";
 import { handleError } from "./utils/errors";
@@ -9,8 +8,8 @@ import { handleError } from "./utils/errors";
 export default function Command() {
   const { isLoading, data } = useCachedPromise(
     async () => {
-      const result = await remoApi.listNotes({ limit: 50 });
-      return result.filter((n: Note) => n.isPinned);
+      const result = await remoApi.infiniteNotes({ view: "pinned", numItems: 50 });
+      return result.page;
     },
     [],
     { onError: (error) => handleError(error, "Failed to fetch pinned notes") },

--- a/extensions/remo-notes/src/search-folders.tsx
+++ b/extensions/remo-notes/src/search-folders.tsx
@@ -2,7 +2,6 @@ import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { useState } from "react";
 import { NoteSections } from "./components/NoteSections";
-import type { Folder, Note } from "./types";
 import { remoApi } from "./utils/api";
 import { handleError } from "./utils/errors";
 
@@ -16,27 +15,6 @@ export default function SearchFolders() {
   return (
     <List isLoading={isLoading} searchBarPlaceholder="Search folders...">
       <List.Section title="System">
-        <List.Item
-          title="Inbox"
-          icon={Icon.Tray}
-          actions={
-            <ActionPanel>
-              <Action.Push title="Open Inbox" target={<FolderNotesList filterType="inbox" title="Inbox" />} />
-            </ActionPanel>
-          }
-        />
-        <List.Item
-          title="Quick Capture"
-          icon={Icon.Bolt}
-          actions={
-            <ActionPanel>
-              <Action.Push
-                title="Open Quick Capture"
-                target={<FolderNotesList filterType="quickCapture" title="Quick Capture" />}
-              />
-            </ActionPanel>
-          }
-        />
         <List.Item
           title="Vault"
           icon={Icon.Shield}
@@ -105,7 +83,7 @@ function FolderNotesList({
   folderId,
   title,
 }: {
-  filterType: "folder" | "inbox" | "trash" | "quickCapture" | "locked" | "vault" | "shared";
+  filterType: "folder" | "trash" | "locked" | "vault" | "shared";
   folderId?: string;
   title: string;
 }) {
@@ -114,31 +92,17 @@ function FolderNotesList({
   const {
     isLoading,
     data,
+    pagination,
     revalidate: fetchNotes,
     mutate,
   } = useCachedPromise(
-    async (type: typeof filterType, fid?: string) => {
-      let result: Note[] = [];
-
-      if (type === "trash") {
-        const deletedNotes = await remoApi.listNotes({ includeDeleted: true, limit: 50 });
-        result = deletedNotes.filter((note: Note) => note.deletedAt !== undefined);
-      } else if (type === "quickCapture") {
-        result = await remoApi.listNotes({ quickCapturedOnly: true, limit: 50 });
-      } else if (type === "inbox") {
-        result = await remoApi.listNotes({ folderId: "inbox", limit: 50 });
-      } else if (type === "locked") {
-        result = await remoApi.listNotes({ lockedOnly: true, limit: 50 });
-      } else if (type === "vault") {
-        result = await remoApi.listNotes({ e2eOnly: true, limit: 50 });
-      } else if (type === "shared") {
-        result = await remoApi.listNotes({ sharedOnly: true, limit: 50 });
-      } else {
-        result = await remoApi.listNotes({ folderId: fid as Folder["_id"], limit: 50 });
-      }
-
-      return result;
-    },
+    (type: typeof filterType, fid?: string) =>
+      async ({ cursor }: { cursor?: string }) => {
+        const result = await remoApi.infiniteNotes(
+          type === "folder" ? { folderId: fid, cursor, numItems: 30 } : { view: type, cursor, numItems: 30 },
+        );
+        return { data: result.page, hasMore: !result.isDone, cursor: result.continueCursor };
+      },
     [filterType, folderId],
     { onError: (error) => handleError(error, "Failed to fetch notes") },
   );
@@ -150,6 +114,7 @@ function FolderNotesList({
   return (
     <List
       isLoading={isLoading}
+      pagination={pagination}
       searchBarPlaceholder={`Search in ${title}...`}
       navigationTitle={title}
       isShowingDetail={isShowingDetail}

--- a/extensions/remo-notes/src/search-notes.tsx
+++ b/extensions/remo-notes/src/search-notes.tsx
@@ -29,7 +29,7 @@ export default function SearchNotes() {
     <List
       isLoading={isLoading}
       onSearchTextChange={setSearchText}
-      searchBarPlaceholder="Search notes (text or semantic)..."
+      searchBarPlaceholder="Search notes by title or content..."
       throttle={true}
       isShowingDetail={isShowingDetail}
     >
@@ -47,6 +47,7 @@ export default function SearchNotes() {
         isShowingDetail={isShowingDetail}
         onToggleDetail={() => setIsShowingDetail((prev) => !prev)}
         othersTitle="Recent"
+        othersSubtitle={isSearching ? undefined : "20 most recent · type to search all notes"}
         groupPinned={!isSearching}
       />
     </List>

--- a/extensions/remo-notes/src/trash.tsx
+++ b/extensions/remo-notes/src/trash.tsx
@@ -13,14 +13,14 @@ export default function Trash() {
   const {
     isLoading,
     data,
+    pagination,
     revalidate: fetchTrash,
   } = useCachedPromise(
-    async () => {
-      const result = await remoApi.listNotes({ includeDeleted: true });
-      return result
-        .filter((n: Note) => n.deletedAt !== undefined)
-        .sort((a: Note, b: Note) => (b.deletedAt ?? b.updatedAt) - (a.deletedAt ?? a.updatedAt));
-    },
+    () =>
+      async ({ cursor }: { cursor?: string }) => {
+        const result = await remoApi.infiniteNotes({ view: "trash", cursor, numItems: 30 });
+        return { data: result.page, hasMore: !result.isDone, cursor: result.continueCursor };
+      },
     [],
     { onError: (error) => handleError(error, "Failed to fetch trash") },
   );
@@ -63,7 +63,12 @@ export default function Trash() {
   }
 
   return (
-    <List isLoading={isLoading} searchBarPlaceholder="Search deleted notes..." isShowingDetail={isShowingDetail}>
+    <List
+      isLoading={isLoading}
+      pagination={pagination}
+      searchBarPlaceholder="Search deleted notes..."
+      isShowingDetail={isShowingDetail}
+    >
       {notes.length === 0 && !isLoading ? (
         <List.EmptyView title="Trash is empty" icon={{ source: Icon.Trash, tintColor: Color.Green }} />
       ) : (

--- a/extensions/remo-notes/src/utils/api.ts
+++ b/extensions/remo-notes/src/utils/api.ts
@@ -2,16 +2,19 @@ import { getPreferenceValues } from "@raycast/api";
 import { DEFAULT_CONVEX_URL } from "../config";
 import type { AskAiResponse, Folder, Note } from "../types";
 
-type ListNotesParams = {
-  includeDeleted?: boolean;
-  tags?: string[];
-  source?: "web" | "raycast";
-  limit?: number;
+export type InfiniteView = "pinned" | "trash" | "locked" | "vault" | "shared";
+
+type InfiniteNotesParams = {
+  view?: InfiniteView;
   folderId?: string;
-  quickCapturedOnly?: boolean;
-  lockedOnly?: boolean;
-  e2eOnly?: boolean;
-  sharedOnly?: boolean;
+  cursor?: string | null;
+  numItems?: number;
+};
+
+export type PaginatedNotes = {
+  page: Note[];
+  isDone: boolean;
+  continueCursor: string;
 };
 
 type ApiErrorPayload = {
@@ -124,20 +127,15 @@ export const remoApi = {
     return request<Note[]>(`/notes/search${toQueryString({ query })}`);
   },
 
-  listNotes(params: ListNotesParams) {
+  infiniteNotes(params: InfiniteNotesParams) {
     const query = toQueryString({
-      includeDeleted: params.includeDeleted,
-      source: params.source,
-      limit: params.limit,
+      view: params.view,
       folderId: params.folderId,
-      quickCapturedOnly: params.quickCapturedOnly,
-      lockedOnly: params.lockedOnly,
-      e2eOnly: params.e2eOnly,
-      sharedOnly: params.sharedOnly,
-      tag: params.tags,
+      cursor: params.cursor ?? undefined,
+      numItems: params.numItems,
     });
 
-    return request<Note[]>(`/notes/list${query}`);
+    return request<PaginatedNotes>(`/notes/infinite${query}`);
   },
 
   listFolders() {

--- a/extensions/remo-notes/src/utils/noteDisplay.ts
+++ b/extensions/remo-notes/src/utils/noteDisplay.ts
@@ -2,11 +2,7 @@ import type { Note } from "../types";
 import { stripHtml } from "./stripHtml";
 import { toMarkdown } from "./toMarkdown";
 
-/**
- * Drop unpaired UTF-16 surrogates. Raycast's render-tree serializer throws
- * ("Cannot parse render tree JSON … expected low-surrogate") when one reaches
- * the UI — which also happens when a fixed-length truncation splits an emoji.
- */
+/** Lone surrogates crash Raycast's render-tree serializer ("expected low-surrogate") when they reach the UI. */
 export function stripLoneSurrogates(text: string): string {
   return text.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "");
 }
@@ -16,20 +12,15 @@ export function truncate(text: string, max: number): string {
   return stripLoneSurrogates(text.slice(0, max));
 }
 
-/** Plain-text view: server-derived `contentText`, falling back to stripped HTML. */
 export function notePlainText(note: Pick<Note, "content" | "contentText">): string {
   return stripLoneSurrogates(note.contentText ?? stripHtml(note.content ?? ""));
 }
 
-/**
- * Markdown view: the API derives `contentMarkdown` from the canonical JSON.
- * Falls back to turndown(HTML) for responses from an older server.
- */
+/** Falls back to turndown(HTML) for older API responses without contentMarkdown. */
 export function noteMarkdown(note: Pick<Note, "content" | "contentMarkdown">): string {
   return stripLoneSurrogates(note.contentMarkdown || toMarkdown(note.content ?? ""));
 }
 
-/** Whether the note carries any renderable body. */
 export function noteHasContent(note: Pick<Note, "content" | "contentMarkdown" | "contentText">): boolean {
   return Boolean(note.contentMarkdown || note.content || note.contentText);
 }

--- a/extensions/remo-notes/src/utils/stripHtml.ts
+++ b/extensions/remo-notes/src/utils/stripHtml.ts
@@ -1,7 +1,5 @@
 export function stripHtml(html: string): string {
-  // Simple regex to strip HTML tags
   const plainText = html.replace(/<[^>]*>/g, " ");
-  // Decode HTML entities (basic ones)
   return plainText
     .replace(/&nbsp;/g, " ")
     .replace(/&amp;/g, "&")

--- a/extensions/remo-notes/src/utils/toMarkdown.ts
+++ b/extensions/remo-notes/src/utils/toMarkdown.ts
@@ -7,9 +7,6 @@ const turndownService = new TurndownService({
   emDelimiter: "_",
 });
 
-/**
- * Converts HTML content to Markdown.
- */
 export function toMarkdown(html: string): string {
   if (!html) return "";
   return turndownService.turndown(html);


### PR DESCRIPTION
## Description

Updates the **Remo** extension:

- **Folders and Trash** now paginate and load more notes as you scroll, instead of stopping at the first batch.
- **Search** shows your 20 most recent notes by default, then searches note titles and content as you type (with a clearer placeholder and section hint).
- **Removed the Inbox and Quick Capture shortcuts** from the Folders view: the notes API now selects by view, and these two views are no longer served. This is an intentional removal, documented in the changelog.
- Internal: note lists now go through a single paginated endpoint.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder use widely supported formats