### PR TITLE
Update pokedex extension

### DIFF
--- a/extensions/pokedex/CHANGELOG.md
+++ b/extensions/pokedex/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Pokédex Changelog
 
-## [Fix Missing Base Stats] - {PR_MERGE_DATE}
+## [Fix Missing Base Stats] - 2026-07-22
 
 - Fixed missing **Type**, **Weaknesses**, and **Base Stats** on some Pokémon profiles by no longer caching incomplete API responses.
 

--- a/extensions/pokedex/CHANGELOG.md
+++ b/extensions/pokedex/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Pokédex Changelog
 
+## [Fix Missing Base Stats] - {PR_MERGE_DATE}
+
+- Fixed missing **Type**, **Weaknesses**, and **Base Stats** on some Pokémon profiles by no longer caching incomplete API responses.
+
 ## [Regional Pokédex] - 2026-03-18
 
 - Added **Regional Pokédex** command to browse Pokémon by regional dex with quick profile navigation.

--- a/extensions/pokedex/package.json
+++ b/extensions/pokedex/package.json
@@ -7,7 +7,8 @@
   "author": "anhthang",
   "contributors": [
     "miguel-felix1",
-    "DanBennett"
+    "DanBennett",
+    "ridemountainpig"
   ],
   "license": "MIT",
   "categories": [

--- a/extensions/pokedex/src/api/index.ts
+++ b/extensions/pokedex/src/api/index.ts
@@ -28,6 +28,7 @@ async function fetchDataWithCaching<T>(
   variables: Record<string, number>,
   prefix: string,
   isArray = false,
+  isComplete: (value: T) => boolean = () => true,
 ): Promise<T | undefined> {
   // Create a simple hash of the query to include in the cache key
   const queryHash = query
@@ -50,7 +51,7 @@ async function fetchDataWithCaching<T>(
         const parsed: CachedData<T> = JSON.parse(cachedData);
 
         // Ensure parsed data has required properties
-        if (parsed.timestamp && parsed.value) {
+        if (parsed.timestamp && parsed.value && isComplete(parsed.value)) {
           if (now - parsed.timestamp < expiration) {
             return parsed.value;
           }
@@ -87,9 +88,11 @@ async function fetchDataWithCaching<T>(
       ? data.data[prefix]
       : data.data[prefix][0]) as unknown as T;
 
-    // Cache the fresh data with a timestamp
-    const dataToCache: CachedData<T> = { timestamp: now, value: fetchedData };
-    cache.set(key, JSON.stringify(dataToCache));
+    // Cache the fresh data with a timestamp, unless the response is incomplete
+    if (fetchedData && isComplete(fetchedData)) {
+      const dataToCache: CachedData<T> = { timestamp: now, value: fetchedData };
+      cache.set(key, JSON.stringify(dataToCache));
+    }
 
     return fetchedData;
   } catch (e: any) {
@@ -389,7 +392,14 @@ export const fetchPokemon = async (
 
   const variables = { language_id, pokemon_id };
 
-  return fetchDataWithCaching(query, variables, "pokemon");
+  return fetchDataWithCaching<Pokemon>(
+    query,
+    variables,
+    "pokemon",
+    false,
+    (pokemon) =>
+      Boolean(pokemon.pokemonstats?.length && pokemon.pokemontypes?.length),
+  );
 };
 
 export const fetchMoves = async (): Promise<Move[] | undefined> => {
@@ -551,7 +561,14 @@ export const fetchTypes = async (): Promise<TypeChartType[] | undefined> => {
 
   const variables = { language_id };
 
-  return fetchDataWithCaching(query, variables, "type", true);
+  return fetchDataWithCaching<TypeChartType[]>(
+    query,
+    variables,
+    "type",
+    true,
+    (types) =>
+      types.length > 0 && types.every((type) => type.typeefficacies?.length),
+  );
 };
 
 export const fetchNatures = async (): Promise<Nature[] | undefined> => {

--- a/extensions/pokedex/src/components/pokemon.tsx
+++ b/extensions/pokedex/src/components/pokemon.tsx
@@ -210,20 +210,24 @@ export default function PokemonDetail(props: { id: number }) {
             />
             <Detail.Metadata.Separator />
             <WeaknessMetadata type="detail" types={pokemon.pokemontypes} />
-            <Detail.Metadata.Separator />
-            <Detail.Metadata.TagList title="Base Stats">
-              {pokemon.pokemonstats.map((stat, idx) => (
-                <Detail.Metadata.TagList.Item
-                  key={idx}
-                  text={`${getLocalizedName(stat.stat.statnames, stat.stat.name)}: ${stat.base_stat}`}
-                  color={
-                    stat.stat.name.startsWith("special")
-                      ? Color.Green
-                      : Color.Yellow
-                  }
-                />
-              ))}
-            </Detail.Metadata.TagList>
+            {pokemon.pokemonstats.length > 0 && (
+              <>
+                <Detail.Metadata.Separator />
+                <Detail.Metadata.TagList title="Base Stats">
+                  {pokemon.pokemonstats.map((stat, idx) => (
+                    <Detail.Metadata.TagList.Item
+                      key={idx}
+                      text={`${getLocalizedName(stat.stat.statnames, stat.stat.name)}: ${stat.base_stat}`}
+                      color={
+                        stat.stat.name.startsWith("special")
+                          ? Color.Green
+                          : Color.Yellow
+                      }
+                    />
+                  ))}
+                </Detail.Metadata.TagList>
+              </>
+            )}
           </Detail.Metadata>
         )
       }

--- a/extensions/pokedex/src/components/pokemon.tsx
+++ b/extensions/pokedex/src/components/pokemon.tsx
@@ -210,7 +210,7 @@ export default function PokemonDetail(props: { id: number }) {
             />
             <Detail.Metadata.Separator />
             <WeaknessMetadata type="detail" types={pokemon.pokemontypes} />
-            {pokemon.pokemonstats.length > 0 && (
+            {(pokemon.pokemonstats?.length ?? 0) > 0 && (
               <>
                 <Detail.Metadata.Separator />
                 <Detail.Metadata.TagList title="Base Stats">


### PR DESCRIPTION
## Description
Fixed missing **Type**, **Weaknesses**, and **Base Stats** on some Pokémon profiles by no longer caching incomplete API responses. Close #29464.
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1000" height="625" alt="pokedex 2026-07-20 at 22 06 23" src="https://github.com/user-attachments/assets/99b2ab60-d693-4d24-8967-c788a3f5d78f" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
