### PR TITLE
feat(google-calendar): expand AI API support

### DIFF
--- a/extensions/google-calendar/CHANGELOG.md
+++ b/extensions/google-calendar/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Google Calendar Changelog
 
+## [Expand AI Calendar API Support] - 2026-07-20
+
+- Expand the AI extension to support rich event creation and editing, including all-day and recurring events, attendees, reminders, visibility, availability, conferencing, attachments, special event types, imports, and recurring instances
+- Add AI tools for event details, invitation responses, suggested meeting times, event moves, quick add, custom event labels, calendar management, calendar-list preferences, sharing rules, settings, and live color palettes
+- Support Google Calendar's custom event labels and colors with `eventLabelId` and `eventLabelVersion=1` while retaining legacy `colorId` compatibility
+- Use safe partial event updates to preserve fields the user did not change, and return consistent rich event data from event tools
+- Upgrade `@googleapis/calendar` to v15 and add unit tests plus expanded AI eval coverage for the new workflows
+
 ## [Revert Narrow OAuth Scope] - 2026-07-15
 
 - Revert [#28925](https://github.com/raycast/extensions/pull/28925) and restore the broad `calendar` OAuth scope to avoid forcing re-authentication for existing users

--- a/extensions/google-calendar/ai.yaml
+++ b/extensions/google-calendar/ai.yaml
@@ -1,110 +1,301 @@
 instructions: |
-  Include a link to the event in your response to make it easier for the user to view it.
-  If no email domain is provided for other attendees, call the `get-current-user` tool and prefer attendees from the same domain as the current user.
-  Try to call the `search-contacts` tool in parallel when possible.
-  Call the `get-current-time` tool if you need to know the current time, e.g. when creating an event within a relative time frame like "today in 1h".
-  If no attendees are provided, just create the event, it will be private.
+  Include an event's htmlLink in responses when one is available.
+  Use get-current-time when resolving relative dates such as today or next week; its timestamp field is iso8601.
+  Use suggest-time, not search-events or check-availability, when the user asks to find an open meeting slot.
+  Event IDs and calendar IDs are opaque: obtain them from search-events, get-event, list-calendars, or a preceding tool result.
+  If an attendee has no email domain, prefer search-contacts and contacts from the current user's domain.
+  If no attendees are provided, create the event without attendees.
+  Custom event labels are calendar-specific. List them with manage-calendar-labels before assigning one.
 evals:
-  - input: "@google-calendar Could you set up a 'Project Sync' meeting for tomorrow at 10:00 that lasts 1 hour?"
+  - input: "@google-calendar Create a one-hour Project Sync tomorrow at 10:00."
     mocks:
-      get-current-user:
-        email: "bob@example.com"
       get-current-time:
-        currentTime: "2025-02-09T12:00:00Z"
+        timezone: "Europe/Paris"
+        iso8601: "2026-07-20T12:00:00+02:00"
+        humanReadableTime: "July 20, 2026 at 12:00:00 PM GMT+2"
       create-event:
+        id: "evt-101"
+        calendarId: "primary"
         title: "Project Sync"
-        startDate: "2025-02-10T10:00:00Z"
-        duration: 60
+        start: "2026-07-21T10:00:00+02:00"
+        end: "2026-07-21T11:00:00+02:00"
+        allDay: false
+        durationMinutes: 60
+        attendees: []
+        htmlLink: "https://calendar.google.com/event?eid=evt-101"
     expected:
+      - callsTool: "get-current-time"
       - callsTool:
           name: "create-event"
           arguments:
             title: "Project Sync"
             startDate:
-              includes: "10:00:00"
+              includes: "T10:00:00"
             duration: 60
-  - input: "@google-calendar I need to get in touch with Alice. Can you look up her contact details?"
+
+  - input: "@google-calendar Look up Alice's contact details."
     mocks:
       search-contacts:
-        contacts:
-          - id: "c-001"
-            name: "Alice Johnson"
-            email: "alice@example.com"
+        - name: "Alice Johnson"
+          email: "alice@example.com"
     expected:
       - callsTool:
           name: "search-contacts"
           arguments:
             query:
-              includes: "lice"
-  - input: "@google-calendar What's on my calendar for today?"
+              includes: "Alice"
+
+  - input: "@google-calendar What's on my calendar today?"
     mocks:
       get-current-time:
-        currentTime: "2025-02-09T12:00:00+01:00"
+        timezone: "Europe/Paris"
+        iso8601: "2026-07-20T12:00:00+02:00"
+        humanReadableTime: "July 20, 2026 at 12:00:00 PM GMT+2"
       search-events:
+        calendarId: "primary"
+        calendarSummary: "Bob"
+        timeZone: "Europe/Paris"
         events:
-          - id: "evt-101"
+          - id: "evt-102"
+            calendarId: "primary"
             title: "Daily Standup"
-            start: "2025-02-09T09:00:00+01:00"
-    expected:
-      - callsTool:
-          name: "search-events"
-  - input: "@google-calendar could you move the 'Project Sync' meeting to next week?"
-    mocks:
-      search-events:
-        events:
-          - id: "evt-123"
-            title: "Project Sync"
-            startDate: "2025-02-10T00:00:00+00:00"
-            duration: 60
-      edit-event:
-        success: true
-        event:
-          eventId: "evt-123"
-          startDate: "2025-02-17T00:00:00+00:00"
-    expected:
-      - callsTool:
-          name: "edit-event"
-          arguments:
-            eventId: "evt-123"
-            startDate: "2025-02-17T00:00:00+00:00"
-  - input: "@google-calendar find 2 hours slot this week for lunch"
-    mocks:
-      search-events:
-        events:
-          - id: "evt-123"
-            title: "Project Sync"
-            startDate: "2025-02-26T10:00:00+04:00"
-            duration: 60
-      check-availability:
-        - busyPeriods:
-            - end: "2025-02-26T16:30:00+04:00"
-              start: "2025-02-26T15:30:00+04:00"
-            - end: "2025-02-27T13:00:00+04:00"
-              start: "2025-02-27T12:00:00+04:00"
-            - end: "2025-02-27T15:30:00+04:00"
-              start: "2025-02-27T15:00:00+04:00"
-      get-current-time:
-        time: "2025-02-10T15:36:39.039+04:00"
+            start: "2026-07-20T09:00:00+02:00"
+            end: "2026-07-20T09:30:00+02:00"
+            allDay: false
+            durationMinutes: 30
+            attendees: []
+            htmlLink: "https://calendar.google.com/event?eid=evt-102"
     expected:
       - callsTool: "get-current-time"
       - callsTool:
+          name: "search-events"
           arguments:
             timeMin:
-              - includes: 2025-02-10
-          name: "check-availability"
-  - input: "@google-calendar cancel sync today"
+              includes: "2026-07-20"
+
+  - input: "@google-calendar Find a free two-hour lunch slot this work week."
     mocks:
-      search-events:
-        events:
-          - id: "evt-123"
-            title: "Project Sync"
-            startDate: "2025-02-10T10:00:00+00:00"
-            duration: 60
-      delete-event: "ok"
       get-current-time:
-        time: "2025-02-10T15:36:39.039+00:00"
+        timezone: "Europe/Paris"
+        iso8601: "2026-07-20T12:00:00+02:00"
+        humanReadableTime: "July 20, 2026 at 12:00:00 PM GMT+2"
+      suggest-time:
+        participants: ["bob@example.com"]
+        durationMinutes: 120
+        searchedRange:
+          start: "2026-07-20T00:00:00+02:00"
+          end: "2026-07-25T00:00:00+02:00"
+          timeZone: "Europe/Paris"
+        workHours:
+          start: "09:00"
+          end: "17:00"
+        suggestions:
+          - start: "2026-07-21T10:00:00.000Z"
+            end: "2026-07-21T12:00:00.000Z"
+            displayStart: "Tuesday, July 21, 2026 at 12:00 PM"
+            displayEnd: "Tuesday, July 21, 2026 at 2:00 PM"
+            timeZone: "Europe/Paris"
+    expected:
+      - callsTool: "get-current-time"
+      - callsTool:
+          name: "suggest-time"
+          arguments:
+            durationMinutes: 120
+
+  - input: "@google-calendar Cancel today's Project Sync."
+    mocks:
+      get-current-time:
+        timezone: "UTC"
+        iso8601: "2026-07-20T08:00:00+00:00"
+        humanReadableTime: "July 20, 2026 at 8:00:00 AM UTC"
+      search-events:
+        calendarId: "primary"
+        timeZone: "UTC"
+        events:
+          - id: "evt-103"
+            calendarId: "primary"
+            title: "Project Sync"
+            start: "2026-07-20T10:00:00Z"
+            end: "2026-07-20T11:00:00Z"
+            allDay: false
+            durationMinutes: 60
+            attendees: []
+            htmlLink: "https://calendar.google.com/event?eid=evt-103"
+      delete-event:
+        deleted: true
+        id: "evt-103"
+        calendarId: "primary"
+        title: "Project Sync"
     expected:
       - callsTool:
           name: "delete-event"
           arguments:
-            eventId: "evt-123"
+            eventId: "evt-103"
+
+  - input: "@google-calendar Add an all-day company offsite on August 3, 2026."
+    mocks:
+      create-event:
+        id: "evt-201"
+        calendarId: "primary"
+        title: "Company Offsite"
+        start: "2026-08-03"
+        end: "2026-08-04"
+        allDay: true
+        durationDays: 1
+        attendees: []
+        htmlLink: "https://calendar.google.com/event?eid=evt-201"
+    expected:
+      - callsTool:
+          name: "create-event"
+          arguments:
+            title:
+              includes: "Offsite"
+            startDate: "2026-08-03"
+            allDay: true
+            durationDays: 1
+
+  - input: "@google-calendar Create a weekly team review every Monday at 9 AM Paris time, starting August 3, 2026, for one hour."
+    mocks:
+      create-event:
+        id: "evt-202"
+        calendarId: "primary"
+        title: "Team Review"
+        start: "2026-08-03T09:00:00+02:00"
+        end: "2026-08-03T10:00:00+02:00"
+        allDay: false
+        timeZone: "Europe/Paris"
+        durationMinutes: 60
+        recurrence: ["RRULE:FREQ=WEEKLY;BYDAY=MO"]
+        attendees: []
+        htmlLink: "https://calendar.google.com/event?eid=evt-202"
+    expected:
+      - callsTool:
+          name: "create-event"
+          arguments:
+            title:
+              includes: "Team Review"
+            startDate:
+              includes: "2026-08-03T09:00:00"
+            duration: 60
+            timeZone: "Europe/Paris"
+            recurrence:
+              includes: "FREQ=WEEKLY"
+
+  - input: "@google-calendar Accept the invitation to Project Kickoff."
+    mocks:
+      search-events:
+        calendarId: "primary"
+        events:
+          - id: "evt-203"
+            calendarId: "primary"
+            title: "Project Kickoff"
+            start: "2026-08-04T09:00:00Z"
+            end: "2026-08-04T10:00:00Z"
+            allDay: false
+            durationMinutes: 60
+            attendees:
+              - email: "bob@example.com"
+                self: true
+                responseStatus: "needsAction"
+            htmlLink: "https://calendar.google.com/event?eid=evt-203"
+      respond-to-event:
+        id: "evt-203"
+        calendarId: "primary"
+        title: "Project Kickoff"
+        start: "2026-08-04T09:00:00Z"
+        end: "2026-08-04T10:00:00Z"
+        allDay: false
+        durationMinutes: 60
+        attendees:
+          - email: "bob@example.com"
+            self: true
+            responseStatus: "accepted"
+        htmlLink: "https://calendar.google.com/event?eid=evt-203"
+    expected:
+      - callsTool:
+          name: "respond-to-event"
+          arguments:
+            eventId: "evt-203"
+            response: "accepted"
+
+  - input: "@google-calendar Apply my Customer label to Project Sync."
+    mocks:
+      search-events:
+        calendarId: "primary"
+        events:
+          - id: "evt-204"
+            calendarId: "primary"
+            title: "Project Sync"
+            start: "2026-08-05T09:00:00Z"
+            end: "2026-08-05T10:00:00Z"
+            allDay: false
+            durationMinutes: 60
+            attendees: []
+      manage-calendar-labels:
+        id: "primary"
+        summary: "Bob"
+        timeZone: "UTC"
+        labels:
+          - id: "label-customer"
+            name: "Customer"
+            backgroundColor: "#039be5"
+      set-event-label:
+        id: "evt-204"
+        calendarId: "primary"
+        title: "Project Sync"
+        start: "2026-08-05T09:00:00Z"
+        end: "2026-08-05T10:00:00Z"
+        allDay: false
+        durationMinutes: 60
+        eventLabelId: "label-customer"
+        eventLabel:
+          id: "label-customer"
+          name: "Customer"
+          backgroundColor: "#039be5"
+        attendees: []
+    expected:
+      - callsTool:
+          name: "manage-calendar-labels"
+          arguments:
+            action: "list"
+      - callsTool:
+          name: "set-event-label"
+          arguments:
+            action: "assign"
+            eventId: "evt-204"
+            labelId: "label-customer"
+
+  - input: "@google-calendar Create a Team Operations calendar in Europe/Paris and give ops@example.com permission to edit events."
+    mocks:
+      get-current-user:
+        displayName: "Bob Example"
+        givenName: "Bob"
+        familyName: "Example"
+        email: "bob@example.com"
+      manage-calendar:
+        id: "team-ops@example.com"
+        summary: "Team Operations"
+        timeZone: "Europe/Paris"
+        labels: []
+      manage-calendar-sharing:
+        id: "user:ops@example.com"
+        role: "writer"
+        scope:
+          type: "user"
+          value: "ops@example.com"
+        etag: "acl-etag-1"
+    expected:
+      - callsTool:
+          name: "manage-calendar"
+          arguments:
+            action: "create"
+            summary: "Team Operations"
+            timeZone: "Europe/Paris"
+      - callsTool:
+          name: "manage-calendar-sharing"
+          arguments:
+            action: "grant"
+            calendarId: "team-ops@example.com"
+            scopeType: "user"
+            scopeValue: "ops@example.com"
+            role: "writer"

--- a/extensions/google-calendar/ai.yaml
+++ b/extensions/google-calendar/ai.yaml
@@ -6,6 +6,7 @@ instructions: |
   If an attendee has no email domain, prefer search-contacts and contacts from the current user's domain.
   If no attendees are provided, create the event without attendees.
   Custom event labels are calendar-specific. List them with manage-calendar-labels before assigning one.
+  Use create-event, not quick-add-event, whenever the user gives structured details such as an explicit duration, time zone, or recurrence.
 evals:
   - input: "@google-calendar Create a one-hour Project Sync tomorrow at 10:00."
     mocks:
@@ -51,6 +52,14 @@ evals:
         timezone: "Europe/Paris"
         iso8601: "2026-07-20T12:00:00+02:00"
         humanReadableTime: "July 20, 2026 at 12:00:00 PM GMT+2"
+      list-calendars:
+        calendars:
+          - id: "primary"
+            summary: "Bob"
+            primary: true
+            hidden: false
+            selected: true
+            accessRole: "owner"
       search-events:
         calendarId: "primary"
         calendarSummary: "Bob"
@@ -79,6 +88,11 @@ evals:
         timezone: "Europe/Paris"
         iso8601: "2026-07-20T12:00:00+02:00"
         humanReadableTime: "July 20, 2026 at 12:00:00 PM GMT+2"
+      get-current-user:
+        displayName: "Bob Example"
+        givenName: "Bob"
+        familyName: "Example"
+        email: "bob@example.com"
       suggest-time:
         participants: ["bob@example.com"]
         durationMinutes: 120
@@ -152,7 +166,6 @@ evals:
               includes: "Offsite"
             startDate: "2026-08-03"
             allDay: true
-            durationDays: 1
 
   - input: "@google-calendar Create a weekly team review every Monday at 9 AM Paris time, starting August 3, 2026, for one hour."
     mocks:
@@ -220,6 +233,14 @@ evals:
 
   - input: "@google-calendar Apply my Customer label to Project Sync."
     mocks:
+      list-calendars:
+        calendars:
+          - id: "primary"
+            summary: "Bob"
+            primary: true
+            hidden: false
+            selected: true
+            accessRole: "owner"
       search-events:
         calendarId: "primary"
         events:
@@ -272,6 +293,23 @@ evals:
         givenName: "Bob"
         familyName: "Example"
         email: "bob@example.com"
+      search-contacts:
+        - name: "Ops Team"
+          email: "ops@example.com"
+      list-calendars:
+        calendars:
+          - id: "primary"
+            summary: "Bob"
+            primary: true
+            hidden: false
+            selected: true
+            accessRole: "owner"
+          - id: "team-ops@example.com"
+            summary: "Team Operations"
+            primary: false
+            hidden: false
+            selected: true
+            accessRole: "owner"
       manage-calendar:
         id: "team-ops@example.com"
         summary: "Team Operations"

--- a/extensions/google-calendar/package-lock.json
+++ b/extensions/google-calendar/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "google-calendar",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "google-calendar",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "MIT",
       "dependencies": {
-        "@googleapis/calendar": "^14.2.0",
+        "@googleapis/calendar": "^15.0.0",
         "@googleapis/people": "^7.0.1",
         "@raycast/api": "^1.104.16",
         "@raycast/utils": "^2.2.4",
@@ -24,6 +24,7 @@
         "@types/react": "19.2.14",
         "eslint": "^10.3.0",
         "prettier": "^3.8.3",
+        "tsx": "^4.23.1",
         "typescript": "^6.0.3"
       }
     },
@@ -551,9 +552,9 @@
       }
     },
     "node_modules/@googleapis/calendar": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@googleapis/calendar/-/calendar-14.2.0.tgz",
-      "integrity": "sha512-oo6bikN3dl7n43vvknpPzJlCD8FZbs82h4bZLfDAx1wWRUkIusg6++RFQvOKF46rNXsUePqyVwnFx+8oOOyK1A==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/calendar/-/calendar-15.0.0.tgz",
+      "integrity": "sha512-K5FVIhFOgAaNsfshvOEmGkT7kkowM69MzMYATGDA6Ol3ZwqIK0nZJnS9/keFVYkId6MT2elAy+omcAMUdadHww==",
       "license": "Apache-2.0",
       "dependencies": {
         "googleapis-common": "^8.0.0"
@@ -2294,6 +2295,21 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3209,6 +3225,509 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/type-check": {

--- a/extensions/google-calendar/package.json
+++ b/extensions/google-calendar/package.json
@@ -26,18 +26,7 @@
       "title": "Create Event",
       "subtitle": "Google Calendar",
       "description": "Creates an event in your Google Calendar",
-      "mode": "view",
-      "preferences": [
-        {
-          "name": "addSignature",
-          "type": "checkbox",
-          "title": "Advanced",
-          "label": "Add Signature",
-          "description": "Add a signature that the event was created using Raycast to the description of the event",
-          "default": true,
-          "required": false
-        }
-      ]
+      "mode": "view"
     },
     {
       "name": "create-quick-event",
@@ -197,6 +186,15 @@
     }
   ],
   "preferences": [
+    {
+      "name": "addSignature",
+      "type": "checkbox",
+      "title": "Advanced",
+      "label": "Add Signature",
+      "description": "Add a signature that the event was created using Raycast to the description of the event",
+      "default": true,
+      "required": false
+    },
     {
       "name": "defaultEventDuration",
       "title": "Default Event Duration",

--- a/extensions/google-calendar/package.json
+++ b/extensions/google-calendar/package.json
@@ -106,6 +106,41 @@
       "description": "Searches events from the user's Google Calendar"
     },
     {
+      "name": "get-event",
+      "title": "Get Event",
+      "description": "Gets complete details for a Google Calendar event by ID"
+    },
+    {
+      "name": "respond-to-event",
+      "title": "Respond to Event",
+      "description": "Accepts, declines, tentatively accepts, or resets the user's response to an invitation"
+    },
+    {
+      "name": "suggest-time",
+      "title": "Suggest Time",
+      "description": "Finds actual meeting slots from attendee availability, work hours, weekends, duration, and timezone"
+    },
+    {
+      "name": "move-event",
+      "title": "Move Event",
+      "description": "Moves a standard event to another Google Calendar and changes its organizer"
+    },
+    {
+      "name": "list-event-instances",
+      "title": "List Event Instances",
+      "description": "Lists individual occurrences and exceptions of a recurring Google Calendar event"
+    },
+    {
+      "name": "quick-add-event",
+      "title": "Quick Add Event",
+      "description": "Lets Google Calendar parse natural-language text and create an event"
+    },
+    {
+      "name": "import-event",
+      "title": "Import Event",
+      "description": "Imports a private copy of an external iCalendar event"
+    },
+    {
       "name": "check-availability",
       "title": "Check Availability",
       "description": "Checks the availability of potential attendees for a given time period"
@@ -123,7 +158,42 @@
     {
       "name": "list-calendars",
       "title": "List Calendars",
-      "description": "Lists the user's Google Calendars"
+      "description": "Lists rich user-specific Google Calendar metadata with pagination and access filters"
+    },
+    {
+      "name": "manage-calendar-labels",
+      "title": "Manage Calendar Labels",
+      "description": "Lists, creates, renames, recolors, or deletes custom event labels on a calendar"
+    },
+    {
+      "name": "set-event-label",
+      "title": "Set Event Label",
+      "description": "Assigns or removes a calendar's custom label on an event"
+    },
+    {
+      "name": "manage-calendar",
+      "title": "Manage Calendar",
+      "description": "Gets, creates, updates, or deletes secondary Google Calendar metadata"
+    },
+    {
+      "name": "manage-calendar-list",
+      "title": "Manage Calendar List",
+      "description": "Gets, adds, updates, or removes user-specific Google Calendar list settings"
+    },
+    {
+      "name": "manage-calendar-sharing",
+      "title": "Manage Calendar Sharing",
+      "description": "Lists, gets, grants, updates, or revokes Google Calendar access rules"
+    },
+    {
+      "name": "get-calendar-settings",
+      "title": "Get Calendar Settings",
+      "description": "Reads one or lists all read-only Google Calendar user settings"
+    },
+    {
+      "name": "get-calendar-colors",
+      "title": "Get Calendar Colors",
+      "description": "Returns the current Google Calendar event and calendar color palettes"
     }
   ],
   "preferences": [
@@ -185,7 +255,7 @@
     }
   ],
   "dependencies": {
-    "@googleapis/calendar": "^14.2.0",
+    "@googleapis/calendar": "^15.0.0",
     "@googleapis/people": "^7.0.1",
     "@raycast/api": "^1.104.16",
     "@raycast/utils": "^2.2.4",
@@ -200,6 +270,7 @@
     "@types/react": "19.2.14",
     "eslint": "^10.3.0",
     "prettier": "^3.8.3",
+    "tsx": "^4.23.1",
     "typescript": "^6.0.3"
   },
   "scripts": {
@@ -207,6 +278,7 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
+    "test": "tsx --test src/**/*.test.ts",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
   },

