### PR TITLE
Add model sync to Raycast AI Custom Providers

### DIFF
--- a/extensions/raycast-ai-custom-providers/CHANGELOG.md
+++ b/extensions/raycast-ai-custom-providers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Raycast AI Custom Providers Changelog
 
+## [Sync OpenAI-Compatible Models] - 2026-07-21
+
+- Add a Sync Models action for OpenAI-compatible custom providers
+- Map available context and capability metadata into Raycast model entries
+- Keep existing model configuration unchanged when synchronization fails
+
 ## [Initial Version] - 2026-03-04
 
 - Initial version

--- a/extensions/raycast-ai-custom-providers/README.md
+++ b/extensions/raycast-ai-custom-providers/README.md
@@ -11,6 +11,9 @@ A Raycast extension that allows you to manage custom AI provider settings throug
 - View a list of all configured providers
 - View detailed information about each provider (models, API keys, additional parameters)
 - Edit existing or add new providers and models
+- Synchronize models from any OpenAI-compatible provider's `/models` endpoint
+
+Use the **Sync Models** action on a provider to replace its configured model list with the provider's live OpenAI-compatible catalog. The request uses the provider's configured API key when present. Existing models remain unchanged if fetching or validating the catalog fails.
 
 The extension automatically works with the Raycast AI configuration file located at:
 ```

--- a/extensions/raycast-ai-custom-providers/package-lock.json
+++ b/extensions/raycast-ai-custom-providers/package-lock.json
@@ -2607,9 +2607,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2796,13 +2796,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/extensions/raycast-ai-custom-providers/src/hooks/useProviders.ts
+++ b/extensions/raycast-ai-custom-providers/src/hooks/useProviders.ts
@@ -3,6 +3,7 @@ import { usePromise } from "@raycast/utils";
 import { readProvidersFile, writeProvidersFile } from "../utils/yaml-handler";
 import { Provider, Model } from "../types";
 import { showFailureToast } from "@raycast/utils";
+import { fetchProviderModels } from "../utils/model-sync";
 
 /**
  * Hook for managing AI providers configuration
@@ -37,6 +38,20 @@ export function useProviders() {
       }
     },
     [revalidate],
+  );
+
+  /**
+   * Replaces a provider's configured models with its live OpenAI-compatible catalog.
+   * The provider file is written only after the full response has been validated.
+   */
+  const syncProviderModels = useCallback(
+    async (provider: Provider, signal?: AbortSignal) => {
+      const models = await fetchProviderModels(provider, signal);
+      const updatedProviders = data.map((item) => (item.id === provider.id ? { ...item, models } : item));
+      saveProviders(updatedProviders);
+      return models.length;
+    },
+    [data, saveProviders],
   );
 
   /**
@@ -158,5 +173,6 @@ export function useProviders() {
     removeModel,
     putProvider,
     putModel,
+    syncProviderModels,
   };
 }

--- a/extensions/raycast-ai-custom-providers/src/manage-custom-providers.tsx
+++ b/extensions/raycast-ai-custom-providers/src/manage-custom-providers.tsx
@@ -1,4 +1,4 @@
-import { ActionPanel, List, Action, Icon, Alert, confirmAlert, Color } from "@raycast/api";
+import { ActionPanel, List, Action, Icon, Alert, confirmAlert, Color, Toast, showToast } from "@raycast/api";
 import { useProviders } from "./hooks/useProviders";
 import { ProviderForm } from "./components/views/ProviderForm";
 import { ModelForm } from "./components/views/ModelForm";
@@ -6,7 +6,7 @@ import { PROVIDERS_FILE_PATH } from "./utils/yaml-handler";
 import { Provider, Model } from "./types";
 
 export default function Command() {
-  const { providers, isLoading, error, removeProvider, removeModel, revalidate } = useProviders();
+  const { providers, isLoading, error, removeProvider, removeModel, revalidate, syncProviderModels } = useProviders();
 
   return (
     <List
@@ -42,6 +42,7 @@ export default function Command() {
                   <ActionPanel>
                     <ActionPanel.Section title={provider.name}>
                       <AddNewModelAction provider={provider} onSave={revalidate} />
+                      <SyncProviderModelsAction provider={provider} syncProviderModels={syncProviderModels} />
                       <EditProviderAction provider={provider} onSave={revalidate} />
                       <RemoveProviderAction provider={provider} removeProvider={removeProvider} />
                     </ActionPanel.Section>
@@ -136,6 +137,7 @@ export default function Command() {
 
                     <ActionPanel.Section title={provider.name}>
                       <AddNewModelAction provider={provider} onSave={revalidate} />
+                      <SyncProviderModelsAction provider={provider} syncProviderModels={syncProviderModels} />
                       <EditProviderAction provider={provider} onSave={revalidate} />
                       <RemoveProviderAction provider={provider} removeProvider={removeProvider} />
                     </ActionPanel.Section>
@@ -230,6 +232,34 @@ function RemoveModelAction({
         });
         if (confirmed) {
           removeModel(provider.id, model.id);
+        }
+      }}
+    />
+  );
+}
+
+function SyncProviderModelsAction({
+  provider,
+  syncProviderModels,
+}: {
+  provider: Provider;
+  syncProviderModels: (provider: Provider, signal?: AbortSignal) => Promise<number>;
+}) {
+  return (
+    <Action
+      title="Sync Models"
+      icon={Icon.ArrowClockwise}
+      onAction={async () => {
+        const toast = await showToast({ style: Toast.Style.Animated, title: `Syncing ${provider.name} models` });
+        try {
+          const count = await syncProviderModels(provider);
+          toast.style = Toast.Style.Success;
+          toast.title = `Synced ${count} models`;
+          toast.message = provider.name;
+        } catch (error) {
+          toast.style = Toast.Style.Failure;
+          toast.title = "Model sync failed";
+          toast.message = error instanceof Error ? error.message : "Unknown error";
         }
       }}
     />

--- a/extensions/raycast-ai-custom-providers/src/utils/model-sync.ts
+++ b/extensions/raycast-ai-custom-providers/src/utils/model-sync.ts
@@ -1,0 +1,109 @@
+import { Model, Provider } from "../types";
+
+interface OpenAIModel {
+  id?: unknown;
+  owned_by?: unknown;
+  context_length?: unknown;
+  max_input_tokens?: unknown;
+  capabilities?: unknown;
+}
+
+interface OpenAIModelsResponse {
+  data?: unknown;
+}
+
+function hasCapability(model: OpenAIModel, ...names: string[]): boolean {
+  if (!model.capabilities || typeof model.capabilities !== "object" || Array.isArray(model.capabilities)) {
+    return false;
+  }
+
+  const capabilities = model.capabilities as Record<string, unknown>;
+  return names.some((name) => capabilities[name] === true);
+}
+
+export function getModelsEndpoint(baseUrl: string): string {
+  const normalized = baseUrl.trim().replace(/\/+$/, "");
+  if (!normalized) {
+    throw new Error("Provider base URL is required");
+  }
+  return `${normalized}/models`;
+}
+
+export function getProviderApiKey(provider: Provider): string | undefined {
+  if (!provider.api_keys) {
+    return undefined;
+  }
+
+  const preferredKey = provider.api_keys[provider.id];
+  if (preferredKey) {
+    return preferredKey;
+  }
+
+  return Object.values(provider.api_keys).find((value) => value.trim().length > 0);
+}
+
+export function mapOpenAIModel(model: OpenAIModel, provider: Provider): Model | null {
+  if (typeof model.id !== "string" || !model.id.trim()) {
+    return null;
+  }
+
+  const id = model.id.trim();
+  const owner = typeof model.owned_by === "string" && model.owned_by ? ` (${model.owned_by})` : "";
+  const contextCandidates = [model.context_length, model.max_input_tokens];
+  const context = contextCandidates.find((value): value is number => typeof value === "number" && value > 0) ?? 128000;
+
+  return {
+    id,
+    name: id,
+    provider: provider.id,
+    description: `${id} via ${provider.name}${owner}`,
+    context,
+    abilities: {
+      temperature: { supported: true },
+      vision: { supported: hasCapability(model, "vision", "image_input") },
+      system_message: { supported: true },
+      tools: { supported: hasCapability(model, "tool_calling", "tools") },
+      reasoning_effort: { supported: hasCapability(model, "reasoning", "thinking") },
+    },
+  };
+}
+
+export function parseModelsResponse(payload: unknown, provider: Provider): Model[] {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("The models endpoint returned an invalid response");
+  }
+
+  const data = (payload as OpenAIModelsResponse).data;
+  if (!Array.isArray(data)) {
+    throw new Error("The models endpoint response does not contain a data array");
+  }
+
+  const models = data
+    .map((model) =>
+      model && typeof model === "object" && !Array.isArray(model) ? mapOpenAIModel(model, provider) : null,
+    )
+    .filter((model): model is Model => model !== null);
+
+  if (models.length === 0) {
+    throw new Error("The models endpoint returned no usable model IDs");
+  }
+
+  return models;
+}
+
+export async function fetchProviderModels(provider: Provider, signal?: AbortSignal): Promise<Model[]> {
+  const apiKey = getProviderApiKey(provider);
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  const timeout = AbortSignal.timeout(15_000);
+  const requestSignal = signal ? AbortSignal.any([signal, timeout]) : timeout;
+  const response = await fetch(getModelsEndpoint(provider.base_url), { headers, signal: requestSignal });
+  if (!response.ok) {
+    throw new Error(`Models request failed (${response.status} ${response.statusText})`);
+  }
+
+  return parseModelsResponse(await response.json(), provider);
+}


### PR DESCRIPTION
## Description

Adds a **Sync Models** action to Raycast AI Custom Providers. It queries the selected provider's OpenAI-compatible `<base_url>/models` endpoint and replaces that provider's configured model list only after receiving a valid, non-empty catalog.

The action:

- authenticates with the provider's configured API key when available;
- keeps the existing model list unchanged on HTTP, timeout, parsing, or empty-catalog failures;
- maps model IDs, ownership, context length, and advertised vision/tool/reasoning capabilities into Raycast's existing model schema;
- uses conservative capability defaults when optional metadata is absent;
- times out after 15 seconds;
- continues to use the extension's existing backup-before-write behavior.

Closes #28414.

## Screencast

N/A — this adds an action to the existing provider/model list and uses the standard Raycast loading/success/failure toasts.

## Checklist

- [x] I read the [contribution guidelines](https://github.com/raycast/extensions/blob/main/CONTRIBUTING.md)
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] No provider credentials or private endpoints are included
