### PR TITLE
[Coffee] Expand AI caffeination tools

### DIFF
--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coffee Changelog
 
-## [AI Extension] - 2026-07-19
+## [AI Extension] - {PR_MERGE_DATE}
 
 - Added AI tools to caffeinate until a specific date and time.
 - Added AI tools to list, pause, resume, and delete recurring caffeination schedules.

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Coffee Changelog
 
+## [AI Extension] - 2026-07-19
+
+- Added AI tools to caffeinate until a specific date and time.
+- Added AI tools to list, pause, resume, and delete recurring caffeination schedules.
+- Expanded AI instructions and evaluations for the new workflows.
+
 ## [Enhancement] - 2026-06-28
 
 - Redesigned the menu bar dropdown: quick-pick durations (10m, 30m, 1h, 2h, 4h, 8h, 12h) and `Indefinitely`, each with a checkmark and live countdown when active.

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coffee Changelog
 
-## [AI Extension] - {PR_MERGE_DATE}
+## [AI Extension] - 2026-07-22
 
 - Added AI tools to caffeinate until a specific date and time.
 - Added AI tools to list, pause, resume, and delete recurring caffeination schedules.

--- a/extensions/coffee/ai.yaml
+++ b/extensions/coffee/ai.yaml
@@ -1,16 +1,19 @@
 instructions: |
   Help users manage their Mac's sleep prevention (caffeination).
 
-  Before performing any action, check the current status with check-caffeination-status.
+  Check the current status with check-caffeination-status before starting or stopping caffeination. Status-only questions need no other tool.
 
   Tool selection guide:
   - User wants indefinite caffeination → use caffeinate
-  - User specifies a duration (hours/minutes) → use caffeinate-for
+  - User specifies a duration → use caffeinate-for
+  - User specifies an end date or time → use caffeinate-until with an ISO 8601 date and time, including the local UTC offset when known
   - User wants to caffeinate while an app runs → use caffeinate-while-app-is-running