--- a/extensions/google-calendar/src/lib/calendar-resources.ts
+++ b/extensions/google-calendar/src/lib/calendar-resources.ts
@@ -1,0 +1,115 @@
+import { calendar_v3 } from "@googleapis/calendar";
+import { getCalendarClient } from "./google";
+import type { EventLabel } from "./calendar-values";
+
+export { assertNonEmpty, assertTimeZone, normalizeHexColor, requireLabel } from "./calendar-values";
+export type { EventLabel } from "./calendar-values";
+
+export type CalendarWithLabels = calendar_v3.Schema$Calendar & {
+  labelProperties?: { eventLabels?: EventLabel[] | null } | null;
+};
+
+export type EventWithLabel = calendar_v3.Schema$Event & {
+  eventLabelId?: string | null;
+};
+
+export type EventLabelVersionParams = { eventLabelVersion: 1 };
+export type OrganizationListParams = { showOwnOrganizationOnly?: boolean };
+
+export function serializeCalendar(calendar: CalendarWithLabels) {
+  return {
+    id: calendar.id,
+    summary: calendar.summary,
+    description: calendar.description,
+    location: calendar.location,
+    timeZone: calendar.timeZone,
+    dataOwner: calendar.dataOwner,
+    autoAcceptInvitations: calendar.autoAcceptInvitations,
+    conferenceProperties: calendar.conferenceProperties,
+    labels: calendar.labelProperties?.eventLabels ?? [],
+    etag: calendar.etag,
+  };
+}
+
+export function serializeCalendarListEntry(entry: calendar_v3.Schema$CalendarListEntry) {
+  return {
+    id: entry.id,
+    summary: entry.summary,
+    summaryOverride: entry.summaryOverride,
+    description: entry.description,
+    location: entry.location,
+    timeZone: entry.timeZone,
+    dataOwner: entry.dataOwner,
+    primary: entry.primary,
+    deleted: entry.deleted,
+    hidden: entry.hidden ?? false,
+    selected: entry.selected ?? false,
+    accessRole: entry.accessRole,
+    color: {
+      id: entry.colorId,
+      background: entry.backgroundColor,
+      foreground: entry.foregroundColor,
+    },
+    defaultReminders: entry.defaultReminders ?? [],
+    notificationSettings: entry.notificationSettings?.notifications ?? [],
+    conferenceProperties: entry.conferenceProperties,
+    autoAcceptInvitations: entry.autoAcceptInvitations,
+    etag: entry.etag,
+  };
+}
+
+export function serializeAclRule(rule: calendar_v3.Schema$AclRule) {
+  return {
+    id: rule.id,
+    role: rule.role,
+    scope: rule.scope,
+    etag: rule.etag,
+  };
+}
+
+export async function requireCalendarOwner(calendarId: string) {
+  const entry = await getCalendarClient().calendarList.get({ calendarId });
+  if (entry.data.accessRole !== "owner") {
+    throw new Error(`Owner access is required for calendar "${calendarId}".`);
+  }
+  return entry.data;
+}
+
+export function getEventLabels(calendar: CalendarWithLabels) {
+  return [...(calendar.labelProperties?.eventLabels ?? [])];
+}
+
+export function writableCalendarListEntry(entry: calendar_v3.Schema$CalendarListEntry) {
+  return {
+    id: entry.id,
+    summaryOverride: entry.summaryOverride,
+    colorId: entry.colorId,
+    backgroundColor: entry.backgroundColor,
+    foregroundColor: entry.foregroundColor,
+    hidden: entry.hidden,
+    selected: entry.selected,
+    defaultReminders: entry.defaultReminders,
+    notificationSettings: entry.notificationSettings,
+  } satisfies calendar_v3.Schema$CalendarListEntry;
+}
+
+export async function getCalendarWithLabels(calendarId: string) {
+  const response = await getCalendarClient().calendars.get({ calendarId });
+  return response.data as CalendarWithLabels;
+}
+
+export async function replaceEventLabels(calendarId: string, current: CalendarWithLabels, labels: EventLabel[]) {
+  if (!current.summary) throw new Error("The calendar has no summary and cannot be safely updated.");
+  const requestBody = {
+    summary: current.summary,
+    ...(current.description !== undefined ? { description: current.description } : {}),
+    ...(current.location !== undefined ? { location: current.location } : {}),
+    ...(current.timeZone !== undefined ? { timeZone: current.timeZone } : {}),
+    labelProperties: { eventLabels: labels },
+  } as CalendarWithLabels;
+  const response = await getCalendarClient().calendars.update(
+    { calendarId, requestBody },
+    current.etag ? { headers: { "If-Match": current.etag } } : undefined,
+  );
+  return response.data as CalendarWithLabels;
+}

--- a/extensions/google-calendar/src/lib/calendar-values.test.ts
+++ b/extensions/google-calendar/src/lib/calendar-values.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { assertTimeZone, mergeEventLabels, normalizeHexColor } from "./calendar-values";
+
+describe("calendar value helpers", () => {
+  it("normalizes six-digit hex colors and rejects malformed values", () => {
+    assert.equal(normalizeHexColor(" #A4BDFC "), "#a4bdfc");
+    assert.throws(() => normalizeHexColor("#fff"), /six-digit hexadecimal/);
+    assert.throws(() => normalizeHexColor("blue"), /six-digit hexadecimal/);
+  });
+
+  it("validates IANA time zones", () => {
+    assert.doesNotThrow(() => assertTimeZone("America/New_York"));
+    assert.throws(() => assertTimeZone("Not/A_Zone"), /Invalid IANA time zone/);
+    assert.throws(() => assertTimeZone("  "), /cannot be empty/);
+  });
+
+  it("merges label changes without mutating the source", () => {
+    const original = [{ id: "one", name: "Old", backgroundColor: "#000000" }];
+    const renamed = mergeEventLabels(original, { action: "rename", labelId: "one", name: "New" });
+    const recolored = mergeEventLabels(renamed, {
+      action: "recolor",
+      labelId: "one",
+      backgroundColor: "#A4BDFC",
+    });
+    const created = mergeEventLabels(recolored, {
+      action: "create",
+      id: "two",
+      name: "Customer",
+      backgroundColor: "#039be5",
+    });
+    const deleted = mergeEventLabels(created, { action: "delete", labelId: "one" });
+
+    assert.equal(original[0].name, "Old");
+    assert.equal(recolored[0].backgroundColor, "#a4bdfc");
+    assert.deepEqual(deleted, [{ id: "two", name: "Customer", backgroundColor: "#039be5" }]);
+    assert.throws(() => mergeEventLabels(original, { action: "delete", labelId: "missing" }), /does not exist/);
+  });
+});

--- a/extensions/google-calendar/src/lib/calendar-values.ts
+++ b/extensions/google-calendar/src/lib/calendar-values.ts
@@ -1,0 +1,63 @@
+export type EventLabel = {
+  id?: string | null;
+  backgroundColor?: string | null;
+  name?: string | null;
+};
+
+const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i;
+
+export function assertNonEmpty(value: string, name: string) {
+  if (!value.trim()) throw new Error(`${name} cannot be empty.`);
+}
+
+export function assertTimeZone(timeZone: string | undefined) {
+  if (timeZone === undefined) return;
+  assertNonEmpty(timeZone, "timeZone");
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone }).format();
+  } catch {
+    throw new Error(`Invalid IANA time zone "${timeZone}".`);
+  }
+}
+
+export function normalizeHexColor(color: string, name = "color") {
+  const normalized = color.trim();
+  if (!HEX_COLOR_PATTERN.test(normalized)) {
+    throw new Error(`${name} must be a six-digit hexadecimal color such as #039be5.`);
+  }
+  return normalized.toLowerCase();
+}
+
+export function requireLabel(labels: EventLabel[], labelId: string) {
+  const label = labels.find((candidate) => candidate.id === labelId);
+  if (!label) throw new Error(`Event label "${labelId}" does not exist on this calendar.`);
+  return label;
+}
+
+export type EventLabelChange =
+  | { action: "create"; id: string; name: string; backgroundColor: string }
+  | { action: "rename"; labelId: string; name: string }
+  | { action: "recolor"; labelId: string; backgroundColor: string }
+  | { action: "delete"; labelId: string };
+
+export function mergeEventLabels(labels: EventLabel[], change: EventLabelChange): EventLabel[] {
+  const result = labels.map((label) => ({ ...label }));
+  if (change.action === "create") {
+    return [
+      ...result,
+      {
+        id: change.id,
+        name: change.name,
+        backgroundColor: normalizeHexColor(change.backgroundColor, "backgroundColor"),
+      },
+    ];
+  }
+
+  const existing = requireLabel(result, change.labelId);
+  if (change.action === "rename") existing.name = change.name;
+  if (change.action === "recolor") {
+    existing.backgroundColor = normalizeHexColor(change.backgroundColor, "backgroundColor");
+  }
+  if (change.action === "delete") result.splice(result.indexOf(existing), 1);
+  return result;
+}

