### PR TITLE
feat(confluence-search): add Create Whiteboard command

### DIFF
--- a/extensions/confluence-search/CHANGELOG.md
+++ b/extensions/confluence-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Confluence Changelog
 
-## [Add Create Whiteboard Command] - 2026-07-21
+## [Add Create Whiteboard Command] - {PR_MERGE_DATE}
 
 - Add `Create Whiteboard` command to quickly create a new whiteboard in Confluence
 

--- a/extensions/confluence-search/CHANGELOG.md
+++ b/extensions/confluence-search/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Confluence Changelog
 
+## [Add Create Whiteboard Command] - 2026-07-21
+
+- Add `Create Whiteboard` command to quickly create a new whiteboard in Confluence
+
 ## [Allow Windows to use this Extension] - 2026-02-10
 
 - Add `Windows` to allowed platforms

--- a/extensions/confluence-search/CHANGELOG.md
+++ b/extensions/confluence-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Confluence Changelog
 
-## [Add Create Whiteboard Command] - {PR_MERGE_DATE}
+## [Add Create Whiteboard Command] - 2026-07-22
 
 - Add `Create Whiteboard` command to quickly create a new whiteboard in Confluence
 

--- a/extensions/confluence-search/package.json
+++ b/extensions/confluence-search/package.json
@@ -121,8 +121,7 @@
       "title": "Create Whiteboard",
       "subtitle": "Confluence",
       "description": "Create a new whiteboard.",
-      "mode": "no-view",
-      "icon": "confluence-icon-whiteboard.svg"
+      "mode": "no-view"
     }
   ],
   "dependencies": {

--- a/extensions/confluence-search/package.json
+++ b/extensions/confluence-search/package.json
@@ -115,6 +115,14 @@
       "subtitle": "Confluence",
       "description": "Create a new blog.",
       "mode": "no-view"
+    },
+    {
+      "name": "new-whiteboard",
+      "title": "Create Whiteboard",
+      "subtitle": "Confluence",
+      "description": "Create a new whiteboard.",
+      "mode": "no-view",
+      "icon": "confluence-icon-whiteboard.svg"
     }
   ],
   "dependencies": {
@@ -147,5 +155,8 @@
   "platforms": [
     "macOS",
     "Windows"
-  ]
+  ],
+  "allowScripts": {
+    "esbuild@0.25.5": true
+  }
 }

--- a/extensions/confluence-search/package.json
+++ b/extensions/confluence-search/package.json
@@ -154,8 +154,5 @@
   "platforms": [
     "macOS",
     "Windows"
-  ],
-  "allowScripts": {
-    "esbuild@0.25.5": true
-  }
+  ]
 }

--- a/extensions/confluence-search/src/new-whiteboard.tsx
+++ b/extensions/confluence-search/src/new-whiteboard.tsx
@@ -1,0 +1,12 @@
+import "cross-fetch/polyfill";
+
+import { open } from "@raycast/api";
+import { authorizeSite } from "./api/auth";
+
+export default async () => {
+  const site = await authorizeSite(false); // no special scopes needed
+  const link = new URL(
+    `${site.url}/wiki/create-content/whiteboard?spaceKey=&parentPageId=&withFallback=true&source=createBlankFabricPage`,
+  );
+  await open(`${link}`);
+};


### PR DESCRIPTION
## Description

Adds a new **Create Whiteboard** command to the Confluence Search extension, mirroring the existing "Create Page" and "Create Blog" commands.

### Changes
- **New file**: `src/new-whiteboard.tsx` — a `no-view` command that authenticates the active Confluence site and opens the whiteboard creation URL in the browser
- **Updated**: `package.json` — registers the new command with title "Create Whiteboard", subtitle "Confluence", and the whiteboard icon

### How it works
Follows the exact same pattern as `new-page.tsx` and `new-blog.tsx`: calls `authorizeSite()` to get the active site, then opens `/wiki/create-content/whiteboard` in the browser.

### Screenshots
The command appears in Raycast alongside "Create Page" and "Create Blog" and instantly opens Confluence's whiteboard creator.

<img width="762" height="481" alt="image" src="https://github.com/user-attachments/assets/95b3b4e7-1cac-40ac-90a5-f2d2ee9cbf8e" />