-  - User wants to set up recurring schedules → use schedule-caffeination
-  - User wants to stop caffeination → use decaffeinate (note: won't work if a schedule is actively running)
+  - User wants to create or replace recurring schedules → use schedule-caffeination
+  - User wants to see recurring schedules → use list-caffeination-schedules
+  - User wants to pause, resume, or delete a recurring schedule → call list-caffeination-schedules first, then use manage-caffeination-schedule with the matching day
+  - User wants to stop caffeination → use decaffeinate. If a schedule is actively running, explain that it must be paused or deleted instead
 
-  When confirming actions, mention the specific duration or condition if applicable.
+  When confirming actions, mention the specific duration, end time, application, or schedule as applicable.
 evals:
   - input: "@coffee keep my mac awake for 2 hours"
     mocks:
@@ -97,3 +100,59 @@ evals:
       - callsTool: check-caffeination-status
       - callsTool: caffeinate
       - meetsCriteria: Confirms that Mac will stay awake
+
+  - input: "@coffee keep my Mac awake until 6pm today"
+    mocks:
+      check-caffeination-status:
+        caffeinated: false
+        scheduled: false
+      caffeinate-until:
+        caffeinated: true
+        until: "2026-07-19T17:00:00.000Z"
+    expected:
+      - callsTool: check-caffeination-status
+      - callsTool:
+          name: caffeinate-until
+          arguments:
+            dateTime:
+              includes: "2026-07-19T18:00:00"
+      - meetsCriteria: Confirms the time until which the Mac will stay awake
+
+  - input: "@coffee show my caffeination schedules"
+    mocks:
+      list-caffeination-schedules:
+        schedules:
+          - day: monday
+            from: "09:00"
+            to: "17:00"
+            paused: false
+            running: false
+        count: 1
+    expected:
+      - callsTool: list-caffeination-schedules
+      - meetsCriteria: Shows the Monday schedule from 09:00 to 17:00
+
+  - input: "@coffee pause my Monday caffeination schedule"
+    mocks:
+      list-caffeination-schedules:
+        schedules:
+          - day: monday
+            from: "09:00"
+            to: "17:00"
+            paused: false
+            running: false
+        count: 1
+      manage-caffeination-schedule:
+        action: pause
+        day: monday
+        paused: true
+        running: false
+        success: true
+    expected:
+      - callsTool: list-caffeination-schedules
+      - callsTool:
+          name: manage-caffeination-schedule
+          arguments:
+            action: pause
+            day: monday
+      - meetsCriteria: Confirms that the Monday schedule is paused

--- a/extensions/coffee/package.json
+++ b/extensions/coffee/package.json
@@ -158,6 +158,21 @@
       "name": "caffeinate-while-app-is-running",
       "title": "Caffeinate While App Is Running",
       "description": "While an app is running, turn on caffeination."
+    },
+    {
+      "name": "caffeinate-until",
+      "title": "Caffeinate Until",
+      "description": "Keep the Mac awake until a specific future date and time."
+    },
+    {
+      "name": "list-caffeination-schedules",
+      "title": "List Caffeination Schedules",
+      "description": "List the recurring caffeination schedules configured for the week."
+    },
+    {
+      "name": "manage-caffeination-schedule",
+      "title": "Manage Caffeination Schedule",
+      "description": "Pause, resume, or delete a recurring caffeination schedule for a day."
     }
   ],
   "preferences": [

--- a/extensions/coffee/src/tools/caffeinate-until.ts
+++ b/extensions/coffee/src/tools/caffeinate-until.ts
@@ -1,0 +1,49 @@
+import { Tool } from "@raycast/api";
+import { startCaffeinate } from "../utils";
+
+type Input = {
+  /**
+   * Future date and time to keep the Mac awake until, in ISO 8601 format.
+   * Include the local UTC offset when known, for example "2026-07-19T17:00:00+01:00".
+   */
+  dateTime: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: `Keep your Mac awake until ${formatDateTime(parseFutureDate(input.dateTime))}?`,
+});
+
+/**
+ * Prevents the Mac from sleeping until a specific future date and time.
+ */
+export default async function tool(input: Input) {
+  const target = parseFutureDate(input.dateTime);
+  const durationSeconds = Math.ceil((target.getTime() - Date.now()) / 1000);
+
+  await startCaffeinate({ menubar: true, status: true }, undefined, `-t ${durationSeconds}`);
+
+  return {
+    caffeinated: true,
+    until: target.toISOString(),
+    durationSeconds,
+    message: `Mac will stay awake until ${formatDateTime(target)}`,
+  };
+}
+
+function parseFutureDate(dateTime: string): Date {
+  const target = new Date(dateTime);
+
+  if (!dateTime?.trim() || Number.isNaN(target.getTime())) {
+    throw new Error("dateTime must be a valid ISO 8601 date and time");
+  }
+
+  if (target.getTime() <= Date.now()) {
+    throw new Error("dateTime must be in the future");
+  }
+
+  return target;
+}
+
+function formatDateTime(date: Date): string {
+  return date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}

--- a/extensions/coffee/src/tools/list-caffeination-schedules.ts
+++ b/extensions/coffee/src/tools/list-caffeination-schedules.ts
@@ -1,0 +1,50 @@
+import { LocalStorage } from "@raycast/api";
+import { Schedule } from "../interfaces";
+import { numberToDayString } from "../utils";
+
+/**
+ * Lists all recurring caffeination schedules in weekday order.
+ */
+export default async function tool() {
+  const storedItems = await LocalStorage.allItems();
+  const schedules = Object.values(storedItems)
+    .map(parseSchedule)
+    .filter((schedule): schedule is Schedule => schedule !== undefined)
+    .sort((a, b) => dayIndex(a.day) - dayIndex(b.day));
+
+  return {
+    schedules: schedules.map((schedule) => ({
+      day: schedule.day,
+      from: schedule.from,
+      to: schedule.to,
+      paused: schedule.IsManuallyDecafed,
+      running: schedule.IsRunning,
+    })),
+    count: schedules.length,
+  };
+}
+
+function parseSchedule(value: string | number | boolean): Schedule | undefined {
+  if (typeof value !== "string") return undefined;
+
+  try {
+    const schedule = JSON.parse(value) as Partial<Schedule>;
+    if (
+      typeof schedule.day === "string" &&
+      typeof schedule.from === "string" &&
+      typeof schedule.to === "string" &&
+      typeof schedule.IsManuallyDecafed === "boolean" &&
+      typeof schedule.IsRunning === "boolean"
+    ) {
+      return schedule as Schedule;
+    }
+  } catch {
+    // Ignore unrelated local storage values.
+  }
+
+  return undefined;
+}
+
+function dayIndex(day: string): number {
+  return Array.from({ length: 7 }, (_, index) => numberToDayString(index).toLowerCase()).indexOf(day.toLowerCase());
+}