--- a/extensions/google-calendar/src/lib/event-values.ts
+++ b/extensions/google-calendar/src/lib/event-values.ts
@@ -1,0 +1,117 @@
+const BASIC_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const ANGLE_BRACKET_EMAIL_REGEX = /<([^<>\s@]+@[^\s@<>]+)>/;
+
+export function parseAttendeeEmails(attendees?: string | string[] | null): {
+  emails: string[];
+  invalidEntries: string[];
+} {
+  if (attendees === undefined || attendees === null) return { emails: [], invalidEntries: [] };
+
+  const entries = (Array.isArray(attendees) ? attendees : attendees.split(/[,\n;]/))
+    .map((entry) => entry.trim().replace(/^[,;]+|[,;]+$/g, ""))
+    .map((entry) => entry.match(ANGLE_BRACKET_EMAIL_REGEX)?.[1]?.trim() ?? entry)
+    .filter(Boolean);
+  const emails: string[] = [];
+  const invalidEntries: string[] = [];
+  for (const entry of entries) (BASIC_EMAIL_REGEX.test(entry) ? emails : invalidEntries).push(entry);
+  return { emails, invalidEntries };
+}
+
+export const EVENT_COLORS = {
+  lavender: "1",
+  sage: "2",
+  grape: "3",
+  flamingo: "4",
+  banana: "5",
+  tangerine: "6",
+  peacock: "7",
+  graphite: "8",
+  blueberry: "9",
+  basil: "10",
+  tomato: "11",
+} as const;
+
+export type EventColorName = keyof typeof EVENT_COLORS;
+
+const COLOR_ID_TO_NAME: Record<string, EventColorName> = Object.fromEntries(
+  Object.entries(EVENT_COLORS).map(([name, id]) => [id, name as EventColorName]),
+);
+
+export const EVENT_COLOR_HEX: Record<string, string> = {
+  "1": "#a4bdfc",
+  "2": "#7ae7bf",
+  "3": "#dbadff",
+  "4": "#ff887c",
+  "5": "#fbd75b",
+  "6": "#ffb878",
+  "7": "#46d6db",
+  "8": "#e1e1e1",
+  "9": "#5484ed",
+  "10": "#51b749",
+  "11": "#dc2127",
+};
+
+function hexToRgb(hex: string): [number, number, number] | undefined {
+  const cleaned = hex.trim().replace(/^#/, "");
+  const normalized = cleaned.length === 3 ? [...cleaned].map((character) => character.repeat(2)).join("") : cleaned;
+  if (!/^[0-9a-f]{6}$/i.test(normalized)) return undefined;
+  const value = Number.parseInt(normalized, 16);
+  return [(value >> 16) & 255, (value >> 8) & 255, value & 255];
+}
+
+export function colorIdToName(colorId?: string | number | null): string {
+  const id = colorId === undefined || colorId === null ? "" : String(colorId).trim();
+  const name = COLOR_ID_TO_NAME[id];
+  return name ? name.charAt(0).toUpperCase() + name.slice(1) : id || "default";
+}
+
+export function resolveColorId(color?: string | number | null): string | undefined {
+  if (color === undefined || color === null || String(color).trim() === "") return undefined;
+  const value = String(color).trim().toLowerCase();
+  if (/^#?[0-9a-f]{3}$/.test(value) || /^#?[0-9a-f]{6}$/.test(value)) {
+    const rgb = hexToRgb(value);
+    if (!rgb) throw new Error(`Invalid hex color "${color}".`);
+    let nearest: string | undefined;
+    let distance = Number.POSITIVE_INFINITY;
+    for (const [id, hex] of Object.entries(EVENT_COLOR_HEX)) {
+      const target = hexToRgb(hex)!;
+      const candidate = (rgb[0] - target[0]) ** 2 + (rgb[1] - target[1]) ** 2 + (rgb[2] - target[2]) ** 2;
+      if (candidate < distance) {
+        nearest = id;
+        distance = candidate;
+      }
+    }
+    return nearest;
+  }
+  if (/^\d+$/.test(value)) {
+    if (Number(value) >= 1 && Number(value) <= 11) return value;
+    throw new Error(`Invalid colorId "${color}". Expected a value between 1 and 11.`);
+  }
+  const aliases: Record<string, EventColorName> = {
+    green: "sage",
+    purple: "grape",
+    violet: "grape",
+    red: "tomato",
+    orange: "tangerine",
+    yellow: "banana",
+    blue: "blueberry",
+    teal: "peacock",
+    cyan: "peacock",
+    gray: "graphite",
+    grey: "graphite",
+    pink: "flamingo",
+  };
+  const colorId = EVENT_COLORS[(aliases[value] ?? value) as EventColorName];
+  if (!colorId) {
+    throw new Error(
+      `Invalid color "${color}". Expected a colorId (1–11) or one of: ${Object.keys(EVENT_COLORS).join(", ")}.`,
+    );
+  }
+  return colorId;
+}
+
+export function addRaycastSignature(description: string | undefined, enabled: boolean) {
+  if (!enabled) return description;
+  const signature = "Created with <a href='https://raycast.com'>Raycast</a>";
+  return description ? `${description}\n<hr>${signature}` : signature;
+}

--- a/extensions/google-calendar/src/lib/events.test.ts
+++ b/extensions/google-calendar/src/lib/events.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import type { EventWithLabel } from "./calendar-resources";
 import { buildEventResource, serializeEvent } from "./events";
 
 describe("buildEventResource", () => {
@@ -89,30 +90,29 @@ describe("buildEventResource", () => {
 
 describe("serializeEvent", () => {
   it("returns rich event details and calculated durations", () => {
-    const serialized = serializeEvent(
-      {
-        id: "evt-1",
-        iCalUID: "ical-1",
-        summary: "Planning",
-        start: { dateTime: "2026-07-20T09:00:00Z", timeZone: "Europe/Paris" },
-        end: { dateTime: "2026-07-20T10:30:00Z" },
-        attendees: [
-          { email: "owner@example.com", self: true, responseStatus: "accepted" },
-          { email: "guest@example.com", optional: true, responseStatus: "tentative" },
-        ],
-        colorId: "2",
-        conferenceData: {
-          conferenceId: "meet-1",
-          conferenceSolution: { name: "Google Meet" },
-          entryPoints: [{ entryPointType: "video", uri: "https://meet.google.com/abc" }],
-        },
-        reminders: { useDefault: false, overrides: [{ method: "popup", minutes: 10 }] },
-        htmlLink: "https://calendar.google.com/event?eid=evt-1",
-        eventLabelId: "label-1",
+    const event: EventWithLabel = {
+      id: "evt-1",
+      iCalUID: "ical-1",
+      summary: "Planning",
+      start: { dateTime: "2026-07-20T09:00:00Z", timeZone: "Europe/Paris" },
+      end: { dateTime: "2026-07-20T10:30:00Z" },
+      attendees: [
+        { email: "owner@example.com", self: true, responseStatus: "accepted" },
+        { email: "guest@example.com", optional: true, responseStatus: "tentative" },
+      ],
+      colorId: "2",
+      conferenceData: {
+        conferenceId: "meet-1",
+        conferenceSolution: { name: "Google Meet" },
+        entryPoints: [{ entryPointType: "video", uri: "https://meet.google.com/abc" }],
       },
-      "primary",
-      [{ id: "label-1", name: "Customer", backgroundColor: "#039be5" }],
-    );
+      reminders: { useDefault: false, overrides: [{ method: "popup", minutes: 10 }] },
+      htmlLink: "https://calendar.google.com/event?eid=evt-1",
+      eventLabelId: "label-1",
+    };
+    const serialized = serializeEvent(event, "primary", [
+      { id: "label-1", name: "Customer", backgroundColor: "#039be5" },
+    ]);
 
     assert.equal(serialized.durationMinutes, 90);
     assert.equal(serialized.timeZone, "Europe/Paris");

--- a/extensions/google-calendar/src/lib/events.test.ts
+++ b/extensions/google-calendar/src/lib/events.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { EventWithLabel } from "./calendar-resources";
-import { buildEventResource, serializeEvent } from "./events";
+import { applyImportedEventLabel, buildEventResource, serializeEvent } from "./events";
 
 describe("buildEventResource", () => {
   it("constructs timed and all-day schedules", () => {
@@ -60,12 +60,13 @@ describe("buildEventResource", () => {
 
   it("merges attendee edits with the existing guest list", () => {
     const body = buildEventResource(
-      { requiredAttendees: "new@example.com" },
+      { requiredAttendees: "new@example.com, optional@example.com, room@example.com" },
       {
         existing: {
           attendees: [
             { email: "existing@example.com", responseStatus: "accepted" },
             { email: "optional@example.com", optional: true, responseStatus: "tentative" },
+            { email: "room@example.com", resource: true, responseStatus: "accepted" },
           ],
         },
       },
@@ -73,6 +74,7 @@ describe("buildEventResource", () => {
     assert.deepEqual(body.attendees, [
       { email: "existing@example.com", responseStatus: "accepted" },
       { email: "optional@example.com", optional: true, responseStatus: "tentative" },
+      { email: "room@example.com", resource: true, responseStatus: "accepted" },
       { email: "new@example.com", optional: false, resource: false },
     ]);
   });
@@ -144,5 +146,50 @@ describe("serializeEvent", () => {
     assert.equal(serialized.attendees[1].optional, true);
     assert.equal(serialized.conference?.entryPoints?.[0].uri, "https://meet.google.com/abc");
     assert.equal(serialized.htmlLink, "https://calendar.google.com/event?eid=evt-1");
+  });
+});
+
+describe("applyImportedEventLabel", () => {
+  it("deletes the imported event when applying its label fails", async () => {
+    const labelError = new Error("label failed");
+    let deleted = false;
+    await assert.rejects(
+      () =>
+        applyImportedEventLabel(
+          async () => {
+            throw labelError;
+          },
+          async () => {
+            deleted = true;
+          },
+        ),
+      labelError,
+    );
+    assert.equal(deleted, true);
+  });
+
+  it("warns against retrying when label application and cleanup both fail", async () => {
+    const labelError = new Error("label failed");
+    const cleanupError = new Error("cleanup failed");
+
+    await assert.rejects(
+      () =>
+        applyImportedEventLabel(
+          async () => {
+            throw labelError;
+          },
+          async () => {
+            throw cleanupError;
+          },
+        ),
+      (error: AggregateError) => {
+        assert.equal(
+          error.message,
+          "The event was imported, but label application and cleanup both failed. Do not retry.",
+        );
+        assert.deepEqual(error.errors, [labelError, cleanupError]);
+        return true;
+      },
+    );
   });
 });

--- a/extensions/google-calendar/src/lib/events.test.ts
+++ b/extensions/google-calendar/src/lib/events.test.ts
@@ -52,9 +52,28 @@ describe("buildEventResource", () => {
       resourceAttendees: "room@example.com",
     });
     assert.deepEqual(body.attendees, [
-      { email: "alice@example.com" },
-      { email: "bob@example.com", optional: true },
-      { email: "room@example.com", resource: true },
+      { email: "alice@example.com", optional: false, resource: false },
+      { email: "bob@example.com", optional: true, resource: false },
+      { email: "room@example.com", optional: false, resource: true },
+    ]);
+  });
+
+  it("merges attendee edits with the existing guest list", () => {
+    const body = buildEventResource(
+      { requiredAttendees: "new@example.com" },
+      {
+        existing: {
+          attendees: [
+            { email: "existing@example.com", responseStatus: "accepted" },
+            { email: "optional@example.com", optional: true, responseStatus: "tentative" },
+          ],
+        },
+      },
+    );
+    assert.deepEqual(body.attendees, [
+      { email: "existing@example.com", responseStatus: "accepted" },
+      { email: "optional@example.com", optional: true, responseStatus: "tentative" },
+      { email: "new@example.com", optional: false, resource: false },
     ]);
   });
 

--- a/extensions/google-calendar/src/lib/events.test.ts
+++ b/extensions/google-calendar/src/lib/events.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildEventResource, serializeEvent } from "./events";
+
+describe("buildEventResource", () => {
+  it("constructs timed and all-day schedules", () => {
+    const timed = buildEventResource(
+      { title: "Sync", startDate: "2026-07-20T10:00:00+02:00", duration: 45 },
+      { isCreate: true, defaultDurationMinutes: 30 },
+    );
+    assert.deepEqual(timed.start, { dateTime: "2026-07-20T10:00:00+02:00" });
+    assert.deepEqual(timed.end, { dateTime: "2026-07-20T08:45:00.000Z" });
+
+    const allDay = buildEventResource(
+      { title: "Offsite", startDate: "2026-07-20", allDay: true, durationDays: 2 },
+      { isCreate: true },
+    );
+    assert.deepEqual(allDay.start, { date: "2026-07-20" });
+    assert.deepEqual(allDay.end, { date: "2026-07-22" });
+  });
+
+  it("preserves an existing duration when only the start moves", () => {
+    const body = buildEventResource(
+      { startDate: "2026-07-21T14:00:00Z" },
+      {
+        existing: {
+          start: { dateTime: "2026-07-20T09:00:00Z" },
+          end: { dateTime: "2026-07-20T10:30:00Z" },
+        },
+      },
+    );
+    assert.equal(body.end?.dateTime, "2026-07-21T15:30:00.000Z");
+  });
+
+  it("omits untouched patch fields and keeps explicit clearing", () => {
+    assert.deepEqual(buildEventResource({}, { existing: { summary: "Existing" } }), {});
+    assert.deepEqual(buildEventResource({ description: "", location: "", recurrence: "", attendees: "", color: "" }), {
+      description: "",
+      location: "",
+      attendees: [],
+      recurrence: [],
+      colorId: null,
+    });
+    assert.deepEqual(buildEventResource({ eventLabelId: "" }), { eventLabelId: "" });
+  });
+
+  it("categorizes and de-duplicates attendees", () => {
+    const body = buildEventResource({
+      requiredAttendees: "Alice <alice@example.com>",
+      optionalAttendees: "bob@example.com",
+      resourceAttendees: "room@example.com",
+    });
+    assert.deepEqual(body.attendees, [
+      { email: "alice@example.com" },
+      { email: "bob@example.com", optional: true },
+      { email: "room@example.com", resource: true },
+    ]);
+  });
+
+  it("validates recurrence and reminder contracts", () => {
+    assert.deepEqual(buildEventResource({ recurrence: "FREQ=WEEKLY;BYDAY=MO" }).recurrence, [
+      "RRULE:FREQ=WEEKLY;BYDAY=MO",
+    ]);
+    assert.throws(() => buildEventResource({ recurrence: "DTSTART:20260720T090000Z" }), /must not include DTSTART/);
+    assert.throws(() => buildEventResource({ recurrence: "RRULE:COUNT=4" }), /must include FREQ/);
+    assert.throws(() => buildEventResource({ popupReminderMinutes: "ten" }), /invalid number/);
+    assert.throws(
+      () => buildEventResource({ useDefaultReminders: true, popupReminderMinutes: "10" }),
+      /cannot be combined/,
+    );
+    assert.throws(
+      () =>
+        buildEventResource(
+          {
+            startDate: "2026-07-20T09:00:00Z",
+            duration: 30,
+            recurrence: "RRULE:FREQ=DAILY",
+          },
+          { isCreate: true },
+        ),
+      /timeZone is required/,
+    );
+  });
+
+  it("rejects custom labels combined with legacy colors", () => {
+    assert.throws(() => buildEventResource({ eventLabelId: "label-1", color: "sage" }), /cannot be used together/);
+  });
+});
+
+describe("serializeEvent", () => {
+  it("returns rich event details and calculated durations", () => {
+    const serialized = serializeEvent(
+      {
+        id: "evt-1",
+        iCalUID: "ical-1",
+        summary: "Planning",
+        start: { dateTime: "2026-07-20T09:00:00Z", timeZone: "Europe/Paris" },
+        end: { dateTime: "2026-07-20T10:30:00Z" },
+        attendees: [
+          { email: "owner@example.com", self: true, responseStatus: "accepted" },
+          { email: "guest@example.com", optional: true, responseStatus: "tentative" },
+        ],
+        colorId: "2",
+        conferenceData: {
+          conferenceId: "meet-1",
+          conferenceSolution: { name: "Google Meet" },
+          entryPoints: [{ entryPointType: "video", uri: "https://meet.google.com/abc" }],
+        },
+        reminders: { useDefault: false, overrides: [{ method: "popup", minutes: 10 }] },
+        htmlLink: "https://calendar.google.com/event?eid=evt-1",
+        eventLabelId: "label-1",
+      },
+      "primary",
+      [{ id: "label-1", name: "Customer", backgroundColor: "#039be5" }],
+    );
+
+    assert.equal(serialized.durationMinutes, 90);
+    assert.equal(serialized.timeZone, "Europe/Paris");
+    assert.deepEqual(serialized.color, { id: "2", name: "Sage" });
+    assert.deepEqual(serialized.eventLabel, {
+      id: "label-1",
+      name: "Customer",
+      backgroundColor: "#039be5",
+    });
+    assert.equal(serialized.attendees[1].optional, true);
+    assert.equal(serialized.conference?.entryPoints?.[0].uri, "https://meet.google.com/abc");
+    assert.equal(serialized.htmlLink, "https://calendar.google.com/event?eid=evt-1");
+  });
+});

--- a/extensions/google-calendar/src/lib/events.ts
+++ b/extensions/google-calendar/src/lib/events.ts
@@ -1,0 +1,522 @@
+import type { calendar_v3 } from "@googleapis/calendar";
+import { randomUUID } from "node:crypto";
+import { addRaycastSignature, colorIdToName, parseAttendeeEmails, resolveColorId } from "./event-values";
+import type { EventLabel, EventWithLabel } from "./calendar-resources";
+
+export type NotificationLevel = "all" | "externalOnly" | "none";
+export type EventType = "default" | "birthday" | "focusTime" | "outOfOffice" | "workingLocation";
+
+export interface EventWriteInput {
+  title?: string;
+  description?: string;
+  location?: string;
+  startDate?: string;
+  endDate?: string;
+  duration?: number;
+  durationDays?: number;
+  allDay?: boolean;
+  timeZone?: string;
+  attendees?: string;
+  requiredAttendees?: string;
+  optionalAttendees?: string;
+  resourceAttendees?: string;
+  recurrence?: string;
+  visibility?: "default" | "public" | "private" | "confidential";
+  transparency?: "opaque" | "transparent";
+  status?: "confirmed" | "tentative" | "cancelled";
+  color?: string;
+  eventLabelId?: string;
+  useDefaultReminders?: boolean;
+  popupReminderMinutes?: string;
+  emailReminderMinutes?: string;
+  guestsCanInviteOthers?: boolean;
+  guestsCanModify?: boolean;
+  guestsCanSeeOtherGuests?: boolean;
+  attachmentUrls?: string;
+  eventType?: EventType;
+  birthdayType?: "birthday";
+  focusTimeAutoDeclineMode?:
+    | "declineNone"
+    | "declineAllConflictingInvitations"
+    | "declineOnlyNewConflictingInvitations";
+  focusTimeChatStatus?: "available" | "doNotDisturb";
+  focusTimeDeclineMessage?: string;
+  outOfOfficeAutoDeclineMode?:
+    | "declineNone"
+    | "declineAllConflictingInvitations"
+    | "declineOnlyNewConflictingInvitations";
+  outOfOfficeDeclineMessage?: string;
+  workingLocationType?: "homeOffice" | "officeLocation" | "customLocation";
+  workingLocationLabel?: string;
+  workingLocationBuildingId?: string;
+  workingLocationFloorId?: string;
+  workingLocationFloorSectionId?: string;
+  workingLocationDeskId?: string;
+  conferenceAction?: "keep" | "add" | "remove";
+}
+
+type BuildOptions = {
+  existing?: calendar_v3.Schema$Event;
+  defaultDurationMinutes?: number;
+  isCreate?: boolean;
+  addSignature?: boolean;
+};
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const RFC3339_PATTERN = /^\d{4}-\d{2}-\d{2}T.+(?:Z|[+-]\d{2}:\d{2})$/i;
+
+function hasAnyDefined(input: object, keys: string[]) {
+  return keys.some((key) => (input as Record<string, unknown>)[key] !== undefined);
+}
+
+function parseIntegerList(value: string | undefined, label: string): number[] {
+  if (value === undefined || value.trim() === "") return [];
+  const values = value
+    .split(/[,\n;]/)
+    .map((item) => Number(item.trim()))
+    .filter((item) => !Number.isNaN(item));
+  if (values.some((minutes) => !Number.isInteger(minutes) || minutes < 0 || minutes > 40320)) {
+    throw new Error(`${label} must contain whole minutes from 0 to 40320.`);
+  }
+  if (values.length !== value.split(/[,\n;]/).filter((item) => item.trim()).length) {
+    throw new Error(`${label} contains an invalid number.`);
+  }
+  return values;
+}
+
+function parseEmails(value: string | undefined, label: string) {
+  const { emails, invalidEntries } = parseAttendeeEmails(value);
+  if (invalidEntries.length > 0) {
+    throw new Error(`Invalid ${label}: ${invalidEntries.join(", ")}`);
+  }
+  return emails;
+}
+
+function buildAttendees(input: EventWriteInput): calendar_v3.Schema$EventAttendee[] | undefined {
+  const keys = ["attendees", "requiredAttendees", "optionalAttendees", "resourceAttendees"];
+  if (!hasAnyDefined(input, keys)) return undefined;
+
+  const attendees = new Map<string, calendar_v3.Schema$EventAttendee>();
+  const add = (emails: string[], properties: Partial<calendar_v3.Schema$EventAttendee>) => {
+    for (const email of emails) attendees.set(email.toLowerCase(), { email, ...properties });
+  };
+
+  add(parseEmails(input.attendees, "attendee email"), {});
+  add(parseEmails(input.requiredAttendees, "required attendee email"), {});
+  add(parseEmails(input.optionalAttendees, "optional attendee email"), { optional: true });
+  add(parseEmails(input.resourceAttendees, "resource attendee email"), { resource: true });
+  return [...attendees.values()];
+}
+
+function addUtcDays(date: string, days: number) {
+  const result = new Date(`${date}T00:00:00Z`);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result.toISOString().slice(0, 10);
+}
+
+function dateDurationDays(start: string, end: string) {
+  return Math.max(1, Math.round((Date.parse(`${end}T00:00:00Z`) - Date.parse(`${start}T00:00:00Z`)) / 86400000));
+}
+
+function assertTimeZone(timeZone: string | undefined) {
+  if (!timeZone) return;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone }).format();
+  } catch {
+    throw new Error(`Invalid IANA time zone "${timeZone}".`);
+  }
+}
+
+function buildSchedule(input: EventWriteInput, options: BuildOptions) {
+  const existing = options.existing;
+  const scheduleTouched =
+    options.isCreate ||
+    hasAnyDefined(input, ["startDate", "endDate", "duration", "durationDays", "allDay", "timeZone"]);
+  if (!scheduleTouched) return undefined;
+
+  assertTimeZone(input.timeZone);
+  const existingAllDay = Boolean(existing?.start?.date);
+  const allDay = input.allDay ?? existingAllDay;
+
+  if (input.allDay !== undefined && input.allDay !== existingAllDay && !input.startDate) {
+    throw new Error("startDate is required when changing between timed and all-day events.");
+  }
+
+  if (allDay) {
+    const start = input.startDate ?? existing?.start?.date;
+    if (!start || !DATE_PATTERN.test(start)) {
+      throw new Error("All-day startDate must use YYYY-MM-DD.");
+    }
+    if (input.duration !== undefined) throw new Error("Use durationDays, not duration, for all-day events.");
+    const previousDays =
+      existing?.start?.date && existing.end?.date ? dateDurationDays(existing.start.date, existing.end.date) : 1;
+    const days = input.durationDays ?? previousDays;
+    if (!Number.isInteger(days) || days < 1) throw new Error("durationDays must be a positive whole number.");
+    const end = input.endDate ?? addUtcDays(start, days);
+    if (!DATE_PATTERN.test(end) || end <= start) {
+      throw new Error("All-day endDate must use YYYY-MM-DD and be after startDate (the end date is exclusive).");
+    }
+    return { start: { date: start }, end: { date: end } };
+  }
+
+  const start = input.startDate ?? existing?.start?.dateTime;
+  if (!start || !RFC3339_PATTERN.test(start) || Number.isNaN(Date.parse(start))) {
+    throw new Error("Timed startDate must be an RFC3339 datetime with Z or a numeric UTC offset.");
+  }
+  if (input.durationDays !== undefined) throw new Error("Use duration, not durationDays, for timed events.");
+
+  const previousDuration =
+    existing?.start?.dateTime && existing.end?.dateTime
+      ? (Date.parse(existing.end.dateTime) - Date.parse(existing.start.dateTime)) / 60000
+      : options.defaultDurationMinutes;
+  const duration = input.duration ?? previousDuration;
+  const end =
+    input.endDate ??
+    (duration !== undefined && duration > 0 ? new Date(Date.parse(start) + duration * 60000).toISOString() : undefined);
+  if (!end || !RFC3339_PATTERN.test(end) || Number.isNaN(Date.parse(end)) || Date.parse(end) <= Date.parse(start)) {
+    throw new Error("Provide an endDate after startDate or a positive duration.");
+  }
+
+  const timeZone =
+    input.timeZone !== undefined ? (input.timeZone === "" ? null : input.timeZone) : existing?.start?.timeZone;
+  return {
+    start: { dateTime: start, ...(timeZone !== undefined ? { timeZone } : {}) },
+    end: { dateTime: end, ...(timeZone !== undefined ? { timeZone } : {}) },
+  };
+}
+
+function buildReminders(input: EventWriteInput) {
+  if (!hasAnyDefined(input, ["useDefaultReminders", "popupReminderMinutes", "emailReminderMinutes"])) return undefined;
+  const overrides: calendar_v3.Schema$EventReminder[] = [
+    ...parseIntegerList(input.popupReminderMinutes, "popupReminderMinutes").map((minutes) => ({
+      method: "popup",
+      minutes,
+    })),
+    ...parseIntegerList(input.emailReminderMinutes, "emailReminderMinutes").map((minutes) => ({
+      method: "email",
+      minutes,
+    })),
+  ];
+  if (input.useDefaultReminders && overrides.length > 0) {
+    throw new Error("Custom reminders cannot be combined with useDefaultReminders=true.");
+  }
+  return { useDefault: input.useDefaultReminders ?? false, overrides };
+}
+
+function buildAttachments(value: string | undefined) {
+  if (value === undefined) return undefined;
+  const urls = value
+    .split(/[,\n]/)
+    .map((url) => url.trim())
+    .filter(Boolean);
+  if (urls.length > 25) throw new Error("Google Calendar supports at most 25 attachments per event.");
+  for (const url of urls) {
+    try {
+      new URL(url);
+    } catch {
+      throw new Error(`Invalid attachment URL "${url}".`);
+    }
+  }
+  return urls.map((fileUrl) => ({ fileUrl }));
+}
+
+function buildRecurrence(value: string | undefined) {
+  if (value === undefined) return undefined;
+  return value
+    .split(/\r?\n/)
+    .map((rule) => rule.trim())
+    .filter(Boolean)
+    .map((rule) => {
+      const normalized = /^FREQ=/i.test(rule) ? `RRULE:${rule}` : rule;
+      if (/^(DTSTART|DTEND)(?:;[^:]*)?:/i.test(normalized)) {
+        throw new Error("Recurrence must not include DTSTART or DTEND; use startDate and endDate instead.");
+      }
+      if (!/^(RRULE|EXRULE|RDATE(?:;[^:]*)?|EXDATE(?:;[^:]*)?):.+/i.test(normalized)) {
+        throw new Error(`Invalid recurrence rule "${rule}".`);
+      }
+      if (/^(RRULE|EXRULE):/i.test(normalized) && !/(?:^|;)FREQ=[A-Z]+(?:;|$)/i.test(normalized.split(":")[1])) {
+        throw new Error(`Recurrence rule "${rule}" must include FREQ.`);
+      }
+      return normalized;
+    });
+}
+
+function buildTypeProperties(input: EventWriteInput, existing?: calendar_v3.Schema$Event) {
+  const eventType = input.eventType ?? (existing?.eventType as EventType | undefined) ?? "default";
+  const properties: calendar_v3.Schema$Event = {};
+  const hasFocusTimeProperties = hasAnyDefined(input, [
+    "focusTimeAutoDeclineMode",
+    "focusTimeChatStatus",
+    "focusTimeDeclineMessage",
+  ]);
+  const hasOutOfOfficeProperties = hasAnyDefined(input, ["outOfOfficeAutoDeclineMode", "outOfOfficeDeclineMessage"]);
+  const hasWorkingLocationProperties = hasAnyDefined(input, [
+    "workingLocationType",
+    "workingLocationLabel",
+    "workingLocationBuildingId",
+    "workingLocationFloorId",
+    "workingLocationFloorSectionId",
+    "workingLocationDeskId",
+  ]);
+
+  if (input.eventType !== undefined && existing?.eventType && input.eventType !== existing.eventType) {
+    throw new Error(`eventType is immutable; this event is already "${existing.eventType}".`);
+  }
+  if (hasFocusTimeProperties && eventType !== "focusTime") {
+    throw new Error("Focus-time properties require eventType=focusTime.");
+  }
+  if (hasOutOfOfficeProperties && eventType !== "outOfOffice") {
+    throw new Error("Out-of-office properties require eventType=outOfOffice.");
+  }
+  if (hasWorkingLocationProperties && eventType !== "workingLocation") {
+    throw new Error("Working-location properties require eventType=workingLocation.");
+  }
+  if (input.eventType !== undefined && !existing) properties.eventType = input.eventType;
+  if (eventType === "workingLocation" && !existing && input.workingLocationType === undefined) {
+    throw new Error("workingLocationType is required when creating a working-location event.");
+  }
+
+  if (eventType === "birthday" && (input.birthdayType !== undefined || !existing)) {
+    properties.birthdayProperties = { type: input.birthdayType ?? "birthday" };
+  }
+  if (eventType === "focusTime" && hasFocusTimeProperties) {
+    properties.focusTimeProperties = {
+      ...(input.focusTimeAutoDeclineMode !== undefined ? { autoDeclineMode: input.focusTimeAutoDeclineMode } : {}),
+      ...(input.focusTimeChatStatus !== undefined ? { chatStatus: input.focusTimeChatStatus } : {}),
+      ...(input.focusTimeDeclineMessage !== undefined ? { declineMessage: input.focusTimeDeclineMessage } : {}),
+    };
+  }
+  if (eventType === "outOfOffice" && hasOutOfOfficeProperties) {
+    properties.outOfOfficeProperties = {
+      ...(input.outOfOfficeAutoDeclineMode !== undefined ? { autoDeclineMode: input.outOfOfficeAutoDeclineMode } : {}),
+      ...(input.outOfOfficeDeclineMessage !== undefined ? { declineMessage: input.outOfOfficeDeclineMessage } : {}),
+    };
+  }
+  if (eventType === "workingLocation" && hasWorkingLocationProperties) {
+    const type = input.workingLocationType ?? existing?.workingLocationProperties?.type;
+    if (!type) throw new Error("workingLocationType is required for a working-location event.");
+    properties.workingLocationProperties = {
+      type,
+      ...(type === "homeOffice" ? { homeOffice: {} } : {}),
+      ...(type === "customLocation" ? { customLocation: { label: input.workingLocationLabel ?? "" } } : {}),
+      ...(type === "officeLocation"
+        ? {
+            officeLocation: {
+              ...(input.workingLocationLabel !== undefined ? { label: input.workingLocationLabel } : {}),
+              ...(input.workingLocationBuildingId !== undefined ? { buildingId: input.workingLocationBuildingId } : {}),
+              ...(input.workingLocationFloorId !== undefined ? { floorId: input.workingLocationFloorId } : {}),
+              ...(input.workingLocationFloorSectionId !== undefined
+                ? { floorSectionId: input.workingLocationFloorSectionId }
+                : {}),
+              ...(input.workingLocationDeskId !== undefined ? { deskId: input.workingLocationDeskId } : {}),
+            },
+          }
+        : {}),
+    };
+  }
+  return properties;
+}
+
+export function buildEventResource(input: EventWriteInput, options: BuildOptions = {}) {
+  const body: EventWithLabel = {};
+  const schedule = buildSchedule(input, options);
+  const attendees = buildAttendees(input);
+  const reminders = buildReminders(input);
+  const attachments = buildAttachments(input.attachmentUrls);
+  const recurrence = buildRecurrence(input.recurrence);
+  if (options.isCreate && recurrence?.length && !input.allDay && !input.timeZone) {
+    throw new Error("timeZone is required for a timed recurring event.");
+  }
+
+  if (input.title !== undefined) body.summary = input.title;
+  if (input.description !== undefined) {
+    body.description =
+      input.description === "" ? "" : addRaycastSignature(input.description, options.addSignature ?? false);
+  } else if (options.isCreate) {
+    body.description = addRaycastSignature(undefined, options.addSignature ?? false);
+  }
+  if (input.location !== undefined) body.location = input.location;
+  if (schedule) Object.assign(body, schedule);
+  if (attendees !== undefined) body.attendees = attendees;
+  if (recurrence !== undefined) body.recurrence = recurrence;
+  if (input.visibility !== undefined) body.visibility = input.visibility;
+  if (input.transparency !== undefined) body.transparency = input.transparency;
+  if (input.status !== undefined) body.status = input.status;
+  if (input.color !== undefined && input.eventLabelId !== undefined) {
+    throw new Error("color and eventLabelId cannot be used together. Custom labels supersede legacy event colors.");
+  }
+  if (input.color !== undefined) body.colorId = resolveColorId(input.color) ?? null;
+  if (input.eventLabelId !== undefined) body.eventLabelId = input.eventLabelId;
+  if (reminders !== undefined) body.reminders = reminders;
+  if (input.guestsCanInviteOthers !== undefined) body.guestsCanInviteOthers = input.guestsCanInviteOthers;
+  if (input.guestsCanModify !== undefined) body.guestsCanModify = input.guestsCanModify;
+  if (input.guestsCanSeeOtherGuests !== undefined) body.guestsCanSeeOtherGuests = input.guestsCanSeeOtherGuests;
+  if (attachments !== undefined) body.attachments = attachments;
+  Object.assign(body, buildTypeProperties(input, options.existing));
+
+  if (input.conferenceAction === "add") {
+    body.conferenceData = {
+      createRequest: { conferenceSolutionKey: { type: "hangoutsMeet" }, requestId: randomUUID() },
+    };
+  } else if (input.conferenceAction === "remove") {
+    body.conferenceData = null as unknown as calendar_v3.Schema$ConferenceData;
+  }
+  return body;
+}
+
+export function hasAttachmentChanges(input: EventWriteInput) {
+  return input.attachmentUrls !== undefined;
+}
+
+export function hasConferenceChanges(input: EventWriteInput) {
+  return input.conferenceAction === "add" || input.conferenceAction === "remove";
+}
+
+export function getNotificationLevel(
+  input: { notificationLevel?: NotificationLevel },
+  fallback: unknown,
+): NotificationLevel {
+  return input.notificationLevel ?? (fallback as NotificationLevel | undefined) ?? "all";
+}
+
+export function serializeEvent(event: calendar_v3.Schema$Event, calendarId?: string, labels?: EventLabel[]) {
+  const eventWithLabel = event as EventWithLabel;
+  const label = labels?.find((candidate) => candidate.id === eventWithLabel.eventLabelId);
+  const start = event.start?.dateTime ?? event.start?.date;
+  const end = event.end?.dateTime ?? event.end?.date;
+  const durationMinutes =
+    event.start?.dateTime && event.end?.dateTime
+      ? (Date.parse(event.end.dateTime) - Date.parse(event.start.dateTime)) / 60000
+      : undefined;
+  const durationDays =
+    event.start?.date && event.end?.date
+      ? (Date.parse(`${event.end.date}T00:00:00Z`) - Date.parse(`${event.start.date}T00:00:00Z`)) / 86400000
+      : undefined;
+  return {
+    id: event.id,
+    calendarId,
+    iCalUID: event.iCalUID,
+    title: event.summary || "Untitled Event",
+    description: event.description,
+    location: event.location,
+    status: event.status,
+    eventType: event.eventType,
+    start,
+    end,
+    allDay: Boolean(event.start?.date),
+    timeZone: event.start?.timeZone ?? event.end?.timeZone,
+    durationMinutes,
+    durationDays,
+    recurrence: event.recurrence,
+    recurringEventId: event.recurringEventId,
+    originalStart: event.originalStartTime?.dateTime ?? event.originalStartTime?.date,
+    organizer: event.organizer,
+    creator: event.creator,
+    attendees:
+      event.attendees?.map((attendee) => ({
+        email: attendee.email,
+        name: attendee.displayName,
+        responseStatus: attendee.responseStatus,
+        comment: attendee.comment,
+        optional: attendee.optional,
+        resource: attendee.resource,
+        organizer: attendee.organizer,
+        self: attendee.self,
+        additionalGuests: attendee.additionalGuests,
+      })) ?? [],
+    visibility: event.visibility,
+    transparency: event.transparency,
+    color: event.colorId ? { id: event.colorId, name: colorIdToName(event.colorId) } : undefined,
+    eventLabelId: eventWithLabel.eventLabelId,
+    eventLabel: eventWithLabel.eventLabelId
+      ? {
+          id: eventWithLabel.eventLabelId,
+          name: label?.name,
+          backgroundColor: label?.backgroundColor,
+        }
+      : undefined,
+    reminders: event.reminders,
+    guestPermissions: {
+      canInviteOthers: event.guestsCanInviteOthers,
+      canModify: event.guestsCanModify,
+      canSeeOtherGuests: event.guestsCanSeeOtherGuests,
+    },
+    conference: event.conferenceData
+      ? {
+          id: event.conferenceData.conferenceId,
+          solution: event.conferenceData.conferenceSolution?.name,
+          status: event.conferenceData.createRequest?.status?.statusCode,
+          entryPoints: event.conferenceData.entryPoints?.map((entry) => ({
+            type: entry.entryPointType,
+            uri: entry.uri,
+            label: entry.label,
+          })),
+        }
+      : undefined,
+    hangoutLink: event.hangoutLink,
+    attachments: event.attachments,
+    focusTimeProperties: event.focusTimeProperties,
+    outOfOfficeProperties: event.outOfOfficeProperties,
+    workingLocationProperties: event.workingLocationProperties,
+    birthdayProperties: event.birthdayProperties,
+    htmlLink: event.htmlLink,
+    created: event.created,
+    updated: event.updated,
+    sequence: event.sequence,
+    locked: event.locked,
+    privateCopy: event.privateCopy,
+  };
+}
+
+export function describeEventInput(input: EventWriteInput) {
+  const display = (value: string | undefined) => (value === "" ? "(clear)" : value);
+  const reminders =
+    input.useDefaultReminders !== undefined ||
+    input.popupReminderMinutes !== undefined ||
+    input.emailReminderMinutes !== undefined
+      ? input.useDefaultReminders
+        ? "Calendar defaults"
+        : `Popup: ${input.popupReminderMinutes || "none"}; email: ${input.emailReminderMinutes || "none"}`
+      : undefined;
+  return [
+    { name: "Title", value: display(input.title) },
+    { name: "Description", value: display(input.description) },
+    { name: "Start", value: input.startDate },
+    { name: "End", value: input.endDate },
+    {
+      name: "Length",
+      value: input.allDay
+        ? input.durationDays
+          ? `${input.durationDays} day(s)`
+          : undefined
+        : input.duration
+          ? `${input.duration} minutes`
+          : undefined,
+    },
+    { name: "Time Zone", value: input.timeZone },
+    { name: "Location", value: display(input.location) },
+    { name: "Required Guests", value: display(input.requiredAttendees ?? input.attendees) },
+    { name: "Optional Guests", value: display(input.optionalAttendees) },
+    { name: "Resources", value: display(input.resourceAttendees) },
+    { name: "Recurrence", value: display(input.recurrence) },
+    { name: "Visibility", value: input.visibility },
+    { name: "Availability", value: input.transparency },
+    { name: "Status", value: input.status },
+    { name: "Color", value: display(input.color) },
+    { name: "Custom Label ID", value: display(input.eventLabelId) },
+    { name: "Reminders", value: reminders },
+    { name: "Guest Can Invite", value: input.guestsCanInviteOthers?.toString() },
+    { name: "Guests Can Modify", value: input.guestsCanModify?.toString() },
+    { name: "Guests See Guest List", value: input.guestsCanSeeOtherGuests?.toString() },
+    { name: "Attachments", value: display(input.attachmentUrls) },
+    { name: "Event Type", value: input.eventType },
+    { name: "Focus Auto-decline", value: input.focusTimeAutoDeclineMode },
+    { name: "Focus Chat Status", value: input.focusTimeChatStatus },
+    { name: "Focus Decline Message", value: display(input.focusTimeDeclineMessage) },
+    { name: "Out of Office Auto-decline", value: input.outOfOfficeAutoDeclineMode },
+    { name: "Out of Office Message", value: display(input.outOfOfficeDeclineMessage) },
+    { name: "Working Location Type", value: input.workingLocationType },
+    { name: "Working Location Label", value: display(input.workingLocationLabel) },
+    { name: "Google Meet", value: input.conferenceAction },
+  ].filter((item) => item.value !== undefined);
+}

--- a/extensions/google-calendar/src/lib/events.ts
+++ b/extensions/google-calendar/src/lib/events.ts
@@ -92,19 +92,56 @@ function parseEmails(value: string | undefined, label: string) {
   return emails;
 }
 
-function buildAttendees(input: EventWriteInput): calendar_v3.Schema$EventAttendee[] | undefined {
+function buildAttendees(
+  input: EventWriteInput,
+  existing?: calendar_v3.Schema$Event,
+): calendar_v3.Schema$EventAttendee[] | undefined {
   const keys = ["attendees", "requiredAttendees", "optionalAttendees", "resourceAttendees"];
   if (!hasAnyDefined(input, keys)) return undefined;
 
   const attendees = new Map<string, calendar_v3.Schema$EventAttendee>();
+  for (const attendee of existing?.attendees ?? []) {
+    if (attendee.email) attendees.set(attendee.email.toLowerCase(), { ...attendee });
+  }
+
   const add = (emails: string[], properties: Partial<calendar_v3.Schema$EventAttendee>) => {
-    for (const email of emails) attendees.set(email.toLowerCase(), { email, ...properties });
+    for (const email of emails) {
+      const key = email.toLowerCase();
+      attendees.set(key, { ...attendees.get(key), email, optional: false, resource: false, ...properties });
+    }
+  };
+  const removeMatching = (predicate: (attendee: calendar_v3.Schema$EventAttendee) => boolean) => {
+    for (const [key, attendee] of attendees) {
+      if (predicate(attendee)) attendees.delete(key);
+    }
+  };
+  const applyField = (
+    value: string | undefined,
+    label: string,
+    properties: Partial<calendar_v3.Schema$EventAttendee>,
+    matches: (attendee: calendar_v3.Schema$EventAttendee) => boolean,
+  ) => {
+    if (value === undefined) return;
+    if (value === "") {
+      removeMatching(matches);
+      return;
+    }
+    add(parseEmails(value, label), properties);
   };
 
-  add(parseEmails(input.attendees, "attendee email"), {});
-  add(parseEmails(input.requiredAttendees, "required attendee email"), {});
-  add(parseEmails(input.optionalAttendees, "optional attendee email"), { optional: true });
-  add(parseEmails(input.resourceAttendees, "resource attendee email"), { resource: true });
+  applyField(input.attendees, "attendee email", {}, (attendee) => !attendee.optional && !attendee.resource);
+  applyField(
+    input.requiredAttendees,
+    "required attendee email",
+    {},
+    (attendee) => !attendee.optional && !attendee.resource,
+  );
+  applyField(input.optionalAttendees, "optional attendee email", { optional: true }, (attendee) =>
+    Boolean(attendee.optional),
+  );
+  applyField(input.resourceAttendees, "resource attendee email", { resource: true }, (attendee) =>
+    Boolean(attendee.resource),
+  );
   return [...attendees.values()];
 }
 
@@ -320,7 +357,7 @@ function buildTypeProperties(input: EventWriteInput, existing?: calendar_v3.Sche
 export function buildEventResource(input: EventWriteInput, options: BuildOptions = {}) {
   const body: EventWithLabel = {};
   const schedule = buildSchedule(input, options);
-  const attendees = buildAttendees(input);
+  const attendees = buildAttendees(input, options.existing);
   const reminders = buildReminders(input);
   const attachments = buildAttachments(input.attachmentUrls);
   const recurrence = buildRecurrence(input.recurrence);

--- a/extensions/google-calendar/src/lib/events.ts
+++ b/extensions/google-calendar/src/lib/events.ts
@@ -107,7 +107,13 @@ function buildAttendees(
   const add = (emails: string[], properties: Partial<calendar_v3.Schema$EventAttendee>) => {
     for (const email of emails) {
       const key = email.toLowerCase();
-      attendees.set(key, { ...attendees.get(key), email, optional: false, resource: false, ...properties });
+      const existingAttendee = attendees.get(key);
+      attendees.set(
+        key,
+        existingAttendee
+          ? { ...existingAttendee, email, ...properties }
+          : { email, optional: false, resource: false, ...properties },
+      );
     }
   };
   const removeMatching = (predicate: (attendee: calendar_v3.Schema$EventAttendee) => boolean) => {
@@ -136,10 +142,10 @@ function buildAttendees(
     {},
     (attendee) => !attendee.optional && !attendee.resource,
   );
-  applyField(input.optionalAttendees, "optional attendee email", { optional: true }, (attendee) =>
+  applyField(input.optionalAttendees, "optional attendee email", { optional: true, resource: false }, (attendee) =>
     Boolean(attendee.optional),
   );
-  applyField(input.resourceAttendees, "resource attendee email", { resource: true }, (attendee) =>
+  applyField(input.resourceAttendees, "resource attendee email", { optional: false, resource: true }, (attendee) =>
     Boolean(attendee.resource),
   );
   return [...attendees.values()];
@@ -407,6 +413,25 @@ export function hasAttachmentChanges(input: EventWriteInput) {
 
 export function hasConferenceChanges(input: EventWriteInput) {
   return input.conferenceAction === "add" || input.conferenceAction === "remove";
+}
+
+export async function applyImportedEventLabel(
+  patchLabel: () => Promise<EventWithLabel>,
+  deleteImportedEvent: () => Promise<void>,
+) {
+  try {
+    return await patchLabel();
+  } catch (labelError) {
+    try {
+      await deleteImportedEvent();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [labelError, cleanupError],
+        "The event was imported, but label application and cleanup both failed. Do not retry.",
+      );
+    }
+    throw labelError;
+  }
 }
 
 export function getNotificationLevel(

--- a/extensions/google-calendar/src/lib/suggest-time.test.ts
+++ b/extensions/google-calendar/src/lib/suggest-time.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { computeSuggestedSlots, mergeBusyPeriods } from "./suggest-time";
+
+describe("suggest-time slot computation", () => {
+  it("honors weekends, work hours, and busy periods", () => {
+    const input = {
+      timeMin: "2026-07-18T00:00:00Z",
+      timeMax: "2026-07-20T15:00:00Z",
+      durationMinutes: 60,
+      timeZone: "UTC",
+      workDayStart: "09:00",
+      workDayEnd: "12:00",
+      incrementMinutes: 30,
+      maxSuggestions: 2,
+    };
+    const busy = [{ start: Date.parse("2026-07-20T09:00:00Z"), end: Date.parse("2026-07-20T10:00:00Z") }];
+
+    assert.deepEqual(
+      computeSuggestedSlots(input, busy).map((slot) => slot.start),
+      ["2026-07-20T10:00:00.000Z", "2026-07-20T10:30:00.000Z"],
+    );
+    assert.equal(computeSuggestedSlots({ ...input, includeWeekends: true }, busy)[0].start, "2026-07-18T09:00:00.000Z");
+  });
+
+  it("treats touching and overlapping busy periods as one block", () => {
+    assert.deepEqual(
+      mergeBusyPeriods([
+        { start: 20, end: 30 },
+        { start: 0, end: 10 },
+        { start: 10, end: 25 },
+      ]),
+      [{ start: 0, end: 30 }],
+    );
+  });
+
+  it("uses the correct UTC offset on both sides of DST", () => {
+    const common = {
+      durationMinutes: 60,
+      timeZone: "America/New_York",
+      workDayStart: "09:00",
+      workDayEnd: "10:00",
+      maxSuggestions: 1,
+    };
+    const summer = computeSuggestedSlots(
+      { ...common, timeMin: "2026-07-20T00:00:00Z", timeMax: "2026-07-21T00:00:00Z" },
+      [],
+    );
+    const winter = computeSuggestedSlots(
+      { ...common, timeMin: "2026-12-07T00:00:00Z", timeMax: "2026-12-08T00:00:00Z" },
+      [],
+    );
+    assert.equal(summer[0].start, "2026-07-20T13:00:00.000Z");
+    assert.equal(winter[0].start, "2026-12-07T14:00:00.000Z");
+  });
+
+  it("rejects invalid work hours and time zones", () => {
+    const input = {
+      timeMin: "2026-07-20T00:00:00Z",
+      timeMax: "2026-07-21T00:00:00Z",
+      durationMinutes: 30,
+      timeZone: "UTC",
+    };
+    assert.throws(() => computeSuggestedSlots({ ...input, workDayStart: "9am" }, []), /HH:mm/);
+    assert.throws(
+      () => computeSuggestedSlots({ ...input, workDayStart: "17:00", workDayEnd: "09:00" }, []),
+      /must be after/,
+    );
+    assert.throws(() => computeSuggestedSlots({ ...input, timeZone: "Mars/Olympus" }, []), /Invalid IANA/);
+  });
+});

--- a/extensions/google-calendar/src/lib/suggest-time.ts
+++ b/extensions/google-calendar/src/lib/suggest-time.ts
@@ -1,0 +1,126 @@
+export type BusyPeriod = { start: number; end: number };
+
+export type SuggestionInput = {
+  timeMin: string;
+  timeMax: string;
+  durationMinutes: number;
+  timeZone: string;
+  workDayStart?: string;
+  workDayEnd?: string;
+  includeWeekends?: boolean;
+  incrementMinutes?: number;
+  maxSuggestions?: number;
+};
+
+export type SuggestedSlot = {
+  start: string;
+  end: string;
+  displayStart: string;
+  displayEnd: string;
+  timeZone: string;
+};
+
+function parseClock(value: string, label: string) {
+  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(value);
+  if (!match) throw new Error(`${label} must use 24-hour HH:mm format.`);
+  return Number(match[1]) * 60 + Number(match[2]);
+}
+
+function zonedParts(date: Date, timeZone: string) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const get = (type: Intl.DateTimeFormatPartTypes) => parts.find((part) => part.type === type)?.value ?? "";
+  return {
+    date: `${get("year")}-${get("month")}-${get("day")}`,
+    weekday: get("weekday"),
+    minutes: Number(get("hour")) * 60 + Number(get("minute")),
+  };
+}
+
+function formatSlot(date: Date, timeZone: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone,
+    dateStyle: "full",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export function mergeBusyPeriods(periods: BusyPeriod[]) {
+  const sorted = [...periods].sort((a, b) => a.start - b.start);
+  const merged: BusyPeriod[] = [];
+  for (const period of sorted) {
+    const previous = merged.at(-1);
+    if (previous && period.start <= previous.end) previous.end = Math.max(previous.end, period.end);
+    else merged.push({ ...period });
+  }
+  return merged;
+}
+
+function prepareSuggestionInput(input: SuggestionInput) {
+  const startRange = Date.parse(input.timeMin);
+  const endRange = Date.parse(input.timeMax);
+  if (Number.isNaN(startRange) || Number.isNaN(endRange) || endRange <= startRange) {
+    throw new Error("timeMin and timeMax must be valid RFC3339 datetimes with timeMax after timeMin.");
+  }
+  if (!Number.isFinite(input.durationMinutes) || input.durationMinutes <= 0) {
+    throw new Error("durationMinutes must be positive.");
+  }
+  const increment = input.incrementMinutes ?? 15;
+  const limit = input.maxSuggestions ?? 10;
+  if (!Number.isInteger(increment) || increment < 1 || increment > 1440) {
+    throw new Error("incrementMinutes must be a whole number from 1 to 1440.");
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > 50) {
+    throw new Error("maxSuggestions must be a whole number from 1 to 50.");
+  }
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: input.timeZone }).format();
+  } catch {
+    throw new Error(`Invalid IANA time zone "${input.timeZone}".`);
+  }
+  const workStart = parseClock(input.workDayStart ?? "09:00", "workDayStart");
+  const workEnd = parseClock(input.workDayEnd ?? "17:00", "workDayEnd");
+  if (workEnd <= workStart) throw new Error("workDayEnd must be after workDayStart.");
+  return { startRange, endRange, increment, limit, workStart, workEnd };
+}
+
+export function validateSuggestionInput(input: SuggestionInput) {
+  prepareSuggestionInput(input);
+}
+
+export function computeSuggestedSlots(input: SuggestionInput, busyPeriods: BusyPeriod[]): SuggestedSlot[] {
+  const { startRange, endRange, increment, limit, workStart, workEnd } = prepareSuggestionInput(input);
+  const durationMs = input.durationMinutes * 60000;
+  const incrementMs = increment * 60000;
+  const busy = mergeBusyPeriods(busyPeriods);
+  let candidate = Math.ceil(startRange / incrementMs) * incrementMs;
+  const suggestions: SuggestedSlot[] = [];
+  while (candidate + durationMs <= endRange && suggestions.length < limit) {
+    const candidateEnd = candidate + durationMs;
+    const start = zonedParts(new Date(candidate), input.timeZone);
+    const end = zonedParts(new Date(candidateEnd), input.timeZone);
+    const weekdayAllowed = input.includeWeekends || (start.weekday !== "Sat" && start.weekday !== "Sun");
+    const withinWorkHours =
+      start.date === end.date && start.minutes >= workStart && end.minutes <= workEnd && end.minutes > start.minutes;
+    const available = !busy.some((period) => candidate < period.end && candidateEnd > period.start);
+    if (weekdayAllowed && withinWorkHours && available) {
+      suggestions.push({
+        start: new Date(candidate).toISOString(),
+        end: new Date(candidateEnd).toISOString(),
+        displayStart: formatSlot(new Date(candidate), input.timeZone),
+        displayEnd: formatSlot(new Date(candidateEnd), input.timeZone),
+        timeZone: input.timeZone,
+      });
+    }
+    candidate += incrementMs;
+  }
+  return suggestions;
+}

--- a/extensions/google-calendar/src/lib/utils.ts
+++ b/extensions/google-calendar/src/lib/utils.ts
@@ -1,6 +1,5 @@
 import { environment, getPreferenceValues } from "@raycast/api";
-
-const SIGNATURE = "Created with <a href='https://raycast.com'>Raycast</a>";
+import { addRaycastSignature } from "./event-values";
 
 const preferences = getPreferenceValues();
 
@@ -10,15 +9,7 @@ export function roundUpTime(date = new Date(), roundMins = 15) {
 }
 
 export function addSignature(description: string | undefined) {
-  if (!preferences.addSignature) {
-    return description;
-  }
-
-  if (!description) {
-    return SIGNATURE;
-  }
-
-  return `${description}\n<hr>${SIGNATURE}`;
+  return addRaycastSignature(description, Boolean(preferences.addSignature));
 }
 
 function parseRRule(rrule: string): string {

--- a/extensions/google-calendar/src/tools/create-event.ts
+++ b/extensions/google-calendar/src/tools/create-event.ts
@@ -1,142 +1,155 @@
-import { getPreferenceValues, Tool } from "@raycast/api";
-import humanizeDuration from "humanize-duration";
-import { withGoogleAPIs, getCalendarClient } from "../lib/google";
-import {
-  addSignature,
-  colorIdToName,
-  parseAttendeeEmails,
-  resolveColorId,
-  toISO8601WithTimezoneOffset,
-} from "../lib/utils";
-import { parseISO, addMinutes } from "date-fns";
 import { calendar_v3 } from "@googleapis/calendar";
-import { randomUUID } from "node:crypto";
+import { getPreferenceValues, Tool } from "@raycast/api";
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+import {
+  EventLabelVersionParams,
+  getCalendarWithLabels,
+  getEventLabels,
+  requireLabel,
+} from "../lib/calendar-resources";
+import {
+  buildEventResource,
+  describeEventInput,
+  getNotificationLevel,
+  hasAttachmentChanges,
+  hasConferenceChanges,
+  serializeEvent,
+} from "../lib/events";
+
 type Input = {
-  /**
-   * The title/summary of the calendar event
-   * @example "Team Weekly Sync" or "Meeting with John"
-   */
+  /** Event title. */
   title: string;
   /**
-   * The start date and time of the event in ISO 8601 format with timezone offset
-   * @example "2024-03-20T15:30:00-07:00" or "2024-03-20T15:30:00+02:00"
-   * @remarks For accurate timezone handling, always include the timezone offset (e.g., -07:00, +02:00) rather than using Z (UTC)
+   * Start as RFC3339 datetime for timed events or YYYY-MM-DD for all-day events.
+   * Always include Z or a numeric UTC offset for timed events.
    */
   startDate: string;
-  /**
-   * The duration of the event in minutes
-   * @example 30 for a 30-minute meeting, 60 for a 1-hour meeting
-   * @remarks If not provided, the event will use the user's default event duration
-   */
+  /** Explicit exclusive end datetime/date. Prefer this when the user gave an end time. */
+  endDate?: string;
+  /** Timed-event length in minutes, used only when endDate is omitted. */
   duration?: number;
-  /**
-   * Comma-separated email addresses for event attendees
-   * @example "john@example.com, jane@example.com"
-   * @remarks The current user will automatically be added as the event organizer
-   */
-  attendees?: string;
-  /**
-   * Detailed description or agenda for the event
-   * @example "Monthly review of project progress and key metrics discussion"
-   * @remarks Only use for additional information, don't duplicate the even title. Useful to add external conference links like Zoom.
-   */
+  /** All-day-event length in whole days, used only when endDate is omitted. */
+  durationDays?: number;
+  /** Set true for an all-day event. */
+  allDay?: boolean;
+  /** IANA time zone, such as "America/Los_Angeles". Required for timed recurring events. */
+  timeZone?: string;
+  /** Event description or agenda. */
   description?: string;
+  /** Physical or virtual location text. */
+  location?: string;
+  /** Comma-separated required guest emails. `attendees` is a backwards-compatible alias. */
+  requiredAttendees?: string;
+  /** Backwards-compatible comma-separated required guest emails. */
+  attendees?: string;
+  /** Comma-separated optional guest emails. */
+  optionalAttendees?: string;
+  /** Comma-separated room/resource calendar emails. */
+  resourceAttendees?: string;
   /**
-   * Whether to add a Google Meet link to the event
-   * @example "with digital conference link"
-   * @defaults false
-   * @remarks If enabled, a Google Meet link will be added to the event. The link will be included in the event details and can be used to join the meeting.
+   * RFC5545 recurrence rules, one per line, e.g. "RRULE:FREQ=WEEKLY;BYDAY=MO,WE".
+   * Do not include DTSTART or DTEND.
    */
-  addGoogleMeetLink?: boolean;
-  /**
-   * The ID of the calendar to create the event in
-   * @example "primary" or "email@abstract...com"
-   * @default "primary"
-   * @remarks If not provided, the event will be created in the user's primary calendar. The calendar ID can be found using the `list-calendars` tool.
-   */
-  calendarId?: string;
-  /**
-   * The color of the event. Accepts a Google Calendar named color, a raw colorId (1–11), or a hex code.
-   * @example "sage" or "green" for green, "grape" or "purple" for purple, "#FF6363" for a custom hex
-   * @remarks Supported names: lavender (1), sage (2, green), grape (3, purple), flamingo (4, pink), banana (5, yellow), tangerine (6, orange), peacock (7, teal), graphite (8, gray), blueberry (9, blue), basil (10), tomato (11, red). Google Calendar only supports these 11 fixed event colors, so a hex code is snapped to the nearest one. If not provided, the event inherits the calendar's default color.
-   */
+  recurrence?: string;
+  /** Event visibility. */
+  visibility?: "default" | "public" | "private" | "confidential";
+  /** Whether the event blocks availability: opaque is busy, transparent is free. */
+  transparency?: "opaque" | "transparent";
+  /** Initial event status. */
+  status?: "confirmed" | "tentative";
+  /** Google event color name, colorId 1-11, or hex color. */
   color?: string;
+  /** Custom label ID from manage-calendar-labels. Supersedes color; omit both to use the calendar default. */
+  eventLabelId?: string;
+  /** Use the calendar's default reminders. Cannot be combined with custom reminders. */
+  useDefaultReminders?: boolean;
+  /** Comma-separated popup reminder offsets in minutes, 0-40320. */
+  popupReminderMinutes?: string;
+  /** Comma-separated email reminder offsets in minutes, 0-40320. */
+  emailReminderMinutes?: string;
+  /** Whether guests can invite other guests. */
+  guestsCanInviteOthers?: boolean;
+  /** Whether guests can modify the event. */
+  guestsCanModify?: boolean;
+  /** Whether guests can see the guest list. */
+  guestsCanSeeOtherGuests?: boolean;
+  /** Comma- or newline-separated attachment URLs (maximum 25). */
+  attachmentUrls?: string;
+  /**
+   * Immutable event type. Special types may only be supported by Google Workspace calendars.
+   * Birthday, working-location, focus-time and out-of-office events have additional constraints.
+   */
+  eventType?: "default" | "birthday" | "focusTime" | "outOfOffice" | "workingLocation";
+  /** Focus-time invitation handling. */
+  focusTimeAutoDeclineMode?:
+    | "declineNone"
+    | "declineAllConflictingInvitations"
+    | "declineOnlyNewConflictingInvitations";
+  /** Chat status during focus time. */
+  focusTimeChatStatus?: "available" | "doNotDisturb";
+  /** Auto-decline message for focus time. */
+  focusTimeDeclineMessage?: string;
+  /** Out-of-office invitation handling. */
+  outOfOfficeAutoDeclineMode?:
+    | "declineNone"
+    | "declineAllConflictingInvitations"
+    | "declineOnlyNewConflictingInvitations";
+  /** Auto-decline message for out-of-office. */
+  outOfOfficeDeclineMessage?: string;
+  /** Working-location kind. */
+  workingLocationType?: "homeOffice" | "officeLocation" | "customLocation";
+  /** Display label for an office or custom working location. */
+  workingLocationLabel?: string;
+  /** Office building identifier. */
+  workingLocationBuildingId?: string;
+  /** Office floor identifier. */
+  workingLocationFloorId?: string;
+  /** Office floor-section identifier. */
+  workingLocationFloorSectionId?: string;
+  /** Office desk identifier. */
+  workingLocationDeskId?: string;
+  /** Add a new Google Meet conference. */
+  addGoogleMeetLink?: boolean;
+  /** Calendar ID from list-calendars. Defaults to "primary". */
+  calendarId?: string;
+  /** Guest notification level. Defaults to the extension preference. */
+  notificationLevel?: "all" | "externalOnly" | "none";
 };
 
-const preferences = getPreferenceValues();
+const preferences = getPreferenceValues<Preferences>();
 
-export const confirmation: Tool.Confirmation<Input> = async (input) => {
-  if (!input.attendees) {
-    return;
-  }
-
-  return {
-    message: "Are you sure you want to create an event with the following details?",
-    info: [
-      { name: "Title", value: input.title },
-      { name: "Start", value: new Date(input.startDate).toLocaleString() },
-      {
-        name: "Duration",
-        value: humanizeDuration((input.duration ?? parseInt(preferences.defaultEventDuration)) * 60 * 1000),
-      },
-      { name: "Attendees", value: input.attendees },
-      { name: "Description", value: input.description },
-      { name: "Add Google Meet Link", value: input.addGoogleMeetLink ? "Yes" : "No" },
-      ...(input.color ? [{ name: "Color", value: colorIdToName(resolveColorId(input.color)) }] : []),
-    ],
-  };
-};
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: "Create this Google Calendar event?",
+  info: describeEventInput({
+    ...input,
+    conferenceAction: input.addGoogleMeetLink ? "add" : undefined,
+  }),
+});
 
 const tool = async (input: Input) => {
   const calendar = getCalendarClient();
-  const { emails: attendeeEmails, invalidEntries } = parseAttendeeEmails(input.attendees);
-  if (invalidEntries.length > 0) {
-    throw new Error(`Invalid attendee email: ${invalidEntries.join(", ")}`);
-  }
-
-  const startDate = parseISO(input.startDate);
-  const endDate = addMinutes(startDate, input.duration ?? parseInt(preferences.defaultEventDuration));
-
-  const colorId = resolveColorId(input.color);
-
-  const requestBody: calendar_v3.Schema$Event = {
-    summary: input.title,
-    description: addSignature(input.description),
-    colorId,
-    start: {
-      dateTime: toISO8601WithTimezoneOffset(startDate),
-    },
-    end: {
-      dateTime: toISO8601WithTimezoneOffset(endDate),
-    },
-    attendees: attendeeEmails.length > 0 ? attendeeEmails.map((email) => ({ email })) : undefined,
-    conferenceData: input.addGoogleMeetLink
-      ? {
-          createRequest: {
-            conferenceSolutionKey: {
-              type: "hangoutsMeet",
-            },
-            requestId: randomUUID(),
-          },
-        }
-      : undefined,
+  const writeInput = {
+    ...input,
+    conferenceAction: input.addGoogleMeetLink ? ("add" as const) : undefined,
   };
-
-  try {
-    const event = await calendar.events.insert({
-      calendarId: input.calendarId || "primary",
-      requestBody,
-      conferenceDataVersion: input.addGoogleMeetLink ? 1 : undefined,
-      sendUpdates: preferences.sendInvitations as "all" | "externalOnly" | "none",
-    });
-    return {
-      id: event.data.id,
-      link: event.data.htmlLink,
-    };
-  } catch (error) {
-    console.error(error);
-    throw new Error("Failed to create event");
-  }
+  const calendarId = input.calendarId ?? "primary";
+  const labels = input.eventLabelId !== undefined ? getEventLabels(await getCalendarWithLabels(calendarId)) : undefined;
+  if (input.eventLabelId) requireLabel(labels ?? [], input.eventLabelId);
+  const requestBody = buildEventResource(writeInput, {
+    isCreate: true,
+    defaultDurationMinutes: Number(preferences.defaultEventDuration ?? 30),
+    addSignature: Boolean(preferences.addSignature),
+  });
+  const requestParams: calendar_v3.Params$Resource$Events$Insert & Partial<EventLabelVersionParams> = {
+    calendarId,
+    requestBody,
+    conferenceDataVersion: hasConferenceChanges(writeInput) ? 1 : undefined,
+    supportsAttachments: hasAttachmentChanges(writeInput) ? true : undefined,
+    sendUpdates: getNotificationLevel(input, preferences.sendInvitations),
+    eventLabelVersion: input.eventLabelId !== undefined ? 1 : undefined,
+  };
+  const response = await calendar.events.insert(requestParams);
+  return serializeEvent(response.data, calendarId, labels);
 };
 
 export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/delete-event.ts
+++ b/extensions/google-calendar/src/tools/delete-event.ts
@@ -1,17 +1,14 @@
-import { Action } from "@raycast/api";
+import { Action, getPreferenceValues } from "@raycast/api";
+import { getNotificationLevel } from "../lib/events";
 import { getCalendarClient, withGoogleAPIs } from "../lib/google";
 
 type Input = {
-  /**
-   * The ID of the event to delete.
-   */
+  /** Event ID from search-events or get-event. An instance ID deletes only that occurrence; a series ID deletes the series. */
   eventId: string;
-  /**
-   * The ID of the calendar where the event is located.
-   * @default "primary"
-   * @remarks If not provided, the event will be deleted from the user's primary calendar. The calendar ID can be found using the `list-calendars` tool.
-   */
+  /** Calendar containing the event. Defaults to "primary". */
   calendarId?: string;
+  /** Guest notification level. Defaults to the extension preference. */
+  notificationLevel?: "all" | "externalOnly" | "none";
 };
 
 export const confirmation = withGoogleAPIs(async (input: Input) => {
@@ -25,8 +22,22 @@ export const confirmation = withGoogleAPIs(async (input: Input) => {
 });
 
 const tool = async (input: Input) => {
+  const preferences = getPreferenceValues<Preferences>();
   const calendar = getCalendarClient();
-  await calendar.events.delete({ calendarId: input.calendarId ?? "primary", eventId: input.eventId });
+  const calendarId = input.calendarId ?? "primary";
+  const event = await calendar.events.get({ calendarId, eventId: input.eventId });
+  await calendar.events.delete({
+    calendarId,
+    eventId: input.eventId,
+    sendUpdates: getNotificationLevel(input, preferences.sendInvitations),
+  });
+  return {
+    deleted: true,
+    id: input.eventId,
+    calendarId,
+    title: event.data.summary,
+    recurringEventId: event.data.recurringEventId,
+  };
 };
 
 export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/edit-event.ts
+++ b/extensions/google-calendar/src/tools/edit-event.ts
@@ -1,172 +1,155 @@
-import humanizeDuration from "humanize-duration";
-import { withGoogleAPIs, getCalendarClient } from "../lib/google";
-import {
-  addSignature,
-  colorIdToName,
-  parseAttendeeEmails,
-  resolveColorId,
-  toISO8601WithTimezoneOffset,
-} from "../lib/utils";
-import { parseISO, addMinutes } from "date-fns";
+import { calendar_v3 } from "@googleapis/calendar";
 import { getPreferenceValues } from "@raycast/api";
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+import {
+  EventLabelVersionParams,
+  getCalendarWithLabels,
+  getEventLabels,
+  requireLabel,
+} from "../lib/calendar-resources";
+import {
+  buildEventResource,
+  describeEventInput,
+  getNotificationLevel,
+  hasAttachmentChanges,
+  hasConferenceChanges,
+  serializeEvent,
+} from "../lib/events";
 
 type Input = {
-  /**
-   * The ID of the event to edit
-   */
+  /** Google Calendar event ID, usually obtained from search-events or get-event. */
   eventId: string;
-  /**
-   * The title of the event
-   */
-  title?: string;
-  /**
-   * The start date of the event in ISO 8601 format with timezone offset
-   * @example "2024-03-20T15:30:00-07:00" or "2024-03-20T15:30:00+02:00"
-   * @remarks For accurate timezone handling, always include the timezone offset (e.g., -07:00, +02:00) rather than using Z (UTC)
-   */
-  startDate?: string;
-  /**
-   * The duration of the event in minutes
-   */
-  duration?: number;
-  /**
-   * Comma-separated email addresses of event attendees
-   */
-  attendees?: string;
-  /**
-   * The conferencing provider of the event
-   */
-  conferencingProvider?: string;
-  /**
-   * The description of the event
-   */
-  description?: string;
-  /**
-   * The ID of the calendar where the event is located
-   * @default "primary"
-   * @remarks If not provided, the event will be updated in the user's primary calendar. The calendar ID can be found using the `list-calendars` tool.
-   */
+  /** Calendar containing the event. Defaults to "primary". */
   calendarId?: string;
+  /** New title. An empty string clears it. */
+  title?: string;
+  /** New description. An empty string intentionally clears it. */
+  description?: string;
+  /** New location. An empty string intentionally clears it. */
+  location?: string;
+  /** New RFC3339 datetime with Z/numeric offset, or YYYY-MM-DD for an all-day event. */
+  startDate?: string;
+  /** New explicit exclusive end datetime/date. */
+  endDate?: string;
+  /** New timed duration in minutes. Moves preserve the existing duration when omitted. */
+  duration?: number;
+  /** New all-day duration in whole days. */
+  durationDays?: number;
+  /** Change between timed and all-day. startDate is required when changing this value. */
+  allDay?: boolean;
+  /** IANA time zone. An empty string clears the custom time zone. */
+  timeZone?: string;
   /**
-   * The color of the event. Accepts a Google Calendar named color, a raw colorId (1–11), or a hex code.
-   * @example "sage" or "green" for green, "grape" or "purple" for purple, "#FF6363" for a custom hex
-   * @remarks Supported names: lavender (1), sage (2, green), grape (3, purple), flamingo (4, pink), banana (5, yellow), tangerine (6, orange), peacock (7, teal), graphite (8, gray), blueberry (9, blue), basil (10), tomato (11, red). Google Calendar only supports these 11 fixed event colors, so a hex code is snapped to the nearest one. If not provided, the event keeps its current color.
+   * Replacement comma-separated required guest list. An empty string clears required guests.
+   * When any attendee-list field is supplied, the complete attendee list is replaced.
    */
+  requiredAttendees?: string;
+  /** Backwards-compatible alias for requiredAttendees. */
+  attendees?: string;
+  /** Replacement comma-separated optional guest list. */
+  optionalAttendees?: string;
+  /** Replacement comma-separated room/resource calendar list. */
+  resourceAttendees?: string;
+  /**
+   * Replacement RFC5545 recurrence rules, one per line. Empty string removes recurrence.
+   * To edit one occurrence, use that occurrence's event ID and do not set recurrence.
+   */
+  recurrence?: string;
+  /** New visibility. */
+  visibility?: "default" | "public" | "private" | "confidential";
+  /** New availability: opaque is busy, transparent is free. */
+  transparency?: "opaque" | "transparent";
+  /** New event status. Setting cancelled cancels the event. */
+  status?: "confirmed" | "tentative" | "cancelled";
+  /** New event color. Empty string restores the calendar default. */
   color?: string;
+  /** Custom label ID from manage-calendar-labels. Empty removes it. Supersedes legacy color. */
+  eventLabelId?: string;
+  /** Use calendar defaults. Cannot be combined with custom reminders. */
+  useDefaultReminders?: boolean;
+  /** Replacement comma-separated popup offsets in minutes. Empty clears popup reminders. */
+  popupReminderMinutes?: string;
+  /** Replacement comma-separated email offsets in minutes. Empty clears email reminders. */
+  emailReminderMinutes?: string;
+  /** Whether guests can invite others. */
+  guestsCanInviteOthers?: boolean;
+  /** Whether guests can modify this event. */
+  guestsCanModify?: boolean;
+  /** Whether guests can see other guests. */
+  guestsCanSeeOtherGuests?: boolean;
+  /** Replacement attachment URLs. Empty string removes all attachments. */
+  attachmentUrls?: string;
+  /** Existing immutable event type. Supplying a different type is rejected. */
+  eventType?: "default" | "birthday" | "focusTime" | "outOfOffice" | "workingLocation";
+  /** Focus-time invitation handling. Only applies to focusTime events. */
+  focusTimeAutoDeclineMode?:
+    | "declineNone"
+    | "declineAllConflictingInvitations"
+    | "declineOnlyNewConflictingInvitations";
+  /** Focus-time Chat status. */
+  focusTimeChatStatus?: "available" | "doNotDisturb";
+  /** Focus-time auto-decline message. Empty clears it. */
+  focusTimeDeclineMessage?: string;
+  /** Out-of-office invitation handling. */
+  outOfOfficeAutoDeclineMode?:
+    | "declineNone"
+    | "declineAllConflictingInvitations"
+    | "declineOnlyNewConflictingInvitations";
+  /** Out-of-office auto-decline message. Empty clears it. */
+  outOfOfficeDeclineMessage?: string;
+  /** Working-location kind. */
+  workingLocationType?: "homeOffice" | "officeLocation" | "customLocation";
+  /** Working-location label. Empty clears it. */
+  workingLocationLabel?: string;
+  /** Office building identifier. Empty clears it. */
+  workingLocationBuildingId?: string;
+  /** Office floor identifier. Empty clears it. */
+  workingLocationFloorId?: string;
+  /** Office floor-section identifier. Empty clears it. */
+  workingLocationFloorSectionId?: string;
+  /** Office desk identifier. Empty clears it. */
+  workingLocationDeskId?: string;
+  /** Keep, add, or remove Google Meet. Omit to preserve conferencing exactly. */
+  googleMeetAction?: "keep" | "add" | "remove";
+  /** Guest notification level. Defaults to the extension preference. */
+  notificationLevel?: "all" | "externalOnly" | "none";
 };
 
 export const confirmation = withGoogleAPIs(async (input: Input) => {
-  const calendar = getCalendarClient();
-  const event = await calendar.events.get({
-    calendarId: input.calendarId ?? "primary",
-    eventId: input.eventId,
-  });
-
-  if (!event.data.start?.dateTime || !event.data.end?.dateTime) {
-    throw new Error("Event has invalid start or end time");
-  }
-
-  if (!input.attendees) {
-    return;
-  }
-
-  const changes: { name: string; value: string }[] = [];
-
-  if (input.title) {
-    changes.push({ name: "Title", value: `${event.data.summary || ""} → ${input.title}` });
-  }
-  if (input.startDate) {
-    changes.push({
-      name: "Start",
-      value: `${new Date(event.data.start.dateTime).toLocaleString()} → ${new Date(input.startDate).toLocaleString()}`,
-    });
-  }
-  if (input.duration) {
-    const currentStart = new Date(event.data.start.dateTime);
-    const currentEnd = new Date(event.data.end.dateTime);
-    const currentDuration = currentEnd.getTime() - currentStart.getTime();
-    changes.push({
-      name: "Duration",
-      value: `${humanizeDuration(currentDuration)} → ${humanizeDuration(input.duration * 60 * 1000)}`,
-    });
-  }
-  if (input.attendees) {
-    const currentAttendees = event.data.attendees?.map((a) => a.email || "").join(", ") || "none";
-    changes.push({ name: "Attendees", value: `${currentAttendees} → ${input.attendees}` });
-  }
-  if (input.description !== undefined) {
-    changes.push({
-      name: "Description",
-      value: `${event.data.description || "none"} → ${input.description || "none"}`,
-    });
-  }
-  if (input.color !== undefined) {
-    changes.push({
-      name: "Color",
-      value: `${colorIdToName(event.data.colorId)} → ${colorIdToName(resolveColorId(input.color))}`,
-    });
-  }
-
-  if (changes.length === 0) {
-    return;
-  }
-
-  return {
-    message: "Are you sure you want to update this event with the following changes?",
-    info: changes,
-  };
+  const calendarId = input.calendarId ?? "primary";
+  const current = await getCalendarClient().events.get({ calendarId, eventId: input.eventId });
+  const info = [
+    { name: "Event", value: current.data.summary ?? "Untitled Event" },
+    ...describeEventInput({ ...input, conferenceAction: input.googleMeetAction }),
+  ];
+  return { message: "Apply these changes to the Google Calendar event?", info };
 });
 
 const tool = async (input: Input) => {
   const preferences = getPreferenceValues<Preferences>();
   const calendar = getCalendarClient();
-  const { emails: attendeeEmails, invalidEntries } = parseAttendeeEmails(input.attendees);
-  if (invalidEntries.length > 0) {
-    throw new Error(`Invalid attendee email: ${invalidEntries.join(", ")}`);
-  }
-
-  const existingEvent = await calendar.events.get({
-    calendarId: input.calendarId ?? "primary",
-    eventId: input.eventId,
+  const calendarId = input.calendarId ?? "primary";
+  const existing = await calendar.events.get({ calendarId, eventId: input.eventId });
+  const labels = input.eventLabelId !== undefined ? getEventLabels(await getCalendarWithLabels(calendarId)) : undefined;
+  if (input.eventLabelId) requireLabel(labels ?? [], input.eventLabelId);
+  const writeInput = { ...input, conferenceAction: input.googleMeetAction };
+  const requestBody = buildEventResource(writeInput, {
+    existing: existing.data,
+    addSignature: Boolean(preferences.addSignature),
   });
+  if (Object.keys(requestBody).length === 0) throw new Error("No event changes were provided.");
 
-  if (!existingEvent.data.start?.dateTime || !existingEvent.data.end?.dateTime) {
-    throw new Error("Event has invalid start or end time");
-  }
-
-  // Calculate the current duration in minutes
-  const currentStart = new Date(existingEvent.data.start.dateTime);
-  const currentEnd = new Date(existingEvent.data.end.dateTime);
-  const currentDurationMinutes = (currentEnd.getTime() - currentStart.getTime()) / (60 * 1000);
-
-  let startDate = currentStart;
-  if (input.startDate) {
-    startDate = parseISO(input.startDate);
-  }
-
-  const endDate = addMinutes(startDate, input.duration ?? currentDurationMinutes);
-
-  const requestBody = {
-    summary: input.title ?? existingEvent.data.summary ?? "",
-    description:
-      input.description !== undefined ? addSignature(input.description) : (existingEvent.data.description ?? ""),
-    start: {
-      dateTime: toISO8601WithTimezoneOffset(startDate),
-    },
-    end: {
-      dateTime: toISO8601WithTimezoneOffset(endDate),
-    },
-    attendees: attendeeEmails.length > 0 ? attendeeEmails.map((email) => ({ email })) : existingEvent.data.attendees,
-    location: input.conferencingProvider ?? existingEvent.data.location ?? "",
-    colorId: input.color !== undefined ? resolveColorId(input.color) : (existingEvent.data.colorId ?? undefined),
-  };
-
-  await calendar.events.update({
-    calendarId: input.calendarId ?? "primary",
+  const requestParams: calendar_v3.Params$Resource$Events$Patch & Partial<EventLabelVersionParams> = {
+    calendarId,
     eventId: input.eventId,
     requestBody,
-    sendUpdates: preferences.sendInvitations as "all" | "externalOnly" | "none",
-  });
+    conferenceDataVersion: hasConferenceChanges(writeInput) ? 1 : undefined,
+    supportsAttachments: hasAttachmentChanges(writeInput) ? true : undefined,
+    sendUpdates: getNotificationLevel(input, preferences.sendInvitations),
+    eventLabelVersion: input.eventLabelId !== undefined ? 1 : undefined,
+  };
+  const response = await calendar.events.patch(requestParams);
+  return serializeEvent(response.data, calendarId, labels);
 };
 
 export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/edit-event.ts
+++ b/extensions/google-calendar/src/tools/edit-event.ts
@@ -39,16 +39,13 @@ type Input = {
   allDay?: boolean;
   /** IANA time zone. An empty string clears the custom time zone. */
   timeZone?: string;
-  /**
-   * Replacement comma-separated required guest list. An empty string clears required guests.
-   * When any attendee-list field is supplied, the complete attendee list is replaced.
-   */
+  /** Comma-separated required guest emails to add. An empty string clears required guests. */
   requiredAttendees?: string;
   /** Backwards-compatible alias for requiredAttendees. */
   attendees?: string;
-  /** Replacement comma-separated optional guest list. */
+  /** Comma-separated optional guest emails to add. An empty string clears optional guests. */
   optionalAttendees?: string;
-  /** Replacement comma-separated room/resource calendar list. */
+  /** Comma-separated room/resource calendar emails to add. An empty string clears resources. */
   resourceAttendees?: string;
   /**
    * Replacement RFC5545 recurrence rules, one per line. Empty string removes recurrence.

--- a/extensions/google-calendar/src/tools/get-calendar-colors.ts
+++ b/extensions/google-calendar/src/tools/get-calendar-colors.ts
@@ -1,0 +1,12 @@
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+
+const tool = async () => {
+  const response = await getCalendarClient().colors.get();
+  return {
+    updated: response.data.updated,
+    eventColors: response.data.event,
+    calendarColors: response.data.calendar,
+  };
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/get-calendar-settings.ts
+++ b/extensions/google-calendar/src/tools/get-calendar-settings.ts
@@ -1,0 +1,35 @@
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+
+type Input = {
+  /** Setting ID to read, such as timezone, locale, weekStart, or autoAddHangouts. Omit to list settings. */
+  setting?: string;
+  /** Maximum settings in a list page, 1-250. Defaults to 100. */
+  maxResults?: number;
+  /** Opaque nextPageToken from an earlier list call. */
+  pageToken?: string;
+};
+
+const tool = async (input: Input) => {
+  const calendar = getCalendarClient();
+  if (input.setting) {
+    const response = await calendar.settings.get({ setting: input.setting });
+    return { id: response.data.id, value: response.data.value, etag: response.data.etag };
+  }
+  const maxResults = input.maxResults ?? 100;
+  if (!Number.isInteger(maxResults) || maxResults < 1 || maxResults > 250) {
+    throw new Error("maxResults must be a whole number from 1 to 250.");
+  }
+  const response = await calendar.settings.list({ maxResults, pageToken: input.pageToken });
+  return {
+    nextPageToken: response.data.nextPageToken,
+    nextSyncToken: response.data.nextSyncToken,
+    settings:
+      response.data.items?.map((setting) => ({
+        id: setting.id,
+        value: setting.value,
+        etag: setting.etag,
+      })) ?? [],
+  };
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/get-event.ts
+++ b/extensions/google-calendar/src/tools/get-event.ts
@@ -1,0 +1,30 @@
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+import { getCalendarWithLabels, getEventLabels } from "../lib/calendar-resources";
+import { serializeEvent } from "../lib/events";
+
+type Input = {
+  /** Google Calendar event ID, usually obtained from search-events. */
+  eventId: string;
+  /** Calendar containing the event. Defaults to "primary". */
+  calendarId?: string;
+  /** IANA time zone used for returned start/end values. */
+  timeZone?: string;
+  /** Maximum attendees to include. Omit for Google's default behavior. */
+  maxAttendees?: number;
+};
+
+const tool = async (input: Input) => {
+  const calendarId = input.calendarId ?? "primary";
+  const [response, calendar] = await Promise.all([
+    getCalendarClient().events.get({
+      calendarId,
+      eventId: input.eventId,
+      timeZone: input.timeZone,
+      maxAttendees: input.maxAttendees,
+    }),
+    getCalendarWithLabels(calendarId),
+  ]);
+  return serializeEvent(response.data, calendarId, getEventLabels(calendar));
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/import-event.ts
+++ b/extensions/google-calendar/src/tools/import-event.ts
@@ -7,7 +7,13 @@ import {
   getEventLabels,
   requireLabel,
 } from "../lib/calendar-resources";
-import { buildEventResource, describeEventInput, hasAttachmentChanges, serializeEvent } from "../lib/events";
+import {
+  applyImportedEventLabel,
+  buildEventResource,
+  describeEventInput,
+  hasAttachmentChanges,
+  serializeEvent,
+} from "../lib/events";
 import { getCalendarClient, withGoogleAPIs } from "../lib/google";
 
 type Input = {
@@ -78,18 +84,24 @@ const tool = async (input: Input) => {
     supportsAttachments: hasAttachmentChanges(input) ? true : undefined,
   };
   const calendar = getCalendarClient();
-  let response = await calendar.events.import(params);
+  const imported = await calendar.events.import(params);
+  let event = imported.data as EventWithLabel;
   if (eventLabelId !== undefined) {
     const labelBody: EventWithLabel = { eventLabelId };
     const patchParams: calendar_v3.Params$Resource$Events$Patch & EventLabelVersionParams = {
       calendarId,
-      eventId: response.data.id!,
+      eventId: event.id!,
       requestBody: labelBody,
       eventLabelVersion: 1,
     };
-    response = await calendar.events.patch(patchParams);
+    event = await applyImportedEventLabel(
+      async () => (await calendar.events.patch(patchParams)).data as EventWithLabel,
+      async () => {
+        await calendar.events.delete({ calendarId, eventId: event.id! });
+      },
+    );
   }
-  return serializeEvent(response.data, calendarId, labels);
+  return serializeEvent(event, calendarId, labels);
 };
 
 export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/import-event.ts
+++ b/extensions/google-calendar/src/tools/import-event.ts
@@ -63,7 +63,8 @@ const tool = async (input: Input) => {
   const labels = input.eventLabelId !== undefined ? getEventLabels(await getCalendarWithLabels(calendarId)) : undefined;
   if (input.eventLabelId) requireLabel(labels ?? [], input.eventLabelId);
 
-  const requestBody = buildEventResource(input, {
+  const eventLabelId = input.eventLabelId;
+  const requestBody = buildEventResource(eventLabelId !== undefined ? { ...input, eventLabelId: undefined } : input, {
     isCreate: true,
     defaultDurationMinutes: Number(preferences.defaultEventDuration ?? 30),
     addSignature: Boolean(preferences.addSignature),
@@ -71,13 +72,23 @@ const tool = async (input: Input) => {
   requestBody.iCalUID = input.iCalUID;
   requestBody.eventType = "default";
 
-  const params: calendar_v3.Params$Resource$Events$Import & Partial<EventLabelVersionParams> = {
+  const params: calendar_v3.Params$Resource$Events$Import = {
     calendarId,
     requestBody,
     supportsAttachments: hasAttachmentChanges(input) ? true : undefined,
-    eventLabelVersion: input.eventLabelId !== undefined ? 1 : undefined,
   };
-  const response = await getCalendarClient().events.import(params);
+  const calendar = getCalendarClient();
+  let response = await calendar.events.import(params);
+  if (eventLabelId !== undefined) {
+    const labelBody: EventWithLabel = { eventLabelId };
+    const patchParams: calendar_v3.Params$Resource$Events$Patch & EventLabelVersionParams = {
+      calendarId,
+      eventId: response.data.id!,
+      requestBody: labelBody,
+      eventLabelVersion: 1,
+    };
+    response = await calendar.events.patch(patchParams);
+  }
   return serializeEvent(response.data, calendarId, labels);
 };
 

--- a/extensions/google-calendar/src/tools/import-event.ts
+++ b/extensions/google-calendar/src/tools/import-event.ts
@@ -1,0 +1,84 @@
+import { calendar_v3 } from "@googleapis/calendar";
+import { getPreferenceValues, Tool } from "@raycast/api";
+import {
+  EventLabelVersionParams,
+  EventWithLabel,
+  getCalendarWithLabels,
+  getEventLabels,
+  requireLabel,
+} from "../lib/calendar-resources";
+import { buildEventResource, describeEventInput, hasAttachmentChanges, serializeEvent } from "../lib/events";
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+
+type Input = {
+  /** RFC5545 iCalendar UID of the source event. Required for imports. */
+  iCalUID: string;
+  /** Event title. */
+  title: string;
+  /** RFC3339 start datetime or YYYY-MM-DD for an all-day event. */
+  startDate: string;
+  /** Explicit exclusive end datetime/date. */
+  endDate?: string;
+  /** Timed duration in minutes when endDate is omitted. */
+  duration?: number;
+  /** All-day duration in days when endDate is omitted. */
+  durationDays?: number;
+  /** Whether this is an all-day event. */
+  allDay?: boolean;
+  /** IANA timezone. Required for timed recurrence. */
+  timeZone?: string;
+  /** Description. */
+  description?: string;
+  /** Location. */
+  location?: string;
+  /** RFC5545 recurrence rules, one per line. */
+  recurrence?: string;
+  /** Visibility of the imported private copy. */
+  visibility?: "default" | "public" | "private" | "confidential";
+  /** Whether the imported event blocks time. */
+  transparency?: "opaque" | "transparent";
+  /** Legacy event color. Cannot be combined with eventLabelId. */
+  color?: string;
+  /** Calendar-specific custom label ID. */
+  eventLabelId?: string;
+  /** Comma- or newline-separated attachment URLs. */
+  attachmentUrls?: string;
+  /** Destination calendar. Defaults to "primary". */
+  calendarId?: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = (input) => ({
+  message: "Import a private copy of this external event?",
+  info: [
+    { name: "iCalendar UID", value: input.iCalUID },
+    { name: "Calendar", value: input.calendarId ?? "primary" },
+    ...describeEventInput(input),
+  ],
+});
+
+const tool = async (input: Input) => {
+  if (!input.iCalUID.trim()) throw new Error("iCalUID cannot be empty.");
+  const preferences = getPreferenceValues<Preferences>();
+  const calendarId = input.calendarId ?? "primary";
+  const labels = input.eventLabelId !== undefined ? getEventLabels(await getCalendarWithLabels(calendarId)) : undefined;
+  if (input.eventLabelId) requireLabel(labels ?? [], input.eventLabelId);
+
+  const requestBody = buildEventResource(input, {
+    isCreate: true,
+    defaultDurationMinutes: Number(preferences.defaultEventDuration ?? 30),
+    addSignature: Boolean(preferences.addSignature),
+  }) as EventWithLabel;
+  requestBody.iCalUID = input.iCalUID;
+  requestBody.eventType = "default";
+
+  const params: calendar_v3.Params$Resource$Events$Import & Partial<EventLabelVersionParams> = {
+    calendarId,
+    requestBody,
+    supportsAttachments: hasAttachmentChanges(input) ? true : undefined,
+    eventLabelVersion: input.eventLabelId !== undefined ? 1 : undefined,
+  };
+  const response = await getCalendarClient().events.import(params);
+  return serializeEvent(response.data, calendarId, labels);
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/import-event.ts
+++ b/extensions/google-calendar/src/tools/import-event.ts
@@ -47,7 +47,7 @@ type Input = {
   calendarId?: string;
 };
 
-export const confirmation: Tool.Confirmation<Input> = (input) => ({
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
   message: "Import a private copy of this external event?",
   info: [
     { name: "iCalendar UID", value: input.iCalUID },

--- a/extensions/google-calendar/src/tools/list-calendars.ts
+++ b/extensions/google-calendar/src/tools/list-calendars.ts
@@ -1,4 +1,5 @@
 import { calendar_v3 } from "@googleapis/calendar";
+import { OrganizationListParams, serializeCalendarListEntry } from "../lib/calendar-resources";
 import { getCalendarClient, withGoogleAPIs } from "../lib/google";
 
 type Input = {
@@ -31,30 +32,37 @@ type Input = {
    * The Google Calendar API has a maximum limit of 250 calendars per request.
    */
   maxResults?: number;
+  /** Opaque nextPageToken returned by an earlier list-calendars call. */
+  pageToken?: string;
+  /** Return only calendars where the current user has at least this access role. */
+  minAccessRole?: "freeBusyReader" | "reader" | "writerWithoutPrivateAccess" | "writer" | "owner";
+  /** For Google Workspace users, return only calendars belonging to their organization. */
+  showOwnOrganizationOnly?: boolean;
 };
 
 const tool = async (input: Input) => {
   const calendar = getCalendarClient();
-  const maxResults = input.maxResults ? Math.max(1, Math.min(250, input.maxResults)) : 10;
+  const maxResults = input.maxResults ?? 100;
+  if (!Number.isInteger(maxResults) || maxResults < 1 || maxResults > 250) {
+    throw new Error("maxResults must be a whole number from 1 to 250.");
+  }
 
-  const requestParams: calendar_v3.Params$Resource$Calendarlist$List = {
+  const requestParams: calendar_v3.Params$Resource$Calendarlist$List & OrganizationListParams = {
     showDeleted: input.showDeleted,
     showHidden: input.showHidden,
     maxResults,
+    pageToken: input.pageToken,
+    minAccessRole: input.minAccessRole,
+    showOwnOrganizationOnly: input.showOwnOrganizationOnly,
   };
 
   const response = await calendar.calendarList.list(requestParams);
 
-  return (
-    response.data.items?.map((calendar) => ({
-      id: calendar.id,
-      name: calendar.summary,
-      description: calendar.description,
-      primary: calendar.primary,
-      visible: calendar.selected,
-      accessRole: calendar.accessRole,
-    })) || []
-  );
+  return {
+    nextPageToken: response.data.nextPageToken,
+    nextSyncToken: response.data.nextSyncToken,
+    calendars: response.data.items?.map(serializeCalendarListEntry) ?? [],
+  };
 };
 
 export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/list-event-instances.ts
+++ b/extensions/google-calendar/src/tools/list-event-instances.ts
@@ -1,0 +1,52 @@
+import { serializeEvent } from "../lib/events";
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+
+type Input = {
+  /** Recurring series event ID from search-events or get-event. */
+  eventId: string;
+  /** Calendar containing the recurring series. Defaults to "primary". */
+  calendarId?: string;
+  /** RFC3339 exclusive lower bound for instance end times. */
+  timeMin?: string;
+  /** RFC3339 exclusive upper bound for instance start times. */
+  timeMax?: string;
+  /** Maximum instances in this page, 1-2500. Defaults to 50. */
+  maxResults?: number;
+  /** Opaque nextPageToken from an earlier call. */
+  pageToken?: string;
+  /** Include cancelled instances. */
+  showDeleted?: boolean;
+  /** IANA timezone used in returned instance times. */
+  timeZone?: string;
+  /** RFC3339 original start time of one specific instance. */
+  originalStart?: string;
+};
+
+const tool = async (input: Input) => {
+  const maxResults = input.maxResults ?? 50;
+  if (!Number.isInteger(maxResults) || maxResults < 1 || maxResults > 2500) {
+    throw new Error("maxResults must be a whole number from 1 to 2500.");
+  }
+
+  const calendarId = input.calendarId ?? "primary";
+  const response = await getCalendarClient().events.instances({
+    calendarId,
+    eventId: input.eventId,
+    timeMin: input.timeMin,
+    timeMax: input.timeMax,
+    maxResults,
+    pageToken: input.pageToken,
+    showDeleted: input.showDeleted,
+    timeZone: input.timeZone,
+    originalStart: input.originalStart,
+  });
+
+  return {
+    calendarId,
+    recurringEventId: input.eventId,
+    nextPageToken: response.data.nextPageToken,
+    instances: response.data.items?.map((event) => serializeEvent(event, calendarId)) ?? [],
+  };
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/manage-calendar-labels.ts
+++ b/extensions/google-calendar/src/tools/manage-calendar-labels.ts
@@ -1,0 +1,100 @@
+import { Action, Tool } from "@raycast/api";
+import { randomUUID } from "node:crypto";
+import { mergeEventLabels } from "../lib/calendar-values";
+import {
+  getCalendarWithLabels,
+  getEventLabels,
+  normalizeHexColor,
+  replaceEventLabels,
+  requireCalendarOwner,
+  requireLabel,
+  serializeCalendar,
+} from "../lib/calendar-resources";
+import { withGoogleAPIs } from "../lib/google";
+
+type Input = {
+  /** Operation to perform. List is read-only; all other operations require owner access. */
+  action: "list" | "create" | "rename" | "recolor" | "delete";
+  /** Calendar ID from list-calendars. Defaults to "primary". */
+  calendarId?: string;
+  /** Label ID from this tool's list action. Required for rename, recolor, and delete. */
+  labelId?: string;
+  /** Label name, at most 50 characters. Required for create and rename. */
+  name?: string;
+  /** Six-digit hexadecimal background color, for example #039be5. Required for create and recolor. */
+  backgroundColor?: string;
+};
+
+function validate(input: Input) {
+  if (input.action === "create" || input.action === "rename") {
+    if (input.name === undefined) throw new Error(`name is required to ${input.action} a label.`);
+    if (input.name.length > 50) throw new Error("Label names can contain at most 50 characters.");
+  }
+  if (input.action === "create" || input.action === "recolor") {
+    if (!input.backgroundColor) throw new Error(`backgroundColor is required to ${input.action} a label.`);
+    normalizeHexColor(input.backgroundColor, "backgroundColor");
+  }
+  if (input.action === "rename" || input.action === "recolor" || input.action === "delete") {
+    if (!input.labelId) throw new Error(`labelId is required to ${input.action} a label.`);
+  }
+}
+
+export const confirmation: Tool.Confirmation<Input> = withGoogleAPIs(async (input) => {
+  if (input.action === "list") return undefined;
+  validate(input);
+  const calendarId = input.calendarId ?? "primary";
+  await requireCalendarOwner(calendarId);
+  const calendar = await getCalendarWithLabels(calendarId);
+  const labels = getEventLabels(calendar);
+  const existing = input.labelId ? requireLabel(labels, input.labelId) : undefined;
+  return {
+    style: input.action === "delete" ? Action.Style.Destructive : Action.Style.Regular,
+    message:
+      input.action === "delete"
+        ? "Delete this custom event label from the calendar?"
+        : `${input.action.charAt(0).toUpperCase() + input.action.slice(1)} this custom event label?`,
+    info: [
+      { name: "Calendar", value: calendar.summary ?? calendarId },
+      { name: "Label", value: existing?.name ?? input.name },
+      { name: "Label ID", value: input.labelId },
+      { name: "New Name", value: input.action === "rename" ? input.name : undefined },
+      { name: "New Color", value: input.backgroundColor },
+    ],
+  };
+});
+
+const tool = async (input: Input) => {
+  validate(input);
+  const calendarId = input.calendarId ?? "primary";
+  const calendar = await getCalendarWithLabels(calendarId);
+  const labels = getEventLabels(calendar);
+  if (input.action === "list") return serializeCalendar(calendar);
+
+  await requireCalendarOwner(calendarId);
+  let updatedLabels;
+  if (input.action === "create") {
+    if (labels.length >= 200) throw new Error("This calendar already has the maximum of 200 event labels.");
+    updatedLabels = mergeEventLabels(labels, {
+      action: "create",
+      id: randomUUID(),
+      name: input.name!,
+      backgroundColor: input.backgroundColor!,
+    });
+  } else {
+    updatedLabels =
+      input.action === "rename"
+        ? mergeEventLabels(labels, { action: "rename", labelId: input.labelId!, name: input.name! })
+        : input.action === "recolor"
+          ? mergeEventLabels(labels, {
+              action: "recolor",
+              labelId: input.labelId!,
+              backgroundColor: input.backgroundColor!,
+            })
+          : mergeEventLabels(labels, { action: "delete", labelId: input.labelId! });
+  }
+
+  const updated = await replaceEventLabels(calendarId, calendar, updatedLabels);
+  return serializeCalendar(updated);
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/manage-calendar-labels.ts
+++ b/extensions/google-calendar/src/tools/manage-calendar-labels.ts
@@ -1,4 +1,4 @@
-import { Action, Tool } from "@raycast/api";
+import { Action } from "@raycast/api";
 import { randomUUID } from "node:crypto";
 import { mergeEventLabels } from "../lib/calendar-values";
 import {
@@ -39,7 +39,7 @@ function validate(input: Input) {
   }
 }
 
-export const confirmation: Tool.Confirmation<Input> = withGoogleAPIs(async (input) => {
+export const confirmation = withGoogleAPIs(async (input: Input) => {
   if (input.action === "list") return undefined;
   validate(input);
   const calendarId = input.calendarId ?? "primary";

--- a/extensions/google-calendar/src/tools/manage-calendar-list.ts
+++ b/extensions/google-calendar/src/tools/manage-calendar-list.ts
@@ -1,0 +1,174 @@
+import { Tool } from "@raycast/api";
+import { calendar_v3 } from "@googleapis/calendar";
+import { normalizeHexColor, serializeCalendarListEntry, writableCalendarListEntry } from "../lib/calendar-resources";
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+
+type Input = {
+  /** Operation on the authenticated user's CalendarList. Get is read-only. */
+  action: "get" | "insert" | "update" | "remove";
+  /** Calendar ID. Insert adds this existing calendar to the user's list. */
+  calendarId: string;
+  /** User-specific display title. Empty string clears the override. */
+  summaryOverride?: string;
+  /** User-specific six-digit hexadecimal background color. */
+  backgroundColor?: string;
+  /** User-specific six-digit hexadecimal foreground color. */
+  foregroundColor?: string;
+  /** Hide or show this entry in the calendar list. */
+  hidden?: boolean;
+  /** Whether events from this calendar appear in the Calendar UI. */
+  selected?: boolean;
+  /**
+   * Complete replacement reminders as comma-separated method:minutes pairs, e.g. "popup:10,email:60".
+   * Empty string clears all defaults.
+   */
+  defaultReminders?: string;
+  /**
+   * Complete replacement email notification types, comma-separated. Allowed: eventCreation,
+   * eventChange, eventCancellation, eventResponse, agenda. Empty string clears all.
+   */
+  notifications?: string;
+};
+
+const NOTIFICATION_TYPES = new Set(["eventCreation", "eventChange", "eventCancellation", "eventResponse", "agenda"]);
+
+function parseReminders(value: string | undefined): calendar_v3.Schema$EventReminder[] | undefined {
+  if (value === undefined) return undefined;
+  if (!value.trim()) return [];
+  return value.split(",").map((item) => {
+    const [method, rawMinutes, ...extra] = item.trim().split(":");
+    const minutes = Number(rawMinutes);
+    if (
+      extra.length ||
+      (method !== "email" && method !== "popup") ||
+      !Number.isInteger(minutes) ||
+      minutes < 0 ||
+      minutes > 40320
+    ) {
+      throw new Error(`Invalid reminder "${item}". Use email:minutes or popup:minutes with 0-40320.`);
+    }
+    return { method, minutes };
+  });
+}
+
+function parseNotifications(value: string | undefined): calendar_v3.Schema$CalendarNotification[] | undefined {
+  if (value === undefined) return undefined;
+  if (!value.trim()) return [];
+  return value.split(",").map((item) => {
+    const type = item.trim();
+    if (!NOTIFICATION_TYPES.has(type)) {
+      throw new Error(`Invalid notification type "${type}".`);
+    }
+    return { type, method: "email" };
+  });
+}
+
+function validate(input: Input) {
+  if (!input.calendarId.trim()) throw new Error("calendarId cannot be empty.");
+  if (input.backgroundColor !== undefined) normalizeHexColor(input.backgroundColor, "backgroundColor");
+  if (input.foregroundColor !== undefined) normalizeHexColor(input.foregroundColor, "foregroundColor");
+  parseReminders(input.defaultReminders);
+  parseNotifications(input.notifications);
+  if (
+    input.action === "update" &&
+    input.summaryOverride === undefined &&
+    input.backgroundColor === undefined &&
+    input.foregroundColor === undefined &&
+    input.hidden === undefined &&
+    input.selected === undefined &&
+    input.defaultReminders === undefined &&
+    input.notifications === undefined
+  ) {
+    throw new Error("No CalendarList changes were provided.");
+  }
+}
+
+function requestedProperties(input: Input): calendar_v3.Schema$CalendarListEntry {
+  return {
+    ...(input.summaryOverride !== undefined ? { summaryOverride: input.summaryOverride } : {}),
+    ...(input.backgroundColor !== undefined
+      ? { backgroundColor: normalizeHexColor(input.backgroundColor, "backgroundColor") }
+      : {}),
+    ...(input.foregroundColor !== undefined
+      ? { foregroundColor: normalizeHexColor(input.foregroundColor, "foregroundColor") }
+      : {}),
+    ...(input.hidden !== undefined ? { hidden: input.hidden } : {}),
+    ...(input.selected !== undefined ? { selected: input.selected } : {}),
+    ...(input.defaultReminders !== undefined ? { defaultReminders: parseReminders(input.defaultReminders) } : {}),
+    ...(input.notifications !== undefined
+      ? { notificationSettings: { notifications: parseNotifications(input.notifications) } }
+      : {}),
+  };
+}
+
+export const confirmation: Tool.Confirmation<Input> = withGoogleAPIs(async (input) => {
+  if (input.action === "get") return undefined;
+  validate(input);
+  const calendar = getCalendarClient();
+  let name: string | undefined;
+  if (input.action === "insert") {
+    name = (await calendar.calendars.get({ calendarId: input.calendarId })).data.summary ?? undefined;
+  } else {
+    const current = await calendar.calendarList.get({ calendarId: input.calendarId });
+    if (input.action === "remove" && current.data.primary) {
+      throw new Error("The primary calendar cannot be removed from CalendarList.");
+    }
+    name = current.data.summaryOverride ?? current.data.summary ?? undefined;
+  }
+  return {
+    message:
+      input.action === "remove"
+        ? "Remove this calendar from your calendar list? The calendar itself will not be deleted."
+        : `${input.action === "insert" ? "Add" : "Update"} this calendar-list entry?`,
+    info: [
+      { name: "Calendar", value: name },
+      { name: "Calendar ID", value: input.calendarId },
+      { name: "Summary Override", value: input.summaryOverride },
+      { name: "Background", value: input.backgroundColor },
+      { name: "Foreground", value: input.foregroundColor },
+      { name: "Hidden", value: input.hidden?.toString() },
+      { name: "Selected", value: input.selected?.toString() },
+      { name: "Default Reminders", value: input.defaultReminders },
+      { name: "Notifications", value: input.notifications },
+    ],
+  };
+});
+
+const tool = async (input: Input) => {
+  validate(input);
+  const calendar = getCalendarClient();
+  if (input.action === "get") {
+    const response = await calendar.calendarList.get({ calendarId: input.calendarId });
+    return serializeCalendarListEntry(response.data);
+  }
+  if (input.action === "remove") {
+    const current = await calendar.calendarList.get({ calendarId: input.calendarId });
+    if (current.data.primary) throw new Error("The primary calendar cannot be removed from CalendarList.");
+    await calendar.calendarList.delete({ calendarId: input.calendarId });
+    return { removed: true, calendarId: input.calendarId };
+  }
+
+  const usesRgb = input.backgroundColor !== undefined || input.foregroundColor !== undefined;
+  if (input.action === "insert") {
+    const response = await calendar.calendarList.insert({
+      colorRgbFormat: usesRgb || undefined,
+      requestBody: { id: input.calendarId, ...requestedProperties(input) },
+    });
+    return serializeCalendarListEntry(response.data);
+  }
+
+  const current = await calendar.calendarList.get({ calendarId: input.calendarId });
+  const preserveRgb = usesRgb || Boolean(current.data.backgroundColor || current.data.foregroundColor);
+  const requestBody = {
+    ...writableCalendarListEntry(current.data),
+    ...requestedProperties(input),
+    id: input.calendarId,
+  };
+  const response = await calendar.calendarList.update(
+    { calendarId: input.calendarId, colorRgbFormat: preserveRgb || undefined, requestBody },
+    current.data.etag ? { headers: { "If-Match": current.data.etag } } : undefined,
+  );
+  return serializeCalendarListEntry(response.data);
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/manage-calendar-list.ts
+++ b/extensions/google-calendar/src/tools/manage-calendar-list.ts
@@ -1,4 +1,3 @@
-import { Tool } from "@raycast/api";
 import { calendar_v3 } from "@googleapis/calendar";
 import { normalizeHexColor, serializeCalendarListEntry, writableCalendarListEntry } from "../lib/calendar-resources";
 import { getCalendarClient, withGoogleAPIs } from "../lib/google";
@@ -101,7 +100,7 @@ function requestedProperties(input: Input): calendar_v3.Schema$CalendarListEntry
   };
 }
 
-export const confirmation: Tool.Confirmation<Input> = withGoogleAPIs(async (input) => {
+export const confirmation = withGoogleAPIs(async (input: Input) => {
   if (input.action === "get") return undefined;
   validate(input);
   const calendar = getCalendarClient();

--- a/extensions/google-calendar/src/tools/manage-calendar-sharing.ts
+++ b/extensions/google-calendar/src/tools/manage-calendar-sharing.ts
@@ -1,4 +1,4 @@
-import { Action, Tool } from "@raycast/api";
+import { Action } from "@raycast/api";
 import { calendar_v3 } from "@googleapis/calendar";
 import { requireCalendarOwner, serializeAclRule } from "../lib/calendar-resources";
 import { getCalendarClient, withGoogleAPIs } from "../lib/google";
@@ -67,7 +67,7 @@ async function currentRule(input: Input) {
   ).data;
 }
 
-export const confirmation: Tool.Confirmation<Input> = withGoogleAPIs(async (input) => {
+export const confirmation = withGoogleAPIs(async (input: Input) => {
   if (input.action === "list" || input.action === "get") return undefined;
   validate(input);
   const calendarId = input.calendarId ?? "primary";

--- a/extensions/google-calendar/src/tools/manage-calendar-sharing.ts
+++ b/extensions/google-calendar/src/tools/manage-calendar-sharing.ts
@@ -1,0 +1,152 @@
+import { Action, Tool } from "@raycast/api";
+import { calendar_v3 } from "@googleapis/calendar";
+import { requireCalendarOwner, serializeAclRule } from "../lib/calendar-resources";
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+
+type ScopeType = "user" | "group" | "domain" | "default";
+type AccessRole = "freeBusyReader" | "reader" | "writerWithoutPrivateAccess" | "writer" | "owner";
+
+type Input = {
+  /** Sharing operation. List and get are read-only. */
+  action: "list" | "get" | "grant" | "update" | "revoke";
+  /** Calendar ID from list-calendars. Defaults to "primary". */
+  calendarId?: string;
+  /** ACL rule ID from list. Required for get, update, and revoke. */
+  ruleId?: string;
+  /** Grantee kind. Required for grant. "default" means public access. */
+  scopeType?: ScopeType;
+  /** User/group email or domain. Required except for default/public scope. */
+  scopeValue?: string;
+  /** Access level. Required for grant and update. */
+  role?: AccessRole;
+  /** Send Google sharing-change notifications. Defaults to true. */
+  sendNotifications?: boolean;
+  /** Maximum rules in a list page, 1-250. Defaults to 100. */
+  maxResults?: number;
+  /** Opaque nextPageToken from an earlier list call. */
+  pageToken?: string;
+  /** Include deleted ACL rules in list results. */
+  showDeleted?: boolean;
+};
+
+function validate(input: Input) {
+  if (["get", "update", "revoke"].includes(input.action) && !input.ruleId) {
+    throw new Error(`ruleId is required to ${input.action} an access rule.`);
+  }
+  if (input.action === "grant") {
+    if (!input.scopeType) throw new Error("scopeType is required to grant access.");
+    if (!input.role) throw new Error("role is required to grant access.");
+    if (input.scopeType === "default" && input.scopeValue) {
+      throw new Error("scopeValue must be omitted for default/public access.");
+    }
+    if (input.scopeType !== "default" && !input.scopeValue?.trim()) {
+      throw new Error(`scopeValue is required for ${input.scopeType} access.`);
+    }
+    if (
+      (input.scopeType === "user" || input.scopeType === "group") &&
+      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input.scopeValue ?? "")
+    ) {
+      throw new Error("User and group scopeValue must be a valid email address.");
+    }
+  }
+  if (input.action === "update" && !input.role) throw new Error("role is required to update access.");
+  if (input.action === "list") {
+    const maxResults = input.maxResults ?? 100;
+    if (!Number.isInteger(maxResults) || maxResults < 1 || maxResults > 250) {
+      throw new Error("maxResults must be a whole number from 1 to 250.");
+    }
+  }
+}
+
+async function currentRule(input: Input) {
+  return (
+    await getCalendarClient().acl.get({
+      calendarId: input.calendarId ?? "primary",
+      ruleId: input.ruleId!,
+    })
+  ).data;
+}
+
+export const confirmation: Tool.Confirmation<Input> = withGoogleAPIs(async (input) => {
+  if (input.action === "list" || input.action === "get") return undefined;
+  validate(input);
+  const calendarId = input.calendarId ?? "primary";
+  await requireCalendarOwner(calendarId);
+  const existing = input.action === "update" || input.action === "revoke" ? await currentRule(input) : undefined;
+  const publicAccess = input.scopeType === "default" || existing?.scope?.type === "default";
+  return {
+    style: input.action === "revoke" || publicAccess ? Action.Style.Destructive : Action.Style.Regular,
+    message:
+      input.action === "revoke"
+        ? "Revoke this calendar access rule?"
+        : publicAccess
+          ? "Apply public access to this calendar?"
+          : `${input.action === "grant" ? "Grant" : "Update"} calendar access?`,
+    info: [
+      { name: "Calendar ID", value: calendarId },
+      { name: "Rule ID", value: input.ruleId },
+      { name: "Scope", value: existing?.scope?.type ?? input.scopeType },
+      { name: "Grantee", value: existing?.scope?.value ?? input.scopeValue ?? (publicAccess ? "Anyone" : undefined) },
+      { name: "Current Role", value: existing?.role ?? undefined },
+      { name: "New Role", value: input.role },
+      { name: "Send Notification", value: (input.sendNotifications ?? true).toString() },
+    ],
+  };
+});
+
+const tool = async (input: Input) => {
+  validate(input);
+  const calendar = getCalendarClient();
+  const calendarId = input.calendarId ?? "primary";
+  if (input.action === "list") {
+    const response = await calendar.acl.list({
+      calendarId,
+      maxResults: input.maxResults ?? 100,
+      pageToken: input.pageToken,
+      showDeleted: input.showDeleted,
+    });
+    return {
+      calendarId,
+      nextPageToken: response.data.nextPageToken,
+      nextSyncToken: response.data.nextSyncToken,
+      rules: response.data.items?.map(serializeAclRule) ?? [],
+    };
+  }
+  if (input.action === "get") return serializeAclRule(await currentRule(input));
+
+  await requireCalendarOwner(calendarId);
+  if (input.action === "revoke") {
+    const existing = await currentRule(input);
+    await calendar.acl.delete({ calendarId, ruleId: input.ruleId! });
+    return { revoked: true, calendarId, rule: serializeAclRule(existing) };
+  }
+  if (input.action === "grant") {
+    const response = await calendar.acl.insert({
+      calendarId,
+      sendNotifications: input.sendNotifications ?? true,
+      requestBody: {
+        role: input.role,
+        scope: {
+          type: input.scopeType,
+          ...(input.scopeType !== "default" ? { value: input.scopeValue } : {}),
+        },
+      },
+    });
+    return serializeAclRule(response.data);
+  }
+
+  const existing = await currentRule(input);
+  const requestBody: calendar_v3.Schema$AclRule = { role: input.role, scope: existing.scope };
+  const response = await calendar.acl.update(
+    {
+      calendarId,
+      ruleId: input.ruleId!,
+      sendNotifications: input.sendNotifications ?? true,
+      requestBody,
+    },
+    existing.etag ? { headers: { "If-Match": existing.etag } } : undefined,
+  );
+  return serializeAclRule(response.data);
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/manage-calendar.ts
+++ b/extensions/google-calendar/src/tools/manage-calendar.ts
@@ -1,0 +1,113 @@
+import { Action, Tool } from "@raycast/api";
+import { assertNonEmpty, assertTimeZone, requireCalendarOwner, serializeCalendar } from "../lib/calendar-resources";
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+
+type Input = {
+  /** Metadata operation. Get is read-only. Create always creates a new secondary calendar. */
+  action: "get" | "create" | "update" | "delete";
+  /** Calendar ID from list-calendars. Required for update/delete; defaults to "primary" for get. */
+  calendarId?: string;
+  /** Calendar title. Required for create. */
+  summary?: string;
+  /** Calendar description. Empty string clears it during update. */
+  description?: string;
+  /** Free-form geographic location. Empty string clears it during update. */
+  location?: string;
+  /** IANA time zone such as Europe/Zurich. */
+  timeZone?: string;
+};
+
+function validate(input: Input) {
+  if ((input.action === "update" || input.action === "delete") && !input.calendarId) {
+    throw new Error(`calendarId is required to ${input.action} a calendar.`);
+  }
+  if (input.action === "create" && input.summary === undefined)
+    throw new Error("summary is required to create a calendar.");
+  if (input.summary !== undefined) assertNonEmpty(input.summary, "summary");
+  assertTimeZone(input.timeZone);
+  if (
+    input.action === "update" &&
+    input.summary === undefined &&
+    input.description === undefined &&
+    input.location === undefined &&
+    input.timeZone === undefined
+  ) {
+    throw new Error("No calendar metadata changes were provided.");
+  }
+}
+
+async function requireSecondaryOwner(calendarId: string) {
+  const entry = await requireCalendarOwner(calendarId);
+  if (entry.primary || calendarId === "primary") {
+    throw new Error("The primary calendar cannot be deleted. This tool never clears a primary calendar.");
+  }
+  return entry;
+}
+
+export const confirmation: Tool.Confirmation<Input> = withGoogleAPIs(async (input) => {
+  if (input.action === "get") return undefined;
+  validate(input);
+  const calendar = getCalendarClient();
+  let currentSummary: string | undefined;
+  if (input.action === "update") {
+    await requireCalendarOwner(input.calendarId!);
+    currentSummary = (await calendar.calendars.get({ calendarId: input.calendarId! })).data.summary ?? undefined;
+  } else if (input.action === "delete") {
+    await requireSecondaryOwner(input.calendarId!);
+    currentSummary = (await calendar.calendars.get({ calendarId: input.calendarId! })).data.summary ?? undefined;
+  }
+  return {
+    style: input.action === "delete" ? Action.Style.Destructive : Action.Style.Regular,
+    message:
+      input.action === "delete"
+        ? "Permanently delete this secondary calendar and all of its events?"
+        : `${input.action === "create" ? "Create" : "Update"} this calendar?`,
+    info: [
+      { name: "Calendar", value: currentSummary ?? input.summary },
+      { name: "Calendar ID", value: input.calendarId },
+      { name: "New Summary", value: input.action === "update" ? input.summary : undefined },
+      { name: "Description", value: input.description },
+      { name: "Location", value: input.location },
+      { name: "Time Zone", value: input.timeZone },
+    ],
+  };
+});
+
+const tool = async (input: Input) => {
+  validate(input);
+  const calendar = getCalendarClient();
+  if (input.action === "get") {
+    const response = await calendar.calendars.get({ calendarId: input.calendarId ?? "primary" });
+    return serializeCalendar(response.data);
+  }
+  if (input.action === "create") {
+    const response = await calendar.calendars.insert({
+      requestBody: {
+        summary: input.summary,
+        description: input.description,
+        location: input.location,
+        timeZone: input.timeZone,
+      },
+    });
+    return serializeCalendar(response.data);
+  }
+  if (input.action === "delete") {
+    await requireSecondaryOwner(input.calendarId!);
+    await calendar.calendars.delete({ calendarId: input.calendarId! });
+    return { deleted: true, calendarId: input.calendarId };
+  }
+
+  await requireCalendarOwner(input.calendarId!);
+  const response = await calendar.calendars.patch({
+    calendarId: input.calendarId!,
+    requestBody: {
+      ...(input.summary !== undefined ? { summary: input.summary } : {}),
+      ...(input.description !== undefined ? { description: input.description } : {}),
+      ...(input.location !== undefined ? { location: input.location } : {}),
+      ...(input.timeZone !== undefined ? { timeZone: input.timeZone } : {}),
+    },
+  });
+  return serializeCalendar(response.data);
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/manage-calendar.ts
+++ b/extensions/google-calendar/src/tools/manage-calendar.ts
@@ -1,4 +1,4 @@
-import { Action, Tool } from "@raycast/api";
+import { Action } from "@raycast/api";
 import { assertNonEmpty, assertTimeZone, requireCalendarOwner, serializeCalendar } from "../lib/calendar-resources";
 import { getCalendarClient, withGoogleAPIs } from "../lib/google";
 
@@ -44,7 +44,7 @@ async function requireSecondaryOwner(calendarId: string) {
   return entry;
 }
 
-export const confirmation: Tool.Confirmation<Input> = withGoogleAPIs(async (input) => {
+export const confirmation = withGoogleAPIs(async (input: Input) => {
   if (input.action === "get") return undefined;
   validate(input);
   const calendar = getCalendarClient();

--- a/extensions/google-calendar/src/tools/move-event.ts
+++ b/extensions/google-calendar/src/tools/move-event.ts
@@ -1,0 +1,49 @@
+import { getPreferenceValues } from "@raycast/api";
+import { getNotificationLevel, serializeEvent } from "../lib/events";
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+
+type Input = {
+  /** Google Calendar event ID, usually obtained from search-events or get-event. */
+  eventId: string;
+  /** Calendar currently containing the event. Defaults to "primary". */
+  sourceCalendarId?: string;
+  /** Destination calendar ID from list-calendars. Moving changes the event organizer. */
+  destinationCalendarId: string;
+  /** Guest notification level. Defaults to the extension preference. */
+  notificationLevel?: "all" | "externalOnly" | "none";
+};
+
+async function getSourceEvent(input: Input) {
+  const calendarId = input.sourceCalendarId ?? "primary";
+  const response = await getCalendarClient().events.get({ calendarId, eventId: input.eventId });
+  if (response.data.eventType && response.data.eventType !== "default") {
+    throw new Error(`Google only supports moving default events; this is a "${response.data.eventType}" event.`);
+  }
+  return response.data;
+}
+
+export const confirmation = withGoogleAPIs(async (input: Input) => {
+  const event = await getSourceEvent(input);
+  return {
+    message: "Move this event to another calendar and change its organizer?",
+    info: [
+      { name: "Event", value: event.summary ?? "Untitled Event" },
+      { name: "From", value: input.sourceCalendarId ?? "primary" },
+      { name: "To", value: input.destinationCalendarId },
+    ],
+  };
+});
+
+const tool = async (input: Input) => {
+  const preferences = getPreferenceValues<Preferences>();
+  await getSourceEvent(input);
+  const response = await getCalendarClient().events.move({
+    calendarId: input.sourceCalendarId ?? "primary",
+    destination: input.destinationCalendarId,
+    eventId: input.eventId,
+    sendUpdates: getNotificationLevel(input, preferences.sendInvitations),
+  });
+  return serializeEvent(response.data, input.destinationCalendarId);
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/quick-add-event.ts
+++ b/extensions/google-calendar/src/tools/quick-add-event.ts
@@ -14,7 +14,7 @@ type Input = {
   notificationLevel?: "all" | "externalOnly" | "none";
 };
 
-export const confirmation: Tool.Confirmation<Input> = (input) => ({
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
   message: "Let Google Calendar parse this text and create an event?",
   info: [
     { name: "Calendar", value: input.calendarId ?? "primary" },

--- a/extensions/google-calendar/src/tools/quick-add-event.ts
+++ b/extensions/google-calendar/src/tools/quick-add-event.ts
@@ -1,0 +1,37 @@
+import { getPreferenceValues, Tool } from "@raycast/api";
+import { getNotificationLevel, serializeEvent } from "../lib/events";
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+
+type Input = {
+  /**
+   * Natural-language event text understood by Google Calendar, such as
+   * "Dinner with Alex tomorrow at 7pm for 2 hours".
+   */
+  text: string;
+  /** Calendar in which to create the event. Defaults to "primary". */
+  calendarId?: string;
+  /** Guest notification level. Defaults to the extension preference. */
+  notificationLevel?: "all" | "externalOnly" | "none";
+};
+
+export const confirmation: Tool.Confirmation<Input> = (input) => ({
+  message: "Let Google Calendar parse this text and create an event?",
+  info: [
+    { name: "Calendar", value: input.calendarId ?? "primary" },
+    { name: "Event Text", value: input.text },
+  ],
+});
+
+const tool = async (input: Input) => {
+  if (!input.text.trim()) throw new Error("text cannot be empty.");
+  const preferences = getPreferenceValues<Preferences>();
+  const calendarId = input.calendarId ?? "primary";
+  const response = await getCalendarClient().events.quickAdd({
+    calendarId,
+    text: input.text,
+    sendUpdates: getNotificationLevel(input, preferences.sendInvitations),
+  });
+  return serializeEvent(response.data, calendarId);
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/respond-to-event.ts
+++ b/extensions/google-calendar/src/tools/respond-to-event.ts
@@ -1,0 +1,71 @@
+import { getPreferenceValues } from "@raycast/api";
+import { getNotificationLevel, serializeEvent } from "../lib/events";
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+import { tool as getCurrentUser } from "./get-current-user";
+
+type Input = {
+  /** Google Calendar event ID, usually obtained from search-events or get-event. */
+  eventId: string;
+  /** Calendar containing the invitation. Defaults to "primary". */
+  calendarId?: string;
+  /** RSVP response. needsAction resets an existing response. */
+  response: "accepted" | "declined" | "tentative" | "needsAction";
+  /** Optional response comment visible to the organizer. Empty string clears a previous comment. */
+  comment?: string;
+  /** Notification level for the response. Defaults to the extension preference. */
+  notificationLevel?: "all" | "externalOnly" | "none";
+};
+
+async function getSelfAttendee(input: Input) {
+  const calendarId = input.calendarId ?? "primary";
+  const event = await getCalendarClient().events.get({ calendarId, eventId: input.eventId });
+  let attendee = event.data.attendees?.find((candidate) => candidate.self);
+  if (!attendee) {
+    const currentUser = await getCurrentUser();
+    attendee = event.data.attendees?.find(
+      (candidate) => candidate.email?.toLowerCase() === currentUser.email?.toLowerCase(),
+    );
+  }
+  if (!attendee?.email) throw new Error("The current user is not an attendee of this event.");
+  return { event: event.data, attendee };
+}
+
+export const confirmation = withGoogleAPIs(async (input: Input) => {
+  const { event, attendee } = await getSelfAttendee(input);
+  return {
+    message: `Respond "${input.response}" to this invitation?`,
+    info: [
+      { name: "Event", value: event.summary ?? "Untitled Event" },
+      { name: "Attendee", value: attendee.email },
+      { name: "Current Response", value: attendee.responseStatus },
+      { name: "New Response", value: input.response },
+      { name: "Comment", value: input.comment },
+    ],
+  };
+});
+
+const tool = async (input: Input) => {
+  const preferences = getPreferenceValues<Preferences>();
+  const calendarId = input.calendarId ?? "primary";
+  const { attendee } = await getSelfAttendee(input);
+  const calendar = getCalendarClient();
+  await calendar.events.patch({
+    calendarId,
+    eventId: input.eventId,
+    sendUpdates: getNotificationLevel(input, preferences.sendInvitations),
+    requestBody: {
+      attendeesOmitted: true,
+      attendees: [
+        {
+          email: attendee.email,
+          responseStatus: input.response,
+          ...(input.comment !== undefined ? { comment: input.comment } : {}),
+        },
+      ],
+    },
+  });
+  const updated = await calendar.events.get({ calendarId, eventId: input.eventId });
+  return serializeEvent(updated.data, calendarId);
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/search-events.ts
+++ b/extensions/google-calendar/src/tools/search-events.ts
@@ -1,101 +1,101 @@
-import { withGoogleAPIs, getCalendarClient } from "../lib/google";
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+import { getCalendarWithLabels, getEventLabels } from "../lib/calendar-resources";
+import { serializeEvent } from "../lib/events";
 
 type Input = {
   /**
-   * Free text search terms to find events
-   *
-   * @example When user asks "find my 1:1 with Beth", use query "beth" to find meetings where Beth is an attendee
-   * @example When user asks "show my team meetings", use query "team" to find relevant meetings
-   *
-   * @remarks
-   * - Focus on key identifying terms rather than guessing exact meeting titles
-   * - For 1:1s or meetings with specific people, search for the person's name only
-   * - For topic-based searches, use key topic words (e.g. "standup", "planning", "review")
-   *
-   * Searches across these calendar event fields:
-   * - summary/title
-   * - description
-   * - location
-   * - attendee's displayName and email
-   * - organizer's displayName and email
+   * Free-text terms matched against title, description, location, attendees, organizer, and
+   * special-event/working-location fields. Use identifying keywords rather than guessed titles.
    */
   query?: string;
-
-  /**
-   * The start date to search from
-   *
-   * @example "2024-03-20T00:00:00-07:00" or "2024-03-20T00:00:00+02:00"
-   *
-   * @remarks
-   * Accepts ISO 8601 format dates with timezone offset for accurate timezone handling.
-   * If not provided, defaults to current time.
-   * Can be a date (YYYY-MM-DD) or datetime with timezone offset (YYYY-MM-DDTHH:mm:ss±HH:MM).
-   * For accurate timezone handling, always include the timezone offset (e.g., -07:00, +02:00) rather than using Z (UTC).
-   */
+  /** RFC3339 lower bound for event end times. Defaults to now unless includePast is true. */
   timeMin?: string;
-
-  /**
-   * The end date to search until
-   *
-   * @example "2024-03-27T23:59:59-07:00" or "2024-03-27T23:59:59+02:00"
-   *
-   * @remarks
-   * Accepts ISO 8601 format dates with timezone offset for accurate timezone handling.
-   * Can be a date (YYYY-MM-DD) or datetime with timezone offset (YYYY-MM-DDTHH:mm:ss±HH:MM).
-   * For accurate timezone handling, always include the timezone offset (e.g., -07:00, +02:00) rather than using Z (UTC).
-   */
+  /** RFC3339 exclusive upper bound for event start times. */
   timeMax?: string;
-
-  /**
-   * Maximum number of events to return
-   *
-   * @default 10
-   * @minimum 1
-   * @maximum 2500
-   *
-   * @remarks
-   * The Google Calendar API has a maximum limit of 2500 events per request.
-   */
+  /** Search before the current time when no timeMin is supplied. */
+  includePast?: boolean;
+  /** Maximum page size, from 1 to 2500. Defaults to 10. */
   maxResults?: number;
-
-  /**
-   * The ID of the calendar to search
-   *
-   * @example "primary" or "email@abstract...com"
-   * @default "primary"
-   *
-   * @remarks
-   * If not provided, searches the user's primary calendar. If used, get this from `list-calendars` tool.
-   */
+  /** Opaque token returned as nextPageToken by an earlier search-events call. */
+  pageToken?: string;
+  /** Calendar ID from list-calendars. Defaults to "primary". */
   calendarId?: string;
+  /** Expand recurring series into individual instances. Defaults to true. */
+  singleEvents?: boolean;
+  /** Sort by startTime (requires singleEvents=true) or updated. Defaults to startTime. */
+  orderBy?: "startTime" | "updated";
+  /** Include cancelled/deleted events. */
+  showDeleted?: boolean;
+  /** Include hidden invitations. */
+  showHiddenInvitations?: boolean;
+  /** Comma-separated event types to return. Omit for all types. */
+  eventTypes?: string;
+  /** Find an event by RFC5545 iCalendar UID rather than Google event ID. */
+  iCalUID?: string;
+  /** Only return events updated at or after this RFC3339 timestamp. */
+  updatedMin?: string;
+  /** IANA time zone used to format returned event times. */
+  timeZone?: string;
+  /** Maximum attendees included per event. */
+  maxAttendees?: number;
+  /** Comma-separated private extended-property filters in propertyName=value form. */
+  privateExtendedProperties?: string;
+  /** Comma-separated shared extended-property filters in propertyName=value form. */
+  sharedExtendedProperties?: string;
 };
+
+function parseList(value?: string) {
+  return value
+    ?.split(/[,\n]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
 
 const tool = async (input: Input) => {
   const calendar = getCalendarClient();
+  const calendarId = input.calendarId ?? "primary";
+  const singleEvents = input.singleEvents ?? true;
+  const orderBy = input.orderBy ?? (singleEvents ? "startTime" : undefined);
+  if (orderBy === "startTime" && !singleEvents) {
+    throw new Error('orderBy="startTime" requires singleEvents=true.');
+  }
+  const maxResults = input.maxResults ?? 10;
+  if (!Number.isInteger(maxResults) || maxResults < 1 || maxResults > 2500) {
+    throw new Error("maxResults must be a whole number from 1 to 2500.");
+  }
 
-  const requestParams = {
-    calendarId: input.calendarId || "primary",
-    q: input.query,
-    timeMin: input.timeMin || new Date().toISOString(),
-    timeMax: input.timeMax,
-    maxResults: input.maxResults || 10,
-    singleEvents: true,
-    orderBy: "startTime" as const,
+  const [response, calendarMetadata] = await Promise.all([
+    calendar.events.list({
+      calendarId,
+      q: input.query,
+      timeMin: input.timeMin ?? (input.includePast ? undefined : new Date().toISOString()),
+      timeMax: input.timeMax,
+      maxResults,
+      pageToken: input.pageToken,
+      singleEvents,
+      orderBy,
+      showDeleted: input.showDeleted,
+      showHiddenInvitations: input.showHiddenInvitations,
+      eventTypes: parseList(input.eventTypes),
+      iCalUID: input.iCalUID,
+      updatedMin: input.updatedMin,
+      timeZone: input.timeZone,
+      maxAttendees: input.maxAttendees,
+      privateExtendedProperty: parseList(input.privateExtendedProperties),
+      sharedExtendedProperty: parseList(input.sharedExtendedProperties),
+    }),
+    getCalendarWithLabels(calendarId),
+  ]);
+
+  return {
+    calendarId,
+    calendarSummary: response.data.summary,
+    timeZone: response.data.timeZone,
+    nextPageToken: response.data.nextPageToken,
+    nextSyncToken: response.data.nextSyncToken,
+    events:
+      response.data.items?.map((event) => serializeEvent(event, calendarId, getEventLabels(calendarMetadata))) ?? [],
   };
-
-  const response = await calendar.events.list(requestParams);
-
-  return (
-    response.data.items?.map((event) => ({
-      id: event.id || "",
-      title: event.summary || "Untitled Event",
-      start: event.start?.dateTime || event.start?.date || "No start date",
-      end: event.end?.dateTime || event.end?.date || "No end date",
-      attendees: event.attendees?.map((a) => a.email) || [],
-      description: event.description,
-      link: event.htmlLink,
-    })) || []
-  );
 };
 
 export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/set-event-label.ts
+++ b/extensions/google-calendar/src/tools/set-event-label.ts
@@ -1,0 +1,66 @@
+import { Tool } from "@raycast/api";
+import {
+  EventLabelVersionParams,
+  EventWithLabel,
+  getCalendarWithLabels,
+  getEventLabels,
+  requireLabel,
+} from "../lib/calendar-resources";
+import { serializeEvent } from "../lib/events";
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+
+type Input = {
+  /** Assign a custom calendar label or remove the current label. */
+  action: "assign" | "remove";
+  /** Event ID from search-events or get-event. */
+  eventId: string;
+  /** Calendar containing the event. Defaults to "primary". */
+  calendarId?: string;
+  /** Label ID from manage-calendar-labels. Required when assigning. */
+  labelId?: string;
+};
+
+async function context(input: Input) {
+  if (input.action === "assign" && !input.labelId) throw new Error("labelId is required when assigning a label.");
+  const calendarId = input.calendarId ?? "primary";
+  const calendar = getCalendarClient();
+  const [entry, event, metadata] = await Promise.all([
+    calendar.calendarList.get({ calendarId }),
+    calendar.events.get({ calendarId, eventId: input.eventId }),
+    getCalendarWithLabels(calendarId),
+  ]);
+  if (!["writerWithoutPrivateAccess", "writer", "owner"].includes(entry.data.accessRole ?? "")) {
+    throw new Error("At least writerWithoutPrivateAccess access is required to assign event labels.");
+  }
+  const label = input.action === "assign" ? requireLabel(getEventLabels(metadata), input.labelId!) : undefined;
+  return { calendarId, event: event.data, label };
+}
+
+export const confirmation: Tool.Confirmation<Input> = withGoogleAPIs(async (input) => {
+  const { event, label } = await context(input);
+  return {
+    message:
+      input.action === "assign" ? "Assign this custom label to the event?" : "Remove the custom label from the event?",
+    info: [
+      { name: "Event", value: event.summary ?? "Untitled Event" },
+      { name: "Label", value: label?.name ?? (input.action === "remove" ? "(remove)" : undefined) },
+      { name: "Label ID", value: label?.id ?? undefined },
+      { name: "Color", value: label?.backgroundColor ?? undefined },
+    ],
+  };
+});
+
+const tool = async (input: Input) => {
+  const { calendarId, label } = await context(input);
+  const requestBody: EventWithLabel = { eventLabelId: input.action === "assign" ? label?.id : "" };
+  const params = {
+    calendarId,
+    eventId: input.eventId,
+    requestBody,
+    eventLabelVersion: 1,
+  } satisfies Parameters<ReturnType<typeof getCalendarClient>["events"]["patch"]>[0] & EventLabelVersionParams;
+  const response = await getCalendarClient().events.patch(params);
+  return serializeEvent(response.data, calendarId, getEventLabels(await getCalendarWithLabels(calendarId)));
+};
+
+export default withGoogleAPIs(tool);

--- a/extensions/google-calendar/src/tools/set-event-label.ts
+++ b/extensions/google-calendar/src/tools/set-event-label.ts
@@ -1,4 +1,4 @@
-import { Tool } from "@raycast/api";
+import { calendar_v3 } from "@googleapis/calendar";
 import {
   EventLabelVersionParams,
   EventWithLabel,
@@ -36,7 +36,7 @@ async function context(input: Input) {
   return { calendarId, event: event.data, label };
 }
 
-export const confirmation: Tool.Confirmation<Input> = withGoogleAPIs(async (input) => {
+export const confirmation = withGoogleAPIs(async (input: Input) => {
   const { event, label } = await context(input);
   return {
     message:
@@ -53,12 +53,12 @@ export const confirmation: Tool.Confirmation<Input> = withGoogleAPIs(async (inpu
 const tool = async (input: Input) => {
   const { calendarId, label } = await context(input);
   const requestBody: EventWithLabel = { eventLabelId: input.action === "assign" ? label?.id : "" };
-  const params = {
+  const params: calendar_v3.Params$Resource$Events$Patch & EventLabelVersionParams = {
     calendarId,
     eventId: input.eventId,
     requestBody,
     eventLabelVersion: 1,
-  } satisfies Parameters<ReturnType<typeof getCalendarClient>["events"]["patch"]>[0] & EventLabelVersionParams;
+  };
   const response = await getCalendarClient().events.patch(params);
   return serializeEvent(response.data, calendarId, getEventLabels(await getCalendarWithLabels(calendarId)));
 };

--- a/extensions/google-calendar/src/tools/suggest-time.ts
+++ b/extensions/google-calendar/src/tools/suggest-time.ts
@@ -1,0 +1,79 @@
+import { getCalendarClient, withGoogleAPIs } from "../lib/google";
+import { computeSuggestedSlots, validateSuggestionInput } from "../lib/suggest-time";
+import { parseAttendeeEmails } from "../lib/utils";
+import { tool as getCurrentUser } from "./get-current-user";
+
+type Input = {
+  /** Comma-separated attendee or calendar emails. The current user is always included. */
+  attendees?: string;
+  /** Inclusive RFC3339 start of the range to search. */
+  timeMin: string;
+  /** Exclusive RFC3339 end of the range to search. */
+  timeMax: string;
+  /** Required meeting length in minutes. */
+  durationMinutes: number;
+  /** IANA time zone used for work hours and displayed suggestions. Defaults to the user's local zone. */
+  timeZone?: string;
+  /** Local workday start as HH:mm. Defaults to 09:00. */
+  workDayStart?: string;
+  /** Local workday end as HH:mm. Defaults to 17:00. */
+  workDayEnd?: string;
+  /** Include Saturday and Sunday. Defaults to false. */
+  includeWeekends?: boolean;
+  /** Slot-start interval in minutes. Defaults to 15. */
+  incrementMinutes?: number;
+  /** Free buffer required before and after busy periods, in minutes. Defaults to 0. */
+  bufferMinutes?: number;
+  /** Maximum suggestions to return. Defaults to 10, maximum 50. */
+  maxSuggestions?: number;
+};
+
+const tool = async (input: Input) => {
+  const buffer = input.bufferMinutes ?? 0;
+  if (!Number.isFinite(buffer) || buffer < 0) throw new Error("bufferMinutes cannot be negative.");
+
+  const timeZone = input.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const suggestionInput = { ...input, timeZone };
+  validateSuggestionInput(suggestionInput);
+
+  const { emails, invalidEntries } = parseAttendeeEmails(input.attendees);
+  if (invalidEntries.length) throw new Error(`Invalid attendee email: ${invalidEntries.join(", ")}`);
+  const currentUser = await getCurrentUser();
+  if (!currentUser.email) throw new Error("Could not determine the current user's calendar email.");
+  const participants = [...new Set([...emails, currentUser.email].map((email) => email.toLowerCase()))];
+
+  const freeBusy = await getCalendarClient().freebusy.query({
+    requestBody: {
+      timeMin: input.timeMin,
+      timeMax: input.timeMax,
+      timeZone,
+      items: participants.map((id) => ({ id })),
+    },
+  });
+  const errors = Object.entries(freeBusy.data.calendars ?? {}).flatMap(([calendarId, result]) =>
+    (result.errors ?? []).map((error) => ({ calendarId, reason: error.reason, domain: error.domain })),
+  );
+  if (errors.length > 0) {
+    throw new Error(`Could not read availability for: ${errors.map((error) => error.calendarId).join(", ")}`);
+  }
+
+  const bufferMs = buffer * 60000;
+  const busy = Object.values(freeBusy.data.calendars ?? {}).flatMap((calendar) =>
+    (calendar.busy ?? []).flatMap((period) =>
+      period.start && period.end
+        ? [{ start: Date.parse(period.start) - bufferMs, end: Date.parse(period.end) + bufferMs }]
+        : [],
+    ),
+  );
+  const suggestions = computeSuggestedSlots(suggestionInput, busy);
+
+  return {
+    participants,
+    durationMinutes: input.durationMinutes,
+    searchedRange: { start: input.timeMin, end: input.timeMax, timeZone },
+    workHours: { start: input.workDayStart ?? "09:00", end: input.workDayEnd ?? "17:00" },
+    suggestions,
+  };
+};
+
+export default withGoogleAPIs(tool);


### PR DESCRIPTION
## Summary
- expand Google Calendar AI tools across rich event workflows, availability, recurring events, custom labels, and colors
- add calendar metadata, list preferences, sharing, and settings management with confirmations for mutating actions
- preserve unmodified event fields through safe partial updates, upgrade the Calendar client, and add unit and AI eval coverage

## Test plan
- [x] Run formatting checks
- [x] Run `npm run lint`
- [x] Run `npm test`
- [x] Run `npm run build`
- [x] Launch with `npm run dev -- --target=x-internal`

Made with [Cursor](https://cursor.com)