### PR TITLE
[Capacities] Add Deadline field to Create Task

### DIFF
--- a/extensions/capacities/CHANGELOG.md
+++ b/extensions/capacities/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Capacities Changelog
 
+## [Add Deadline to Create Task] - 2026-06-29
+
+- Add "Deadline" date picker to the Create Task command, mirroring Capacities' native two-date task creation (Date + Deadline).
+
 ## [Fix space dropdown selection] - 2026-05-20
 
 - Fixed space dropdown selection in the task, weblink, and daily note commands.

--- a/extensions/capacities/CHANGELOG.md
+++ b/extensions/capacities/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Capacities Changelog
 
-## [Add Deadline to Create Task] - {PR_MERGE_DATE}
+## [Add Deadline to Create Task] - 2026-07-21
 
 - Add "Deadline" date picker to the Create Task command, mirroring Capacities' native two-date task creation (Date + Deadline).
 

--- a/extensions/capacities/CHANGELOG.md
+++ b/extensions/capacities/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Capacities Changelog
 
-## [Add Deadline to Create Task] - 2026-06-29
+## [Add Deadline to Create Task] - {PR_MERGE_DATE}
 
 - Add "Deadline" date picker to the Create Task command, mirroring Capacities' native two-date task creation (Date + Deadline).
 

--- a/extensions/capacities/src/create-task.tsx
+++ b/extensions/capacities/src/create-task.tsx
@@ -1,18 +1,49 @@
 import { ActionPanel, Action, Form, Icon, closeMainWindow, showToast, Toast, showHUD } from "@raycast/api";
 import { FormValidation, useForm } from "@raycast/utils";
 import { useEffect, useRef } from "react";
-import { getInitialSpaceId, setStoredSpaceId } from "./helpers/spaces";
 import { API_HEADERS, API_URL, handleAPIError, handleUnexpectedError, useCapacitiesStore } from "./helpers/storage";
 