--- a/extensions/coffee/src/tools/manage-caffeination-schedule.ts
+++ b/extensions/coffee/src/tools/manage-caffeination-schedule.ts
@@ -35,14 +35,11 @@ export default async function tool(input: Input) {
     return { action: input.action, day, success: true };
   }
 
+  const wasRunning = schedule.IsRunning;
   schedule.IsManuallyDecafed = input.action === "pause";
-  if (input.action === "pause") {
-    schedule.IsRunning = false;
-    if (isTodaysSchedule(schedule)) {
-      await stopCaffeinate({ menubar: true, status: true });
-    }
-  } else {
-    schedule.IsRunning = false;
+  schedule.IsRunning = false;
+  if (input.action === "pause" && wasRunning && isTodaysSchedule(schedule)) {
+    await stopCaffeinate({ menubar: true, status: true });
   }
 
   await LocalStorage.setItem(day, JSON.stringify(schedule));

--- a/extensions/coffee/src/tools/manage-caffeination-schedule.ts
+++ b/extensions/coffee/src/tools/manage-caffeination-schedule.ts
@@ -1,0 +1,80 @@
+import { Action, LocalStorage, Tool } from "@raycast/api";
+import { checkSchedule } from "../status";
+import { Schedule } from "../interfaces";
+import { isTodaysSchedule, stopCaffeinate } from "../utils";
+
+type Input = {
+  /** Action to perform on the schedule. */
+  action: "pause" | "resume" | "delete";
+  /** Day whose schedule should be changed, for example "monday". */
+  day: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: `${capitalize(input.action)} the caffeination schedule for ${capitalize(input.day)}?`,
+  style: input.action === "delete" ? Action.Style.Destructive : Action.Style.Regular,
+});
+
+/**
+ * Pauses, resumes, or deletes the recurring caffeination schedule for one day.
+ */
+export default async function tool(input: Input) {
+  const day = normalizeDay(input.day);
+  const storedSchedule = await LocalStorage.getItem<string>(day);
+  if (!storedSchedule) {
+    throw new Error(`No caffeination schedule exists for ${capitalize(day)}`);
+  }
+
+  const schedule = JSON.parse(storedSchedule) as Schedule;
+
+  if (input.action === "delete") {
+    if (isTodaysSchedule(schedule) && schedule.IsRunning) {
+      await stopCaffeinate({ menubar: true, status: true });
+    }
+    await LocalStorage.removeItem(day);
+    return { action: input.action, day, success: true };
+  }
+
+  schedule.IsManuallyDecafed = input.action === "pause";
+  if (input.action === "pause") {
+    schedule.IsRunning = false;
+    if (isTodaysSchedule(schedule)) {
+      await stopCaffeinate({ menubar: true, status: true });
+    }
+  } else {
+    schedule.IsRunning = false;
+  }
+
+  await LocalStorage.setItem(day, JSON.stringify(schedule));
+
+  if (input.action === "resume" && isTodaysSchedule(schedule)) {
+    await checkSchedule();
+  }
+
+  return {
+    action: input.action,
+    day,
+    paused: schedule.IsManuallyDecafed,
+    running: input.action === "resume" && isTodaysSchedule(schedule) ? (await getSchedule(day)).IsRunning : false,
+    success: true,
+  };
+}
+
+async function getSchedule(day: string): Promise<Schedule> {
+  const value = await LocalStorage.getItem<string>(day);
+  if (!value) throw new Error(`No caffeination schedule exists for ${capitalize(day)}`);
+  return JSON.parse(value) as Schedule;
+}
+
+function normalizeDay(day: string): string {
+  const normalized = day.trim().toLowerCase();
+  const days = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
+  if (!days.includes(normalized)) {
+    throw new Error(`Invalid day "${day}". Use a weekday name such as Monday.`);
+  }
+  return normalized;
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}


### PR DESCRIPTION
## Description

Expands Coffee's AI extension with tools to:

- Keep the Mac awake until a specific date and time
- List recurring caffeination schedules
- Pause, resume, or delete an existing schedule

The new mutating tools use confirmation dialogs. This also updates the AI instructions, evaluations, tool manifest, and changelog.

## Screencast

Not applicable. This change adds AI tools without modifying the command UI.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)