### PR TITLE
[Agent Usage] Support Claude model-scoped limits (i.e. Fable)

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Support Claude Fable Usage Limits] - 2026-07-20
+## [Support Claude Fable Usage Limits] - {YYYY-MM-DD}
 
 ### Improvements
 

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Agent Usage Changelog
 
+## [Support Claude Fable Usage Limits] - 2026-07-20
+
+### Improvements
+
+- Support Claude Fable and future model-scoped weekly usage limits from the Claude API structured `limits` array
+
 ## [Antigravity badge] - 2026-07-15
 
 ### Fixed

--- a/extensions/agent-usage/src/agents/hooks.ts
+++ b/extensions/agent-usage/src/agents/hooks.ts
@@ -17,7 +17,7 @@ import type { CachedUsagePayload } from "./usage-cache";
 
 // Versioned namespace: bump the suffix whenever the persisted payload shape
 // changes so entries written by older extension versions read as cache misses.
-const usageCache = new Cache({ namespace: "agent-usage-ttl-v2" });
+const usageCache = new Cache({ namespace: "agent-usage-ttl-v3" });
 
 function getTtlMs(): number {
   const prefs = getPreferenceValues<{ cacheTtl?: string }>();

--- a/extensions/agent-usage/src/claude/fetcher.ts
+++ b/extensions/agent-usage/src/claude/fetcher.ts
@@ -481,7 +481,14 @@ export async function fetchClaudeUsage(
 
     // Dynamically collect any seven_day_<model> windows (e.g. sonnet, opus, ...)
     const modelWindows: Record<string, import("./types").ClaudeRateWindow> = {};
-    const KNOWN_NON_MODEL_KEYS = new Set(["five_hour", "seven_day", "extra_usage", "limits", "spend", "member_dashboard_available"]);
+    const KNOWN_NON_MODEL_KEYS = new Set([
+      "five_hour",
+      "seven_day",
+      "extra_usage",
+      "limits",
+      "spend",
+      "member_dashboard_available",
+    ]);
     for (const [key, value] of Object.entries(data)) {
       if (KNOWN_NON_MODEL_KEYS.has(key)) continue;
       if (!key.startsWith("seven_day_")) continue;
@@ -499,8 +506,8 @@ export async function fetchClaudeUsage(
     // (e.g. Fable). These take precedence over any seven_day_* flat key.
     if (Array.isArray(data.limits)) {
       for (const limit of data.limits) {
-        if (limit.kind !== "weekly_scoped") continue;
-        const modelName = limit.scope?.model?.display_name;
+        if (limit.kind !== "weekly_scoped" || limit.is_active === false) continue;
+        const modelName = limit.scope?.model?.display_name ?? limit.scope?.model?.id;
         if (!modelName || typeof limit.percent !== "number") continue;
         const key = modelName.toLowerCase();
         modelWindows[key] = {

--- a/extensions/agent-usage/src/claude/fetcher.ts
+++ b/extensions/agent-usage/src/claude/fetcher.ts
@@ -52,12 +52,27 @@ interface OAuthExtraUsage {
   currency?: string;
 }
 
+interface OAuthLimitScope {
+  model?: { id?: string | null; display_name?: string | null };
+  surface?: string | null;
+}
+
+interface OAuthLimit {
+  kind?: string;
+  group?: string;
+  percent?: number;
+  severity?: string;
+  resets_at?: string;
+  scope?: OAuthLimitScope | null;
+  is_active?: boolean;
+}
+
 interface OAuthUsageResponse {
   five_hour?: OAuthWindow;
   seven_day?: OAuthWindow;
-  seven_day_sonnet?: OAuthWindow;
-  seven_day_opus?: OAuthWindow;
   extra_usage?: OAuthExtraUsage;
+  limits?: OAuthLimit[];
+  [key: string]: OAuthWindow | OAuthExtraUsage | OAuthLimit[] | undefined;
 }
 
 interface OAuthRefreshResponse {
@@ -463,9 +478,39 @@ export async function fetchClaudeUsage(
     }
 
     const sevenDay = data.seven_day;
-    const sevenDayModel = data.seven_day_sonnet ?? data.seven_day_opus;
 
-    const extra = data.extra_usage;
+    // Dynamically collect any seven_day_<model> windows (e.g. sonnet, opus, ...)
+    const modelWindows: Record<string, import("./types").ClaudeRateWindow> = {};
+    const KNOWN_NON_MODEL_KEYS = new Set(["five_hour", "seven_day", "extra_usage", "limits", "spend", "member_dashboard_available"]);
+    for (const [key, value] of Object.entries(data)) {
+      if (KNOWN_NON_MODEL_KEYS.has(key)) continue;
+      if (!key.startsWith("seven_day_")) continue;
+      const window = value as OAuthWindow | undefined;
+      if (window && typeof window.utilization === "number") {
+        const modelName = key.slice("seven_day_".length);
+        modelWindows[modelName] = {
+          percentageRemaining: clampPercent(100 - window.utilization),
+          resetsIn: formatResetsIn(window.resets_at),
+        };
+      }
+    }
+
+    // Also parse the structured `limits` array for model-scoped weekly limits
+    // (e.g. Fable). These take precedence over any seven_day_* flat key.
+    if (Array.isArray(data.limits)) {
+      for (const limit of data.limits) {
+        if (limit.kind !== "weekly_scoped") continue;
+        const modelName = limit.scope?.model?.display_name;
+        if (!modelName || typeof limit.percent !== "number") continue;
+        const key = modelName.toLowerCase();
+        modelWindows[key] = {
+          percentageRemaining: clampPercent(100 - limit.percent),
+          resetsIn: formatResetsIn(limit.resets_at),
+        };
+      }
+    }
+
+    const extra = data.extra_usage as OAuthExtraUsage | undefined;
     const extraUsage =
       extra?.is_enabled && typeof extra.monthly_limit === "number" && typeof extra.used_credits === "number"
         ? {
@@ -488,13 +533,7 @@ export async function fetchClaudeUsage(
               resetsIn: formatResetsIn(sevenDay.resets_at),
             }
           : null,
-      sevenDayModel:
-        sevenDayModel && typeof sevenDayModel.utilization === "number"
-          ? {
-              percentageRemaining: clampPercent(100 - sevenDayModel.utilization),
-              resetsIn: formatResetsIn(sevenDayModel.resets_at),
-            }
-          : null,
+      modelWindows,
       extraUsage,
     };
 

--- a/extensions/agent-usage/src/claude/renderer.tsx
+++ b/extensions/agent-usage/src/claude/renderer.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { List } from "@raycast/api";
 import type { Accessory } from "../agents/types";
 import {
@@ -18,6 +19,10 @@ function formatWindow(name: string, percent: number, resetsIn: string | null): s
   return text;
 }
 
+function formatModelLabel(key: string): string {
+  return `Weekly ${key.charAt(0).toUpperCase()}${key.slice(1)}`;
+}
+
 export function formatClaudeUsageText(usage: ClaudeUsage | null, error: ClaudeError | null): string {
   const fallback = formatErrorOrNoData("Claude", usage, error);
   if (fallback !== null) return fallback;
@@ -30,8 +35,8 @@ export function formatClaudeUsageText(usage: ClaudeUsage | null, error: ClaudeEr
     text += formatWindow("Weekly Limit", u.sevenDay.percentageRemaining, u.sevenDay.resetsIn);
   }
 
-  if (u.sevenDayModel) {
-    text += formatWindow("Weekly Sonnet", u.sevenDayModel.percentageRemaining, u.sevenDayModel.resetsIn);
+  for (const [model, window] of Object.entries(u.modelWindows || {})) {
+    text += formatWindow(formatModelLabel(model), window.percentageRemaining, window.resetsIn);
   }
 
   if (u.extraUsage) {
@@ -68,18 +73,16 @@ export function renderClaudeDetail(usage: ClaudeUsage | null, error: ClaudeError
         </>
       )}
 
-      {u.sevenDayModel && (
-        <>
+      {Object.entries(u.modelWindows || {}).map(([model, window]) => (
+        <React.Fragment key={model}>
           <List.Item.Detail.Metadata.Separator />
           <List.Item.Detail.Metadata.Label
-            title="Weekly Sonnet"
-            text={`${generateAsciiBar(u.sevenDayModel.percentageRemaining)} ${u.sevenDayModel.percentageRemaining}% remaining`}
+            title={formatModelLabel(model)}
+            text={`${generateAsciiBar(window.percentageRemaining)} ${window.percentageRemaining}% remaining`}
           />
-          {u.sevenDayModel.resetsIn && (
-            <List.Item.Detail.Metadata.Label title="Resets In" text={u.sevenDayModel.resetsIn} />
-          )}
-        </>
-      )}
+          {window.resetsIn && <List.Item.Detail.Metadata.Label title="Resets In" text={window.resetsIn} />}
+        </React.Fragment>
+      ))}
 
       {u.extraUsage && (
         <>
@@ -127,8 +130,8 @@ export function getClaudeAccessory(
   if (usage.sevenDay) {
     tooltipParts.push(`Weekly Limit: ${usage.sevenDay.percentageRemaining}%`);
   }
-  if (usage.sevenDayModel) {
-    tooltipParts.push(`Weekly Sonnet: ${usage.sevenDayModel.percentageRemaining}%`);
+  for (const [model, window] of Object.entries(usage.modelWindows || {})) {
+    tooltipParts.push(`${formatModelLabel(model)}: ${window.percentageRemaining}%`);
   }
   if (usage.extraUsage) {
     tooltipParts.push(

--- a/extensions/agent-usage/src/claude/types.ts
+++ b/extensions/agent-usage/src/claude/types.ts
@@ -13,7 +13,7 @@ export interface ClaudeUsage {
   plan: string;
   fiveHour: ClaudeRateWindow;
   sevenDay: ClaudeRateWindow | null;
-  sevenDayModel: ClaudeRateWindow | null;
+  modelWindows: Record<string, ClaudeRateWindow>;
   extraUsage: ClaudeExtraUsage | null;
 }
 


### PR DESCRIPTION
## Summary

Now that Fable usage will be included in plans, support Claude Fable (and future model-specific) weekly usage limits by replacing the hardcoded `sevenDayModel` field with a generic `modelWindows` map.

## Problem

The Anthropic OAuth usage API now returns model-scoped weekly limits in a **structured `limits` array** rather than flat `seven_day_*` keys. Fable limits only appear in this new format:

```json
{
  "kind": "weekly_scoped",
  "group": "weekly",
  "percent": 100,
  "scope": { "model": { "display_name": "Fable" } },
  "is_active": true
}
```

The previous code only parsed `seven_day_sonnet` / `seven_day_opus` flat keys, missing Fable entirely.

## Approach

Instead of adding yet another hardcoded field per model...

- **`ClaudeUsage.sevenDayModel`** → **`ClaudeUsage.modelWindows: Record<string, ClaudeRateWindow>`**
- Fetcher dynamically collects model windows from **two sources**:
  1. Legacy `seven_day_*` flat keys (sonnet, opus, cowork, etc.)
  2. Structured `limits[]` entries with `kind: "weekly_scoped"` (Fable)
- Renderer iterates the map with `Object.entries()` — zero code changes needed for future models
- `formatModelLabel()` converts API keys to display labels (`"fable"` → `"Weekly Fable"`)

## Changes

| File | Change |
|------|--------|
| `src/claude/types.ts` | `sevenDayModel` → `modelWindows: Record<string, ClaudeRateWindow>` |
| `src/claude/fetcher.ts` | Parse both `seven_day_*` keys and `limits[]` array into `modelWindows` |
| `src/claude/renderer.tsx` | Dynamic iteration with defensive `|| {}` guards for stale cache |
| `src/agents/hooks.ts` | Cache namespace v2→v3 (evicts stale payloads with old shape) |

## Testing

- Build passes cleanly
- Lint passes cleanly
- Verified against live API — correctly surfaces Fable at 0% remaining when rate-limited
- Menu bar and list view both render model windows correctly
- Accounts without model-specific limits show no extra rows (graceful no-op)