-interface SaveWeblinkBody {
+interface SaveTaskBody {
   spaceId: string;
   title: string;
   mdText?: string;
   priority?: string;
   date?: Date;
+  deadline?: Date;
 }
 
-const SPACE_STORAGE_KEY = "create-task-space-id";
+type DateApiObject =
+  | {
+      dateResolution: "time" | "day";
+      startTime: string;
+    }
+  | undefined;
+
+function toDateApiObject(dateTime: Date | undefined): DateApiObject {
+  if (!dateTime) return undefined;
+
+  if (
+    (dateTime.getMilliseconds() === 0 || dateTime.getMilliseconds() === 1) &&
+    dateTime.getSeconds() === 0 &&
+    dateTime.getMinutes() === 0 &&
+    dateTime.getHours() === 0
+  ) {
+    const newDate = new Date();
+    newDate.setUTCHours(0, 0, 0, 0);
+    newDate.setUTCDate(dateTime.getDate());
+    newDate.setUTCMonth(dateTime.getMonth());
+    newDate.setUTCFullYear(dateTime.getFullYear());
+    return {
+      dateResolution: "day",
+      startTime: newDate.toISOString(),
+    };
+  }
+
+  return {
+    dateResolution: "time",
+    startTime: dateTime.toISOString(),
+  };
+}
 
 export default function Command() {
   const { store, triggerLoading, isLoading: storeIsLoading } = useCapacitiesStore();
@@ -23,54 +54,21 @@ export default function Command() {
 
   const spacesDropdown = useRef(null);
 
-  const { handleSubmit, itemProps, setValue } = useForm<SaveWeblinkBody>({
+  const { handleSubmit, itemProps, setValue } = useForm<SaveTaskBody>({
     async onSubmit(values) {
       showToast({
         style: Toast.Style.Animated,
         title: "Saving",
       });
 
-      // date processing
-      const dateTime = values.date;
-      let dateObject:
-        | {
-            dateResolution: "time" | "day";
-            startTime: string;
-          }
-        | undefined = undefined;
-      if (dateTime) {
-        if (
-          (dateTime.getMilliseconds() === 0 || dateTime.getMilliseconds() === 1) &&
-          dateTime.getSeconds() === 0 &&
-          dateTime.getMinutes() === 0 &&
-          dateTime.getHours() === 0
-        ) {
-          const newDate = new Date();
-          newDate.setUTCHours(0, 0, 0, 0);
-          newDate.setUTCDate(dateTime.getDate());
-          newDate.setUTCMonth(dateTime.getMonth());
-          newDate.setUTCFullYear(dateTime.getFullYear());
-          dateObject = {
-            dateResolution: "day",
-            startTime: newDate.toISOString(),
-          };
-        } else {
-          dateObject = {
-            dateResolution: "time",
-            startTime: dateTime.toISOString(),
-          };
-        }
-      }
-
       const body = {
         spaceId: store?.spaces.length === 1 ? store.spaces[0].id : values.spaceId,
         title: values.title,
         mdText: values.mdText?.trim()?.length ? values.mdText.trim() : undefined,
         priority: values.priority === "empty" ? undefined : values.priority,
-        date: dateObject,
+        date: toDateApiObject(values.date),
+        deadline: toDateApiObject(values.deadline),
       };
-
-      console.log(body);
 
       try {
         const response = await fetch(`${API_URL}/save-task`, {
@@ -107,26 +105,6 @@ export default function Command() {
     },
   });
 
-  const spaces = store?.spaces ?? [];
-  const spaceIds = spaces.map((space) => space.id).join(",");
-
-  useEffect(() => {
-    if (!spaces.length || itemProps.spaceId.value) {
-      return;
-    }
-    let cancelled = false;
-
-    getInitialSpaceId(SPACE_STORAGE_KEY, spaces).then((spaceId) => {
-      if (!cancelled && spaceId) {
-        setValue("spaceId", spaceId);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [spaceIds, itemProps.spaceId.value, setValue]);
-
   return (
     <Form
       isLoading={storeIsLoading}
@@ -141,10 +119,8 @@ export default function Command() {
           <Form.Dropdown
             title="Space"
             {...itemProps.spaceId}
-            onChange={(value) => {
-              setValue("spaceId", value);
-              setStoredSpaceId(SPACE_STORAGE_KEY, value);
-            }}
+            storeValue
+            onChange={(value) => setValue("spaceId", value)}
             ref={spacesDropdown}
           >
             {store.spaces &&
@@ -163,6 +139,7 @@ export default function Command() {
         <Form.Dropdown.Item value="high" title="High" icon={Icon.Exclamationmark3} />
       </Form.Dropdown>
       <Form.DatePicker id="date" title="Date" defaultValue={null} />
+      <Form.DatePicker id="deadline" title="Deadline" defaultValue={null} />
       <Form.TextArea title="Notes" {...itemProps.mdText} info="Optional. Notes can be formatted in markdown." />
     </Form>
   );

--- a/extensions/capacities/src/create-task.tsx
+++ b/extensions/capacities/src/create-task.tsx
@@ -1,6 +1,7 @@
 import { ActionPanel, Action, Form, Icon, closeMainWindow, showToast, Toast, showHUD } from "@raycast/api";
 import { FormValidation, useForm } from "@raycast/utils";
 import { useEffect, useRef } from "react";
+import { getInitialSpaceId, setStoredSpaceId } from "./helpers/spaces";
 import { API_HEADERS, API_URL, handleAPIError, handleUnexpectedError, useCapacitiesStore } from "./helpers/storage";
 
 interface SaveTaskBody {
@@ -11,6 +12,8 @@ interface SaveTaskBody {
   date?: Date;
   deadline?: Date;
 }
+
+const SPACE_STORAGE_KEY = "create-task-space-id";
 
 type DateApiObject =
   | {
@@ -105,6 +108,26 @@ export default function Command() {
     },
   });
 
+  const spaces = store?.spaces ?? [];
+  const spaceIds = spaces.map((space) => space.id).join(",");
+
+  useEffect(() => {
+    if (!spaces.length || itemProps.spaceId.value) {
+      return;
+    }
+    let cancelled = false;
+
+    getInitialSpaceId(SPACE_STORAGE_KEY, spaces).then((spaceId) => {
+      if (!cancelled && spaceId) {
+        setValue("spaceId", spaceId);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [spaceIds, itemProps.spaceId.value, setValue]);
+
   return (
     <Form
       isLoading={storeIsLoading}
@@ -119,8 +142,10 @@ export default function Command() {
           <Form.Dropdown
             title="Space"
             {...itemProps.spaceId}
-            storeValue
-            onChange={(value) => setValue("spaceId", value)}
+            onChange={(value) => {
+              setValue("spaceId", value);
+              setStoredSpaceId(SPACE_STORAGE_KEY, value);
+            }}
             ref={spacesDropdown}
           >
             {store.spaces &&


### PR DESCRIPTION
## Description

Adds a **Deadline** date picker to the Create Task command, mirroring Capacities' native two-date task creation UI (Date + Deadline).

Previously only a single "Date" field was available. The Capacities app itself exposes two separate date properties on tasks: **Date** (creation/scheduled date) and **Deadline** (due date). This PR brings the Raycast extension in line with that.

Closes #28966.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder

Made with [Cursor](https://cursor.com)