### PR TITLE
[mymind] Prepopulate saves from clipboard

### DIFF
--- a/extensions/mymind/CHANGELOG.md
+++ b/extensions/mymind/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mymind Changelog
 
+## [Faster Saves from Clipboard] - 2026-07-20
+
+- Updated `Save to mymind` to detect links, notes, images, videos, and other supported files from recent clipboard history, then select the matching type and prepopulate the form
+
 ## [Rebuild Around Official API] - 2026-07-08
 
 - Rebuilt the extension around the official mymind API

--- a/extensions/mymind/src/save-input.test.ts
+++ b/extensions/mymind/src/save-input.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { strict as assert } from "node:assert";
 import test from "node:test";
+import { pathToFileURL } from "url";
 import {
   classifyClipboardContent,
   classifyFilePaths,
@@ -31,6 +32,52 @@ test("classifyClipboardContent prefers files over text", () => {
     kind: "files",
     value: [filePath],
   });
+});
+
+test("classifyClipboardContent detects links and notes", () => {
+  assert.deepEqual(classifyClipboardContent({ text: "https://example.com/article" }), {
+    kind: "url",
+    value: "https://example.com/article",
+  });
+  assert.deepEqual(classifyClipboardContent({ text: "Remember this" }), {
+    kind: "note",
+    value: "Remember this",
+  });
+});
+
+test("classifyClipboardContent converts file URLs to upload paths", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "mymind-save-input-"));
+  const filePath = join(tempDir, "clip.mp4");
+  writeFileSync(filePath, "video");
+
+  assert.deepEqual(classifyClipboardContent({ file: pathToFileURL(filePath).href }), {
+    kind: "files",
+    value: [filePath],
+  });
+});
+
+test("classifyClipboardContent recognizes extensionless clipboard images", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "mymind-save-input-"));
+  const filePath = join(tempDir, "Image 1");
+  writeFileSync(filePath, Buffer.from("89504e470d0a1a0a0000000d49484452", "hex"));
+
+  assert.deepEqual(classifyClipboardContent({ file: pathToFileURL(filePath).href }), {
+    kind: "files",
+    value: [filePath],
+  });
+  assert.equal(getUploadMimeType(filePath), "image/png");
+});
+
+test("classifyClipboardContent recognizes extensionless clipboard videos", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "mymind-save-input-"));
+  const filePath = join(tempDir, "Video 1");
+  writeFileSync(filePath, Buffer.from("000000186674797069736f6d00000000", "hex"));
+
+  assert.deepEqual(classifyClipboardContent({ file: pathToFileURL(filePath).href }), {
+    kind: "files",
+    value: [filePath],
+  });
+  assert.equal(getUploadMimeType(filePath), "video/mp4");
 });
 
 test("classifyFilePaths filters unsupported files", () => {

--- a/extensions/mymind/src/save-input.ts
+++ b/extensions/mymind/src/save-input.ts
@@ -1,5 +1,6 @@
-import { existsSync, statSync } from "fs";
+import { closeSync, existsSync, openSync, readSync, statSync } from "fs";
 import { basename, extname } from "path";
+import { fileURLToPath } from "url";
 
 type ClipboardLike = {
   text?: string;
@@ -42,6 +43,69 @@ function normalizeText(value?: string): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function normalizeFilePath(value: string): string {
+  const trimmed = value.trim();
+
+  if (!trimmed.startsWith("file:")) {
+    return trimmed;
+  }
+
+  try {
+    return fileURLToPath(trimmed);
+  } catch {
+    return trimmed;
+  }
+}
+
+function readFileHeader(filePath: string): Buffer | undefined {
+  let fileDescriptor: number | undefined;
+
+  try {
+    fileDescriptor = openSync(filePath, "r");
+    const header = Buffer.alloc(16);
+    const bytesRead = readSync(fileDescriptor, header, 0, header.length, 0);
+    return header.subarray(0, bytesRead);
+  } catch {
+    return undefined;
+  } finally {
+    if (fileDescriptor !== undefined) {
+      closeSync(fileDescriptor);
+    }
+  }
+}
+
+function detectUploadMimeType(filePath: string): string | undefined {
+  const header = readFileHeader(filePath);
+
+  if (!header) {
+    return undefined;
+  }
+
+  const ascii = header.toString("ascii");
+  const hex = header.toString("hex");
+
+  if (hex.startsWith("89504e470d0a1a0a")) return "image/png";
+  if (hex.startsWith("ffd8ff")) return "image/jpeg";
+  if (ascii.startsWith("GIF87a") || ascii.startsWith("GIF89a")) return "image/gif";
+  if (ascii.startsWith("BM")) return "image/bmp";
+  if (hex.startsWith("49492a00") || hex.startsWith("4d4d002a")) return "image/tiff";
+  if (ascii.startsWith("8BPS")) return "image/vnd.adobe.photoshop";
+  if (ascii.startsWith("%PDF")) return "application/pdf";
+  if (ascii.startsWith("RIFF") && ascii.slice(8, 12) === "WEBP") return "image/webp";
+  if (ascii.startsWith("RIFF") && ascii.slice(8, 12) === "AVI ") return "video/x-msvideo";
+  if (hex.startsWith("1a45dfa3")) return "video/webm";
+
+  if (ascii.slice(4, 8) === "ftyp") {
+    const brand = ascii.slice(8, 12);
+    if (brand === "avif" || brand === "avis") return "image/avif";
+    if (["heic", "heix", "hevc", "hevx", "mif1", "msf1"].includes(brand)) return "image/heif";
+    if (brand === "qt  ") return "video/quicktime";
+    return "video/mp4";
+  }
+
+  return undefined;
+}
+
 export function isProbablyUrl(value: string): boolean {
   try {
     const url = new URL(value);
@@ -75,23 +139,26 @@ export function classifyClipboardContent(content: ClipboardLike): SaveInput {
 }
 
 export function getUploadMimeType(filePath: string): string | undefined {
-  return UPLOAD_MIME_TYPES[extname(filePath).toLowerCase()];
+  const normalizedPath = normalizeFilePath(filePath);
+  return UPLOAD_MIME_TYPES[extname(normalizedPath).toLowerCase()] ?? detectUploadMimeType(normalizedPath);
 }
 
 export function isUploadCandidate(filePath: string): boolean {
-  if (!filePath || !existsSync(filePath)) {
+  const normalizedPath = normalizeFilePath(filePath);
+
+  if (!normalizedPath || !existsSync(normalizedPath)) {
     return false;
   }
 
   try {
-    return statSync(filePath).isFile() && Boolean(getUploadMimeType(filePath));
+    return statSync(normalizedPath).isFile() && Boolean(getUploadMimeType(normalizedPath));
   } catch {
     return false;
   }
 }
 
 export function classifyFilePaths(filePaths: string[]): SaveInput {
-  const supportedFiles = Array.from(new Set(filePaths.filter(isUploadCandidate)));
+  const supportedFiles = Array.from(new Set(filePaths.map(normalizeFilePath).filter(isUploadCandidate)));
   return supportedFiles.length > 0 ? { kind: "files", value: supportedFiles } : { kind: "empty" };
 }
 

--- a/extensions/mymind/src/save-to-mymind.tsx
+++ b/extensions/mymind/src/save-to-mymind.tsx
@@ -1,6 +1,7 @@
 import {
   Action,
   ActionPanel,
+  Clipboard,
   Form,
   getSelectedFinderItems,
   getPreferenceValues,
@@ -28,7 +29,13 @@ import { getAccessKeyScope, useEffectiveAccessLevel, useWriteAccess } from "./ac
 import { ObjectDetail } from "./components/ObjectActions";
 import { getBatchUploadFailureMessage } from "./error-utils";
 import { getSpaceIcon } from "./helpers";
-import { classifyFilePaths, classifyTextInput, getUnsupportedUploadFiles } from "./save-input";
+import {
+  classifyClipboardContent,
+  classifyFilePaths,
+  classifyTextInput,
+  getUnsupportedUploadFiles,
+  SaveInput,
+} from "./save-input";
 import { isUserTag } from "./tag-utils";
 
 type SaveValues = {
@@ -64,6 +71,38 @@ const EMPTY_INITIAL_STATE: InitialState = {
   url: "",
 };
 
+function getInitialStateFromInput(input: SaveInput): InitialState | undefined {
+  if (input.kind === "files") {
+    return { ...EMPTY_INITIAL_STATE, kind: "file", files: input.value };
+  }
+
+  if (input.kind === "url") {
+    return { ...EMPTY_INITIAL_STATE, kind: "url", url: input.value };
+  }
+
+  if (input.kind === "note") {
+    return { ...EMPTY_INITIAL_STATE, kind: "note", content: input.value };
+  }
+
+  return undefined;
+}
+
+async function getClipboardInitialState(): Promise<InitialState | undefined> {
+  for (let offset = 0; offset <= 5; offset++) {
+    try {
+      const initialState = getInitialStateFromInput(classifyClipboardContent(await Clipboard.read({ offset })));
+
+      if (initialState) {
+        return initialState;
+      }
+    } catch {
+      // Continue through the available clipboard history when an item can't be read.
+    }
+  }
+
+  return undefined;
+}
+
 async function resolveInitialState(fallbackText?: string, launchContext?: SaveLaunchContext): Promise<InitialState> {
   const launchContextFiles = classifyFilePaths([
     ...(Array.isArray(launchContext?.files) ? launchContext.files : []),
@@ -80,6 +119,12 @@ async function resolveInitialState(fallbackText?: string, launchContext?: SaveLa
 
   if (launchContext?.content) {
     return { ...EMPTY_INITIAL_STATE, kind: "note", content: launchContext.content };
+  }
+
+  const clipboardInitialState = await getClipboardInitialState();
+
+  if (clipboardInitialState) {
+    return clipboardInitialState;
   }
 
   try {


### PR DESCRIPTION
## Summary
- scan recent clipboard history when opening `Save to mymind`
- automatically choose Link, Note, or File and prepopulate the matching field
- support file URLs and extensionless clipboard images/videos through content detection
- document the faster clipboard save flow in the changelog

## Test plan
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`


Made with [Cursor](https://cursor.com)