### PR TITLE
[Slack] Fix file upload signatures and permissions

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Fix AI signatures on file uploads] - {PR_MERGE_DATE}
+## [Fix AI signatures on file uploads] - 2026-07-21
 
 - Show the “Sent via Raycast” signature on Slack messages that include uploaded files.
 - Prompt existing OAuth users to reauthorize Slack when file-upload permission is missing.

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Slack Changelog
 
+## [Fix AI signatures on file uploads] - {PR_MERGE_DATE}
+
+- Show the “Sent via Raycast” signature on Slack messages that include uploaded files.
+- Prompt existing OAuth users to reauthorize Slack when file-upload permission is missing.
+- Add the required `files:write` scope to the manual access-token setup instructions.
+
 ## [Add Slack file upload AI tool] - 2026-07-18
 
 - Add an `upload-files` AI tool that uploads one or more local files to Slack channels, DMs, group DMs, or threads, optionally with an accompanying message.

--- a/extensions/slack/README.md
+++ b/extensions/slack/README.md
@@ -83,6 +83,9 @@ If you don't want to log in through OAuth, you can use an access token instead. 
          # Command & AI Tool: Send Message
          - chat:write
 
+         # AI Tool: Upload Files
+         - files:write
+
          # Command: Search Emojis
          - emoji:read
 

--- a/extensions/slack/src/tools/upload-files.ts
+++ b/extensions/slack/src/tools/upload-files.ts
@@ -1,4 +1,4 @@
-import { getSlackWebClient } from "../shared/client/WebClient";
+import { getSlackWebClient, slack } from "../shared/client/WebClient";
 import { withSlackClient } from "../shared/withSlackClient";
 import { getAiMessageBlocks } from "./message-signature";
 import { access } from "node:fs/promises";
@@ -40,6 +40,10 @@ const CONVERSATION_ID_PATTERN = /^[CDG][A-Z0-9]{8,}$/;
 const MESSAGE_TIMESTAMP_PATTERN = /^\d+\.\d+$/;
 
 async function uploadFiles(input: Input) {
+  return performUploadFiles(input);
+}
+
+async function performUploadFiles(input: Input, retried = false) {
   const channel = input.channel.trim();
   if (!CONVERSATION_ID_PATTERN.test(channel)) {
     throw new Error("Invalid Slack conversation ID");
@@ -74,16 +78,29 @@ async function uploadFiles(input: Input) {
   const messageBlocks = text ? getAiMessageBlocks(text) : undefined;
 
   const slackWebClient = getSlackWebClient();
-  const response = await slackWebClient.filesUploadV2({
-    channel_id: channel,
-    ...(threadTs ? { thread_ts: threadTs } : {}),
-    ...(text ? { initial_comment: text, ...(messageBlocks ? { blocks: messageBlocks } : {}) } : {}),
-    file_uploads: filePaths.map((filePath) => ({
-      file: filePath,
-      filename: path.basename(filePath),
-      title: path.basename(filePath),
-    })),
-  });
+  let response;
+
+  try {
+    response = await slackWebClient.filesUploadV2({
+      channel_id: channel,
+      ...(threadTs ? { thread_ts: threadTs } : {}),
+      ...(messageBlocks ? { blocks: messageBlocks } : text ? { initial_comment: text } : {}),
+      file_uploads: filePaths.map((filePath) => ({
+        file: filePath,
+        filename: path.basename(filePath),
+        title: path.basename(filePath),
+      })),
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("missing_scope") && !retried) {
+      const isUsingOAuth = !!(await slack.client.getTokens());
+      if (isUsingOAuth) {
+        await slack.client.removeTokens();
+        return withSlackClient((input: Input) => performUploadFiles(input, true))(input);
+      }
+    }
+    throw error;
+  }
 
   if (!response.ok) {
     throw new Error(response.error || "Slack failed to upload the files");


### PR DESCRIPTION
## Description

This fixes two issues with Slack file uploads:

* Slack ignores `blocks` when `initial_comment` is also supplied, which dropped the “Sent via Raycast” signature. The upload now sends Block Kit without `initial_comment`, and falls back to `initial_comment` when signatures are disabled.
* Existing OAuth tokens predate the new `files:write` scope. On `missing_scope`, OAuth users are prompted to reauthorize and the upload is retried once. The manual access-token manifest now documents `files:write` as well.

## Screencast

N/A

## Checklist

- [x] I ran `npm run lint`
- [x] I ran `npm run build`