### PR TITLE
Make `$USER` available to zed-recent-projects

### DIFF
--- a/extensions/zed-recent-projects/CHANGELOG.md
+++ b/extensions/zed-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zed Recent Projects Changelog
 
-## [Fix Nix aware `$PATH` lookup] - {PR_MERGE_DATE}
+## [Fix Nix aware `$PATH` lookup] - 2026-07-21
 
 - Fix an issue where nix-managed language tooling (e.g. LSPs) could never be resolved from `$PATH` due to the missing `$USER` env var
 

--- a/extensions/zed-recent-projects/CHANGELOG.md
+++ b/extensions/zed-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zed Recent Projects Changelog
 
-## Fix Nix aware `$PATH` lookup - {PR_MERGE_DATE}
+## [Fix Nix aware `$PATH` lookup] - {PR_MERGE_DATE}
 
 - Fix an issue where nix-managed language tooling (e.g. LSPs) could never be resolved from `$PATH` due to the missing `$USER` env var
 

--- a/extensions/zed-recent-projects/CHANGELOG.md
+++ b/extensions/zed-recent-projects/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Zed Recent Projects Changelog
 
+## Fix Nix aware `$PATH` lookup - {PR_MERGE_DATE}
+
+- Fix an issue where nix-managed language tooling (e.g. LSPs) could never be resolved from `$PATH` due to the missing `$USER` env var
+
 ## [Fix Remote Project Launch] - 2026-06-29
+
 - Fix an issue where remote projects fail to launch from "Search Recent Projects" menu.
 
 ## [Fix Stale Project Status in Search Menu] - 2026-06-07

--- a/extensions/zed-recent-projects/src/lib/utils.ts
+++ b/extensions/zed-recent-projects/src/lib/utils.ts
@@ -80,7 +80,7 @@ export async function execWithCleanEnv(command: string, args: string[]): Promise
   await execFilePromise("env", [
     "-i",
     `HOME=${process.env.HOME || homedir()}`,
-    `USER=${process.env.USER || userInfo().username}`,
+    `USER=${userInfo().username}`,
     posixShell,
     "-lc",
     shellCommand,

--- a/extensions/zed-recent-projects/src/lib/utils.ts
+++ b/extensions/zed-recent-projects/src/lib/utils.ts
@@ -35,7 +35,7 @@ export function isPosixShell(shellPath: string): boolean {
  */
 function getUserShell(): string {
   try {
-    const username = process.env.USER || userInfo().username;
+    const username = userInfo().username;
     const result = execFileSync("dscl", [".", "-read", `/Users/${username}`, "UserShell"], {
       encoding: "utf8",
     });

--- a/extensions/zed-recent-projects/src/lib/utils.ts
+++ b/extensions/zed-recent-projects/src/lib/utils.ts
@@ -77,7 +77,14 @@ export async function execWithCleanEnv(command: string, args: string[]): Promise
 
   // Use env -i to start with empty environment, then login shell for user's profile
   // -l = login shell (sources profile), -c = execute command
-  await execFilePromise("env", ["-i", `HOME=${process.env.HOME || homedir()}`, posixShell, "-lc", shellCommand]);
+  await execFilePromise("env", [
+    "-i",
+    `HOME=${process.env.HOME || homedir()}`,
+    `USER=${process.env.USER || userInfo().username}`,
+    posixShell,
+    "-lc",
+    shellCommand,
+  ]);
 }
 
 export function exists(p: string) {


### PR DESCRIPTION
## Description

I've recently switched to nix and nix-darwin. One thing I had to do to get things working is put all the nix specific stuff on `$PATH` which is fine, but I noticed that the zed-recent-projects extension was the only thing now not resolving those paths.

Nix PATH entries look like this: `/etc/profiles/per-user/{your user}/bin`. It _uses_ and resolves the value of `$USER` to build these paths

And since zed-recent-projects was being `execWithCleanEnv` launched with an environment that _only_ contained `$HOME`, this would evaluate to:

```
/etc/profiles/per-user//bin
# Note the gap........^
# No $USER
````

This means that any tooling like LSPs, linting tools etc. that I manage with nix (all of them now), would never be resolved _despite_ the correct nix paths being on my `$PATH`

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

### Current Version

Launching into a Go project from the recent projects search

<img width="775" height="178" alt="image" src="https://github.com/user-attachments/assets/e5fbda0b-91cc-4d2d-885f-35139b9edf40" />

### With Fix

Exactly the same project with `npm run dev`

gopls fires up just fine:

<img width="211" height="59" alt="image" src="https://github.com/user-attachments/assets/94229486-ef9d-43ce-a72a-ba820f505ef9" />

LSP and other tools work:

<img width="551" height="217" alt="image" src="https://github.com/user-attachments/assets/5a490ef7-0eb0-41e1-a4a1-d28703233d45" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [] I checked that files in the `assets` folder are used by the extension itself
- [] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
